### PR TITLE
Add validation for exporting references to destroyed resources

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -228,8 +228,11 @@ func exportValueWithInterpreter(
 		}
 		defer delete(seenReferences, v)
 		seenReferences[v] = struct{}{}
+
+		referencedValue := v.MustReferencedValue(inter, locationRange)
+
 		return exportValueWithInterpreter(
-			v.Value,
+			referencedValue,
 			inter,
 			locationRange,
 			seenReferences,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -17427,7 +17427,7 @@ func (v *EphemeralReferenceValue) ReferencedValue(
 	}
 }
 
-func (v *EphemeralReferenceValue) mustReferencedValue(
+func (v *EphemeralReferenceValue) MustReferencedValue(
 	interpreter *Interpreter,
 	locationRange LocationRange,
 ) Value {
@@ -17450,7 +17450,7 @@ func (v *EphemeralReferenceValue) GetMember(
 	locationRange LocationRange,
 	name string,
 ) Value {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.MustReferencedValue(interpreter, locationRange)
 
 	return interpreter.getMember(self, locationRange, name)
 }
@@ -17460,7 +17460,7 @@ func (v *EphemeralReferenceValue) RemoveMember(
 	locationRange LocationRange,
 	identifier string,
 ) Value {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.MustReferencedValue(interpreter, locationRange)
 
 	if memberAccessibleValue, ok := self.(MemberAccessibleValue); ok {
 		return memberAccessibleValue.RemoveMember(interpreter, locationRange, identifier)
@@ -17475,7 +17475,7 @@ func (v *EphemeralReferenceValue) SetMember(
 	name string,
 	value Value,
 ) bool {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.MustReferencedValue(interpreter, locationRange)
 
 	return interpreter.setMember(self, locationRange, name, value)
 }
@@ -17485,7 +17485,7 @@ func (v *EphemeralReferenceValue) GetKey(
 	locationRange LocationRange,
 	key Value,
 ) Value {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.MustReferencedValue(interpreter, locationRange)
 
 	return self.(ValueIndexableValue).
 		GetKey(interpreter, locationRange, key)
@@ -17497,7 +17497,7 @@ func (v *EphemeralReferenceValue) SetKey(
 	key Value,
 	value Value,
 ) {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.MustReferencedValue(interpreter, locationRange)
 
 	self.(ValueIndexableValue).
 		SetKey(interpreter, locationRange, key, value)
@@ -17509,7 +17509,7 @@ func (v *EphemeralReferenceValue) InsertKey(
 	key Value,
 	value Value,
 ) {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.MustReferencedValue(interpreter, locationRange)
 
 	self.(ValueIndexableValue).
 		InsertKey(interpreter, locationRange, key, value)
@@ -17520,7 +17520,7 @@ func (v *EphemeralReferenceValue) RemoveKey(
 	locationRange LocationRange,
 	key Value,
 ) Value {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.MustReferencedValue(interpreter, locationRange)
 
 	return self.(ValueIndexableValue).
 		RemoveKey(interpreter, locationRange, key)
@@ -17531,7 +17531,7 @@ func (v *EphemeralReferenceValue) GetTypeKey(
 	locationRange LocationRange,
 	key sema.Type,
 ) Value {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.MustReferencedValue(interpreter, locationRange)
 
 	return self.(TypeIndexableValue).
 		GetTypeKey(interpreter, locationRange, key)
@@ -17543,7 +17543,7 @@ func (v *EphemeralReferenceValue) SetTypeKey(
 	key sema.Type,
 	value Value,
 ) {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.MustReferencedValue(interpreter, locationRange)
 
 	self.(TypeIndexableValue).
 		SetTypeKey(interpreter, locationRange, key, value)
@@ -17554,7 +17554,7 @@ func (v *EphemeralReferenceValue) RemoveTypeKey(
 	locationRange LocationRange,
 	key sema.Type,
 ) Value {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.MustReferencedValue(interpreter, locationRange)
 
 	return self.(TypeIndexableValue).
 		RemoveTypeKey(interpreter, locationRange, key)


### PR DESCRIPTION
## Description

Trying to export a reference to a destroyed resource currently gives an internal error (nil pointer error). This PR fixes it by adding validation and throwing a more user friendly error. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
