### PR TITLE
[v0.31] Change account linking pragma to run-time configuration of execution

### DIFF
--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -2911,4 +2911,119 @@ func TestRuntimeAccountLink(t *testing.T) {
 		)
 	})
 
+	t.Run("enabled, contract, pragma in script", func(t *testing.T) {
+
+		t.Parallel()
+
+		runtime := NewInterpreterRuntime(Config{
+			AtreeValidationEnabled: true,
+			AccountLinkingEnabled:  true,
+		})
+
+		address := common.MustBytesToAddress([]byte{0x1})
+
+		accountCodes := map[Location][]byte{}
+		var logs []string
+		var events []cadence.Event
+
+		signerAccount := address
+
+		runtimeInterface := &testRuntimeInterface{
+			getCode: func(location Location) (bytes []byte, err error) {
+				return accountCodes[location], nil
+			},
+			storage: newTestLedger(nil, nil),
+			getSigningAccounts: func() ([]Address, error) {
+				return []Address{signerAccount}, nil
+			},
+			resolveLocation: singleIdentifierLocationResolver(t),
+			getAccountContractCode: func(address Address, name string) (code []byte, err error) {
+				location := common.AddressLocation{
+					Address: address,
+					Name:    name,
+				}
+				return accountCodes[location], nil
+			},
+			updateAccountContractCode: func(address Address, name string, code []byte) (err error) {
+				location := common.AddressLocation{
+					Address: address,
+					Name:    name,
+				}
+				accountCodes[location] = code
+				return nil
+			},
+			log: func(message string) {
+				logs = append(logs, message)
+			},
+			emitEvent: func(event cadence.Event) error {
+				events = append(events, event)
+				return nil
+			},
+		}
+
+		nextTransactionLocation := newTransactionLocationGenerator()
+
+		// Deploy contract
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: DeploymentTransaction(
+					"AccountLinker",
+					[]byte(`
+                      pub contract AccountLinker {
+
+                          pub fun link(_ account: AuthAccount) {
+                              account.linkAccount(/private/foo)
+                          }
+                      }
+                    `,
+					),
+				),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+
+		// Set up account
+
+		setupTransaction := []byte(`
+          #allowAccountLinking
+
+          import AccountLinker from 0x1
+
+          pub fun main() {
+              AccountLinker.link(getAuthAccount(0x1))
+          }
+        `)
+
+		events = nil
+
+		_, err = runtime.ExecuteScript(
+			Script{
+				Source: setupTransaction,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  common.ScriptLocation{},
+			},
+		)
+		require.NoError(t, err)
+
+		require.Len(t, events, 1)
+
+		require.Equal(t,
+			string(stdlib.AccountLinkedEventType.ID()),
+			events[0].EventType.ID(),
+		)
+		require.Equal(t,
+			[]cadence.Value{
+				cadence.NewAddress(common.MustBytesToAddress([]byte{0x1})),
+				cadence.NewPath("private", "foo"),
+			},
+			events[0].Fields,
+		)
+	})
+
 }

--- a/runtime/interpreter/config.go
+++ b/runtime/interpreter/config.go
@@ -62,6 +62,8 @@ type Config struct {
 	AtreeStorageValidationEnabled bool
 	// AtreeValueValidationEnabled determines if the validation of atree values is enabled
 	AtreeValueValidationEnabled bool
+	// AccountLinkingAllowed determines if the account linking function is allowed to be used
+	AccountLinkingAllowed bool
 	// OnAccountLinked is triggered when an account is linked by the program
 	OnAccountLinked OnAccountLinkedFunc
 }

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -875,3 +875,18 @@ func (InvalidHexLengthError) IsUserError() {}
 func (InvalidHexLengthError) Error() string {
 	return "hex string has non-even length"
 }
+
+// AccountLinkingForbiddenError is the error which is reported
+// when a user uses the account link function,
+// but account linking is not allowed
+type AccountLinkingForbiddenError struct {
+	LocationRange
+}
+
+var _ errors.UserError = AccountLinkingForbiddenError{}
+
+func (AccountLinkingForbiddenError) IsUserError() {}
+
+func (e AccountLinkingForbiddenError) Error() string {
+	return "account linking is not allowed"
+}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4692,19 +4692,15 @@ func (interpreter *Interpreter) ConfigureAccountLinkingAllowed() {
 
 	config.AccountLinkingAllowed = false
 
-	var rejectAllowAccountLinkingPragma bool
-
-	for _, declaration := range interpreter.Program.Program.Declarations() {
-
-		if pragmaDeclaration, isPragma := declaration.(*ast.PragmaDeclaration); isPragma {
-			if sema.IsAllowAccountLinkingPragma(pragmaDeclaration) {
-				if !rejectAllowAccountLinkingPragma {
-					config.AccountLinkingAllowed = true
-				}
-				continue
-			}
-		}
-
-		rejectAllowAccountLinkingPragma = true
+	declarations := interpreter.Program.Program.Declarations()
+	if len(declarations) < 1 {
+		return
 	}
+
+	pragmaDeclaration, isPragma := declarations[0].(*ast.PragmaDeclaration)
+	if !isPragma || !sema.IsAllowAccountLinkingPragma(pragmaDeclaration) {
+		return
+	}
+
+	config.AccountLinkingAllowed = true
 }

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -228,6 +228,8 @@ func (executor *interpreterScriptExecutor) scriptExecutionFunction() InterpretFu
 			err = internalErr
 		})
 
+		inter.ConfigureAccountLinkingAllowed()
+
 		values, err := validateArgumentParams(
 			inter,
 			executor.environment,
@@ -238,6 +240,7 @@ func (executor *interpreterScriptExecutor) scriptExecutionFunction() InterpretFu
 		if err != nil {
 			return nil, err
 		}
+
 		return inter.Invoke("main", values...)
 	}
 }

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -112,7 +112,6 @@ type Checker struct {
 	inInvocation                       bool
 	inCreate                           bool
 	isChecked                          bool
-	allowAccountLinking                bool
 }
 
 var _ ast.DeclarationVisitor[struct{}] = &Checker{}
@@ -335,20 +334,18 @@ func (checker *Checker) CheckProgram(program *ast.Program) {
 	for _, declaration := range declarations {
 
 		// A pragma declaration #allowAccountLinking determines
-		// if the program is allowed to use the account linking.
+		// if the program is allowed to use account linking.
 		//
 		// It must appear as a top-level declaration (i.e. not nested in the program),
 		// and must appear before all other declarations (i.e. at the top of the program).
 		//
-		// This is a temporary feature, which is planned to get replaced
-		// by capability controllers, a new Account type, and account entitlements.
+		// This is a temporary feature, which is planned to get replaced by capability controllers,
+		// and a new Account type with entitlements.
 
 		if pragmaDeclaration, isPragma := declaration.(*ast.PragmaDeclaration); isPragma {
 			if IsAllowAccountLinkingPragma(pragmaDeclaration) {
 				if rejectAllowAccountLinkingPragma {
 					checker.reportInvalidNonHeaderPragma(pragmaDeclaration)
-				} else {
-					checker.allowAccountLinking = true
 				}
 				continue
 			}
@@ -2413,8 +2410,7 @@ func (checker *Checker) isAvailableMember(expressionType Type, identifier string
 	if expressionType == AuthAccountType &&
 		identifier == AuthAccountTypeLinkAccountFunctionName {
 
-		return checker.Config.AccountLinkingEnabled &&
-			checker.allowAccountLinking
+		return checker.Config.AccountLinkingEnabled
 	}
 
 	return true

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -1120,37 +1120,27 @@ func TestCheckAccount_linkAccount(t *testing.T) {
 	type testCase struct {
 		domain  common.PathDomain
 		enabled bool
-		allowed bool
 	}
 
 	test := func(tc testCase) {
 
 		testName := fmt.Sprintf(
-			"%s, enabled=%v, allowed=%v",
+			"%s, enabled=%v",
 			tc.domain.Identifier(),
 			tc.enabled,
-			tc.allowed,
 		)
 
 		t.Run(testName, func(t *testing.T) {
 
 			t.Parallel()
 
-			var pragma string
-			if tc.allowed {
-				pragma = "#allowAccountLinking"
-			}
-
 			code := fmt.Sprintf(`
-                  %s
-
                   resource R {}
 
                   fun test(authAccount: AuthAccount): Capability<&AuthAccount>? {
                       return authAccount.linkAccount(/%s/r)
                   }
                 `,
-				pragma,
 				tc.domain.Identifier(),
 			)
 
@@ -1170,14 +1160,6 @@ func TestCheckAccount_linkAccount(t *testing.T) {
 				return
 			}
 
-			if !tc.allowed {
-				errs := RequireCheckerErrors(t, err, 1)
-
-				require.IsType(t, &sema.NotDeclaredMemberError{}, errs[0])
-
-				return
-			}
-
 			if tc.domain != common.PathDomainPrivate {
 				errs := RequireCheckerErrors(t, err, 1)
 
@@ -1189,17 +1171,12 @@ func TestCheckAccount_linkAccount(t *testing.T) {
 		})
 	}
 
-	options := []bool{true, false}
-
-	for _, enabled := range options {
-		for _, allowed := range options {
-			for _, domain := range common.AllPathDomainsByIdentifier {
-				test(testCase{
-					domain:  domain,
-					enabled: enabled,
-					allowed: allowed,
-				})
-			}
+	for _, enabled := range []bool{true, false} {
+		for _, domain := range common.AllPathDomainsByIdentifier {
+			test(testCase{
+				domain:  domain,
+				enabled: enabled,
+			})
 		}
 	}
 }

--- a/runtime/tests/checker/pragma_test.go
+++ b/runtime/tests/checker/pragma_test.go
@@ -113,6 +113,19 @@ func TestCheckAllowAccountLinkingPragma(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("top-level, after other pragmas", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          #someOtherPragma
+          #allowAccountLinking
+
+          let x = 1
+        `)
+		errs := RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.InvalidPragmaError{}, errs[0])
+	})
+
 	t.Run("top-level, after other declarations", func(t *testing.T) {
 		t.Parallel()
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -153,6 +153,8 @@ func parseCheckAndInterpretWithOptionsAndMemoryMetering(
 
 	require.NoError(t, err)
 
+	inter.ConfigureAccountLinkingAllowed()
+
 	err = inter.Interpret()
 
 	if err == nil {

--- a/runtime/tests/interpreter/pragma_test.go
+++ b/runtime/tests/interpreter/pragma_test.go
@@ -1,0 +1,107 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/tests/checker"
+)
+
+func TestInterpretAllowAccountLinkingPragma(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("top-level, before other declarations", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          #allowAccountLinking
+
+          let x = 1
+        `)
+		require.True(t, inter.SharedState.Config.AccountLinkingAllowed)
+	})
+
+	t.Run("top-level, after other pragmas", func(t *testing.T) {
+		t.Parallel()
+
+		inter, err := parseCheckAndInterpretWithOptions(t,
+			`
+              #someOtherPragma
+              #allowAccountLinking
+
+              let x = 1
+            `,
+			ParseCheckAndInterpretOptions{
+				HandleCheckerError: func(err error) {
+					errs := checker.RequireCheckerErrors(t, err, 1)
+					assert.IsType(t, &sema.InvalidPragmaError{}, errs[0])
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.False(t, inter.SharedState.Config.AccountLinkingAllowed)
+	})
+
+	t.Run("top-level, after other declarations", func(t *testing.T) {
+		t.Parallel()
+
+		inter, err := parseCheckAndInterpretWithOptions(t,
+			`
+               let x = 1
+
+               #allowAccountLinking
+            `,
+			ParseCheckAndInterpretOptions{
+				HandleCheckerError: func(err error) {
+					errs := checker.RequireCheckerErrors(t, err, 1)
+					assert.IsType(t, &sema.InvalidPragmaError{}, errs[0])
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.False(t, inter.SharedState.Config.AccountLinkingAllowed)
+	})
+
+	t.Run("nested", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter, err := parseCheckAndInterpretWithOptions(t,
+			`
+              fun test() {
+                  #allowAccountLinking
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				HandleCheckerError: func(err error) {
+					errs := checker.RequireCheckerErrors(t, err, 1)
+					require.IsType(t, &sema.InvalidDeclarationError{}, errs[0])
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.False(t, inter.SharedState.Config.AccountLinkingAllowed)
+	})
+}

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -250,6 +250,8 @@ func (executor *interpreterTransactionExecutor) transactionExecutionFunction(
 			err = internalErr
 		})
 
+		inter.ConfigureAccountLinkingAllowed()
+
 		values, err := validateArgumentParams(
 			inter,
 			executor.environment,


### PR DESCRIPTION
Port of #2380 to special v0.31 branch for MN update

______

<!-- Complete: -->

- [x] Targeted PR against ~`master`~ release branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
