### PR TITLE
Implement `check` functionality in AuthAccount

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4037,7 +4037,9 @@ func (interpreter *Interpreter) authAccountCheckFunction(addressValue AddressVal
 			domain := path.Domain.Identifier()
 			identifier := path.Identifier
 
-			value := interpreter.ReadStored(address, domain, identifier)
+			storageMapKey := StringStorageMapKey(identifier)
+
+			value := interpreter.ReadStored(address, domain, storageMapKey)
 
 			if value == nil {
 				return FalseValue

--- a/runtime/interpreter/value_account.go
+++ b/runtime/interpreter/value_account.go
@@ -72,6 +72,7 @@ func NewAuthAccountValue(
 	var copyFunction *HostFunctionValue
 	var saveFunction *HostFunctionValue
 	var borrowFunction *HostFunctionValue
+	var checkFunction *HostFunctionValue
 	var linkFunction *HostFunctionValue
 	var linkAccountFunction *HostFunctionValue
 	var unlinkFunction *HostFunctionValue
@@ -187,6 +188,12 @@ func NewAuthAccountValue(
 				borrowFunction = inter.authAccountBorrowFunction(address)
 			}
 			return borrowFunction
+
+		case sema.AuthAccountTypeCheckFunctionName:
+			if checkFunction == nil {
+				checkFunction = inter.authAccountCheckFunction(address)
+			}
+			return checkFunction
 
 		case sema.AuthAccountTypeLinkFunctionName:
 			if linkFunction == nil {

--- a/runtime/sema/authaccount.cdc
+++ b/runtime/sema/authaccount.cdc
@@ -112,6 +112,8 @@ pub struct AuthAccount {
     /// Returns true if the object in account storage under the given path satisfies the given type, 
     /// i.e. could be borrowed using the given type.
     ///
+    /// The given type must not necessarily be exactly the same as the type of the borrowed object.
+    ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
     pub fun check<T: &Any>(from: StoragePath): Bool
 

--- a/runtime/sema/authaccount.cdc
+++ b/runtime/sema/authaccount.cdc
@@ -109,6 +109,12 @@ pub struct AuthAccount {
     /// The path must be a storage path, i.e., only the domain `storage` is allowed
     pub fun borrow<T: &Any>(from: StoragePath): T?
 
+    /// Returns true if the object in account storage under the given path satisfies the given type, 
+    /// i.e. could be borrowed using the given type.
+    ///
+    /// The path must be a storage path, i.e., only the domain `storage` is allowed.
+    pub fun check<T: &Any>(from: StoragePath): Bool
+
     /// **DEPRECATED**: Instead, use `capabilities.storage.issue`, and `capabilities.publish` if the path is public.
     ///
     /// Creates a capability at the given public or private path,

--- a/runtime/sema/authaccount.cdc
+++ b/runtime/sema/authaccount.cdc
@@ -115,7 +115,7 @@ pub struct AuthAccount {
     /// The given type must not necessarily be exactly the same as the type of the borrowed object.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
-    pub fun check<T: &Any>(from: StoragePath): Bool
+    pub fun check<T: Any>(from: StoragePath): Bool
 
     /// **DEPRECATED**: Instead, use `capabilities.storage.issue`, and `capabilities.publish` if the path is public.
     ///

--- a/runtime/sema/authaccount.gen.go
+++ b/runtime/sema/authaccount.gen.go
@@ -366,10 +366,8 @@ The path must be a storage path, i.e., only the domain ` + "`storage`" + ` is al
 const AuthAccountTypeCheckFunctionName = "check"
 
 var AuthAccountTypeCheckFunctionTypeParameterT = &TypeParameter{
-	Name: "T",
-	TypeBound: &ReferenceType{
-		Type: AnyType,
-	},
+	Name:      "T",
+	TypeBound: AnyType,
 }
 
 var AuthAccountTypeCheckFunctionType = &FunctionType{

--- a/runtime/sema/authaccount.gen.go
+++ b/runtime/sema/authaccount.gen.go
@@ -391,6 +391,8 @@ const AuthAccountTypeCheckFunctionDocString = `
 Returns true if the object in account storage under the given path satisfies the given type,
 i.e. could be borrowed using the given type.
 
+The given type must not necessarily be exactly the same as the type of the borrowed object.
+
 The path must be a storage path, i.e., only the domain ` + "`storage`" + ` is allowed.
 `
 

--- a/runtime/sema/authaccount.gen.go
+++ b/runtime/sema/authaccount.gen.go
@@ -363,6 +363,37 @@ The given type must not necessarily be exactly the same as the type of the borro
 The path must be a storage path, i.e., only the domain ` + "`storage`" + ` is allowed
 `
 
+const AuthAccountTypeCheckFunctionName = "check"
+
+var AuthAccountTypeCheckFunctionTypeParameterT = &TypeParameter{
+	Name: "T",
+	TypeBound: &ReferenceType{
+		Type: AnyType,
+	},
+}
+
+var AuthAccountTypeCheckFunctionType = &FunctionType{
+	TypeParameters: []*TypeParameter{
+		AuthAccountTypeCheckFunctionTypeParameterT,
+	},
+	Parameters: []Parameter{
+		{
+			Identifier:     "from",
+			TypeAnnotation: NewTypeAnnotation(StoragePathType),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		BoolType,
+	),
+}
+
+const AuthAccountTypeCheckFunctionDocString = `
+Returns true if the object in account storage under the given path satisfies the given type,
+i.e. could be borrowed using the given type.
+
+The path must be a storage path, i.e., only the domain ` + "`storage`" + ` is allowed.
+`
+
 const AuthAccountTypeLinkFunctionName = "link"
 
 var AuthAccountTypeLinkFunctionTypeParameterT = &TypeParameter{
@@ -1959,6 +1990,13 @@ func init() {
 			AuthAccountTypeBorrowFunctionName,
 			AuthAccountTypeBorrowFunctionType,
 			AuthAccountTypeBorrowFunctionDocString,
+		),
+		NewUnmeteredFunctionMember(
+			AuthAccountType,
+			ast.AccessPublic,
+			AuthAccountTypeCheckFunctionName,
+			AuthAccountTypeCheckFunctionType,
+			AuthAccountTypeCheckFunctionDocString,
 		),
 		NewUnmeteredFunctionMember(
 			AuthAccountType,

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -644,6 +644,10 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
                   account.save(<-r, to: /storage/r)
               }
 
+			  fun checkR(): Bool {
+				  return account.check<&R>(from: /storage/r)
+			  }
+
               fun borrowR(): &R? {
                   return account.borrow<&R>(from: /storage/r)
               }
@@ -651,6 +655,10 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
               fun foo(): Int {
                   return account.borrow<&R>(from: /storage/r)!.foo
               }
+
+			  fun checkR2(): Bool {
+				  return account.check<&R2>(from: /storage/r)
+			  }
 
               fun borrowR2(): &R2? {
                   return account.borrow<&R2>(from: /storage/r)
@@ -680,7 +688,15 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 		t.Run("borrow R ", func(t *testing.T) {
 
-			// first borrow
+			// first check & borrow
+			checkRes, err := inter.Invoke("checkR")
+			require.NoError(t, err)
+			AssertValuesEqual(
+				t,
+				inter,
+				interpreter.AsBoolValue(true),
+				checkRes,
+			)
 
 			value, err := inter.Invoke("borrowR")
 			require.NoError(t, err)
@@ -711,7 +727,15 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			// TODO: should fail, i.e. return nil
 
-			// second borrow
+			// second check & borrow
+			checkRes, err = inter.Invoke("checkR")
+			require.NoError(t, err)
+			AssertValuesEqual(
+				t,
+				inter,
+				interpreter.AsBoolValue(true),
+				checkRes,
+			)
 
 			value, err = inter.Invoke("borrowR")
 			require.NoError(t, err)
@@ -727,8 +751,16 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 		})
 
 		t.Run("borrow R2", func(t *testing.T) {
+			checkRes, err := inter.Invoke("checkR2")
+			require.NoError(t, err)
+			AssertValuesEqual(
+				t,
+				inter,
+				interpreter.AsBoolValue(false),
+				checkRes,
+			)
 
-			_, err := inter.Invoke("borrowR2")
+			_, err = inter.Invoke("borrowR2")
 			RequireError(t, err)
 
 			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
@@ -778,6 +810,10 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
                   account.save(s, to: /storage/s)
               }
 
+			  fun checkS(): Bool {
+				  return account.check<&S>(from: /storage/s)
+			  }
+
               fun borrowS(): &S? {
                   return account.borrow<&S>(from: /storage/s)
               }
@@ -785,8 +821,12 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
               fun foo(): Int {
                   return account.borrow<&S>(from: /storage/s)!.foo
               }
-
-              fun borrowS2(): &S2? {
+			 
+			  fun checkS2(): Bool {
+				  return account.check<&S2>(from: /storage/s)
+			  }
+             
+			  fun borrowS2(): &S2? {
                   return account.borrow<&S2>(from: /storage/s)
               }
 
@@ -821,7 +861,15 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 		t.Run("borrow S", func(t *testing.T) {
 
-			// first borrow
+			// first check & borrow
+			checkRes, err := inter.Invoke("checkS")
+			require.NoError(t, err)
+			AssertValuesEqual(
+				t,
+				inter,
+				interpreter.AsBoolValue(true),
+				checkRes,
+			)
 
 			value, err := inter.Invoke("borrowS")
 			require.NoError(t, err)
@@ -852,7 +900,15 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 
 			// TODO: should fail, i.e. return nil
 
-			// second borrow
+			// second check & borrow
+			checkRes, err = inter.Invoke("checkS")
+			require.NoError(t, err)
+			AssertValuesEqual(
+				t,
+				inter,
+				interpreter.AsBoolValue(true),
+				checkRes,
+			)
 
 			value, err = inter.Invoke("borrowS")
 			require.NoError(t, err)
@@ -868,6 +924,14 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 		})
 
 		t.Run("borrow S2", func(t *testing.T) {
+			checkRes, err := inter.Invoke("checkS2")
+			require.NoError(t, err)
+			AssertValuesEqual(
+				t,
+				inter,
+				interpreter.AsBoolValue(false),
+				checkRes,
+			)
 
 			_, err = inter.Invoke("borrowS2")
 			RequireError(t, err)

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -645,7 +645,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
               }
 
 			  fun checkR(): Bool {
-				  return account.check<&R>(from: /storage/r)
+				  return account.check<@R>(from: /storage/r)
 			  }
 
               fun borrowR(): &R? {
@@ -657,7 +657,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
               }
 
 			  fun checkR2(): Bool {
-				  return account.check<&R2>(from: /storage/r)
+				  return account.check<@R2>(from: /storage/r)
 			  }
 
               fun borrowR2(): &R2? {
@@ -811,7 +811,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
               }
 
 			  fun checkS(): Bool {
-				  return account.check<&S>(from: /storage/s)
+				  return account.check<S>(from: /storage/s)
 			  }
 
               fun borrowS(): &S? {
@@ -823,7 +823,7 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
               }
 			 
 			  fun checkS2(): Bool {
-				  return account.check<&S2>(from: /storage/s)
+				  return account.check<S2>(from: /storage/s)
 			  }
              
 			  fun borrowS2(): &S2? {

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -664,6 +664,10 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
                   return account.borrow<&R2>(from: /storage/r)
               }
 
+			  fun checkR2WithInvalidPath(): Bool {
+				  return account.check<@R2>(from: /storage/wrongpath)
+			  }
+
               fun changeAfterBorrow(): Int {
                  let ref = account.borrow<&R>(from: /storage/r)!
 
@@ -775,6 +779,17 @@ func TestInterpretAuthAccount_borrow(t *testing.T) {
 			RequireError(t, err)
 
 			require.ErrorAs(t, err, &interpreter.DereferenceError{})
+		})
+
+		t.Run("check R2 with wrong path", func(t *testing.T) {
+			checkRes, err := inter.Invoke("checkR2WithInvalidPath")
+			require.NoError(t, err)
+			AssertValuesEqual(
+				t,
+				inter,
+				interpreter.AsBoolValue(false),
+				checkRes,
+			)
 		})
 	})
 


### PR DESCRIPTION
Closes #564
Work towards https://github.com/onflow/developer-grants/issues/179

## Description
Adds `AuthAccount.check(storagePath)` function to check if the type parameters can be used to create a reference for the object stored in the storage path.

TODO:
- [x] Tests
- [x] Documentation

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
