### PR TITLE
Fix release notes configuration 

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,8 +1,12 @@
 changelog:
   categories:
-    - title: 💥 Breaking Changes
+    - title: 💥 Language Breaking Changes
       labels:
-        - Breaking Change
+        - Language Breaking Change
+        - Storage Breaking Change
+    - title: 💥 Go API Breaking Chance
+      labels:
+        - Go API Breaking Change
     - title: ⭐ Features
       labels:
         - Feature


### PR DESCRIPTION
## Description

The GitHub issue labels for breaking changes have been renamed and additional breaking changes labels have been introduced.

Fix the release notes configuration and add the new labels to it.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
