### PR TITLE
Emit an event when an account is linked

### DIFF
--- a/docs/language/run-time-types.md
+++ b/docs/language/run-time-types.md
@@ -93,7 +93,7 @@ fun InterfaceType(_ identifier: String): Type?
 fun RestrictedType(identifier: String?, restrictions: [String]): Type?
 ```
 
-Given a type identifer (as well as a list of identifiers for restricting interfaces
+Given a type identifier (as well as a list of identifiers for restricting interfaces
 in the case of `RestrictedType`), these functions will look up nominal types and
 produce their run-time equivalents. If the provided identifiers do not correspond
 to any types, or (in the case of `RestrictedType`) the provided combination of 

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -2674,6 +2674,25 @@ func TestRuntimeAccountLink(t *testing.T) {
 		)
 		require.NoError(t, err)
 
+		require.Len(t, events, 2)
+
+		require.Equal(t,
+			string(stdlib.AccountLinkedEventType.ID()),
+			events[0].EventType.ID(),
+		)
+		require.Equal(t,
+			[]cadence.Value{
+				cadence.NewAddress(common.MustBytesToAddress([]byte{0x1})),
+				cadence.NewPath("private", "foo"),
+			},
+			events[0].Fields,
+		)
+
+		require.Equal(t,
+			string(stdlib.AccountInboxPublishedEventType.ID()),
+			events[1].EventType.ID(),
+		)
+
 		// Claim
 
 		accessTransaction := []byte(`

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -127,6 +127,7 @@ func (e *interpreterEnvironment) newInterpreterConfig() *interpreter.Config {
 		MemoryGauge:                          e,
 		BaseActivation:                       e.baseActivation,
 		OnEventEmitted:                       e.newOnEventEmittedHandler(),
+		OnAccountLinked:                      e.newOnAccountLinkedHandler(),
 		InjectedCompositeFieldsHandler:       e.newInjectedCompositeFieldsHandler(),
 		UUIDHandler:                          e.newUUIDHandler(),
 		ContractValueHandler:                 e.newContractValueHandler(),
@@ -272,17 +273,11 @@ func (e *interpreterEnvironment) EmitEvent(
 	values []interpreter.Value,
 	locationRange interpreter.LocationRange,
 ) {
-	eventFields := make([]exportableValue, 0, len(values))
-
-	for _, value := range values {
-		eventFields = append(eventFields, newExportableValue(value, inter))
-	}
-
 	emitEventFields(
 		inter,
 		locationRange,
 		eventType,
-		eventFields,
+		newExportableValues(inter, values),
 		e.runtimeInterface.EmitEvent,
 	)
 }
@@ -764,6 +759,26 @@ func (e *interpreterEnvironment) newOnEventEmittedHandler() interpreter.OnEventE
 			e.runtimeInterface.EmitEvent,
 		)
 
+		return nil
+	}
+}
+
+func (e *interpreterEnvironment) newOnAccountLinkedHandler() interpreter.OnAccountLinkedFunc {
+	return func(
+		inter *interpreter.Interpreter,
+		locationRange interpreter.LocationRange,
+		addressValue interpreter.AddressValue,
+		pathValue interpreter.PathValue,
+	) error {
+		e.EmitEvent(
+			inter,
+			stdlib.AccountLinkedEventType,
+			[]interpreter.Value{
+				addressValue,
+				pathValue,
+			},
+			locationRange,
+		)
 		return nil
 	}
 }

--- a/runtime/interpreter/config.go
+++ b/runtime/interpreter/config.go
@@ -62,4 +62,6 @@ type Config struct {
 	AtreeStorageValidationEnabled bool
 	// AtreeValueValidationEnabled determines if the validation of atree values is enabled
 	AtreeValueValidationEnabled bool
+	// OnAccountLinked is triggered when an account is linked by the program
+	OnAccountLinked OnAccountLinkedFunc
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -112,6 +112,14 @@ type OnMeterComputationFunc func(
 	intensity uint,
 )
 
+// OnAccountLinkedFunc is a function that is triggered when an account is linked by the program.
+type OnAccountLinkedFunc func(
+	inter *Interpreter,
+	locationRange LocationRange,
+	address AddressValue,
+	path PathValue,
+) error
+
 // InjectedCompositeFieldsHandlerFunc is a function that handles storage reads.
 type InjectedCompositeFieldsHandlerFunc func(
 	inter *Interpreter,
@@ -3731,6 +3739,19 @@ func (interpreter *Interpreter) authAccountLinkAccountFunction(addressValue Addr
 				newCapabilityIdentifier,
 				accountLinkValue,
 			)
+
+			onAccountLinked := interpreter.SharedState.Config.OnAccountLinked
+			if onAccountLinked != nil {
+				err := onAccountLinked(
+					interpreter,
+					invocation.LocationRange,
+					addressValue,
+					newCapabilityPath,
+				)
+				if err != nil {
+					panic(err)
+				}
+			}
 
 			return NewSomeValueNonCopying(
 				interpreter,

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -56,6 +56,8 @@ const AuthAccountTypeInboxClaimFunctionName = "claim"
 
 var AuthAccountTypeLinkAccountFunctionType *FunctionType
 
+var AuthAccountTypeLinkAccountFunctionTypePathParameterType = PrivatePathType
+
 // AuthAccountType represents the authorized access to an account.
 // Access to an AuthAccount means having full access to its storage, public keys, and code.
 // Only signed transactions can get the AuthAccount for an account.
@@ -78,9 +80,11 @@ var AuthAccountType = func() *CompositeType {
 	AuthAccountTypeLinkAccountFunctionType = &FunctionType{
 		Parameters: []Parameter{
 			{
-				Label:          ArgumentLabelNotRequired,
-				Identifier:     "newCapabilityPath",
-				TypeAnnotation: NewTypeAnnotation(PrivatePathType),
+				Label:      ArgumentLabelNotRequired,
+				Identifier: "newCapabilityPath",
+				TypeAnnotation: NewTypeAnnotation(
+					AuthAccountTypeLinkAccountFunctionTypePathParameterType,
+				),
 			},
 		},
 		ReturnTypeAnnotation: NewTypeAnnotation(

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -272,13 +272,11 @@ var AccountInboxClaimedEventType = newFlowEventType(
 	AccountEventNameParameter,
 )
 
-var AccountEventPathParameter = sema.Parameter{
-	Identifier:     "path",
-	TypeAnnotation: sema.NewTypeAnnotation(sema.PrivatePathType),
-}
-
 var AccountLinkedEventType = newFlowEventType(
 	"AccountLinked",
 	AccountEventAddressParameter,
-	AccountEventPathParameter,
+	sema.Parameter{
+		Identifier:     "path",
+		TypeAnnotation: sema.NewTypeAnnotation(sema.PrivatePathType),
+	},
 )

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -276,7 +276,9 @@ var AccountLinkedEventType = newFlowEventType(
 	"AccountLinked",
 	AccountEventAddressParameter,
 	sema.Parameter{
-		Identifier:     "path",
-		TypeAnnotation: sema.NewTypeAnnotation(sema.PrivatePathType),
+		Identifier: "path",
+		TypeAnnotation: sema.NewTypeAnnotation(
+			sema.AuthAccountTypeLinkAccountFunctionTypePathParameterType,
+		),
 	},
 )

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -271,3 +271,14 @@ var AccountInboxClaimedEventType = newFlowEventType(
 	AccountEventRecipientParameter,
 	AccountEventNameParameter,
 )
+
+var AccountEventPathParameter = sema.Parameter{
+	Identifier:     "path",
+	TypeAnnotation: sema.NewTypeAnnotation(sema.PrivatePathType),
+}
+
+var AccountLinkedEventType = newFlowEventType(
+	"AccountLinked",
+	AccountEventAddressParameter,
+	AccountEventPathParameter,
+)

--- a/runtime/value.go
+++ b/runtime/value.go
@@ -40,6 +40,16 @@ func newExportableValue(v interpreter.Value, inter *interpreter.Interpreter) exp
 	}
 }
 
+func newExportableValues(inter *interpreter.Interpreter, values []interpreter.Value) []exportableValue {
+	exportableValues := make([]exportableValue, 0, len(values))
+
+	for _, value := range values {
+		exportableValues = append(exportableValues, newExportableValue(value, inter))
+	}
+
+	return exportableValues
+}
+
 func (v exportableValue) Interpreter() *interpreter.Interpreter {
 	return v.inter
 }

--- a/types.go
+++ b/types.go
@@ -1052,12 +1052,12 @@ func NewStructType(
 func NewMeteredStructType(
 	gauge common.MemoryGauge,
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *StructType {
 	common.UseMemory(gauge, common.CadenceStructTypeMemoryUsage)
-	return NewStructType(location, qualifiedIdentifer, fields, initializers)
+	return NewStructType(location, qualifiedIdentifier, fields, initializers)
 }
 
 func (*StructType) isType() {}
@@ -1113,13 +1113,13 @@ type ResourceType struct {
 
 func NewResourceType(
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ResourceType {
 	return &ResourceType{
 		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
+		QualifiedIdentifier: qualifiedIdentifier,
 		Fields:              fields,
 		Initializers:        initializers,
 	}
@@ -1128,12 +1128,12 @@ func NewResourceType(
 func NewMeteredResourceType(
 	gauge common.MemoryGauge,
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *ResourceType {
 	common.UseMemory(gauge, common.CadenceResourceTypeMemoryUsage)
-	return NewResourceType(location, qualifiedIdentifer, fields, initializers)
+	return NewResourceType(location, qualifiedIdentifier, fields, initializers)
 }
 
 func (*ResourceType) isType() {}
@@ -1189,13 +1189,13 @@ type EventType struct {
 
 func NewEventType(
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializer []Parameter,
 ) *EventType {
 	return &EventType{
 		Location:            location,
-		QualifiedIdentifier: qualifiedIdentifer,
+		QualifiedIdentifier: qualifiedIdentifier,
 		Fields:              fields,
 		Initializer:         initializer,
 	}
@@ -1204,12 +1204,12 @@ func NewEventType(
 func NewMeteredEventType(
 	gauge common.MemoryGauge,
 	location common.Location,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializer []Parameter,
 ) *EventType {
 	common.UseMemory(gauge, common.CadenceEventTypeMemoryUsage)
-	return NewEventType(location, qualifiedIdentifer, fields, initializer)
+	return NewEventType(location, qualifiedIdentifier, fields, initializer)
 }
 
 func (*EventType) isType() {}


### PR DESCRIPTION
Work towards #2192

## Description

When an account is linked, emit the new built-in event `flow.AccountLinked(address: Address, path: PrivatePath)`

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
