### PR TITLE
Adding contract init as entry points

### DIFF
--- a/runtime/sema/entrypoint.go
+++ b/runtime/sema/entrypoint.go
@@ -70,5 +70,12 @@ func (checker *Checker) EntryPointParameters() []Parameter {
 		return functionType.Parameters
 	}
 
+	compositeDeclarations := checker.Program.CompositeDeclarations()
+	if len(compositeDeclarations) > 0 {
+		compositeDeclaration := compositeDeclarations[0]
+		compositeType := checker.Elaboration.CompositeDeclarationType(compositeDeclaration)
+		return compositeType.ConstructorParameters
+	}
+
 	return nil
 }

--- a/runtime/tests/checker/entrypoint_test.go
+++ b/runtime/tests/checker/entrypoint_test.go
@@ -193,4 +193,51 @@ func TestEntryPointParameters(t *testing.T) {
 
 		require.Empty(t, parameters)
 	})
+
+	t.Run("contract with init params", func(t *testing.T) {
+
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+			pub contract SimpleContract {
+				pub let v: Int
+				init(a: Int) {
+					self.v = a
+				}
+			}		
+        `)
+
+		require.NoError(t, err)
+
+		parameters := checker.EntryPointParameters()
+
+		require.Equal(t,
+			[]sema.Parameter{
+				{
+					Label:          "",
+					Identifier:     "a",
+					TypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
+				},
+			},
+			parameters,
+		)
+	})
+
+
+	t.Run("contract init empty", func(t *testing.T) {
+
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+			pub contract SimpleContract {
+				init() {}
+			}		
+        `)
+
+		require.NoError(t, err)
+
+		parameters := checker.EntryPointParameters()
+
+		require.Empty(t, parameters)
+	})
 }

--- a/runtime/tests/checker/entrypoint_test.go
+++ b/runtime/tests/checker/entrypoint_test.go
@@ -223,7 +223,6 @@ func TestEntryPointParameters(t *testing.T) {
 		)
 	})
 
-
 	t.Run("contract init empty", func(t *testing.T) {
 
 		t.Parallel()

--- a/tools/unkeyed/analyzer.go
+++ b/tools/unkeyed/analyzer.go
@@ -64,7 +64,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				continue
 			}
 
-
 			// check if the struct contains an unkeyed field
 			allKeyValue := true
 			var suggestedFixAvailable = len(cl.Elts) == strct.NumFields()


### PR DESCRIPTION
Closes: https://github.com/onflow/cadence-tools/issues/129

## Description

Change to Sema which is used by the Cadence Checker.
The Change includes Contract file types `init` method as a "entry point".
This will treat contracts files the same as transactions and scripts.

As I understand it "Entry points" are user inputs. The issue is with the Language Server and how it adds methods for getting entry points and parsing entry points. It has a method for getting contract initialization parameters but not for parsing. By adding contracts into the "Entry Points" then the language server can treat all file types the same.

Also, added tests for contracts init parameters


______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
