### PR TITLE
Fix userPanicToError to handle wrapped user error.

### DIFF
--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -8032,3 +8032,12 @@ func TestRuntimeAccountTypeEquality(t *testing.T) {
 
 	require.Equal(t, cadence.Bool(true), result)
 }
+
+func TestUserPanicToError(t *testing.T) {
+	err := fmt.Errorf(
+		"wrapped: %w",
+		runtimeErrors.NewDefaultUserError("user error"),
+	)
+	retErr := userPanicToError(func() { panic(err) })
+	require.Equal(t, retErr, err)
+}


### PR DESCRIPTION
## Description

`runtime.Interface` (in particular `GetOrLoadProgram`) may panic with a wrapped user (parse) error to provide additional error context.  Error misclassification in FVM program cache causes non-deterministic execution.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
