### PR TITLE
Improve export and encoding

### DIFF
--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -615,6 +615,8 @@ func prepareAttachment(v cadence.Attachment) jsonValue {
 }
 
 func prepareComposite(kind, id string, fieldTypes []cadence.Field, fields []cadence.Value) jsonValue {
+	// Ensure there are _at least _ as many field values as field types.
+	// There might be more field values in the case of attachments.
 	if len(fields) < len(fieldTypes) {
 		panic(fmt.Errorf(
 			"%s field count (%d) does not match declared type (%d)",
@@ -628,6 +630,9 @@ func prepareComposite(kind, id string, fieldTypes []cadence.Field, fields []cade
 
 	for i, value := range fields {
 		var name string
+		// Provide the field name, if the field type is available.
+		// In the case of attachments, they are provided as field values,
+		// but there is no corresponding field type.
 		if i < len(fieldTypes) {
 			fieldType := fieldTypes[i]
 			name = fieldType.Identifier

--- a/runtime/attachments_test.go
+++ b/runtime/attachments_test.go
@@ -146,6 +146,7 @@ func TestAccountAttachmentSaveAndLoad(t *testing.T) {
 }
 
 func TestAccountAttachmentExport(t *testing.T) {
+
 	t.Parallel()
 
 	storage := newTestLedger(nil, nil)
@@ -233,6 +234,7 @@ func TestAccountAttachmentExport(t *testing.T) {
 }
 
 func TestAccountAttachedExport(t *testing.T) {
+
 	t.Parallel()
 
 	storage := newTestLedger(nil, nil)

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1466,8 +1466,11 @@ func TestExportStructValue(t *testing.T) {
 	}
 
 	actual := exportValueFromScript(t, script)
-	expected := cadence.NewStruct([]cadence.Value{cadence.NewInt(42)}).
-		WithType(fooStructType)
+	expected := cadence.ValueWithCachedTypeID(
+		cadence.NewStruct([]cadence.Value{
+			cadence.NewInt(42),
+		}).WithType(fooStructType),
+	)
 
 	assert.Equal(t, expected, actual)
 }
@@ -1491,11 +1494,12 @@ func TestExportResourceValue(t *testing.T) {
     `
 
 	actual := exportValueFromScript(t, script)
-	expected :=
+	expected := cadence.ValueWithCachedTypeID(
 		cadence.NewResource([]cadence.Value{
 			cadence.NewUInt64(0),
 			cadence.NewInt(42),
-		}).WithType(newFooResourceType())
+		}).WithType(newFooResourceType()),
+	)
 
 	assert.Equal(t, expected, actual)
 }
@@ -1520,32 +1524,37 @@ func TestExportResourceArrayValue(t *testing.T) {
 
 	fooResourceType := newFooResourceType()
 
-	actual := exportValueFromScript(t, script)
-	expected := cadence.NewArray([]cadence.Value{
-		cadence.NewResource([]cadence.Value{
-			cadence.NewUInt64(0),
-			cadence.NewInt(1),
-		}).WithType(fooResourceType),
-		cadence.NewResource([]cadence.Value{
-			cadence.NewUInt64(0),
-			cadence.NewInt(2),
-		}).WithType(fooResourceType),
-	}).WithType(&cadence.VariableSizedArrayType{
-		ElementType: &cadence.ResourceType{
-			Location:            common.ScriptLocation{},
-			QualifiedIdentifier: "Foo",
-			Fields: []cadence.Field{
-				{
-					Identifier: "uuid",
-					Type:       cadence.UInt64Type{},
-				},
-				{
-					Identifier: "bar",
-					Type:       cadence.IntType{},
+	actual := cadence.ValueWithCachedTypeID(
+		exportValueFromScript(t, script),
+	)
+
+	expected := cadence.ValueWithCachedTypeID(
+		cadence.NewArray([]cadence.Value{
+			cadence.NewResource([]cadence.Value{
+				cadence.NewUInt64(0),
+				cadence.NewInt(1),
+			}).WithType(fooResourceType),
+			cadence.NewResource([]cadence.Value{
+				cadence.NewUInt64(0),
+				cadence.NewInt(2),
+			}).WithType(fooResourceType),
+		}).WithType(&cadence.VariableSizedArrayType{
+			ElementType: &cadence.ResourceType{
+				Location:            common.ScriptLocation{},
+				QualifiedIdentifier: "Foo",
+				Fields: []cadence.Field{
+					{
+						Identifier: "uuid",
+						Type:       cadence.UInt64Type{},
+					},
+					{
+						Identifier: "bar",
+						Type:       cadence.IntType{},
+					},
 				},
 			},
-		},
-	})
+		}),
+	)
 
 	assert.Equal(t, expected, actual)
 }
@@ -1573,39 +1582,44 @@ func TestExportResourceDictionaryValue(t *testing.T) {
 
 	fooResourceType := newFooResourceType()
 
-	actual := exportValueFromScript(t, script)
-	expected := cadence.NewDictionary([]cadence.KeyValuePair{
-		{
-			Key: cadence.String("b"),
-			Value: cadence.NewResource([]cadence.Value{
-				cadence.NewUInt64(0),
-				cadence.NewInt(2),
-			}).WithType(fooResourceType),
-		},
-		{
-			Key: cadence.String("a"),
-			Value: cadence.NewResource([]cadence.Value{
-				cadence.NewUInt64(0),
-				cadence.NewInt(1),
-			}).WithType(fooResourceType),
-		},
-	}).WithType(&cadence.DictionaryType{
-		KeyType: cadence.StringType{},
-		ElementType: &cadence.ResourceType{
-			Location:            common.ScriptLocation{},
-			QualifiedIdentifier: "Foo",
-			Fields: []cadence.Field{
-				{
-					Identifier: "uuid",
-					Type:       cadence.UInt64Type{},
-				},
-				{
-					Identifier: "bar",
-					Type:       cadence.IntType{},
+	actual := cadence.ValueWithCachedTypeID(
+		exportValueFromScript(t, script),
+	)
+
+	expected := cadence.ValueWithCachedTypeID(
+		cadence.NewDictionary([]cadence.KeyValuePair{
+			{
+				Key: cadence.String("b"),
+				Value: cadence.NewResource([]cadence.Value{
+					cadence.NewUInt64(0),
+					cadence.NewInt(2),
+				}).WithType(fooResourceType),
+			},
+			{
+				Key: cadence.String("a"),
+				Value: cadence.NewResource([]cadence.Value{
+					cadence.NewUInt64(0),
+					cadence.NewInt(1),
+				}).WithType(fooResourceType),
+			},
+		}).WithType(&cadence.DictionaryType{
+			KeyType: cadence.StringType{},
+			ElementType: &cadence.ResourceType{
+				Location:            common.ScriptLocation{},
+				QualifiedIdentifier: "Foo",
+				Fields: []cadence.Field{
+					{
+						Identifier: "uuid",
+						Type:       cadence.UInt64Type{},
+					},
+					{
+						Identifier: "bar",
+						Type:       cadence.IntType{},
+					},
 				},
 			},
-		},
-	})
+		}),
+	)
 
 	assert.Equal(t, expected, actual)
 }
@@ -1670,14 +1684,18 @@ func TestExportNestedResourceValueFromScript(t *testing.T) {
         }
     `
 
-	actual := exportValueFromScript(t, script)
-	expected := cadence.NewResource([]cadence.Value{
-		cadence.NewUInt64(0),
+	actual := cadence.ValueWithCachedTypeID(
+		exportValueFromScript(t, script),
+	)
+	expected := cadence.ValueWithCachedTypeID(
 		cadence.NewResource([]cadence.Value{
 			cadence.NewUInt64(0),
-			cadence.NewInt(42),
-		}).WithType(barResourceType),
-	}).WithType(fooResourceType)
+			cadence.NewResource([]cadence.Value{
+				cadence.NewUInt64(0),
+				cadence.NewInt(42),
+			}).WithType(barResourceType),
+		}).WithType(fooResourceType),
+	)
 
 	assert.Equal(t, expected, actual)
 }
@@ -2444,15 +2462,20 @@ func TestExportCompositeValueWithFunctionValueField(t *testing.T) {
 		},
 	}
 
-	actual := exportValueFromScript(t, script)
-	expected := cadence.NewStruct([]cadence.Value{
-		cadence.NewInt(42),
-		cadence.Function{
-			FunctionType: &cadence.FunctionType{
-				ReturnType: cadence.VoidType{},
+	actual := cadence.ValueWithCachedTypeID(
+		exportValueFromScript(t, script),
+	)
+
+	expected := cadence.ValueWithCachedTypeID(
+		cadence.NewStruct([]cadence.Value{
+			cadence.NewInt(42),
+			cadence.Function{
+				FunctionType: &cadence.FunctionType{
+					ReturnType: cadence.VoidType{},
+				},
 			},
-		},
-	}).WithType(fooStructType)
+		}).WithType(fooStructType),
+	)
 
 	assert.Equal(t, expected, actual)
 }
@@ -2539,24 +2562,28 @@ func TestRuntimeEnumValue(t *testing.T) {
 
 	t.Parallel()
 
-	enumValue := cadence.Enum{
-		EnumType: &cadence.EnumType{
-			Location:            common.ScriptLocation{},
-			QualifiedIdentifier: "Direction",
-			Fields: []cadence.Field{
-				{
-					Identifier: sema.EnumRawValueFieldName,
-					Type:       cadence.IntType{},
+	newEnumValue := func() cadence.Enum {
+		return cadence.Enum{
+			EnumType: &cadence.EnumType{
+				Location:            common.ScriptLocation{},
+				QualifiedIdentifier: "Direction",
+				Fields: []cadence.Field{
+					{
+						Identifier: sema.EnumRawValueFieldName,
+						Type:       cadence.IntType{},
+					},
 				},
+				RawType: cadence.IntType{},
 			},
-			RawType: cadence.IntType{},
-		},
-		Fields: []cadence.Value{
-			cadence.NewInt(3),
-		},
+			Fields: []cadence.Value{
+				cadence.NewInt(3),
+			},
+		}
 	}
 
 	t.Run("test export", func(t *testing.T) {
+		t.Parallel()
+
 		script := `
             pub fun main(): Direction {
                 return Direction.RIGHT
@@ -2570,11 +2597,18 @@ func TestRuntimeEnumValue(t *testing.T) {
             }
         `
 
+		expected := newEnumValue()
 		actual := exportValueFromScript(t, script)
-		assert.Equal(t, enumValue, actual)
+
+		assert.Equal(t,
+			cadence.ValueWithCachedTypeID(expected),
+			cadence.ValueWithCachedTypeID(actual),
+		)
 	})
 
 	t.Run("test import", func(t *testing.T) {
+		t.Parallel()
+
 		script := `
             pub fun main(dir: Direction): Direction {
                 if !dir.isInstance(Type<Direction>()) {
@@ -2592,9 +2626,11 @@ func TestRuntimeEnumValue(t *testing.T) {
             }
         `
 
-		actual, err := executeTestScript(t, script, enumValue)
+		expected := newEnumValue()
+		actual, err := executeTestScript(t, script, expected)
 		require.NoError(t, err)
-		assert.Equal(t, enumValue, actual)
+
+		assert.Equal(t, expected, actual)
 	})
 }
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -149,7 +149,13 @@ func (r testInterpreterRuntime) ExecuteTransaction(script Script, context Contex
 func (r testInterpreterRuntime) ExecuteScript(script Script, context Context) (cadence.Value, error) {
 	i := context.Interface.(*testRuntimeInterface)
 	i.onScriptExecutionStart()
-	return r.interpreterRuntime.ExecuteScript(script, context)
+	value, err := r.interpreterRuntime.ExecuteScript(script, context)
+	// If there was a return value, let's also ensure it can be encoded
+	// TODO: also test CCF
+	if value != nil && err == nil {
+		_ = jsoncdc.MustEncode(value)
+	}
+	return value, err
 }
 
 type testRuntimeInterface struct {


### PR DESCRIPTION
## Description

- Add support for encoding attachments to JSON-CDC codec
- Handle `nil` values when encoding JSON-CDC. This occurs for example in the result of a cyclic reference
- Fix encoding of composite values which have attachments attached to them in JSON-CDC encoding 
- In general, test that script return values in test cases can also be encoded by JSON-CDC. 
  It would be nice to do that for CCF as well, once it is ready

cc @fxamacker 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
