### PR TITLE
Revised and extended documentation of `unsafeRandom`

### DIFF
--- a/docs/language/built-in-functions.mdx
+++ b/docs/language/built-in-functions.mdx
@@ -37,10 +37,30 @@ fun unsafeRandom(): UInt64
 
   Returns a pseudo-random number.
 
-  NOTE: The use of this function is unsafe if not used correctly.
+  NOTE: 
+  Smart contract developers should be mindful about the limitations of unsafeRandom. 
+  The stream of random numbers produced is potentially unsafe in the following two regards:
 
-  Follow [best practices](https://consensys.github.io/smart-contract-best-practices/development-recommendations/general/public-data/)
-  to prevent security issues when using this function.
+  1. The sequence of random numbers is potentially predictable by transactions within the same block
+  and by other smart contracts calling into your smart contract.
+  2. A transaction calling into your smart contract can potentially bias the sequence of random numbers which
+  your smart contract internally generates. 
+  
+  We are working towards removing these limitations incrementally. Once these points are addressed, 
+  Flow’s randomness is safe and we will remove the "unsafe" qualifier.
+
+  Nevertheless, there is an additional safety-relevant aspect that developers need to be mindful about:
+
+  * A transaction can atomically revert all its action at any time. Therefore, it is possible for a transaction calling into
+  your smart contract to post-select favourable results and revert the transaction for unfavourable results.
+  ([example](https://consensys.github.io/smart-contract-best-practices/development-recommendations/general/public-data/))
+
+  This limitation is inherent to any smart contract platform that allows transactions to roll back atomically and cannot be
+  solved through safe randomness alone.  Providing additional Cadence language primitives to simplify this challenge for
+  developers is on our roadmap as well. Nevertheless, with safe randomness (points 1 and 2 above resolved), developers can prevent
+  clients from post-select favourable outcomes using approaches such as described in the
+  [example](https://consensys.github.io/smart-contract-best-practices/development-recommendations/general/public-data/).
+
 
 ## RLP
 


### PR DESCRIPTION
## Description

Up to this point, our documentation of `unsafeRandom` was rudimentary skipping over safety-critical aspects. This revision adds the missing details and provides an outlook on the further evolution of unsafe random. 

Note:
* In the documentation, we are only covering the aspects of `unsafeRandom` here that are relevant to the developer. 
* There is an additional subtle topic about consensus nodes potentially being able to bias the random beacon and thereby implicitly stream of random numbers generated by `unsafeRandom`:
  * At the moment, we use the block hash to seed unsafe random, which allows consensus nodes to easily sample a few seeds and select one by hash-grinding the block.  However, at the moment, all consensus nodes are operated by trusted entities and therefore we can be certain that this kind of attack is not happening. 

    Before consensus nodes become permissionless, we will switch `unsafeRandom` from using the block hash to using the random beacon for seeding (probably some but not too much work).  
  * The consensus upgrade from vanilla HotStuff to its derivative Jolteon makes it significantly harder for individual consensus nodes to bias the random beacon. This is because we now finalize on the happy path already at 2 children instead of previously 3. This gives malicious consensus nodes just less opportunities to create forks to bias the random beacon. In addition, the new active pacemaker carries quorum certificates through timeout rounds and thereby restricts possibility choices for basing consensus nodes even further.
  
    Furthermore, a consensus nodes would need to collude with execution nodes to determine what seed results in a favourable sequence of randoms. A consensus nodes only has 1 - 3 seconds of a time window to publish its block. In practise this time window is significantly too small for any consensus nodes needing to make an _informed_ decision whether it wants to bias the random beacon (i.e. orphan the last block). 
  
    So a theoretical possibility to bias the random beacon is still there, but it is very hard, with still vanishing success probability in practise.


   However, there is nothing the developer can do about these and at the moment there is no risk of these biassing attacks  being mounted at the moment. We will fix them on a platform level before we admit any untrusted consensus nodes. 

---

- [x] Targeted PR against master branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed Files changed in the Github PR explorer
- [x] Added appropriate labels