### PR TITLE
Implement Auth/PublicAccount.Capabilities functions

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2229,7 +2229,7 @@ func (interpreter *Interpreter) NewSubInterpreter(
 	)
 }
 
-func (interpreter *Interpreter) storedValueExists(
+func (interpreter *Interpreter) StoredValueExists(
 	storageAddress common.Address,
 	domain string,
 	identifier string,
@@ -3471,7 +3471,7 @@ func (interpreter *Interpreter) authAccountSaveFunction(addressValue AddressValu
 
 			locationRange := invocation.LocationRange
 
-			if interpreter.storedValueExists(
+			if interpreter.StoredValueExists(
 				address,
 				domain,
 				identifier,
@@ -3708,7 +3708,7 @@ func (interpreter *Interpreter) authAccountLinkFunction(addressValue AddressValu
 			newCapabilityDomain := newCapabilityPath.Domain.Identifier()
 			newCapabilityIdentifier := newCapabilityPath.Identifier
 
-			if interpreter.storedValueExists(
+			if interpreter.StoredValueExists(
 				address,
 				newCapabilityDomain,
 				newCapabilityIdentifier,
@@ -3796,7 +3796,7 @@ func (interpreter *Interpreter) authAccountLinkAccountFunction(addressValue Addr
 			newCapabilityDomain := newCapabilityPath.Domain.Identifier()
 			newCapabilityIdentifier := newCapabilityPath.Identifier
 
-			if interpreter.storedValueExists(
+			if interpreter.StoredValueExists(
 				address,
 				newCapabilityDomain,
 				newCapabilityIdentifier,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3911,6 +3911,66 @@ func (interpreter *Interpreter) authAccountUnlinkFunction(addressValue AddressVa
 	)
 }
 
+func (interpreter *Interpreter) BorrowCapability(
+	address common.Address,
+	pathValue PathValue,
+	borrowType *sema.ReferenceType,
+	locationRange LocationRange,
+) ReferenceValue {
+	target, authorized, err :=
+		interpreter.GetStorageCapabilityFinalTarget(
+			address,
+			pathValue,
+			borrowType,
+			locationRange,
+		)
+	if err != nil {
+		panic(err)
+	}
+
+	if target == nil {
+		return nil
+	}
+
+	switch target := target.(type) {
+	case AccountCapabilityTarget:
+		return NewAccountReferenceValue(
+			interpreter,
+			address,
+			pathValue,
+			borrowType.Type,
+		)
+
+	case PathCapabilityTarget:
+		targetPath := PathValue(target)
+
+		reference := NewStorageReferenceValue(
+			interpreter,
+			authorized,
+			address,
+			targetPath,
+			borrowType.Type,
+		)
+
+		// Attempt to dereference,
+		// which reads the stored value
+		// and performs a dynamic type check
+
+		value, err := reference.dereference(interpreter, locationRange)
+		if err != nil {
+			panic(err)
+		}
+		if value == nil {
+			return nil
+		}
+
+		return reference
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
 func (interpreter *Interpreter) storageCapabilityBorrowFunction(
 	addressValue AddressValue,
 	pathValue PathValue,
@@ -3944,61 +4004,11 @@ func (interpreter *Interpreter) storageCapabilityBorrowFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			target, authorized, err :=
-				interpreter.GetStorageCapabilityFinalTarget(
-					address,
-					pathValue,
-					borrowType,
-					invocation.LocationRange,
-				)
-			if err != nil {
-				panic(err)
-			}
-
-			if target == nil {
+			reference := interpreter.BorrowCapability(address, pathValue, borrowType, invocation.LocationRange)
+			if reference == nil {
 				return Nil
 			}
-
-			switch target := target.(type) {
-			case AccountCapabilityTarget:
-				return NewSomeValueNonCopying(
-					interpreter,
-					NewAccountReferenceValue(
-						interpreter,
-						address,
-						pathValue,
-						borrowType.Type,
-					),
-				)
-
-			case PathCapabilityTarget:
-				targetPath := PathValue(target)
-
-				reference := NewStorageReferenceValue(
-					interpreter,
-					authorized,
-					address,
-					targetPath,
-					borrowType.Type,
-				)
-
-				// Attempt to dereference,
-				// which reads the stored value
-				// and performs a dynamic type check
-
-				value, err := reference.dereference(interpreter, invocation.LocationRange)
-				if err != nil {
-					panic(err)
-				}
-				if value == nil {
-					return Nil
-				}
-
-				return NewSomeValueNonCopying(interpreter, reference)
-
-			default:
-				panic(errors.NewUnreachableError())
-			}
+			return NewSomeValueNonCopying(interpreter, reference)
 		},
 	)
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -16976,6 +16976,7 @@ func (s SomeStorable) ChildStorables() []atree.Storable {
 }
 
 type ReferenceValue interface {
+	Value
 	isReference()
 }
 

--- a/runtime/interpreter/value_accountreference.go
+++ b/runtime/interpreter/value_accountreference.go
@@ -39,6 +39,7 @@ var _ Value = &AccountReferenceValue{}
 var _ EquatableValue = &AccountReferenceValue{}
 var _ ValueIndexableValue = &AccountReferenceValue{}
 var _ MemberAccessibleValue = &AccountReferenceValue{}
+var _ ReferenceValue = &AccountReferenceValue{}
 
 func NewUnmeteredAccountReferenceValue(
 	address common.Address,
@@ -67,6 +68,8 @@ func NewAccountReferenceValue(
 }
 
 func (*AccountReferenceValue) IsValue() {}
+
+func (*AccountReferenceValue) isReference() {}
 
 func (v *AccountReferenceValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitAccountReferenceValue(interpreter, v)

--- a/runtime/sema/authaccount.go
+++ b/runtime/sema/authaccount.go
@@ -24,6 +24,6 @@ var AuthAccountTypeLinkAccountFunctionTypePathParameterTypeAnnotation = AuthAcco
 
 func init() {
 	AuthAccountContractsTypeAddFunctionType.RequiredArgumentCount = RequiredArgumentCount(2)
-	AuthAccountTypeGetCapabilityFunctionType.TypeParameters[0].Optional = true
-	PublicAccountTypeGetCapabilityFunctionType.TypeParameters[0].Optional = true
+	AuthAccountTypeGetCapabilityFunctionTypeParameterT.Optional = true
+	PublicAccountTypeGetCapabilityFunctionTypeParameterT.Optional = true
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -6563,27 +6563,6 @@ func (t *CapabilityType) initializeMemberResolvers() {
 	})
 }
 
-var NativeCompositeTypes = map[string]*CompositeType{}
-
-func init() {
-	types := []*CompositeType{
-		AccountKeyType,
-		PublicKeyType,
-		HashAlgorithmType,
-		SignatureAlgorithmType,
-		AuthAccountType,
-		AuthAccountKeysType,
-		AuthAccountContractsType,
-		PublicAccountType,
-		PublicAccountKeysType,
-		PublicAccountContractsType,
-	}
-
-	for _, semaType := range types {
-		NativeCompositeTypes[semaType.QualifiedIdentifier()] = semaType
-	}
-}
-
 const AccountKeyTypeName = "AccountKey"
 const AccountKeyKeyIndexFieldName = "keyIndex"
 const AccountKeyPublicKeyFieldName = "publicKey"
@@ -6824,4 +6803,40 @@ func isNumericSuperType(typ Type) bool {
 	}
 
 	return false
+}
+
+var NativeCompositeTypes = map[string]*CompositeType{}
+
+func init() {
+	compositeTypes := []*CompositeType{
+		AccountKeyType,
+		PublicKeyType,
+		HashAlgorithmType,
+		SignatureAlgorithmType,
+		AuthAccountType,
+		PublicAccountType,
+	}
+
+	for len(compositeTypes) > 0 {
+		lastIndex := len(compositeTypes) - 1
+		compositeType := compositeTypes[lastIndex]
+		compositeTypes[lastIndex] = nil
+		compositeTypes = compositeTypes[:lastIndex]
+
+		NativeCompositeTypes[compositeType.QualifiedIdentifier()] = compositeType
+
+		nestedTypes := compositeType.NestedTypes
+		if nestedTypes == nil {
+			continue
+		}
+
+		nestedTypes.Foreach(func(_ string, nestedType Type) {
+			nestedCompositeType, ok := nestedType.(*CompositeType)
+			if !ok {
+				return
+			}
+
+			compositeTypes = append(compositeTypes, nestedCompositeType)
+		})
+	}
 }

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -224,7 +224,7 @@ func NewAuthAccountValue(
 				gauge,
 				false,
 				capabilities,
-				sema.AuthAccountTypeCapabilitiesFieldType,
+				sema.AuthAccountTypeCapabilitiesFieldType.Type,
 			)
 		},
 	)
@@ -2115,7 +2115,7 @@ func NewPublicAccountValue(
 				gauge,
 				false,
 				capabilities,
-				sema.PublicAccountTypeCapabilitiesFieldType,
+				sema.PublicAccountTypeCapabilitiesFieldType.Type,
 			)
 		},
 	)
@@ -2230,7 +2230,7 @@ func newAuthAccountCapabilitiesValue(
 				gauge,
 				false,
 				storageCapabilities,
-				sema.AuthAccountCapabilitiesTypeStorageFieldType,
+				sema.AuthAccountCapabilitiesTypeStorageFieldType.Type,
 			)
 		},
 		func() interpreter.Value {
@@ -2242,7 +2242,7 @@ func newAuthAccountCapabilitiesValue(
 				gauge,
 				false,
 				accountCapabilities,
-				sema.AuthAccountCapabilitiesTypeAccountFieldType,
+				sema.AuthAccountCapabilitiesTypeAccountFieldType.Type,
 			)
 		},
 	)

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -2190,7 +2190,7 @@ func newAuthAccountStorageCapabilitiesValue(
 		nil,
 		nil,
 		nil,
-		nil,
+		newAuthAccountStorageCapabilitiesIssueFunction(gauge, addressValue),
 	)
 }
 
@@ -2243,6 +2243,46 @@ func newAuthAccountCapabilitiesValue(
 				false,
 				accountCapabilities,
 				sema.AuthAccountCapabilitiesTypeAccountFieldType.Type,
+			)
+		},
+	)
+}
+
+func newAuthAccountStorageCapabilitiesIssueFunction(
+	gauge common.MemoryGauge,
+	addressValue interpreter.AddressValue,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewHostFunctionValue(
+		gauge,
+		sema.AuthAccountStorageCapabilitiesTypeIssueFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+
+			// Get path argument
+
+			pathValue, ok := invocation.Arguments[0].(interpreter.PathValue)
+			if !ok || pathValue.Domain != common.PathDomainStorage {
+				panic(errors.NewUnreachableError())
+			}
+
+			// Get borrow type type argument
+
+			typeParameterPair := invocation.TypeParameterTypes.Oldest()
+			borrowType, ok := typeParameterPair.Value.(*sema.ReferenceType)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			// TODO: create and write StorageCapabilityController
+
+			borrowStaticType := interpreter.ConvertSemaReferenceTypeToStaticReferenceType(gauge, borrowType)
+
+			return interpreter.NewStorageCapabilityValue(
+				gauge,
+				// TODO:
+				interpreter.TodoCapabilityID,
+				addressValue,
+				pathValue,
+				borrowStaticType,
 			)
 		},
 	)

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -2217,8 +2217,8 @@ func newAuthAccountCapabilitiesValue(
 	return interpreter.NewAuthAccountCapabilitiesValue(
 		gauge,
 		addressValue,
-		newAccountCapabilitiesGetFunction(gauge, addressValue, sema.AuthAccountCapabilitiesTypeGetFunctionType, false),
-		newAccountCapabilitiesGetFunction(gauge, addressValue, sema.AuthAccountCapabilitiesTypeBorrowFunctionType, true),
+		newAccountCapabilitiesGetFunction(gauge, addressValue, sema.AuthAccountType, false),
+		newAccountCapabilitiesGetFunction(gauge, addressValue, sema.AuthAccountType, true),
 		newAuthAccountCapabilitiesPublishFunction(gauge, addressValue),
 		newAuthAccountCapabilitiesUnpublishFunction(gauge, addressValue),
 		func() interpreter.Value {
@@ -2407,18 +2407,36 @@ func newPublicAccountCapabilitiesValue(
 	return interpreter.NewPublicAccountCapabilitiesValue(
 		gauge,
 		addressValue,
-		newAccountCapabilitiesGetFunction(gauge, addressValue, sema.PublicAccountCapabilitiesTypeGetFunctionType, false),
-		newAccountCapabilitiesGetFunction(gauge, addressValue, sema.PublicAccountCapabilitiesTypeBorrowFunctionType, true),
+		newAccountCapabilitiesGetFunction(gauge, addressValue, sema.PublicAccountType, false),
+		newAccountCapabilitiesGetFunction(gauge, addressValue, sema.PublicAccountType, true),
 	)
 }
 
 func newAccountCapabilitiesGetFunction(
 	gauge common.MemoryGauge,
 	addressValue interpreter.AddressValue,
-	funcType *sema.FunctionType,
+	accountType *sema.CompositeType,
 	borrow bool,
 ) *interpreter.HostFunctionValue {
 	address := addressValue.ToAddress()
+
+	var funcType *sema.FunctionType
+	switch accountType {
+	case sema.AuthAccountType:
+		if borrow {
+			funcType = sema.AuthAccountCapabilitiesTypeBorrowFunctionType
+		} else {
+			funcType = sema.AuthAccountCapabilitiesTypeGetFunctionType
+		}
+	case sema.PublicAccountType:
+		if borrow {
+			funcType = sema.PublicAccountCapabilitiesTypeBorrowFunctionType
+		} else {
+			funcType = sema.PublicAccountCapabilitiesTypeGetFunctionType
+		}
+	default:
+		panic(errors.NewUnreachableError())
+	}
 
 	return interpreter.NewHostFunctionValue(
 		gauge,

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -9285,7 +9285,7 @@ func newTestAuthAccountValue(gauge common.MemoryGauge, addressValue interpreter.
 						gauge,
 						false,
 						storageCapabilities,
-						sema.AuthAccountCapabilitiesTypeStorageFieldType,
+						sema.AuthAccountCapabilitiesTypeStorageFieldType.Type,
 					)
 				},
 				func() interpreter.Value {
@@ -9301,7 +9301,7 @@ func newTestAuthAccountValue(gauge common.MemoryGauge, addressValue interpreter.
 						gauge,
 						false,
 						accountCapabilities,
-						sema.AuthAccountCapabilitiesTypeAccountFieldType,
+						sema.AuthAccountCapabilitiesTypeAccountFieldType.Type,
 					)
 				},
 			)
@@ -9309,7 +9309,7 @@ func newTestAuthAccountValue(gauge common.MemoryGauge, addressValue interpreter.
 				gauge,
 				false,
 				capabilities,
-				sema.AuthAccountTypeCapabilitiesFieldType,
+				sema.AuthAccountTypeCapabilitiesFieldType.Type,
 			)
 		},
 	)
@@ -9369,7 +9369,7 @@ func newTestPublicAccountValue(gauge common.MemoryGauge, addressValue interprete
 				gauge,
 				false,
 				capabilities,
-				sema.PublicAccountTypeCapabilitiesFieldType,
+				sema.PublicAccountTypeCapabilitiesFieldType.Type,
 			)
 		},
 	)


### PR DESCRIPTION
Work towards #2091 

## Description

Implement
- `Auth/PublicAccount.Capabilities.get`
- `Auth/PublicAccount.Capabilities.borrow`
- `AuthAccount.Capabilities.publish`
- `AuthAccount.Capabilities.unpublish`

I have test cases, but will open them in a separate PR, as they depend on issuing, which is currently stubbed out.

______

<!-- Complete: -->

- [x] Targeted PR against ~`master`~ feature branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
