### PR TITLE
Improve documentation sidebar

### DIFF
--- a/docs/flow-docs.json
+++ b/docs/flow-docs.json
@@ -46,12 +46,25 @@
   "sidebars": {
     "": [
       {
-        "title": "Developer Guides",
+        "title": "Cadence",
         "items": [
           {
             "title": "Introduction to Cadence",
             "href": ""
           },
+          {
+            "title": "Tutorial",
+            "href": "tutorial/02-hello-world"
+          },
+          {
+            "title": "Language Reference",
+            "href": "language"
+          },
+        ]
+      },
+      {
+        "title": "Developer Guides",
+        "items": [
           {
             "title": "Cadence Design Patterns",
             "href": "design-patterns"
@@ -94,20 +107,8 @@
               "href": "style-guide"
             }
           ]
-        },      
-      {
-        "title": "Cadence",
-        "items": [
-          {
-            "title": "Language Reference",
-            "href": "language"
-          },
-          {
-            "title": "Tutorial",
-            "href": "tutorial/02-hello-world"
-          }
-        ]
-      }
+        }     
+      
     ],
     "language": [
       {


### PR DESCRIPTION


## Description

Move language reference and tutorials to the top, they got buried at the bottom, and one had to scroll to find them ...

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
