### PR TITLE
Add support for generating code of nested types

### DIFF
--- a/runtime/sema/authaccount_contracts.go
+++ b/runtime/sema/authaccount_contracts.go
@@ -75,8 +75,8 @@ var AuthAccountContractsType = func() *CompositeType {
 		),
 	}
 
-	authAccountContractsType.Members = GetMembersAsMap(members)
-	authAccountContractsType.Fields = GetFieldNames(members)
+	authAccountContractsType.Members = MembersAsMap(members)
+	authAccountContractsType.Fields = MembersFieldNames(members)
 	return authAccountContractsType
 }()
 

--- a/runtime/sema/authaccount_contracts.go
+++ b/runtime/sema/authaccount_contracts.go
@@ -80,11 +80,6 @@ var AuthAccountContractsType = func() *CompositeType {
 	return authAccountContractsType
 }()
 
-func init() {
-	// Set the container type after initializing the `AuthAccountContractsType`, to avoid initializing loop.
-	AuthAccountContractsType.SetContainerType(AuthAccountType)
-}
-
 const authAccountContractsTypeAddFunctionDocString = `
 Adds the given contract to the account.
 

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -254,8 +254,8 @@ var AuthAccountType = func() *CompositeType {
 		),
 	}
 
-	authAccountType.Members = GetMembersAsMap(members)
-	authAccountType.Fields = GetFieldNames(members)
+	authAccountType.Members = MembersAsMap(members)
+	authAccountType.Fields = MembersFieldNames(members)
 	return authAccountType
 }()
 
@@ -712,8 +712,8 @@ var AuthAccountKeysType = func() *CompositeType {
 		),
 	}
 
-	accountKeys.Members = GetMembersAsMap(members)
-	accountKeys.Fields = GetFieldNames(members)
+	accountKeys.Members = MembersAsMap(members)
+	accountKeys.Fields = MembersFieldNames(members)
 	return accountKeys
 }()
 
@@ -975,7 +975,7 @@ var AuthAccountInboxType = func() *CompositeType {
 		),
 	}
 
-	accountInbox.Members = GetMembersAsMap(members)
-	accountInbox.Fields = GetFieldNames(members)
+	accountInbox.Members = MembersAsMap(members)
+	accountInbox.Fields = MembersFieldNames(members)
 	return accountInbox
 }()

--- a/runtime/sema/authaccount_type.go
+++ b/runtime/sema/authaccount_type.go
@@ -68,14 +68,11 @@ var AuthAccountType = func() *CompositeType {
 		Kind:               common.CompositeKindStructure,
 		hasComputedMembers: true,
 		importable:         false,
-		NestedTypes: func() *StringTypeOrderedMap {
-			nestedTypes := &StringTypeOrderedMap{}
-			nestedTypes.Set(AuthAccountContractsTypeName, AuthAccountContractsType)
-			nestedTypes.Set(AccountKeysTypeName, AuthAccountKeysType)
-			nestedTypes.Set(AuthAccountInboxTypeName, AuthAccountInboxType)
-			return nestedTypes
-		}(),
 	}
+
+	authAccountType.SetNestedType(AuthAccountContractsTypeName, AuthAccountContractsType)
+	authAccountType.SetNestedType(AccountKeysTypeName, AuthAccountKeysType)
+	authAccountType.SetNestedType(AuthAccountInboxTypeName, AuthAccountInboxType)
 
 	AuthAccountTypeLinkAccountFunctionType = &FunctionType{
 		Parameters: []Parameter{
@@ -785,11 +782,6 @@ var AuthAccountKeysTypeRevokeFunctionType = &FunctionType{
 	},
 	ReturnTypeAnnotation:  NewTypeAnnotation(&OptionalType{Type: AccountKeyType}),
 	RequiredArgumentCount: RequiredArgumentCount(1),
-}
-
-func init() {
-	// Set the container type after initializing the AccountKeysTypes, to avoid initializing loop.
-	AuthAccountKeysType.SetContainerType(AuthAccountType)
 }
 
 const AccountKeysTypeName = "Keys"

--- a/runtime/sema/block.gen.go
+++ b/runtime/sema/block.gen.go
@@ -19,11 +19,6 @@
 
 package sema
 
-import (
-	"github.com/onflow/cadence/runtime/ast"
-	"github.com/onflow/cadence/runtime/common"
-)
-
 const BlockTypeHeightFieldName = "height"
 
 var BlockTypeHeightFieldType = UInt64Type
@@ -79,71 +74,31 @@ var BlockType = &SimpleType{
 	Exportable:    false,
 	Importable:    false,
 	Members: func(t *SimpleType) map[string]MemberResolver {
-		return map[string]MemberResolver{
-			BlockTypeHeightFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						BlockTypeHeightFieldType,
-						BlockTypeHeightFieldDocString,
-					)
-				},
-			},
-			BlockTypeViewFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						BlockTypeViewFieldType,
-						BlockTypeViewFieldDocString,
-					)
-				},
-			},
-			BlockTypeTimestampFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						BlockTypeTimestampFieldType,
-						BlockTypeTimestampFieldDocString,
-					)
-				},
-			},
-			BlockTypeIdFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						BlockTypeIdFieldType,
-						BlockTypeIdFieldDocString,
-					)
-				},
-			},
-		}
+		return MembersAsResolvers([]*Member{
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				BlockTypeHeightFieldName,
+				BlockTypeHeightFieldType,
+				BlockTypeHeightFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				BlockTypeViewFieldName,
+				BlockTypeViewFieldType,
+				BlockTypeViewFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				BlockTypeTimestampFieldName,
+				BlockTypeTimestampFieldType,
+				BlockTypeTimestampFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				BlockTypeIdFieldName,
+				BlockTypeIdFieldType,
+				BlockTypeIdFieldDocString,
+			),
+		})
 	},
 }

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -303,8 +303,8 @@ func newNativeEnumType(
 		),
 	)
 
-	ty.Members = GetMembersAsMap(members)
-	ty.Fields = GetFieldNames(members)
+	ty.Members = MembersAsMap(members)
+	ty.Fields = MembersFieldNames(members)
 	return ty
 }
 

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -388,7 +388,7 @@ func (g *generator) VisitCompositeDeclaration(decl *ast.CompositeDeclaration) (_
 		case "Storable":
 			if !canGenerateSimpleType {
 				panic(fmt.Errorf(
-					"composite types cannot be explictly marked as storable: %s",
+					"composite types cannot be explicitly marked as storable: %s",
 					g.currentTypeID(),
 				))
 			}
@@ -397,7 +397,7 @@ func (g *generator) VisitCompositeDeclaration(decl *ast.CompositeDeclaration) (_
 		case "Equatable":
 			if !canGenerateSimpleType {
 				panic(fmt.Errorf(
-					"composite types cannot be explictly marked as equatable: %s",
+					"composite types cannot be explicitly marked as equatable: %s",
 					g.currentTypeID(),
 				))
 			}
@@ -406,7 +406,7 @@ func (g *generator) VisitCompositeDeclaration(decl *ast.CompositeDeclaration) (_
 		case "Exportable":
 			if !canGenerateSimpleType {
 				panic(fmt.Errorf(
-					"composite types cannot be explictly marked as exportable: %s",
+					"composite types cannot be explicitly marked as exportable: %s",
 					g.currentTypeID(),
 				))
 			}
@@ -874,13 +874,6 @@ func goBoolLit(b bool) dst.Expr {
 		return dst.NewIdent(strconv.FormatBool(true))
 	}
 	return dst.NewIdent(strconv.FormatBool(false))
-}
-
-func declarationKindExpr(kind string) *dst.Ident {
-	return &dst.Ident{
-		Path: "github.com/onflow/cadence/runtime/common",
-		Name: fmt.Sprintf("DeclarationKind%s", kind),
-	}
 }
 
 func compositeKindExpr(compositeKind common.CompositeKind) *dst.Ident {

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -578,6 +578,10 @@ func typeExpr(t ast.Type, typeParams map[string]string) dst.Expr {
 					Type: dst.NewIdent("CapabilityType"),
 				},
 			}
+		default:
+			for _, nestedIdentifier := range t.NestedIdentifiers {
+				identifier += nestedIdentifier.Identifier
+			}
 		}
 
 		return typeVarIdent(identifier)

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -662,7 +662,6 @@ func functionTypeExpr(
 					// and code generation will still succeed
 					if parameter.Label == "_" {
 						lit = &dst.Ident{
-							Path: "github.com/onflow/cadence/runtime/sema",
 							Name: "ArgumentLabelNotRequired",
 						}
 					} else {

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -30,13 +30,12 @@ import (
 	"github.com/dave/dst/decorator"
 	"github.com/dave/dst/decorator/resolver/guess"
 
+	"github.com/dave/dst"
+
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/pretty"
-	"github.com/onflow/cadence/runtime/sema"
-
-	"github.com/dave/dst"
 )
 
 const headerTemplate = `// Code generated from {{ . }}. DO NOT EDIT.
@@ -658,7 +657,10 @@ func functionTypeExpr(
 
 				if parameter.Label != "" {
 					var lit dst.Expr
-					if parameter.Label == sema.ArgumentLabelNotRequired {
+					// NOTE: avoid import of sema (ArgumentLabelNotRequired),
+					// so sema can be in a non-buildable state
+					// and code generation will still succeed
+					if parameter.Label == "_" {
 						lit = &dst.Ident{
 							Path: "github.com/onflow/cadence/runtime/sema",
 							Name: "ArgumentLabelNotRequired",

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -162,9 +162,7 @@ type generator struct {
 var _ ast.DeclarationVisitor[struct{}] = &generator{}
 
 func (g *generator) addDecls(decls ...dst.Decl) {
-	for _, decl := range decls {
-		g.decls = append(g.decls, decl)
-	}
+	g.decls = append(g.decls, decls...)
 }
 
 func (*generator) VisitVariableDeclaration(_ *ast.VariableDeclaration) struct{} {

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -143,9 +143,21 @@ func renderDocString(s string) dst.Expr {
 	return result
 }
 
+type typeDecl struct {
+	typeName           string
+	fullTypeName       string
+	compositeKind      common.CompositeKind
+	storable           bool
+	equatable          bool
+	exportable         bool
+	importable         bool
+	memberDeclarations []ast.Declaration
+	nestedTypes        []*typeDecl
+}
+
 type generator struct {
-	containerTypeNames []string
-	decls              []dst.Decl
+	typeStack []*typeDecl
+	decls     []dst.Decl
 }
 
 var _ ast.DeclarationVisitor[struct{}] = &generator{}
@@ -161,7 +173,7 @@ func (*generator) VisitVariableDeclaration(_ *ast.VariableDeclaration) struct{} 
 }
 
 func (g *generator) VisitFunctionDeclaration(decl *ast.FunctionDeclaration) (_ struct{}) {
-	if len(g.containerTypeNames) == 0 {
+	if len(g.typeStack) == 0 {
 		panic("global function declarations are not supported")
 	}
 
@@ -170,7 +182,7 @@ func (g *generator) VisitFunctionDeclaration(decl *ast.FunctionDeclaration) (_ s
 	}
 
 	functionName := decl.Identifier.Identifier
-	fullTypeName := g.fullTypeName()
+	fullTypeName := g.currentFullTypeName()
 
 	g.addFunctionNameDeclaration(fullTypeName, functionName)
 
@@ -296,7 +308,7 @@ func (g *generator) declarationDocString(decl ast.Declaration) dst.Expr {
 	if len(docString) == 0 {
 		panic(fmt.Errorf(
 			"missing doc string for %s",
-			g.memberID(identifier),
+			g.currentMemberID(identifier),
 		))
 	}
 
@@ -308,72 +320,119 @@ func (*generator) VisitSpecialFunctionDeclaration(_ *ast.SpecialFunctionDeclarat
 }
 
 func (g *generator) VisitCompositeDeclaration(decl *ast.CompositeDeclaration) (_ struct{}) {
-	var isResource bool
 
 	compositeKind := decl.CompositeKind
 	switch compositeKind {
-	case common.CompositeKindStructure:
+	case common.CompositeKindStructure,
+		common.CompositeKindResource:
 		break
-	case common.CompositeKindResource:
-		isResource = true
 	default:
 		panic(fmt.Sprintf("%s declarations are not supported", compositeKind.Name()))
 	}
 
 	typeName := decl.Identifier.Identifier
 
-	g.containerTypeNames = append(g.containerTypeNames, typeName)
+	typeDecl := &typeDecl{
+		typeName:      typeName,
+		fullTypeName:  g.newFullTypeName(typeName),
+		compositeKind: compositeKind,
+	}
+
+	if len(g.typeStack) > 0 {
+		parentType := g.typeStack[len(g.typeStack)-1]
+		parentType.nestedTypes = append(
+			parentType.nestedTypes,
+			typeDecl,
+		)
+	}
+
+	g.typeStack = append(
+		g.typeStack,
+		typeDecl,
+	)
 	defer func() {
-		g.containerTypeNames = g.containerTypeNames[:len(g.containerTypeNames)-1]
+		// Pop
+		lastIndex := len(g.typeStack) - 1
+		g.typeStack[lastIndex] = nil
+		g.typeStack = g.typeStack[:lastIndex]
 	}()
 
-	var memberDeclarations []ast.Declaration
+	// We can generate a SimpleType declaration,
+	// if this is a top-level type,
+	// and this declaration has no nested type declarations.
+	// Otherwise, we have to generate a CompositeType
+
+	canGenerateSimpleType := len(g.typeStack) == 1
 
 	for _, memberDeclaration := range decl.Members.Declarations() {
 		ast.AcceptDeclaration[struct{}](memberDeclaration, g)
 
 		// Visiting unsupported declarations panics,
 		// so only supported member declarations are added
-		memberDeclarations = append(memberDeclarations, memberDeclaration)
-	}
+		typeDecl.memberDeclarations = append(
+			typeDecl.memberDeclarations,
+			memberDeclaration,
+		)
 
-	var (
-		equatable,
-		storable,
-		exportable,
-		importable bool
-	)
+		switch memberDeclaration.(type) {
+		case *ast.FieldDeclaration,
+			*ast.FunctionDeclaration:
+			break
+
+		default:
+			canGenerateSimpleType = false
+		}
+	}
 
 	for _, conformance := range decl.Conformances {
 		switch conformance.Identifier.Identifier {
 		case "Storable":
-			storable = true
+			if !canGenerateSimpleType {
+				panic(fmt.Errorf(
+					"composite types cannot be explictly marked as storable: %s",
+					g.currentTypeID(),
+				))
+			}
+			typeDecl.storable = true
+
 		case "Equatable":
-			equatable = true
+			if !canGenerateSimpleType {
+				panic(fmt.Errorf(
+					"composite types cannot be explictly marked as equatable: %s",
+					g.currentTypeID(),
+				))
+			}
+			typeDecl.equatable = true
+
 		case "Exportable":
-			exportable = true
+			if !canGenerateSimpleType {
+				panic(fmt.Errorf(
+					"composite types cannot be explictly marked as exportable: %s",
+					g.currentTypeID(),
+				))
+			}
+			typeDecl.exportable = true
+
 		case "Importable":
-			importable = true
+			typeDecl.importable = true
 		}
+	}
+
+	var typeVarDecl dst.Expr
+	if canGenerateSimpleType {
+		typeVarDecl = simpleTypeLiteral(typeDecl)
+	} else {
+		typeVarDecl = compositeTypeExpr(typeDecl)
 	}
 
 	g.addDecls(
 		goConstDecl(
-			typeNameVarName(typeName),
+			typeNameVarName(typeDecl.fullTypeName),
 			goStringLit(typeName),
 		),
 		goVarDecl(
-			fmt.Sprintf("%sType", typeName),
-			simpleTypeLiteral(simpleType{
-				typeName:           typeName,
-				fullTypeName:       g.fullTypeName(),
-				isResource:         isResource,
-				Storable:           storable,
-				Equatable:          equatable,
-				Exportable:         exportable,
-				Importable:         importable,
-				memberDeclarations: memberDeclarations,
-			}),
+			typeVarName(typeDecl.fullTypeName),
+			typeVarDecl,
 		),
 	)
 
@@ -394,7 +453,7 @@ func (*generator) VisitTransactionDeclaration(_ *ast.TransactionDeclaration) str
 
 func (g *generator) VisitFieldDeclaration(decl *ast.FieldDeclaration) (_ struct{}) {
 	fieldName := decl.Identifier.Identifier
-	fullTypeName := g.fullTypeName()
+	fullTypeName := g.currentFullTypeName()
 	docString := g.declarationDocString(decl)
 
 	g.addDecls(
@@ -413,6 +472,10 @@ func (g *generator) VisitFieldDeclaration(decl *ast.FieldDeclaration) (_ struct{
 	)
 
 	return
+}
+
+func (g *generator) currentFullTypeName() string {
+	return g.typeStack[len(g.typeStack)-1].fullTypeName
 }
 
 func typeExpr(t ast.Type, typeParams map[string]string) dst.Expr {
@@ -710,15 +773,36 @@ func (*generator) VisitImportDeclaration(_ *ast.ImportDeclaration) struct{} {
 	panic("import declarations are not supported")
 }
 
-func (g *generator) fullTypeName() string {
-	return strings.Join(g.containerTypeNames, "")
+func (g *generator) newFullTypeName(typeName string) string {
+	if len(g.typeStack) == 0 {
+		return typeName
+	}
+	parentFullTypeName := g.typeStack[len(g.typeStack)-1].fullTypeName
+	return parentFullTypeName + typeName
 }
 
-func (g *generator) memberID(fieldName string) string {
-	return fmt.Sprintf("%s.%s",
-		strings.Join(g.containerTypeNames, "."),
-		fieldName,
-	)
+func (g *generator) currentTypeID() string {
+	var b strings.Builder
+	for i := range g.typeStack {
+		if i > 0 {
+			b.WriteByte('.')
+		}
+		b.WriteString(g.typeStack[i].typeName)
+	}
+	return b.String()
+}
+
+func (g *generator) currentMemberID(memberName string) string {
+	var b strings.Builder
+	for i := range g.typeStack {
+		if i > 0 {
+			b.WriteByte('.')
+		}
+		b.WriteString(g.typeStack[i].typeName)
+	}
+	b.WriteByte('.')
+	b.WriteString(memberName)
+	return b.String()
 }
 
 func goField(name string, ty dst.Expr) *dst.Field {
@@ -798,6 +882,13 @@ func declarationKindExpr(kind string) *dst.Ident {
 	}
 }
 
+func compositeKindExpr(compositeKind common.CompositeKind) *dst.Ident {
+	return &dst.Ident{
+		Path: "github.com/onflow/cadence/runtime/common",
+		Name: compositeKind.String(),
+	}
+}
+
 func typeVarName(typeName string) string {
 	return fmt.Sprintf("%sType", typeName)
 }
@@ -856,28 +947,31 @@ func functionDocStringVarName(fullTypeName, functionName string) string {
 	return memberVarName(fullTypeName, functionName, "Function", "DocString")
 }
 
-type simpleType struct {
-	typeName           string
-	fullTypeName       string
-	isResource         bool
-	Storable           bool
-	Equatable          bool
-	Exportable         bool
-	Importable         bool
-	memberDeclarations []ast.Declaration
-}
+func simpleTypeLiteral(ty *typeDecl) dst.Expr {
 
-func simpleTypeLiteral(ty simpleType) dst.Expr {
+	// &SimpleType{
+	//	Name:          TestTypeName,
+	//	QualifiedName: TestTypeName,
+	//	TypeID:        TestTypeName,
+	//	tag:           TestTypeTag,
+	//	IsResource:    true,
+	//	Storable:      false,
+	//	Equatable:     false,
+	//	Exportable:    false,
+	//	Importable:    false,
+	//}
+
+	isResource := ty.compositeKind == common.CompositeKindResource
 	elements := []dst.Expr{
-		goKeyValue("Name", typeNameVarIdent(ty.typeName)),
-		goKeyValue("QualifiedName", typeNameVarIdent(ty.typeName)),
-		goKeyValue("TypeID", typeNameVarIdent(ty.typeName)),
-		goKeyValue("tag", typeTagVarIdent(ty.typeName)),
-		goKeyValue("IsResource", goBoolLit(ty.isResource)),
-		goKeyValue("Storable", goBoolLit(ty.Storable)),
-		goKeyValue("Equatable", goBoolLit(ty.Equatable)),
-		goKeyValue("Exportable", goBoolLit(ty.Exportable)),
-		goKeyValue("Importable", goBoolLit(ty.Importable)),
+		goKeyValue("Name", typeNameVarIdent(ty.fullTypeName)),
+		goKeyValue("QualifiedName", typeNameVarIdent(ty.fullTypeName)),
+		goKeyValue("TypeID", typeNameVarIdent(ty.fullTypeName)),
+		goKeyValue("tag", typeTagVarIdent(ty.fullTypeName)),
+		goKeyValue("IsResource", goBoolLit(isResource)),
+		goKeyValue("Storable", goBoolLit(ty.storable)),
+		goKeyValue("Equatable", goBoolLit(ty.equatable)),
+		goKeyValue("Exportable", goBoolLit(ty.exportable)),
+		goKeyValue("Importable", goBoolLit(ty.importable)),
 	}
 
 	if len(ty.memberDeclarations) > 0 {
@@ -903,8 +997,6 @@ func simpleTypeMembers(fullTypeName string, declarations []ast.Declaration) dst.
 	elements := make([]dst.Expr, 0, len(declarations))
 
 	for _, declaration := range declarations {
-		resolve := simpleTypeMemberResolver(fullTypeName, declaration)
-
 		var memberName string
 		var kind dst.Expr
 
@@ -927,12 +1019,21 @@ func simpleTypeMembers(fullTypeName string, declarations []ast.Declaration) dst.
 			)
 			kind = declarationKindExpr("Function")
 
+		case common.DeclarationKindStructureInterface,
+			common.DeclarationKindStructure,
+			common.DeclarationKindResource,
+			common.DeclarationKindResourceInterface:
+
+			continue
+
 		default:
 			panic(fmt.Errorf(
 				"%s members are not supported",
 				declarationKind.Name(),
 			))
 		}
+
+		resolve := simpleTypeMemberResolver(fullTypeName, declaration)
 
 		elements = append(
 			elements,
@@ -1123,6 +1224,98 @@ func stringMemberResolverMapType() *dst.MapType {
 	return &dst.MapType{
 		Key:   dst.NewIdent("string"),
 		Value: dst.NewIdent("MemberResolver"),
+	}
+}
+
+func compositeTypeExpr(ty *typeDecl) dst.Expr {
+
+	// func() *CompositeType {
+	// 	var t = &CompositeType{
+	// 		Identifier:         FooTypeName,
+	// 		Kind:               common.CompositeKindStructure,
+	// 		importable:         false,
+	// 		hasComputedMembers: true,
+	// 	}
+	//
+	// 	t.SetNestedType(FooBarTypeName, FooBarType)
+	// 	return t
+	// }()
+
+	const typeVarName = "t"
+
+	statements := []dst.Stmt{
+		&dst.DeclStmt{
+			Decl: goVarDecl(
+				typeVarName,
+				compositeTypeLiteral(ty),
+			),
+		},
+	}
+
+	for _, nestedType := range ty.nestedTypes {
+		statements = append(
+			statements,
+			&dst.ExprStmt{
+				X: &dst.CallExpr{
+					Fun: &dst.SelectorExpr{
+						X:   dst.NewIdent(typeVarName),
+						Sel: dst.NewIdent("SetNestedType"),
+					},
+					Args: []dst.Expr{
+						typeNameVarIdent(nestedType.fullTypeName),
+						typeVarIdent(nestedType.fullTypeName),
+					},
+				},
+			},
+		)
+	}
+
+	statements = append(
+		statements,
+		&dst.ReturnStmt{
+			Results: []dst.Expr{
+				dst.NewIdent(typeVarName),
+			},
+		},
+	)
+
+	return &dst.CallExpr{
+		Fun: &dst.FuncLit{
+			Type: &dst.FuncType{
+				Func: true,
+				Results: &dst.FieldList{
+					List: []*dst.Field{
+						{
+							Type: &dst.StarExpr{
+								X: dst.NewIdent("CompositeType"),
+							},
+						},
+					},
+				},
+			},
+			Body: &dst.BlockStmt{
+				List: statements,
+			},
+		},
+	}
+}
+
+func compositeTypeLiteral(ty *typeDecl) dst.Expr {
+	kind := compositeKindExpr(ty.compositeKind)
+
+	elements := []dst.Expr{
+		goKeyValue("Identifier", typeNameVarIdent(ty.fullTypeName)),
+		goKeyValue("Kind", kind),
+		goKeyValue("importable", goBoolLit(ty.importable)),
+		goKeyValue("hasComputedMembers", goBoolLit(true)),
+	}
+
+	return &dst.UnaryExpr{
+		Op: token.AND,
+		X: &dst.CompositeLit{
+			Type: dst.NewIdent("CompositeType"),
+			Elts: elements,
+		},
 	}
 }
 

--- a/runtime/sema/gen/testdata/docstrings.golden.go
+++ b/runtime/sema/gen/testdata/docstrings.golden.go
@@ -19,11 +19,6 @@
 
 package sema
 
-import (
-	"github.com/onflow/cadence/runtime/ast"
-	"github.com/onflow/cadence/runtime/common"
-)
-
 const DocstringsTypeOwoFieldName = "owo"
 
 var DocstringsTypeOwoFieldType = IntType
@@ -117,103 +112,43 @@ var DocstringsType = &SimpleType{
 	Exportable:    false,
 	Importable:    false,
 	Members: func(t *SimpleType) map[string]MemberResolver {
-		return map[string]MemberResolver{
-			DocstringsTypeOwoFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						DocstringsTypeOwoFieldType,
-						DocstringsTypeOwoFieldDocString,
-					)
-				},
-			},
-			DocstringsTypeUwuFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						DocstringsTypeUwuFieldType,
-						DocstringsTypeUwuFieldDocString,
-					)
-				},
-			},
-			DocstringsTypeNwnFunctionName: {
-				Kind: common.DeclarationKindFunction,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicFunctionMember(
-						memoryGauge,
-						t,
-						identifier,
-						DocstringsTypeNwnFunctionType,
-						DocstringsTypeNwnFunctionDocString,
-					)
-				},
-			},
-			DocstringsTypeWithBlanksFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						DocstringsTypeWithBlanksFieldType,
-						DocstringsTypeWithBlanksFieldDocString,
-					)
-				},
-			},
-			DocstringsTypeIsSmolBeanFunctionName: {
-				Kind: common.DeclarationKindFunction,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicFunctionMember(
-						memoryGauge,
-						t,
-						identifier,
-						DocstringsTypeIsSmolBeanFunctionType,
-						DocstringsTypeIsSmolBeanFunctionDocString,
-					)
-				},
-			},
-			DocstringsTypeRunningOutOfIdeasFunctionName: {
-				Kind: common.DeclarationKindFunction,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicFunctionMember(
-						memoryGauge,
-						t,
-						identifier,
-						DocstringsTypeRunningOutOfIdeasFunctionType,
-						DocstringsTypeRunningOutOfIdeasFunctionDocString,
-					)
-				},
-			},
-		}
+		return MembersAsResolvers([]*Member{
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				DocstringsTypeOwoFieldName,
+				DocstringsTypeOwoFieldType,
+				DocstringsTypeOwoFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				DocstringsTypeUwuFieldName,
+				DocstringsTypeUwuFieldType,
+				DocstringsTypeUwuFieldDocString,
+			),
+			NewUnmeteredPublicFunctionMember(
+				t,
+				DocstringsTypeNwnFunctionName,
+				DocstringsTypeNwnFunctionType,
+				DocstringsTypeNwnFunctionDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				DocstringsTypeWithBlanksFieldName,
+				DocstringsTypeWithBlanksFieldType,
+				DocstringsTypeWithBlanksFieldDocString,
+			),
+			NewUnmeteredPublicFunctionMember(
+				t,
+				DocstringsTypeIsSmolBeanFunctionName,
+				DocstringsTypeIsSmolBeanFunctionType,
+				DocstringsTypeIsSmolBeanFunctionDocString,
+			),
+			NewUnmeteredPublicFunctionMember(
+				t,
+				DocstringsTypeRunningOutOfIdeasFunctionName,
+				DocstringsTypeRunningOutOfIdeasFunctionType,
+				DocstringsTypeRunningOutOfIdeasFunctionDocString,
+			),
+		})
 	},
 }

--- a/runtime/sema/gen/testdata/fields.golden.go
+++ b/runtime/sema/gen/testdata/fields.golden.go
@@ -19,11 +19,6 @@
 
 package sema
 
-import (
-	"github.com/onflow/cadence/runtime/ast"
-	"github.com/onflow/cadence/runtime/common"
-)
-
 const TestTypeTestIntFieldName = "testInt"
 
 var TestTypeTestIntFieldType = UInt64Type
@@ -132,167 +127,67 @@ var TestType = &SimpleType{
 	Exportable:    false,
 	Importable:    false,
 	Members: func(t *SimpleType) map[string]MemberResolver {
-		return map[string]MemberResolver{
-			TestTypeTestIntFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeTestIntFieldType,
-						TestTypeTestIntFieldDocString,
-					)
-				},
-			},
-			TestTypeTestOptIntFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeTestOptIntFieldType,
-						TestTypeTestOptIntFieldDocString,
-					)
-				},
-			},
-			TestTypeTestRefIntFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeTestRefIntFieldType,
-						TestTypeTestRefIntFieldDocString,
-					)
-				},
-			},
-			TestTypeTestVarIntsFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeTestVarIntsFieldType,
-						TestTypeTestVarIntsFieldDocString,
-					)
-				},
-			},
-			TestTypeTestConstIntsFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeTestConstIntsFieldType,
-						TestTypeTestConstIntsFieldDocString,
-					)
-				},
-			},
-			TestTypeTestParamFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeTestParamFieldType,
-						TestTypeTestParamFieldDocString,
-					)
-				},
-			},
-			TestTypeTestAddressFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeTestAddressFieldType,
-						TestTypeTestAddressFieldDocString,
-					)
-				},
-			},
-			TestTypeTestTypeFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeTestTypeFieldType,
-						TestTypeTestTypeFieldDocString,
-					)
-				},
-			},
-			TestTypeTestCapFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeTestCapFieldType,
-						TestTypeTestCapFieldDocString,
-					)
-				},
-			},
-			TestTypeTestCapIntFieldName: {
-				Kind: common.DeclarationKindField,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicConstantFieldMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeTestCapIntFieldType,
-						TestTypeTestCapIntFieldDocString,
-					)
-				},
-			},
-		}
+		return MembersAsResolvers([]*Member{
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				TestTypeTestIntFieldName,
+				TestTypeTestIntFieldType,
+				TestTypeTestIntFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				TestTypeTestOptIntFieldName,
+				TestTypeTestOptIntFieldType,
+				TestTypeTestOptIntFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				TestTypeTestRefIntFieldName,
+				TestTypeTestRefIntFieldType,
+				TestTypeTestRefIntFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				TestTypeTestVarIntsFieldName,
+				TestTypeTestVarIntsFieldType,
+				TestTypeTestVarIntsFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				TestTypeTestConstIntsFieldName,
+				TestTypeTestConstIntsFieldType,
+				TestTypeTestConstIntsFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				TestTypeTestParamFieldName,
+				TestTypeTestParamFieldType,
+				TestTypeTestParamFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				TestTypeTestAddressFieldName,
+				TestTypeTestAddressFieldType,
+				TestTypeTestAddressFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				TestTypeTestTypeFieldName,
+				TestTypeTestTypeFieldType,
+				TestTypeTestTypeFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				TestTypeTestCapFieldName,
+				TestTypeTestCapFieldType,
+				TestTypeTestCapFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				TestTypeTestCapIntFieldName,
+				TestTypeTestCapIntFieldType,
+				TestTypeTestCapIntFieldDocString,
+			),
+		})
 	},
 }

--- a/runtime/sema/gen/testdata/functions.golden.go
+++ b/runtime/sema/gen/testdata/functions.golden.go
@@ -19,11 +19,6 @@
 
 package sema
 
-import (
-	"github.com/onflow/cadence/runtime/ast"
-	"github.com/onflow/cadence/runtime/common"
-)
-
 const TestTypeNothingFunctionName = "nothing"
 
 var TestTypeNothingFunctionType = &FunctionType{
@@ -175,119 +170,49 @@ var TestType = &SimpleType{
 	Exportable:    false,
 	Importable:    false,
 	Members: func(t *SimpleType) map[string]MemberResolver {
-		return map[string]MemberResolver{
-			TestTypeNothingFunctionName: {
-				Kind: common.DeclarationKindFunction,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicFunctionMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeNothingFunctionType,
-						TestTypeNothingFunctionDocString,
-					)
-				},
-			},
-			TestTypeParamsFunctionName: {
-				Kind: common.DeclarationKindFunction,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicFunctionMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeParamsFunctionType,
-						TestTypeParamsFunctionDocString,
-					)
-				},
-			},
-			TestTypeReturnFunctionName: {
-				Kind: common.DeclarationKindFunction,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicFunctionMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeReturnFunctionType,
-						TestTypeReturnFunctionDocString,
-					)
-				},
-			},
-			TestTypeParamsAndReturnFunctionName: {
-				Kind: common.DeclarationKindFunction,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicFunctionMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeParamsAndReturnFunctionType,
-						TestTypeParamsAndReturnFunctionDocString,
-					)
-				},
-			},
-			TestTypeTypeParamFunctionName: {
-				Kind: common.DeclarationKindFunction,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicFunctionMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeTypeParamFunctionType,
-						TestTypeTypeParamFunctionDocString,
-					)
-				},
-			},
-			TestTypeTypeParamWithBoundFunctionName: {
-				Kind: common.DeclarationKindFunction,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicFunctionMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeTypeParamWithBoundFunctionType,
-						TestTypeTypeParamWithBoundFunctionDocString,
-					)
-				},
-			},
-			TestTypeTypeParamWithBoundAndParamFunctionName: {
-				Kind: common.DeclarationKindFunction,
-				Resolve: func(memoryGauge common.MemoryGauge,
-					identifier string,
-					targetRange ast.Range,
-					report func(error)) *Member {
-
-					return NewPublicFunctionMember(
-						memoryGauge,
-						t,
-						identifier,
-						TestTypeTypeParamWithBoundAndParamFunctionType,
-						TestTypeTypeParamWithBoundAndParamFunctionDocString,
-					)
-				},
-			},
-		}
+		return MembersAsResolvers([]*Member{
+			NewUnmeteredPublicFunctionMember(
+				t,
+				TestTypeNothingFunctionName,
+				TestTypeNothingFunctionType,
+				TestTypeNothingFunctionDocString,
+			),
+			NewUnmeteredPublicFunctionMember(
+				t,
+				TestTypeParamsFunctionName,
+				TestTypeParamsFunctionType,
+				TestTypeParamsFunctionDocString,
+			),
+			NewUnmeteredPublicFunctionMember(
+				t,
+				TestTypeReturnFunctionName,
+				TestTypeReturnFunctionType,
+				TestTypeReturnFunctionDocString,
+			),
+			NewUnmeteredPublicFunctionMember(
+				t,
+				TestTypeParamsAndReturnFunctionName,
+				TestTypeParamsAndReturnFunctionType,
+				TestTypeParamsAndReturnFunctionDocString,
+			),
+			NewUnmeteredPublicFunctionMember(
+				t,
+				TestTypeTypeParamFunctionName,
+				TestTypeTypeParamFunctionType,
+				TestTypeTypeParamFunctionDocString,
+			),
+			NewUnmeteredPublicFunctionMember(
+				t,
+				TestTypeTypeParamWithBoundFunctionName,
+				TestTypeTypeParamWithBoundFunctionType,
+				TestTypeTypeParamWithBoundFunctionDocString,
+			),
+			NewUnmeteredPublicFunctionMember(
+				t,
+				TestTypeTypeParamWithBoundAndParamFunctionName,
+				TestTypeTypeParamWithBoundAndParamFunctionType,
+				TestTypeTypeParamWithBoundAndParamFunctionDocString,
+			),
+		})
 	},
 }

--- a/runtime/sema/gen/testdata/functions.golden.go
+++ b/runtime/sema/gen/testdata/functions.golden.go
@@ -22,7 +22,6 @@ package sema
 import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/sema"
 )
 
 const TestTypeNothingFunctionName = "nothing"
@@ -46,7 +45,7 @@ var TestTypeParamsFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(IntType),
 		},
 		{
-			Label:          sema.ArgumentLabelNotRequired,
+			Label:          ArgumentLabelNotRequired,
 			Identifier:     "b",
 			TypeAnnotation: NewTypeAnnotation(StringType),
 		},
@@ -81,7 +80,7 @@ var TestTypeParamsAndReturnFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(IntType),
 		},
 		{
-			Label:          sema.ArgumentLabelNotRequired,
+			Label:          ArgumentLabelNotRequired,
 			Identifier:     "b",
 			TypeAnnotation: NewTypeAnnotation(StringType),
 		},

--- a/runtime/sema/gen/testdata/nested.cdc
+++ b/runtime/sema/gen/testdata/nested.cdc
@@ -2,6 +2,9 @@ struct Foo {
     /// foo
     fun foo()
 
+    /// Bar
+    let bar: Foo.Bar
+
     struct Bar {
         /// bar
         fun bar()

--- a/runtime/sema/gen/testdata/nested.cdc
+++ b/runtime/sema/gen/testdata/nested.cdc
@@ -1,0 +1,9 @@
+struct Foo {
+    /// foo
+    fun foo()
+
+    struct Bar {
+        /// bar
+        fun bar()
+    }
+}

--- a/runtime/sema/gen/testdata/nested.golden.go
+++ b/runtime/sema/gen/testdata/nested.golden.go
@@ -55,6 +55,17 @@ var FooBarType = func() *CompositeType {
 		hasComputedMembers: true,
 	}
 
+	var members = []*Member{
+		NewUnmeteredPublicFunctionMember(
+			t,
+			FooBarTypeBarFunctionName,
+			FooBarTypeBarFunctionType,
+			FooBarTypeBarFunctionDocString,
+		),
+	}
+
+	t.Members = MembersAsMap(members)
+	t.Fields = MembersFieldNames(members)
 	return t
 }()
 
@@ -68,6 +79,17 @@ var FooType = func() *CompositeType {
 		hasComputedMembers: true,
 	}
 
+	var members = []*Member{
+		NewUnmeteredPublicFunctionMember(
+			t,
+			FooTypeFooFunctionName,
+			FooTypeFooFunctionType,
+			FooTypeFooFunctionDocString,
+		),
+	}
+
+	t.Members = MembersAsMap(members)
+	t.Fields = MembersFieldNames(members)
 	t.SetNestedType(FooBarTypeName, FooBarType)
 	return t
 }()

--- a/runtime/sema/gen/testdata/nested.golden.go
+++ b/runtime/sema/gen/testdata/nested.golden.go
@@ -1,0 +1,73 @@
+// Code generated from testdata/nested.cdc. DO NOT EDIT.
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import "github.com/onflow/cadence/runtime/common"
+
+const FooTypeFooFunctionName = "foo"
+
+var FooTypeFooFunctionType = &FunctionType{
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		VoidType,
+	),
+}
+
+const FooTypeFooFunctionDocString = `
+foo
+`
+
+const FooBarTypeBarFunctionName = "bar"
+
+var FooBarTypeBarFunctionType = &FunctionType{
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		VoidType,
+	),
+}
+
+const FooBarTypeBarFunctionDocString = `
+bar
+`
+
+const FooBarTypeName = "Bar"
+
+var FooBarType = func() *CompositeType {
+	var t = &CompositeType{
+		Identifier:         FooBarTypeName,
+		Kind:               common.CompositeKindStructure,
+		importable:         false,
+		hasComputedMembers: true,
+	}
+
+	return t
+}()
+
+const FooTypeName = "Foo"
+
+var FooType = func() *CompositeType {
+	var t = &CompositeType{
+		Identifier:         FooTypeName,
+		Kind:               common.CompositeKindStructure,
+		importable:         false,
+		hasComputedMembers: true,
+	}
+
+	t.SetNestedType(FooBarTypeName, FooBarType)
+	return t
+}()

--- a/runtime/sema/gen/testdata/nested.golden.go
+++ b/runtime/sema/gen/testdata/nested.golden.go
@@ -33,6 +33,14 @@ const FooTypeFooFunctionDocString = `
 foo
 `
 
+const FooTypeBarFieldName = "bar"
+
+var FooTypeBarFieldType = FooBarType
+
+const FooTypeBarFieldDocString = `
+Bar
+`
+
 const FooBarTypeBarFunctionName = "bar"
 
 var FooBarTypeBarFunctionType = &FunctionType{
@@ -93,6 +101,12 @@ func init() {
 			FooTypeFooFunctionName,
 			FooTypeFooFunctionType,
 			FooTypeFooFunctionDocString,
+		),
+		NewUnmeteredPublicConstantFieldMember(
+			FooType,
+			FooTypeBarFieldName,
+			FooTypeBarFieldType,
+			FooTypeBarFieldDocString,
 		),
 	}
 

--- a/runtime/sema/gen/testdata/nested.golden.go
+++ b/runtime/sema/gen/testdata/nested.golden.go
@@ -55,19 +55,22 @@ var FooBarType = func() *CompositeType {
 		hasComputedMembers: true,
 	}
 
+	return t
+}()
+
+func init() {
 	var members = []*Member{
 		NewUnmeteredPublicFunctionMember(
-			t,
+			FooBarType,
 			FooBarTypeBarFunctionName,
 			FooBarTypeBarFunctionType,
 			FooBarTypeBarFunctionDocString,
 		),
 	}
 
-	t.Members = MembersAsMap(members)
-	t.Fields = MembersFieldNames(members)
-	return t
-}()
+	FooBarType.Members = MembersAsMap(members)
+	FooBarType.Fields = MembersFieldNames(members)
+}
 
 const FooTypeName = "Foo"
 
@@ -79,17 +82,20 @@ var FooType = func() *CompositeType {
 		hasComputedMembers: true,
 	}
 
+	t.SetNestedType(FooBarTypeName, FooBarType)
+	return t
+}()
+
+func init() {
 	var members = []*Member{
 		NewUnmeteredPublicFunctionMember(
-			t,
+			FooType,
 			FooTypeFooFunctionName,
 			FooTypeFooFunctionType,
 			FooTypeFooFunctionDocString,
 		),
 	}
 
-	t.Members = MembersAsMap(members)
-	t.Fields = MembersFieldNames(members)
-	t.SetNestedType(FooBarTypeName, FooBarType)
-	return t
-}()
+	FooType.Members = MembersAsMap(members)
+	FooType.Fields = MembersFieldNames(members)
+}

--- a/runtime/sema/public_account_contracts.go
+++ b/runtime/sema/public_account_contracts.go
@@ -58,8 +58,3 @@ var PublicAccountContractsType = func() *CompositeType {
 	publicAccountContractsType.Fields = GetFieldNames(members)
 	return publicAccountContractsType
 }()
-
-func init() {
-	// Set the container type after initializing the `PublicAccountContractsType`, to avoid initializing loop.
-	PublicAccountContractsType.SetContainerType(PublicAccountType)
-}

--- a/runtime/sema/public_account_contracts.go
+++ b/runtime/sema/public_account_contracts.go
@@ -54,7 +54,7 @@ var PublicAccountContractsType = func() *CompositeType {
 		),
 	}
 
-	publicAccountContractsType.Members = GetMembersAsMap(members)
-	publicAccountContractsType.Fields = GetFieldNames(members)
+	publicAccountContractsType.Members = MembersAsMap(members)
+	publicAccountContractsType.Fields = MembersFieldNames(members)
 	return publicAccountContractsType
 }()

--- a/runtime/sema/publicaccount_type.go
+++ b/runtime/sema/publicaccount_type.go
@@ -117,8 +117,8 @@ var PublicAccountType = func() *CompositeType {
 		),
 	}
 
-	publicAccountType.Members = GetMembersAsMap(members)
-	publicAccountType.Fields = GetFieldNames(members)
+	publicAccountType.Members = MembersAsMap(members)
+	publicAccountType.Fields = MembersFieldNames(members)
 	return publicAccountType
 }()
 
@@ -199,8 +199,8 @@ var PublicAccountKeysType = func() *CompositeType {
 		),
 	}
 
-	accountKeys.Members = GetMembersAsMap(members)
-	accountKeys.Fields = GetFieldNames(members)
+	accountKeys.Members = MembersAsMap(members)
+	accountKeys.Fields = MembersFieldNames(members)
 	return accountKeys
 }()
 

--- a/runtime/sema/publicaccount_type.go
+++ b/runtime/sema/publicaccount_type.go
@@ -43,13 +43,10 @@ var PublicAccountType = func() *CompositeType {
 		Kind:               common.CompositeKindStructure,
 		hasComputedMembers: true,
 		importable:         false,
-		NestedTypes: func() *StringTypeOrderedMap {
-			nestedTypes := &StringTypeOrderedMap{}
-			nestedTypes.Set(AccountKeysTypeName, PublicAccountKeysType)
-			nestedTypes.Set(PublicAccountContractsTypeName, PublicAccountContractsType)
-			return nestedTypes
-		}(),
 	}
+
+	publicAccountType.SetNestedType(AccountKeysTypeName, PublicAccountKeysType)
+	publicAccountType.SetNestedType(PublicAccountContractsTypeName, PublicAccountContractsType)
 
 	var members = []*Member{
 		NewUnmeteredPublicConstantFieldMember(
@@ -206,11 +203,6 @@ var PublicAccountKeysType = func() *CompositeType {
 	accountKeys.Fields = GetFieldNames(members)
 	return accountKeys
 }()
-
-func init() {
-	// Set the container type after initializing the AccountKeysTypes, to avoid initializing loop.
-	PublicAccountKeysType.SetContainerType(PublicAccountType)
-}
 
 var PublicAccountTypeGetCapabilityFunctionType = func() *FunctionType {
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3918,6 +3918,14 @@ func (t *CompositeType) FieldPosition(name string, declaration ast.CompositeLike
 	return pos
 }
 
+func (t *CompositeType) SetNestedType(name string, nestedType ContainedType) {
+	if t.NestedTypes == nil {
+		t.NestedTypes = &StringTypeOrderedMap{}
+	}
+	t.NestedTypes.Set(name, nestedType)
+	nestedType.SetContainerType(t)
+}
+
 // Member
 
 type Member struct {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -6641,8 +6641,8 @@ var AccountKeyType = func() *CompositeType {
 		),
 	}
 
-	accountKeyType.Members = GetMembersAsMap(members)
-	accountKeyType.Fields = GetFieldNames(members)
+	accountKeyType.Members = MembersAsMap(members)
+	accountKeyType.Fields = MembersFieldNames(members)
 	return accountKeyType
 }()
 
@@ -6709,8 +6709,8 @@ var PublicKeyType = func() *CompositeType {
 		),
 	}
 
-	publicKeyType.Members = GetMembersAsMap(members)
-	publicKeyType.Fields = GetFieldNames(members)
+	publicKeyType.Members = MembersAsMap(members)
+	publicKeyType.Fields = MembersFieldNames(members)
 
 	return publicKeyType
 }()
@@ -6766,7 +6766,7 @@ type CryptoAlgorithm interface {
 	DocString() string
 }
 
-func GetMembersAsMap(members []*Member) *StringMemberOrderedMap {
+func MembersAsMap(members []*Member) *StringMemberOrderedMap {
 	membersMap := &StringMemberOrderedMap{}
 	for _, member := range members {
 		name := member.Identifier.Identifier
@@ -6779,7 +6779,7 @@ func GetMembersAsMap(members []*Member) *StringMemberOrderedMap {
 	return membersMap
 }
 
-func GetFieldNames(members []*Member) []string {
+func MembersFieldNames(members []*Member) []string {
 	fields := make([]string, 0)
 	for _, member := range members {
 		if member.DeclarationKind == common.DeclarationKindField {

--- a/runtime/stdlib/bls.go
+++ b/runtime/stdlib/bls.go
@@ -31,7 +31,7 @@ var blsContractType = func() *sema.CompositeType {
 		Kind:       common.CompositeKindContract,
 	}
 
-	ty.Members = sema.GetMembersAsMap([]*sema.Member{
+	ty.Members = sema.MembersAsMap([]*sema.Member{
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
 			blsAggregatePublicKeysFunctionName,

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -151,7 +151,7 @@ func cryptoAlgorithmEnumConstructorType[T sema.CryptoAlgorithm](
 				Type: enumType,
 			},
 		),
-		Members: sema.GetMembersAsMap(members),
+		Members: sema.MembersAsMap(members),
 	}
 
 	return constructorType

--- a/runtime/stdlib/rlp.go
+++ b/runtime/stdlib/rlp.go
@@ -34,7 +34,7 @@ var rlpContractType = func() *sema.CompositeType {
 		Kind:       common.CompositeKindContract,
 	}
 
-	ty.Members = sema.GetMembersAsMap([]*sema.Member{
+	ty.Members = sema.MembersAsMap([]*sema.Member{
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
 			rlpDecodeListFunctionName,

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -774,8 +774,8 @@ var EmulatorBackendType = func() *sema.CompositeType {
 		),
 	}
 
-	ty.Members = sema.GetMembersAsMap(members)
-	ty.Fields = sema.GetFieldNames(members)
+	ty.Members = sema.MembersAsMap(members)
+	ty.Fields = sema.MembersFieldNames(members)
 
 	return ty
 }()


### PR DESCRIPTION
Work towards #2293

## Description

The `AuthAccount` and `PublicAccount` types will get extended with additional nested types in #2293.

Allow those new types to be declared in Cadence by adding support for nested types to the Go code generator for sema type definitions.

The next step is to refactor the existing type definitions of `AuthAccount` and `PublicAccount` to Cadence.

While adding code generation of members for composite types, also simplify the code generation for members of simple types. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
