### PR TITLE
Add an `Examples` section on the Cadence Testing Framework doc

### DIFF
--- a/docs/testing-framework.mdx
+++ b/docs/testing-framework.mdx
@@ -529,3 +529,9 @@ let contractCode = Test.readFile("./sample/contracts/FooContract.cdc")
 ```
 
 `readFile` returns the content of the file as a string.
+
+## Examples
+
+This [repository](https://github.com/Build-Squad/flow-code-coverage) contains many functional examples
+that demonstrate most of the above features, both for contrived and real-world smart contracts.
+It also contains detailed explanation on using code coverage for Cadence.


### PR DESCRIPTION
## Description

Linked the https://github.com/Build-Squad/flow-code-coverage repository, on this new section. It contains many useful examples on how to utilize the Cadence Testing Framework, and also the code coverage feature.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
