### PR TITLE
Properly wrap nil in optionals depending on the nested optional type

### DIFF
--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -311,7 +311,14 @@ func LiteralValue(inter *interpreter.Interpreter, expression ast.Expression, ty 
 
 	case *sema.OptionalType:
 		if _, ok := expression.(*ast.NilExpression); ok {
-			return cadence.NewMeteredOptional(inter, nil), nil
+			value := cadence.NewMeteredOptional(inter, nil)
+			for {
+				ty, ok = ty.Type.(*sema.OptionalType)
+				if !ok {
+					return value, nil
+				}
+				value = cadence.NewMeteredOptional(inter, value)
+			}
 		}
 
 		converted, err := LiteralValue(inter, expression, ty.Type)

--- a/runtime/literal_test.go
+++ b/runtime/literal_test.go
@@ -31,7 +31,7 @@ import (
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
-func TestLiteralValue(t *testing.T) {
+func TestParseLiteral(t *testing.T) {
 	t.Parallel()
 
 	t.Run("String, valid literal", func(t *testing.T) {
@@ -79,6 +79,25 @@ func TestLiteralValue(t *testing.T) {
 		)
 	})
 
+	t.Run("nested Optional, nil", func(t *testing.T) {
+		value, err := ParseLiteral(
+			`nil`,
+			&sema.OptionalType{
+				Type: &sema.OptionalType{
+					Type: sema.BoolType,
+				},
+			},
+			newTestInterpreter(t),
+		)
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.NewOptional(
+				cadence.NewOptional(nil),
+			),
+			value,
+		)
+	})
+
 	t.Run("Optional, valid literal", func(t *testing.T) {
 		value, err := ParseLiteral(
 			`true`,
@@ -88,6 +107,27 @@ func TestLiteralValue(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.NewOptional(cadence.NewBool(true)),
+			value,
+		)
+	})
+
+	t.Run("nested Optional, valid literal", func(t *testing.T) {
+		value, err := ParseLiteral(
+			`true`,
+			&sema.OptionalType{
+				Type: &sema.OptionalType{
+					Type: sema.BoolType,
+				},
+			},
+			newTestInterpreter(t),
+		)
+		require.NoError(t, err)
+		require.Equal(t,
+			cadence.NewOptional(
+				cadence.NewOptional(
+					cadence.NewBool(true),
+				),
+			),
 			value,
 		)
 	})


### PR DESCRIPTION
## Description

Noticed in https://github.com/onflow/flow-cli/pull/996:
`ParseLiteral` is used by the CLI to parse arguments.
It calls `LiteralValue`, which converts an AST expression and type into a value.

`LiteralValue` was not handling nested optional types correctly, when the literal is `nil`.

Properly wrap the value in optionals, depending on the nesting level of optional types.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
