### PR TITLE
Add Address.fromBytes to create Address from [UInt8]

### DIFF
--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -405,6 +405,16 @@ let aNumber = 0x436164656E636521
 // `aNumber` has type `Int`
 ```
 
+Address can also be created using a byte array.
+
+```cadence
+// Declare an address with hex representation as 0x436164656E636521.
+let someAddress: Address = Address.fromBytes([67, 97, 100, 101, 110, 99, 101, 33])
+
+// Invalid: Provided value is not compatible with type `Address`. The function panics.
+let invalidAddress: Address = Address.fromBytes([12, 34, 56, 11, 22, 33, 44, 55, 66, 77, 88, 99, 111])
+```
+
 ### Address Functions
 
 Addresses have multiple built-in functions you can use.

--- a/runtime/common/address.go
+++ b/runtime/common/address.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 )
 
-var addressOverflowError = goErrors.New("address too large")
+var AddressOverflowError = goErrors.New("address too large")
 
 const AddressLength = 8
 
@@ -50,7 +50,7 @@ func MustBytesToAddress(b []byte) Address {
 // If the address is too large, then the function returns an error.
 func BytesToAddress(b []byte) (Address, error) {
 	if len(b) > AddressLength {
-		return Address{}, addressOverflowError
+		return Address{}, AddressOverflowError
 	}
 	var a Address
 	a.SetBytes(b)

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2492,8 +2492,11 @@ type ValueConverterDeclaration struct {
 	max             Value
 	convert         func(*Interpreter, Value, LocationRange) Value
 	functionType    *sema.FunctionType
-	nestedVariables map[string]Value
-	name            string
+	nestedVariables []struct {
+		Name  string
+		Value Value
+	}
+	name string
 }
 
 // It would be nice if return types in Go's function types would be covariant
@@ -2681,12 +2684,16 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		convert: func(interpreter *Interpreter, value Value, locationRange LocationRange) Value {
 			return ConvertAddress(interpreter, value, locationRange)
 		},
-		nestedVariables: map[string]Value{
-			sema.AddressTypeFromBytesFunctionName: NewUnmeteredHostFunctionValue(
+		nestedVariables: []struct {
+			Name  string
+			Value Value
+		}{{
+			Name: sema.AddressTypeFromBytesFunctionName,
+			Value: NewUnmeteredHostFunctionValue(
 				sema.AddressConversionFunctionType,
 				AddressFromBytes,
 			),
-		},
+		}},
 	},
 	{
 		name:         sema.PublicPathType.Name,
@@ -3064,8 +3071,8 @@ var converterFunctionValues = func() []converterFunction {
 		addMember(sema.FromStringFunctionName, fromStringVal.hostFunction)
 
 		if declaration.nestedVariables != nil {
-			for name, variable := range declaration.nestedVariables {
-				addMember(name, variable)
+			for _, variable := range declaration.nestedVariables {
+				addMember(variable.Name, variable.Value)
 			}
 		}
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -17996,6 +17996,22 @@ func (AddressValue) ChildStorables() []atree.Storable {
 	return nil
 }
 
+func AddressFromBytes(invocation Invocation) Value {
+	argument, ok := invocation.Arguments[0].(*ArrayValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+
+	inter := invocation.Interpreter
+
+	bytes, err := ByteArrayValueToByteSlice(inter, argument, invocation.LocationRange)
+	if err != nil {
+		panic(errors.NewUnreachableError())
+	}
+
+	return NewAddressValue(invocation.Interpreter, common.MustBytesToAddress(bytes))
+}
+
 func accountGetCapabilityFunction(
 	gauge common.MemoryGauge,
 	addressValue AddressValue,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -18006,7 +18006,7 @@ func AddressFromBytes(invocation Invocation) Value {
 
 	bytes, err := ByteArrayValueToByteSlice(inter, argument, invocation.LocationRange)
 	if err != nil {
-		panic(errors.NewUnreachableError())
+		panic(err)
 	}
 
 	return NewAddressValue(invocation.Interpreter, common.MustBytesToAddress(bytes))

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3366,6 +3366,22 @@ var AddressConversionFunctionType = &FunctionType{
 	},
 }
 
+const AddressTypeFromBytesFunctionName = "fromBytes"
+const AddressTypeFromBytesFunctionDocString = `
+Returns an Address from the given byte array
+`
+
+var AddressTypeFromBytesFunctionType = &FunctionType{
+	Parameters: []Parameter{
+		{
+			Label:          ArgumentLabelNotRequired,
+			Identifier:     "bytes",
+			TypeAnnotation: NewTypeAnnotation(ByteArrayType),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(TheAddressType),
+}
+
 func init() {
 	// Declare a conversion function for the address type
 
@@ -3377,11 +3393,31 @@ func init() {
 		panic(errors.NewUnreachableError())
 	}
 
+	functionType := AddressConversionFunctionType
+
+	addMember := func(member *Member) {
+		if functionType.Members == nil {
+			functionType.Members = &StringMemberOrderedMap{}
+		}
+		name := member.Identifier.Identifier
+		if functionType.Members.Contains(name) {
+			panic(errors.NewUnreachableError())
+		}
+		functionType.Members.Set(name, member)
+	}
+
+	addMember(NewUnmeteredPublicFunctionMember(
+		functionType,
+		AddressTypeFromBytesFunctionName,
+		AddressTypeFromBytesFunctionType,
+		AddressTypeFromBytesFunctionDocString,
+	))
+
 	BaseValueActivation.Set(
 		typeName,
 		baseFunctionVariable(
 			typeName,
-			AddressConversionFunctionType,
+			functionType,
 			numberConversionDocString("an address"),
 		),
 	)

--- a/runtime/tests/checker/builtinfunctions_test.go
+++ b/runtime/tests/checker/builtinfunctions_test.go
@@ -85,6 +85,23 @@ func TestCheckToBytes(t *testing.T) {
 	})
 }
 
+func TestCheckAddressFromBytes(t *testing.T) {
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+		let address = Address.fromBytes([1])
+	`)
+
+	require.NoError(t, err)
+
+	resType := RequireGlobalValue(t, checker.Elaboration, "address")
+
+	assert.Equal(t,
+		sema.TheAddressType,
+		resType,
+	)
+}
+
 func TestCheckToBigEndianBytes(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/checker/builtinfunctions_test.go
+++ b/runtime/tests/checker/builtinfunctions_test.go
@@ -19,6 +19,7 @@
 package checker
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,18 +89,47 @@ func TestCheckToBytes(t *testing.T) {
 func TestCheckAddressFromBytes(t *testing.T) {
 	t.Parallel()
 
-	checker, err := ParseAndCheck(t, `
-		let address = Address.fromBytes([1])
-	`)
+	runValidCase := func(t *testing.T, innerCode string) {
+		t.Run(innerCode, func(t *testing.T) {
+			t.Parallel()
 
-	require.NoError(t, err)
+			code := fmt.Sprintf("let address = Address.fromBytes(%s)", innerCode)
 
-	resType := RequireGlobalValue(t, checker.Elaboration, "address")
+			checker, err := ParseAndCheck(t, code)
 
-	assert.Equal(t,
-		sema.TheAddressType,
-		resType,
-	)
+			require.NoError(t, err)
+
+			resType := RequireGlobalValue(t, checker.Elaboration, "address")
+
+			assert.Equal(t,
+				sema.TheAddressType,
+				resType,
+			)
+		})
+	}
+
+	runInvalidCase := func(t *testing.T, innerCode string, expectedErrorType sema.SemanticError) {
+		t.Run(innerCode, func(t *testing.T) {
+			t.Parallel()
+
+			code := fmt.Sprintf("let address = Address.fromBytes(%s)", innerCode)
+
+			_, err := ParseAndCheck(t, code)
+
+			errs := RequireCheckerErrors(t, err, 1)
+			assert.IsType(t, expectedErrorType, errs[0])
+		})
+	}
+
+	runValidCase(t, "[1]")
+	runValidCase(t, "[12, 34, 56]")
+	runValidCase(t, "[67, 97, 100, 101, 110, 99, 101, 33]")
+
+	runInvalidCase(t, "[\"abc\"]", &sema.TypeMismatchError{})
+	runInvalidCase(t, "1", &sema.TypeMismatchError{})
+	runInvalidCase(t, "[1], [2, 3, 4]", &sema.ArgumentCountError{})
+	runInvalidCase(t, "", &sema.ArgumentCountError{})
+	runInvalidCase(t, "typo: [1]", &sema.IncorrectArgumentLabelError{})
 }
 
 func TestCheckToBigEndianBytes(t *testing.T) {

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -221,12 +221,14 @@ func TestInterpretAddressFromBytes(t *testing.T) {
 		})
 	}
 
+	runValidCase(t, []byte{}, "[]")
 	runValidCase(t, []byte{1}, "[1]")
 	runValidCase(t, []byte{12, 34, 56}, "[12, 34, 56]")
 	runValidCase(t, []byte{67, 97, 100, 101, 110, 99, 101, 33}, "[67, 97, 100, 101, 110, 99, 101, 33]")
 
-	runValidRoundTripCase(t, "0x436164656E636521")
+	runValidRoundTripCase(t, "0x0")
 	runValidRoundTripCase(t, "0x01")
+	runValidRoundTripCase(t, "0x436164656E636521")
 	runValidRoundTripCase(t, "0x46716465AE633188")
 
 	runInvalidCase(t, "[12, 34, 56, 11, 22, 33, 44, 55, 66, 77, 88, 99, 111]")

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -218,6 +218,7 @@ func TestInterpretAddressFromBytes(t *testing.T) {
 			_, err := inter.Invoke("test")
 
 			RequireError(t, err)
+			require.ErrorContains(t, err, common.AddressOverflowError.Error())
 		})
 	}
 

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -22,11 +22,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	. "github.com/onflow/cadence/runtime/tests/utils"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInterpretToString(t *testing.T) {

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -218,7 +218,7 @@ func TestInterpretAddressFromBytes(t *testing.T) {
 			_, err := inter.Invoke("test")
 
 			RequireError(t, err)
-			require.ErrorContains(t, err, common.AddressOverflowError.Error())
+			require.ErrorAs(t, err, &common.AddressOverflowError)
 		})
 	}
 

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -218,7 +218,7 @@ func TestInterpretAddressFromBytes(t *testing.T) {
 			_, err := inter.Invoke("test")
 
 			RequireError(t, err)
-			require.ErrorAs(t, err, &common.AddressOverflowError)
+			require.ErrorIs(t, err, common.AddressOverflowError)
 		})
 	}
 

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -184,7 +184,13 @@ func TestInterpretAddressFromBytesInvalid(t *testing.T) {
 		t.Run(innerCode, func(t *testing.T) {
 			t.Parallel()
 
-			code := fmt.Sprintf("fun test(): Address { \n return Address.fromBytes(%s) \n }", innerCode)
+			code := fmt.Sprintf(`
+                  fun test(): Address {
+                      return Address.fromBytes(%s)
+                  }
+            	`,
+				innerCode,
+			)
 
 			inter := parseCheckAndInterpret(t, code)
 			_, err := inter.Invoke("test")


### PR DESCRIPTION
Closes #2433 

## Description
This PR adds a new method `Address.fromBytes` to create an address from a byte array `[UInt8]`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
