### PR TITLE
Add more built-in matchers to the Cadence Testing Framework

### DIFF
--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -270,7 +270,7 @@ pub contract Test {
             } else if let result = value as? ScriptResult {
                 return result.status == ResultStatus.succeeded
             } else {
-                panic("Only TransactionResult & ScriptResult types are supported.")
+                panic("expected TransactionResult or ScriptResult argument")
             }
             return false
         })
@@ -287,7 +287,7 @@ pub contract Test {
             } else if let result = value as? ScriptResult {
                 return result.status == ResultStatus.failed
             } else {
-                panic("Only TransactionResult & ScriptResult types are supported.")
+                panic("expected TransactionResult or ScriptResult argument")
             }
             return false
         })

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -250,4 +250,13 @@ pub contract Test {
         ///
         pub fun useConfiguration(_ configuration: Configuration)
     }
+
+    /// Returns a new matcher that negates the test of the given matcher.
+    ///
+    pub fun not(_ matcher: Matcher): Matcher {
+        return Matcher(test: fun (value: AnyStruct): Bool {
+            return !matcher.test(value)
+        })
+    }
+
 }

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -291,4 +291,12 @@ pub contract Test {
         })
     }
 
+    /// Returns a new matcher that checks if the given test value is nil.
+    ///
+    pub fun beNil(): Matcher {
+        return Matcher(test: fun (value: AnyStruct): Bool {
+            return value == nil
+        })
+    }
+
 }

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -132,9 +132,18 @@ pub contract Test {
         pub case failed
     }
 
+    /// Result is the interface to be implemented by the various execution
+    /// operations, such as transactions and scripts.
+    ///
+    pub struct interface Result {
+        /// The resulted status of an executed operation.
+        ///
+        pub let status: ResultStatus
+    }
+
     /// The result of a transaction execution.
     ///
-    pub struct TransactionResult {
+    pub struct TransactionResult: Result {
         pub let status: ResultStatus
         pub let error: Error?
 
@@ -146,7 +155,7 @@ pub contract Test {
 
     /// The result of a script execution.
     ///
-    pub struct ScriptResult {
+    pub struct ScriptResult: Result {
         pub let status: ResultStatus
         pub let returnValue: AnyStruct?
         pub let error: Error?
@@ -265,14 +274,7 @@ pub contract Test {
     ///
     pub fun beSucceeded(): Matcher {
         return Matcher(test: fun (value: AnyStruct): Bool {
-            if let result = value as? TransactionResult {
-                return result.status == ResultStatus.succeeded
-            } else if let result = value as? ScriptResult {
-                return result.status == ResultStatus.succeeded
-            } else {
-                panic("expected TransactionResult or ScriptResult argument")
-            }
-            return false
+            return (value as! {Result}).status == ResultStatus.succeeded
         })
     }
 
@@ -282,14 +284,7 @@ pub contract Test {
     ///
     pub fun beFailed(): Matcher {
         return Matcher(test: fun (value: AnyStruct): Bool {
-            if let result = value as? TransactionResult {
-                return result.status == ResultStatus.failed
-            } else if let result = value as? ScriptResult {
-                return result.status == ResultStatus.failed
-            } else {
-                panic("expected TransactionResult or ScriptResult argument")
-            }
-            return false
+            return (value as! {Result}).status == ResultStatus.failed
         })
     }
 

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -275,4 +275,20 @@ pub contract Test {
         })
     }
 
+    /// Returns a new matcher that checks if the given test value is either
+    /// a ScriptResult or TransactionResult and the ResultStatus is failed.
+    /// Returns false in any other case.
+    ///
+    pub fun beFailed(): Matcher {
+        return Matcher(test: fun (value: AnyStruct): Bool {
+            if let result = value as? TransactionResult {
+                return result.status == ResultStatus.failed
+            } else if let result = value as? ScriptResult {
+                return result.status == ResultStatus.failed
+            } else {
+                return false
+            }
+        })
+    }
+
 }

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -138,7 +138,7 @@ pub contract Test {
         pub let status: ResultStatus
         pub let error: Error?
 
-        init(status: ResultStatus, error: Error) {
+        init(status: ResultStatus, error: Error?) {
             self.status = status
             self.error = error
         }
@@ -256,6 +256,22 @@ pub contract Test {
     pub fun not(_ matcher: Matcher): Matcher {
         return Matcher(test: fun (value: AnyStruct): Bool {
             return !matcher.test(value)
+        })
+    }
+
+    /// Returns a new matcher that checks if the given test value is either
+    /// a ScriptResult or TransactionResult and the ResultStatus is succeeded.
+    /// Returns false in any other case.
+    ///
+    pub fun beSucceeded(): Matcher {
+        return Matcher(test: fun (value: AnyStruct): Bool {
+            if let result = value as? TransactionResult {
+                return result.status == ResultStatus.succeeded
+            } else if let result = value as? ScriptResult {
+                return result.status == ResultStatus.succeeded
+            } else {
+                return false
+            }
         })
     }
 

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -270,8 +270,9 @@ pub contract Test {
             } else if let result = value as? ScriptResult {
                 return result.status == ResultStatus.succeeded
             } else {
-                return false
+                panic("Only TransactionResult & ScriptResult types are supported.")
             }
+            return false
         })
     }
 
@@ -286,8 +287,9 @@ pub contract Test {
             } else if let result = value as? ScriptResult {
                 return result.status == ResultStatus.failed
             } else {
-                return false
+                panic("Only TransactionResult & ScriptResult types are supported.")
             }
+            return false
         })
     }
 

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -1458,7 +1458,7 @@ var beEmptyMatcherFunction = interpreter.NewUnmeteredHostFunctionValue(
 				case *interpreter.DictionaryValue:
 					isEmpty = value.Count() == 0
 				default:
-					panic(errors.NewUnexpectedError("expected Array or Dictionary argument"))
+					panic(errors.NewDefaultUserError("expected Array or Dictionary argument"))
 				}
 
 				return interpreter.AsBoolValue(isEmpty)
@@ -1512,7 +1512,7 @@ var haveElementCountMatcherFunction = interpreter.NewUnmeteredHostFunctionValue(
 				case *interpreter.DictionaryValue:
 					matchingCount = value.Count() == count.ToInt(invocation.LocationRange)
 				default:
-					panic(errors.NewUnexpectedError("expected Array or Dictionary argument"))
+					panic(errors.NewDefaultUserError("expected Array or Dictionary argument"))
 				}
 
 				return interpreter.AsBoolValue(matchingCount)
@@ -1577,7 +1577,7 @@ var containMatcherFunction = interpreter.NewUnmeteredHostFunctionValue(
 						element,
 					)
 				default:
-					panic(errors.NewUnexpectedError("expected Array or Dictionary argument"))
+					panic(errors.NewDefaultUserError("expected Array or Dictionary argument"))
 				}
 
 				return elementFound

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -1458,7 +1458,7 @@ var beEmptyMatcherFunction = interpreter.NewUnmeteredHostFunctionValue(
 				case *interpreter.DictionaryValue:
 					isEmpty = value.Count() == 0
 				default:
-					panic(errors.NewUnreachableError())
+					panic(errors.NewUnexpectedError("expected Array or Dictionary argument"))
 				}
 
 				return interpreter.AsBoolValue(isEmpty)
@@ -1512,7 +1512,7 @@ var haveElementCountMatcherFunction = interpreter.NewUnmeteredHostFunctionValue(
 				case *interpreter.DictionaryValue:
 					matchingCount = value.Count() == count.ToInt(invocation.LocationRange)
 				default:
-					panic(errors.NewUnreachableError())
+					panic(errors.NewUnexpectedError("expected Array or Dictionary argument"))
 				}
 
 				return interpreter.AsBoolValue(matchingCount)
@@ -1577,7 +1577,7 @@ var containMatcherFunction = interpreter.NewUnmeteredHostFunctionValue(
 						element,
 					)
 				default:
-					panic(errors.NewUnreachableError())
+					panic(errors.NewUnexpectedError("expected Array or Dictionary argument"))
 				}
 
 				return elementFound

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -69,6 +69,7 @@ var TestContractChecker = func() *sema.Checker {
 
 	activation := sema.NewVariableActivation(sema.BaseValueActivation)
 	activation.DeclareValue(AssertFunction)
+	activation.DeclareValue(PanicFunction)
 
 	var checker *sema.Checker
 	checker, err = sema.NewChecker(

--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -1528,7 +1528,7 @@ const containMatcherFunctionName = "contain"
 const containMatcherFunctionDocString = `
 Returns a matcher that succeeds if the tested value is an array that contains
 a value that is equal to the given value, or the tested value is a dictionary
-that contains an entry where the value is equal to the given value.
+that contains an entry where the key is equal to the given value.
 `
 
 var containMatcherFunctionType = func() *sema.FunctionType {

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -887,6 +887,95 @@ func TestTestBeNilMatcher(t *testing.T) {
 	})
 }
 
+func TestTestBeEmptyMatcher(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("matcher beEmpty with Array", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let emptyArray = Test.beEmpty()
+
+		        return emptyArray.test([])
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let emptyArray = Test.beEmpty()
+
+		        return emptyArray.test([42, 23, 31])
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("matcher beEmpty with Dictionary", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let emptyDict = Test.beEmpty()
+		        let dict: {Bool: Int} = {}
+
+		        return emptyDict.test(dict)
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let emptyDict = Test.beEmpty()
+		        let dict: {Bool: Int} = {true: 1, false: 0}
+
+		        return emptyDict.test(dict)
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("matcher beEmpty with type mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun test(): Bool {
+		        let emptyDict = Test.beEmpty()
+
+		        return emptyDict.test("empty")
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("testMatch")
+		require.Error(t, err)
+	})
+}
+
 func TestTestExpect(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -631,6 +631,116 @@ func TestTestEqualMatcher(t *testing.T) {
 	})
 }
 
+func TestTestBeSucceededMatcher(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("matcher beSucceeded with ScriptResult", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let successful = Test.beSucceeded()
+
+		        let scriptResult = Test.ScriptResult(
+		            status: Test.ResultStatus.succeeded,
+		            returnValue: 42,
+		            error: nil
+		        )
+
+		        return successful.test(scriptResult)
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let successful = Test.beSucceeded()
+
+		        let scriptResult = Test.ScriptResult(
+		            status: Test.ResultStatus.failed,
+		            returnValue: nil,
+		            error: Test.Error("Exceeding limit")
+		        )
+
+		        return successful.test(scriptResult)
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("matcher beSucceeded with TransactionResult", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let successful = Test.beSucceeded()
+
+		        let transactionResult = Test.TransactionResult(
+		            status: Test.ResultStatus.succeeded,
+		            error: nil
+		        )
+
+		        return successful.test(transactionResult)
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let successful = Test.beSucceeded()
+
+		        let transactionResult = Test.TransactionResult(
+		            status: Test.ResultStatus.failed,
+		            error: Test.Error("Exceeded Limit")
+		        )
+
+		        return successful.test(transactionResult)
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("matcher beSucceeded with type mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun test(): Bool {
+		        let successful = Test.beSucceeded()
+
+		        return successful.test("hello")
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+}
+
 func TestTestExpect(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -741,6 +741,116 @@ func TestTestBeSucceededMatcher(t *testing.T) {
 	})
 }
 
+func TestTestBeFailedMatcher(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("matcher beFailed with ScriptResult", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let failed = Test.beFailed()
+
+		        let scriptResult = Test.ScriptResult(
+		            status: Test.ResultStatus.failed,
+		            returnValue: nil,
+		            error: Test.Error("Exceeding limit")
+		        )
+
+		        return failed.test(scriptResult)
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let failed = Test.beFailed()
+
+		        let scriptResult = Test.ScriptResult(
+		            status: Test.ResultStatus.succeeded,
+		            returnValue: 42,
+		            error: nil
+		        )
+
+		        return failed.test(scriptResult)
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("matcher beFailed with TransactionResult", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let failed = Test.beFailed()
+
+		        let transactionResult = Test.TransactionResult(
+		            status: Test.ResultStatus.failed,
+		            error: Test.Error("Exceeding limit")
+		        )
+
+		        return failed.test(transactionResult)
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let failed = Test.beFailed()
+
+		        let transactionResult = Test.TransactionResult(
+		            status: Test.ResultStatus.succeeded,
+		            error: nil
+		        )
+
+		        return failed.test(transactionResult)
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("matcher beFailed with type mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun test(): Bool {
+		        let failed = Test.beFailed()
+
+		        return failed.test([])
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+}
+
 func TestTestExpect(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -974,8 +974,9 @@ func TestTestBeEmptyMatcher(t *testing.T) {
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
 
-		_, err = inter.Invoke("testMatch")
+		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		assert.ErrorContains(t, err, "expected Array or Dictionary argument")
 	})
 }
 
@@ -1065,6 +1066,7 @@ func TestTestHaveElementCountMatcher(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		assert.ErrorContains(t, err, "expected Array or Dictionary argument")
 	})
 }
 
@@ -1154,6 +1156,7 @@ func TestTestContainMatcher(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		assert.ErrorContains(t, err, "expected Array or Dictionary argument")
 	})
 }
 

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -851,6 +851,42 @@ func TestTestBeFailedMatcher(t *testing.T) {
 	})
 }
 
+func TestTestBeNilMatcher(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("matcher beNil", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let isNil = Test.beNil()
+
+		        return isNil.test(nil)
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let isNil = Test.beNil()
+
+		        return isNil.test([1, 2])
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+}
+
 func TestTestExpect(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -508,6 +508,41 @@ func TestTestEqualMatcher(t *testing.T) {
 		assert.Equal(t, interpreter.FalseValue, result)
 	})
 
+	t.Run("matcher not", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let one = Test.equal(1)
+
+		        let notOne = Test.not(one)
+
+		        return notOne.test(2)
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let one = Test.equal(1)
+
+		        let notOne = Test.not(one)
+
+		        return notOne.test(1)
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
 	t.Run("chained matchers", func(t *testing.T) {
 		t.Parallel()
 

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -42,12 +42,17 @@ func newTestContractInterpreter(t *testing.T, code string) (*interpreter.Interpr
 	)
 	require.NoError(t, err)
 
+	activation := sema.NewVariableActivation(sema.BaseValueActivation)
+	activation.DeclareValue(AssertFunction)
+	activation.DeclareValue(PanicFunction)
+
 	checker, err := sema.NewChecker(
 		program,
 		utils.TestLocation,
 		nil,
 		&sema.Config{
-			AccessCheckMode: sema.AccessCheckModeStrict,
+			BaseValueActivation: activation,
+			AccessCheckMode:     sema.AccessCheckModeStrict,
 			ImportHandler: func(
 				checker *sema.Checker,
 				importedLocation common.Location,
@@ -735,9 +740,8 @@ func TestTestBeSucceededMatcher(t *testing.T) {
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
 
-		result, err := inter.Invoke("test")
-		require.NoError(t, err)
-		assert.Equal(t, interpreter.FalseValue, result)
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
 	})
 }
 
@@ -845,9 +849,8 @@ func TestTestBeFailedMatcher(t *testing.T) {
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
 
-		result, err := inter.Invoke("test")
-		require.NoError(t, err)
-		assert.Equal(t, interpreter.FalseValue, result)
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
 	})
 }
 

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	cdcErrors "github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/sema"
@@ -976,6 +977,7 @@ func TestTestBeEmptyMatcher(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		assert.ErrorAs(t, err, &cdcErrors.DefaultUserError{})
 		assert.ErrorContains(t, err, "expected Array or Dictionary argument")
 	})
 }
@@ -1066,6 +1068,7 @@ func TestTestHaveElementCountMatcher(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		assert.ErrorAs(t, err, &cdcErrors.DefaultUserError{})
 		assert.ErrorContains(t, err, "expected Array or Dictionary argument")
 	})
 }
@@ -1156,6 +1159,7 @@ func TestTestContainMatcher(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
+		assert.ErrorAs(t, err, &cdcErrors.DefaultUserError{})
 		assert.ErrorContains(t, err, "expected Array or Dictionary argument")
 	})
 }

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -1065,6 +1065,95 @@ func TestTestHaveElementCountMatcher(t *testing.T) {
 	})
 }
 
+func TestTestContainMatcher(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("matcher contain with Array", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let containsTwenty = Test.contain(20)
+
+		        return containsTwenty.test([42, 20, 31])
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let containsTwenty = Test.contain(20)
+
+		        return containsTwenty.test([42])
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("matcher contain with Dictionary", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let containsFalse = Test.contain(false)
+		        let dict: {Bool: Int} = {true: 1, false: 0}
+
+		        return containsFalse.test(dict)
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let containsFive = Test.contain(5)
+		        let dict: {Int: Bool} = {1: true, 0: false}
+
+		        return containsFive.test(dict)
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("matcher contain with type mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun test(): Bool {
+		        let containsFalse = Test.contain(false)
+
+		        return containsFalse.test("false")
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
+	})
+}
+
 func TestTestExpect(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -1210,6 +1210,62 @@ func TestTestBeGreaterThanMatcher(t *testing.T) {
 	})
 }
 
+func TestTestBeLessThanMatcher(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("matcher beLessThan", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let lessThanSeven = Test.beLessThan(7)
+
+		        return lessThanSeven.test(5)
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let lessThanSeven = Test.beLessThan(7)
+
+		        return lessThanSeven.test(9)
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("matcher beLessThan with type mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun test(): Bool {
+		        let lessThanSeven = Test.beLessThan(7)
+
+		        return lessThanSeven.test(true)
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
+	})
+}
+
 func TestTestExpect(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -976,6 +976,95 @@ func TestTestBeEmptyMatcher(t *testing.T) {
 	})
 }
 
+func TestTestHaveElementCountMatcher(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("matcher haveElementCount with Array", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let hasThreeElements = Test.haveElementCount(3)
+
+		        return hasThreeElements.test([42, 23, 31])
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let hasThreeElements = Test.haveElementCount(3)
+
+		        return hasThreeElements.test([42])
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("matcher haveElementCount with Dictionary", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let hasTwoElements = Test.haveElementCount(2)
+		        let dict: {Bool: Int} = {true: 1, false: 0}
+
+		        return hasTwoElements.test(dict)
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let hasTwoElements = Test.haveElementCount(2)
+		        let dict: {Bool: Int} = {}
+
+		        return hasTwoElements.test(dict)
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("matcher haveElementCount with type mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun test(): Bool {
+		        let hasTwoElements = Test.haveElementCount(2)
+
+		        return hasTwoElements.test("two")
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
+	})
+}
+
 func TestTestExpect(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -1154,6 +1154,62 @@ func TestTestContainMatcher(t *testing.T) {
 	})
 }
 
+func TestTestBeGreaterThanMatcher(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("matcher beGreaterThan", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun testMatch(): Bool {
+		        let greaterThanFive = Test.beGreaterThan(5)
+
+		        return greaterThanFive.test(7)
+		    }
+
+		    pub fun testNoMatch(): Bool {
+		        let greaterThanFive = Test.beGreaterThan(5)
+
+		        return greaterThanFive.test(2)
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("testMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.TrueValue, result)
+
+		result, err = inter.Invoke("testNoMatch")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.FalseValue, result)
+	})
+
+	t.Run("matcher beGreaterThan with type mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		    import Test
+
+		    pub fun test(): Bool {
+		        let greaterThanFive = Test.beGreaterThan(5)
+
+		        return greaterThanFive.test("7")
+		    }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
+	})
+}
+
 func TestTestExpect(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
**Work towards:** https://github.com/onflow/developer-grants/issues/148

## Description

Implements the matchers described in https://github.com/onflow/cadence/issues/1889
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
