### PR TITLE
Introduce a `CoverageReport` field on `runtime.Config` type

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -34,7 +34,10 @@ type Config struct {
 	// ResourceOwnerChangeCallbackEnabled configures if the resource owner change callback is enabled
 	ResourceOwnerChangeHandlerEnabled bool
 	// CoverageReportingEnabled configures if coverage reporting is enabled
+	// Deprecated: Use the `CoverageReport` field instead
 	CoverageReportingEnabled bool
+	// CoverageReport enables and collects coverage reporting metrics
+	CoverageReport *CoverageReport
 	// AccountLinkingEnabled specifies if account linking is enabled
 	AccountLinkingEnabled bool
 	// AttachmentsEnabled specifies if attachments are enabled

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -33,9 +33,6 @@ type Config struct {
 	TracingEnabled bool
 	// ResourceOwnerChangeCallbackEnabled configures if the resource owner change callback is enabled
 	ResourceOwnerChangeHandlerEnabled bool
-	// CoverageReportingEnabled configures if coverage reporting is enabled
-	// Deprecated: Use the `CoverageReport` field instead
-	CoverageReportingEnabled bool
 	// CoverageReport enables and collects coverage reporting metrics
 	CoverageReport *CoverageReport
 	// AccountLinkingEnabled specifies if account linking is enabled

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -1150,10 +1150,6 @@ func TestRuntimeCoverage(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewInterpreterRuntime(Config{
-		CoverageReportingEnabled: true,
-	})
-
 	importedScript := []byte(`
 	  pub let specialNumbers: {Int: String} = {
 	    1729: "Harshad",
@@ -1234,6 +1230,7 @@ func TestRuntimeCoverage(t *testing.T) {
 	  }
 	`)
 
+	coverageReport := NewCoverageReport()
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(location Location) (bytes []byte, err error) {
 			switch location {
@@ -1244,8 +1241,9 @@ func TestRuntimeCoverage(t *testing.T) {
 			}
 		},
 	}
-
-	coverageReport := NewCoverageReport()
+	runtime := NewInterpreterRuntime(Config{
+		CoverageReport: coverageReport,
+	})
 
 	value, err := runtime.ExecuteScript(
 		Script{
@@ -1326,10 +1324,6 @@ func TestRuntimeCoverageWithExcludedLocation(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewInterpreterRuntime(Config{
-		CoverageReportingEnabled: true,
-	})
-
 	importedScript := []byte(`
 	  pub let specialNumbers: {Int: String} = {
 	    1729: "Harshad",
@@ -1390,6 +1384,10 @@ func TestRuntimeCoverageWithExcludedLocation(t *testing.T) {
 	  }
 	`)
 
+	coverageReport := NewCoverageReport()
+	scriptlocation := common.ScriptLocation{}
+	coverageReport.ExcludeLocation(scriptlocation)
+
 	runtimeInterface := &testRuntimeInterface{
 		getCode: func(location Location) (bytes []byte, err error) {
 			switch location {
@@ -1400,10 +1398,9 @@ func TestRuntimeCoverageWithExcludedLocation(t *testing.T) {
 			}
 		},
 	}
-
-	coverageReport := NewCoverageReport()
-	scriptlocation := common.ScriptLocation{}
-	coverageReport.ExcludeLocation(scriptlocation)
+	runtime := NewInterpreterRuntime(Config{
+		CoverageReport: coverageReport,
+	})
 
 	value, err := runtime.ExecuteScript(
 		Script{

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -906,6 +906,10 @@ func TestCoverageReportMerge(t *testing.T) {
 
 	otherLocation := common.StringLocation("Factorial")
 	otherCoverageReport.InspectProgram(otherLocation, otherProgram)
+	// We add `IntegerTraits` to both coverage reports, to test that their
+	// line hits are properly merged.
+	coverageReport.InspectProgram(location, program)
+	coverageReport.AddLineHit(location, 9)
 
 	excludedLocation := common.StringLocation("FooContract")
 	otherCoverageReport.ExcludeLocation(excludedLocation)
@@ -945,11 +949,11 @@ func TestCoverageReportMerge(t *testing.T) {
 	          "25": 0,
 	          "26": 0,
 	          "29": 0,
-	          "9": 0
+	          "9": 1
 	        },
-	        "missed_lines": [9, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 25, 26, 29],
+	        "missed_lines": [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 25, 26, 29],
 	        "statements": 14,
-	        "percentage": "0.0%"
+	        "percentage": "7.1%"
 	      }
 	    },
 	    "excluded_locations": ["S.FooContract"]

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -606,7 +606,7 @@ func (e *interpreterEnvironment) newInterpreter(
 }
 
 func (e *interpreterEnvironment) newOnStatementHandler() interpreter.OnStatementFunc {
-	if !e.config.CoverageReportingEnabled {
+	if e.config.CoverageReport == nil {
 		return nil
 	}
 


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2415

## Description

Introduce a `CoverageReport` field, which will hold the actual object. This can also deprecate the usage of `CoverageReportingEnabled`, by checking whether the `CoverageReport` is `nil` or not. If it's present, then coverage reporting should be enabled.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
