### PR TITLE
Support 2 new attachment types in CCF codec

### DIFF
--- a/encoding/ccf/ccf_test.go
+++ b/encoding/ccf/ccf_test.go
@@ -7746,6 +7746,8 @@ func TestEncodeSimpleTypes(t *testing.T) {
 	for _, ty := range []simpleTypes{
 		{cadence.AnyType{}, ccf.TypeAny},
 		{cadence.AnyResourceType{}, ccf.TypeAnyResource},
+		{cadence.AnyStructAttachmentType{}, ccf.TypeAnyStructAttachmentType},
+		{cadence.AnyResourceAttachmentType{}, ccf.TypeAnyResourceAttachmentType},
 		{cadence.MetaType{}, ccf.TypeMetaType},
 		{cadence.VoidType{}, ccf.TypeVoid},
 		{cadence.NeverType{}, ccf.TypeNever},

--- a/encoding/ccf/decode_type.go
+++ b/encoding/ccf/decode_type.go
@@ -269,6 +269,12 @@ func (d *Decoder) decodeSimpleTypeID() (cadence.Type, error) {
 	case TypeVoid:
 		return cadence.TheVoidType, nil
 
+	case TypeAnyStructAttachmentType:
+		return cadence.TheAnyStructAttachmentType, nil
+
+	case TypeAnyResourceAttachmentType:
+		return cadence.TheAnyResourceAttachmentType, nil
+
 	default:
 		return nil, fmt.Errorf("unsupported encoded simple type ID %d", simpleTypeID)
 	}

--- a/encoding/ccf/simple_type_utils.go
+++ b/encoding/ccf/simple_type_utils.go
@@ -83,6 +83,8 @@ const ( // Cadence simple type IDs
 	TypeFunction
 	TypeWord128
 	TypeWord256
+	TypeAnyStructAttachmentType
+	TypeAnyResourceAttachmentType
 )
 
 // NOTE: cadence.FunctionType isn't included in simpleTypeIDByType
@@ -249,6 +251,12 @@ func simpleTypeIDByType(typ cadence.Type) (uint64, bool) {
 
 	case cadence.DeployedContractType:
 		return TypeDeployedContract, true
+
+	case cadence.AnyStructAttachmentType:
+		return TypeAnyStructAttachmentType, true
+
+	case cadence.AnyResourceAttachmentType:
+		return TypeAnyResourceAttachmentType, true
 	}
 
 	return 0, false


### PR DESCRIPTION
## Description

Update CCF codec to add support for
- `AnyStructAttachmentType`
- `AnyResourceAttachmentType`

Closes #2515 
Updates #2379 #2283 #2157

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
