### PR TITLE
Add attachment keywords to keyword lists

### DIFF
--- a/runtime/parser/keyword.go
+++ b/runtime/parser/keyword.go
@@ -120,6 +120,10 @@ var allKeywords = []string{
 	KeywordDefault,
 	KeywordEnum,
 	KeywordView,
+	keywordAttach,
+	keywordAttachment,
+	keywordTo,
+	keywordRemove,
 }
 
 // Keywords that can be used in identifier position without ambiguity.
@@ -129,6 +133,9 @@ var softKeywords = []string{
 	KeywordSet,
 	KeywordAll,
 	KeywordView,
+	keywordAttach,
+	keywordRemove,
+	keywordTo,
 }
 
 var softKeywordsTable = mph.Build(softKeywords)

--- a/runtime/parser/statement_test.go
+++ b/runtime/parser/statement_test.go
@@ -2684,6 +2684,11 @@ func TestSoftKeywordsInStatement(t *testing.T) {
 	}
 
 	for _, keyword := range softKeywords {
+		// it's not worth the additional complexity to support assigning to `remove` or `attach`-named
+		// variables, so we just accept this as a parsing error
+		if keyword == keywordAttach || keyword == keywordRemove {
+			continue
+		}
 		testSoftKeyword(keyword)
 	}
 }


### PR DESCRIPTION
This properly adds the new attachments keywords to the keyword lists, which was missed when merging this to stable cadence. This also makes `remove`, `attach` and `to` soft keywords, so they can be used as names for fields and functions. Note that it will still fail to parse however when attempting to assign to a variable named `attach` or `remove`, as this is ambiguous. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
