### PR TITLE
Fix test: Pass interpreter when iterating over arrays

### DIFF
--- a/runtime/stdlib/test.go
+++ b/runtime/stdlib/test.go
@@ -116,7 +116,7 @@ func getNestedTypeConstructorValue(parent interpreter.Value, typeName string) *i
 	return constructor
 }
 
-func arrayValueToSlice(value interpreter.Value) ([]interpreter.Value, error) {
+func arrayValueToSlice(inter *interpreter.Interpreter, value interpreter.Value) ([]interpreter.Value, error) {
 	array, ok := value.(*interpreter.ArrayValue)
 	if !ok {
 		return nil, errors.NewDefaultUserError("value is not an array")
@@ -124,7 +124,7 @@ func arrayValueToSlice(value interpreter.Value) ([]interpreter.Value, error) {
 
 	result := make([]interpreter.Value, 0, array.Count())
 
-	array.Iterate(nil, func(element interpreter.Value) (resume bool) {
+	array.Iterate(inter, func(element interpreter.Value) (resume bool) {
 		result = append(result, element)
 		return true
 	})
@@ -185,7 +185,7 @@ func getConstructor(inter *interpreter.Interpreter, typeName string) *interprete
 	return resultStatusConstructor
 }
 
-func addressArrayValueToSlice(accountsValue interpreter.Value) []common.Address {
+func addressArrayValueToSlice(inter *interpreter.Interpreter, accountsValue interpreter.Value) []common.Address {
 	accountsArray, ok := accountsValue.(*interpreter.ArrayValue)
 	if !ok {
 		panic(errors.NewUnreachableError())
@@ -193,7 +193,7 @@ func addressArrayValueToSlice(accountsValue interpreter.Value) []common.Address 
 
 	addresses := make([]common.Address, 0)
 
-	accountsArray.Iterate(nil, func(element interpreter.Value) (resume bool) {
+	accountsArray.Iterate(inter, func(element interpreter.Value) (resume bool) {
 		address, ok := element.(interpreter.AddressValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
@@ -220,7 +220,7 @@ func accountsArrayValueToSlice(
 
 	accounts := make([]*Account, 0)
 
-	accountsArray.Iterate(nil, func(element interpreter.Value) (resume bool) {
+	accountsArray.Iterate(inter, func(element interpreter.Value) (resume bool) {
 		accountValue, ok := element.(interpreter.MemberAccessibleValue)
 		if !ok {
 			panic(errors.NewUnreachableError())

--- a/runtime/stdlib/test_emulatorbackend.go
+++ b/runtime/stdlib/test_emulatorbackend.go
@@ -214,17 +214,17 @@ func (t *testEmulatorBackendType) newExecuteScriptFunction(testFramework TestFra
 	return interpreter.NewUnmeteredHostFunctionValue(
 		t.executeScriptFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+
 			script, ok := invocation.Arguments[0].(*interpreter.StringValue)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}
 
-			args, err := arrayValueToSlice(invocation.Arguments[1])
+			args, err := arrayValueToSlice(inter, invocation.Arguments[1])
 			if err != nil {
 				panic(errors.NewUnexpectedErrorFromCause(err))
 			}
-
-			inter := invocation.Interpreter
 
 			result := testFramework.RunScript(inter, script.Str, args)
 
@@ -346,7 +346,7 @@ func (t *testEmulatorBackendType) newAddTransactionFunction(testFramework TestFr
 				testTransactionTypeAuthorizersFieldName,
 			)
 
-			authorizers := addressArrayValueToSlice(authorizerValue)
+			authorizers := addressArrayValueToSlice(inter, authorizerValue)
 
 			// Get signers
 			signersValue := transactionValue.GetMember(
@@ -367,13 +367,13 @@ func (t *testEmulatorBackendType) newAddTransactionFunction(testFramework TestFr
 				locationRange,
 				testTransactionTypeArgumentsFieldName,
 			)
-			args, err := arrayValueToSlice(argsValue)
+			args, err := arrayValueToSlice(inter, argsValue)
 			if err != nil {
 				panic(errors.NewUnexpectedErrorFromCause(err))
 			}
 
 			err = testFramework.AddTransaction(
-				invocation.Interpreter,
+				inter,
 				code.Str,
 				authorizers,
 				signerAccounts,
@@ -471,7 +471,7 @@ func (t *testEmulatorBackendType) newDeployContractFunction(testFramework TestFr
 			account := accountFromValue(inter, accountValue, invocation.LocationRange)
 
 			// Contract init arguments
-			args, err := arrayValueToSlice(invocation.Arguments[3])
+			args, err := arrayValueToSlice(inter, invocation.Arguments[3])
 			if err != nil {
 				panic(err)
 			}
@@ -521,7 +521,7 @@ func (t *testEmulatorBackendType) newUseConfigFunction(testFramework TestFramewo
 
 			mapping := make(map[string]common.Address, addresses.Count())
 
-			addresses.Iterate(nil, func(locationValue, addressValue interpreter.Value) bool {
+			addresses.Iterate(inter, func(locationValue, addressValue interpreter.Value) bool {
 				location, ok := locationValue.(*interpreter.StringValue)
 				if !ok {
 					panic(errors.NewUnreachableError())


### PR DESCRIPTION
## Description

Since #2544, the interpreter must be passed to the `ArrayValue.Iterate` function. Previously it only needed a memory gauge.

Pass the interpreter everywhere the `Iterate` function is called, `nil` is not a valid value.

Thanks @SupunS for finding this issue.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
