### PR TITLE
fetch event fields by name

### DIFF
--- a/types.go
+++ b/types.go
@@ -1074,6 +1074,42 @@ func NewField(identifier string, typ Type) Field {
 	}
 }
 
+type HasFields interface {
+	GetFields() []Field
+	GetFieldValues() []Value
+}
+
+func GetFieldByName(v HasFields, fieldName string) Value {
+	fieldValues := v.GetFieldValues()
+	fields := v.GetFields()
+
+	if fieldValues == nil || fields == nil {
+		return nil
+	}
+
+	for i, field := range v.GetFields() {
+		if field.Identifier == fieldName {
+			return v.GetFieldValues()[i]
+		}
+	}
+	return nil
+}
+
+func GetFieldsMappedByName(v HasFields) map[string]Value {
+	fieldValues := v.GetFieldValues()
+	fields := v.GetFields()
+
+	if fieldValues == nil || fields == nil {
+		return nil
+	}
+
+	fieldsMap := make(map[string]Value, len(fields))
+	for i, field := range fields {
+		fieldsMap[field.Identifier] = fieldValues[i]
+	}
+	return fieldsMap
+}
+
 // Parameter
 
 type Parameter struct {

--- a/values.go
+++ b/values.go
@@ -1929,6 +1929,23 @@ func (v Event) String() string {
 	return formatComposite(v.EventType.ID(), v.EventType.Fields, v.Fields)
 }
 
+func (v Event) GetFieldByName(fieldName string) Value {
+	for i, field := range v.EventType.Fields {
+		if field.Identifier == fieldName {
+			return v.Fields[i]
+		}
+	}
+	return nil
+}
+
+func (v Event) GetFieldsMappedByName() map[string]Value {
+	fields := make(map[string]Value, len(v.EventType.Fields))
+	for i, field := range v.EventType.Fields {
+		fields[field.Identifier] = v.Fields[i]
+	}
+	return fields
+}
+
 // Contract
 
 type Contract struct {

--- a/values.go
+++ b/values.go
@@ -1723,6 +1723,18 @@ func (v Struct) String() string {
 	return formatComposite(v.StructType.ID(), v.StructType.Fields, v.Fields)
 }
 
+func (v Struct) GetFields() []Field {
+	if v.StructType == nil {
+		return nil
+	}
+
+	return v.StructType.Fields
+}
+
+func (v Struct) GetFieldValues() []Value {
+	return v.Fields
+}
+
 func formatComposite(typeID string, fields []Field, values []Value) string {
 	preparedFields := make([]struct {
 		Name  string
@@ -1806,6 +1818,17 @@ func (v Resource) String() string {
 	return formatComposite(v.ResourceType.ID(), v.ResourceType.Fields, v.Fields)
 }
 
+func (v Resource) GetFields() []Field {
+	if v.ResourceType == nil {
+		return nil
+	}
+	return v.ResourceType.Fields
+}
+
+func (v Resource) GetFieldValues() []Value {
+	return v.Fields
+}
+
 // Attachment
 
 type Attachment struct {
@@ -1866,6 +1889,18 @@ func (v Attachment) ToGoValue() any {
 
 func (v Attachment) String() string {
 	return formatComposite(v.AttachmentType.ID(), v.AttachmentType.Fields, v.Fields)
+}
+
+func (v Attachment) GetFields() []Field {
+	if v.AttachmentType == nil {
+		return nil
+	}
+
+	return v.AttachmentType.Fields
+}
+
+func (v Attachment) GetFieldValues() []Value {
+	return v.Fields
 }
 
 // Event
@@ -1929,21 +1964,16 @@ func (v Event) String() string {
 	return formatComposite(v.EventType.ID(), v.EventType.Fields, v.Fields)
 }
 
-func (v Event) GetFieldByName(fieldName string) Value {
-	for i, field := range v.EventType.Fields {
-		if field.Identifier == fieldName {
-			return v.Fields[i]
-		}
+func (v Event) GetFields() []Field {
+	if v.EventType == nil {
+		return nil
 	}
-	return nil
+
+	return v.EventType.Fields
 }
 
-func (v Event) GetFieldsMappedByName() map[string]Value {
-	fields := make(map[string]Value, len(v.EventType.Fields))
-	for i, field := range v.EventType.Fields {
-		fields[field.Identifier] = v.Fields[i]
-	}
-	return fields
+func (v Event) GetFieldValues() []Value {
+	return v.Fields
 }
 
 // Contract
@@ -2006,6 +2036,18 @@ func (v Contract) ToGoValue() any {
 
 func (v Contract) String() string {
 	return formatComposite(v.ContractType.ID(), v.ContractType.Fields, v.Fields)
+}
+
+func (v Contract) GetFields() []Field {
+	if v.ContractType == nil {
+		return nil
+	}
+
+	return v.ContractType.Fields
+}
+
+func (v Contract) GetFieldValues() []Value {
+	return v.Fields
 }
 
 // PathLink
@@ -2369,6 +2411,18 @@ func (v Enum) ToGoValue() any {
 
 func (v Enum) String() string {
 	return formatComposite(v.EnumType.ID(), v.EnumType.Fields, v.Fields)
+}
+
+func (v Enum) GetFields() []Field {
+	if v.EnumType == nil {
+		return nil
+	}
+
+	return v.EnumType.Fields
+}
+
+func (v Enum) GetFieldValues() []Value {
+	return v.Fields
 }
 
 // Function

--- a/values.go
+++ b/values.go
@@ -1822,6 +1822,7 @@ func (v Resource) GetFields() []Field {
 	if v.ResourceType == nil {
 		return nil
 	}
+
 	return v.ResourceType.Fields
 }
 

--- a/values_test.go
+++ b/values_test.go
@@ -917,6 +917,34 @@ func TestValue_Type(t *testing.T) {
 	}
 }
 
+func TestValue_HasFields(t *testing.T) {
+	t.Parallel()
+
+	test := func(name string, testCase valueTestCase) {
+
+		t.Run(name, func(t *testing.T) {
+			value := testCase.value
+			switch value.(type) {
+			case Event, Struct, Contract, Enum, Resource, Attachment:
+				valueWithType := testCase.withType(value, testCase.exampleType)
+				assert.Implements(t, (*HasFields)(nil), valueWithType)
+				fieldedValueWithType := valueWithType.(HasFields)
+				assert.NotNil(t, fieldedValueWithType.GetFieldValues())
+				assert.NotNil(t, fieldedValueWithType.GetFields())
+
+				fieldedValue := value.(HasFields)
+
+				assert.Nil(t, fieldedValue.GetFields())
+			}
+		})
+
+	}
+
+	for name, testCase := range newValueTestCases() {
+		test(name, testCase)
+	}
+}
+
 func TestEvent_GetFieldByName(t *testing.T) {
 	t.Parallel()
 
@@ -925,7 +953,11 @@ func TestEvent_GetFieldByName(t *testing.T) {
 			NewInt(1),
 			String("foo"),
 		},
-	).WithType(&EventType{
+	)
+	assert.Nil(t, GetFieldsMappedByName(simpleEvent))
+	assert.Nil(t, GetFieldByName(simpleEvent, "a"))
+
+	simpleEventWithType := simpleEvent.WithType(&EventType{
 		Location:            utils.TestLocation,
 		QualifiedIdentifier: "SimpleEvent",
 		Fields: []Field{
@@ -940,12 +972,12 @@ func TestEvent_GetFieldByName(t *testing.T) {
 		},
 	})
 
-	assert.Equal(t, NewInt(1), simpleEvent.GetFieldByName("a").(Int))
-	assert.Equal(t, String("foo"), simpleEvent.GetFieldByName("b").(String))
-	assert.Nil(t, simpleEvent.GetFieldByName("c"))
+	assert.Equal(t, NewInt(1), GetFieldByName(simpleEventWithType, "a").(Int))
+	assert.Equal(t, String("foo"), GetFieldByName(simpleEventWithType, "b").(String))
+	assert.Nil(t, GetFieldByName(simpleEventWithType, "c"))
 
 	assert.Equal(t, map[string]Value{
 		"a": NewInt(1),
 		"b": String("foo"),
-	}, simpleEvent.GetFieldsMappedByName())
+	}, GetFieldsMappedByName(simpleEventWithType))
 }

--- a/values_test.go
+++ b/values_test.go
@@ -916,3 +916,36 @@ func TestValue_Type(t *testing.T) {
 		test(name, testCase)
 	}
 }
+
+func TestEvent_GetFieldByName(t *testing.T) {
+	t.Parallel()
+
+	simpleEvent := NewEvent(
+		[]Value{
+			NewInt(1),
+			String("foo"),
+		},
+	).WithType(&EventType{
+		Location:            utils.TestLocation,
+		QualifiedIdentifier: "SimpleEvent",
+		Fields: []Field{
+			{
+				Identifier: "a",
+				Type:       IntType{},
+			},
+			{
+				Identifier: "b",
+				Type:       StringType{},
+			},
+		},
+	})
+
+	assert.Equal(t, NewInt(1), simpleEvent.GetFieldByName("a").(Int))
+	assert.Equal(t, String("foo"), simpleEvent.GetFieldByName("b").(String))
+	assert.Nil(t, simpleEvent.GetFieldByName("c"))
+
+	assert.Equal(t, map[string]Value{
+		"a": NewInt(1),
+		"b": String("foo"),
+	}, simpleEvent.GetFieldsMappedByName())
+}


### PR DESCRIPTION
## Description

Added two methods to make it easy fetching event fields by their names. 
- `GetFieldByName`
- `GetFieldsMappedByName`
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
