### PR TITLE
Check for potential resource loss in reference expression

### DIFF
--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -71,11 +71,13 @@ func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.Refere
 
 	referencedExpression := referenceExpression.Expression
 
-	_ = checker.VisitExpression(referencedExpression, targetType)
+	referencedType := checker.VisitExpression(referencedExpression, targetType)
 
 	if referenceType == nil {
 		return InvalidType
 	}
+
+	checker.checkUnusedExpressionResourceLoss(referencedType, referencedExpression)
 
 	checker.Elaboration.SetReferenceExpressionBorrowType(referenceExpression, returnType)
 

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -721,6 +721,27 @@ func TestCheckInvalidReferenceResourceLoss(t *testing.T) {
 	assert.IsType(t, &sema.ResourceLossError{}, errs[0])
 }
 
+func TestCheckInvalidReferenceResourceLoss2(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      resource R {}
+
+      fun f(): @R {
+          return <- create R()
+      }
+
+      fun test() {
+          let ref = &f() as &R
+      }
+    `)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+}
+
 func TestCheckInvalidReferenceIndexingIfReferencedNotIndexable(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -9003,8 +9003,9 @@ func TestCheckResourceInvalidationWithMove(t *testing.T) {
             }
         `)
 
-		errs := RequireCheckerErrors(t, err, 1)
-		assert.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
+		errs := RequireCheckerErrors(t, err, 2)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+		assert.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[1])
 	})
 
 	t.Run("in casting expression", func(t *testing.T) {

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -1748,8 +1748,9 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
             }`,
 			ParseCheckAndInterpretOptions{
 				HandleCheckerError: func(err error) {
-					errs := checker.RequireCheckerErrors(t, err, 1)
-					require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
+					errs := checker.RequireCheckerErrors(t, err, 2)
+					require.IsType(t, &sema.ResourceLossError{}, errs[0])
+					require.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[1])
 				},
 			},
 		)


### PR DESCRIPTION
## Description

Port of dapperlabs/cadence-internal#118

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
