### PR TITLE
Bring back type IDs in JSON encoding of funtion types and restricted types

### DIFF
--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -178,6 +178,7 @@ type jsonReferenceType struct {
 
 type jsonRestrictedType struct {
 	Kind         string      `json:"kind"`
+	TypeID       string      `json:"typeID"`
 	Type         jsonValue   `json:"type"`
 	Restrictions []jsonValue `json:"restrictions"`
 }
@@ -195,6 +196,7 @@ type jsonParameterType struct {
 
 type jsonFunctionType struct {
 	Kind           string              `json:"kind"`
+	TypeID         string              `json:"typeID"`
 	TypeParameters []jsonTypeParameter `json:"typeParameters"`
 	Parameters     []jsonParameterType `json:"parameters"`
 	Return         jsonValue           `json:"return"`
@@ -898,6 +900,7 @@ func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 	case *cadence.FunctionType:
 		return jsonFunctionType{
 			Kind:           "Function",
+			TypeID:         typ.ID(),
 			TypeParameters: prepareTypeParameters(typ.TypeParameters, results),
 			Parameters:     prepareParameters(typ.Parameters, results),
 			Return:         prepareType(typ.ReturnType, results),
@@ -915,6 +918,7 @@ func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 		}
 		return jsonRestrictedType{
 			Kind:         "Restriction",
+			TypeID:       typ.ID(),
 			Type:         prepareType(typ.Type, results),
 			Restrictions: restrictions,
 		}

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -2462,6 +2462,7 @@ func TestEncodeType(t *testing.T) {
                 "value": {
                   "staticType": {
                     "kind": "Function",
+                    "typeID": "(<T>(String):Int)",
                     "return": {
                       "kind": "Int"
                     },
@@ -2536,6 +2537,7 @@ func TestEncodeType(t *testing.T) {
                 "value": {
                   "staticType": {
                     "kind": "Restriction",
+                    "typeID": "Int{String}",
                     "type": {
                       "kind": "Int"
                     },
@@ -3402,6 +3404,7 @@ func TestExportFunctionValue(t *testing.T) {
             "value": {
               "functionType": {
                 "kind": "Function",
+                "typeID": "(():Void)",
                 "parameters": [],
                 "typeParameters": [],
                 "return": {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2766,9 +2766,11 @@ func TestRuntimeScriptReturnSpecial(t *testing.T) {
                   }
                 `,
 				expected: cadence.Function{
-					FunctionType: &cadence.FunctionType{
-						ReturnType: cadence.IntType{},
-					},
+					FunctionType: cadence.TypeWithCachedTypeID(
+						&cadence.FunctionType{
+							ReturnType: cadence.IntType{},
+						},
+					).(*cadence.FunctionType),
 				},
 			},
 		)
@@ -2786,16 +2788,18 @@ func TestRuntimeScriptReturnSpecial(t *testing.T) {
                   }
                 `,
 				expected: cadence.Function{
-					FunctionType: &cadence.FunctionType{
-						Parameters: []cadence.Parameter{
-							{
-								Label:      sema.ArgumentLabelNotRequired,
-								Identifier: "message",
-								Type:       cadence.StringType{},
+					FunctionType: cadence.TypeWithCachedTypeID(
+						&cadence.FunctionType{
+							Parameters: []cadence.Parameter{
+								{
+									Label:      sema.ArgumentLabelNotRequired,
+									Identifier: "message",
+									Type:       cadence.StringType{},
+								},
 							},
+							ReturnType: cadence.NeverType{},
 						},
-						ReturnType: cadence.NeverType{},
-					},
+					).(*cadence.FunctionType),
 				},
 			},
 		)
@@ -2818,9 +2822,11 @@ func TestRuntimeScriptReturnSpecial(t *testing.T) {
                   }
                 `,
 				expected: cadence.Function{
-					FunctionType: &cadence.FunctionType{
-						ReturnType: cadence.VoidType{},
-					},
+					FunctionType: cadence.TypeWithCachedTypeID(
+						&cadence.FunctionType{
+							ReturnType: cadence.VoidType{},
+						},
+					).(*cadence.FunctionType),
 				},
 			},
 		)


### PR DESCRIPTION

## Description

The JSON-CDC encoding of restricted types and function types used to have type IDs. 

The type IDs got replaced with structured equivalents. For example, function types used to _only_ have a type ID, but now include parameter types, return type, etc.

#2401 removed the redundant type IDs.

However, before the removal, the JSON decoder _required_ these type IDs. The older decoder is still used by developers in older Go SDK and Flow CLI releases.

Bring back the type IDs for backward compatibility. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
