### PR TITLE
Improve function type decoding

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -135,6 +135,7 @@ const (
 	typeParametersKey = "typeParameters"
 	returnKey         = "return"
 	typeBoundKey      = "typeBound"
+	functionTypeKey   = "functionType"
 )
 
 func (d *Decoder) decodeJSON(v any) cadence.Value {
@@ -229,6 +230,8 @@ func (d *Decoder) decodeJSON(v any) cadence.Value {
 		return d.decodeCapability(valueJSON)
 	case enumTypeStr:
 		return d.decodeEnum(valueJSON)
+	case functionTypeStr:
+		return d.decodeFunction(valueJSON)
 	}
 
 	panic(errors.NewDefaultUserError("invalid type: %s", typeStr))
@@ -880,6 +883,20 @@ func (d *Decoder) decodePath(valueJSON any) cadence.Path {
 		panic(errors.NewDefaultUserError("failed to decode path: %w", err))
 	}
 	return path
+}
+
+func (d *Decoder) decodeFunction(valueJSON any) cadence.Function {
+	obj := toObject(valueJSON)
+
+	functionType, ok := d.decodeType(obj.Get(functionTypeKey), typeDecodingResults{}).(*cadence.FunctionType)
+	if !ok {
+		panic(errors.NewDefaultUserError("invalid function: invalid function type"))
+	}
+
+	return cadence.NewMeteredFunction(
+		d.gauge,
+		functionType,
+	)
 }
 
 func (d *Decoder) decodeTypeParameter(valueJSON any, results typeDecodingResults) cadence.TypeParameter {

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -960,7 +960,10 @@ func (d *Decoder) decodeFieldType(valueJSON any, results typeDecodingResults) ca
 }
 
 func (d *Decoder) decodeFunctionType(typeParametersValue, parametersValue, returnValue any, results typeDecodingResults) cadence.Type {
-	typeParameters := d.decodeTypeParameters(toSlice(typeParametersValue), results)
+	var typeParameters []cadence.TypeParameter
+	if typeParametersValue != nil {
+		typeParameters = d.decodeTypeParameters(toSlice(typeParametersValue), results)
+	}
 	parameters := d.decodeParameters(toSlice(parametersValue), results)
 	returnType := d.decodeType(returnValue, results)
 
@@ -1132,7 +1135,7 @@ func (d *Decoder) decodeType(valueJSON any, results typeDecodingResults) cadence
 
 	switch kindValue {
 	case "Function":
-		typeParametersValue := obj.Get(typeParametersKey)
+		typeParametersValue := obj[typeParametersKey]
 		parametersValue := obj.Get(parametersKey)
 		returnValue := obj.Get(returnKey)
 		return d.decodeFunctionType(typeParametersValue, parametersValue, returnValue, results)

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -3456,3 +3456,77 @@ func TestExportFunctionValue(t *testing.T) {
         `,
 	)
 }
+
+func TestImportFunctionValue(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("without type parameters", func(t *testing.T) {
+
+		t.Parallel()
+
+		testDecode(
+			t,
+			// language=json
+			`
+              {
+                "type": "Function",
+                "value": {
+                  "functionType": {
+                    "kind": "Function",
+                    "typeID": "(():Void)",
+                    "parameters": [],
+                    "return": {
+                      "kind": "Void"
+                    }
+                  }
+                }
+              }
+            `,
+			cadence.Function{
+				FunctionType: &cadence.FunctionType{
+					Parameters: []cadence.Parameter{},
+					ReturnType: cadence.VoidType{},
+				},
+			},
+		)
+	})
+
+	t.Run("with type parameters", func(t *testing.T) {
+
+		t.Parallel()
+
+		testDecode(
+			t,
+			// language=json
+			`
+              {
+                "type": "Function",
+                "value": {
+                  "functionType": {
+                    "kind": "Function",
+                    "typeID": "(<T>():Void)",
+                    "typeParameters": [
+                      {"name": "T"}
+                    ],
+                    "parameters": [],
+                    "return": {
+                      "kind": "Void"
+                    }
+                  }
+                }
+              }
+            `,
+			cadence.Function{
+				FunctionType: &cadence.FunctionType{
+					TypeParameters: []cadence.TypeParameter{
+						{Name: "T"},
+					},
+					Parameters: []cadence.Parameter{},
+					ReturnType: cadence.VoidType{},
+				},
+			},
+		)
+	})
+
+}

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -3415,20 +3415,6 @@ func TestExportFunctionValue(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &cadence.ResourceType{
-		Location:            utils.TestLocation,
-		QualifiedIdentifier: "Foo",
-		Fields: []cadence.Field{
-			{
-				Identifier: "foo",
-			},
-		},
-	}
-
-	ty.Fields[0].Type = &cadence.OptionalType{
-		Type: ty,
-	}
-
 	testEncode(
 		t,
 		cadence.Function{

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -2440,7 +2440,7 @@ func TestEncodeType(t *testing.T) {
 
 	})
 
-	t.Run("with static function", func(t *testing.T) {
+	t.Run("with static function, with type parameters", func(t *testing.T) {
 
 		testEncodeAndDecode(
 			t,
@@ -2487,6 +2487,46 @@ func TestEncodeType(t *testing.T) {
                 }
               }
             `,
+		)
+
+	})
+
+	t.Run("with static function, without type parameters (decode only)", func(t *testing.T) {
+
+		testDecode(
+			t,
+			// language=json
+			`
+              {
+                "type": "Type",
+                "value": {
+                  "staticType": {
+                    "kind": "Function",
+                    "typeID": "((String):Int)",
+                    "return": {
+                      "kind": "Int"
+                    },
+                    "parameters": [
+                      {
+                        "label": "qux",
+                        "id": "baz",
+                        "type": {
+                          "kind": "String"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            `,
+			cadence.TypeValue{
+				StaticType: &cadence.FunctionType{
+					Parameters: []cadence.Parameter{
+						{Label: "qux", Identifier: "baz", Type: cadence.StringType{}},
+					},
+					ReturnType: cadence.IntType{},
+				},
+			},
 		)
 
 	})


### PR DESCRIPTION
## Description

Address an accidental breaking change introduced in #2401: When decoding function types, make type parameters optional, for backward compatibility.

Also, allow decoding of function values (import is already forbidden).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
