### PR TITLE
Use AddressLocation in Interface

### DIFF
--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -1648,7 +1648,7 @@ func TestAuthAccountContracts(t *testing.T) {
 			getSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			getAccountContractCode: func(address Address, name string) ([]byte, error) {
+			getAccountContractCode: func(_ common.AddressLocation) ([]byte, error) {
 				invoked = true
 				return []byte{1, 2}, nil
 			},
@@ -1690,7 +1690,7 @@ func TestAuthAccountContracts(t *testing.T) {
 			getSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			getAccountContractCode: func(address Address, name string) ([]byte, error) {
+			getAccountContractCode: func(_ common.AddressLocation) ([]byte, error) {
 				invoked = true
 				return nil, nil
 			},
@@ -1729,18 +1729,10 @@ func TestAuthAccountContracts(t *testing.T) {
 				return []Address{{0, 0, 0, 0, 0, 0, 0, 0x42}}, nil
 			},
 			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(address Address, name string, code []byte) error {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
@@ -1830,18 +1822,10 @@ func TestAuthAccountContracts(t *testing.T) {
 				return []Address{{0, 0, 0, 0, 0, 0, 0, 0x42}}, nil
 			},
 			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(address Address, name string, code []byte) error {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
@@ -1922,7 +1906,7 @@ func TestAuthAccountContracts(t *testing.T) {
 			getSigningAccounts: func() ([]Address, error) {
 				return []Address{{0, 0, 0, 0, 0, 0, 0, 0x42}}, nil
 			},
-			getAccountContractCode: func(address Address, name string) ([]byte, error) {
+			getAccountContractCode: func(_ common.AddressLocation) ([]byte, error) {
 				return nil, nil
 			},
 		}
@@ -2094,7 +2078,7 @@ func TestPublicAccountContracts(t *testing.T) {
 			getSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			getAccountContractCode: func(address Address, name string) ([]byte, error) {
+			getAccountContractCode: func(_ common.AddressLocation) ([]byte, error) {
 				invoked = true
 				return []byte{1, 2}, nil
 			},
@@ -2150,7 +2134,7 @@ func TestPublicAccountContracts(t *testing.T) {
 			getSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			getAccountContractCode: func(address Address, name string) ([]byte, error) {
+			getAccountContractCode: func(_ common.AddressLocation) ([]byte, error) {
 				invoked = true
 				return nil, nil
 			},
@@ -2478,18 +2462,10 @@ func TestRuntimeAccountLink(t *testing.T) {
 				return []Address{signerAccount}, nil
 			},
 			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
 				accountCodes[location] = code
 				return nil
 			},
@@ -2549,18 +2525,11 @@ func TestRuntimeAccountLink(t *testing.T) {
 				return []Address{signerAccount}, nil
 			},
 			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
 				accountCodes[location] = code
 				return nil
 			},
@@ -2622,18 +2591,10 @@ func TestRuntimeAccountLink(t *testing.T) {
 				return []Address{signerAccount}, nil
 			},
 			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
 				accountCodes[location] = code
 				return nil
 			},

--- a/runtime/attachments_test.go
+++ b/runtime/attachments_test.go
@@ -97,19 +97,11 @@ func TestAccountAttachmentSaveAndLoad(t *testing.T) {
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
@@ -196,19 +188,11 @@ func TestAccountAttachmentExport(t *testing.T) {
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
@@ -284,19 +268,11 @@ func TestAccountAttachedExport(t *testing.T) {
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
@@ -399,19 +375,11 @@ func TestAccountAttachmentSaveAndBorrow(t *testing.T) {
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
@@ -523,19 +491,11 @@ func TestAccountAttachmentCapability(t *testing.T) {
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
@@ -554,19 +514,11 @@ func TestAccountAttachmentCapability(t *testing.T) {
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 2}}, nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -177,24 +177,24 @@ func TestRuntimeContract(t *testing.T) {
 			log: func(message string) {
 				loggedMessages = append(loggedMessages, message)
 			},
-			updateAccountContractCode: func(address Address, name string, code []byte) error {
-				require.Equal(t, tc.name, name)
-				assert.Equal(t, signerAddress, address)
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+				require.Equal(t, tc.name, location.Name)
+				assert.Equal(t, signerAddress, location.Address)
 
 				deployedCode = code
 
 				return nil
 			},
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				if name == tc.name {
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+				if location.Name == tc.name {
 					return deployedCode, nil
 				}
 
 				return nil, nil
 			},
-			removeAccountContractCode: func(address Address, name string) error {
-				require.Equal(t, tc.name, name)
-				assert.Equal(t, signerAddress, address)
+			removeAccountContractCode: func(location common.AddressLocation) error {
+				require.Equal(t, tc.name, location.Name)
+				assert.Equal(t, signerAddress, location.Address)
 
 				deployedCode = nil
 
@@ -662,27 +662,15 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
-		removeAccountContractCode: func(address Address, name string) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		removeAccountContractCode: func(location common.AddressLocation) error {
 			delete(accountCodes, location)
 			return nil
 		},

--- a/runtime/contract_update_test.go
+++ b/runtime/contract_update_test.go
@@ -60,18 +60,10 @@ func TestContractUpdateWithDependencies(t *testing.T) {
 			return []Address{signerAccount}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -93,26 +93,14 @@ func newContractDeploymentTransactor(t *testing.T) func(code string) error {
 			return []Address{common.MustBytesToAddress([]byte{0x42})}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		removeAccountContractCode: func(address Address, name string) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		removeAccountContractCode: func(location common.AddressLocation) error {
 			delete(accountCodes, location)
 			return nil
 		},
@@ -2163,26 +2151,14 @@ func TestRuntimeContractUpdateConformanceChanges(t *testing.T) {
 				return []Address{address}, nil
 			},
 			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(address Address, name string, code []byte) error {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
-			removeAccountContractCode: func(address Address, name string) error {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			removeAccountContractCode: func(location common.AddressLocation) error {
 				delete(accountCodes, location)
 				return nil
 			},
@@ -2280,26 +2256,14 @@ func TestRuntimeContractUpdateProgramCaching(t *testing.T) {
 				return []Address{address}, nil
 			},
 			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(address Address, name string, code []byte) error {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
-			removeAccountContractCode: func(address Address, name string) error {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			removeAccountContractCode: func(location common.AddressLocation) error {
 				delete(accountCodes, location)
 				return nil
 			},

--- a/runtime/deployedcontract_test.go
+++ b/runtime/deployedcontract_test.go
@@ -73,10 +73,7 @@ func TestDeployedContracts(t *testing.T) {
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
-		getAccountContractCode: func(address Address, name string) ([]byte, error) {
-			location := common.AddressLocation{
-				Address: address, Name: name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
 			return accountCodes[location], nil
 		},
 		getAccountContractNames: func(_ Address) ([]string, error) {
@@ -89,10 +86,7 @@ func TestDeployedContracts(t *testing.T) {
 		emitEvent: func(_ cadence.Event) error {
 			return nil
 		},
-		updateAccountContractCode: func(address common.Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address, Name: name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -161,10 +161,10 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 			getSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
+			getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 				return accountCode, nil
 			},
-			updateAccountContractCode: func(_ Address, _ string, code []byte) error {
+			updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 				accountCode = code
 				return nil
 			},

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -260,8 +260,8 @@ func (e *interpreterEnvironment) GetAccountContractNames(address common.Address)
 	return e.runtimeInterface.GetAccountContractNames(address)
 }
 
-func (e *interpreterEnvironment) GetAccountContractCode(address common.Address, name string) ([]byte, error) {
-	return e.runtimeInterface.GetAccountContractCode(address, name)
+func (e *interpreterEnvironment) GetAccountContractCode(location common.AddressLocation) ([]byte, error) {
+	return e.runtimeInterface.GetAccountContractCode(location)
 }
 
 func (e *interpreterEnvironment) CreateAccount(payer common.Address) (address common.Address, err error) {
@@ -304,24 +304,23 @@ func (e *interpreterEnvironment) RevokeAccountKey(address common.Address, index 
 	return e.runtimeInterface.RevokeAccountKey(address, index)
 }
 
-func (e *interpreterEnvironment) UpdateAccountContractCode(address common.Address, name string, code []byte) error {
-	return e.runtimeInterface.UpdateAccountContractCode(address, name, code)
+func (e *interpreterEnvironment) UpdateAccountContractCode(location common.AddressLocation, code []byte) error {
+	return e.runtimeInterface.UpdateAccountContractCode(location, code)
 }
 
-func (e *interpreterEnvironment) RemoveAccountContractCode(address common.Address, name string) error {
-	return e.runtimeInterface.RemoveAccountContractCode(address, name)
+func (e *interpreterEnvironment) RemoveAccountContractCode(location common.AddressLocation) error {
+	return e.runtimeInterface.RemoveAccountContractCode(location)
 }
 
-func (e *interpreterEnvironment) RecordContractRemoval(address common.Address, name string) {
-	e.storage.recordContractUpdate(address, name, nil)
+func (e *interpreterEnvironment) RecordContractRemoval(location common.AddressLocation) {
+	e.storage.recordContractUpdate(location, nil)
 }
 
 func (e *interpreterEnvironment) RecordContractUpdate(
-	address common.Address,
-	name string,
+	location common.AddressLocation,
 	contractValue *interpreter.CompositeValue,
 ) {
-	e.storage.recordContractUpdate(address, name, contractValue)
+	e.storage.recordContractUpdate(location, contractValue)
 }
 
 func (e *interpreterEnvironment) TemporarilyRecordCode(location common.AddressLocation, code []byte) {
@@ -563,10 +562,7 @@ func (e *interpreterEnvironment) getProgram(
 func (e *interpreterEnvironment) getCode(location common.Location) (code []byte, err error) {
 	if addressLocation, ok := location.(common.AddressLocation); ok {
 		errors.WrapPanic(func() {
-			code, err = e.runtimeInterface.GetAccountContractCode(
-				addressLocation.Address,
-				addressLocation.Name,
-			)
+			code, err = e.runtimeInterface.GetAccountContractCode(addressLocation)
 		})
 	} else {
 		errors.WrapPanic(func() {

--- a/runtime/error_test.go
+++ b/runtime/error_test.go
@@ -388,11 +388,7 @@ func TestRuntimeError(t *testing.T) {
 				}
 				return
 			},
-			getAccountContractCode: func(address Address, name string) ([]byte, error) {
-				location := common.AddressLocation{
-					Name:    name,
-					Address: address,
-				}
+			getAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
 				code := codes[location]
 				return []byte(code), nil
 			},

--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -524,18 +524,10 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			return []Address{signerAccount}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(b),
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -83,11 +83,11 @@ type Interface interface {
 	// RevokeAccountKey removes a key from an account by index.
 	RevokeAccountKey(address Address, index int) (*AccountKey, error)
 	// UpdateAccountContractCode updates the code associated with an account contract.
-	UpdateAccountContractCode(address Address, name string, code []byte) (err error)
+	UpdateAccountContractCode(location common.AddressLocation, code []byte) (err error)
 	// GetAccountContractCode returns the code associated with an account contract.
-	GetAccountContractCode(address Address, name string) (code []byte, err error)
+	GetAccountContractCode(location common.AddressLocation) (code []byte, err error)
 	// RemoveAccountContractCode removes the code associated with an account contract.
-	RemoveAccountContractCode(address Address, name string) (err error)
+	RemoveAccountContractCode(location common.AddressLocation) (err error)
 	// GetSigningAccounts returns the signing accounts.
 	GetSigningAccounts() ([]Address, error)
 	// ProgramLog logs program logs.

--- a/runtime/missingmember_test.go
+++ b/runtime/missingmember_test.go
@@ -2048,18 +2048,10 @@ pub contract ItemNFT: NonFungibleToken {
 			return []Address{signerAddress}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
@@ -3868,18 +3860,10 @@ pub contract AuctionDutch {
 			return []Address{signerAddress}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
@@ -4704,18 +4688,10 @@ pub contract ExampleMarketplace {
 			return []Address{signerAddress}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -75,10 +75,10 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 			return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
+		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ Address, _ string, code []byte) error {
+		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},

--- a/runtime/program_params_validation_test.go
+++ b/runtime/program_params_validation_test.go
@@ -605,11 +605,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 		runtimeInterface := &testRuntimeInterface{
 			storage:         storage,
 			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return contracts[location], nil
 			},
 			meterMemory: func(_ common.MemoryUsage) error {

--- a/runtime/resource_duplicate_test.go
+++ b/runtime/resource_duplicate_test.go
@@ -55,18 +55,10 @@ func TestRuntimeResourceDuplicationWithContractTransfer(t *testing.T) {
 			return []Address{signerAccount}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},

--- a/runtime/resourcedictionary_test.go
+++ b/runtime/resourcedictionary_test.go
@@ -114,14 +114,14 @@ func TestRuntimeResourceDictionaryValues(t *testing.T) {
 
 	runtimeInterface := &testRuntimeInterface{
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ Address, _ string) (bytes []byte, err error) {
+		getAccountContractCode: func(_ common.AddressLocation) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: newTestLedger(nil, nil),
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{Address(addressValue)}, nil
 		},
-		updateAccountContractCode: func(_ Address, _ string, code []byte) error {
+		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
@@ -467,7 +467,7 @@ func TestRuntimeResourceDictionaryValues_Nested(t *testing.T) {
 
 	runtimeInterface := &testRuntimeInterface{
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
+		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
 		getCode: func(_ Location) (bytes []byte, err error) {
@@ -477,7 +477,7 @@ func TestRuntimeResourceDictionaryValues_Nested(t *testing.T) {
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{Address(addressValue)}, nil
 		},
-		updateAccountContractCode: func(_ Address, _ string, code []byte) error {
+		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
@@ -661,10 +661,10 @@ func TestRuntimeResourceDictionaryValues_DictionaryTransfer(t *testing.T) {
 			}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
+		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ Address, _ string, code []byte) (err error) {
+		updateAccountContractCode: func(_ common.AddressLocation, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
@@ -798,10 +798,10 @@ func TestRuntimeResourceDictionaryValues_Removal(t *testing.T) {
 			return []Address{signer}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
+		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ Address, _ string, code []byte) (err error) {
+		updateAccountContractCode: func(_ common.AddressLocation, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
@@ -912,10 +912,10 @@ func TestRuntimeSResourceDictionaryValues_Destruction(t *testing.T) {
 			return []Address{signer}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
+		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ Address, _ string, code []byte) error {
+		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
@@ -1053,10 +1053,10 @@ func TestRuntimeResourceDictionaryValues_Insertion(t *testing.T) {
 			return []Address{signer}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
+		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ Address, _ string, code []byte) error {
+		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
@@ -1206,10 +1206,10 @@ func TestRuntimeResourceDictionaryValues_ValueTransferAndDestroy(t *testing.T) {
 			return signers, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
+		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ Address, _ string, code []byte) error {
+		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
@@ -1340,14 +1340,14 @@ func BenchmarkRuntimeResourceDictionaryValues(b *testing.B) {
 
 	runtimeInterface := &testRuntimeInterface{
 		resolveLocation: singleIdentifierLocationResolver(b),
-		getAccountContractCode: func(_ Address, _ string) (bytes []byte, err error) {
+		getAccountContractCode: func(_ common.AddressLocation) (bytes []byte, err error) {
 			return accountCode, nil
 		},
 		storage: storage,
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{Address(addressValue)}, nil
 		},
-		updateAccountContractCode: func(_ Address, _ string, code []byte) error {
+		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},

--- a/runtime/runtime_memory_metering_test.go
+++ b/runtime/runtime_memory_metering_test.go
@@ -77,7 +77,7 @@ func TestInterpreterAddressLocationMetering(t *testing.T) {
 			meterMemory: func(usage common.MemoryUsage) error {
 				return meter.MeterMemory(usage)
 			},
-			getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
+			getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 				return accountCode, nil
 			},
 		}
@@ -145,19 +145,11 @@ func TestInterpreterElaborationImportMetering(t *testing.T) {
 					return []Address{Address(addressValue)}, nil
 				},
 				resolveLocation: singleIdentifierLocationResolver(t),
-				updateAccountContractCode: func(address Address, name string, code []byte) error {
-					location := common.AddressLocation{
-						Address: address,
-						Name:    name,
-					}
+				updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 					accountCodes[location] = code
 					return nil
 				},
-				getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-					location := common.AddressLocation{
-						Address: address,
-						Name:    name,
-					}
+				getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 					code = accountCodes[location]
 					return code, nil
 				},
@@ -795,7 +787,7 @@ func TestLogFunctionStringConversionMetering(t *testing.T) {
 			meterMemory: func(usage common.MemoryUsage) error {
 				return meter.MeterMemory(usage)
 			},
-			getAccountContractCode: func(_ Address, _ string) (code []byte, err error) {
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCode, nil
 			},
 			log: func(s string) {

--- a/runtime/sharedstate_test.go
+++ b/runtime/sharedstate_test.go
@@ -83,27 +83,15 @@ func TestRuntimeSharedState(t *testing.T) {
 		getSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAddress}, nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
-		removeAccountContractCode: func(address Address, name string) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		removeAccountContractCode: func(location common.AddressLocation) error {
 			delete(accountCodes, location)
 			return nil
 		},

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -1231,7 +1231,7 @@ func newAccountContractsGetNamesFunction(
 
 type AccountContractProvider interface {
 	// GetAccountContractCode returns the code associated with an account contract.
-	GetAccountContractCode(address common.Address, name string) ([]byte, error)
+	GetAccountContractCode(location common.AddressLocation) ([]byte, error)
 }
 
 func newAccountContractsGetFunction(
@@ -1252,11 +1252,12 @@ func newAccountContractsGetFunction(
 				panic(errors.NewUnreachableError())
 			}
 			name := nameValue.Str
+			location := common.NewAddressLocation(invocation.Interpreter, address, name)
 
 			var code []byte
 			var err error
 			errors.WrapPanic(func() {
-				code, err = provider.GetAccountContractCode(address, name)
+				code, err = provider.GetAccountContractCode(location)
 			})
 			if err != nil {
 				panic(err)
@@ -1303,6 +1304,7 @@ func newAccountContractsBorrowFunction(
 				panic(errors.NewUnreachableError())
 			}
 			name := nameValue.Str
+			location := common.NewAddressLocation(invocation.Interpreter, address, name)
 
 			typeParameterPair := invocation.TypeParameterTypes.Oldest()
 			if typeParameterPair == nil {
@@ -1320,7 +1322,7 @@ func newAccountContractsBorrowFunction(
 			var code []byte
 			var err error
 			errors.WrapPanic(func() {
-				code, err = handler.GetAccountContractCode(address, name)
+				code, err = handler.GetAccountContractCode(location)
 			})
 			if err != nil {
 				panic(err)
@@ -1370,8 +1372,8 @@ type AccountContractAdditionHandler interface {
 		getAndSetProgram bool,
 	) (*interpreter.Program, error)
 	// UpdateAccountContractCode updates the code associated with an account contract.
-	UpdateAccountContractCode(address common.Address, name string, code []byte) error
-	RecordContractUpdate(address common.Address, name string, value *interpreter.CompositeValue)
+	UpdateAccountContractCode(location common.AddressLocation, code []byte) error
+	RecordContractUpdate(location common.AddressLocation, value *interpreter.CompositeValue)
 	InterpretContract(
 		location common.AddressLocation,
 		program *interpreter.Program,
@@ -1432,7 +1434,9 @@ func newAuthAccountContractsChangeFunction(
 			}
 
 			address := addressValue.ToAddress()
-			existingCode, err := handler.GetAccountContractCode(address, contractName)
+			location := common.NewAddressLocation(invocation.Interpreter, address, contractName)
+
+			existingCode, err := handler.GetAccountContractCode(location)
 			if err != nil {
 				panic(err)
 			}
@@ -1463,9 +1467,6 @@ func newAuthAccountContractsChangeFunction(
 			}
 
 			// Check the code
-
-			location := common.NewAddressLocation(invocation.Interpreter, address, contractName)
-
 			handleContractUpdateError := func(err error) {
 				if err == nil {
 					return
@@ -1567,7 +1568,7 @@ func newAuthAccountContractsChangeFunction(
 			// Validate the contract update
 
 			if isUpdate {
-				oldCode, err := handler.GetAccountContractCode(address, contractName)
+				oldCode, err := handler.GetAccountContractCode(location)
 				handleContractUpdateError(err)
 
 				oldProgram, err := parser.ParseProgram(
@@ -1596,9 +1597,7 @@ func newAuthAccountContractsChangeFunction(
 				handler,
 				location,
 				program,
-				declaredName,
 				code,
-				addressValue,
 				contractType,
 				constructorArguments,
 				constructorArgumentTypes,
@@ -1719,9 +1718,7 @@ func updateAccountContractCode(
 	handler AccountContractAdditionHandler,
 	location common.AddressLocation,
 	program *interpreter.Program,
-	name string,
 	code []byte,
-	addressValue interpreter.AddressValue,
 	contractType *sema.CompositeType,
 	constructorArguments []interpreter.Value,
 	constructorArgumentTypes []sema.Type,
@@ -1743,8 +1740,6 @@ func updateAccountContractCode(
 
 	createContract := contractType != nil && options.createContract
 
-	address := addressValue.ToAddress()
-
 	var err error
 
 	if createContract {
@@ -1752,7 +1747,6 @@ func updateAccountContractCode(
 			handler,
 			location,
 			program,
-			address,
 			contractType,
 			constructorArguments,
 			constructorArgumentTypes,
@@ -1765,7 +1759,7 @@ func updateAccountContractCode(
 
 	// NOTE: only update account code if contract instantiation succeeded
 	errors.WrapPanic(func() {
-		err = handler.UpdateAccountContractCode(address, name, code)
+		err = handler.UpdateAccountContractCode(location, code)
 	})
 	if err != nil {
 		return err
@@ -1776,8 +1770,7 @@ func updateAccountContractCode(
 		// until the end of the execution of the program
 
 		handler.RecordContractUpdate(
-			address,
-			name,
+			location,
 			contractValue,
 		)
 	}
@@ -1821,7 +1814,6 @@ func instantiateContract(
 	handler AccountContractAdditionHandler,
 	location common.AddressLocation,
 	program *interpreter.Program,
-	address common.Address,
 	contractType *sema.CompositeType,
 	constructorArguments []interpreter.Value,
 	argumentTypes []sema.Type,
@@ -1881,7 +1873,7 @@ func instantiateContract(
 		program,
 		contractType.Identifier,
 		DeployedContractConstructorInvocation{
-			Address:              address,
+			Address:              location.Address,
 			ContractType:         contractType,
 			ConstructorArguments: constructorArguments,
 			ArgumentTypes:        argumentTypes,
@@ -1893,8 +1885,8 @@ func instantiateContract(
 type AccountContractRemovalHandler interface {
 	EventEmitter
 	AccountContractProvider
-	RemoveAccountContractCode(address common.Address, name string) error
-	RecordContractRemoval(address common.Address, name string)
+	RemoveAccountContractCode(location common.AddressLocation) error
+	RecordContractRemoval(location common.AddressLocation)
 }
 
 func newAuthAccountContractsRemoveFunction(
@@ -1917,13 +1909,14 @@ func newAuthAccountContractsRemoveFunction(
 				panic(errors.NewUnreachableError())
 			}
 			name := nameValue.Str
+			location := common.NewAddressLocation(invocation.Interpreter, address, name)
 
 			// Get the current code
 
 			var code []byte
 			var err error
 			errors.WrapPanic(func() {
-				code, err = handler.GetAccountContractCode(address, name)
+				code, err = handler.GetAccountContractCode(location)
 			})
 			if err != nil {
 				panic(err)
@@ -1951,7 +1944,7 @@ func newAuthAccountContractsRemoveFunction(
 				}
 
 				errors.WrapPanic(func() {
-					err = handler.RemoveAccountContractCode(address, name)
+					err = handler.RemoveAccountContractCode(location)
 				})
 				if err != nil {
 					panic(err)
@@ -1960,7 +1953,7 @@ func newAuthAccountContractsRemoveFunction(
 				// NOTE: the contract recording function delays the write
 				// until the end of the execution of the program
 
-				handler.RecordContractRemoval(address, name)
+				handler.RecordContractRemoval(location)
 
 				codeHashValue := CodeToHashValue(inter, code)
 

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -161,11 +161,10 @@ func (s *Storage) storeNewStorageMap(address atree.Address, domain string) *inte
 }
 
 func (s *Storage) recordContractUpdate(
-	address common.Address,
-	name string,
+	location common.AddressLocation,
 	contractValue *interpreter.CompositeValue,
 ) {
-	key := interpreter.NewStorageKey(s.memoryGauge, address, name)
+	key := interpreter.NewStorageKey(s.memoryGauge, location.Address, location.Name)
 
 	// NOTE: do NOT delete the map entry,
 	// otherwise the removal write is lost

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -526,19 +526,11 @@ func TestRuntimePublicCapabilityBorrowTypeConfusion(t *testing.T) {
 			return []Address{signingAddress}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
@@ -765,19 +757,11 @@ func TestRuntimeTopShotContractDeployment(t *testing.T) {
 			return []Address{testAddress}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = string(code)
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = []byte(accountCodes[location])
 			return code, nil
 		},
@@ -868,19 +852,11 @@ func TestRuntimeTopShotBatchTransfer(t *testing.T) {
 			return []Address{signerAddress}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = string(code)
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = []byte(accountCodes[location])
 			return code, nil
 		},
@@ -1156,19 +1132,11 @@ func TestRuntimeBatchMintAndTransfer(t *testing.T) {
 			return []Address{signerAddress}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = string(code)
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = []byte(accountCodes[location])
 			return code, nil
 		},
@@ -1522,19 +1490,11 @@ func TestRuntimeStorageReferenceCast(t *testing.T) {
 			return []Address{signerAddress}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
@@ -1827,19 +1787,11 @@ func TestRuntimeResourceOwnerChange(t *testing.T) {
 			return signers, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
@@ -2241,18 +2193,10 @@ transaction {
 			return []Address{signerAccount}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
@@ -2374,18 +2318,10 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				return signers, nil
 			},
 			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(address Address, name string, code []byte) error {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
@@ -2509,18 +2445,10 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				return []Address{signerAccount}, nil
 			},
 			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(address Address, name string, code []byte) error {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
@@ -2650,18 +2578,10 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				return []Address{signerAccount}, nil
 			},
 			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(address Address, name string, code []byte) error {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
@@ -2778,18 +2698,10 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				return []Address{signerAccount}, nil
 			},
 			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(address Address, name string, code []byte) error {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
@@ -2904,18 +2816,10 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
 				return []Address{signerAccount}, nil
 			},
 			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(address Address, name string, code []byte) error {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
@@ -3042,19 +2946,11 @@ func TestRuntimeStorageEnumCase(t *testing.T) {
 			return []Address{address}, nil
 		},
 		resolveLocation: singleIdentifierLocationResolver(t),
-		updateAccountContractCode: func(address Address, name string, code []byte) error {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-			location := common.AddressLocation{
-				Address: address,
-				Name:    name,
-			}
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
@@ -3268,19 +3164,11 @@ func TestRuntimeStorageInternalAccess(t *testing.T) {
 				return []Address{address}, nil
 			},
 			resolveLocation: singleIdentifierLocationResolver(t),
-			updateAccountContractCode: func(address Address, name string, code []byte) error {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-				location := common.AddressLocation{
-					Address: address,
-					Name:    name,
-				}
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				code = accountCodes[location]
 				return code, nil
 			},
@@ -3413,20 +3301,11 @@ func TestRuntimeStorageIteration(t *testing.T) {
 					return []Address{address}, nil
 				},
 				resolveLocation: singleIdentifierLocationResolver(t),
-				updateAccountContractCode: func(address Address, name string, code []byte) error {
-					location := common.AddressLocation{
-						Address: address,
-						Name:    name,
-					}
+				updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 					accountCodes[location] = code
 					return nil
 				},
-				getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-					location := common.AddressLocation{
-						Address: address,
-						Name:    name,
-					}
-
+				getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 					if contractIsBroken {
 						// Contract no longer has the type
 						return []byte(`pub contract Test {}`), nil
@@ -3547,20 +3426,11 @@ func TestRuntimeStorageIteration(t *testing.T) {
 					return []Address{address}, nil
 				},
 				resolveLocation: singleIdentifierLocationResolver(t),
-				updateAccountContractCode: func(address Address, name string, code []byte) error {
-					location := common.AddressLocation{
-						Address: address,
-						Name:    name,
-					}
+				updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 					accountCodes[location] = code
 					return nil
 				},
-				getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-					location := common.AddressLocation{
-						Address: address,
-						Name:    name,
-					}
-
+				getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 					if contractIsBroken {
 						// Contract has a syntax problem
 						return []byte(`BROKEN`), nil
@@ -3683,20 +3553,11 @@ func TestRuntimeStorageIteration(t *testing.T) {
 					return []Address{address}, nil
 				},
 				resolveLocation: singleIdentifierLocationResolver(t),
-				updateAccountContractCode: func(address Address, name string, code []byte) error {
-					location := common.AddressLocation{
-						Address: address,
-						Name:    name,
-					}
+				updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 					accountCodes[location] = code
 					return nil
 				},
-				getAccountContractCode: func(address Address, name string) (code []byte, err error) {
-					location := common.AddressLocation{
-						Address: address,
-						Name:    name,
-					}
-
+				getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 					if contractIsBroken {
 						// Contract has a semantic error. i.e: cannot find `Bar`
 						return []byte(`pub contract Test {

--- a/runtime/validation_test.go
+++ b/runtime/validation_test.go
@@ -52,7 +52,7 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 			getSigningAccounts: func() ([]Address, error) {
 				return nil, nil
 			},
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 				return nil, nil
 			},
 			meterMemory: func(_ common.MemoryUsage) error {
@@ -102,7 +102,7 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 			getSigningAccounts: func() ([]Address, error) {
 				return nil, nil
 			},
-			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+			getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 				return nil, nil
 			},
 			meterMemory: func(_ common.MemoryUsage) error {


### PR DESCRIPTION
## Description

Some internal FVM types and checks can be removed, if functions that operate with contracts, use AddressLocation directly.

The only change here is to replace all pairs of (address, name) (when it relates to a contract) with AddressLocation

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
