### PR TITLE
Improvements to `CoverageReport` public API

### DIFF
--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -202,8 +202,7 @@ func (r *CoverageReport) InspectProgram(location Location, program *ast.Program)
 			return true
 		})
 
-	locationCoverage := NewLocationCoverage(lineHits)
-	r.Coverage[location] = locationCoverage
+	r.Coverage[location] = NewLocationCoverage(lineHits)
 }
 
 // IsLocationInspected checks whether the given location,

--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -213,21 +213,26 @@ func (r *CoverageReport) IsProgramInspected(location Location) bool {
 	return isInspected
 }
 
-// CoveredStatementsPercentage returns a string representation of
-// the covered statements percentage. It is defined as the ratio
-// of total covered lines over total statements, for all locations.
-func (r *CoverageReport) CoveredStatementsPercentage() string {
+// Percentage returns a string representation of the covered statements
+// percentage. It is defined as the ratio of total covered lines over
+// total statements, for all locations.
+func (r *CoverageReport) Percentage() string {
 	totalStatements := 0
 	totalCoveredLines := 0
 	for _, locationCoverage := range r.Coverage { // nolint:maprange
 		totalStatements += locationCoverage.Statements
 		totalCoveredLines += locationCoverage.CoveredLines()
 	}
-	percentage := fmt.Sprintf(
+	return fmt.Sprintf(
 		"%0.1f%%",
 		100*float64(totalCoveredLines)/float64(totalStatements),
 	)
-	return fmt.Sprintf("Coverage: %v of statements", percentage)
+}
+
+// String returns a human-friendly message for the covered
+// statements percentage.
+func (r *CoverageReport) String() string {
+	return fmt.Sprintf("Coverage: %v of statements", r.Percentage())
 }
 
 // Reset flushes the collected coverage information for all locations

--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -241,8 +241,23 @@ func (r *CoverageReport) Reset() {
 	for location := range r.Coverage { // nolint:maprange
 		delete(r.Coverage, location)
 	}
-	for program := range r.Programs { // nolint:maprange
-		delete(r.Programs, program)
+	for location := range r.Programs { // nolint:maprange
+		delete(r.Programs, location)
+	}
+}
+
+// Merge adds all the collected coverage information to the
+// calling object. Excluded locations are also taken into
+// account.
+func (r *CoverageReport) Merge(other CoverageReport) {
+	for location, locationCoverage := range other.Coverage { // nolint:maprange
+		r.Coverage[location] = locationCoverage
+	}
+	for location, program := range other.Programs { // nolint:maprange
+		r.Programs[location] = program
+	}
+	for location := range other.ExcludedLocations {
+		r.ExcludedLocations[location] = struct{}{}
 	}
 }
 

--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -431,7 +431,10 @@ func (r *CoverageReport) UnmarshalJSON(data []byte) error {
 	}
 
 	for locationID, locationCoverage := range cr.Coverage { // nolint:maprange
-		location, _, _ := common.DecodeTypeID(nil, locationID)
+		location, _, err := common.DecodeTypeID(nil, locationID)
+		if err != nil {
+			return err
+		}
 		if location == nil {
 			return fmt.Errorf("invalid Location ID: %s", locationID)
 		}
@@ -442,7 +445,10 @@ func (r *CoverageReport) UnmarshalJSON(data []byte) error {
 		r.Locations[location] = struct{}{}
 	}
 	for _, locationID := range cr.ExcludedLocations {
-		location, _, _ := common.DecodeTypeID(nil, locationID)
+		location, _, err := common.DecodeTypeID(nil, locationID)
+		if err != nil {
+			return err
+		}
 		if location == nil {
 			return fmt.Errorf("invalid Location ID: %s", locationID)
 		}

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -105,6 +105,7 @@ func TestLocationCoverageCoveredLines(t *testing.T) {
 }
 
 func TestLocationCoverageMissedLines(t *testing.T) {
+
 	t.Parallel()
 
 	lineHits := map[int]int{3: 0, 4: 0, 5: 0, 7: 0, 9: 0, 11: 0}
@@ -147,7 +148,7 @@ func TestNewCoverageReport(t *testing.T) {
 	coverageReport := NewCoverageReport()
 
 	assert.Equal(t, 0, len(coverageReport.Coverage))
-	assert.Equal(t, 0, len(coverageReport.Programs))
+	assert.Equal(t, 0, len(coverageReport.Locations))
 	assert.Equal(t, 0, len(coverageReport.ExcludedLocations))
 }
 
@@ -189,8 +190,8 @@ func TestCoverageReportInspectProgram(t *testing.T) {
 	coverageReport.InspectProgram(location, program)
 
 	assert.Equal(t, 1, len(coverageReport.Coverage))
-	assert.Equal(t, 1, len(coverageReport.Programs))
-	assert.Equal(t, true, coverageReport.IsProgramInspected(location))
+	assert.Equal(t, 1, len(coverageReport.Locations))
+	assert.Equal(t, true, coverageReport.IsLocationInspected(location))
 }
 
 func TestCoverageReportInspectProgramForExcludedLocation(t *testing.T) {
@@ -217,8 +218,8 @@ func TestCoverageReportInspectProgramForExcludedLocation(t *testing.T) {
 	coverageReport.InspectProgram(location, program)
 
 	assert.Equal(t, 0, len(coverageReport.Coverage))
-	assert.Equal(t, 0, len(coverageReport.Programs))
-	assert.Equal(t, false, coverageReport.IsProgramInspected(location))
+	assert.Equal(t, 0, len(coverageReport.Locations))
+	assert.Equal(t, false, coverageReport.IsLocationInspected(location))
 }
 
 func TestCoverageReportAddLineHit(t *testing.T) {
@@ -303,7 +304,8 @@ func TestCoverageReportWithFlowLocation(t *testing.T) {
 	        "statements": 4,
 	        "percentage": "0.0%"
 	      }
-	    }
+	    },
+	    "excluded_locations": []
 	  }
 	`
 	require.JSONEq(t, expected, string(actual))
@@ -348,7 +350,8 @@ func TestCoverageReportWithREPLLocation(t *testing.T) {
 	        "statements": 4,
 	        "percentage": "0.0%"
 	      }
-	    }
+	    },
+	    "excluded_locations": []
 	  }
 	`
 	require.JSONEq(t, expected, string(actual))
@@ -393,7 +396,8 @@ func TestCoverageReportWithScriptLocation(t *testing.T) {
 	        "statements": 4,
 	        "percentage": "0.0%"
 	      }
-	    }
+	    },
+	    "excluded_locations": []
 	  }
 	`
 	require.JSONEq(t, expected, string(actual))
@@ -438,7 +442,8 @@ func TestCoverageReportWithStringLocation(t *testing.T) {
 	        "statements": 4,
 	        "percentage": "0.0%"
 	      }
-	    }
+	    },
+	    "excluded_locations": []
 	  }
 	`
 	require.JSONEq(t, expected, string(actual))
@@ -483,7 +488,8 @@ func TestCoverageReportWithIdentifierLocation(t *testing.T) {
 	        "statements": 4,
 	        "percentage": "0.0%"
 	      }
-	    }
+	    },
+	    "excluded_locations": []
 	  }
 	`
 	require.JSONEq(t, expected, string(actual))
@@ -528,7 +534,8 @@ func TestCoverageReportWithTransactionLocation(t *testing.T) {
 	        "statements": 4,
 	        "percentage": "0.0%"
 	      }
-	    }
+	    },
+	    "excluded_locations": []
 	  }
 	`
 	require.JSONEq(t, expected, string(actual))
@@ -576,11 +583,11 @@ func TestCoverageReportWithAddressLocation(t *testing.T) {
 	        "statements": 4,
 	        "percentage": "0.0%"
 	      }
-	    }
+	    },
+	    "excluded_locations": []
 	  }
 	`
 	require.JSONEq(t, expected, string(actual))
-
 }
 
 func TestCoverageReportReset(t *testing.T) {
@@ -612,17 +619,17 @@ func TestCoverageReportReset(t *testing.T) {
 	coverageReport.ExcludeLocation(excludedLocation)
 
 	assert.Equal(t, 1, len(coverageReport.Coverage))
-	assert.Equal(t, 1, len(coverageReport.Programs))
+	assert.Equal(t, 1, len(coverageReport.Locations))
 	assert.Equal(t, 1, len(coverageReport.ExcludedLocations))
-	assert.Equal(t, true, coverageReport.IsProgramInspected(location))
+	assert.Equal(t, true, coverageReport.IsLocationInspected(location))
 	assert.Equal(t, true, coverageReport.IsLocationExcluded(excludedLocation))
 
 	coverageReport.Reset()
 
 	assert.Equal(t, 0, len(coverageReport.Coverage))
-	assert.Equal(t, 0, len(coverageReport.Programs))
+	assert.Equal(t, 0, len(coverageReport.Locations))
 	assert.Equal(t, 1, len(coverageReport.ExcludedLocations))
-	assert.Equal(t, false, coverageReport.IsProgramInspected(location))
+	assert.Equal(t, false, coverageReport.IsLocationInspected(location))
 	assert.Equal(t, true, coverageReport.IsLocationExcluded(excludedLocation))
 }
 
@@ -639,8 +646,8 @@ func TestCoverageReportAddLineHitForExcludedLocation(t *testing.T) {
 	coverageReport.AddLineHit(location, 5)
 
 	assert.Equal(t, 0, len(coverageReport.Coverage))
-	assert.Equal(t, 0, len(coverageReport.Programs))
-	assert.Equal(t, false, coverageReport.IsProgramInspected(location))
+	assert.Equal(t, 0, len(coverageReport.Locations))
+	assert.Equal(t, false, coverageReport.IsLocationInspected(location))
 }
 
 func TestCoverageReportAddLineHitForNonInspectedProgram(t *testing.T) {
@@ -655,8 +662,8 @@ func TestCoverageReportAddLineHitForNonInspectedProgram(t *testing.T) {
 	coverageReport.AddLineHit(location, 5)
 
 	assert.Equal(t, 0, len(coverageReport.Coverage))
-	assert.Equal(t, 0, len(coverageReport.Programs))
-	assert.Equal(t, false, coverageReport.IsProgramInspected(location))
+	assert.Equal(t, 0, len(coverageReport.Locations))
+	assert.Equal(t, false, coverageReport.IsLocationInspected(location))
 }
 
 func TestCoverageReportPercentage(t *testing.T) {
@@ -700,7 +707,8 @@ func TestCoverageReportPercentage(t *testing.T) {
 	        "statements": 4,
 	        "percentage": "50.0%"
 	      }
-	    }
+	    },
+	    "excluded_locations": []
 	  }
 	`
 	require.JSONEq(t, expected, string(actual))
@@ -750,7 +758,8 @@ func TestCoverageReportString(t *testing.T) {
 	        "statements": 4,
 	        "percentage": "75.0%"
 	      }
-	    }
+	    },
+	    "excluded_locations": []
 	  }
 	`
 	require.JSONEq(t, expected, string(actual))
@@ -942,10 +951,195 @@ func TestCoverageReportMerge(t *testing.T) {
 	        "statements": 14,
 	        "percentage": "0.0%"
 	      }
-	    }
+	    },
+	    "excluded_locations": ["S.FooContract"]
 	  }
 	`
 	require.JSONEq(t, expected, string(actual))
+}
+
+func TestCoverageReportUnmarshalJSON(t *testing.T) {
+
+	t.Parallel()
+
+	data := `
+	  {
+	    "coverage": {
+	      "S.Factorial": {
+	        "line_hits": {
+	          "12": 0,
+	          "13": 0,
+	          "16": 0,
+	          "4": 0,
+	          "8": 0
+	        },
+	        "missed_lines": [4, 8, 12, 13, 16],
+	        "statements": 5,
+	        "percentage": "0.0%"
+	      },
+	      "S.IntegerTraits": {
+	        "line_hits": {
+	          "13": 0,
+	          "14": 0,
+	          "15": 0,
+	          "16": 0,
+	          "17": 0,
+	          "18": 0,
+	          "19": 0,
+	          "20": 0,
+	          "21": 0,
+	          "22": 0,
+	          "25": 0,
+	          "26": 0,
+	          "29": 0,
+	          "9": 0
+	        },
+	        "missed_lines": [9, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 25, 26, 29],
+	        "statements": 14,
+	        "percentage": "0.0%"
+	      }
+	    },
+	    "excluded_locations": ["I.Test"]
+	  }
+	`
+
+	coverageReport := NewCoverageReport()
+	err := json.Unmarshal([]byte(data), coverageReport)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, coverageReport.TotalLocations())
+
+	factorialLocation := common.StringLocation("Factorial")
+
+	assert.Equal(
+		t,
+		5,
+		coverageReport.Coverage[factorialLocation].Statements,
+	)
+	assert.Equal(
+		t,
+		"0.0%",
+		coverageReport.Coverage[factorialLocation].Percentage(),
+	)
+	assert.EqualValues(
+		t,
+		[]int{4, 8, 12, 13, 16},
+		coverageReport.Coverage[factorialLocation].MissedLines(),
+	)
+	assert.Equal(
+		t,
+		map[int]int{4: 0, 8: 0, 12: 0, 13: 0, 16: 0},
+		coverageReport.Coverage[factorialLocation].LineHits,
+	)
+
+	actual, err := json.Marshal(coverageReport)
+	require.NoError(t, err)
+
+	require.JSONEq(t, data, string(actual))
+
+	integerTraitsLocation := common.StringLocation("IntegerTraits")
+
+	assert.Equal(
+		t,
+		coverageReport.Coverage[integerTraitsLocation].Statements,
+		14,
+	)
+	assert.Equal(
+		t,
+		"0.0%",
+		coverageReport.Coverage[integerTraitsLocation].Percentage(),
+	)
+	assert.EqualValues(
+		t,
+		[]int{9, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 25, 26, 29},
+		coverageReport.Coverage[integerTraitsLocation].MissedLines(),
+	)
+	assert.EqualValues(
+		t,
+		map[int]int{9: 0, 13: 0, 14: 0, 15: 0, 16: 0, 17: 0, 18: 0, 19: 0, 20: 0, 21: 0, 22: 0, 25: 0, 26: 0, 29: 0},
+		coverageReport.Coverage[integerTraitsLocation].LineHits,
+	)
+
+	assert.Equal(
+		t,
+		2,
+		len(coverageReport.Locations),
+	)
+
+	assert.Equal(
+		t,
+		[]string{"I.Test"},
+		coverageReport.ExcludedLocationIDs(),
+	)
+}
+
+func TestCoverageReportUnmarshalJSONWithFormatError(t *testing.T) {
+
+	t.Parallel()
+
+	data := "My previous coverage report.txt"
+
+	coverageReport := NewCoverageReport()
+	err := coverageReport.UnmarshalJSON([]byte(data))
+	require.Error(t, err)
+}
+
+func TestCoverageReportUnmarshalJSONWithDecodeLocationError(t *testing.T) {
+
+	t.Parallel()
+
+	data := `
+	  {
+	    "coverage": {
+	      "X.Factorial": {
+	        "line_hits": {
+	          "12": 0,
+	          "13": 0,
+	          "16": 0,
+	          "4": 0,
+	          "8": 0
+	        },
+	        "missed_lines": [4, 8, 12, 13, 16],
+	        "statements": 5,
+	        "percentage": "0.0%"
+	      }
+	    },
+	    "excluded_locations": ["I.Test"]
+	  }
+	`
+
+	coverageReport := NewCoverageReport()
+	err := json.Unmarshal([]byte(data), coverageReport)
+	require.ErrorContains(t, err, "invalid Location ID: X.Factorial")
+}
+
+func TestCoverageReportUnmarshalJSONWithDecodeExcludedLocationError(t *testing.T) {
+
+	t.Parallel()
+
+	data := `
+	  {
+	    "coverage": {
+	      "S.Factorial": {
+	        "line_hits": {
+	          "12": 0,
+	          "13": 0,
+	          "16": 0,
+	          "4": 0,
+	          "8": 0
+	        },
+	        "missed_lines": [4, 8, 12, 13, 16],
+	        "statements": 5,
+	        "percentage": "0.0%"
+	      }
+	    },
+	    "excluded_locations": ["XI.Test"]
+	  }
+	`
+
+	coverageReport := NewCoverageReport()
+	err := json.Unmarshal([]byte(data), coverageReport)
+	require.ErrorContains(t, err, "invalid Location ID: XI.Test")
 }
 
 func TestRuntimeCoverage(t *testing.T) {
@@ -1111,7 +1305,8 @@ func TestRuntimeCoverage(t *testing.T) {
 	        "statements": 9,
 	        "percentage": "100.0%"
 	      }
-	    }
+	    },
+	    "excluded_locations": []
 	  }
 	`
 	require.JSONEq(t, expected, string(actual))
@@ -1247,7 +1442,8 @@ func TestRuntimeCoverageWithExcludedLocation(t *testing.T) {
 	        "statements": 14,
 	        "percentage": "100.0%"
 	      }
-	    }
+	    },
+	    "excluded_locations": ["s.0000000000000000000000000000000000000000000000000000000000000000"]
 	  }
 	`
 	require.JSONEq(t, expected, string(actual))

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -612,7 +612,7 @@ func (e *interpreterEnvironment) newOnStatementHandler() interpreter.OnStatement
 
 	return func(inter *interpreter.Interpreter, statement ast.Statement) {
 		location := inter.Location
-		if !e.coverageReport.IsProgramInspected(location) {
+		if !e.coverageReport.IsLocationInspected(location) {
 			program := inter.Program.Program
 			e.coverageReport.InspectProgram(location, program)
 		}


### PR DESCRIPTION
⚠️ Depends on #2396
Closes #2390

## Description

The `CoverageReport` type should expose more public methods, and provide developers with a flexible API. Including methods to:

- Get the total percentage of covered statements, as a raw value (now it is returned only through a human-friendly message)
- Merge `CoverageReport` objects
- Calculate a `CoverageReport` summary and incremental diff between `CoverageReport` objects
- Unmarshal previously marshaled `CoverageReport` objects

The ideal end result should contain the necessary information to build a tool like this:

![Screenshot from 2023-03-17 11-05-08](https://user-images.githubusercontent.com/1778965/225938197-ede21db6-0631-4fe9-97ad-9fa42fdc7106.png)

Feedback is more than welcome! :pray: 

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
