### PR TITLE
Fix `codeHash` types to match (static and runtime)

### DIFF
--- a/runtime/interpreter/conversion.go
+++ b/runtime/interpreter/conversion.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
-	"github.com/onflow/cadence/runtime/sema"
 )
 
 func ByteArrayValueToByteSlice(memoryGauge common.MemoryGauge, value Value, locationRange LocationRange) ([]byte, error) {
@@ -128,12 +127,11 @@ func ByteSliceToConstantSizedByteArrayValue(interpreter *Interpreter, buf []byte
 		}
 	}
 
-	constantSizedByteArrayStaticType := ConvertSemaArrayTypeToStaticArrayType(
+	constantSizedByteArrayStaticType := NewConstantSizedStaticType(
 		interpreter,
-		&sema.ConstantSizedType{
-			Type: sema.UInt8Type,
-			Size: int64(len(buf)),
-		})
+		PrimitiveStaticTypeUInt8,
+		int64(len(buf)),
+	)
 
 	return NewArrayValue(
 		interpreter,

--- a/runtime/interpreter/conversion.go
+++ b/runtime/interpreter/conversion.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
+	"github.com/onflow/cadence/runtime/sema"
 )
 
 func ByteArrayValueToByteSlice(memoryGauge common.MemoryGauge, value Value, locationRange LocationRange) ([]byte, error) {
@@ -108,6 +109,36 @@ func ByteSliceToByteArrayValue(interpreter *Interpreter, buf []byte) *ArrayValue
 		interpreter,
 		EmptyLocationRange,
 		ByteArrayStaticType,
+		common.ZeroAddress,
+		values...,
+	)
+}
+
+func ByteSliceToConstantSizedByteArrayValue(interpreter *Interpreter, buf []byte) *ArrayValue {
+
+	common.UseMemory(interpreter, common.NewBytesMemoryUsage(len(buf)))
+
+	var values []Value
+
+	count := len(buf)
+	if count > 0 {
+		values = make([]Value, count)
+		for i, b := range buf {
+			values[i] = UInt8Value(b)
+		}
+	}
+
+	constantSizedByteArrayStaticType := ConvertSemaArrayTypeToStaticArrayType(
+		interpreter,
+		&sema.ConstantSizedType{
+			Type: sema.UInt8Type,
+			Size: int64(len(buf)),
+		})
+
+	return NewArrayValue(
+		interpreter,
+		EmptyLocationRange,
+		constantSizedByteArrayStaticType,
 		common.ZeroAddress,
 		values...,
 	)

--- a/runtime/interpreter/conversion_test.go
+++ b/runtime/interpreter/conversion_test.go
@@ -153,3 +153,56 @@ func TestByteValueToByte(t *testing.T) {
 		}
 	})
 }
+
+func TestByteSliceToArrayValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("variable sized", func(t *testing.T) {
+		b := []byte{0, 1, 2}
+
+		inter := newTestInterpreter(t)
+
+		expectedType := VariableSizedStaticType{
+			Type: PrimitiveStaticTypeUInt8,
+		}
+
+		expected := NewArrayValue(
+			inter,
+			EmptyLocationRange,
+			expectedType,
+			common.ZeroAddress,
+			NewUnmeteredUInt8Value(0),
+			NewUnmeteredUInt8Value(1),
+			NewUnmeteredUInt8Value(2),
+		)
+
+		result := ByteSliceToByteArrayValue(inter, b)
+		require.Equal(t, expectedType, result.Type)
+		require.True(t, result.Equal(inter, EmptyLocationRange, expected))
+	})
+
+	t.Run("const sized", func(t *testing.T) {
+		b := []byte{0, 1, 2}
+
+		inter := newTestInterpreter(t)
+
+		expectedType := ConstantSizedStaticType{
+			Size: int64(len(b)),
+			Type: PrimitiveStaticTypeUInt8,
+		}
+
+		expected := NewArrayValue(
+			inter,
+			EmptyLocationRange,
+			expectedType,
+			common.ZeroAddress,
+			NewUnmeteredUInt8Value(0),
+			NewUnmeteredUInt8Value(1),
+			NewUnmeteredUInt8Value(2),
+		)
+
+		result := ByteSliceToConstantSizedByteArrayValue(inter, b)
+		require.Equal(t, expectedType, result.Type)
+		require.True(t, result.Equal(inter, EmptyLocationRange, expected))
+	})
+}

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -2194,7 +2194,7 @@ func NewHashAlgorithmFromValue(
 
 func CodeToHashValue(inter *interpreter.Interpreter, code []byte) *interpreter.ArrayValue {
 	codeHash := sha3.Sum256(code)
-	return interpreter.ByteSliceToByteArrayValue(inter, codeHash[:])
+	return interpreter.ByteSliceToConstantSizedByteArrayValue(inter, codeHash[:])
 }
 
 func newAuthAccountStorageCapabilitiesValue(


### PR DESCRIPTION
Closes #2527 

## Description

Currently, `codeHash` static type and runtime type doesn't match.

For example, `flow.AccountContractAdded`:
- event type has `codeHash` field type `[UInt8; 32]` (static type).
- event value has `codeHash` field as `[UInt8]` (runtime type).

This commit changes runtime type to `[UInt8; 32]` to be consistent with static type.

Thanks @turbolent [commenting](https://github.com/onflow/cadence/issues/2527#issuecomment-1575725552) on issue #2527 during weekend. 👍 
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
