### PR TITLE
Fix  `publicKey` to have matching static and runtime types

### DIFF
--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -157,7 +157,7 @@ func TestRuntimeTransaction_AddPublicKey(t *testing.T) {
 			assert.EqualValues(t, stdlib.AccountCreatedEventType.ID(), events[0].Type().ID())
 
 			for _, event := range events[1:] {
-				assert.EqualValues(t, stdlib.AccountKeyAddedEventTypeV1.ID(), event.Type().ID())
+				assert.EqualValues(t, stdlib.AccountKeyAddedFromByteArrayEventType.ID(), event.Type().ID())
 			}
 		})
 	}
@@ -641,7 +641,7 @@ func TestRuntimeAuthAccountKeysAdd(t *testing.T) {
 	)
 
 	assert.EqualValues(t,
-		stdlib.AccountKeyAddedEventTypeV2.ID(),
+		stdlib.AccountKeyAddedFromPublicKeyEventType.ID(),
 		storage.events[1].Type().ID(),
 	)
 }

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -157,7 +157,7 @@ func TestRuntimeTransaction_AddPublicKey(t *testing.T) {
 			assert.EqualValues(t, stdlib.AccountCreatedEventType.ID(), events[0].Type().ID())
 
 			for _, event := range events[1:] {
-				assert.EqualValues(t, stdlib.AccountKeyAddedEventType.ID(), event.Type().ID())
+				assert.EqualValues(t, stdlib.AccountKeyAddedEventTypeV1.ID(), event.Type().ID())
 			}
 		})
 	}
@@ -641,7 +641,7 @@ func TestRuntimeAuthAccountKeysAdd(t *testing.T) {
 	)
 
 	assert.EqualValues(t,
-		stdlib.AccountKeyAddedEventType.ID(),
+		stdlib.AccountKeyAddedEventTypeV2.ID(),
 		storage.events[1].Type().ID(),
 	)
 }

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -502,7 +502,7 @@ func newAddPublicKeyFunction(
 			inter := invocation.Interpreter
 			handler.EmitEvent(
 				inter,
-				AccountKeyAddedEventType,
+				AccountKeyAddedEventTypeV1,
 				[]interpreter.Value{
 					addressValue,
 					publicKeyValue,
@@ -558,7 +558,7 @@ func newRemovePublicKeyFunction(
 
 			handler.EmitEvent(
 				inter,
-				AccountKeyRemovedEventType,
+				AccountKeyRemovedEventTypeV1,
 				[]interpreter.Value{
 					addressValue,
 					publicKeyValue,
@@ -624,7 +624,7 @@ func newAccountKeysAddFunction(
 
 			handler.EmitEvent(
 				inter,
-				AccountKeyAddedEventType,
+				AccountKeyAddedEventTypeV2,
 				[]interpreter.Value{
 					addressValue,
 					publicKeyValue,
@@ -895,7 +895,7 @@ func newAccountKeysRevokeFunction(
 
 			handler.EmitEvent(
 				inter,
-				AccountKeyRemovedEventType,
+				AccountKeyRemovedEventTypeV2,
 				[]interpreter.Value{
 					addressValue,
 					indexValue,

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -502,7 +502,7 @@ func newAddPublicKeyFunction(
 			inter := invocation.Interpreter
 			handler.EmitEvent(
 				inter,
-				AccountKeyAddedEventTypeV1,
+				AccountKeyAddedFromByteArrayEventType,
 				[]interpreter.Value{
 					addressValue,
 					publicKeyValue,
@@ -558,7 +558,7 @@ func newRemovePublicKeyFunction(
 
 			handler.EmitEvent(
 				inter,
-				AccountKeyRemovedEventTypeV1,
+				AccountKeyRemovedFromByteArrayEventType,
 				[]interpreter.Value{
 					addressValue,
 					publicKeyValue,
@@ -624,7 +624,7 @@ func newAccountKeysAddFunction(
 
 			handler.EmitEvent(
 				inter,
-				AccountKeyAddedEventTypeV2,
+				AccountKeyAddedFromPublicKeyEventType,
 				[]interpreter.Value{
 					addressValue,
 					publicKeyValue,
@@ -895,7 +895,7 @@ func newAccountKeysRevokeFunction(
 
 			handler.EmitEvent(
 				inter,
-				AccountKeyRemovedEventTypeV2,
+				AccountKeyRemovedFromPublicKeyIndexEventType,
 				[]interpreter.Value{
 					addressValue,
 					indexValue,

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -184,10 +184,24 @@ var AccountEventCodeHashParameter = sema.Parameter{
 	TypeAnnotation: sema.NewTypeAnnotation(HashType),
 }
 
-var AccountEventPublicKeyParameter = sema.Parameter{
+var AccountEventPublicKeyParameterAsByteArrayType = sema.Parameter{
 	Identifier: "publicKey",
 	TypeAnnotation: sema.NewTypeAnnotation(
 		sema.ByteArrayType,
+	),
+}
+
+var AccountEventPublicKeyParameterAsCompositeType = sema.Parameter{
+	Identifier: "publicKey",
+	TypeAnnotation: sema.NewTypeAnnotation(
+		sema.PublicKeyType,
+	),
+}
+
+var AccountEventPublicKeyIndexParameter = sema.Parameter{
+	Identifier: "publicKey",
+	TypeAnnotation: sema.NewTypeAnnotation(
+		sema.IntType,
 	),
 }
 
@@ -201,16 +215,28 @@ var AccountCreatedEventType = newFlowEventType(
 	AccountEventAddressParameter,
 )
 
-var AccountKeyAddedEventType = newFlowEventType(
+var AccountKeyAddedEventTypeV1 = newFlowEventType(
 	"AccountKeyAdded",
 	AccountEventAddressParameter,
-	AccountEventPublicKeyParameter,
+	AccountEventPublicKeyParameterAsByteArrayType,
 )
 
-var AccountKeyRemovedEventType = newFlowEventType(
+var AccountKeyAddedEventTypeV2 = newFlowEventType(
+	"AccountKeyAdded",
+	AccountEventAddressParameter,
+	AccountEventPublicKeyParameterAsCompositeType,
+)
+
+var AccountKeyRemovedEventTypeV1 = newFlowEventType(
 	"AccountKeyRemoved",
 	AccountEventAddressParameter,
-	AccountEventPublicKeyParameter,
+	AccountEventPublicKeyParameterAsByteArrayType,
+)
+
+var AccountKeyRemovedEventTypeV2 = newFlowEventType(
+	"AccountKeyRemoved",
+	AccountEventAddressParameter,
+	AccountEventPublicKeyIndexParameter,
 )
 
 var AccountContractAddedEventType = newFlowEventType(

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -215,25 +215,25 @@ var AccountCreatedEventType = newFlowEventType(
 	AccountEventAddressParameter,
 )
 
-var AccountKeyAddedEventTypeV1 = newFlowEventType(
+var AccountKeyAddedFromByteArrayEventType = newFlowEventType(
 	"AccountKeyAdded",
 	AccountEventAddressParameter,
 	AccountEventPublicKeyParameterAsByteArrayType,
 )
 
-var AccountKeyAddedEventTypeV2 = newFlowEventType(
+var AccountKeyAddedFromPublicKeyEventType = newFlowEventType(
 	"AccountKeyAdded",
 	AccountEventAddressParameter,
 	AccountEventPublicKeyParameterAsCompositeType,
 )
 
-var AccountKeyRemovedEventTypeV1 = newFlowEventType(
+var AccountKeyRemovedFromByteArrayEventType = newFlowEventType(
 	"AccountKeyRemoved",
 	AccountEventAddressParameter,
 	AccountEventPublicKeyParameterAsByteArrayType,
 )
 
-var AccountKeyRemovedEventTypeV2 = newFlowEventType(
+var AccountKeyRemovedFromPublicKeyIndexEventType = newFlowEventType(
 	"AccountKeyRemoved",
 	AccountEventAddressParameter,
 	AccountEventPublicKeyIndexParameter,

--- a/runtime/stdlib/flow_test.go
+++ b/runtime/stdlib/flow_test.go
@@ -37,8 +37,10 @@ func TestFlowEventTypeIDs(t *testing.T) {
 
 	for _, ty := range []sema.Type{
 		AccountCreatedEventType,
-		AccountKeyAddedEventType,
-		AccountKeyRemovedEventType,
+		AccountKeyAddedEventTypeV1,
+		AccountKeyAddedEventTypeV2,
+		AccountKeyRemovedEventTypeV1,
+		AccountKeyRemovedEventTypeV2,
 		AccountContractAddedEventType,
 		AccountContractUpdatedEventType,
 		AccountContractRemovedEventType,

--- a/runtime/stdlib/flow_test.go
+++ b/runtime/stdlib/flow_test.go
@@ -37,10 +37,10 @@ func TestFlowEventTypeIDs(t *testing.T) {
 
 	for _, ty := range []sema.Type{
 		AccountCreatedEventType,
-		AccountKeyAddedEventTypeV1,
-		AccountKeyAddedEventTypeV2,
-		AccountKeyRemovedEventTypeV1,
-		AccountKeyRemovedEventTypeV2,
+		AccountKeyAddedFromByteArrayEventType,
+		AccountKeyAddedFromPublicKeyEventType,
+		AccountKeyRemovedFromByteArrayEventType,
+		AccountKeyRemovedFromPublicKeyIndexEventType,
 		AccountContractAddedEventType,
 		AccountContractUpdatedEventType,
 		AccountContractRemovedEventType,


### PR DESCRIPTION
Closes #2525 

## Changes

This PR updates `publicKey` field's static type to match runtime type for `AccountKeyAdded` and `AccountKeyRemoved` events.

## Reason for change

Currently, `publicKey` field's static type and runtime type are different in the latest version of `AccountKeyAdded` and `AccountKeyRemoved` events.

For example, `flow.AccountKeyAdded`:
- event type has `publicKey` field type `[UInt8]` (static type).
- event value has `publicKey` field as `Struct` (runtime type).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
