### PR TITLE
Add support for restricted types to Go code generator

### DIFF
--- a/runtime/sema/gen/testdata/fields.cdc
+++ b/runtime/sema/gen/testdata/fields.cdc
@@ -23,9 +23,18 @@ pub struct Test {
     /// This is a test type field.
     let testType: Type
 
-    /// This is a test capability field.
+    /// This is a test unparameterized capability field.
     let testCap: Capability
 
-    /// This is a test specific capability field.
+    /// This is a test parameterized capability field.
     let testCapInt: Capability<Int>
+
+    /// This is a test restricted type (without type) field.
+    let testRestrictedWithoutType: {Bar, Baz}
+
+    /// This is a test restricted type (with type) field.
+    let testRestrictedWithType: Foo{Bar, Baz}
+
+    /// This is a test restricted type (without restrictions) field.
+    let testRestrictedWithoutRestrictions: Foo{}
 }

--- a/runtime/sema/gen/testdata/fields.golden.go
+++ b/runtime/sema/gen/testdata/fields.golden.go
@@ -100,7 +100,7 @@ const TestTypeTestCapFieldName = "testCap"
 var TestTypeTestCapFieldType = &CapabilityType{}
 
 const TestTypeTestCapFieldDocString = `
-This is a test capability field.
+This is a test unparameterized capability field.
 `
 
 const TestTypeTestCapIntFieldName = "testCapInt"
@@ -111,7 +111,38 @@ var TestTypeTestCapIntFieldType = MustInstantiate(
 )
 
 const TestTypeTestCapIntFieldDocString = `
-This is a test specific capability field.
+This is a test parameterized capability field.
+`
+
+const TestTypeTestRestrictedWithoutTypeFieldName = "testRestrictedWithoutType"
+
+var TestTypeTestRestrictedWithoutTypeFieldType = &RestrictedType{
+	Restrictions: []*InterfaceType{BarType, BazType},
+}
+
+const TestTypeTestRestrictedWithoutTypeFieldDocString = `
+This is a test restricted type (without type) field.
+`
+
+const TestTypeTestRestrictedWithTypeFieldName = "testRestrictedWithType"
+
+var TestTypeTestRestrictedWithTypeFieldType = &RestrictedType{
+	Type:         FooType,
+	Restrictions: []*InterfaceType{BarType, BazType},
+}
+
+const TestTypeTestRestrictedWithTypeFieldDocString = `
+This is a test restricted type (with type) field.
+`
+
+const TestTypeTestRestrictedWithoutRestrictionsFieldName = "testRestrictedWithoutRestrictions"
+
+var TestTypeTestRestrictedWithoutRestrictionsFieldType = &RestrictedType{
+	Type: FooType,
+}
+
+const TestTypeTestRestrictedWithoutRestrictionsFieldDocString = `
+This is a test restricted type (without restrictions) field.
 `
 
 const TestTypeName = "Test"
@@ -191,6 +222,24 @@ func init() {
 				TestTypeTestCapIntFieldName,
 				TestTypeTestCapIntFieldType,
 				TestTypeTestCapIntFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				TestTypeTestRestrictedWithoutTypeFieldName,
+				TestTypeTestRestrictedWithoutTypeFieldType,
+				TestTypeTestRestrictedWithoutTypeFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				TestTypeTestRestrictedWithTypeFieldName,
+				TestTypeTestRestrictedWithTypeFieldType,
+				TestTypeTestRestrictedWithTypeFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				TestTypeTestRestrictedWithoutRestrictionsFieldName,
+				TestTypeTestRestrictedWithoutRestrictionsFieldType,
+				TestTypeTestRestrictedWithoutRestrictionsFieldDocString,
 			),
 		})
 	}


### PR DESCRIPTION
Work towards #2091 

## Description

The latest update to the CapCon FLIP uses a restricted type for a type parameter bound.

Add support for restricted types to the Go code generator.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
