### PR TITLE
Return a text message instead of NaN

### DIFF
--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -64,6 +64,7 @@ func (c *LocationCoverage) Percentage() string {
 		// location.
 		coveredLines = c.Statements
 	}
+
 	percentage := 100 * float64(coveredLines) / float64(c.Statements)
 	return fmt.Sprintf("%0.1f%%", percentage)
 }
@@ -245,6 +246,10 @@ func (r *CoverageReport) Percentage() string {
 // String returns a human-friendly message for the covered
 // statements percentage.
 func (r *CoverageReport) String() string {
+	percentage := r.Percentage()
+	if percentage == "NaN%" {
+		return fmt.Sprintf("There are no statements to cover")
+	}
 	return fmt.Sprintf("Coverage: %v of statements", r.Percentage())
 }
 

--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -237,17 +237,20 @@ func (r *CoverageReport) IsLocationInspected(location Location) bool {
 func (r *CoverageReport) Percentage() string {
 	totalStatements := r.Statements()
 	totalCoveredLines := r.Hits()
+	var percentage float64 = 100
+	if totalStatements != 0 {
+		percentage = 100 * float64(totalCoveredLines) / float64(totalStatements)
+	}
 	return fmt.Sprintf(
 		"%0.1f%%",
-		100*float64(totalCoveredLines)/float64(totalStatements),
+		percentage,
 	)
 }
 
 // String returns a human-friendly message for the covered
 // statements percentage.
 func (r *CoverageReport) String() string {
-	percentage := r.Percentage()
-	if percentage == "NaN%" {
+	if r.Statements() == 0 {
 		return fmt.Sprintf("There are no statements to cover")
 	}
 	return fmt.Sprintf("Coverage: %v of statements", r.Percentage())

--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -251,7 +251,7 @@ func (r *CoverageReport) Percentage() string {
 // statements percentage.
 func (r *CoverageReport) String() string {
 	if r.Statements() == 0 {
-		return fmt.Sprintf("There are no statements to cover")
+		return "There are no statements to cover"
 	}
 	return fmt.Sprintf("Coverage: %v of statements", r.Percentage())
 }

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -1708,4 +1708,20 @@ func TestRuntimeCoverageWithNoStatements(t *testing.T) {
 		"There are no statements to cover",
 		coverageReport.String(),
 	)
+
+	summary := coverageReport.Summary()
+
+	actual, err := json.Marshal(summary)
+	require.NoError(t, err)
+
+	expected := `
+	  {
+	    "coverage": "100.0%",
+	    "hits": 0,
+	    "locations": 0,
+	    "misses": 0,
+	    "statements": 0
+	  }
+	`
+	require.JSONEq(t, expected, string(actual))
 }

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -1648,3 +1648,64 @@ func TestRuntimeCoverageWithLocationFilter(t *testing.T) {
 		coverageReport.String(),
 	)
 }
+
+func TestRuntimeCoverageWithNoStatements(t *testing.T) {
+
+	t.Parallel()
+
+	importedScript := []byte(`
+	  pub contract FooContract {
+	    pub resource interface Receiver {
+	    }
+	  }
+	`)
+
+	script := []byte(`
+	  import "FooContract"
+	  pub fun main(): Int {
+		Type<@{FooContract.Receiver}>().identifier
+		return 42
+	  }
+	`)
+
+	coverageReport := NewCoverageReport()
+
+	scriptlocation := common.ScriptLocation{0x1b, 0x2c}
+
+	runtimeInterface := &testRuntimeInterface{
+		getCode: func(location Location) (bytes []byte, err error) {
+			switch location {
+			case common.StringLocation("FooContract"):
+				return importedScript, nil
+			default:
+				return nil, fmt.Errorf("unknown import location: %s", location)
+			}
+		},
+	}
+	runtime := NewInterpreterRuntime(Config{
+		CoverageReport: coverageReport,
+	})
+	coverageReport.ExcludeLocation(scriptlocation)
+	value, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface:      runtimeInterface,
+			Location:       scriptlocation,
+			CoverageReport: coverageReport,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, cadence.NewInt(42), value)
+
+	_, err = json.Marshal(coverageReport)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"There are no statements to cover",
+		coverageReport.String(),
+	)
+}


### PR DESCRIPTION
## Description

Return a text message instead of NaN for contracts that don't have non trivial runnable statments in relation to code coverage.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
