### PR TITLE
Allow empty qualified identifier when decoding type IDs

### DIFF
--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -2972,7 +2972,7 @@ func TestDecodeInvalidType(t *testing.T) {
 		assert.Equal(t, "failed to decode JSON-Cadence value: invalid type ID for built-in: ``", err.Error())
 	})
 
-	t.Run("undefined type", func(t *testing.T) {
+	t.Run("invalid type ID", func(t *testing.T) {
 		t.Parallel()
 
 		// language=json
@@ -2980,14 +2980,14 @@ func TestDecodeInvalidType(t *testing.T) {
           {
             "type": "Struct",
             "value": {
-              "id": "I.Foo",
+              "id": "I",
               "fields": []
             }
           }
         `
 		_, err := json.Decode(nil, []byte(encodedValue))
 		require.Error(t, err)
-		assert.Equal(t, "failed to decode JSON-Cadence value: invalid type ID `I.Foo`: invalid identifier location type ID: missing qualified identifier", err.Error())
+		assert.Equal(t, "failed to decode JSON-Cadence value: invalid type ID `I`: invalid identifier location type ID: missing location", err.Error())
 	})
 
 	t.Run("unknown location prefix", func(t *testing.T) {

--- a/runtime/common/addresslocation.go
+++ b/runtime/common/addresslocation.go
@@ -144,9 +144,7 @@ func decodeAddressLocationTypeID(gauge MemoryGauge, typeID string) (AddressLocat
 		panic(errors.NewUnreachableError())
 	case 1:
 		return newError("missing location")
-	case 2:
-		return newError("missing qualified identifier")
-	case 3, 4:
+	case 2, 3, 4:
 		break
 	default:
 		// strings.SplitN will never return more than 4 parts
@@ -181,6 +179,11 @@ func decodeAddressLocationTypeID(gauge MemoryGauge, typeID string) (AddressLocat
 	var qualifiedIdentifier string
 
 	switch partCount {
+	case 2:
+		// If there are only 2 parts,
+		// then `<qualifiedIdentifier>` is empty,
+		// and both the contract name and the qualified identifier are empty (default)s
+
 	case 3:
 		// If there are only 3 parts,
 		// then `<qualifiedIdentifier>` is both the contract name and the qualified identifier.

--- a/runtime/common/addresslocation_test.go
+++ b/runtime/common/addresslocation_test.go
@@ -98,12 +98,38 @@ func TestDecodeAddressLocationTypeID(t *testing.T) {
 		require.EqualError(t, err, "invalid address location type ID: missing location")
 	})
 
-	t.Run("missing qualified identifier", func(t *testing.T) {
+	t.Run("missing qualified identifier part", func(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeAddressLocationTypeID(nil, "A.0000000000000001")
-		require.EqualError(t, err, "invalid address location type ID: missing qualified identifier")
+		location, qualifiedIdentifier, err := decodeAddressLocationTypeID(nil, "A.0000000000000001")
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			AddressLocation{
+				Address: MustBytesToAddress([]byte{1}),
+				Name:    "",
+			},
+			location,
+		)
+		assert.Equal(t, "", qualifiedIdentifier)
+	})
+
+	t.Run("empty qualified identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		location, qualifiedIdentifier, err := decodeAddressLocationTypeID(nil, "A.0000000000000001.")
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			AddressLocation{
+				Address: MustBytesToAddress([]byte{1}),
+				Name:    "",
+			},
+			location,
+		)
+		assert.Equal(t, "", qualifiedIdentifier)
 	})
 
 	t.Run("invalid prefix", func(t *testing.T) {

--- a/runtime/common/identifierlocation.go
+++ b/runtime/common/identifierlocation.go
@@ -103,11 +103,8 @@ func decodeIdentifierLocationTypeID(_ MemoryGauge, typeID string) (IdentifierLoc
 	parts := strings.SplitN(typeID, ".", 3)
 
 	pieceCount := len(parts)
-	switch pieceCount {
-	case 1:
+	if pieceCount == 1 {
 		return newError("missing location")
-	case 2:
-		return newError("missing qualified identifier")
 	}
 
 	prefix := parts[0]
@@ -122,7 +119,11 @@ func decodeIdentifierLocationTypeID(_ MemoryGauge, typeID string) (IdentifierLoc
 	}
 
 	location := IdentifierLocation(parts[1])
-	qualifiedIdentifier := parts[2]
+
+	var qualifiedIdentifier string
+	if pieceCount > 2 {
+		qualifiedIdentifier = parts[2]
+	}
 
 	return location, qualifiedIdentifier, nil
 }

--- a/runtime/common/identifierlocation_test.go
+++ b/runtime/common/identifierlocation_test.go
@@ -91,15 +91,35 @@ func TestDecodeIdentifierLocationTypeID(t *testing.T) {
 		require.EqualError(t, err, "invalid identifier location type ID: missing location")
 	})
 
-	t.Run("missing qualified identifier", func(t *testing.T) {
+	t.Run("missing qualified identifier part", func(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeIdentifierLocationTypeID(nil, "I.test")
-		require.EqualError(t, err, "invalid identifier location type ID: missing qualified identifier")
+		location, qualifiedIdentifier, err := decodeIdentifierLocationTypeID(nil, "I.test")
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			IdentifierLocation("test"),
+			location,
+		)
+		assert.Equal(t, "", qualifiedIdentifier)
 	})
 
-	t.Run("missing qualified identifier", func(t *testing.T) {
+	t.Run("empty qualified identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		location, qualifiedIdentifier, err := decodeIdentifierLocationTypeID(nil, "I.test.")
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			IdentifierLocation("test"),
+			location,
+		)
+		assert.Equal(t, "", qualifiedIdentifier)
+	})
+
+	t.Run("invalid prefix", func(t *testing.T) {
 
 		t.Parallel()
 

--- a/runtime/common/repllocation.go
+++ b/runtime/common/repllocation.go
@@ -106,11 +106,6 @@ func decodeREPLLocationTypeID(typeID string) (REPLLocation, string, error) {
 
 	parts := strings.SplitN(typeID, ".", 2)
 
-	pieceCount := len(parts)
-	if pieceCount == 1 {
-		return newError("missing qualified identifier")
-	}
-
 	prefix := parts[0]
 
 	if prefix != REPLLocationPrefix {
@@ -122,7 +117,11 @@ func decodeREPLLocationTypeID(typeID string) (REPLLocation, string, error) {
 		)
 	}
 
-	qualifiedIdentifier := parts[1]
+	pieceCount := len(parts)
+	var qualifiedIdentifier string
+	if pieceCount > 1 {
+		qualifiedIdentifier = parts[1]
+	}
 
 	return REPLLocation{}, qualifiedIdentifier, nil
 }

--- a/runtime/common/repllocation_test.go
+++ b/runtime/common/repllocation_test.go
@@ -82,15 +82,35 @@ func TestDecodeREPLLocationTypeID(t *testing.T) {
 		require.EqualError(t, err, "invalid REPL location type ID: missing prefix")
 	})
 
-	t.Run("missing qualified identifier", func(t *testing.T) {
+	t.Run("missing qualified identifier part", func(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeREPLLocationTypeID("REPL")
-		require.EqualError(t, err, "invalid REPL location type ID: missing qualified identifier")
+		location, qualifiedIdentifier, err := decodeREPLLocationTypeID("REPL")
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			REPLLocation{},
+			location,
+		)
+		assert.Equal(t, "", qualifiedIdentifier)
 	})
 
-	t.Run("missing qualified identifier", func(t *testing.T) {
+	t.Run("empty qualified identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		location, qualifiedIdentifier, err := decodeREPLLocationTypeID("REPL.")
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			REPLLocation{},
+			location,
+		)
+		assert.Equal(t, "", qualifiedIdentifier)
+	})
+
+	t.Run("invalid prefix", func(t *testing.T) {
 
 		t.Parallel()
 

--- a/runtime/common/scriptlocation_test.go
+++ b/runtime/common/scriptlocation_test.go
@@ -105,10 +105,10 @@ func TestDecodeScriptLocationTypeID(t *testing.T) {
 			ScriptLocation{0x1, 0x2},
 			location,
 		)
-		assert.Empty(t, qualifiedIdentifier)
+		assert.Equal(t, "", qualifiedIdentifier)
 	})
 
-	t.Run("missing qualified identifier", func(t *testing.T) {
+	t.Run("invalid prefix", func(t *testing.T) {
 
 		t.Parallel()
 

--- a/runtime/common/stringlocation.go
+++ b/runtime/common/stringlocation.go
@@ -103,11 +103,8 @@ func decodeStringLocationTypeID(gauge MemoryGauge, typeID string) (StringLocatio
 	parts := strings.SplitN(typeID, ".", 3)
 
 	pieceCount := len(parts)
-	switch pieceCount {
-	case 1:
+	if pieceCount == 1 {
 		return newError("missing location")
-	case 2:
-		return newError("missing qualified identifier")
 	}
 
 	prefix := parts[0]
@@ -122,7 +119,10 @@ func decodeStringLocationTypeID(gauge MemoryGauge, typeID string) (StringLocatio
 	}
 
 	location := NewStringLocation(gauge, parts[1])
-	qualifiedIdentifier := parts[2]
+	var qualifiedIdentifier string
+	if pieceCount > 2 {
+		qualifiedIdentifier = parts[2]
+	}
 
 	return location, qualifiedIdentifier, nil
 }

--- a/runtime/common/stringlocation_test.go
+++ b/runtime/common/stringlocation_test.go
@@ -91,15 +91,35 @@ func TestDecodeStringLocationTypeID(t *testing.T) {
 		require.EqualError(t, err, "invalid string location type ID: missing location")
 	})
 
-	t.Run("missing qualified identifier", func(t *testing.T) {
+	t.Run("missing qualified identifier part", func(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeStringLocationTypeID(nil, "S.test")
-		require.EqualError(t, err, "invalid string location type ID: missing qualified identifier")
+		location, qualifiedIdentifier, err := decodeStringLocationTypeID(nil, "S.test")
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			StringLocation("test"),
+			location,
+		)
+		assert.Equal(t, "", qualifiedIdentifier)
 	})
 
-	t.Run("missing qualified identifier", func(t *testing.T) {
+	t.Run("empty qualified identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		location, qualifiedIdentifier, err := decodeStringLocationTypeID(nil, "S.test.")
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			StringLocation("test"),
+			location,
+		)
+		assert.Equal(t, "", qualifiedIdentifier)
+	})
+
+	t.Run("invalid prefix", func(t *testing.T) {
 
 		t.Parallel()
 

--- a/runtime/common/transactionlocation_test.go
+++ b/runtime/common/transactionlocation_test.go
@@ -105,10 +105,10 @@ func TestDecodeTransactionLocationTypeID(t *testing.T) {
 			TransactionLocation{0x1, 0x2},
 			location,
 		)
-		assert.Empty(t, qualifiedIdentifier)
+		assert.Equal(t, "", qualifiedIdentifier)
 	})
 
-	t.Run("missing qualified identifier", func(t *testing.T) {
+	t.Run("invalid prefix", func(t *testing.T) {
 
 		t.Parallel()
 

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -109,11 +109,6 @@ func decodeFlowLocationTypeID(typeID string) (FlowLocation, string, error) {
 
 	parts := strings.SplitN(typeID, ".", 2)
 
-	pieceCount := len(parts)
-	if pieceCount == 1 {
-		return newError("missing qualified identifier")
-	}
-
 	prefix := parts[0]
 
 	if prefix != FlowLocationPrefix {
@@ -125,7 +120,11 @@ func decodeFlowLocationTypeID(typeID string) (FlowLocation, string, error) {
 		)
 	}
 
-	qualifiedIdentifier := parts[1]
+	var qualifiedIdentifier string
+	pieceCount := len(parts)
+	if pieceCount > 1 {
+		qualifiedIdentifier = parts[1]
+	}
 
 	return FlowLocation{}, qualifiedIdentifier, nil
 }

--- a/runtime/stdlib/flow_test.go
+++ b/runtime/stdlib/flow_test.go
@@ -103,15 +103,35 @@ func TestDecodeFlowLocationTypeID(t *testing.T) {
 		require.EqualError(t, err, "invalid Flow location type ID: missing prefix")
 	})
 
-	t.Run("missing qualified identifier", func(t *testing.T) {
+	t.Run("missing qualified identifier part", func(t *testing.T) {
 
 		t.Parallel()
 
-		_, _, err := decodeFlowLocationTypeID("flow")
-		require.EqualError(t, err, "invalid Flow location type ID: missing qualified identifier")
+		location, qualifiedIdentifier, err := decodeFlowLocationTypeID("flow")
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			FlowLocation{},
+			location,
+		)
+		assert.Equal(t, "", qualifiedIdentifier)
 	})
 
-	t.Run("missing qualified identifier", func(t *testing.T) {
+	t.Run("empty qualified identifier", func(t *testing.T) {
+
+		t.Parallel()
+
+		location, qualifiedIdentifier, err := decodeFlowLocationTypeID("flow.")
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			FlowLocation{},
+			location,
+		)
+		assert.Equal(t, "", qualifiedIdentifier)
+	})
+
+	t.Run("invalid prefix", func(t *testing.T) {
 
 		t.Parallel()
 


### PR DESCRIPTION
Work towards 

## Description

The code coverage functionality serializes locations to strings using the new `ID` function on `Location`.
It is also necessary to deserialize a location ID back into a location.

The type ID decoding function `DecodeTypeID` already decodes type IDs, which are location + qualified identifier. However, it rejects missing qualified identifiers.

Instead of duplicating the location decoding part, change `DecodeTypeID` to return an empty qualified identifier instead of an error. Returning an error is not strictly necessary, there is nothing special about an empty qualified identifier per-se. Users of the `DecodeTypeID` function may decide themselves if an empty qualified identifier is an error or not.

See #2391 for more details

cc @m-Peter 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
