### PR TITLE
Extend ordering comparison (<, <=, >, >=) to String

### DIFF
--- a/docs/language/operators.md
+++ b/docs/language/operators.md
@@ -427,7 +427,7 @@ Comparison operators work with boolean and integer values.
   d3 != d4 // is `false`
   ```
 
-- Less than: `<`, for integers, booleans and characters
+- Less than: `<`, for integers, booleans, characters and strings
 
   ```cadence
   1 < 1  // is `false`
@@ -445,9 +445,17 @@ Comparison operators work with boolean and integer values.
   "z" < "a"    // is `false`
 
   "a" < "A"    // is `false`
+
+  "" < ""      // is `false`
+
+  "" < "a"     // is `true`
+
+  "az" < "b"   // is `true`
+
+  "xAB" < "Xab"  // is `false`
   ```
 
-- Less or equal than: `<=`, for integers, booleans and characters
+- Less or equal than: `<=`, for integers, booleans, characters and strings
 
   ```cadence
   1 <= 1  // is `true`
@@ -467,9 +475,17 @@ Comparison operators work with boolean and integer values.
   "z"  <= "z"   // is `true`
 
   "a" <= "A"    // is `false`
+
+  "" <= ""      // is `true`
+
+  "" <= "a"     // is `true`
+
+  "az" <= "b"   // is `true`
+
+  "xAB" <= "Xab"  // is `false`
   ```
 
-- Greater than: `>`, for integers, booleans and characters
+- Greater than: `>`, for integers, booleans, characters and strings
 
   ```cadence
   1 > 1  // is `false`
@@ -489,9 +505,17 @@ Comparison operators work with boolean and integer values.
   "g"  > "g"   // is `false`
 
   "a" > "A"    // is `true`
+
+  "" > ""      // is `false`
+
+  "" > "a"     // is `false`
+
+  "az" > "b"   // is `false`
+
+  "xAB" > "Xab"  // is `true`
   ```
 
-- Greater or equal than: `>=`, for integers, booleans and characters
+- Greater or equal than: `>=`, for integers, booleans, characters and strings
 
   ```cadence
   1 >= 1  // is `true`
@@ -511,6 +535,14 @@ Comparison operators work with boolean and integer values.
   "q"  >= "q"   // is `true`
 
   "a" >= "A"    // is `true`
+
+  "" >= ""      // is `true`
+
+  "" >= "a"     // is `true`
+
+  "az" >= "b"   // is `true`
+
+  "xAB" >= "Xab"  // is `false`
   ```
 
 ### Comparing number super-types

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1009,6 +1009,7 @@ func NewStringValue(
 var _ Value = &StringValue{}
 var _ atree.Storable = &StringValue{}
 var _ EquatableValue = &StringValue{}
+var _ ComparableValue = &StringValue{}
 var _ HashableValue = &StringValue{}
 var _ ValueIndexableValue = &StringValue{}
 var _ MemberAccessibleValue = &StringValue{}
@@ -1060,6 +1061,58 @@ func (v *StringValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 		return false
 	}
 	return v.NormalForm() == otherString.NormalForm()
+}
+
+func (v *StringValue) Less(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
+	otherString, ok := other.(*StringValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLess,
+			LeftType:  v.StaticType(interpreter),
+			RightType: other.StaticType(interpreter),
+		})
+	}
+
+	return AsBoolValue(v.NormalForm() < otherString.NormalForm())
+}
+
+func (v *StringValue) LessEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
+	otherString, ok := other.(*StringValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationLessEqual,
+			LeftType:  v.StaticType(interpreter),
+			RightType: other.StaticType(interpreter),
+		})
+	}
+
+	return AsBoolValue(v.NormalForm() <= otherString.NormalForm())
+}
+
+func (v *StringValue) Greater(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
+	otherString, ok := other.(*StringValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreater,
+			LeftType:  v.StaticType(interpreter),
+			RightType: other.StaticType(interpreter),
+		})
+	}
+
+	return AsBoolValue(v.NormalForm() > otherString.NormalForm())
+}
+
+func (v *StringValue) GreaterEqual(interpreter *Interpreter, other ComparableValue, locationRange LocationRange) BoolValue {
+	otherString, ok := other.(*StringValue)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation: ast.OperationGreaterEqual,
+			LeftType:  v.StaticType(interpreter),
+			RightType: other.StaticType(interpreter),
+		})
+	}
+
+	return AsBoolValue(v.NormalForm() >= otherString.NormalForm())
 }
 
 // HashInput returns a byte slice containing:

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -46,7 +46,7 @@ var StringType = &SimpleType{
 	IsResource:    false,
 	Storable:      true,
 	Equatable:     true,
-	Comparable:    false,
+	Comparable:    true,
 	Exportable:    true,
 	Importable:    true,
 	ValueIndexingInfo: ValueIndexingInfo{

--- a/runtime/tests/checker/operations_test.go
+++ b/runtime/tests/checker/operations_test.go
@@ -354,6 +354,15 @@ func TestCheckNonIntegerComparisonOperations(t *testing.T) {
 				{sema.BoolType, "1.2", "\"b\"", "Fix64", "Character", []error{
 					&sema.InvalidBinaryOperandsError{},
 				}},
+				{sema.BoolType, "\"\"", "\"\"", "String", "String", nil},
+				{sema.BoolType, "\"\"", "\"b\"", "String", "String", nil},
+				{sema.BoolType, "\"xyz\"", "\"b\"", "String", "String", nil},
+				{sema.BoolType, "\"x\"", "\"b\"", "Character", "String", []error{
+					&sema.InvalidBinaryOperandsError{},
+				}},
+				{sema.BoolType, "1.2", "\"bcd\"", "Fix64", "String", []error{
+					&sema.InvalidBinaryOperandsError{},
+				}},
 			},
 		},
 	}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4737,6 +4737,22 @@ func TestInterpretComparison(t *testing.T) {
 		{"a >= b", false, "let left: Character = \"a\";\nlet right: Character = \"b\"; return left >= right"},
 		{"a >= a", true, "let left: Character = \"a\";\nlet right: Character = \"a\"; return left >= right"},
 		{"A >= a", false, "let left: Character = \"A\";\nlet right: Character = \"a\"; return left >= right"},
+		{"\"\" < \"\"", false, "let left: String = \"\";\nlet right: String = \"\"; return left < right"},
+		{"\"\" <= \"\"", true, "let left: String = \"\";\nlet right: String = \"\"; return left <= right"},
+		{"\"\" > \"\"", false, "let left: String = \"\";\nlet right: String = \"\"; return left > right"},
+		{"\"\" >= \"\"", true, "let left: String = \"\";\nlet right: String = \"\"; return left >= right"},
+		{"\"\" < \"a\"", true, "let left: String = \"\";\nlet right: String = \"a\"; return left < right"},
+		{"\"\" <= \"a\"", true, "let left: String = \"\";\nlet right: String = \"a\"; return left <= right"},
+		{"\"\" > \"a\"", false, "let left: String = \"\";\nlet right: String = \"a\"; return left > right"},
+		{"\"\" >= \"a\"", false, "let left: String = \"\";\nlet right: String = \"a\"; return left >= right"},
+		{"\"az\" < \"b\"", true, "let left: String = \"az\";\nlet right: String = \"b\"; return left < right"},
+		{"\"az\" <= \"b\"", true, "let left: String = \"az\";\nlet right: String = \"b\"; return left <= right"},
+		{"\"az\" > \"b\"", false, "let left: String = \"az\";\nlet right: String = \"b\"; return left > right"},
+		{"\"az\" >= \"b\"", false, "let left: String = \"az\";\nlet right: String = \"b\"; return left >= right"},
+		{"\"xAB\" < \"Xab\"", false, "let left: String = \"xAB\";\nlet right: String = \"Xab\"; return left < right"},
+		{"\"xAB\" <= \"Xab\"", false, "let left: String = \"xAB\";\nlet right: String = \"Xab\"; return left <= right"},
+		{"\"xAB\" > \"Xab\"", true, "let left: String = \"xAB\";\nlet right: String = \"Xab\"; return left > right"},
+		{"\"xAB\" >= \"Xab\"", true, "let left: String = \"xAB\";\nlet right: String = \"Xab\"; return left >= right"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Closes #2276 

## Description
Adds comparison support for `String`
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

