### PR TITLE
Improve cadence.Path

### DIFF
--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -627,7 +627,7 @@ func preparePath(x cadence.Path) jsonValue {
 	return jsonValueObject{
 		Type: pathTypeStr,
 		Value: jsonPathValue{
-			Domain:     x.Domain,
+			Domain:     x.Domain.Identifier(),
 			Identifier: x.Identifier,
 		},
 	}

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -2645,7 +2645,10 @@ func TestRuntimeAccountLink(t *testing.T) {
 		require.Equal(t,
 			[]cadence.Value{
 				cadence.NewAddress(common.MustBytesToAddress([]byte{0x1})),
-				cadence.NewPath("private", "foo"),
+				cadence.Path{
+					Domain:     common.PathDomainPrivate,
+					Identifier: "foo",
+				},
 			},
 			events[0].Fields,
 		)
@@ -2886,7 +2889,10 @@ func TestRuntimeAccountLink(t *testing.T) {
 		require.Equal(t,
 			[]cadence.Value{
 				cadence.NewAddress(common.MustBytesToAddress([]byte{0x1})),
-				cadence.NewPath("private", "foo"),
+				cadence.Path{
+					Domain:     common.PathDomainPrivate,
+					Identifier: "foo",
+				},
 			},
 			events[0].Fields,
 		)
@@ -2993,7 +2999,10 @@ func TestRuntimeAccountLink(t *testing.T) {
 		require.Equal(t,
 			[]cadence.Value{
 				cadence.NewAddress(common.MustBytesToAddress([]byte{0x1})),
-				cadence.NewPath("private", "foo"),
+				cadence.Path{
+					Domain:     common.PathDomainPrivate,
+					Identifier: "foo",
+				},
 			},
 			events[0].Fields,
 		)

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -383,7 +383,7 @@ func TestExportValue(t *testing.T) {
 				Identifier: "foo",
 			},
 			expected: cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 		},
@@ -813,7 +813,7 @@ func TestImportValue(t *testing.T) {
 		{
 			label: "Path",
 			value: cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 			expected: interpreter.PathValue{
@@ -825,7 +825,7 @@ func TestImportValue(t *testing.T) {
 			label: "Path Link (invalid)",
 			value: cadence.PathLink{
 				TargetPath: cadence.Path{
-					Domain:     "storage",
+					Domain:     common.PathDomainStorage,
 					Identifier: "test",
 				},
 				BorrowType: "Int",
@@ -841,7 +841,7 @@ func TestImportValue(t *testing.T) {
 			label: "Capability (invalid)",
 			value: cadence.StorageCapability{
 				Path: cadence.Path{
-					Domain:     "public",
+					Domain:     common.PathDomainPublic,
 					Identifier: "test",
 				},
 				BorrowType: cadence.IntType{},
@@ -2081,7 +2081,7 @@ func TestExportStorageCapabilityValue(t *testing.T) {
 
 		expected := cadence.StorageCapability{
 			Path: cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 			Address:    cadence.Address{0x1},
@@ -2135,7 +2135,7 @@ func TestExportStorageCapabilityValue(t *testing.T) {
 
 		expected := cadence.StorageCapability{
 			Path: cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 			Address: cadence.Address{0x1},
@@ -2169,7 +2169,7 @@ func TestExportStorageCapabilityValue(t *testing.T) {
 
 		expected := cadence.StorageCapability{
 			Path: cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 			Address: cadence.Address{0x1},
@@ -2203,7 +2203,7 @@ func TestExportPathLinkValue(t *testing.T) {
 
 		expected := cadence.PathLink{
 			TargetPath: cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 			BorrowType: "Int",
@@ -2254,7 +2254,7 @@ func TestExportPathLinkValue(t *testing.T) {
 
 		expected := cadence.PathLink{
 			TargetPath: cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 			BorrowType: "S.test.S",
@@ -2684,7 +2684,7 @@ func TestRuntimeArgumentPassing(t *testing.T) {
 			label:         "StoragePath",
 			typeSignature: "StoragePath",
 			exportedValue: cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 			skipExport: true,
@@ -2693,7 +2693,7 @@ func TestRuntimeArgumentPassing(t *testing.T) {
 			label:         "PrivatePath",
 			typeSignature: "PrivatePath",
 			exportedValue: cadence.Path{
-				Domain:     "private",
+				Domain:     common.PathDomainPrivate,
 				Identifier: "foo",
 			},
 			skipExport: true,
@@ -2702,7 +2702,7 @@ func TestRuntimeArgumentPassing(t *testing.T) {
 			label:         "PublicPath",
 			typeSignature: "PublicPath",
 			exportedValue: cadence.Path{
-				Domain:     "public",
+				Domain:     common.PathDomainPublic,
 				Identifier: "foo",
 			},
 			skipExport: true,
@@ -2849,15 +2849,15 @@ func TestRuntimeComplexStructArgumentPassing(t *testing.T) {
 			cadence.NewAddress([8]byte{0, 0, 0, 0, 0, 1, 0, 2}),
 			cadence.NewBool(true),
 			cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 			cadence.Path{
-				Domain:     "public",
+				Domain:     common.PathDomainPublic,
 				Identifier: "foo",
 			},
 			cadence.Path{
-				Domain:     "private",
+				Domain:     common.PathDomainPrivate,
 				Identifier: "foo",
 			},
 			cadence.String("foo"),
@@ -2980,7 +2980,7 @@ func TestRuntimeComplexStructWithAnyStructFields(t *testing.T) {
 				Size:        2,
 			}),
 			cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 		},
@@ -4015,7 +4015,7 @@ func TestStorageCapabilityValueImport(t *testing.T) {
 			BorrowType: &cadence.ReferenceType{Type: cadence.IntType{}},
 			Address:    cadence.Address{0x1},
 			Path: cadence.Path{
-				Domain:     common.PathDomainPublic.Identifier(),
+				Domain:     common.PathDomainPublic,
 				Identifier: "foo",
 			},
 		}
@@ -4069,7 +4069,7 @@ func TestStorageCapabilityValueImport(t *testing.T) {
 			BorrowType: cadence.IntType{},
 			Address:    cadence.Address{0x1},
 			Path: cadence.Path{
-				Domain:     common.PathDomainPublic.Identifier(),
+				Domain:     common.PathDomainPublic,
 				Identifier: "foo",
 			},
 		}
@@ -4116,7 +4116,7 @@ func TestStorageCapabilityValueImport(t *testing.T) {
 			BorrowType: &cadence.ReferenceType{Type: cadence.IntType{}},
 			Address:    cadence.Address{0x1},
 			Path: cadence.Path{
-				Domain:     common.PathDomainPrivate.Identifier(),
+				Domain:     common.PathDomainPrivate,
 				Identifier: "foo",
 			},
 		}
@@ -4163,7 +4163,7 @@ func TestStorageCapabilityValueImport(t *testing.T) {
 			BorrowType: &cadence.ReferenceType{Type: cadence.IntType{}},
 			Address:    cadence.Address{0x1},
 			Path: cadence.Path{
-				Domain:     common.PathDomainStorage.Identifier(),
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 		}
@@ -4219,7 +4219,7 @@ func TestStorageCapabilityValueImport(t *testing.T) {
 			BorrowType: borrowType,
 			Address:    cadence.Address{0x1},
 			Path: cadence.Path{
-				Domain:     common.PathDomainPublic.Identifier(),
+				Domain:     common.PathDomainPublic,
 				Identifier: "foo",
 			},
 		}

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -338,4 +338,17 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 		})
 	})
 
+	t.Run("Path subtype", func(t *testing.T) {
+		test(t, testCase{
+			contract: `
+              pub contract Test {
+                  init(_ path: StoragePath) {}
+              }
+            `,
+			arguments: []argument{
+				interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "test"),
+			},
+			check: expectSuccess,
+		})
+	})
 }

--- a/runtime/imported_values_memory_metering_test.go
+++ b/runtime/imported_values_memory_metering_test.go
@@ -419,16 +419,16 @@ func TestImportedValueMemoryMeteringForSimpleTypes(t *testing.T) {
 			MemoryKind: common.MemoryKindPathValue,
 			Weight:     1,
 			TypeInstance: cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "id3",
 			},
 		},
 		{
 			TypeName:   "Path",
 			MemoryKind: common.MemoryKindRawString,
-			Weight:     3 + 1 + 10,
+			Weight:     (1 + 3) + (1 + 3),
 			TypeInstance: cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "id3",
 			},
 		},
@@ -440,7 +440,7 @@ func TestImportedValueMemoryMeteringForSimpleTypes(t *testing.T) {
 			Weight:     1,
 			TypeInstance: cadence.StorageCapability{
 				Path: cadence.Path{
-					Domain:     "public",
+					Domain:     common.PathDomainPublic,
 					Identifier: "foobarrington",
 				},
 				Address: cadence.Address{},
@@ -456,7 +456,7 @@ func TestImportedValueMemoryMeteringForSimpleTypes(t *testing.T) {
 			Weight:     1,
 			TypeInstance: cadence.StorageCapability{
 				Path: cadence.Path{
-					Domain:     "public",
+					Domain:     common.PathDomainPublic,
 					Identifier: "foobarrington",
 				},
 				Address: cadence.Address{},
@@ -469,10 +469,10 @@ func TestImportedValueMemoryMeteringForSimpleTypes(t *testing.T) {
 		{
 			TypeName:   "Capability",
 			MemoryKind: common.MemoryKindRawString,
-			Weight:     13 + 1 + 19,
+			Weight:     (1 + 13) + (1 + 13),
 			TypeInstance: cadence.StorageCapability{
 				Path: cadence.Path{
-					Domain:     "public",
+					Domain:     common.PathDomainPublic,
 					Identifier: "foobarrington",
 				},
 				Address: cadence.Address{},

--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -126,15 +126,25 @@ func arrayLiteralValue(inter *interpreter.Interpreter, elements []ast.Expression
 		})
 }
 
-func pathLiteralValue(memoryGauge common.MemoryGauge, expression ast.Expression, ty sema.Type) (result cadence.Value, errResult error) {
+func pathLiteralValue(
+	memoryGauge common.MemoryGauge,
+	expression ast.Expression,
+	ty sema.Type,
+) (
+	cadence.Value,
+	error,
+) {
 	pathExpression, ok := expression.(*ast.PathExpression)
 	if !ok {
 		return nil, LiteralExpressionTypeError
 	}
 
+	pathDomain := pathExpression.Domain.Identifier
+	pathIdentifier := pathExpression.Identifier.Identifier
+
 	pathType, err := sema.CheckPathLiteral(
-		pathExpression.Domain.Identifier,
-		pathExpression.Identifier.Identifier,
+		pathDomain,
+		pathIdentifier,
 		func() ast.Range {
 			return ast.NewRangeFromPositioned(memoryGauge, pathExpression.Domain)
 		},
@@ -155,9 +165,9 @@ func pathLiteralValue(memoryGauge common.MemoryGauge, expression ast.Expression,
 
 	return cadence.NewMeteredPath(
 		memoryGauge,
-		pathExpression.Domain.Identifier,
-		pathExpression.Identifier.Identifier,
-	), nil
+		common.PathDomainFromIdentifier(pathDomain),
+		pathIdentifier,
+	)
 }
 
 func integerLiteralValue(

--- a/runtime/literal_test.go
+++ b/runtime/literal_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -240,7 +241,7 @@ func TestLiteralValue(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 			value,
@@ -256,7 +257,7 @@ func TestLiteralValue(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.Path{
-				Domain:     "private",
+				Domain:     common.PathDomainPrivate,
 				Identifier: "foo",
 			},
 			value,
@@ -272,7 +273,7 @@ func TestLiteralValue(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.Path{
-				Domain:     "public",
+				Domain:     common.PathDomainPublic,
 				Identifier: "foo",
 			},
 			value,
@@ -299,7 +300,7 @@ func TestLiteralValue(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 			value,
@@ -348,7 +349,7 @@ func TestLiteralValue(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.Path{
-				Domain:     "private",
+				Domain:     common.PathDomainPrivate,
 				Identifier: "foo",
 			},
 			value,
@@ -360,7 +361,7 @@ func TestLiteralValue(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.Path{
-				Domain:     "public",
+				Domain:     common.PathDomainPublic,
 				Identifier: "foo",
 			},
 			value,
@@ -386,7 +387,7 @@ func TestLiteralValue(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.Path{
-				Domain:     "public",
+				Domain:     common.PathDomainPublic,
 				Identifier: "foo",
 			},
 			value,
@@ -419,7 +420,7 @@ func TestLiteralValue(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.Path{
-				Domain:     "private",
+				Domain:     common.PathDomainPrivate,
 				Identifier: "foo",
 			},
 			value,

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -7025,7 +7025,7 @@ func TestRuntimeGetCapability(t *testing.T) {
 			cadence.StorageCapability{
 				Address: cadence.BytesToAddress([]byte{0x1}),
 				Path: cadence.Path{
-					Domain:     "public",
+					Domain:     common.PathDomainPublic,
 					Identifier: "xxx",
 				},
 			},
@@ -7355,7 +7355,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		_, err = runtime.ReadStored(
 			address,
 			cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "test",
 			},
 			Context{
@@ -7388,7 +7388,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		_, err = runtime.ReadLinked(
 			address,
 			cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "test",
 			},
 			Context{

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1706,6 +1706,23 @@ func TestRuntimeScriptArguments(t *testing.T) {
 			},
 			expectedLogs: []string{`"bar"`},
 		},
+		{
+			name: "Path subtype",
+			script: `
+                pub fun main(x: StoragePath) {
+                    log(x)
+                }
+            `,
+			args: [][]byte{
+				jsoncdc.MustEncode(cadence.Path{
+					Domain:     common.PathDomainStorage,
+					Identifier: "foo",
+				}),
+			},
+			expectedLogs: []string{
+				"/storage/foo",
+			},
+		},
 	}
 
 	test := func(tt testCase) {

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -664,7 +664,7 @@ func TestRuntimeStorageReadAndBorrow(t *testing.T) {
 		value, err := runtime.ReadStored(
 			signer,
 			cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "test",
 			},
 			Context{
@@ -681,7 +681,7 @@ func TestRuntimeStorageReadAndBorrow(t *testing.T) {
 		value, err := runtime.ReadStored(
 			signer,
 			cadence.Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "other",
 			},
 			Context{
@@ -698,7 +698,7 @@ func TestRuntimeStorageReadAndBorrow(t *testing.T) {
 		value, err := runtime.ReadLinked(
 			signer,
 			cadence.Path{
-				Domain:     "private",
+				Domain:     common.PathDomainPrivate,
 				Identifier: "test",
 			},
 			Context{
@@ -715,7 +715,7 @@ func TestRuntimeStorageReadAndBorrow(t *testing.T) {
 		value, err := runtime.ReadLinked(
 			signer,
 			cadence.Path{
-				Domain:     "private",
+				Domain:     common.PathDomainPrivate,
 				Identifier: "other",
 			},
 			Context{
@@ -1402,7 +1402,7 @@ func TestRuntimeStorageSaveStorageCapability(t *testing.T) {
 			t.Run(fmt.Sprintf("%s %s", domain.Identifier(), typeDescription), func(t *testing.T) {
 
 				storagePath := cadence.Path{
-					Domain: "storage",
+					Domain: common.PathDomainStorage,
 					Identifier: fmt.Sprintf(
 						"test%s%s",
 						typeDescription,
@@ -1445,7 +1445,7 @@ func TestRuntimeStorageSaveStorageCapability(t *testing.T) {
 
 				expected := cadence.StorageCapability{
 					Path: cadence.Path{
-						Domain:     domain.Identifier(),
+						Domain:     domain,
 						Identifier: "test",
 					},
 					Address:    cadence.Address(signer),

--- a/values.go
+++ b/values.go
@@ -1948,8 +1948,17 @@ func NewMeteredPath(gauge common.MemoryGauge, domain common.PathDomain, identifi
 
 func (Path) isValue() {}
 
-func (Path) Type() Type {
-	return ThePathType
+func (v Path) Type() Type {
+	switch v.Domain {
+	case common.PathDomainStorage:
+		return TheStoragePathType
+	case common.PathDomainPrivate:
+		return ThePrivatePathType
+	case common.PathDomainPublic:
+		return ThePublicPathType
+	}
+
+	panic(errors.NewUnreachableError())
 }
 
 func (v Path) MeteredType(common.MemoryGauge) Type {

--- a/values.go
+++ b/values.go
@@ -1924,20 +1924,24 @@ func (v AccountLink) String() string {
 // Path
 
 type Path struct {
-	Domain     string
+	Domain     common.PathDomain
 	Identifier string
 }
 
 var _ Value = Path{}
 
-func NewPath(domain, identifier string) Path {
+func NewPath(domain common.PathDomain, identifier string) (Path, error) {
+	if domain == common.PathDomainUnknown {
+		return Path{}, errors.NewDefaultUserError("unknown domain in path")
+	}
+
 	return Path{
 		Domain:     domain,
 		Identifier: identifier,
-	}
+	}, nil
 }
 
-func NewMeteredPath(gauge common.MemoryGauge, domain, identifier string) Path {
+func NewMeteredPath(gauge common.MemoryGauge, domain common.PathDomain, identifier string) (Path, error) {
 	common.UseMemory(gauge, common.CadencePathValueMemoryUsage)
 	return NewPath(domain, identifier)
 }
@@ -1958,7 +1962,7 @@ func (Path) ToGoValue() any {
 
 func (v Path) String() string {
 	return format.Path(
-		v.Domain,
+		v.Domain.Identifier(),
 		v.Identifier,
 	)
 }

--- a/values_test.go
+++ b/values_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -333,7 +334,7 @@ func newValueTestCases() map[string]valueTestCase {
 		"PathLink": {
 			value: NewPathLink(
 				Path{
-					Domain:     "storage",
+					Domain:     common.PathDomainStorage,
 					Identifier: "foo",
 				},
 				"Int",
@@ -346,9 +347,9 @@ func newValueTestCases() map[string]valueTestCase {
 			string: "AccountLink()",
 			noType: true,
 		},
-		"Path": {
+		"StoragePath": {
 			value: Path{
-				Domain:     "storage",
+				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
 			expectedType: PathType{},
@@ -361,7 +362,10 @@ func newValueTestCases() map[string]valueTestCase {
 		},
 		"Capability": {
 			value: StorageCapability{
-				Path:       Path{Domain: "storage", Identifier: "foo"},
+				Path: Path{
+					Domain:     common.PathDomainStorage,
+					Identifier: "foo",
+				},
 				Address:    BytesToAddress([]byte{1, 2, 3, 4, 5}),
 				BorrowType: IntType{},
 			},

--- a/values_test.go
+++ b/values_test.go
@@ -352,8 +352,24 @@ func newValueTestCases() map[string]valueTestCase {
 				Domain:     common.PathDomainStorage,
 				Identifier: "foo",
 			},
-			expectedType: PathType{},
+			expectedType: TheStoragePathType,
 			string:       "/storage/foo",
+		},
+		"PrivatePath": {
+			value: Path{
+				Domain:     common.PathDomainPrivate,
+				Identifier: "foo",
+			},
+			expectedType: ThePrivatePathType,
+			string:       "/private/foo",
+		},
+		"PublicPath": {
+			value: Path{
+				Domain:     common.PathDomainPublic,
+				Identifier: "foo",
+			},
+			expectedType: ThePublicPathType,
+			string:       "/public/foo",
 		},
 		"Type": {
 			value:        TypeValue{StaticType: IntType{}},


### PR DESCRIPTION
## Description

Triggered by https://dapperlabs.slack.com/archives/C0447MS42KX/p1680724003020649

- Improve type of `cadence.Path.domain`: Instead of stringly-typing, use the enum. That prevents representing invalid path values
- In the `cadence.Path` constructor function, ensure the domain is known. This fixes a bug where a path with an invalid domain was not validated. e.g. see https://testnet.flowscan.org/transaction/c3eb670d0ac98d8a5ffda6e4be4f5b1d343d7829dab1eb5b610f93c016f6640b/script
- Instead of always returning the supertype `Path` for all `cadence.Path` values, return an appropriate subtype, depending on the domain. 

  The CLI uses the return value when preparing a deployment transaction.

  When a user would pass e.g. a storage path as an argument to a contract initializer which expects a `StoragePath`, the CLI would prepare a transaction where the transaction parameter is just `Path`.

  See e.g https://testnet.flowscan.org/transaction/e7419fd3c7b5ad429cedd23af2ec410ed4f0df63a84069034c6958b1efbf3321


______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
