### PR TITLE
Add integration tests (in Cadence) for `Crypto` contract and generate code coverage

### DIFF
--- a/runtime/stdlib/contracts/crypto_test.cdc
+++ b/runtime/stdlib/contracts/crypto_test.cdc
@@ -1,0 +1,84 @@
+import Test
+
+pub var blockchain = Test.newEmulatorBlockchain()
+pub var account = blockchain.createAccount()
+
+pub fun setup() {
+    blockchain.useConfiguration(Test.Configuration({
+        "Crypto": account.address
+    }))
+
+    var crypto = Test.readFile("crypto.cdc")
+    var err = blockchain.deployContract(
+        name: "Crypto",
+        code: crypto,
+        account: account,
+        arguments: []
+    )
+
+    Test.assert(err == nil)
+}
+
+pub fun testCryptoHash() {
+    let returnedValue = executeScript("./scripts/crypto_hash.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testCryptoHashWithTag() {
+    let returnedValue = executeScript("./scripts/crypto_hash_with_tag.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testAddKeyToKeyList() {
+    let returnedValue = executeScript("./scripts/crypto_key_list_add.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testGetKeyFromList() {
+    let returnedValue = executeScript("./scripts/crypto_get_key_from_list.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testRevokeKeyFromList() {
+    let returnedValue = executeScript("./scripts/crypto_revoke_key_from_list.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testKeyListVerify() {
+    let returnedValue = executeScript("./scripts/crypto_key_list_verify.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testKeyListVerifyInsufficientWeights() {
+    let returnedValue = executeScript("./scripts/crypto_key_list_verify_insufficient_weights.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testKeyListVerifyWithRevokedKey() {
+    let returnedValue = executeScript("./scripts/crypto_key_list_verify_revoked.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testKeyListVerifyWithMissingSignature() {
+    let returnedValue = executeScript("./scripts/crypto_key_list_verify_missing_signature.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testKeyListVerifyDuplicateSignature() {
+    let returnedValue = executeScript("./scripts/crypto_key_list_verify_duplicate_signature.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testKeyListVerifyInvalidSignature() {
+    let returnedValue = executeScript("./scripts/crypto_key_list_verify_invalid_signature.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+priv fun executeScript(_ scriptPath: String): Bool {
+    var script = Test.readFile(scriptPath)
+    let value = blockchain.executeScript(script, [])
+
+    Test.assert(value.status == Test.ResultStatus.succeeded)
+
+    return value.returnValue! as! Bool
+}

--- a/runtime/stdlib/contracts/flow.json
+++ b/runtime/stdlib/contracts/flow.json
@@ -1,0 +1,24 @@
+{
+  "networks": {
+    "emulator": "127.0.0.1:3569",
+    "mainnet": "access.mainnet.nodes.onflow.org:9000",
+    "sandboxnet": "access.sandboxnet.nodes.onflow.org:9000",
+    "testnet": "access.devnet.nodes.onflow.org:9000"
+  },
+  "contracts": {
+    "Crypto": "crypto.cdc"
+  },
+  "deployments": {
+    "emulator": {
+      "emulator-account": [
+        "Crypto"
+      ]
+    }
+  },
+  "accounts": {
+    "emulator-account": {
+      "address": "f8d6e0586b0a20c7",
+      "key": "b775d6da04a0b4819903d89a25395bfd90eb8559182255690c7c141edaeae923"
+    }
+  }
+}

--- a/runtime/stdlib/contracts/scripts/crypto_get_key_from_list.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_get_key_from_list.cdc
@@ -1,0 +1,21 @@
+import Crypto from "Crypto"
+
+pub fun main(): Bool {
+    let keyList = Crypto.KeyList()
+
+    let publicKey = PublicKey(
+        publicKey:
+            "db04940e18ec414664ccfd31d5d2d4ece3985acb8cb17a2025b2f1673427267968e52e2bbf3599059649d4b2cce98fdb8a3048e68abf5abe3e710129e90696ca".decodeHex(),
+        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+    )
+    keyList.add(
+        publicKey,
+        hashAlgorithm: HashAlgorithm.SHA3_256,
+        weight: 1.0
+    )
+
+    assert(keyList.get(keyIndex: 0) != nil)
+    assert(keyList.get(keyIndex: 2) == nil)
+    
+    return true
+}

--- a/runtime/stdlib/contracts/scripts/crypto_hash.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_hash.cdc
@@ -1,0 +1,6 @@
+import Crypto from "Crypto"
+
+pub fun main(): Bool {
+    let hash = Crypto.hash([1, 2, 3], algorithm: HashAlgorithm.SHA3_256)
+    return hash.length == 32
+}

--- a/runtime/stdlib/contracts/scripts/crypto_hash_with_tag.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_hash_with_tag.cdc
@@ -1,0 +1,10 @@
+import Crypto from "Crypto"
+
+pub fun main(): Bool {
+    let hash = Crypto.hashWithTag(
+        [1, 2, 3],
+        tag: "v0.1.tag",
+        algorithm: HashAlgorithm.SHA3_256
+    )
+    return hash.length == 32
+}

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_add.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_add.cdc
@@ -1,0 +1,18 @@
+import Crypto from "Crypto"
+
+pub fun main(): Bool {
+    let keyList = Crypto.KeyList()
+
+    let publicKey = PublicKey(
+        publicKey:
+            "db04940e18ec414664ccfd31d5d2d4ece3985acb8cb17a2025b2f1673427267968e52e2bbf3599059649d4b2cce98fdb8a3048e68abf5abe3e710129e90696ca".decodeHex(),
+        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+    )
+    keyList.add(
+        publicKey,
+        hashAlgorithm: HashAlgorithm.SHA3_256,
+        weight: 1.0
+    )
+    
+    return keyList.get(keyIndex: 0) != nil
+}

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_verify.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_verify.cdc
@@ -1,0 +1,51 @@
+import Crypto from "Crypto"
+
+pub fun main(): Bool {
+    let keyList = Crypto.KeyList()
+
+    let publicKeyA = PublicKey(
+        publicKey:
+            "db04940e18ec414664ccfd31d5d2d4ece3985acb8cb17a2025b2f1673427267968e52e2bbf3599059649d4b2cce98fdb8a3048e68abf5abe3e710129e90696ca".decodeHex(),
+        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+    )
+
+    keyList.add(
+        publicKeyA,
+        hashAlgorithm: HashAlgorithm.SHA3_256,
+        weight: 0.5
+    )
+
+    let publicKeyB = PublicKey(
+        publicKey:
+            "df9609ee588dd4a6f7789df8d56f03f545d4516f0c99b200d73b9a3afafc14de5d21a4fc7a2a2015719dc95c9e756cfa44f2a445151aaf42479e7120d83df956".decodeHex(),
+        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+    )
+
+    keyList.add(
+        publicKeyB,
+        hashAlgorithm: HashAlgorithm.SHA3_256,
+        weight: 0.5
+    )
+
+    let signatureSet = [
+        Crypto.KeyListSignature(
+            keyIndex: 0,
+            signature:
+                "8870a8cbe6f44932ba59e0d15a706214cc4ad2538deb12c0cf718d86f32c47765462a92ce2da15d4a29eb4e2b6fa05d08c7db5d5b2a2cd8c2cb98ded73da31f6".decodeHex()
+        ),
+        Crypto.KeyListSignature(
+            keyIndex: 1,
+            signature:
+                "bbdc5591c3f937a730d4f6c0a6fde61a0a6ceaa531ccb367c3559335ab9734f4f2b9da8adbe371f1f7da913b5a3fdd96a871e04f078928ca89a83d841c72fadf".decodeHex()
+        )
+    ]
+
+    // "foo", encoded as UTF-8, in hex representation
+    let signedData = "666f6f".decodeHex()
+
+    let isValid = keyList.verify(
+        signatureSet: signatureSet,
+        signedData: signedData
+    )
+    return isValid
+}

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_verify_duplicate_signature.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_verify_duplicate_signature.cdc
@@ -1,0 +1,39 @@
+import Crypto from "Crypto"
+
+pub fun main(): Bool {
+    let keyList = Crypto.KeyList()
+
+    let publicKey = PublicKey(
+        publicKey:
+            "db04940e18ec414664ccfd31d5d2d4ece3985acb8cb17a2025b2f1673427267968e52e2bbf3599059649d4b2cce98fdb8a3048e68abf5abe3e710129e90696ca".decodeHex(),
+        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+    )
+    keyList.add(
+        publicKey,
+        hashAlgorithm: HashAlgorithm.SHA3_256,
+        weight: 0.5
+    )
+
+    let signatureSet = [
+        Crypto.KeyListSignature(
+            keyIndex: 0,
+            signature:
+                "8870a8cbe6f44932ba59e0d15a706214cc4ad2538deb12c0cf718d86f32c47765462a92ce2da15d4a29eb4e2b6fa05d08c7db5d5b2a2cd8c2cb98ded73da31f6".decodeHex()
+        ),
+        Crypto.KeyListSignature(
+            keyIndex: 0,
+            signature:
+                "8870a8cbe6f44932ba59e0d15a706214cc4ad2538deb12c0cf718d86f32c47765462a92ce2da15d4a29eb4e2b6fa05d08c7db5d5b2a2cd8c2cb98ded73da31f6".decodeHex()
+        )
+    ]
+
+    // "foo", encoded as UTF-8, in hex representation
+    let signedData = "666f6f".decodeHex()
+
+    var isValid = keyList.verify(
+        signatureSet: signatureSet,
+        signedData: signedData
+    )
+
+    return !isValid
+}

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_verify_insufficient_weights.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_verify_insufficient_weights.cdc
@@ -1,0 +1,51 @@
+import Crypto from "Crypto"
+
+pub fun main(): Bool {
+    let keyList = Crypto.KeyList()
+
+    let publicKeyA = PublicKey(
+        publicKey:
+            "db04940e18ec414664ccfd31d5d2d4ece3985acb8cb17a2025b2f1673427267968e52e2bbf3599059649d4b2cce98fdb8a3048e68abf5abe3e710129e90696ca".decodeHex(),
+        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+    )
+
+    keyList.add(
+        publicKeyA,
+        hashAlgorithm: HashAlgorithm.SHA3_256,
+        weight: 0.4
+    )
+
+    let publicKeyB = PublicKey(
+        publicKey:
+            "df9609ee588dd4a6f7789df8d56f03f545d4516f0c99b200d73b9a3afafc14de5d21a4fc7a2a2015719dc95c9e756cfa44f2a445151aaf42479e7120d83df956".decodeHex(),
+        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+    )
+
+    keyList.add(
+        publicKeyB,
+        hashAlgorithm: HashAlgorithm.SHA3_256,
+        weight: 0.5
+    )
+
+    let signatureSet = [
+        Crypto.KeyListSignature(
+            keyIndex: 0,
+            signature:
+                "8870a8cbe6f44932ba59e0d15a706214cc4ad2538deb12c0cf718d86f32c47765462a92ce2da15d4a29eb4e2b6fa05d08c7db5d5b2a2cd8c2cb98ded73da31f6".decodeHex()
+        ),
+        Crypto.KeyListSignature(
+            keyIndex: 1,
+            signature:
+                "bbdc5591c3f937a730d4f6c0a6fde61a0a6ceaa531ccb367c3559335ab9734f4f2b9da8adbe371f1f7da913b5a3fdd96a871e04f078928ca89a83d841c72fadf".decodeHex()
+        )
+    ]
+
+    // "foo", encoded as UTF-8, in hex representation
+    let signedData = "666f6f".decodeHex()
+
+    let isValid = keyList.verify(
+        signatureSet: signatureSet,
+        signedData: signedData
+    )
+    return !isValid
+}

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_verify_invalid_signature.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_verify_invalid_signature.cdc
@@ -1,0 +1,34 @@
+import Crypto from "Crypto"
+
+pub fun main(): Bool {
+    let keyList = Crypto.KeyList()
+
+    let publicKey = PublicKey(
+        publicKey:
+            "db04940e18ec414664ccfd31d5d2d4ece3985acb8cb17a2025b2f1673427267968e52e2bbf3599059649d4b2cce98fdb8a3048e68abf5abe3e710129e90696ca".decodeHex(),
+        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+    )
+    keyList.add(
+        publicKey,
+        hashAlgorithm: HashAlgorithm.SHA3_256,
+        weight: 0.5
+    )
+
+    let signatureSet = [
+        Crypto.KeyListSignature(
+            keyIndex: 0,
+            signature:
+                "db70a8cbe6f44932ba59e0d15a706214cc4ad2538deb12c0cf718d86f32c47765462a92ce2da15d4a29eb4e2b6fa05d08c7db5d5b2a2cd8c2cb98ded73da31f6".decodeHex()
+        )
+    ]
+
+    // "foo", encoded as UTF-8, in hex representation
+    let signedData = "666f6f".decodeHex()
+
+    var isValid = keyList.verify(
+        signatureSet: signatureSet,
+        signedData: signedData
+    )
+
+    return !isValid
+}

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_verify_missing_signature.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_verify_missing_signature.cdc
@@ -1,0 +1,34 @@
+import Crypto from "Crypto"
+
+pub fun main(): Bool {
+    let keyList = Crypto.KeyList()
+
+    let publicKey = PublicKey(
+        publicKey:
+            "db04940e18ec414664ccfd31d5d2d4ece3985acb8cb17a2025b2f1673427267968e52e2bbf3599059649d4b2cce98fdb8a3048e68abf5abe3e710129e90696ca".decodeHex(),
+        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+    )
+    keyList.add(
+        publicKey,
+        hashAlgorithm: HashAlgorithm.SHA3_256,
+        weight: 0.5
+    )
+
+    let signatureSet = [
+        Crypto.KeyListSignature(
+            keyIndex: 1,
+            signature:
+                "8870a8cbe6f44932ba59e0d15a706214cc4ad2538deb12c0cf718d86f32c47765462a92ce2da15d4a29eb4e2b6fa05d08c7db5d5b2a2cd8c2cb98ded73da31f6".decodeHex()
+        )
+    ]
+
+    // "foo", encoded as UTF-8, in hex representation
+    let signedData = "666f6f".decodeHex()
+
+    var isValid = keyList.verify(
+        signatureSet: signatureSet,
+        signedData: signedData
+    )
+
+    return !isValid
+}

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_verify_revoked.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_verify_revoked.cdc
@@ -1,0 +1,36 @@
+import Crypto from "Crypto"
+
+pub fun main(): Bool {
+    let keyList = Crypto.KeyList()
+
+    let publicKey = PublicKey(
+        publicKey:
+            "db04940e18ec414664ccfd31d5d2d4ece3985acb8cb17a2025b2f1673427267968e52e2bbf3599059649d4b2cce98fdb8a3048e68abf5abe3e710129e90696ca".decodeHex(),
+        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+    )
+    keyList.add(
+        publicKey,
+        hashAlgorithm: HashAlgorithm.SHA3_256,
+        weight: 0.5
+    )
+
+    let signatureSet = [
+        Crypto.KeyListSignature(
+            keyIndex: 0,
+            signature:
+                "8870a8cbe6f44932ba59e0d15a706214cc4ad2538deb12c0cf718d86f32c47765462a92ce2da15d4a29eb4e2b6fa05d08c7db5d5b2a2cd8c2cb98ded73da31f6".decodeHex()
+        )
+    ]
+
+    // "foo", encoded as UTF-8, in hex representation
+    let signedData = "666f6f".decodeHex()
+
+    keyList.revoke(keyIndex: 0)
+
+    var isValid = keyList.verify(
+        signatureSet: signatureSet,
+        signedData: signedData
+    )
+
+    return !isValid
+}

--- a/runtime/stdlib/contracts/scripts/crypto_revoke_key_from_list.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_revoke_key_from_list.cdc
@@ -1,0 +1,24 @@
+import Crypto from "Crypto"
+
+pub fun main(): Bool {
+    let keyList = Crypto.KeyList()
+
+    let publicKey = PublicKey(
+        publicKey:
+            "db04940e18ec414664ccfd31d5d2d4ece3985acb8cb17a2025b2f1673427267968e52e2bbf3599059649d4b2cce98fdb8a3048e68abf5abe3e710129e90696ca".decodeHex(),
+        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+    )
+    keyList.add(
+        publicKey,
+        hashAlgorithm: HashAlgorithm.SHA3_256,
+        weight: 0.5
+    )
+
+    keyList.revoke(keyIndex: 0)
+    keyList.revoke(keyIndex: 2)
+
+    assert(keyList.get(keyIndex: 0)!.isRevoked)
+    assert(keyList.get(keyIndex: 2) == nil)
+    
+    return true
+}


### PR DESCRIPTION
Work towards: https://github.com/onflow/developer-grants/issues/132

## Description

This is addressing the 2nd Milestone (`Adoption`) for the above grant. We want to have some official examples, which Flow builders can use as a starting point. Besides that, it is helpful for us to make use of the tool that we built, to drive forward its functionality :pray: 

From the `runtime/stdlib/contracts` directory, run:
**Note:** Needs `flow-cli@v1.0.2` or greater

```bash
flow test --cover crypto_test.cdc

Test results: "crypto_test.cdc"
- PASS: testCryptoHash
- PASS: testCryptoHashWithTag
- PASS: testAddKeyToKeyList
- PASS: testGetKeyFromList
- PASS: testRevokeKeyFromList
- PASS: testKeyListVerify
- PASS: testKeyListVerifyInsufficientWeights
- PASS: testKeyListVerifyWithRevokedKey
- PASS: testKeyListVerifyWithMissingSignature
- PASS: testKeyListVerifyDuplicateSignature
- PASS: testKeyListVerifyInvalidSignature
Coverage: 58.2% of statements
```

**Note:** To have better code coverage metrics, there are two PRs to address this:
- https://github.com/onflow/cadence-tools/pull/110
- https://github.com/onflow/cadence/pull/2474

And to view the code coverage:

```bash
cat coverage.json | jq '.coverage."A.01cf0e2f2f715450.Crypto"'     
{
  "line_hits": {
    "100": 9,
    "101": 1,
    "106": 8,
    "107": 1,
    "112": 7,
    "116": 7,
    "120": 7,
    "121": 1,
    "126": 6,
    "132": 1,
    "135": 5,
    "138": 2,
    "147": 9,
    "148": 9,
    "155": 1,
    "26": 13,
    "27": 13,
    "28": 13,
    "29": 13,
    "30": 13,
    "39": 9,
    "49": 11,
    "5": 1,
    "50": 11,
    "57": 11,
    "58": 11,
    "64": 5,
    "65": 2,
    "68": 3,
    "73": 3,
    "74": 1,
    "76": 2,
    "77": 2,
    "9": 1,
    "92": 6,
    "94": 6,
    "96": 6
  },
  "missed_lines": [],
  "statements": 37,
  "percentage": "100.0%"
}
```
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
