### PR TITLE
Add a Reset method on CoverageReport type

### DIFF
--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -230,6 +230,17 @@ func (r *CoverageReport) CoveredStatementsPercentage() string {
 	return fmt.Sprintf("Coverage: %v of statements", percentage)
 }
 
+// Reset flushes the collected coverage information for all locations
+// and inspected programs. Excluded locations remain intact.
+func (r *CoverageReport) Reset() {
+	for location := range r.Coverage { // nolint:maprange
+		delete(r.Coverage, location)
+	}
+	for program := range r.Programs { // nolint:maprange
+		delete(r.Programs, program)
+	}
+}
+
 // NewCoverageReport creates and returns a *CoverageReport.
 func NewCoverageReport() *CoverageReport {
 	return &CoverageReport{


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2385

## Description

Add a `Reset` method on `CoverageReport` type. This is helpful when `CoverageReport` is used in a context such as the Flow emulator, and the user/developer wants to flush everything. The `ExcludedLocations`, however, still remain intact.

Ref: https://github.com/onflow/flow-emulator/pull/332#discussion_r1135216916

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
