### PR TITLE
Fix and run interpreter smoke tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: make -j8 build
 
       - name: Test
-        run: make test
+        run: make ci
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          make test
+          make ci
           make lint-github-actions
 
       - name: Config git

--- a/runtime/interpreter/storage.go
+++ b/runtime/interpreter/storage.go
@@ -65,6 +65,7 @@ func ConvertStoredValue(gauge common.MemoryGauge, value atree.Value) (Value, err
 			panic(errors.NewUnreachableError())
 		}
 		return newArrayValueFromConstructor(gauge, staticType, value.Count(), func() *atree.Array { return value }), nil
+
 	case *atree.OrderedMap:
 		typeInfo := value.Type()
 		switch typeInfo := typeInfo.(type) {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -14955,7 +14955,10 @@ func (v *CompositeValue) Clone(interpreter *Interpreter) Value {
 				return nil, nil, nil
 			}
 
-			key := MustConvertStoredValue(interpreter, atreeKey).Clone(interpreter)
+			// The key is always interpreter.StringAtreeValue,
+			// an "atree-level string", not an interpreter.Value.
+			// Thus, we do not, and cannot, convert.
+			key := atreeKey
 			value := MustConvertStoredValue(interpreter, atreeValue).Clone(interpreter)
 
 			return key, value, nil

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -50,7 +50,7 @@ var validateAtree = flag.Bool("validateAtree", true, "Enable atree validation")
 
 func TestRandomMapOperations(t *testing.T) {
 	if !*runSmokeTests {
-		t.SkipNow()
+		t.Skip("smoke tests are disabled")
 	}
 
 	t.Parallel()
@@ -357,7 +357,25 @@ func TestRandomMapOperations(t *testing.T) {
 	t.Run("random insert & remove", func(t *testing.T) {
 		keyValues := make([][2]interpreter.Value, numberOfValues)
 		for i := 0; i < numberOfValues; i++ {
-			keyValues[i][0] = randomHashableValue(inter)
+			// Generate unique key
+			var key interpreter.Value
+			for {
+				key = randomHashableValue(inter)
+
+				var foundConflict bool
+				for j := 0; j < i; j++ {
+					existingKey := keyValues[j][0]
+					if key.(interpreter.EquatableValue).Equal(inter, interpreter.EmptyLocationRange, existingKey) {
+						foundConflict = true
+						break
+					}
+				}
+				if !foundConflict {
+					break
+				}
+			}
+
+			keyValues[i][0] = key
 			keyValues[i][1] = randomStorableValue(inter, 0)
 		}
 
@@ -497,7 +515,7 @@ func TestRandomMapOperations(t *testing.T) {
 
 func TestRandomArrayOperations(t *testing.T) {
 	if !*runSmokeTests {
-		t.SkipNow()
+		t.Skip("smoke tests are disabled")
 	}
 
 	seed := time.Now().UnixNano()
@@ -861,7 +879,7 @@ func TestRandomArrayOperations(t *testing.T) {
 
 func TestRandomCompositeValueOperations(t *testing.T) {
 	if !*runSmokeTests {
-		t.SkipNow()
+		t.Skip("smoke tests are disabled")
 	}
 
 	seed := time.Now().UnixNano()


### PR DESCRIPTION
## Description

We have some existing smoke tests in the interpreter that create random containers and perform random operations on them.

These tests were broken in two ways:
- `CompositeValue.Clone` was broken: Keys should not be converted
- The test case for random operations on dictionaries was generating invalid test cases (duplicate keys)

Now that the test cases are fixed, run them on CI.

Also, reorganize and rename the Makefiles, so the default target is building, instead of running tests for CI (coverage enabled).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
