### PR TITLE
Improve contract address for code coverage report

### DIFF
--- a/runtime/common/addresslocation.go
+++ b/runtime/common/addresslocation.go
@@ -85,6 +85,10 @@ func (l AddressLocation) Description() string {
 	)
 }
 
+func (l AddressLocation) ID() string {
+	return fmt.Sprintf("%s.%s", AddressLocationPrefix, l)
+}
+
 func (l AddressLocation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Type    string

--- a/runtime/common/addresslocation_test.go
+++ b/runtime/common/addresslocation_test.go
@@ -65,6 +65,19 @@ func TestAddressLocationTypeID(t *testing.T) {
 	)
 }
 
+func TestAddressLocationID(t *testing.T) {
+
+	t.Parallel()
+
+	location, _, err := decodeAddressLocationTypeID(nil, "A.0000000000000001.Bar.Baz")
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"A.0000000000000001.Bar",
+		location.ID(),
+	)
+}
+
 func TestDecodeAddressLocationTypeID(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/common/identifierlocation.go
+++ b/runtime/common/identifierlocation.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/onflow/cadence/runtime/errors"
@@ -62,6 +63,10 @@ func (l IdentifierLocation) String() string {
 
 func (l IdentifierLocation) Description() string {
 	return string(l)
+}
+
+func (l IdentifierLocation) ID() string {
+	return fmt.Sprintf("%s.%s", IdentifierLocationPrefix, l)
 }
 
 func (l IdentifierLocation) MarshalJSON() ([]byte, error) {

--- a/runtime/common/identifierlocation_test.go
+++ b/runtime/common/identifierlocation_test.go
@@ -58,6 +58,19 @@ func TestIdentifierLocation_TypeID(t *testing.T) {
 	)
 }
 
+func TestIdentifierLocation_ID(t *testing.T) {
+
+	t.Parallel()
+
+	location, _, err := decodeIdentifierLocationTypeID(nil, "I.foo.Bar.Baz")
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"I.foo",
+		location.ID(),
+	)
+}
+
 func TestDecodeIdentifierLocationTypeID(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/common/location.go
+++ b/runtime/common/location.go
@@ -36,6 +36,9 @@ type Location interface {
 	QualifiedIdentifier(typeID TypeID) string
 	// Description returns a human-readable description. For example, it can be used in error messages
 	Description() string
+	// ID returns a string representation of the location, including the location prefix.
+	// This is helpful to differentiate a location, e.g in the context of code coverage.
+	ID() string
 }
 
 // LocationsInSameAccount returns true if both locations are nil,

--- a/runtime/common/repllocation.go
+++ b/runtime/common/repllocation.go
@@ -71,6 +71,10 @@ func (l REPLLocation) Description() string {
 	return REPLLocationPrefix
 }
 
+func (l REPLLocation) ID() string {
+	return REPLLocationPrefix
+}
+
 func (l REPLLocation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Type string

--- a/runtime/common/repllocation_test.go
+++ b/runtime/common/repllocation_test.go
@@ -57,6 +57,19 @@ func TestREPLLocation_TypeID(t *testing.T) {
 	)
 }
 
+func TestREPLLocation_ID(t *testing.T) {
+
+	t.Parallel()
+
+	location, _, err := decodeREPLLocationTypeID("REPL.Bar.Baz")
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"REPL",
+		location.ID(),
+	)
+}
+
 func TestDecodeREPLLocationTypeID(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/common/scriptlocation.go
+++ b/runtime/common/scriptlocation.go
@@ -70,6 +70,10 @@ func (l ScriptLocation) Description() string {
 	return fmt.Sprintf("script with ID %s", hex.EncodeToString(l[:]))
 }
 
+func (l ScriptLocation) ID() string {
+	return fmt.Sprintf("%s.%s", ScriptLocationPrefix, l)
+}
+
 func (l ScriptLocation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Type   string

--- a/runtime/common/scriptlocation_test.go
+++ b/runtime/common/scriptlocation_test.go
@@ -58,6 +58,22 @@ func TestScriptLocationTypeID(t *testing.T) {
 	)
 }
 
+func TestScriptLocationID(t *testing.T) {
+
+	t.Parallel()
+
+	location, _, err := decodeScriptLocationTypeID(
+		nil,
+		"s.0102000000000000000000000000000000000000000000000000000000000000.Bar.Baz",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"s.0102000000000000000000000000000000000000000000000000000000000000",
+		location.ID(),
+	)
+}
+
 func TestDecodeScriptLocationTypeID(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/common/stringlocation.go
+++ b/runtime/common/stringlocation.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/onflow/cadence/runtime/errors"
@@ -62,6 +63,10 @@ func (l StringLocation) String() string {
 
 func (l StringLocation) Description() string {
 	return string(l)
+}
+
+func (l StringLocation) ID() string {
+	return fmt.Sprintf("%s.%s", StringLocationPrefix, l)
 }
 
 func (l StringLocation) MarshalJSON() ([]byte, error) {

--- a/runtime/common/stringlocation_test.go
+++ b/runtime/common/stringlocation_test.go
@@ -58,6 +58,19 @@ func TestStringLocation_TypeID(t *testing.T) {
 	)
 }
 
+func TestStringLocation_ID(t *testing.T) {
+
+	t.Parallel()
+
+	location, _, err := decodeStringLocationTypeID(nil, "S.foo.Bar.Baz")
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"S.foo",
+		location.ID(),
+	)
+}
+
 func TestDecodeStringLocationTypeID(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/common/transactionlocation.go
+++ b/runtime/common/transactionlocation.go
@@ -70,6 +70,10 @@ func (l TransactionLocation) Description() string {
 	return fmt.Sprintf("transaction with ID %s", hex.EncodeToString(l[:]))
 }
 
+func (l TransactionLocation) ID() string {
+	return fmt.Sprintf("%s.%s", TransactionLocationPrefix, l)
+}
+
 func (l TransactionLocation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Type        string

--- a/runtime/common/transactionlocation_test.go
+++ b/runtime/common/transactionlocation_test.go
@@ -58,6 +58,22 @@ func TestTransactionLocation_TypeID(t *testing.T) {
 	)
 }
 
+func TestTransactionLocation_ID(t *testing.T) {
+
+	t.Parallel()
+
+	location, _, err := decodeTransactionLocationTypeID(
+		nil,
+		"t.0102000000000000000000000000000000000000000000000000000000000000.Bar.Baz",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"t.0102000000000000000000000000000000000000000000000000000000000000",
+		location.ID(),
+	)
+}
+
 func TestDecodeTransactionLocationTypeID(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -256,9 +256,7 @@ func (r *CoverageReport) MarshalJSON() ([]byte, error) {
 
 	coverage := make(map[string]LC, len(r.Coverage))
 	for location, locationCoverage := range r.Coverage { // nolint:maprange
-		typeID := location.TypeID(nil, "")
-		locationID := typeID[:len(typeID)-1]
-		coverage[string(locationID)] = LC{
+		coverage[location.ID()] = LC{
 			LineHits:    locationCoverage.LineHits,
 			MissedLines: locationCoverage.MissedLines(),
 			Statements:  locationCoverage.Statements,

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/parser"
+	"github.com/onflow/cadence/runtime/stdlib"
 )
 
 func TestNewLocationCoverage(t *testing.T) {
@@ -261,6 +262,324 @@ func TestCoverageReportAddLineHit(t *testing.T) {
 	assert.Equal(t, 4, locationCoverage.Statements)
 	assert.Equal(t, "50.0%", locationCoverage.Percentage())
 	assert.Equal(t, 2, locationCoverage.CoveredLines())
+}
+
+func TestCoverageReportWithFlowLocation(t *testing.T) {
+
+	t.Parallel()
+
+	script := []byte(`
+	  pub fun answer(): Int {
+	    var i = 0
+	    while i < 42 {
+	      i = i + 1
+	    }
+	    return i
+	  }
+	`)
+
+	program, err := parser.ParseProgram(nil, script, parser.Config{})
+	require.NoError(t, err)
+
+	coverageReport := NewCoverageReport()
+
+	location := stdlib.FlowLocation{}
+	coverageReport.InspectProgram(location, program)
+
+	actual, err := json.Marshal(coverageReport)
+	require.NoError(t, err)
+
+	expected := `
+	  {
+	    "coverage": {
+	      "flow": {
+	        "line_hits": {
+	          "3": 0,
+	          "4": 0,
+	          "5": 0,
+	          "7": 0
+	        },
+	        "missed_lines": [3, 4, 5, 7],
+	        "statements": 4,
+	        "percentage": "0.0%"
+	      }
+	    }
+	  }
+	`
+	require.JSONEq(t, expected, string(actual))
+}
+
+func TestCoverageReportWithREPLLocation(t *testing.T) {
+
+	t.Parallel()
+
+	script := []byte(`
+	  pub fun answer(): Int {
+	    var i = 0
+	    while i < 42 {
+	      i = i + 1
+	    }
+	    return i
+	  }
+	`)
+
+	program, err := parser.ParseProgram(nil, script, parser.Config{})
+	require.NoError(t, err)
+
+	coverageReport := NewCoverageReport()
+
+	location := common.REPLLocation{}
+	coverageReport.InspectProgram(location, program)
+
+	actual, err := json.Marshal(coverageReport)
+	require.NoError(t, err)
+
+	expected := `
+	  {
+	    "coverage": {
+	      "REPL": {
+	        "line_hits": {
+	          "3": 0,
+	          "4": 0,
+	          "5": 0,
+	          "7": 0
+	        },
+	        "missed_lines": [3, 4, 5, 7],
+	        "statements": 4,
+	        "percentage": "0.0%"
+	      }
+	    }
+	  }
+	`
+	require.JSONEq(t, expected, string(actual))
+}
+
+func TestCoverageReportWithScriptLocation(t *testing.T) {
+
+	t.Parallel()
+
+	script := []byte(`
+	  pub fun answer(): Int {
+	    var i = 0
+	    while i < 42 {
+	      i = i + 1
+	    }
+	    return i
+	  }
+	`)
+
+	program, err := parser.ParseProgram(nil, script, parser.Config{})
+	require.NoError(t, err)
+
+	coverageReport := NewCoverageReport()
+
+	location := common.ScriptLocation{0x1, 0x2}
+	coverageReport.InspectProgram(location, program)
+
+	actual, err := json.Marshal(coverageReport)
+	require.NoError(t, err)
+
+	expected := `
+	  {
+	    "coverage": {
+	      "s.0102000000000000000000000000000000000000000000000000000000000000": {
+	        "line_hits": {
+	          "3": 0,
+	          "4": 0,
+	          "5": 0,
+	          "7": 0
+	        },
+	        "missed_lines": [3, 4, 5, 7],
+	        "statements": 4,
+	        "percentage": "0.0%"
+	      }
+	    }
+	  }
+	`
+	require.JSONEq(t, expected, string(actual))
+}
+
+func TestCoverageReportWithStringLocation(t *testing.T) {
+
+	t.Parallel()
+
+	script := []byte(`
+	  pub fun answer(): Int {
+	    var i = 0
+	    while i < 42 {
+	      i = i + 1
+	    }
+	    return i
+	  }
+	`)
+
+	program, err := parser.ParseProgram(nil, script, parser.Config{})
+	require.NoError(t, err)
+
+	coverageReport := NewCoverageReport()
+
+	location := common.StringLocation("AnswerScript")
+	coverageReport.InspectProgram(location, program)
+
+	actual, err := json.Marshal(coverageReport)
+	require.NoError(t, err)
+
+	expected := `
+	  {
+	    "coverage": {
+	      "S.AnswerScript": {
+	        "line_hits": {
+	          "3": 0,
+	          "4": 0,
+	          "5": 0,
+	          "7": 0
+	        },
+	        "missed_lines": [3, 4, 5, 7],
+	        "statements": 4,
+	        "percentage": "0.0%"
+	      }
+	    }
+	  }
+	`
+	require.JSONEq(t, expected, string(actual))
+}
+
+func TestCoverageReportWithIdentifierLocation(t *testing.T) {
+
+	t.Parallel()
+
+	script := []byte(`
+	  pub fun answer(): Int {
+	    var i = 0
+	    while i < 42 {
+	      i = i + 1
+	    }
+	    return i
+	  }
+	`)
+
+	program, err := parser.ParseProgram(nil, script, parser.Config{})
+	require.NoError(t, err)
+
+	coverageReport := NewCoverageReport()
+
+	location := common.IdentifierLocation("Answer")
+	coverageReport.InspectProgram(location, program)
+
+	actual, err := json.Marshal(coverageReport)
+	require.NoError(t, err)
+
+	expected := `
+	  {
+	    "coverage": {
+	      "I.Answer": {
+	        "line_hits": {
+	          "3": 0,
+	          "4": 0,
+	          "5": 0,
+	          "7": 0
+	        },
+	        "missed_lines": [3, 4, 5, 7],
+	        "statements": 4,
+	        "percentage": "0.0%"
+	      }
+	    }
+	  }
+	`
+	require.JSONEq(t, expected, string(actual))
+}
+
+func TestCoverageReportWithTransactionLocation(t *testing.T) {
+
+	t.Parallel()
+
+	script := []byte(`
+	  pub fun answer(): Int {
+	    var i = 0
+	    while i < 42 {
+	      i = i + 1
+	    }
+	    return i
+	  }
+	`)
+
+	program, err := parser.ParseProgram(nil, script, parser.Config{})
+	require.NoError(t, err)
+
+	coverageReport := NewCoverageReport()
+
+	location := common.TransactionLocation{0x1, 0x2}
+	coverageReport.InspectProgram(location, program)
+
+	actual, err := json.Marshal(coverageReport)
+	require.NoError(t, err)
+
+	expected := `
+	  {
+	    "coverage": {
+	      "t.0102000000000000000000000000000000000000000000000000000000000000": {
+	        "line_hits": {
+	          "3": 0,
+	          "4": 0,
+	          "5": 0,
+	          "7": 0
+	        },
+	        "missed_lines": [3, 4, 5, 7],
+	        "statements": 4,
+	        "percentage": "0.0%"
+	      }
+	    }
+	  }
+	`
+	require.JSONEq(t, expected, string(actual))
+}
+
+func TestCoverageReportWithAddressLocation(t *testing.T) {
+
+	t.Parallel()
+
+	script := []byte(`
+	  pub fun answer(): Int {
+	    var i = 0
+	    while i < 42 {
+	      i = i + 1
+	    }
+	    return i
+	  }
+	`)
+
+	program, err := parser.ParseProgram(nil, script, parser.Config{})
+	require.NoError(t, err)
+
+	coverageReport := NewCoverageReport()
+
+	location := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{1, 2}),
+		Name:    "Answer",
+	}
+	coverageReport.InspectProgram(location, program)
+
+	actual, err := json.Marshal(coverageReport)
+	require.NoError(t, err)
+
+	expected := `
+	  {
+	    "coverage": {
+	      "A.0000000000000102.Answer": {
+	        "line_hits": {
+	          "3": 0,
+	          "4": 0,
+	          "5": 0,
+	          "7": 0
+	        },
+	        "missed_lines": [3, 4, 5, 7],
+	        "statements": 4,
+	        "percentage": "0.0%"
+	      }
+	    }
+	  }
+	`
+	require.JSONEq(t, expected, string(actual))
 }
 
 func TestCoverageReportAddLineHitForExcludedLocation(t *testing.T) {

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -74,6 +74,10 @@ func (l FlowLocation) Description() string {
 	return FlowLocationPrefix
 }
 
+func (l FlowLocation) ID() string {
+	return FlowLocationPrefix
+}
+
 func (l FlowLocation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Type string

--- a/runtime/stdlib/flow_test.go
+++ b/runtime/stdlib/flow_test.go
@@ -78,6 +78,19 @@ func TestFlowLocationTypeID(t *testing.T) {
 	)
 }
 
+func TestFlowLocationID(t *testing.T) {
+
+	t.Parallel()
+
+	location, _, err := decodeFlowLocationTypeID("flow.Bar.Baz")
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"flow",
+		location.ID(),
+	)
+}
+
 func TestDecodeFlowLocationTypeID(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2360

## Description

The location key format looks now like this: `A.f8d6e0586b0a20c7.FlowEpoch` . This will allow us to differentiate between contracts that are deployed in the same Flow address. This is useful when using the code coverage feature outside a testing context, such as flow emulator. For example:

![Screenshot from 2023-03-06 10-12-46](https://user-images.githubusercontent.com/1778965/223056010-407ffb6e-3af2-4f55-92bb-6c34d8c78f63.png)
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
