### PR TITLE
Improve linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,9 @@ linters:
     - goimports
     - unconvert
     - nilerr
+    - forbidigo
+    - bidichk
+    - asciicheck
 
 issues:
   exclude-rules:
@@ -38,6 +41,10 @@ linters-settings:
       - exitAfterDefer
   goimports:
     local-prefixes: github.com/onflow/cadence
+  forbidigo:
+    forbid:
+      - '^maps.Keys.*(# has indeterminate order\.)?$'
+      - '^maps.Values.*(# has indeterminate order\.)?$'
   custom:
     maprange:
       path: tools/maprange/maprange.so

--- a/runtime/cmd/check/main.go
+++ b/runtime/cmd/check/main.go
@@ -91,7 +91,7 @@ func main() {
 }
 
 type benchResult struct {
-	// N is the the number of iterations
+	// N is the number of iterations
 	Iterations int `json:"iterations"`
 	// T is the total time taken
 	Time time.Duration `json:"time"`

--- a/runtime/cmd/parse/main.go
+++ b/runtime/cmd/parse/main.go
@@ -50,7 +50,7 @@ func main() {
 }
 
 type benchResult struct {
-	// N is the the number of iterations
+	// N is the number of iterations
 	Iterations int `json:"iterations"`
 	// T is the total time taken
 	Time time.Duration `json:"time"`

--- a/runtime/stdlib/rlp/rlp.go
+++ b/runtime/stdlib/rlp/rlp.go
@@ -97,7 +97,7 @@ func ReadSize(inp []byte, startIndex int) (isString bool, dataStartIndex, dataSi
 	var bytesToReadForLen uint
 	// long string mode (55+ long strings)
 	// firstByte minus the end range of short string, returns the number of bytes to read
-	// for calculating the the len of data. bytesToReadForlen is at least 1 and at most 8.
+	// for calculating the len of data. bytesToReadForlen is at least 1 and at most 8.
 	if firstByte >= LongStringRangeStart && firstByte <= LongStringRangeEnd {
 		bytesToReadForLen = uint(firstByte - ShortStringRangeEnd)
 		isString = true
@@ -105,7 +105,7 @@ func ReadSize(inp []byte, startIndex int) (isString bool, dataStartIndex, dataSi
 
 	// long list mode
 	// firstByte minus the end range of short list, returns the number of bytes to read
-	// for calculating the the len of data. bytesToReadForlen is at least 1 and at most 8.
+	// for calculating the len of data. bytesToReadForlen is at least 1 and at most 8.
 	if firstByte >= LongListRangeStart {
 		bytesToReadForLen = uint(firstByte - ShortListRangeEnd)
 		isString = false


### PR DESCRIPTION
## Description

Noticed in #2405.

Forbid `golang.org/x/exp/maps.Keys/Values`, because they have nondeterministic results.

Also, enable some more linters, and remove some duplicate words.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
