### PR TITLE
Support cyclic reference value in CCF codec

### DIFF
--- a/encoding/ccf/encode.go
+++ b/encoding/ccf/encode.go
@@ -343,6 +343,10 @@ func (e *Encoder) encodeValue(
 	tids ccfTypeIDByCadenceType,
 ) error {
 
+	if v == nil {
+		return e.enc.EncodeNil()
+	}
+
 	runtimeType := v.Type()
 
 	// CCF requires value to have non-nil type.

--- a/encoding/ccf/traverse_value.go
+++ b/encoding/ccf/traverse_value.go
@@ -65,6 +65,10 @@ func compositeTypesFromValue(v cadence.Value) ([]cadence.Type, ccfTypeIDByCadenc
 
 func (ct *compositeTypes) traverseValue(v cadence.Value) {
 
+	if v == nil {
+		return
+	}
+
 	// Traverse type for composite/interface types.
 	checkRuntimeType := ct.traverseType(v.Type())
 


### PR DESCRIPTION
Closes #2518 

## Description

Cadence exports cyclic reference value as nil, so this PR updates CCF codec to support that.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
