### PR TITLE
Add basic support for multiline input to REPL

### DIFF
--- a/runtime/parser/parser.go
+++ b/runtime/parser/parser.go
@@ -556,6 +556,24 @@ func ParseStatements(
 	)
 }
 
+func ParseStatementsFromTokenStream(
+	memoryGauge common.MemoryGauge,
+	tokens lexer.TokenStream,
+	config Config,
+) (
+	statements []ast.Statement,
+	errs []error,
+) {
+	return ParseTokenStream(
+		memoryGauge,
+		tokens,
+		func(p *parser) ([]ast.Statement, error) {
+			return parseStatements(p, nil)
+		},
+		config,
+	)
+}
+
 func ParseType(memoryGauge common.MemoryGauge, input []byte, config Config) (ty ast.Type, errs []error) {
 	return Parse(
 		memoryGauge,


### PR DESCRIPTION
Work towards #2023

## Description

Add basic support for multiline input by checking unmatched parentheses, braces, and brackets.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
