### PR TITLE
Extend ordering comparisons (< , <=, etc) to Bool & Character

### DIFF
--- a/docs/language/operators.md
+++ b/docs/language/operators.md
@@ -443,6 +443,8 @@ Comparison operators work with boolean and integer values.
   "a" < "b"    // is `true`
 
   "z" < "a"    // is `false`
+
+  "a" < "A"    // is `false`
   ```
 
 - Less or equal than: `<=`, for integers, booleans and characters
@@ -463,6 +465,8 @@ Comparison operators work with boolean and integer values.
   "c"  <= "a"   // is `false`
 
   "z"  <= "z"   // is `true`
+
+  "a" <= "A"    // is `false`
   ```
 
 - Greater than: `>`, for integers, booleans and characters
@@ -483,6 +487,8 @@ Comparison operators work with boolean and integer values.
   "c"  > "a"   // is `true`
 
   "g"  > "g"   // is `false`
+
+  "a" > "A"    // is `true`
   ```
 
 - Greater or equal than: `>=`, for integers, booleans and characters
@@ -503,6 +509,8 @@ Comparison operators work with boolean and integer values.
   "c"  >= "a"   // is `true`
 
   "q"  >= "q"   // is `true`
+
+  "a" >= "A"    // is `true`
   ```
 
 ### Comparing number super-types

--- a/docs/language/operators.md
+++ b/docs/language/operators.md
@@ -427,7 +427,7 @@ Comparison operators work with boolean and integer values.
   d3 != d4 // is `false`
   ```
 
-- Less than: `<`, for integers
+- Less than: `<`, for integers, booleans and characters
 
   ```cadence
   1 < 1  // is `false`
@@ -435,9 +435,17 @@ Comparison operators work with boolean and integer values.
   1 < 2  // is `true`
 
   2 < 1  // is `false`
+
+  false < true // is `true`
+
+  true < true  // is `false`
+
+  "a" < "b"    // is `true`
+
+  "z" < "a"    // is `false`
   ```
 
-- Less or equal than: `<=`, for integers
+- Less or equal than: `<=`, for integers, booleans and characters
 
   ```cadence
   1 <= 1  // is `true`
@@ -445,9 +453,19 @@ Comparison operators work with boolean and integer values.
   1 <= 2  // is `true`
 
   2 <= 1  // is `false`
+
+  false <= true // is `true`
+
+  true <= true  // is `true`
+
+  true <= false // is `false`
+
+  "c"  <= "a"   // is `false`
+
+  "z"  <= "z"   // is `true`
   ```
 
-- Greater than: `>`, for integers
+- Greater than: `>`, for integers, booleans and characters
 
   ```cadence
   1 > 1  // is `false`
@@ -455,9 +473,19 @@ Comparison operators work with boolean and integer values.
   1 > 2  // is `false`
 
   2 > 1  // is `true`
+
+  false > true // is `false`
+
+  true > true  // is `false`
+
+  true > false // is `true`
+
+  "c"  > "a"   // is `true`
+
+  "g"  > "g"   // is `false`
   ```
 
-- Greater or equal than: `>=`, for integers
+- Greater or equal than: `>=`, for integers, booleans and characters
 
   ```cadence
   1 >= 1  // is `true`
@@ -465,6 +493,16 @@ Comparison operators work with boolean and integer values.
   1 >= 2  // is `false`
 
   2 >= 1  // is `true`
+
+  false >= true // is `false`
+
+  true >= true  // is `true`
+
+  true >= false // is `true`
+
+  "c"  >= "a"   // is `true`
+
+  "q"  >= "q"   // is `true`
   ```
 
 ### Comparing number super-types

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -498,22 +498,6 @@ func (interpreter *Interpreter) testEqual(left, right Value, expression *ast.Bin
 }
 
 func (interpreter *Interpreter) testComparison(left, right Value, expression *ast.BinaryExpression) BoolValue {
-	left = interpreter.Unbox(
-		LocationRange{
-			Location:    interpreter.Location,
-			HasPosition: expression.Left,
-		},
-		left,
-	)
-
-	right = interpreter.Unbox(
-		LocationRange{
-			Location:    interpreter.Location,
-			HasPosition: expression.Right,
-		},
-		right,
-	)
-
 	locationRange := LocationRange{
 		Location:    interpreter.Location,
 		HasPosition: expression,

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -514,19 +514,21 @@ func (interpreter *Interpreter) testComparison(left, right Value, expression *as
 		right,
 	)
 
-	leftComparable, ok := left.(ComparableValue)
-	if !ok {
-		return FalseValue
-	}
-
-	rightComparable, ok := right.(ComparableValue)
-	if !ok {
-		return FalseValue
-	}
-
 	locationRange := LocationRange{
 		Location:    interpreter.Location,
 		HasPosition: expression,
+	}
+
+	leftComparable, leftOk := left.(ComparableValue)
+	rightComparable, rightOk := right.(ComparableValue)
+
+	if !leftOk || !rightOk {
+		panic(InvalidOperandsError{
+			Operation:     expression.Operation,
+			LeftType:      left.StaticType(interpreter),
+			RightType:     right.StaticType(interpreter),
+			LocationRange: locationRange,
+		})
 	}
 
 	switch expression.Operation {

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -524,45 +524,38 @@ func (interpreter *Interpreter) testComparison(left, right Value, expression *as
 		return FalseValue
 	}
 
+	locationRange := LocationRange{
+		Location:    interpreter.Location,
+		HasPosition: expression,
+	}
+
 	switch expression.Operation {
 	case ast.OperationLess:
 		return leftComparable.Less(
 			interpreter,
 			rightComparable,
-			LocationRange{
-				Location:    interpreter.Location,
-				HasPosition: expression,
-			},
+			locationRange,
 		)
 
 	case ast.OperationLessEqual:
 		return leftComparable.LessEqual(
 			interpreter,
 			rightComparable,
-			LocationRange{
-				Location:    interpreter.Location,
-				HasPosition: expression,
-			},
+			locationRange,
 		)
 
 	case ast.OperationGreater:
 		return leftComparable.Greater(
 			interpreter,
 			rightComparable,
-			LocationRange{
-				Location:    interpreter.Location,
-				HasPosition: expression,
-			},
+			locationRange,
 		)
 
 	case ast.OperationGreaterEqual:
 		return leftComparable.GreaterEqual(
 			interpreter,
 			rightComparable,
-			LocationRange{
-				Location:    interpreter.Location,
-				HasPosition: expression,
-			},
+			locationRange,
 		)
 
 	default:

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2919,6 +2919,7 @@ var _ atree.Storable = IntValue{}
 var _ NumberValue = IntValue{}
 var _ IntegerValue = IntValue{}
 var _ EquatableValue = IntValue{}
+var _ ComparableValue = IntValue{}
 var _ HashableValue = IntValue{}
 var _ MemberAccessibleValue = IntValue{}
 
@@ -3447,6 +3448,7 @@ var _ atree.Storable = Int8Value(0)
 var _ NumberValue = Int8Value(0)
 var _ IntegerValue = Int8Value(0)
 var _ EquatableValue = Int8Value(0)
+var _ ComparableValue = Int8Value(0)
 var _ HashableValue = Int8Value(0)
 
 func (Int8Value) IsValue() {}
@@ -4033,6 +4035,7 @@ var _ atree.Storable = Int16Value(0)
 var _ NumberValue = Int16Value(0)
 var _ IntegerValue = Int16Value(0)
 var _ EquatableValue = Int16Value(0)
+var _ ComparableValue = Int16Value(0)
 var _ HashableValue = Int16Value(0)
 var _ MemberAccessibleValue = Int16Value(0)
 
@@ -4621,6 +4624,7 @@ var _ atree.Storable = Int32Value(0)
 var _ NumberValue = Int32Value(0)
 var _ IntegerValue = Int32Value(0)
 var _ EquatableValue = Int32Value(0)
+var _ ComparableValue = Int32Value(0)
 var _ HashableValue = Int32Value(0)
 var _ MemberAccessibleValue = Int32Value(0)
 
@@ -5207,6 +5211,7 @@ var _ atree.Storable = Int64Value(0)
 var _ NumberValue = Int64Value(0)
 var _ IntegerValue = Int64Value(0)
 var _ EquatableValue = Int64Value(0)
+var _ ComparableValue = Int64Value(0)
 var _ HashableValue = Int64Value(0)
 var _ MemberAccessibleValue = Int64Value(0)
 
@@ -5808,6 +5813,7 @@ var _ atree.Storable = Int128Value{}
 var _ NumberValue = Int128Value{}
 var _ IntegerValue = Int128Value{}
 var _ EquatableValue = Int128Value{}
+var _ ComparableValue = Int128Value{}
 var _ HashableValue = Int128Value{}
 var _ MemberAccessibleValue = Int128Value{}
 
@@ -6496,6 +6502,7 @@ var _ atree.Storable = Int256Value{}
 var _ NumberValue = Int256Value{}
 var _ IntegerValue = Int256Value{}
 var _ EquatableValue = Int256Value{}
+var _ ComparableValue = Int256Value{}
 var _ HashableValue = Int256Value{}
 var _ MemberAccessibleValue = Int256Value{}
 
@@ -7218,6 +7225,7 @@ var _ atree.Storable = UIntValue{}
 var _ NumberValue = UIntValue{}
 var _ IntegerValue = UIntValue{}
 var _ EquatableValue = UIntValue{}
+var _ ComparableValue = UIntValue{}
 var _ HashableValue = UIntValue{}
 var _ MemberAccessibleValue = UIntValue{}
 
@@ -7741,6 +7749,7 @@ var _ atree.Storable = UInt8Value(0)
 var _ NumberValue = UInt8Value(0)
 var _ IntegerValue = UInt8Value(0)
 var _ EquatableValue = UInt8Value(0)
+var _ ComparableValue = UInt8Value(0)
 var _ HashableValue = UInt8Value(0)
 var _ MemberAccessibleValue = UInt8Value(0)
 
@@ -8289,6 +8298,7 @@ var _ atree.Storable = UInt16Value(0)
 var _ NumberValue = UInt16Value(0)
 var _ IntegerValue = UInt16Value(0)
 var _ EquatableValue = UInt16Value(0)
+var _ ComparableValue = UInt16Value(0)
 var _ HashableValue = UInt16Value(0)
 var _ MemberAccessibleValue = UInt16Value(0)
 
@@ -8812,6 +8822,7 @@ var _ atree.Storable = UInt32Value(0)
 var _ NumberValue = UInt32Value(0)
 var _ IntegerValue = UInt32Value(0)
 var _ EquatableValue = UInt32Value(0)
+var _ ComparableValue = UInt32Value(0)
 var _ HashableValue = UInt32Value(0)
 var _ MemberAccessibleValue = UInt32Value(0)
 
@@ -9312,6 +9323,7 @@ var _ atree.Storable = UInt64Value(0)
 var _ NumberValue = UInt64Value(0)
 var _ IntegerValue = UInt64Value(0)
 var _ EquatableValue = UInt64Value(0)
+var _ ComparableValue = UInt64Value(0)
 var _ HashableValue = UInt64Value(0)
 var _ MemberAccessibleValue = UInt64Value(0)
 
@@ -9880,6 +9892,7 @@ var _ atree.Storable = UInt128Value{}
 var _ NumberValue = UInt128Value{}
 var _ IntegerValue = UInt128Value{}
 var _ EquatableValue = UInt128Value{}
+var _ ComparableValue = UInt128Value{}
 var _ HashableValue = UInt128Value{}
 var _ MemberAccessibleValue = UInt128Value{}
 
@@ -10511,6 +10524,7 @@ var _ atree.Storable = UInt256Value{}
 var _ NumberValue = UInt256Value{}
 var _ IntegerValue = UInt256Value{}
 var _ EquatableValue = UInt256Value{}
+var _ ComparableValue = UInt256Value{}
 var _ HashableValue = UInt256Value{}
 var _ MemberAccessibleValue = UInt256Value{}
 
@@ -11112,6 +11126,7 @@ var _ atree.Storable = Word8Value(0)
 var _ NumberValue = Word8Value(0)
 var _ IntegerValue = Word8Value(0)
 var _ EquatableValue = Word8Value(0)
+var _ ComparableValue = Word8Value(0)
 var _ HashableValue = Word8Value(0)
 var _ MemberAccessibleValue = Word8Value(0)
 
@@ -11529,6 +11544,7 @@ var _ atree.Storable = Word16Value(0)
 var _ NumberValue = Word16Value(0)
 var _ IntegerValue = Word16Value(0)
 var _ EquatableValue = Word16Value(0)
+var _ ComparableValue = Word16Value(0)
 var _ HashableValue = Word16Value(0)
 var _ MemberAccessibleValue = Word16Value(0)
 
@@ -11947,6 +11963,7 @@ var _ atree.Storable = Word32Value(0)
 var _ NumberValue = Word32Value(0)
 var _ IntegerValue = Word32Value(0)
 var _ EquatableValue = Word32Value(0)
+var _ ComparableValue = Word32Value(0)
 var _ HashableValue = Word32Value(0)
 var _ MemberAccessibleValue = Word32Value(0)
 
@@ -12366,6 +12383,7 @@ var _ atree.Storable = Word64Value(0)
 var _ NumberValue = Word64Value(0)
 var _ IntegerValue = Word64Value(0)
 var _ EquatableValue = Word64Value(0)
+var _ ComparableValue = Word64Value(0)
 var _ HashableValue = Word64Value(0)
 var _ MemberAccessibleValue = Word64Value(0)
 
@@ -12848,6 +12866,7 @@ var _ atree.Storable = Fix64Value(0)
 var _ NumberValue = Fix64Value(0)
 var _ FixedPointValue = Fix64Value(0)
 var _ EquatableValue = Fix64Value(0)
+var _ ComparableValue = Fix64Value(0)
 var _ HashableValue = Fix64Value(0)
 var _ MemberAccessibleValue = Fix64Value(0)
 
@@ -13383,6 +13402,7 @@ var _ atree.Storable = UFix64Value(0)
 var _ NumberValue = UFix64Value(0)
 var _ FixedPointValue = Fix64Value(0)
 var _ EquatableValue = UFix64Value(0)
+var _ ComparableValue = UFix64Value(0)
 var _ HashableValue = UFix64Value(0)
 var _ MemberAccessibleValue = UFix64Value(0)
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -658,11 +658,7 @@ func (v BoolValue) Less(interpreter *Interpreter, other ComparableValue, locatio
 		})
 	}
 
-	if v {
-		return false
-	} else {
-		return o
-	}
+	return !v && o
 }
 
 func (v BoolValue) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -684,11 +684,7 @@ func (v BoolValue) Greater(interpreter *Interpreter, other ComparableValue, loca
 		})
 	}
 
-	if v {
-		return !o
-	} else {
-		return false
-	}
+	return v && !o
 }
 
 func (v BoolValue) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -651,11 +651,7 @@ func (v BoolValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 func (v BoolValue) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(BoolValue)
 	if !ok {
-		panic(InvalidOperandsError{
-			Operation: ast.OperationLess,
-			LeftType:  v.StaticType(interpreter),
-			RightType: other.StaticType(interpreter),
-		})
+		panic(errors.NewUnreachableError())
 	}
 
 	return !v && o
@@ -664,11 +660,7 @@ func (v BoolValue) Less(interpreter *Interpreter, other ComparableValue, locatio
 func (v BoolValue) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(BoolValue)
 	if !ok {
-		panic(InvalidOperandsError{
-			Operation: ast.OperationLessEqual,
-			LeftType:  v.StaticType(interpreter),
-			RightType: other.StaticType(interpreter),
-		})
+		panic(errors.NewUnreachableError())
 	}
 
 	return !v || o
@@ -677,11 +669,7 @@ func (v BoolValue) LessEqual(interpreter *Interpreter, other ComparableValue, lo
 func (v BoolValue) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(BoolValue)
 	if !ok {
-		panic(InvalidOperandsError{
-			Operation: ast.OperationGreater,
-			LeftType:  v.StaticType(interpreter),
-			RightType: other.StaticType(interpreter),
-		})
+		panic(errors.NewUnreachableError())
 	}
 
 	return v && !o
@@ -690,11 +678,7 @@ func (v BoolValue) Greater(interpreter *Interpreter, other ComparableValue, loca
 func (v BoolValue) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(BoolValue)
 	if !ok {
-		panic(InvalidOperandsError{
-			Operation: ast.OperationGreaterEqual,
-			LeftType:  v.StaticType(interpreter),
-			RightType: other.StaticType(interpreter),
-		})
+		panic(errors.NewUnreachableError())
 	}
 
 	return v || !o

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -697,11 +697,7 @@ func (v BoolValue) GreaterEqual(interpreter *Interpreter, other ComparableValue,
 		})
 	}
 
-	if v {
-		return true
-	} else {
-		return !o
-	}
+	return v || !o
 }
 
 // HashInput returns a byte slice containing:

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -648,6 +648,74 @@ func (v BoolValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 	return bool(v) == bool(otherBool)
 }
 
+func (v BoolValue) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
+	o, ok := other.(BoolValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(interpreter),
+			RightType: other.StaticType(interpreter),
+		})
+	}
+
+	if v {
+		return false
+	} else {
+		return o
+	}
+}
+
+func (v BoolValue) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
+	o, ok := other.(BoolValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(interpreter),
+			RightType: other.StaticType(interpreter),
+		})
+	}
+
+	if v {
+		return o
+	} else {
+		return true
+	}
+}
+
+func (v BoolValue) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
+	o, ok := other.(BoolValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(interpreter),
+			RightType: other.StaticType(interpreter),
+		})
+	}
+
+	if v {
+		return !o
+	} else {
+		return false
+	}
+}
+
+func (v BoolValue) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
+	o, ok := other.(BoolValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(interpreter),
+			RightType: other.StaticType(interpreter),
+		})
+	}
+
+	if v {
+		return true
+	} else {
+		return !o
+	}
+}
+
 // HashInput returns a byte slice containing:
 // - HashInputTypeBool (1 byte)
 // - 1/0 (1 byte)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -860,7 +860,7 @@ func (v CharacterValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool
 func (v CharacterValue) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	otherChar, ok := other.(CharacterValue)
 	if !ok {
-		return false
+		panic(errors.NewUnreachableError())
 	}
 	return v.NormalForm() < otherChar.NormalForm()
 }
@@ -868,7 +868,7 @@ func (v CharacterValue) Less(interpreter *Interpreter, other ComparableValue, lo
 func (v CharacterValue) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	otherChar, ok := other.(CharacterValue)
 	if !ok {
-		return false
+		panic(errors.NewUnreachableError())
 	}
 	return v.NormalForm() <= otherChar.NormalForm()
 }
@@ -876,7 +876,7 @@ func (v CharacterValue) LessEqual(interpreter *Interpreter, other ComparableValu
 func (v CharacterValue) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	otherChar, ok := other.(CharacterValue)
 	if !ok {
-		return false
+		panic(errors.NewUnreachableError())
 	}
 	return v.NormalForm() > otherChar.NormalForm()
 }
@@ -884,7 +884,7 @@ func (v CharacterValue) Greater(interpreter *Interpreter, other ComparableValue,
 func (v CharacterValue) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	otherChar, ok := other.(CharacterValue)
 	if !ok {
-		return false
+		panic(errors.NewUnreachableError())
 	}
 	return v.NormalForm() >= otherChar.NormalForm()
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -188,7 +188,7 @@ func newValueComparator(interpreter *Interpreter, locationRange LocationRange) a
 
 // ComparableValue
 type ComparableValue interface {
-	Value
+	EquatableValue
 	Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue
 	LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue
 	Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2799,7 +2799,6 @@ func (v *ArrayValue) Slice(
 
 // NumberValue
 type NumberValue interface {
-	EquatableValue
 	ComparableValue
 	ToInt(locationRange LocationRange) int
 	Negate(*Interpreter, LocationRange) NumberValue

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -825,6 +825,7 @@ func NewCharacterValue(
 var _ Value = CharacterValue("a")
 var _ atree.Storable = CharacterValue("a")
 var _ EquatableValue = CharacterValue("a")
+var _ ComparableValue = CharacterValue("a")
 var _ HashableValue = CharacterValue("a")
 var _ MemberAccessibleValue = CharacterValue("a")
 
@@ -870,6 +871,38 @@ func (v CharacterValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool
 		return false
 	}
 	return v.NormalForm() == otherChar.NormalForm()
+}
+
+func (v CharacterValue) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
+	otherChar, ok := other.(CharacterValue)
+	if !ok {
+		return false
+	}
+	return v.NormalForm() < otherChar.NormalForm()
+}
+
+func (v CharacterValue) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
+	otherChar, ok := other.(CharacterValue)
+	if !ok {
+		return false
+	}
+	return v.NormalForm() <= otherChar.NormalForm()
+}
+
+func (v CharacterValue) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
+	otherChar, ok := other.(CharacterValue)
+	if !ok {
+		return false
+	}
+	return v.NormalForm() > otherChar.NormalForm()
+}
+
+func (v CharacterValue) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
+	otherChar, ok := other.(CharacterValue)
+	if !ok {
+		return false
+	}
+	return v.NormalForm() >= otherChar.NormalForm()
 }
 
 func (v CharacterValue) HashInput(_ *Interpreter, _ LocationRange, scratch []byte) []byte {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -186,6 +186,15 @@ func newValueComparator(interpreter *Interpreter, locationRange LocationRange) a
 	}
 }
 
+// ComparableValue
+type ComparableValue interface {
+	Value
+	Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue
+	LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue
+	Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue
+	GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue
+}
+
 // ResourceKindedValue
 
 type ResourceKindedValue interface {
@@ -2690,6 +2699,7 @@ func (v *ArrayValue) Slice(
 // NumberValue
 type NumberValue interface {
 	EquatableValue
+	ComparableValue
 	ToInt(locationRange LocationRange) int
 	Negate(*Interpreter, LocationRange) NumberValue
 	Plus(interpreter *Interpreter, other NumberValue, locationRange LocationRange) NumberValue
@@ -2701,10 +2711,6 @@ type NumberValue interface {
 	SaturatingMul(interpreter *Interpreter, other NumberValue, locationRange LocationRange) NumberValue
 	Div(interpreter *Interpreter, other NumberValue, locationRange LocationRange) NumberValue
 	SaturatingDiv(interpreter *Interpreter, other NumberValue, locationRange LocationRange) NumberValue
-	Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue
-	LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue
-	Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue
-	GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue
 	ToBigEndianBytes() []byte
 }
 
@@ -3146,7 +3152,7 @@ func (v IntValue) SaturatingDiv(interpreter *Interpreter, other NumberValue, loc
 	return v.Div(interpreter, other, locationRange)
 }
 
-func (v IntValue) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v IntValue) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(IntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3160,7 +3166,7 @@ func (v IntValue) Less(interpreter *Interpreter, other NumberValue, locationRang
 	return AsBoolValue(cmp == -1)
 }
 
-func (v IntValue) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v IntValue) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(IntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3174,7 +3180,7 @@ func (v IntValue) LessEqual(interpreter *Interpreter, other NumberValue, locatio
 	return AsBoolValue(cmp <= 0)
 }
 
-func (v IntValue) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v IntValue) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(IntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3189,7 +3195,7 @@ func (v IntValue) Greater(interpreter *Interpreter, other NumberValue, locationR
 
 }
 
-func (v IntValue) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v IntValue) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(IntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3749,7 +3755,7 @@ func (v Int8Value) SaturatingDiv(interpreter *Interpreter, other NumberValue, lo
 	return NewInt8Value(interpreter, valueGetter)
 }
 
-func (v Int8Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int8Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3762,7 +3768,7 @@ func (v Int8Value) Less(interpreter *Interpreter, other NumberValue, locationRan
 	return AsBoolValue(v < o)
 }
 
-func (v Int8Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int8Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3775,7 +3781,7 @@ func (v Int8Value) LessEqual(interpreter *Interpreter, other NumberValue, locati
 	return AsBoolValue(v <= o)
 }
 
-func (v Int8Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int8Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -3788,7 +3794,7 @@ func (v Int8Value) Greater(interpreter *Interpreter, other NumberValue, location
 	return AsBoolValue(v > o)
 }
 
-func (v Int8Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int8Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4335,7 +4341,7 @@ func (v Int16Value) SaturatingDiv(interpreter *Interpreter, other NumberValue, l
 	return NewInt16Value(interpreter, valueGetter)
 }
 
-func (v Int16Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int16Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4348,7 +4354,7 @@ func (v Int16Value) Less(interpreter *Interpreter, other NumberValue, locationRa
 	return AsBoolValue(v < o)
 }
 
-func (v Int16Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int16Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4361,7 +4367,7 @@ func (v Int16Value) LessEqual(interpreter *Interpreter, other NumberValue, locat
 	return AsBoolValue(v <= o)
 }
 
-func (v Int16Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int16Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4374,7 +4380,7 @@ func (v Int16Value) Greater(interpreter *Interpreter, other NumberValue, locatio
 	return AsBoolValue(v > o)
 }
 
-func (v Int16Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int16Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4924,7 +4930,7 @@ func (v Int32Value) SaturatingDiv(interpreter *Interpreter, other NumberValue, l
 	return NewInt32Value(interpreter, valueGetter)
 }
 
-func (v Int32Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int32Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4937,7 +4943,7 @@ func (v Int32Value) Less(interpreter *Interpreter, other NumberValue, locationRa
 	return AsBoolValue(v < o)
 }
 
-func (v Int32Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int32Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4950,7 +4956,7 @@ func (v Int32Value) LessEqual(interpreter *Interpreter, other NumberValue, locat
 	return AsBoolValue(v <= o)
 }
 
-func (v Int32Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int32Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -4963,7 +4969,7 @@ func (v Int32Value) Greater(interpreter *Interpreter, other NumberValue, locatio
 	return AsBoolValue(v > o)
 }
 
-func (v Int32Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int32Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -5512,7 +5518,7 @@ func (v Int64Value) SaturatingDiv(interpreter *Interpreter, other NumberValue, l
 	return NewInt64Value(interpreter, valueGetter)
 }
 
-func (v Int64Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int64Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -5525,7 +5531,7 @@ func (v Int64Value) Less(interpreter *Interpreter, other NumberValue, locationRa
 	return AsBoolValue(v < o)
 }
 
-func (v Int64Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int64Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -5538,7 +5544,7 @@ func (v Int64Value) LessEqual(interpreter *Interpreter, other NumberValue, locat
 	return AsBoolValue(v <= o)
 }
 
-func (v Int64Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int64Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -5552,7 +5558,7 @@ func (v Int64Value) Greater(interpreter *Interpreter, other NumberValue, locatio
 
 }
 
-func (v Int64Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int64Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6161,7 +6167,7 @@ func (v Int128Value) SaturatingDiv(interpreter *Interpreter, other NumberValue, 
 	return NewInt128ValueFromBigInt(interpreter, valueGetter)
 }
 
-func (v Int128Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int128Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6175,7 +6181,7 @@ func (v Int128Value) Less(interpreter *Interpreter, other NumberValue, locationR
 	return AsBoolValue(cmp == -1)
 }
 
-func (v Int128Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int128Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6189,7 +6195,7 @@ func (v Int128Value) LessEqual(interpreter *Interpreter, other NumberValue, loca
 	return AsBoolValue(cmp <= 0)
 }
 
-func (v Int128Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int128Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6203,7 +6209,7 @@ func (v Int128Value) Greater(interpreter *Interpreter, other NumberValue, locati
 	return AsBoolValue(cmp == 1)
 }
 
-func (v Int128Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int128Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6847,7 +6853,7 @@ func (v Int256Value) SaturatingDiv(interpreter *Interpreter, other NumberValue, 
 	return NewInt256ValueFromBigInt(interpreter, valueGetter)
 }
 
-func (v Int256Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int256Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6861,7 +6867,7 @@ func (v Int256Value) Less(interpreter *Interpreter, other NumberValue, locationR
 	return AsBoolValue(cmp == -1)
 }
 
-func (v Int256Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int256Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6875,7 +6881,7 @@ func (v Int256Value) LessEqual(interpreter *Interpreter, other NumberValue, loca
 	return AsBoolValue(cmp <= 0)
 }
 
-func (v Int256Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int256Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -6889,7 +6895,7 @@ func (v Int256Value) Greater(interpreter *Interpreter, other NumberValue, locati
 	return AsBoolValue(cmp == 1)
 }
 
-func (v Int256Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Int256Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7455,7 +7461,7 @@ func (v UIntValue) SaturatingDiv(interpreter *Interpreter, other NumberValue, lo
 	return v.Div(interpreter, other, locationRange)
 }
 
-func (v UIntValue) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UIntValue) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7469,7 +7475,7 @@ func (v UIntValue) Less(interpreter *Interpreter, other NumberValue, locationRan
 	return AsBoolValue(cmp == -1)
 }
 
-func (v UIntValue) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UIntValue) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7483,7 +7489,7 @@ func (v UIntValue) LessEqual(interpreter *Interpreter, other NumberValue, locati
 	return AsBoolValue(cmp <= 0)
 }
 
-func (v UIntValue) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UIntValue) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7497,7 +7503,7 @@ func (v UIntValue) Greater(interpreter *Interpreter, other NumberValue, location
 	return AsBoolValue(cmp == 1)
 }
 
-func (v UIntValue) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UIntValue) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7981,7 +7987,7 @@ func (v UInt8Value) SaturatingDiv(interpreter *Interpreter, other NumberValue, l
 	return v.Div(interpreter, other, locationRange)
 }
 
-func (v UInt8Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt8Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -7994,7 +8000,7 @@ func (v UInt8Value) Less(interpreter *Interpreter, other NumberValue, locationRa
 	return AsBoolValue(v < o)
 }
 
-func (v UInt8Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt8Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -8007,7 +8013,7 @@ func (v UInt8Value) LessEqual(interpreter *Interpreter, other NumberValue, locat
 	return AsBoolValue(v <= o)
 }
 
-func (v UInt8Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt8Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -8020,7 +8026,7 @@ func (v UInt8Value) Greater(interpreter *Interpreter, other NumberValue, locatio
 	return AsBoolValue(v > o)
 }
 
-func (v UInt8Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt8Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -8534,7 +8540,7 @@ func (v UInt16Value) SaturatingDiv(interpreter *Interpreter, other NumberValue, 
 	return v.Div(interpreter, other, locationRange)
 }
 
-func (v UInt16Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt16Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -8547,7 +8553,7 @@ func (v UInt16Value) Less(interpreter *Interpreter, other NumberValue, locationR
 	return AsBoolValue(v < o)
 }
 
-func (v UInt16Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt16Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -8560,7 +8566,7 @@ func (v UInt16Value) LessEqual(interpreter *Interpreter, other NumberValue, loca
 	return AsBoolValue(v <= o)
 }
 
-func (v UInt16Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt16Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -8573,7 +8579,7 @@ func (v UInt16Value) Greater(interpreter *Interpreter, other NumberValue, locati
 	return AsBoolValue(v > o)
 }
 
-func (v UInt16Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt16Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9046,7 +9052,7 @@ func (v UInt32Value) SaturatingDiv(interpreter *Interpreter, other NumberValue, 
 	return v.Div(interpreter, other, locationRange)
 }
 
-func (v UInt32Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt32Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9059,7 +9065,7 @@ func (v UInt32Value) Less(interpreter *Interpreter, other NumberValue, locationR
 	return AsBoolValue(v < o)
 }
 
-func (v UInt32Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt32Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9072,7 +9078,7 @@ func (v UInt32Value) LessEqual(interpreter *Interpreter, other NumberValue, loca
 	return AsBoolValue(v <= o)
 }
 
-func (v UInt32Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt32Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9085,7 +9091,7 @@ func (v UInt32Value) Greater(interpreter *Interpreter, other NumberValue, locati
 	return AsBoolValue(v > o)
 }
 
-func (v UInt32Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt32Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9585,7 +9591,7 @@ func (v UInt64Value) SaturatingDiv(interpreter *Interpreter, other NumberValue, 
 	return v.Div(interpreter, other, locationRange)
 }
 
-func (v UInt64Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt64Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9598,7 +9604,7 @@ func (v UInt64Value) Less(interpreter *Interpreter, other NumberValue, locationR
 	return AsBoolValue(v < o)
 }
 
-func (v UInt64Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt64Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9611,7 +9617,7 @@ func (v UInt64Value) LessEqual(interpreter *Interpreter, other NumberValue, loca
 	return AsBoolValue(v <= o)
 }
 
-func (v UInt64Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt64Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -9624,7 +9630,7 @@ func (v UInt64Value) Greater(interpreter *Interpreter, other NumberValue, locati
 	return AsBoolValue(v > o)
 }
 
-func (v UInt64Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt64Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10171,7 +10177,7 @@ func (v UInt128Value) SaturatingDiv(interpreter *Interpreter, other NumberValue,
 	return v.Div(interpreter, other, locationRange)
 }
 
-func (v UInt128Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt128Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10185,7 +10191,7 @@ func (v UInt128Value) Less(interpreter *Interpreter, other NumberValue, location
 	return AsBoolValue(cmp == -1)
 }
 
-func (v UInt128Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt128Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10199,7 +10205,7 @@ func (v UInt128Value) LessEqual(interpreter *Interpreter, other NumberValue, loc
 	return AsBoolValue(cmp <= 0)
 }
 
-func (v UInt128Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt128Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10213,7 +10219,7 @@ func (v UInt128Value) Greater(interpreter *Interpreter, other NumberValue, locat
 	return AsBoolValue(cmp == 1)
 }
 
-func (v UInt128Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt128Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10804,7 +10810,7 @@ func (v UInt256Value) SaturatingDiv(interpreter *Interpreter, other NumberValue,
 	return v.Div(interpreter, other, locationRange)
 }
 
-func (v UInt256Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt256Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10818,7 +10824,7 @@ func (v UInt256Value) Less(interpreter *Interpreter, other NumberValue, location
 	return AsBoolValue(cmp == -1)
 }
 
-func (v UInt256Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt256Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10832,7 +10838,7 @@ func (v UInt256Value) LessEqual(interpreter *Interpreter, other NumberValue, loc
 	return AsBoolValue(cmp <= 0)
 }
 
-func (v UInt256Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt256Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -10846,7 +10852,7 @@ func (v UInt256Value) Greater(interpreter *Interpreter, other NumberValue, locat
 	return AsBoolValue(cmp == 1)
 }
 
-func (v UInt256Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UInt256Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -11276,7 +11282,7 @@ func (v Word8Value) SaturatingDiv(*Interpreter, NumberValue, LocationRange) Numb
 	panic(errors.NewUnreachableError())
 }
 
-func (v Word8Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word8Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -11289,7 +11295,7 @@ func (v Word8Value) Less(interpreter *Interpreter, other NumberValue, locationRa
 	return AsBoolValue(v < o)
 }
 
-func (v Word8Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word8Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -11302,7 +11308,7 @@ func (v Word8Value) LessEqual(interpreter *Interpreter, other NumberValue, locat
 	return AsBoolValue(v <= o)
 }
 
-func (v Word8Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word8Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -11315,7 +11321,7 @@ func (v Word8Value) Greater(interpreter *Interpreter, other NumberValue, locatio
 	return AsBoolValue(v > o)
 }
 
-func (v Word8Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word8Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word8Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -11692,7 +11698,7 @@ func (v Word16Value) SaturatingDiv(*Interpreter, NumberValue, LocationRange) Num
 	panic(errors.NewUnreachableError())
 }
 
-func (v Word16Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word16Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -11705,7 +11711,7 @@ func (v Word16Value) Less(interpreter *Interpreter, other NumberValue, locationR
 	return AsBoolValue(v < o)
 }
 
-func (v Word16Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word16Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -11718,7 +11724,7 @@ func (v Word16Value) LessEqual(interpreter *Interpreter, other NumberValue, loca
 	return AsBoolValue(v <= o)
 }
 
-func (v Word16Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word16Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -11731,7 +11737,7 @@ func (v Word16Value) Greater(interpreter *Interpreter, other NumberValue, locati
 	return AsBoolValue(v > o)
 }
 
-func (v Word16Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word16Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word16Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -12111,7 +12117,7 @@ func (v Word32Value) SaturatingDiv(*Interpreter, NumberValue, LocationRange) Num
 	panic(errors.NewUnreachableError())
 }
 
-func (v Word32Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word32Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -12124,7 +12130,7 @@ func (v Word32Value) Less(interpreter *Interpreter, other NumberValue, locationR
 	return AsBoolValue(v < o)
 }
 
-func (v Word32Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word32Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -12137,7 +12143,7 @@ func (v Word32Value) LessEqual(interpreter *Interpreter, other NumberValue, loca
 	return AsBoolValue(v <= o)
 }
 
-func (v Word32Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word32Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -12150,7 +12156,7 @@ func (v Word32Value) Greater(interpreter *Interpreter, other NumberValue, locati
 	return AsBoolValue(v > o)
 }
 
-func (v Word32Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word32Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word32Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -12554,7 +12560,7 @@ func (v Word64Value) SaturatingDiv(*Interpreter, NumberValue, LocationRange) Num
 	panic(errors.NewUnreachableError())
 }
 
-func (v Word64Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word64Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -12567,7 +12573,7 @@ func (v Word64Value) Less(interpreter *Interpreter, other NumberValue, locationR
 	return AsBoolValue(v < o)
 }
 
-func (v Word64Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word64Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -12580,7 +12586,7 @@ func (v Word64Value) LessEqual(interpreter *Interpreter, other NumberValue, loca
 	return AsBoolValue(v <= o)
 }
 
-func (v Word64Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word64Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -12593,7 +12599,7 @@ func (v Word64Value) Greater(interpreter *Interpreter, other NumberValue, locati
 	return AsBoolValue(v > o)
 }
 
-func (v Word64Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Word64Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -13138,7 +13144,7 @@ func (v Fix64Value) Mod(interpreter *Interpreter, other NumberValue, locationRan
 	)
 }
 
-func (v Fix64Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Fix64Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -13151,7 +13157,7 @@ func (v Fix64Value) Less(interpreter *Interpreter, other NumberValue, locationRa
 	return AsBoolValue(v < o)
 }
 
-func (v Fix64Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Fix64Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -13164,7 +13170,7 @@ func (v Fix64Value) LessEqual(interpreter *Interpreter, other NumberValue, locat
 	return AsBoolValue(v <= o)
 }
 
-func (v Fix64Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Fix64Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -13177,7 +13183,7 @@ func (v Fix64Value) Greater(interpreter *Interpreter, other NumberValue, locatio
 	return AsBoolValue(v > o)
 }
 
-func (v Fix64Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v Fix64Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -13635,7 +13641,7 @@ func (v UFix64Value) Mod(interpreter *Interpreter, other NumberValue, locationRa
 	)
 }
 
-func (v UFix64Value) Less(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UFix64Value) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -13648,7 +13654,7 @@ func (v UFix64Value) Less(interpreter *Interpreter, other NumberValue, locationR
 	return AsBoolValue(v < o)
 }
 
-func (v UFix64Value) LessEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UFix64Value) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -13661,7 +13667,7 @@ func (v UFix64Value) LessEqual(interpreter *Interpreter, other NumberValue, loca
 	return AsBoolValue(v <= o)
 }
 
-func (v UFix64Value) Greater(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UFix64Value) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
 		panic(InvalidOperandsError{
@@ -13674,7 +13680,7 @@ func (v UFix64Value) Greater(interpreter *Interpreter, other NumberValue, locati
 	return AsBoolValue(v > o)
 }
 
-func (v UFix64Value) GreaterEqual(interpreter *Interpreter, other NumberValue, locationRange LocationRange) BoolValue {
+func (v UFix64Value) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
 		panic(InvalidOperandsError{

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -671,11 +671,7 @@ func (v BoolValue) LessEqual(interpreter *Interpreter, other ComparableValue, lo
 		})
 	}
 
-	if v {
-		return o
-	} else {
-		return true
-	}
+	return !v || o
 }
 
 func (v BoolValue) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {

--- a/runtime/sema/any_type.go
+++ b/runtime/sema/any_type.go
@@ -27,8 +27,9 @@ var AnyType = &SimpleType{
 	tag:           AnyTypeTag,
 	IsResource:    false,
 	// `Any` is never a valid type in user programs
-	Storable:  true,
-	Equatable: false,
+	Storable:   true,
+	Equatable:  false,
+	Comparable: false,
 	// `Any` is never a valid type in user programs
 	Exportable: false,
 	Importable: false,

--- a/runtime/sema/anyattachment_types.go
+++ b/runtime/sema/anyattachment_types.go
@@ -28,8 +28,9 @@ var AnyResourceAttachmentType = &SimpleType{
 	tag:           AnyResourceAttachmentTypeTag,
 	IsResource:    true,
 	// The actual storability of a value is checked at run-time
-	Storable:  true,
-	Equatable: false,
+	Storable:   true,
+	Equatable:  false,
+	Comparable: false,
 	// The actual returnability of a value is checked at run-time
 	Exportable: true,
 	Importable: false,
@@ -45,8 +46,9 @@ var AnyStructAttachmentType = &SimpleType{
 	tag:           AnyStructAttachmentTypeTag,
 	IsResource:    false,
 	// The actual storability of a value is checked at run-time
-	Storable:  true,
-	Equatable: false,
+	Storable:   true,
+	Equatable:  false,
+	Comparable: false,
 	// The actual returnability of a value is checked at run-time
 	Exportable: true,
 	Importable: false,

--- a/runtime/sema/anyresource_type.go
+++ b/runtime/sema/anyresource_type.go
@@ -26,8 +26,9 @@ var AnyResourceType = &SimpleType{
 	tag:           AnyResourceTypeTag,
 	IsResource:    true,
 	// The actual storability of a value is checked at run-time
-	Storable:  true,
-	Equatable: false,
+	Storable:   true,
+	Equatable:  false,
+	Comparable: false,
 	// The actual returnability of a value is checked at run-time
 	Exportable: true,
 	Importable: false,

--- a/runtime/sema/anystruct_type.go
+++ b/runtime/sema/anystruct_type.go
@@ -28,6 +28,7 @@ var AnyStructType = &SimpleType{
 	// The actual storability of a value is checked at run-time
 	Storable:   true,
 	Equatable:  false,
+	Comparable: false,
 	Exportable: true,
 	// The actual importability is checked at runtime
 	Importable: true,

--- a/runtime/sema/block.gen.go
+++ b/runtime/sema/block.gen.go
@@ -71,6 +71,7 @@ var BlockType = &SimpleType{
 	IsResource:    false,
 	Storable:      false,
 	Equatable:     false,
+	Comparable:    false,
 	Exportable:    false,
 	Importable:    false,
 }

--- a/runtime/sema/character.cdc
+++ b/runtime/sema/character.cdc
@@ -1,5 +1,5 @@
 
-pub struct Character: Storable, Equatable, Exportable, Importable {
+pub struct Character: Storable, Equatable, Comparable, Exportable, Importable {
 
     /// Returns this character as a String
     pub fun toString(): String

--- a/runtime/sema/character.cdc
+++ b/runtime/sema/character.cdc
@@ -1,5 +1,5 @@
 
-pub struct Character: Storable, Equatable, Comparable, Exportable, Importable {
+pub struct Character: Storable, Equatable, Exportable, Importable {
 
     /// Returns this character as a String
     pub fun toString(): String

--- a/runtime/sema/character.gen.go
+++ b/runtime/sema/character.gen.go
@@ -41,7 +41,7 @@ var CharacterType = &SimpleType{
 	IsResource:    false,
 	Storable:      true,
 	Equatable:     true,
-	Comparable:    false,
+	Comparable:    true,
 	Exportable:    true,
 	Importable:    true,
 }

--- a/runtime/sema/character.gen.go
+++ b/runtime/sema/character.gen.go
@@ -41,7 +41,7 @@ var CharacterType = &SimpleType{
 	IsResource:    false,
 	Storable:      true,
 	Equatable:     true,
-	Comparable:    true,
+	Comparable:    false,
 	Exportable:    true,
 	Importable:    true,
 }

--- a/runtime/sema/character.gen.go
+++ b/runtime/sema/character.gen.go
@@ -41,6 +41,7 @@ var CharacterType = &SimpleType{
 	IsResource:    false,
 	Storable:      true,
 	Equatable:     true,
+	Comparable:    true,
 	Exportable:    true,
 	Importable:    true,
 }

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -131,13 +131,20 @@ func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) 
 
 		switch operationKind {
 		case BinaryOperationKindArithmetic,
-			BinaryOperationKindNonEqualityComparison,
 			BinaryOperationKindBitwise:
 
-			resultType = checker.checkBinaryExpressionArithmeticOrNonEqualityComparisonOrBitwise(
+			resultType = checker.checkBinaryExpressionArithmeticOrBitwise(
 				expression, operation, operationKind,
 				leftType, rightType,
 				leftIsInvalid, rightIsInvalid, anyInvalid,
+			)
+			return resultType
+
+		case BinaryOperationKindNonEqualityComparison:
+			resultType = checker.checkBinaryExpressionNonEquality(
+				expression, operation,
+				leftType, rightType,
+				anyInvalid,
 			)
 			return resultType
 
@@ -199,7 +206,7 @@ func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) 
 	}
 }
 
-func (checker *Checker) checkBinaryExpressionArithmeticOrNonEqualityComparisonOrBitwise(
+func (checker *Checker) checkBinaryExpressionArithmeticOrBitwise(
 	expression *ast.BinaryExpression,
 	operation ast.Operation,
 	operationKind BinaryOperationKind,
@@ -211,9 +218,7 @@ func (checker *Checker) checkBinaryExpressionArithmeticOrNonEqualityComparisonOr
 	var expectedSuperType Type
 
 	switch operationKind {
-	case BinaryOperationKindArithmetic,
-		BinaryOperationKindNonEqualityComparison:
-
+	case BinaryOperationKindArithmetic:
 		expectedSuperType = NumberType
 
 	case BinaryOperationKindBitwise:
@@ -277,8 +282,7 @@ func (checker *Checker) checkBinaryExpressionArithmeticOrNonEqualityComparisonOr
 			return true
 		}
 
-		// Arithmetic, bitwise and non-equality comparison operators
-		// are not supported for numeric supertypes.
+		// Arithmetic, bitwise are not supported for numeric supertypes.
 		return isNumericSuperType(leftType)
 	}
 
@@ -293,18 +297,32 @@ func (checker *Checker) checkBinaryExpressionArithmeticOrNonEqualityComparisonOr
 		)
 	}
 
-	switch operationKind {
-	case BinaryOperationKindArithmetic,
-		BinaryOperationKindBitwise:
+	return leftType
+}
 
-		return leftType
+func (checker *Checker) checkBinaryExpressionNonEquality(
+	expression *ast.BinaryExpression,
+	operation ast.Operation,
+	leftType, rightType Type,
+	anyInvalid bool,
+) (resultType Type) {
+	resultType = BoolType
 
-	case BinaryOperationKindNonEqualityComparison:
-		return BoolType
-
-	default:
-		panic(errors.NewUnreachableError())
+	// TODO: Do we want to use IsSameTypeKind for comparing leftType and rightType?
+	if !(leftType.Equal(rightType) && leftType.IsComparable() && rightType.IsComparable()) {
+		if !anyInvalid {
+			checker.report(
+				&InvalidBinaryOperandsError{
+					Operation: operation,
+					LeftType:  leftType,
+					RightType: rightType,
+					Range:     ast.NewRangeFromPositioned(checker.memoryGauge, expression),
+				},
+			)
+		}
 	}
+
+	return
 }
 
 func (checker *Checker) checkBinaryExpressionEquality(

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -308,7 +308,6 @@ func (checker *Checker) checkBinaryExpressionNonEquality(
 ) (resultType Type) {
 	resultType = BoolType
 
-	// TODO: Do we want to use IsSameTypeKind for comparing leftType and rightType?
 	if !(leftType.Equal(rightType) && leftType.IsComparable() && rightType.IsComparable()) {
 		if !anyInvalid {
 			checker.report(

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -282,7 +282,7 @@ func (checker *Checker) checkBinaryExpressionArithmeticOrBitwise(
 			return true
 		}
 
-		// Arithmetic, bitwise are not supported for numeric supertypes.
+		// Arithmetic and bitwise operations are not supported for numeric supertypes.
 		return isNumericSuperType(leftType)
 	}
 

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -308,17 +308,15 @@ func (checker *Checker) checkBinaryExpressionNonEquality(
 ) (resultType Type) {
 	resultType = BoolType
 
-	if !(leftType.Equal(rightType) && leftType.IsComparable() && rightType.IsComparable()) {
-		if !anyInvalid {
-			checker.report(
-				&InvalidBinaryOperandsError{
-					Operation: operation,
-					LeftType:  leftType,
-					RightType: rightType,
-					Range:     ast.NewRangeFromPositioned(checker.memoryGauge, expression),
-				},
-			)
-		}
+	if !(leftType.Equal(rightType) && leftType.IsComparable() && rightType.IsComparable()) && !anyInvalid {
+		checker.report(
+			&InvalidBinaryOperandsError{
+				Operation: operation,
+				LeftType:  leftType,
+				RightType: rightType,
+				Range:     ast.NewRangeFromPositioned(checker.memoryGauge, expression),
+			},
+		)
 	}
 
 	return

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -308,7 +308,11 @@ func (checker *Checker) checkBinaryExpressionNonEquality(
 ) (resultType Type) {
 	resultType = BoolType
 
-	if !(leftType.Equal(rightType) && leftType.IsComparable() && rightType.IsComparable()) && !anyInvalid {
+	areEqualAndComparable := leftType.Equal(rightType) &&
+		leftType.IsComparable() &&
+		rightType.IsComparable()
+
+	if !areEqualAndComparable && !anyInvalid {
 		checker.report(
 			&InvalidBinaryOperandsError{
 				Operation: operation,

--- a/runtime/sema/deployedcontract.gen.go
+++ b/runtime/sema/deployedcontract.gen.go
@@ -79,6 +79,7 @@ var DeployedContractType = &SimpleType{
 	IsResource:    false,
 	Storable:      false,
 	Equatable:     false,
+	Comparable:    false,
 	Exportable:    false,
 	Importable:    false,
 }

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -149,6 +149,7 @@ type typeDecl struct {
 	storable           bool
 	equatable          bool
 	exportable         bool
+	comparable         bool
 	importable         bool
 	memberDeclarations []ast.Declaration
 	nestedTypes        []*typeDecl
@@ -400,6 +401,15 @@ func (g *generator) VisitCompositeDeclaration(decl *ast.CompositeDeclaration) (_
 				))
 			}
 			typeDecl.equatable = true
+
+		case "Comparable":
+			if !canGenerateSimpleType {
+				panic(fmt.Errorf(
+					"composite types cannot be explicitly marked as comparable: %s",
+					g.currentTypeID(),
+				))
+			}
+			typeDecl.comparable = true
 
 		case "Exportable":
 			if !canGenerateSimpleType {
@@ -1057,6 +1067,7 @@ func simpleTypeLiteral(ty *typeDecl) dst.Expr {
 	//	IsResource:    true,
 	//	Storable:      false,
 	//	Equatable:     false,
+	//  Comparable:    false,
 	//	Exportable:    false,
 	//	Importable:    false,
 	//}
@@ -1070,6 +1081,7 @@ func simpleTypeLiteral(ty *typeDecl) dst.Expr {
 		goKeyValue("IsResource", goBoolLit(isResource)),
 		goKeyValue("Storable", goBoolLit(ty.storable)),
 		goKeyValue("Equatable", goBoolLit(ty.equatable)),
+		goKeyValue("Comparable", goBoolLit(ty.comparable)),
 		goKeyValue("Exportable", goBoolLit(ty.exportable)),
 		goKeyValue("Importable", goBoolLit(ty.importable)),
 	}

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -1067,7 +1067,7 @@ func simpleTypeLiteral(ty *typeDecl) dst.Expr {
 	//	IsResource:    true,
 	//	Storable:      false,
 	//	Equatable:     false,
-	//  Comparable:    false,
+	//	Comparable:    false,
 	//	Exportable:    false,
 	//	Importable:    false,
 	//}

--- a/runtime/sema/gen/testdata/comparable.cdc
+++ b/runtime/sema/gen/testdata/comparable.cdc
@@ -1,0 +1,1 @@
+pub struct Test: Comparable {}

--- a/runtime/sema/gen/testdata/comparable.golden.go
+++ b/runtime/sema/gen/testdata/comparable.golden.go
@@ -1,3 +1,4 @@
+// Code generated from testdata/comparable.cdc. DO NOT EDIT.
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
@@ -18,16 +19,17 @@
 
 package sema
 
-// BoolType represents the boolean type
-var BoolType = &SimpleType{
-	Name:          "Bool",
-	QualifiedName: "Bool",
-	TypeID:        "Bool",
-	tag:           BoolTypeTag,
+const TestTypeName = "Test"
+
+var TestType = &SimpleType{
+	Name:          TestTypeName,
+	QualifiedName: TestTypeName,
+	TypeID:        TestTypeName,
+	tag:           TestTypeTag,
 	IsResource:    false,
-	Storable:      true,
-	Equatable:     true,
+	Storable:      false,
+	Equatable:     false,
 	Comparable:    true,
-	Exportable:    true,
-	Importable:    true,
+	Exportable:    false,
+	Importable:    false,
 }

--- a/runtime/sema/gen/testdata/docstrings.golden.go
+++ b/runtime/sema/gen/testdata/docstrings.golden.go
@@ -109,6 +109,7 @@ var DocstringsType = &SimpleType{
 	IsResource:    false,
 	Storable:      false,
 	Equatable:     false,
+	Comparable:    false,
 	Exportable:    false,
 	Importable:    false,
 }

--- a/runtime/sema/gen/testdata/equatable.golden.go
+++ b/runtime/sema/gen/testdata/equatable.golden.go
@@ -29,6 +29,7 @@ var TestType = &SimpleType{
 	IsResource:    false,
 	Storable:      false,
 	Equatable:     true,
+	Comparable:    false,
 	Exportable:    false,
 	Importable:    false,
 }

--- a/runtime/sema/gen/testdata/exportable.golden.go
+++ b/runtime/sema/gen/testdata/exportable.golden.go
@@ -29,6 +29,7 @@ var TestType = &SimpleType{
 	IsResource:    false,
 	Storable:      false,
 	Equatable:     false,
+	Comparable:    false,
 	Exportable:    true,
 	Importable:    false,
 }

--- a/runtime/sema/gen/testdata/fields.golden.go
+++ b/runtime/sema/gen/testdata/fields.golden.go
@@ -124,6 +124,7 @@ var TestType = &SimpleType{
 	IsResource:    false,
 	Storable:      false,
 	Equatable:     false,
+	Comparable:    false,
 	Exportable:    false,
 	Importable:    false,
 }

--- a/runtime/sema/gen/testdata/functions.golden.go
+++ b/runtime/sema/gen/testdata/functions.golden.go
@@ -167,6 +167,7 @@ var TestType = &SimpleType{
 	IsResource:    false,
 	Storable:      false,
 	Equatable:     false,
+	Comparable:    false,
 	Exportable:    false,
 	Importable:    false,
 }

--- a/runtime/sema/gen/testdata/importable.golden.go
+++ b/runtime/sema/gen/testdata/importable.golden.go
@@ -29,6 +29,7 @@ var TestType = &SimpleType{
 	IsResource:    false,
 	Storable:      false,
 	Equatable:     false,
+	Comparable:    false,
 	Exportable:    false,
 	Importable:    true,
 }

--- a/runtime/sema/gen/testdata/simple-resource.golden.go
+++ b/runtime/sema/gen/testdata/simple-resource.golden.go
@@ -29,6 +29,7 @@ var TestType = &SimpleType{
 	IsResource:    true,
 	Storable:      false,
 	Equatable:     false,
+	Comparable:    false,
 	Exportable:    false,
 	Importable:    false,
 }

--- a/runtime/sema/gen/testdata/simple-struct.golden.go
+++ b/runtime/sema/gen/testdata/simple-struct.golden.go
@@ -29,6 +29,7 @@ var TestType = &SimpleType{
 	IsResource:    false,
 	Storable:      false,
 	Equatable:     false,
+	Comparable:    false,
 	Exportable:    false,
 	Importable:    false,
 }

--- a/runtime/sema/gen/testdata/storable.golden.go
+++ b/runtime/sema/gen/testdata/storable.golden.go
@@ -29,6 +29,7 @@ var TestType = &SimpleType{
 	IsResource:    false,
 	Storable:      true,
 	Equatable:     false,
+	Comparable:    false,
 	Exportable:    false,
 	Importable:    false,
 }

--- a/runtime/sema/invalid_type.go
+++ b/runtime/sema/invalid_type.go
@@ -29,6 +29,7 @@ var InvalidType = &SimpleType{
 	IsResource:    false,
 	Storable:      false,
 	Equatable:     false,
+	Comparable:    false,
 	Exportable:    false,
 	Importable:    false,
 }

--- a/runtime/sema/meta_type.go
+++ b/runtime/sema/meta_type.go
@@ -41,6 +41,7 @@ var MetaType = &SimpleType{
 	IsResource:    false,
 	Storable:      true,
 	Equatable:     true,
+	Comparable:    false,
 	Exportable:    true,
 	Importable:    true,
 }

--- a/runtime/sema/never_type.go
+++ b/runtime/sema/never_type.go
@@ -27,6 +27,7 @@ var NeverType = &SimpleType{
 	IsResource:    false,
 	Storable:      false,
 	Equatable:     false,
+	Comparable:    false,
 	Exportable:    false,
 	Importable:    false,
 }

--- a/runtime/sema/path_type.go
+++ b/runtime/sema/path_type.go
@@ -27,6 +27,7 @@ var PathType = &SimpleType{
 	IsResource:    false,
 	Storable:      true,
 	Equatable:     true,
+	Comparable:    false,
 	Exportable:    true,
 	Importable:    true,
 	IsSuperTypeOf: func(subType Type) bool {
@@ -44,6 +45,7 @@ var StoragePathType = &SimpleType{
 	IsResource:    false,
 	Storable:      true,
 	Equatable:     true,
+	Comparable:    false,
 	Exportable:    true,
 	Importable:    true,
 }
@@ -57,6 +59,7 @@ var CapabilityPathType = &SimpleType{
 	IsResource:    false,
 	Storable:      true,
 	Equatable:     true,
+	Comparable:    false,
 	Exportable:    true,
 	Importable:    true,
 	IsSuperTypeOf: func(subType Type) bool {
@@ -74,6 +77,7 @@ var PublicPathType = &SimpleType{
 	IsResource:    false,
 	Storable:      true,
 	Equatable:     true,
+	Comparable:    false,
 	Exportable:    true,
 	Importable:    true,
 }
@@ -87,6 +91,7 @@ var PrivatePathType = &SimpleType{
 	IsResource:    false,
 	Storable:      true,
 	Equatable:     true,
+	Comparable:    false,
 	Exportable:    true,
 	Importable:    true,
 }

--- a/runtime/sema/simple_type.go
+++ b/runtime/sema/simple_type.go
@@ -47,6 +47,7 @@ type SimpleType struct {
 	Importable          bool
 	Exportable          bool
 	Equatable           bool
+	Comparable          bool
 	Storable            bool
 	IsResource          bool
 }
@@ -91,6 +92,10 @@ func (t *SimpleType) IsStorable(_ map[*Member]bool) bool {
 
 func (t *SimpleType) IsEquatable() bool {
 	return t.Equatable
+}
+
+func (t *SimpleType) IsComparable() bool {
+	return t.Comparable
 }
 
 func (t *SimpleType) IsExportable(_ map[*Member]bool) bool {

--- a/runtime/sema/storable_type.go
+++ b/runtime/sema/storable_type.go
@@ -36,6 +36,7 @@ var StorableType = &SimpleType{
 	IsResource: false,
 	Storable:   true,
 	Equatable:  false,
+	Comparable: false,
 	Exportable: false,
 	Importable: false,
 	IsSuperTypeOf: func(subType Type) bool {

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -46,6 +46,7 @@ var StringType = &SimpleType{
 	IsResource:    false,
 	Storable:      true,
 	Equatable:     true,
+	Comparable:    false,
 	Exportable:    true,
 	Importable:    true,
 	ValueIndexingInfo: ValueIndexingInfo{

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -131,6 +131,9 @@ type Type interface {
 	// IsEquatable returns true if values of the type can be equated
 	IsEquatable() bool
 
+	// IsComparable returns true if values of the type can be compared
+	IsComparable() bool
+
 	TypeAnnotationState() TypeAnnotationState
 	RewriteWithRestrictedTypes() (result Type, rewritten bool)
 
@@ -583,6 +586,10 @@ func (t *OptionalType) IsEquatable() bool {
 	return t.Type.IsEquatable()
 }
 
+func (*OptionalType) IsComparable() bool {
+	return false
+}
+
 func (t *OptionalType) TypeAnnotationState() TypeAnnotationState {
 	return t.Type.TypeAnnotationState()
 }
@@ -766,6 +773,10 @@ func (t *GenericType) IsImportable(_ map[*Member]bool) bool {
 }
 
 func (*GenericType) IsEquatable() bool {
+	return false
+}
+
+func (*GenericType) IsComparable() bool {
 	return false
 }
 
@@ -1050,6 +1061,10 @@ func (*NumericType) IsEquatable() bool {
 	return true
 }
 
+func (t *NumericType) IsComparable() bool {
+	return !t.IsSuperType()
+}
+
 func (*NumericType) TypeAnnotationState() TypeAnnotationState {
 	return TypeAnnotationStateValid
 }
@@ -1240,6 +1255,10 @@ func (t *FixedPointNumericType) IsImportable(_ map[*Member]bool) bool {
 
 func (*FixedPointNumericType) IsEquatable() bool {
 	return true
+}
+
+func (t *FixedPointNumericType) IsComparable() bool {
+	return !t.IsSuperType()
 }
 
 func (*FixedPointNumericType) TypeAnnotationState() TypeAnnotationState {
@@ -2174,6 +2193,10 @@ func (v *VariableSizedType) IsEquatable() bool {
 	return v.Type.IsEquatable()
 }
 
+func (t *VariableSizedType) IsComparable() bool {
+	return t.Type.IsComparable()
+}
+
 func (t *VariableSizedType) TypeAnnotationState() TypeAnnotationState {
 	return t.Type.TypeAnnotationState()
 }
@@ -2314,6 +2337,10 @@ func (t *ConstantSizedType) IsImportable(results map[*Member]bool) bool {
 
 func (t *ConstantSizedType) IsEquatable() bool {
 	return t.Type.IsEquatable()
+}
+
+func (t *ConstantSizedType) IsComparable() bool {
+	return t.Type.IsComparable()
 }
 
 func (t *ConstantSizedType) TypeAnnotationState() TypeAnnotationState {
@@ -2784,6 +2811,10 @@ func (t *FunctionType) IsImportable(_ map[*Member]bool) bool {
 }
 
 func (*FunctionType) IsEquatable() bool {
+	return false
+}
+
+func (*FunctionType) IsComparable() bool {
 	return false
 }
 
@@ -3779,6 +3810,10 @@ func (t *CompositeType) IsEquatable() bool {
 	return t.Kind == common.CompositeKindEnum
 }
 
+func (*CompositeType) IsComparable() bool {
+	return false
+}
+
 func (c *CompositeType) TypeAnnotationState() TypeAnnotationState {
 	if c.Kind == common.CompositeKindAttachment {
 		return TypeAnnotationStateDirectAttachmentTypeAnnotation
@@ -4273,6 +4308,10 @@ func (*InterfaceType) IsEquatable() bool {
 	return false
 }
 
+func (*InterfaceType) IsComparable() bool {
+	return false
+}
+
 func (*InterfaceType) TypeAnnotationState() TypeAnnotationState {
 	return TypeAnnotationStateValid
 }
@@ -4408,6 +4447,10 @@ func (t *DictionaryType) IsImportable(results map[*Member]bool) bool {
 func (t *DictionaryType) IsEquatable() bool {
 	return t.KeyType.IsEquatable() &&
 		t.ValueType.IsEquatable()
+}
+
+func (*DictionaryType) IsComparable() bool {
+	return false
 }
 
 func (t *DictionaryType) TypeAnnotationState() TypeAnnotationState {
@@ -4849,6 +4892,10 @@ func (*ReferenceType) IsEquatable() bool {
 	return true
 }
 
+func (*ReferenceType) IsComparable() bool {
+	return false
+}
+
 func (*ReferenceType) TypeAnnotationState() TypeAnnotationState {
 	return TypeAnnotationStateValid
 }
@@ -5010,6 +5057,10 @@ func (t *AddressType) IsImportable(_ map[*Member]bool) bool {
 
 func (*AddressType) IsEquatable() bool {
 	return true
+}
+
+func (*AddressType) IsComparable() bool {
+	return false
 }
 
 func (*AddressType) TypeAnnotationState() TypeAnnotationState {
@@ -5923,6 +5974,10 @@ func (*TransactionType) IsEquatable() bool {
 	return false
 }
 
+func (*TransactionType) IsComparable() bool {
+	return false
+}
+
 func (*TransactionType) TypeAnnotationState() TypeAnnotationState {
 	return TypeAnnotationStateValid
 }
@@ -6146,6 +6201,10 @@ func (*RestrictedType) IsEquatable() bool {
 	return false
 }
 
+func (t *RestrictedType) IsComparable() bool {
+	return false
+}
+
 func (*RestrictedType) TypeAnnotationState() TypeAnnotationState {
 	return TypeAnnotationStateValid
 }
@@ -6364,6 +6423,10 @@ func (t *CapabilityType) IsImportable(_ map[*Member]bool) bool {
 
 func (*CapabilityType) IsEquatable() bool {
 	// TODO:
+	return false
+}
+
+func (*CapabilityType) IsComparable() bool {
 	return false
 }
 

--- a/runtime/sema/void_type.go
+++ b/runtime/sema/void_type.go
@@ -27,6 +27,7 @@ var VoidType = &SimpleType{
 	IsResource:    false,
 	Storable:      false,
 	Equatable:     true,
+	Comparable:    false,
 	Exportable:    true,
 	Importable:    false,
 }

--- a/runtime/tests/checker/operations_test.go
+++ b/runtime/tests/checker/operations_test.go
@@ -186,7 +186,6 @@ func TestCheckIntegerBinaryOperations(t *testing.T) {
 				{sema.BoolType, "1", "2", nil},
 				{sema.BoolType, "1.2", "3.4", nil},
 				{sema.BoolType, "true", "2", []error{
-					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
 				{sema.BoolType, "1.2", "3", []error{
@@ -196,20 +195,15 @@ func TestCheckIntegerBinaryOperations(t *testing.T) {
 					&sema.InvalidBinaryOperandsError{},
 				}},
 				{sema.BoolType, "true", "1.2", []error{
-					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
 				{sema.BoolType, "1", "true", []error{
-					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
 				{sema.BoolType, "1.2", "true", []error{
-					&sema.InvalidBinaryOperandError{},
 					&sema.InvalidBinaryOperandsError{},
 				}},
-				{sema.BoolType, "true", "false", []error{
-					&sema.InvalidBinaryOperandsError{},
-				}},
+				{sema.BoolType, "true", "false", nil},
 			},
 		},
 		{

--- a/runtime/tests/checker/operations_test.go
+++ b/runtime/tests/checker/operations_test.go
@@ -322,6 +322,75 @@ func TestCheckIntegerBinaryOperations(t *testing.T) {
 	}
 }
 
+type operationWithTypeTest struct {
+	ty                  sema.Type
+	left, right         string
+	leftType, rightType string
+	expectedErrors      []error
+}
+
+type operationWithTypeTests struct {
+	operations []ast.Operation
+	tests      []operationWithTypeTest
+}
+
+func TestCheckNonIntegerComparisonOperations(t *testing.T) {
+	t.Parallel()
+
+	allOperationTests := []operationWithTypeTests{
+		{
+			operations: []ast.Operation{
+				ast.OperationLess,
+				ast.OperationLessEqual,
+				ast.OperationGreater,
+				ast.OperationGreaterEqual,
+			},
+			tests: []operationWithTypeTest{
+				{sema.BoolType, "false", "true", "Bool", "Bool", nil},
+				{sema.BoolType, "false", "1", "Bool", "Int", []error{
+					&sema.InvalidBinaryOperandsError{},
+				}},
+				{sema.BoolType, "\"a\"", "\"b\"", "Character", "Character", nil},
+				{sema.BoolType, "1.2", "\"b\"", "Fix64", "Character", []error{
+					&sema.InvalidBinaryOperandsError{},
+				}},
+			},
+		},
+	}
+
+	for _, operationTests := range allOperationTests {
+		for _, operation := range operationTests.operations {
+			for _, test := range operationTests.tests {
+
+				testName := fmt.Sprintf(
+					"%s / %s %s %s",
+					test.ty, test.left, operation.Symbol(), test.right,
+				)
+
+				t.Run(testName, func(t *testing.T) {
+
+					_, err := ParseAndCheck(t,
+						fmt.Sprintf(
+							`fun test(): %s { 
+								let a: %s = %s
+								let b: %s = %s
+								return a %s b 
+							}`,
+							test.ty, test.leftType, test.left, test.rightType, test.right, operation.Symbol(),
+						),
+					)
+
+					errs := RequireCheckerErrors(t, err, len(test.expectedErrors))
+
+					for i, expectedErr := range test.expectedErrors {
+						assert.IsType(t, expectedErr, errs[i])
+					}
+				})
+			}
+		}
+	}
+}
+
 func TestCheckSaturatedArithmeticFunctions(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4698,7 +4698,7 @@ func TestInterpretComparison(t *testing.T) {
 			boolVal, ok := res.(interpreter.BoolValue)
 			require.True(t, ok)
 
-			require.Equal(t, bool(boolVal), expected)
+			require.Equal(t, expected, bool(boolVal))
 		})
 	}
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4740,11 +4740,7 @@ func TestInterpretComparison(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test // capture range variable
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			runBooleanTest(t, test.name, test.expected, test.inner)
-		})
+		runBooleanTest(t, test.name, test.expected, test.inner)
 	}
 }
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4681,6 +4681,73 @@ func TestInterpretDictionaryEquality(t *testing.T) {
 	}
 }
 
+func TestInterpretComparison(t *testing.T) {
+	t.Parallel()
+
+	runBooleanTest := func(t *testing.T, name string, expected bool, innerCode string) {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			code := fmt.Sprintf("fun test(): Bool { \n %s \n }", innerCode)
+
+			inter := parseCheckAndInterpret(t, code)
+			res, err := inter.Invoke("test")
+
+			require.NoError(t, err)
+
+			boolVal, ok := res.(interpreter.BoolValue)
+			require.True(t, ok)
+
+			require.Equal(t, bool(boolVal), expected)
+		})
+	}
+
+	tests := []struct {
+		name     string
+		expected bool
+		inner    string
+	}{
+		{"true < true", false, "return true < true"},
+		{"true <= true", true, "return true <= true"},
+		{"true > true", false, "return true > true"},
+		{"true >= true", true, "return true >= true"},
+		{"false < false", false, "return false < false"},
+		{"false <= false", true, "return false <= false"},
+		{"false > false", false, "return false > false"},
+		{"false >= false", true, "return false >= false"},
+		{"true < false", false, "return true < false"},
+		{"true <= false", false, "return true <= false"},
+		{"true > false", true, "return true > false"},
+		{"true >= false", true, "return true >= false"},
+		{"false < true", true, "return false < true"},
+		{"false <= true", true, "return false <= true"},
+		{"false > true", false, "return false > true"},
+		{"false >= true", false, "return false >= true"},
+		{"a < b", true, "let left: Character = \"a\";\nlet right: Character = \"b\"; return left < right"},
+		{"b < a", false, "let left: Character = \"b\";\nlet right: Character = \"a\"; return left < right"},
+		{"a < A", false, "let left: Character = \"a\";\nlet right: Character = \"A\"; return left < right"},
+		{"A < a", true, "let left: Character = \"A\";\nlet right: Character = \"a\"; return left < right"},
+		{"A < Z", true, "let left: Character = \"A\";\nlet right: Character = \"Z\"; return left < right"},
+		{"a <= b", true, "let left: Character = \"a\";\nlet right: Character = \"b\"; return left <= right"},
+		{"a <= a", true, "let left: Character = \"a\";\nlet right: Character = \"a\"; return left <= right"},
+		{"A <= a", true, "let left: Character = \"A\";\nlet right: Character = \"a\"; return left <= right"},
+		{"a > b", false, "let left: Character = \"a\";\nlet right: Character = \"b\"; return left > right"},
+		{"b > a", true, "let left: Character = \"b\";\nlet right: Character = \"a\"; return left > right"},
+		{"A > a", false, "let left: Character = \"A\";\nlet right: Character = \"a\"; return left > right"},
+		{"a >= b", false, "let left: Character = \"a\";\nlet right: Character = \"b\"; return left >= right"},
+		{"a >= a", true, "let left: Character = \"a\";\nlet right: Character = \"a\"; return left >= right"},
+		{"A >= a", false, "let left: Character = \"A\";\nlet right: Character = \"a\"; return left >= right"},
+	}
+
+	for _, test := range tests {
+		test := test // capture range variable
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			runBooleanTest(t, test.name, test.expected, test.inner)
+		})
+	}
+}
+
 func TestInterpretOptionalAnyStruct(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
Work towards #2276 

## Description
This PR does the following:
- Extracts comparison related interface methods to a new interface `ComparableValue`
- Adds `IsComparable` to the type interface
- Updates the checker to use the `IsComparable` method to detemine comparability
- Implements the comparison support for `Bool` and `Character`

Support for  `String` can be done as a follow up.

TODOs before this is ready for review:
- [x] Fix tests for numbers
- [x] Add tests for bool & character
- [x] Update documentation
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
