### PR TITLE
Code coverage support for pre/post conditions inside functions

### DIFF
--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -155,6 +155,10 @@ func (r *CoverageReport) InspectProgram(location Location, program *ast.Program)
 	}
 	r.Programs[location] = program
 	lineHits := make(map[int]int, 0)
+	recordLine := func(hasPosition ast.HasPosition) {
+		line := hasPosition.StartPosition().Line
+		lineHits[line] = 0
+	}
 	var depth int
 
 	inspector := ast.NewInspector(program)
@@ -174,8 +178,22 @@ func (r *CoverageReport) InspectProgram(location Location, program *ast.Program)
 				// However, also track local (i.e. non-top level) variable declarations.
 				if (isStatement && !isDeclaration) ||
 					(isVariableDeclaration && depth > 2) {
-					line := element.StartPosition().Line
-					lineHits[line] = 0
+					recordLine(element)
+				}
+
+				functionBlock, isFunctionBlock := element.(*ast.FunctionBlock)
+				// Track also pre/post conditions defined inside functions.
+				if isFunctionBlock {
+					if functionBlock.PreConditions != nil {
+						for _, condition := range *functionBlock.PreConditions {
+							recordLine(condition.Test)
+						}
+					}
+					if functionBlock.PostConditions != nil {
+						for _, condition := range *functionBlock.PostConditions {
+							recordLine(condition.Test)
+						}
+					}
 				}
 			} else {
 				depth--

--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -38,6 +38,10 @@ type LocationCoverage struct {
 
 // AddLineHit increments the hit count for the given line.
 func (c *LocationCoverage) AddLineHit(line int) {
+	// Lines below 1 are dropped.
+	if line < 1 {
+		return
+	}
 	c.LineHits[line]++
 }
 

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -334,6 +334,23 @@ func TestRuntimeCoverage(t *testing.T) {
 
 	    return "Enormous"
 	  }
+
+	  pub fun factorial(_ n: Int): Int {
+	    pre {
+	      n >= 0:
+	        "factorial is only defined for integers greater than or equal to zero"
+	    }
+	    post {
+	      result >= 1:
+	        "the result must be greater than or equal to 1"
+	    }
+
+	    if n < 1 {
+	      return 1
+	    }
+
+	    return n * factorial(n - 1)
+	  }
 	`)
 
 	script := []byte(`
@@ -359,6 +376,9 @@ func TestRuntimeCoverage(t *testing.T) {
 
 	    addSpecialNumber(78557, "Sierpinski")
 	    assert("Sierpinski" == getIntegerTrait(78557))
+
+	    factorial(5)
+	    factorial(0)
 
 	    return 42
 	  }
@@ -412,10 +432,15 @@ func TestRuntimeCoverage(t *testing.T) {
 	          "25": 5,
 	          "26": 4,
 	          "29": 1,
+	          "34": 7,
+	          "38": 7,
+	          "42": 7,
+	          "43": 2,
+	          "46": 5,
 	          "9": 1
 	        },
 	        "missed_lines": [],
-	        "statements": 14,
+	        "statements": 19,
 	        "percentage": "100.0%"
 	      },
 	      "s.0000000000000000000000000000000000000000000000000000000000000000": {
@@ -426,10 +451,12 @@ func TestRuntimeCoverage(t *testing.T) {
 	          "22": 1,
 	          "23": 1,
 	          "25": 1,
+	          "26": 1,
+	          "28": 1,
 	          "5": 1
 	        },
 	        "missed_lines": [],
-	        "statements": 7,
+	        "statements": 9,
 	        "percentage": "100.0%"
 	      }
 	    }

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -64,6 +64,8 @@ func TestLocationCoverageAddLineHit(t *testing.T) {
 	lineHits := map[int]int{3: 0, 4: 0, 5: 0, 7: 0, 9: 0, 11: 0}
 	locationCoverage := NewLocationCoverage(lineHits)
 
+	// Lines below 1 are dropped.
+	locationCoverage.AddLineHit(0)
 	locationCoverage.AddLineHit(3)
 	locationCoverage.AddLineHit(3)
 	locationCoverage.AddLineHit(7)


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2361

## Description

When inspecting a program, now we also count `pre/post` conditions inside functions. We do this by checking for:

```go
functionBlock, isFunctionBlock := element.(*ast.FunctionBlock)
```
and adding the corresponding lines of expressions contained in the conditions.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
