### PR TITLE
Add support for generic function declarations

### DIFF
--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -1246,13 +1246,7 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := ParseDeclarations(
-			nil,
-			[]byte("fun foo  < > () {}"),
-			Config{
-				TypeParametersEnabled: true,
-			},
-		)
+		result, errs := testParseDeclarations("fun foo  < > () {}")
 		require.Empty(t, errs)
 
 		utils.AssertEqualWithDiff(t,
@@ -1295,13 +1289,7 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := ParseDeclarations(
-			nil,
-			[]byte("fun foo  < A  > () {}"),
-			Config{
-				TypeParametersEnabled: true,
-			},
-		)
+		result, errs := testParseDeclarations("fun foo  < A  > () {}")
 		require.Empty(t, errs)
 
 		utils.AssertEqualWithDiff(t,
@@ -1351,13 +1339,7 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := ParseDeclarations(
-			nil,
-			[]byte("fun foo  < A  , B : C > () {}"),
-			Config{
-				TypeParametersEnabled: true,
-			},
-		)
+		result, errs := testParseDeclarations("fun foo  < A  , B : C > () {}")
 		require.Empty(t, errs)
 
 		utils.AssertEqualWithDiff(t,
@@ -1418,34 +1400,11 @@ func TestParseFunctionDeclaration(t *testing.T) {
 		)
 	})
 
-	t.Run("with type parameters, disabled", func(t *testing.T) {
-
-		t.Parallel()
-
-		_, errs := testParseDeclarations("fun foo<A>() {}")
-
-		utils.AssertEqualWithDiff(t,
-			[]error{
-				&SyntaxError{
-					Message: "expected '(' as start of parameter list, got '<'",
-					Pos:     ast.Position{Offset: 7, Line: 1, Column: 7},
-				},
-			},
-			errs,
-		)
-	})
-
 	t.Run("missing type parameter list end, enabled", func(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte("fun foo  < "),
-			Config{
-				TypeParametersEnabled: true,
-			},
-		)
+		_, errs := testParseDeclarations("fun foo  < ")
 
 		utils.AssertEqualWithDiff(t,
 			[]error{
@@ -1462,13 +1421,7 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte("fun foo  < A B > () { } "),
-			Config{
-				TypeParametersEnabled: true,
-			},
-		)
+		_, errs := testParseDeclarations("fun foo  < A B > () { } ")
 
 		utils.AssertEqualWithDiff(t,
 			[]error{

--- a/runtime/parser/function.go
+++ b/runtime/parser/function.go
@@ -313,12 +313,10 @@ func parseFunctionDeclaration(
 
 	var typeParameterList *ast.TypeParameterList
 
-	if p.config.TypeParametersEnabled {
-		var err error
-		typeParameterList, err = parseTypeParameterList(p)
-		if err != nil {
-			return nil, err
-		}
+	var err error
+	typeParameterList, err = parseTypeParameterList(p)
+	if err != nil {
+		return nil, err
 	}
 
 	parameterList, returnTypeAnnotation, functionBlock, err :=

--- a/runtime/parser/parser.go
+++ b/runtime/parser/parser.go
@@ -46,8 +46,6 @@ type Config struct {
 	StaticModifierEnabled bool
 	// NativeModifierEnabled determines if the native modifier is enabled
 	NativeModifierEnabled bool
-	// TypeParametersEnabled determines if type parameters are enabled
-	TypeParametersEnabled bool
 }
 
 type parser struct {

--- a/runtime/parser/statement.go
+++ b/runtime/parser/statement.go
@@ -167,12 +167,10 @@ func parseFunctionDeclarationOrFunctionExpressionStatement(p *parser) (ast.State
 
 		var typeParameterList *ast.TypeParameterList
 
-		if p.config.TypeParametersEnabled {
-			var err error
-			typeParameterList, err = parseTypeParameterList(p)
-			if err != nil {
-				return nil, err
-			}
+		var err error
+		typeParameterList, err = parseTypeParameterList(p)
+		if err != nil {
+			return nil, err
 		}
 
 		parameterList, returnTypeAnnotation, functionBlock, err :=

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -1758,7 +1758,11 @@ func (checker *Checker) defaultMembersAndOrigins(
 
 		identifier := function.Identifier.Identifier
 
-		functionType := checker.functionType(function.ParameterList, function.ReturnTypeAnnotation)
+		functionType := checker.functionType(
+			function.TypeParameterList,
+			function.ParameterList,
+			function.ReturnTypeAnnotation,
+		)
 
 		argumentLabels := function.ParameterList.EffectiveArgumentLabels()
 
@@ -2035,6 +2039,7 @@ func (checker *Checker) checkSpecialFunction(
 	}
 
 	checker.checkFunction(
+		nil,
 		specialFunction.FunctionDeclaration.ParameterList,
 		nil,
 		functionType,

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -205,6 +205,14 @@ func (checker *Checker) checkInterfaceFunctions(
 				}
 			}
 
+			if function.TypeParameterList != nil {
+				checker.report(
+					&InvalidTypeParameterizedInterfaceFunctionError{
+						Range: ast.NewUnmeteredRangeFromPositioned(function.TypeParameterList),
+					},
+				)
+			}
+
 			checker.visitFunctionDeclaration(
 				function,
 				functionDeclarationOptions{

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -182,6 +182,7 @@ func (checker *Checker) visitTransactionPrepareFunction(
 	prepareFunctionType := transactionType.PrepareFunctionType()
 
 	checker.checkFunction(
+		nil,
 		prepareFunction.FunctionDeclaration.ParameterList,
 		nil,
 		prepareFunctionType,
@@ -231,6 +232,7 @@ func (checker *Checker) visitTransactionExecuteFunction(
 	executeFunctionType := transactionType.ExecuteFunctionType()
 
 	checker.checkFunction(
+		nil,
 		&ast.ParameterList{},
 		nil,
 		executeFunctionType,

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -4046,3 +4046,41 @@ func (*AttachmentsNotEnabledError) IsUserError() {}
 func (e *AttachmentsNotEnabledError) Error() string {
 	return "attachments are not enabled and cannot be used in this environment"
 }
+
+// MissingTypeParameterTypeBoundError
+
+type MissingTypeParameterTypeBoundError struct {
+	Name string
+	ast.Range
+}
+
+var _ SemanticError = &MissingTypeParameterTypeBoundError{}
+var _ errors.UserError = &MissingTypeParameterTypeBoundError{}
+
+func (*MissingTypeParameterTypeBoundError) isSemanticError() {}
+
+func (*MissingTypeParameterTypeBoundError) IsUserError() {}
+
+func (e *MissingTypeParameterTypeBoundError) Error() string {
+	return fmt.Sprintf(
+		"missing type bound for type parameter `%s`",
+		e.Name,
+	)
+}
+
+// InvalidTypeParameterizedInterfaceFunctionError
+
+type InvalidTypeParameterizedInterfaceFunctionError struct {
+	ast.Range
+}
+
+var _ SemanticError = &InvalidTypeParameterizedInterfaceFunctionError{}
+var _ errors.UserError = &InvalidTypeParameterizedInterfaceFunctionError{}
+
+func (*InvalidTypeParameterizedInterfaceFunctionError) isSemanticError() {}
+
+func (*InvalidTypeParameterizedInterfaceFunctionError) IsUserError() {}
+
+func (e *InvalidTypeParameterizedInterfaceFunctionError) Error() string {
+	return "invalid type parameters in interface function"
+}

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -64,7 +64,6 @@ var parsedHeaderTemplate = template.Must(template.New("header").Parse(headerTemp
 var parserConfig = parser.Config{
 	StaticModifierEnabled: true,
 	NativeModifierEnabled: true,
-	TypeParametersEnabled: true,
 }
 
 func initialUpper(s string) string {


### PR DESCRIPTION
## Description

It turns out that adding basic support for generic functions does not take much effort, as we already have support for generic built-in functions.

- Remove the type parameter lists feature flag in the parser, enabling them constantly
- Add support function declarations with type parameter lists.

Even with the following limitations, this feature should already make some programs safer and allow developer to express their intent better:

- For now, type parameters may only occur in the parameter list and the return type.
 
   We may add support for type parameter occurrences in the function body later, which would require some work in the interpreter.

- Interface function declarations may not be generic (yet).
 
  

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
…clarations