### PR TITLE
Improve errors

### DIFF
--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -91,8 +91,9 @@ func (checker *Checker) checkTransactionParameters(declaration *ast.TransactionD
 
 	// Check parameter types
 
-	for _, parameter := range parameters {
+	for parameterIndex, parameter := range parameters {
 		parameterType := parameter.TypeAnnotation.Type
+		astParameter := declaration.ParameterList.Parameters[parameterIndex]
 
 		// Ignore invalid parameter types
 
@@ -105,7 +106,8 @@ func (checker *Checker) checkTransactionParameters(declaration *ast.TransactionD
 		if !parameterType.IsImportable(map[*Member]bool{}) {
 			checker.report(
 				&InvalidNonImportableTransactionParameterTypeError{
-					Type: parameterType,
+					Type:  parameterType,
+					Range: ast.NewRangeFromPositioned(checker.memoryGauge, astParameter),
 				},
 			)
 		}

--- a/runtime/tests/checker/attachments_test.go
+++ b/runtime/tests/checker/attachments_test.go
@@ -475,10 +475,8 @@ func TestCheckNestedBaseType(t *testing.T) {
 			`,
 		)
 
-		errs := RequireCheckerErrors(t, err, 2)
+		errs := RequireCheckerErrors(t, err, 1)
 
-		// 2 errors, for undeclared type, one for invalid type in base type
-		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
 		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
 	})
 }

--- a/runtime/tests/checker/attachments_test.go
+++ b/runtime/tests/checker/attachments_test.go
@@ -297,11 +297,10 @@ func TestCheckBaseType(t *testing.T) {
 			attachment B for A {}`,
 		)
 
-		errs := RequireCheckerErrors(t, err, 3)
+		errs := RequireCheckerErrors(t, err, 2)
 
 		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
 		assert.IsType(t, &sema.InvalidBaseTypeError{}, errs[1])
-		assert.IsType(t, &sema.InvalidBaseTypeError{}, errs[2])
 	})
 
 	t.Run("invalid type", func(t *testing.T) {
@@ -313,10 +312,9 @@ func TestCheckBaseType(t *testing.T) {
 			attachment A for B {}`,
 		)
 
-		errs := RequireCheckerErrors(t, err, 2)
+		errs := RequireCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
-		assert.IsType(t, &sema.InvalidBaseTypeError{}, errs[1])
 	})
 }
 
@@ -2844,11 +2842,10 @@ func TestCheckAttachInvalidType(t *testing.T) {
 		}`,
 	)
 
-	errs := RequireCheckerErrors(t, err, 3)
+	errs := RequireCheckerErrors(t, err, 2)
 
 	assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
-	assert.IsType(t, &sema.InvalidBaseTypeError{}, errs[1])
-	assert.IsType(t, &sema.TypeMismatchError{}, errs[2])
+	assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
 }
 
 func TestCheckAnyAttachmentTypes(t *testing.T) {

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -132,6 +132,7 @@ func (programs Programs) check(
 					if seenImports[importedLocation] {
 						return nil, &sema.CyclicImportsError{
 							Location: importedLocation,
+							Range:    importRange,
 						}
 					}
 					seenImports[importedLocation] = true


### PR DESCRIPTION
## Description

- Some errors were missing position information, which is especially confusing when using the Language Server / an IDE. 
  Add the missing position information.

- The attachment base type error check is currently re-reporting an error when the base type was not declared.
  Remove the unnecessary re-reported error.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
