### PR TITLE
Add `fromBigEndianBytes` conversion function to `Number` types

### DIFF
--- a/runtime/interpreter/big.go
+++ b/runtime/interpreter/big.go
@@ -57,6 +57,31 @@ func SignedBigIntToBigEndianBytes(bigInt *big.Int) []byte {
 	}
 }
 
+func BigEndianBytesToSignedBigInt(b []byte) *big.Int {
+	// Check for special cases of 0 and 1
+	if len(b) == 1 && b[0] == 0 {
+		return big.NewInt(0)
+	} else if len(b) == 1 && b[0] <= 0x7f {
+		return big.NewInt(int64(b[0]))
+	}
+
+	// Check if number is negative (high bit set)
+	isNegative := b[0]&0x80 != 0
+
+	// Perform two's complement transformation if negative
+	if isNegative {
+		for i := range b {
+			b[i] ^= 0xff
+		}
+		result := new(big.Int).SetBytes(b)
+		result.Add(result, big.NewInt(1)).Neg(result)
+		return result
+	}
+
+	// Positive number
+	return new(big.Int).SetBytes(b)
+}
+
 func UnsignedBigIntToBigEndianBytes(bigInt *big.Int) []byte {
 
 	switch bigInt.Sign() {
@@ -72,4 +97,8 @@ func UnsignedBigIntToBigEndianBytes(bigInt *big.Int) []byte {
 	default:
 		panic(errors.NewUnreachableError())
 	}
+}
+
+func BigEndianBytesToUnsignedBigInt(b []byte) *big.Int {
+	return new(big.Int).SetBytes(b)
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2548,8 +2548,10 @@ var fromBigEndianBytesFunctionValues = func() map[string]fromBigEndianBytesFunct
 	declarations := []fromBigEndianBytesFunctionValue{
 		// signed int values
 		newFromBigEndianBytesFunction(sema.Int8Type, 1, func(i *Interpreter, b []byte) OptionalValue {
-			bytes := padWithZeroes(b, 1)
-			return NewSomeValueNonCopying(i, NewInt8Value(i, func() int8 { return int8(bytes[0]) }))
+			return NewSomeValueNonCopying(i, NewInt8Value(i, func() int8 {
+				bytes := padWithZeroes(b, 1)
+				return int8(bytes[0])
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.Int16Type, 2, func(i *Interpreter, b []byte) OptionalValue {
 			bytes := padWithZeroes(b, 2)

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2502,8 +2502,22 @@ func padWithZeroes(b []byte, expectedLen int) []byte {
 		return b
 	}
 
-	res := make([]byte, expectedLen)
+	var res []byte
+	// use existing allocated slice if possible.
+	if cap(b) >= expectedLen {
+		res = b[:expectedLen]
+	} else {
+		res = make([]byte, expectedLen)
+	}
+
 	copy(res[expectedLen-l:], b)
+
+	// explicitly set to 0 for the first expectedLen - l bytes.
+	if cap(b) >= expectedLen {
+		for i := 0; i < expectedLen-l; i++ {
+			res[i] = 0
+		}
+	}
 	return res
 }
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2530,6 +2530,7 @@ func newFromBigEndianBytesFunction(
 				return Nil
 			}
 
+			// overflow
 			if byteLength != 0 && len(bytes) > byteLength {
 				return Nil
 			}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2554,27 +2554,37 @@ var fromBigEndianBytesFunctionValues = func() map[string]fromBigEndianBytesFunct
 			}))
 		}),
 		newFromBigEndianBytesFunction(sema.Int16Type, 2, func(i *Interpreter, b []byte) OptionalValue {
-			bytes := padWithZeroes(b, 2)
-			val := binary.BigEndian.Uint16(bytes)
-			return NewSomeValueNonCopying(i, NewInt16Value(i, func() int16 { return int16(val) }))
+			return NewSomeValueNonCopying(i, NewInt16Value(i, func() int16 {
+				bytes := padWithZeroes(b, 2)
+				val := binary.BigEndian.Uint16(bytes)
+				return int16(val)
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.Int32Type, 4, func(i *Interpreter, b []byte) OptionalValue {
-			bytes := padWithZeroes(b, 4)
-			val := binary.BigEndian.Uint32(bytes)
-			return NewSomeValueNonCopying(i, NewInt32Value(i, func() int32 { return int32(val) }))
+			return NewSomeValueNonCopying(i, NewInt32Value(i, func() int32 {
+				bytes := padWithZeroes(b, 4)
+				val := binary.BigEndian.Uint32(bytes)
+				return int32(val)
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.Int64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			bytes := padWithZeroes(b, 8)
-			val := binary.BigEndian.Uint64(bytes)
-			return NewSomeValueNonCopying(i, NewInt64Value(i, func() int64 { return int64(val) }))
+			return NewSomeValueNonCopying(i, NewInt64Value(i, func() int64 {
+				bytes := padWithZeroes(b, 8)
+				val := binary.BigEndian.Uint64(bytes)
+				return int64(val)
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.Int128Type, 16, func(i *Interpreter, b []byte) OptionalValue {
-			bi := BigEndianBytesToSignedBigInt(b)
-			return NewSomeValueNonCopying(i, NewInt128ValueFromBigInt(i, func() *big.Int { return bi }))
+			return NewSomeValueNonCopying(i, NewInt128ValueFromBigInt(i, func() *big.Int {
+				bi := BigEndianBytesToSignedBigInt(b)
+				return bi
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.Int256Type, 32, func(i *Interpreter, b []byte) OptionalValue {
-			bi := BigEndianBytesToSignedBigInt(b)
-			return NewSomeValueNonCopying(i, NewInt256ValueFromBigInt(i, func() *big.Int { return bi }))
+			return NewSomeValueNonCopying(i, NewInt256ValueFromBigInt(i, func() *big.Int {
+				bi := BigEndianBytesToSignedBigInt(b)
+				return bi
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.IntType, 0, func(i *Interpreter, b []byte) OptionalValue {
 			bi := BigEndianBytesToSignedBigInt(b)
@@ -2589,27 +2599,35 @@ var fromBigEndianBytesFunctionValues = func() map[string]fromBigEndianBytesFunct
 			return NewSomeValueNonCopying(i, NewUInt8Value(i, func() uint8 { return b[0] }))
 		}),
 		newFromBigEndianBytesFunction(sema.UInt16Type, 2, func(i *Interpreter, b []byte) OptionalValue {
-			bytes := padWithZeroes(b, 2)
-			val := binary.BigEndian.Uint16(bytes)
-			return NewSomeValueNonCopying(i, NewUInt16Value(i, func() uint16 { return val }))
+			return NewSomeValueNonCopying(i, NewUInt16Value(i, func() uint16 {
+				bytes := padWithZeroes(b, 2)
+				val := binary.BigEndian.Uint16(bytes)
+				return val
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.UInt32Type, 4, func(i *Interpreter, b []byte) OptionalValue {
-			bytes := padWithZeroes(b, 4)
-			val := binary.BigEndian.Uint32(bytes)
-			return NewSomeValueNonCopying(i, NewUInt32Value(i, func() uint32 { return val }))
+			return NewSomeValueNonCopying(i, NewUInt32Value(i, func() uint32 {
+				bytes := padWithZeroes(b, 4)
+				val := binary.BigEndian.Uint32(bytes)
+				return val
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.UInt64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			bytes := padWithZeroes(b, 8)
-			val := binary.BigEndian.Uint64(bytes)
-			return NewSomeValueNonCopying(i, NewUInt64Value(i, func() uint64 { return val }))
+			return NewSomeValueNonCopying(i, NewUInt64Value(i, func() uint64 {
+				bytes := padWithZeroes(b, 8)
+				val := binary.BigEndian.Uint64(bytes)
+				return val
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.UInt128Type, 16, func(i *Interpreter, b []byte) OptionalValue {
-			bi := BigEndianBytesToUnsignedBigInt(b)
-			return NewSomeValueNonCopying(i, NewUInt128ValueFromBigInt(i, func() *big.Int { return bi }))
+			return NewSomeValueNonCopying(i, NewUInt128ValueFromBigInt(i, func() *big.Int {
+				return BigEndianBytesToUnsignedBigInt(b)
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.UInt256Type, 32, func(i *Interpreter, b []byte) OptionalValue {
-			bi := BigEndianBytesToUnsignedBigInt(b)
-			return NewSomeValueNonCopying(i, NewUInt256ValueFromBigInt(i, func() *big.Int { return bi }))
+			return NewSomeValueNonCopying(i, NewUInt256ValueFromBigInt(i, func() *big.Int {
+				return BigEndianBytesToUnsignedBigInt(b)
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.UIntType, 0, func(i *Interpreter, b []byte) OptionalValue {
 			bi := BigEndianBytesToUnsignedBigInt(b)
@@ -2624,31 +2642,41 @@ var fromBigEndianBytesFunctionValues = func() map[string]fromBigEndianBytesFunct
 			return NewSomeValueNonCopying(i, NewWord8Value(i, func() uint8 { return b[0] }))
 		}),
 		newFromBigEndianBytesFunction(sema.Word16Type, 2, func(i *Interpreter, b []byte) OptionalValue {
-			bytes := padWithZeroes(b, 2)
-			val := binary.BigEndian.Uint16(bytes)
-			return NewSomeValueNonCopying(i, NewWord16Value(i, func() uint16 { return val }))
+			return NewSomeValueNonCopying(i, NewWord16Value(i, func() uint16 {
+				bytes := padWithZeroes(b, 2)
+				val := binary.BigEndian.Uint16(bytes)
+				return val
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.Word32Type, 4, func(i *Interpreter, b []byte) OptionalValue {
-			bytes := padWithZeroes(b, 4)
-			val := binary.BigEndian.Uint32(bytes)
-			return NewSomeValueNonCopying(i, NewWord32Value(i, func() uint32 { return val }))
+			return NewSomeValueNonCopying(i, NewWord32Value(i, func() uint32 {
+				bytes := padWithZeroes(b, 4)
+				val := binary.BigEndian.Uint32(bytes)
+				return val
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.Word64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			bytes := padWithZeroes(b, 8)
-			val := binary.BigEndian.Uint64(bytes)
-			return NewSomeValueNonCopying(i, NewWord64Value(i, func() uint64 { return val }))
+			return NewSomeValueNonCopying(i, NewWord64Value(i, func() uint64 {
+				bytes := padWithZeroes(b, 8)
+				val := binary.BigEndian.Uint64(bytes)
+				return val
+			}))
 		}),
 
 		// fixed-points
 		newFromBigEndianBytesFunction(sema.Fix64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			bytes := padWithZeroes(b, 8)
-			val := binary.BigEndian.Uint64(bytes)
-			return NewSomeValueNonCopying(i, NewFix64Value(i, func() int64 { return int64(val) }))
+			return NewSomeValueNonCopying(i, NewFix64Value(i, func() int64 {
+				bytes := padWithZeroes(b, 8)
+				val := binary.BigEndian.Uint64(bytes)
+				return int64(val)
+			}))
 		}),
 		newFromBigEndianBytesFunction(sema.UFix64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			bytes := padWithZeroes(b, 8)
-			val := binary.BigEndian.Uint64(bytes)
-			return NewSomeValueNonCopying(i, NewUFix64Value(i, func() uint64 { return val }))
+			return NewSomeValueNonCopying(i, NewUFix64Value(i, func() uint64 {
+				bytes := padWithZeroes(b, 8)
+				val := binary.BigEndian.Uint64(bytes)
+				return val
+			}))
 		}),
 	}
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2494,10 +2494,26 @@ type fromBigEndianBytesFunctionValue struct {
 	hostFunction *HostFunctionValue
 }
 
+func padWithZeroes(b []byte, expectedLen int) []byte {
+	l := len(b)
+	if l > expectedLen {
+		panic(errors.NewUnreachableError())
+	} else if l == expectedLen {
+		return b
+	}
+
+	res := make([]byte, expectedLen)
+	copy(res[expectedLen-l:], b)
+	return res
+}
+
 // a function that attempts to create a Number from a big-endian bytes.
 type bigEndianBytesConverter func(*Interpreter, []byte) OptionalValue
 
-func newFromBigEndianBytesFunction(ty sema.Type, converter bigEndianBytesConverter) fromBigEndianBytesFunctionValue {
+func newFromBigEndianBytesFunction(
+	ty sema.Type,
+	byteLength int,
+	converter bigEndianBytesConverter) fromBigEndianBytesFunctionValue {
 	functionType := sema.FromBigEndianBytesFunctionType(ty)
 
 	hostFunctionImpl := NewUnmeteredHostFunctionValue(
@@ -2514,6 +2530,10 @@ func newFromBigEndianBytesFunction(ty sema.Type, converter bigEndianBytesConvert
 				return Nil
 			}
 
+			if byteLength != 0 && len(bytes) > byteLength {
+				return Nil
+			}
+
 			return converter(inter, bytes)
 		},
 	)
@@ -2523,34 +2543,37 @@ func newFromBigEndianBytesFunction(ty sema.Type, converter bigEndianBytesConvert
 	}
 }
 
-// TODO: Validate ranges for each type.
 var fromBigEndianBytesFunctionValues = func() map[string]fromBigEndianBytesFunctionValue {
 	declarations := []fromBigEndianBytesFunctionValue{
 		// signed int values
-		newFromBigEndianBytesFunction(sema.Int8Type, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewInt8Value(i, func() int8 { return int8(b[0]) }))
+		newFromBigEndianBytesFunction(sema.Int8Type, 1, func(i *Interpreter, b []byte) OptionalValue {
+			bytes := padWithZeroes(b, 1)
+			return NewSomeValueNonCopying(i, NewInt8Value(i, func() int8 { return int8(bytes[0]) }))
 		}),
-		newFromBigEndianBytesFunction(sema.Int16Type, func(i *Interpreter, b []byte) OptionalValue {
-			val := binary.BigEndian.Uint16(b)
+		newFromBigEndianBytesFunction(sema.Int16Type, 2, func(i *Interpreter, b []byte) OptionalValue {
+			bytes := padWithZeroes(b, 2)
+			val := binary.BigEndian.Uint16(bytes)
 			return NewSomeValueNonCopying(i, NewInt16Value(i, func() int16 { return int16(val) }))
 		}),
-		newFromBigEndianBytesFunction(sema.Int32Type, func(i *Interpreter, b []byte) OptionalValue {
-			val := binary.BigEndian.Uint32(b)
+		newFromBigEndianBytesFunction(sema.Int32Type, 4, func(i *Interpreter, b []byte) OptionalValue {
+			bytes := padWithZeroes(b, 4)
+			val := binary.BigEndian.Uint32(bytes)
 			return NewSomeValueNonCopying(i, NewInt32Value(i, func() int32 { return int32(val) }))
 		}),
-		newFromBigEndianBytesFunction(sema.Int64Type, func(i *Interpreter, b []byte) OptionalValue {
-			val := binary.BigEndian.Uint64(b)
+		newFromBigEndianBytesFunction(sema.Int64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
+			bytes := padWithZeroes(b, 8)
+			val := binary.BigEndian.Uint64(bytes)
 			return NewSomeValueNonCopying(i, NewInt64Value(i, func() int64 { return int64(val) }))
 		}),
-		newFromBigEndianBytesFunction(sema.Int128Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.Int128Type, 16, func(i *Interpreter, b []byte) OptionalValue {
 			bi := BigEndianBytesToSignedBigInt(b)
 			return NewSomeValueNonCopying(i, NewInt128ValueFromBigInt(i, func() *big.Int { return bi }))
 		}),
-		newFromBigEndianBytesFunction(sema.Int256Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.Int256Type, 32, func(i *Interpreter, b []byte) OptionalValue {
 			bi := BigEndianBytesToSignedBigInt(b)
 			return NewSomeValueNonCopying(i, NewInt256ValueFromBigInt(i, func() *big.Int { return bi }))
 		}),
-		newFromBigEndianBytesFunction(sema.IntType, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.IntType, 0, func(i *Interpreter, b []byte) OptionalValue {
 			bi := BigEndianBytesToSignedBigInt(b)
 			memoryUsage := common.NewBigIntMemoryUsage(
 				common.BigIntByteLength(bi),
@@ -2559,30 +2582,30 @@ var fromBigEndianBytesFunctionValues = func() map[string]fromBigEndianBytesFunct
 		}),
 
 		// unsigned int values
-		newFromBigEndianBytesFunction(sema.UInt8Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.UInt8Type, 1, func(i *Interpreter, b []byte) OptionalValue {
 			return NewSomeValueNonCopying(i, NewUInt8Value(i, func() uint8 { return uint8(b[0]) }))
 		}),
-		newFromBigEndianBytesFunction(sema.UInt16Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.UInt16Type, 2, func(i *Interpreter, b []byte) OptionalValue {
 			val := binary.BigEndian.Uint16(b)
 			return NewSomeValueNonCopying(i, NewUInt16Value(i, func() uint16 { return val }))
 		}),
-		newFromBigEndianBytesFunction(sema.UInt32Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.UInt32Type, 4, func(i *Interpreter, b []byte) OptionalValue {
 			val := binary.BigEndian.Uint32(b)
 			return NewSomeValueNonCopying(i, NewUInt32Value(i, func() uint32 { return val }))
 		}),
-		newFromBigEndianBytesFunction(sema.UInt64Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.UInt64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
 			val := binary.BigEndian.Uint64(b)
 			return NewSomeValueNonCopying(i, NewUInt64Value(i, func() uint64 { return val }))
 		}),
-		newFromBigEndianBytesFunction(sema.UInt128Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.UInt128Type, 16, func(i *Interpreter, b []byte) OptionalValue {
 			bi := BigEndianBytesToUnsignedBigInt(b)
 			return NewSomeValueNonCopying(i, NewUInt128ValueFromBigInt(i, func() *big.Int { return bi }))
 		}),
-		newFromBigEndianBytesFunction(sema.UInt256Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.UInt256Type, 32, func(i *Interpreter, b []byte) OptionalValue {
 			bi := BigEndianBytesToUnsignedBigInt(b)
 			return NewSomeValueNonCopying(i, NewUInt256ValueFromBigInt(i, func() *big.Int { return bi }))
 		}),
-		newFromBigEndianBytesFunction(sema.UIntType, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.UIntType, 0, func(i *Interpreter, b []byte) OptionalValue {
 			bi := BigEndianBytesToUnsignedBigInt(b)
 			memoryUsage := common.NewBigIntMemoryUsage(
 				common.BigIntByteLength(bi),
@@ -2591,28 +2614,28 @@ var fromBigEndianBytesFunctionValues = func() map[string]fromBigEndianBytesFunct
 		}),
 
 		// machine-sized word types
-		newFromBigEndianBytesFunction(sema.Word8Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.Word8Type, 1, func(i *Interpreter, b []byte) OptionalValue {
 			return NewSomeValueNonCopying(i, NewWord8Value(i, func() uint8 { return uint8(b[0]) }))
 		}),
-		newFromBigEndianBytesFunction(sema.Word16Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.Word16Type, 2, func(i *Interpreter, b []byte) OptionalValue {
 			val := binary.BigEndian.Uint16(b)
 			return NewSomeValueNonCopying(i, NewWord16Value(i, func() uint16 { return val }))
 		}),
-		newFromBigEndianBytesFunction(sema.Word32Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.Word32Type, 4, func(i *Interpreter, b []byte) OptionalValue {
 			val := binary.BigEndian.Uint32(b)
 			return NewSomeValueNonCopying(i, NewWord32Value(i, func() uint32 { return val }))
 		}),
-		newFromBigEndianBytesFunction(sema.Word64Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.Word64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
 			val := binary.BigEndian.Uint64(b)
 			return NewSomeValueNonCopying(i, NewWord64Value(i, func() uint64 { return val }))
 		}),
 
 		// fixed-points
-		newFromBigEndianBytesFunction(sema.Fix64Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.Fix64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
 			val := binary.BigEndian.Uint64(b)
 			return NewSomeValueNonCopying(i, NewFix64Value(i, func() int64 { return int64(val) }))
 		}),
-		newFromBigEndianBytesFunction(sema.UFix64Type, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.UFix64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
 			val := binary.BigEndian.Uint64(b)
 			return NewSomeValueNonCopying(i, NewUFix64Value(i, func() uint64 { return val }))
 		}),

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2508,7 +2508,7 @@ func padWithZeroes(b []byte, expectedLen int) []byte {
 }
 
 // a function that attempts to create a Number from a big-endian bytes.
-type bigEndianBytesConverter func(*Interpreter, []byte) OptionalValue
+type bigEndianBytesConverter func(*Interpreter, []byte) Value
 
 func newFromBigEndianBytesFunction(
 	ty sema.Type,
@@ -2535,7 +2535,7 @@ func newFromBigEndianBytesFunction(
 				return Nil
 			}
 
-			return converter(inter, bytes)
+			return NewSomeValueNonCopying(inter, converter(inter, bytes))
 		},
 	)
 	return fromBigEndianBytesFunctionValue{
@@ -2547,136 +2547,136 @@ func newFromBigEndianBytesFunction(
 var fromBigEndianBytesFunctionValues = func() map[string]fromBigEndianBytesFunctionValue {
 	declarations := []fromBigEndianBytesFunctionValue{
 		// signed int values
-		newFromBigEndianBytesFunction(sema.Int8Type, 1, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewInt8Value(i, func() int8 {
+		newFromBigEndianBytesFunction(sema.Int8Type, 1, func(i *Interpreter, b []byte) Value {
+			return NewInt8Value(i, func() int8 {
 				bytes := padWithZeroes(b, 1)
 				return int8(bytes[0])
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.Int16Type, 2, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewInt16Value(i, func() int16 {
+		newFromBigEndianBytesFunction(sema.Int16Type, 2, func(i *Interpreter, b []byte) Value {
+			return NewInt16Value(i, func() int16 {
 				bytes := padWithZeroes(b, 2)
 				val := binary.BigEndian.Uint16(bytes)
 				return int16(val)
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.Int32Type, 4, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewInt32Value(i, func() int32 {
+		newFromBigEndianBytesFunction(sema.Int32Type, 4, func(i *Interpreter, b []byte) Value {
+			return NewInt32Value(i, func() int32 {
 				bytes := padWithZeroes(b, 4)
 				val := binary.BigEndian.Uint32(bytes)
 				return int32(val)
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.Int64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewInt64Value(i, func() int64 {
+		newFromBigEndianBytesFunction(sema.Int64Type, 8, func(i *Interpreter, b []byte) Value {
+			return NewInt64Value(i, func() int64 {
 				bytes := padWithZeroes(b, 8)
 				val := binary.BigEndian.Uint64(bytes)
 				return int64(val)
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.Int128Type, 16, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewInt128ValueFromBigInt(i, func() *big.Int {
+		newFromBigEndianBytesFunction(sema.Int128Type, 16, func(i *Interpreter, b []byte) Value {
+			return NewInt128ValueFromBigInt(i, func() *big.Int {
 				bi := BigEndianBytesToSignedBigInt(b)
 				return bi
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.Int256Type, 32, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewInt256ValueFromBigInt(i, func() *big.Int {
+		newFromBigEndianBytesFunction(sema.Int256Type, 32, func(i *Interpreter, b []byte) Value {
+			return NewInt256ValueFromBigInt(i, func() *big.Int {
 				bi := BigEndianBytesToSignedBigInt(b)
 				return bi
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.IntType, 0, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.IntType, 0, func(i *Interpreter, b []byte) Value {
 			bi := BigEndianBytesToSignedBigInt(b)
 			memoryUsage := common.NewBigIntMemoryUsage(
 				common.BigIntByteLength(bi),
 			)
-			return NewSomeValueNonCopying(i, NewIntValueFromBigInt(i, memoryUsage, func() *big.Int { return bi }))
+			return NewIntValueFromBigInt(i, memoryUsage, func() *big.Int { return bi })
 		}),
 
 		// unsigned int values
-		newFromBigEndianBytesFunction(sema.UInt8Type, 1, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewUInt8Value(i, func() uint8 { return b[0] }))
+		newFromBigEndianBytesFunction(sema.UInt8Type, 1, func(i *Interpreter, b []byte) Value {
+			return NewUInt8Value(i, func() uint8 { return b[0] })
 		}),
-		newFromBigEndianBytesFunction(sema.UInt16Type, 2, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewUInt16Value(i, func() uint16 {
+		newFromBigEndianBytesFunction(sema.UInt16Type, 2, func(i *Interpreter, b []byte) Value {
+			return NewUInt16Value(i, func() uint16 {
 				bytes := padWithZeroes(b, 2)
 				val := binary.BigEndian.Uint16(bytes)
 				return val
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.UInt32Type, 4, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewUInt32Value(i, func() uint32 {
+		newFromBigEndianBytesFunction(sema.UInt32Type, 4, func(i *Interpreter, b []byte) Value {
+			return NewUInt32Value(i, func() uint32 {
 				bytes := padWithZeroes(b, 4)
 				val := binary.BigEndian.Uint32(bytes)
 				return val
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.UInt64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewUInt64Value(i, func() uint64 {
+		newFromBigEndianBytesFunction(sema.UInt64Type, 8, func(i *Interpreter, b []byte) Value {
+			return NewUInt64Value(i, func() uint64 {
 				bytes := padWithZeroes(b, 8)
 				val := binary.BigEndian.Uint64(bytes)
 				return val
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.UInt128Type, 16, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewUInt128ValueFromBigInt(i, func() *big.Int {
+		newFromBigEndianBytesFunction(sema.UInt128Type, 16, func(i *Interpreter, b []byte) Value {
+			return NewUInt128ValueFromBigInt(i, func() *big.Int {
 				return BigEndianBytesToUnsignedBigInt(b)
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.UInt256Type, 32, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewUInt256ValueFromBigInt(i, func() *big.Int {
+		newFromBigEndianBytesFunction(sema.UInt256Type, 32, func(i *Interpreter, b []byte) Value {
+			return NewUInt256ValueFromBigInt(i, func() *big.Int {
 				return BigEndianBytesToUnsignedBigInt(b)
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.UIntType, 0, func(i *Interpreter, b []byte) OptionalValue {
+		newFromBigEndianBytesFunction(sema.UIntType, 0, func(i *Interpreter, b []byte) Value {
 			bi := BigEndianBytesToUnsignedBigInt(b)
 			memoryUsage := common.NewBigIntMemoryUsage(
 				common.BigIntByteLength(bi),
 			)
-			return NewSomeValueNonCopying(i, NewUIntValueFromBigInt(i, memoryUsage, func() *big.Int { return bi }))
+			return NewUIntValueFromBigInt(i, memoryUsage, func() *big.Int { return bi })
 		}),
 
 		// machine-sized word types
-		newFromBigEndianBytesFunction(sema.Word8Type, 1, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewWord8Value(i, func() uint8 { return b[0] }))
+		newFromBigEndianBytesFunction(sema.Word8Type, 1, func(i *Interpreter, b []byte) Value {
+			return NewWord8Value(i, func() uint8 { return b[0] })
 		}),
-		newFromBigEndianBytesFunction(sema.Word16Type, 2, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewWord16Value(i, func() uint16 {
+		newFromBigEndianBytesFunction(sema.Word16Type, 2, func(i *Interpreter, b []byte) Value {
+			return NewWord16Value(i, func() uint16 {
 				bytes := padWithZeroes(b, 2)
 				val := binary.BigEndian.Uint16(bytes)
 				return val
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.Word32Type, 4, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewWord32Value(i, func() uint32 {
+		newFromBigEndianBytesFunction(sema.Word32Type, 4, func(i *Interpreter, b []byte) Value {
+			return NewWord32Value(i, func() uint32 {
 				bytes := padWithZeroes(b, 4)
 				val := binary.BigEndian.Uint32(bytes)
 				return val
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.Word64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewWord64Value(i, func() uint64 {
+		newFromBigEndianBytesFunction(sema.Word64Type, 8, func(i *Interpreter, b []byte) Value {
+			return NewWord64Value(i, func() uint64 {
 				bytes := padWithZeroes(b, 8)
 				val := binary.BigEndian.Uint64(bytes)
 				return val
-			}))
+			})
 		}),
 
 		// fixed-points
-		newFromBigEndianBytesFunction(sema.Fix64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewFix64Value(i, func() int64 {
+		newFromBigEndianBytesFunction(sema.Fix64Type, 8, func(i *Interpreter, b []byte) Value {
+			return NewFix64Value(i, func() int64 {
 				bytes := padWithZeroes(b, 8)
 				val := binary.BigEndian.Uint64(bytes)
 				return int64(val)
-			}))
+			})
 		}),
-		newFromBigEndianBytesFunction(sema.UFix64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewUFix64Value(i, func() uint64 {
+		newFromBigEndianBytesFunction(sema.UFix64Type, 8, func(i *Interpreter, b []byte) Value {
+			return NewUFix64Value(i, func() uint64 {
 				bytes := padWithZeroes(b, 8)
 				val := binary.BigEndian.Uint64(bytes)
 				return val
-			}))
+			})
 		}),
 	}
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2583,18 +2583,21 @@ var fromBigEndianBytesFunctionValues = func() map[string]fromBigEndianBytesFunct
 
 		// unsigned int values
 		newFromBigEndianBytesFunction(sema.UInt8Type, 1, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewUInt8Value(i, func() uint8 { return uint8(b[0]) }))
+			return NewSomeValueNonCopying(i, NewUInt8Value(i, func() uint8 { return b[0] }))
 		}),
 		newFromBigEndianBytesFunction(sema.UInt16Type, 2, func(i *Interpreter, b []byte) OptionalValue {
-			val := binary.BigEndian.Uint16(b)
+			bytes := padWithZeroes(b, 2)
+			val := binary.BigEndian.Uint16(bytes)
 			return NewSomeValueNonCopying(i, NewUInt16Value(i, func() uint16 { return val }))
 		}),
 		newFromBigEndianBytesFunction(sema.UInt32Type, 4, func(i *Interpreter, b []byte) OptionalValue {
-			val := binary.BigEndian.Uint32(b)
+			bytes := padWithZeroes(b, 4)
+			val := binary.BigEndian.Uint32(bytes)
 			return NewSomeValueNonCopying(i, NewUInt32Value(i, func() uint32 { return val }))
 		}),
 		newFromBigEndianBytesFunction(sema.UInt64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			val := binary.BigEndian.Uint64(b)
+			bytes := padWithZeroes(b, 8)
+			val := binary.BigEndian.Uint64(bytes)
 			return NewSomeValueNonCopying(i, NewUInt64Value(i, func() uint64 { return val }))
 		}),
 		newFromBigEndianBytesFunction(sema.UInt128Type, 16, func(i *Interpreter, b []byte) OptionalValue {
@@ -2615,28 +2618,33 @@ var fromBigEndianBytesFunctionValues = func() map[string]fromBigEndianBytesFunct
 
 		// machine-sized word types
 		newFromBigEndianBytesFunction(sema.Word8Type, 1, func(i *Interpreter, b []byte) OptionalValue {
-			return NewSomeValueNonCopying(i, NewWord8Value(i, func() uint8 { return uint8(b[0]) }))
+			return NewSomeValueNonCopying(i, NewWord8Value(i, func() uint8 { return b[0] }))
 		}),
 		newFromBigEndianBytesFunction(sema.Word16Type, 2, func(i *Interpreter, b []byte) OptionalValue {
-			val := binary.BigEndian.Uint16(b)
+			bytes := padWithZeroes(b, 2)
+			val := binary.BigEndian.Uint16(bytes)
 			return NewSomeValueNonCopying(i, NewWord16Value(i, func() uint16 { return val }))
 		}),
 		newFromBigEndianBytesFunction(sema.Word32Type, 4, func(i *Interpreter, b []byte) OptionalValue {
-			val := binary.BigEndian.Uint32(b)
+			bytes := padWithZeroes(b, 4)
+			val := binary.BigEndian.Uint32(bytes)
 			return NewSomeValueNonCopying(i, NewWord32Value(i, func() uint32 { return val }))
 		}),
 		newFromBigEndianBytesFunction(sema.Word64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			val := binary.BigEndian.Uint64(b)
+			bytes := padWithZeroes(b, 8)
+			val := binary.BigEndian.Uint64(bytes)
 			return NewSomeValueNonCopying(i, NewWord64Value(i, func() uint64 { return val }))
 		}),
 
 		// fixed-points
 		newFromBigEndianBytesFunction(sema.Fix64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			val := binary.BigEndian.Uint64(b)
+			bytes := padWithZeroes(b, 8)
+			val := binary.BigEndian.Uint64(bytes)
 			return NewSomeValueNonCopying(i, NewFix64Value(i, func() int64 { return int64(val) }))
 		}),
 		newFromBigEndianBytesFunction(sema.UFix64Type, 8, func(i *Interpreter, b []byte) OptionalValue {
-			val := binary.BigEndian.Uint64(b)
+			bytes := padWithZeroes(b, 8)
+			val := binary.BigEndian.Uint64(bytes)
 			return NewSomeValueNonCopying(i, NewUFix64Value(i, func() uint64 { return val }))
 		}),
 	}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -423,26 +423,10 @@ func FromStringFunctionType(ty Type) *FunctionType {
 const FromBigEndianBytesFunctionName = "fromBigEndianBytes"
 
 func FromBigEndianBytesFunctionDocstring(ty Type) string {
-
-	builder := new(strings.Builder)
-	builder.WriteString(
-		fmt.Sprintf(
-			"Attempts to parse %s from a big-endian byte representation. Returns `nil` on overflow or invalid input.\n",
-			ty.String(),
-		))
-
-	if IsSameTypeKind(ty, FixedPointType) {
-		builder.WriteString(
-			`TODO\n`,
-		)
-	}
-	if IsSameTypeKind(ty, SignedIntegerType) || IsSameTypeKind(ty, SignedFixedPointType) {
-		builder.WriteString(
-			"TODO.\n",
-		)
-	}
-
-	return builder.String()
+	return fmt.Sprintf(
+		"Attempts to parse %s from a big-endian byte representation. Returns `nil` on invalid input.",
+		ty.String(),
+	)
 }
 
 func FromBigEndianBytesFunctionType(ty Type) *FunctionType {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -418,6 +418,50 @@ func FromStringFunctionType(ty Type) *FunctionType {
 	}
 }
 
+// fromBigEndianBytes
+
+const FromBigEndianBytesFunctionName = "fromBigEndianBytes"
+
+func FromBigEndianBytesFunctionDocstring(ty Type) string {
+
+	builder := new(strings.Builder)
+	builder.WriteString(
+		fmt.Sprintf(
+			"Attempts to parse %s from a big-endian byte representation. Returns `nil` on overflow or invalid input.\n",
+			ty.String(),
+		))
+
+	if IsSameTypeKind(ty, FixedPointType) {
+		builder.WriteString(
+			`TODO\n`,
+		)
+	}
+	if IsSameTypeKind(ty, SignedIntegerType) || IsSameTypeKind(ty, SignedFixedPointType) {
+		builder.WriteString(
+			"TODO.\n",
+		)
+	}
+
+	return builder.String()
+}
+
+func FromBigEndianBytesFunctionType(ty Type) *FunctionType {
+	return &FunctionType{
+		Parameters: []Parameter{
+			{
+				Label:          ArgumentLabelNotRequired,
+				Identifier:     "bytes",
+				TypeAnnotation: NewTypeAnnotation(ByteArrayType),
+			},
+		},
+		ReturnTypeAnnotation: NewTypeAnnotation(
+			&OptionalType{
+				Type: ty,
+			},
+		),
+	}
+}
+
 // toBigEndianBytes
 
 const ToBigEndianBytesFunctionName = "toBigEndianBytes"
@@ -3292,6 +3336,16 @@ func init() {
 				FromStringFunctionName,
 				fromStringFnType,
 				fromStringDocstring,
+			))
+
+			// add .fromBigEndianBytes() method
+			fromBigEndianBytesFnType := FromBigEndianBytesFunctionType(numberType)
+			fromBigEndianBytesDocstring := FromBigEndianBytesFunctionDocstring(numberType)
+			addMember(NewUnmeteredPublicFunctionMember(
+				functionType,
+				FromBigEndianBytesFunctionName,
+				fromBigEndianBytesFnType,
+				fromBigEndianBytesDocstring,
 			))
 
 			BaseValueActivation.Set(

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -559,6 +559,7 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 		},
 		"Int16": {
 			"[0, 0]":     interpreter.NewUnmeteredInt16Value(0),
+			"[42]":       interpreter.NewUnmeteredInt16Value(42),
 			"[0, 42]":    interpreter.NewUnmeteredInt16Value(42),
 			"[127, 255]": interpreter.NewUnmeteredInt16Value(32767),
 			"[255, 255]": interpreter.NewUnmeteredInt16Value(-1),
@@ -567,6 +568,7 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 		},
 		"Int32": {
 			"[0, 0, 0, 0]":         interpreter.NewUnmeteredInt32Value(0),
+			"[42]":                 interpreter.NewUnmeteredInt32Value(42),
 			"[0, 0, 0, 42]":        interpreter.NewUnmeteredInt32Value(42),
 			"[127, 255, 255, 255]": interpreter.NewUnmeteredInt32Value(2147483647),
 			"[255, 255, 255, 255]": interpreter.NewUnmeteredInt32Value(-1),
@@ -574,8 +576,9 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 			"[128, 0, 0, 0]":       interpreter.NewUnmeteredInt32Value(-2147483648),
 		},
 		"Int64": {
-			"[0, 0, 0, 0, 0, 0, 0, 0]":                 interpreter.NewUnmeteredInt64Value(0),
-			"[0, 0, 0, 0, 0, 0, 0, 42]":                interpreter.NewUnmeteredInt64Value(42),
+			"[0, 0, 0, 0, 0, 0, 0, 0]":  interpreter.NewUnmeteredInt64Value(0),
+			"[42]":                      interpreter.NewUnmeteredInt64Value(42),
+			"[0, 0, 0, 0, 0, 0, 0, 42]": interpreter.NewUnmeteredInt64Value(42),
 			"[127, 255, 255, 255, 255, 255, 255, 255]": interpreter.NewUnmeteredInt64Value(9223372036854775807),
 			"[255, 255, 255, 255, 255, 255, 255, 255]": interpreter.NewUnmeteredInt64Value(-1),
 			"[128, 0, 0, 0, 0, 0, 0, 1]":               interpreter.NewUnmeteredInt64Value(-9223372036854775807),
@@ -618,6 +621,7 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 		},
 		"UInt16": {
 			"[0, 0]":     interpreter.NewUnmeteredUInt16Value(0),
+			"[42]":       interpreter.NewUnmeteredUInt16Value(42),
 			"[0, 42]":    interpreter.NewUnmeteredUInt16Value(42),
 			"[127, 255]": interpreter.NewUnmeteredUInt16Value(32767),
 			"[128, 0]":   interpreter.NewUnmeteredUInt16Value(32768),
@@ -625,14 +629,16 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 		},
 		"UInt32": {
 			"[0, 0, 0, 0]":         interpreter.NewUnmeteredUInt32Value(0),
+			"[42]":                 interpreter.NewUnmeteredUInt32Value(42),
 			"[0, 0, 0, 42]":        interpreter.NewUnmeteredUInt32Value(42),
 			"[127, 255, 255, 255]": interpreter.NewUnmeteredUInt32Value(2147483647),
 			"[128, 0, 0, 0]":       interpreter.NewUnmeteredUInt32Value(2147483648),
 			"[255, 255, 255, 255]": interpreter.NewUnmeteredUInt32Value(4294967295),
 		},
 		"UInt64": {
-			"[0, 0, 0, 0, 0, 0, 0, 0]":                 interpreter.NewUnmeteredUInt64Value(0),
-			"[0, 0, 0, 0, 0, 0, 0, 42]":                interpreter.NewUnmeteredUInt64Value(42),
+			"[0, 0, 0, 0, 0, 0, 0, 0]":  interpreter.NewUnmeteredUInt64Value(0),
+			"[42]":                      interpreter.NewUnmeteredUInt64Value(42),
+			"[0, 0, 0, 0, 0, 0, 0, 42]": interpreter.NewUnmeteredUInt64Value(42),
 			"[127, 255, 255, 255, 255, 255, 255, 255]": interpreter.NewUnmeteredUInt64Value(9223372036854775807),
 			"[128, 0, 0, 0, 0, 0, 0, 0]":               interpreter.NewUnmeteredUInt64Value(9223372036854775808),
 			"[255, 255, 255, 255, 255, 255, 255, 255]": interpreter.NewUnmeteredUInt64Value(18446744073709551615),
@@ -661,6 +667,7 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 		},
 		"Word16": {
 			"[0, 0]":     interpreter.NewUnmeteredWord16Value(0),
+			"[42]":       interpreter.NewUnmeteredWord16Value(42),
 			"[0, 42]":    interpreter.NewUnmeteredWord16Value(42),
 			"[127, 255]": interpreter.NewUnmeteredWord16Value(32767),
 			"[128, 0]":   interpreter.NewUnmeteredWord16Value(32768),
@@ -668,14 +675,16 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 		},
 		"Word32": {
 			"[0, 0, 0, 0]":         interpreter.NewUnmeteredWord32Value(0),
+			"[42]":                 interpreter.NewUnmeteredWord32Value(42),
 			"[0, 0, 0, 42]":        interpreter.NewUnmeteredWord32Value(42),
 			"[127, 255, 255, 255]": interpreter.NewUnmeteredWord32Value(2147483647),
 			"[128, 0, 0, 0]":       interpreter.NewUnmeteredWord32Value(2147483648),
 			"[255, 255, 255, 255]": interpreter.NewUnmeteredWord32Value(4294967295),
 		},
 		"Word64": {
-			"[0, 0, 0, 0, 0, 0, 0, 0]":                 interpreter.NewUnmeteredWord64Value(0),
-			"[0, 0, 0, 0, 0, 0, 0, 42]":                interpreter.NewUnmeteredWord64Value(42),
+			"[0, 0, 0, 0, 0, 0, 0, 0]":  interpreter.NewUnmeteredWord64Value(0),
+			"[42]":                      interpreter.NewUnmeteredWord64Value(42),
+			"[0, 0, 0, 0, 0, 0, 0, 42]": interpreter.NewUnmeteredWord64Value(42),
 			"[127, 255, 255, 255, 255, 255, 255, 255]": interpreter.NewUnmeteredWord64Value(9223372036854775807),
 			"[128, 0, 0, 0, 0, 0, 0, 0]":               interpreter.NewUnmeteredWord64Value(9223372036854775808),
 			"[255, 255, 255, 255, 255, 255, 255, 255]": interpreter.NewUnmeteredWord64Value(18446744073709551615),
@@ -683,6 +692,7 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 		// Fix*
 		"Fix64": {
 			"[0, 0, 0, 0, 0, 0, 0, 0]":             interpreter.NewUnmeteredFix64Value(0),
+			"[250, 86, 234, 0]":                    interpreter.NewUnmeteredFix64Value(42 * sema.Fix64Factor), // 42.0 with padding
 			"[0, 0, 0, 0, 250, 86, 234, 0]":        interpreter.NewUnmeteredFix64Value(42 * sema.Fix64Factor), // 42.0
 			"[0, 0, 0, 0, 251, 197, 32, 0]":        interpreter.NewUnmeteredFix64Value(4224_000_000),          // 42.24
 			"[255, 255, 255, 255, 250, 10, 31, 0]": interpreter.NewUnmeteredFix64Value(-1 * sema.Fix64Factor), // -1.0
@@ -690,6 +700,7 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 		// UFix*
 		"UFix64": {
 			"[0, 0, 0, 0, 0, 0, 0, 0]":      interpreter.NewUnmeteredUFix64Value(0),
+			"[250, 86, 234, 0]":             interpreter.NewUnmeteredUFix64Value(42 * sema.Fix64Factor), // 42.0 with padding
 			"[0, 0, 0, 0, 250, 86, 234, 0]": interpreter.NewUnmeteredUFix64Value(42 * sema.Fix64Factor), // 42.0
 			"[0, 0, 0, 0, 251, 197, 32, 0]": interpreter.NewUnmeteredUFix64Value(4224_000_000),          // 42.24
 		},

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -708,7 +708,7 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 
 	invalidTests := map[string][]string{
 		// Int*
-		"Int": {},
+		"Int": {}, // No overflow
 		"Int8": {
 			"[0, 0]",
 			"[0, 22]",
@@ -734,7 +734,7 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 			"[0, 22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
 		},
 		// UInt*
-		"UInt": {},
+		"UInt": {}, // No overflow
 		"UInt8": {
 			"[0, 0]",
 			"[0, 22]",

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -20,6 +20,7 @@ package interpreter_test
 
 import (
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -526,6 +527,219 @@ func TestInterpretToBigEndianBytes(t *testing.T) {
 					inter,
 					interpreter.ByteSliceToByteArrayValue(inter, expected),
 					inter.Globals.Get("result").GetValue(),
+				)
+			})
+		}
+	}
+}
+
+func TestInterpretFromBigEndianBytes(t *testing.T) {
+
+	t.Parallel()
+
+	validTestsWithRoundtrip := map[string]map[string]interpreter.Value{
+		// Int*
+		"Int": {
+			"[0]":                           interpreter.NewUnmeteredIntValueFromBigInt(big.NewInt(0)),
+			"[42]":                          interpreter.NewUnmeteredIntValueFromBigInt(big.NewInt(42)),
+			"[127]":                         interpreter.NewUnmeteredIntValueFromBigInt(big.NewInt(127)),
+			"[0, 128]":                      interpreter.NewUnmeteredIntValueFromBigInt(big.NewInt(128)),
+			"[0, 200]":                      interpreter.NewUnmeteredIntValueFromBigInt(big.NewInt(200)),
+			"[255]":                         interpreter.NewUnmeteredIntValueFromBigInt(big.NewInt(-1)),
+			"[255, 56]":                     interpreter.NewUnmeteredIntValueFromBigInt(big.NewInt(-200)),
+			"[220, 121, 13, 144, 63, 0, 0]": interpreter.NewUnmeteredIntValueFromBigInt(big.NewInt(-10000000000000000)),
+		},
+		"Int8": {
+			"[0]":   interpreter.NewUnmeteredInt8Value(0),
+			"[42]":  interpreter.NewUnmeteredInt8Value(42),
+			"[127]": interpreter.NewUnmeteredInt8Value(127),
+			"[255]": interpreter.NewUnmeteredInt8Value(-1),
+			"[129]": interpreter.NewUnmeteredInt8Value(-127),
+			"[128]": interpreter.NewUnmeteredInt8Value(-128),
+		},
+		"Int16": {
+			"[0, 0]":     interpreter.NewUnmeteredInt16Value(0),
+			"[0, 42]":    interpreter.NewUnmeteredInt16Value(42),
+			"[127, 255]": interpreter.NewUnmeteredInt16Value(32767),
+			"[255, 255]": interpreter.NewUnmeteredInt16Value(-1),
+			"[128, 1]":   interpreter.NewUnmeteredInt16Value(-32767),
+			"[128, 0]":   interpreter.NewUnmeteredInt16Value(-32768),
+		},
+		"Int32": {
+			"[0, 0, 0, 0]":         interpreter.NewUnmeteredInt32Value(0),
+			"[0, 0, 0, 42]":        interpreter.NewUnmeteredInt32Value(42),
+			"[127, 255, 255, 255]": interpreter.NewUnmeteredInt32Value(2147483647),
+			"[255, 255, 255, 255]": interpreter.NewUnmeteredInt32Value(-1),
+			"[128, 0, 0, 1]":       interpreter.NewUnmeteredInt32Value(-2147483647),
+			"[128, 0, 0, 0]":       interpreter.NewUnmeteredInt32Value(-2147483648),
+		},
+		"Int64": {
+			"[0, 0, 0, 0, 0, 0, 0, 0]":                 interpreter.NewUnmeteredInt64Value(0),
+			"[0, 0, 0, 0, 0, 0, 0, 42]":                interpreter.NewUnmeteredInt64Value(42),
+			"[127, 255, 255, 255, 255, 255, 255, 255]": interpreter.NewUnmeteredInt64Value(9223372036854775807),
+			"[255, 255, 255, 255, 255, 255, 255, 255]": interpreter.NewUnmeteredInt64Value(-1),
+			"[128, 0, 0, 0, 0, 0, 0, 1]":               interpreter.NewUnmeteredInt64Value(-9223372036854775807),
+			"[128, 0, 0, 0, 0, 0, 0, 0]":               interpreter.NewUnmeteredInt64Value(-9223372036854775808),
+		},
+		"Int128": {
+			"[0]":                           interpreter.NewUnmeteredInt128ValueFromBigInt(big.NewInt(0)),
+			"[42]":                          interpreter.NewUnmeteredInt128ValueFromBigInt(big.NewInt(42)),
+			"[127]":                         interpreter.NewUnmeteredInt128ValueFromBigInt(big.NewInt(127)),
+			"[0, 128]":                      interpreter.NewUnmeteredInt128ValueFromBigInt(big.NewInt(128)),
+			"[0, 200]":                      interpreter.NewUnmeteredInt128ValueFromBigInt(big.NewInt(200)),
+			"[255]":                         interpreter.NewUnmeteredInt128ValueFromBigInt(big.NewInt(-1)),
+			"[255, 56]":                     interpreter.NewUnmeteredInt128ValueFromBigInt(big.NewInt(-200)),
+			"[220, 121, 13, 144, 63, 0, 0]": interpreter.NewUnmeteredInt128ValueFromBigInt(big.NewInt(-10000000000000000)),
+		},
+		"Int256": {
+			"[0]":                           interpreter.NewUnmeteredInt256ValueFromBigInt(big.NewInt(0)),
+			"[42]":                          interpreter.NewUnmeteredInt256ValueFromBigInt(big.NewInt(42)),
+			"[127]":                         interpreter.NewUnmeteredInt256ValueFromBigInt(big.NewInt(127)),
+			"[0, 128]":                      interpreter.NewUnmeteredInt256ValueFromBigInt(big.NewInt(128)),
+			"[0, 200]":                      interpreter.NewUnmeteredInt256ValueFromBigInt(big.NewInt(200)),
+			"[255]":                         interpreter.NewUnmeteredInt256ValueFromBigInt(big.NewInt(-1)),
+			"[255, 56]":                     interpreter.NewUnmeteredInt256ValueFromBigInt(big.NewInt(-200)),
+			"[220, 121, 13, 144, 63, 0, 0]": interpreter.NewUnmeteredInt256ValueFromBigInt(big.NewInt(-10000000000000000)),
+		},
+		// UInt*
+		"UInt": {
+			"[0]":   interpreter.NewUnmeteredUIntValueFromUint64(0),
+			"[42]":  interpreter.NewUnmeteredUIntValueFromUint64(42),
+			"[127]": interpreter.NewUnmeteredUIntValueFromUint64(127),
+			"[128]": interpreter.NewUnmeteredUIntValueFromUint64(128),
+			"[200]": interpreter.NewUnmeteredUIntValueFromUint64(200),
+		},
+		"UInt8": {
+			"[0]":   interpreter.NewUnmeteredUInt8Value(0),
+			"[42]":  interpreter.NewUnmeteredUInt8Value(42),
+			"[127]": interpreter.NewUnmeteredUInt8Value(127),
+			"[128]": interpreter.NewUnmeteredUInt8Value(128),
+			"[255]": interpreter.NewUnmeteredUInt8Value(255),
+		},
+		"UInt16": {
+			"[0, 0]":     interpreter.NewUnmeteredUInt16Value(0),
+			"[0, 42]":    interpreter.NewUnmeteredUInt16Value(42),
+			"[127, 255]": interpreter.NewUnmeteredUInt16Value(32767),
+			"[128, 0]":   interpreter.NewUnmeteredUInt16Value(32768),
+			"[255, 255]": interpreter.NewUnmeteredUInt16Value(65535),
+		},
+		"UInt32": {
+			"[0, 0, 0, 0]":         interpreter.NewUnmeteredUInt32Value(0),
+			"[0, 0, 0, 42]":        interpreter.NewUnmeteredUInt32Value(42),
+			"[127, 255, 255, 255]": interpreter.NewUnmeteredUInt32Value(2147483647),
+			"[128, 0, 0, 0]":       interpreter.NewUnmeteredUInt32Value(2147483648),
+			"[255, 255, 255, 255]": interpreter.NewUnmeteredUInt32Value(4294967295),
+		},
+		"UInt64": {
+			"[0, 0, 0, 0, 0, 0, 0, 0]":                 interpreter.NewUnmeteredUInt64Value(0),
+			"[0, 0, 0, 0, 0, 0, 0, 42]":                interpreter.NewUnmeteredUInt64Value(42),
+			"[127, 255, 255, 255, 255, 255, 255, 255]": interpreter.NewUnmeteredUInt64Value(9223372036854775807),
+			"[128, 0, 0, 0, 0, 0, 0, 0]":               interpreter.NewUnmeteredUInt64Value(9223372036854775808),
+			"[255, 255, 255, 255, 255, 255, 255, 255]": interpreter.NewUnmeteredUInt64Value(18446744073709551615),
+		},
+		"UInt128": {
+			"[0]":   interpreter.NewUnmeteredUInt128ValueFromBigInt(big.NewInt(0)),
+			"[42]":  interpreter.NewUnmeteredUInt128ValueFromBigInt(big.NewInt(42)),
+			"[127]": interpreter.NewUnmeteredUInt128ValueFromBigInt(big.NewInt(127)),
+			"[128]": interpreter.NewUnmeteredUInt128ValueFromBigInt(big.NewInt(128)),
+			"[200]": interpreter.NewUnmeteredUInt128ValueFromBigInt(big.NewInt(200)),
+		},
+		"UInt256": {
+			"[0]":   interpreter.NewUnmeteredUInt256ValueFromBigInt(big.NewInt(0)),
+			"[42]":  interpreter.NewUnmeteredUInt256ValueFromBigInt(big.NewInt(42)),
+			"[127]": interpreter.NewUnmeteredUInt256ValueFromBigInt(big.NewInt(127)),
+			"[128]": interpreter.NewUnmeteredUInt256ValueFromBigInt(big.NewInt(128)),
+			"[200]": interpreter.NewUnmeteredUInt256ValueFromBigInt(big.NewInt(200)),
+		},
+		// Word*
+		"Word8": {
+			"[0]":   interpreter.NewUnmeteredWord8Value(0),
+			"[42]":  interpreter.NewUnmeteredWord8Value(42),
+			"[127]": interpreter.NewUnmeteredWord8Value(127),
+			"[128]": interpreter.NewUnmeteredWord8Value(128),
+			"[255]": interpreter.NewUnmeteredWord8Value(255),
+		},
+		"Word16": {
+			"[0, 0]":     interpreter.NewUnmeteredWord16Value(0),
+			"[0, 42]":    interpreter.NewUnmeteredWord16Value(42),
+			"[127, 255]": interpreter.NewUnmeteredWord16Value(32767),
+			"[128, 0]":   interpreter.NewUnmeteredWord16Value(32768),
+			"[255, 255]": interpreter.NewUnmeteredWord16Value(65535),
+		},
+		"Word32": {
+			"[0, 0, 0, 0]":         interpreter.NewUnmeteredWord32Value(0),
+			"[0, 0, 0, 42]":        interpreter.NewUnmeteredWord32Value(42),
+			"[127, 255, 255, 255]": interpreter.NewUnmeteredWord32Value(2147483647),
+			"[128, 0, 0, 0]":       interpreter.NewUnmeteredWord32Value(2147483648),
+			"[255, 255, 255, 255]": interpreter.NewUnmeteredWord32Value(4294967295),
+		},
+		"Word64": {
+			"[0, 0, 0, 0, 0, 0, 0, 0]":                 interpreter.NewUnmeteredWord64Value(0),
+			"[0, 0, 0, 0, 0, 0, 0, 42]":                interpreter.NewUnmeteredWord64Value(42),
+			"[127, 255, 255, 255, 255, 255, 255, 255]": interpreter.NewUnmeteredWord64Value(9223372036854775807),
+			"[128, 0, 0, 0, 0, 0, 0, 0]":               interpreter.NewUnmeteredWord64Value(9223372036854775808),
+			"[255, 255, 255, 255, 255, 255, 255, 255]": interpreter.NewUnmeteredWord64Value(18446744073709551615),
+		},
+		// Fix*
+		"Fix64": {
+			"[0, 0, 0, 0, 0, 0, 0, 0]":             interpreter.NewUnmeteredFix64Value(0),
+			"[0, 0, 0, 0, 250, 86, 234, 0]":        interpreter.NewUnmeteredFix64Value(42 * sema.Fix64Factor), // 42.0
+			"[0, 0, 0, 0, 251, 197, 32, 0]":        interpreter.NewUnmeteredFix64Value(4224_000_000),          // 42.24
+			"[255, 255, 255, 255, 250, 10, 31, 0]": interpreter.NewUnmeteredFix64Value(-1 * sema.Fix64Factor), // -1.0
+		},
+		// UFix*
+		"UFix64": {
+			"[0, 0, 0, 0, 0, 0, 0, 0]":      interpreter.NewUnmeteredUFix64Value(0),
+			"[0, 0, 0, 0, 250, 86, 234, 0]": interpreter.NewUnmeteredUFix64Value(42 * sema.Fix64Factor), // 42.0
+			"[0, 0, 0, 0, 251, 197, 32, 0]": interpreter.NewUnmeteredUFix64Value(4224_000_000),          // 42.24
+		},
+	}
+
+	// Ensure the test cases are complete
+
+	for _, integerType := range sema.AllNumberTypes {
+		switch integerType {
+		case sema.NumberType, sema.SignedNumberType,
+			sema.IntegerType, sema.SignedIntegerType,
+			sema.FixedPointType, sema.SignedFixedPointType:
+			continue
+		}
+
+		if _, ok := validTestsWithRoundtrip[integerType.String()]; !ok {
+			panic(fmt.Sprintf("broken test: missing %s", integerType))
+		}
+	}
+
+	for ty, tests := range validTestsWithRoundtrip {
+		for value, expected := range tests {
+			t.Run(fmt.Sprintf("%s: %s", ty, value), func(t *testing.T) {
+				inter := parseCheckAndInterpret(t,
+					fmt.Sprintf(
+						`
+	                      let resultOpt: %s? = %s.fromBigEndianBytes(%s)
+						  let result: %s = resultOpt!
+						  let expectedBytes: [UInt8] = %s
+						  let bytesEqual = expectedBytes == result.toBigEndianBytes()
+	                    `,
+						ty,
+						ty,
+						value,
+						ty,
+						value,
+					),
+				)
+
+				AssertValuesEqual(
+					t,
+					inter,
+					expected,
+					inter.Globals.Get("result").GetValue(),
+				)
+				AssertValuesEqual(
+					t,
+					inter,
+					interpreter.TrueValue,
+					inter.Globals.Get("bytesEqual").GetValue(),
 				)
 			})
 		}


### PR DESCRIPTION
Closes #2448 
Work towards https://github.com/onflow/developer-grants/issues/179

## Description
Added `fromBigEndianBytes` to all the `Number` types - `Int*`, `UInt*`, `Fix*`, `Word*`.

We return `Nil` in case of invalid input such as overflow. Note that we also return `Nil` if the size of the byte array is greater than the size needed for the target type. E.g. `[0, 0]` does not lead to overflow for `UInt8` but we return `Nil` since we expect the byte array size to only be 1.

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
