### PR TITLE
Add position information to rewritten post condition before statement

### DIFF
--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1996,17 +1996,20 @@ func (checker *Checker) rewritePostConditions(postConditions []*ast.Condition) P
 			}
 
 			for _, extractedExpression := range extractedExpressions {
+				expression := extractedExpression.Expression
+				startPos := expression.StartPosition()
 
 				// NOTE: no need to check the before statements or update elaboration here:
 				// The before statements are visited/checked later
 				variableDeclaration := ast.NewEmptyVariableDeclaration(checker.memoryGauge)
+				variableDeclaration.StartPos = startPos
 				variableDeclaration.Identifier = extractedExpression.Identifier
 				variableDeclaration.Transfer = ast.NewTransfer(
 					checker.memoryGauge,
 					ast.TransferOperationCopy,
-					ast.EmptyPosition,
+					startPos,
 				)
-				variableDeclaration.Value = extractedExpression.Expression
+				variableDeclaration.Value = expression
 
 				beforeStatements = append(beforeStatements,
 					variableDeclaration,


### PR DESCRIPTION
Fixes #2361

## Description

Post conditions with `before` expressions are rewritten into statements.

Add correct position information to these statements, as both code coverage and debugger rely on it.

cc @m-Peter @bluesign 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
