### PR TITLE
Add function type to function wrapper host functions

### DIFF
--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -8075,7 +8075,9 @@ func TestRuntimeAccountTypeEquality(t *testing.T) {
 	require.Equal(t, cadence.Bool(true), result)
 }
 
-func TestUserPanicToError(t *testing.T) {
+func TestRuntimeUserPanicToError(t *testing.T) {
+	t.Parallel()
+
 	err := fmt.Errorf(
 		"wrapped: %w",
 		runtimeErrors.NewDefaultUserError("user error"),


### PR DESCRIPTION
## Description

Functions are wrapped with interface / type requirement functions' conditions.

Specify the function type of the host function, as the resulting wrapper function might actually be used as a first-class value, and so is assumed to have a function type.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
