### PR TITLE
Add composite type handler, allow loading of `flow.*` event types

### DIFF
--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -136,6 +136,7 @@ func (e *interpreterEnvironment) newInterpreterConfig() *interpreter.Config {
 		AuthAccountHandler:                   e.newAuthAccountHandler(),
 		OnRecordTrace:                        e.newOnRecordTraceHandler(),
 		OnResourceOwnerChange:                e.newResourceOwnerChangedHandler(),
+		CompositeTypeHandler:                 e.newCompositeTypeHandler(),
 		TracingEnabled:                       e.config.TracingEnabled,
 		AtreeValueValidationEnabled:          e.config.AtreeValidationEnabled,
 		// NOTE: ignore e.config.AtreeValidationEnabled here,
@@ -864,6 +865,16 @@ func (e *interpreterEnvironment) newImportLocationHandler() interpreter.ImportLo
 				Interpreter: subInterpreter,
 			}
 		}
+	}
+}
+
+func (e *interpreterEnvironment) newCompositeTypeHandler() interpreter.CompositeTypeHandlerFunc {
+	return func(location common.Location, typeID common.TypeID) *sema.CompositeType {
+		if _, ok := location.(stdlib.FlowLocation); ok {
+			return stdlib.FlowEventTypes[typeID]
+		}
+
+		return nil
 	}
 }
 

--- a/runtime/interpreter/config.go
+++ b/runtime/interpreter/config.go
@@ -48,9 +48,11 @@ type Config struct {
 	// AuthAccountHandler is used to handle accounts
 	AuthAccountHandler AuthAccountHandlerFunc
 	// UUIDHandler is used to handle the generation of UUIDs
-	UUIDHandler    UUIDHandlerFunc
-	BaseActivation *VariableActivation
-	Debugger       *Debugger
+	UUIDHandler UUIDHandlerFunc
+	// CompositeTypeHandler is used to load composite types
+	CompositeTypeHandler CompositeTypeHandlerFunc
+	BaseActivation       *VariableActivation
+	Debugger             *Debugger
 	// OnStatement is triggered when a statement is about to be executed
 	OnStatement OnStatementFunc
 	// OnLoopIteration is triggered when a loop iteration is about to be executed

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -8083,3 +8083,45 @@ func TestUserPanicToError(t *testing.T) {
 	retErr := userPanicToError(func() { panic(err) })
 	require.Equal(t, retErr, err)
 }
+
+func TestRuntimeFlowEventTypes(t *testing.T) {
+
+	t.Parallel()
+
+	rt := newTestInterpreterRuntime()
+
+	script := []byte(`
+      pub fun main(): Type? {
+          return CompositeType("flow.AccountContractAdded")
+      }
+    `)
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: newTestLedger(nil, nil),
+	}
+
+	result, err := rt.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  common.ScriptLocation{},
+		},
+	)
+	require.NoError(t, err)
+
+	accountContractAddedType := ExportType(
+		stdlib.AccountContractAddedEventType,
+		map[sema.TypeID]cadence.Type{},
+	)
+
+	require.Equal(t,
+		cadence.Optional{
+			Value: cadence.TypeValue{
+				StaticType: accountContractAddedType,
+			},
+		},
+		result,
+	)
+}

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -131,6 +131,8 @@ func decodeFlowLocationTypeID(typeID string) (FlowLocation, string, error) {
 
 // built-in event types
 
+var FlowEventTypes = map[common.TypeID]*sema.CompositeType{}
+
 func newFlowEventType(identifier string, parameters ...sema.Parameter) *sema.CompositeType {
 
 	eventType := &sema.CompositeType{
@@ -163,6 +165,8 @@ func newFlowEventType(identifier string, parameters ...sema.Parameter) *sema.Com
 			parameter,
 		)
 	}
+
+	FlowEventTypes[eventType.ID()] = eventType
 
 	return eventType
 }


### PR DESCRIPTION
## Description

- Add an optional "composite type handler", which is used to load the type given a type ID. This allows making type loading more configurable, and allows e.g. types defined in stdlib to be supported
- Define a composite type handler in the runtime environment, which looks up `flow.*` event types in stdlib

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
