### PR TITLE
Generate labels and identifiers for function parameters in Go code generator

### DIFF
--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/pretty"
+	"github.com/onflow/cadence/runtime/sema"
 
 	"github.com/dave/dst"
 )
@@ -265,6 +266,7 @@ func (g *generator) addFunctionTypeDeclaration(
 					ReturnTypeAnnotation:     decl.ReturnTypeAnnotation,
 					ParameterTypeAnnotations: parameterTypeAnnotations,
 				},
+				decl.ParameterList,
 				decl.TypeParameterList,
 				typeParams,
 			),
@@ -501,7 +503,7 @@ func typeExpr(t ast.Type, typeParams map[string]string) dst.Expr {
 		}
 
 	case *ast.FunctionType:
-		return functionTypeExpr(t, nil, typeParams)
+		return functionTypeExpr(t, nil, nil, typeParams)
 
 	case *ast.InstantiationType:
 		typeArguments := t.TypeArguments
@@ -533,6 +535,7 @@ func typeExpr(t ast.Type, typeParams map[string]string) dst.Expr {
 
 func functionTypeExpr(
 	t *ast.FunctionType,
+	parameters *ast.ParameterList,
 	typeParameterList *ast.TypeParameterList,
 	typeParams map[string]string,
 ) dst.Expr {
@@ -583,16 +586,48 @@ func functionTypeExpr(
 	if parameterCount > 0 {
 		parameterExprs := make([]dst.Expr, 0, parameterCount)
 
-		for _, parameterTypeAnnotation := range parameterTypeAnnotations {
+		for parameterIndex, parameterTypeAnnotation := range parameterTypeAnnotations {
+
+			var parameterElements []dst.Expr
+
+			if parameters != nil {
+				parameter := parameters.Parameters[parameterIndex]
+
+				if parameter.Label != "" {
+					var lit dst.Expr
+					if parameter.Label == sema.ArgumentLabelNotRequired {
+						lit = &dst.Ident{
+							Path: "github.com/onflow/cadence/runtime/sema",
+							Name: "ArgumentLabelNotRequired",
+						}
+					} else {
+						lit = goStringLit(parameter.Label)
+					}
+
+					parameterElements = append(
+						parameterElements,
+						goKeyValue("Label", lit),
+					)
+				}
+
+				parameterElements = append(
+					parameterElements,
+					goKeyValue("Identifier", goStringLit(parameter.Identifier.Identifier)),
+				)
+			}
+
+			parameterElements = append(
+				parameterElements,
+				goKeyValue(
+					"TypeAnnotation",
+					typeAnnotationCallExpr(typeExpr(parameterTypeAnnotation.Type, typeParams)),
+				),
+			)
 
 			parameterExpr := &dst.CompositeLit{
-				Elts: []dst.Expr{
-					goKeyValue(
-						"TypeAnnotation",
-						typeAnnotationCallExpr(typeExpr(parameterTypeAnnotation.Type, typeParams)),
-					),
-				},
+				Elts: parameterElements,
 			}
+
 			parameterExpr.Decorations().Before = dst.NewLine
 			parameterExpr.Decorations().After = dst.NewLine
 

--- a/runtime/sema/gen/testdata/docstrings.golden.go
+++ b/runtime/sema/gen/testdata/docstrings.golden.go
@@ -48,6 +48,7 @@ const DocstringsTypeNwnFunctionName = "nwn"
 var DocstringsTypeNwnFunctionType = &FunctionType{
 	Parameters: []Parameter{
 		{
+			Identifier:     "x",
 			TypeAnnotation: NewTypeAnnotation(IntType),
 		},
 	},

--- a/runtime/sema/gen/testdata/functions.golden.go
+++ b/runtime/sema/gen/testdata/functions.golden.go
@@ -22,6 +22,7 @@ package sema
 import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
 )
 
 const TestTypeNothingFunctionName = "nothing"
@@ -41,9 +42,12 @@ const TestTypeParamsFunctionName = "params"
 var TestTypeParamsFunctionType = &FunctionType{
 	Parameters: []Parameter{
 		{
+			Identifier:     "a",
 			TypeAnnotation: NewTypeAnnotation(IntType),
 		},
 		{
+			Label:          sema.ArgumentLabelNotRequired,
+			Identifier:     "b",
 			TypeAnnotation: NewTypeAnnotation(StringType),
 		},
 	},
@@ -73,9 +77,12 @@ const TestTypeParamsAndReturnFunctionName = "paramsAndReturn"
 var TestTypeParamsAndReturnFunctionType = &FunctionType{
 	Parameters: []Parameter{
 		{
+			Identifier:     "a",
 			TypeAnnotation: NewTypeAnnotation(IntType),
 		},
 		{
+			Label:          sema.ArgumentLabelNotRequired,
+			Identifier:     "b",
 			TypeAnnotation: NewTypeAnnotation(StringType),
 		},
 	},
@@ -141,6 +148,7 @@ var TestTypeTypeParamWithBoundAndParamFunctionType = &FunctionType{
 	},
 	Parameters: []Parameter{
 		{
+			Identifier: "t",
 			TypeAnnotation: NewTypeAnnotation(&GenericType{
 				TypeParameter: TestTypeTypeParamWithBoundAndParamFunctionTypeParameterT,
 			}),


### PR DESCRIPTION
## Description

When translating a function declaration in a Cadence to equivalent Go code, also translate the parameters' identifier and argument label accordingly.

Required for #2091 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
