### PR TITLE
Add support for CCF encoding/decoding modes and options

### DIFF
--- a/encoding/ccf/ccf_test.go
+++ b/encoding/ccf/ccf_test.go
@@ -26,6 +26,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -38,6 +39,16 @@ import (
 	"github.com/onflow/cadence/runtime/tests/checker"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
+
+var deterministicEncMode, _ = ccf.EncOptions{
+	SortCompositeFields: ccf.SortBytewiseLexical,
+	SortRestrictedTypes: ccf.SortBytewiseLexical,
+}.EncMode()
+
+var deterministicDecMode, _ = ccf.DecOptions{
+	EnforceSortCompositeFields: ccf.EnforceSortBytewiseLexical,
+	EnforceSortRestrictedTypes: ccf.EnforceSortBytewiseLexical,
+}.DecMode()
 
 type encodeTest struct {
 	name        string
@@ -2533,32 +2544,36 @@ func TestEncodeWord128(t *testing.T) {
 func TestDecodeWord128Invalid(t *testing.T) {
 	t.Parallel()
 
-	_, err := ccf.Decode(nil, []byte{
-		// language=json, format=json-cdc
-		// {"type":"Word128","value":"0"}
-		//
-		// language=edn, format=ccf
-		// 130([137(52), 0])
-		//
-		// language=cbor, format=ccf
-		// tag
-		0xd8, ccf.CBORTagTypeAndValue,
-		// array, 2 items follow
-		0x82,
-		// tag
-		0xd8, ccf.CBORTagSimpleType,
-		// Word128 type ID (52)
-		0x18, 0x34,
-		// Invalid type
-		0xd7,
-		// bytes, 16 bytes follow
-		0x50,
-		// 340282366920938463463374607431768211455
-		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-	})
-	require.Error(t, err)
-	assert.Equal(t, "ccf: failed to decode: failed to decode Word128: cbor: cannot decode CBOR tag type to big.Int", err.Error())
+	decModes := []ccf.DecMode{ccf.EventsDecMode, deterministicDecMode}
+
+	for _, dm := range decModes {
+		_, err := dm.Decode(nil, []byte{
+			// language=json, format=json-cdc
+			// {"type":"Word128","value":"0"}
+			//
+			// language=edn, format=ccf
+			// 130([137(52), 0])
+			//
+			// language=cbor, format=ccf
+			// tag
+			0xd8, ccf.CBORTagTypeAndValue,
+			// array, 2 items follow
+			0x82,
+			// tag
+			0xd8, ccf.CBORTagSimpleType,
+			// Word128 type ID (52)
+			0x18, 0x34,
+			// Invalid type
+			0xd7,
+			// bytes, 16 bytes follow
+			0x50,
+			// 340282366920938463463374607431768211455
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		})
+		require.Error(t, err)
+		assert.Equal(t, "ccf: failed to decode: failed to decode Word128: cbor: cannot decode CBOR tag type to big.Int", err.Error())
+	}
 }
 
 func TestEncodeWord256(t *testing.T) {
@@ -2627,34 +2642,38 @@ func TestEncodeWord256(t *testing.T) {
 func TestDecodeWord256Invalid(t *testing.T) {
 	t.Parallel()
 
-	_, err := ccf.Decode(nil, []byte{
-		// language=json, format=json-cdc
-		// {"type":"Word256","value":"115792089237316195423570985008687907853269984665640564039457584007913129639935"}
-		//
-		// language=edn, format=ccf
-		// 130([137(53), 0])
-		//
-		// language=cbor, format=ccf
-		// tag
-		0xd8, ccf.CBORTagTypeAndValue,
-		// array, 2 items follow
-		0x82,
-		// tag
-		0xd8, ccf.CBORTagSimpleType,
-		// Word256 type ID (53)
-		0x18, 0x35,
-		// Invalid type
-		0xd7,
-		// bytes, 32 bytes follow
-		0x58, 0x20,
-		// 115792089237316195423570985008687907853269984665640564039457584007913129639935
-		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-	})
-	require.Error(t, err)
-	assert.Equal(t, "ccf: failed to decode: failed to decode Word256: cbor: cannot decode CBOR tag type to big.Int", err.Error())
+	decModes := []ccf.DecMode{ccf.EventsDecMode, deterministicDecMode}
+
+	for _, dm := range decModes {
+		_, err := dm.Decode(nil, []byte{
+			// language=json, format=json-cdc
+			// {"type":"Word256","value":"115792089237316195423570985008687907853269984665640564039457584007913129639935"}
+			//
+			// language=edn, format=ccf
+			// 130([137(53), 0])
+			//
+			// language=cbor, format=ccf
+			// tag
+			0xd8, ccf.CBORTagTypeAndValue,
+			// array, 2 items follow
+			0x82,
+			// tag
+			0xd8, ccf.CBORTagSimpleType,
+			// Word256 type ID (53)
+			0x18, 0x35,
+			// Invalid type
+			0xd7,
+			// bytes, 32 bytes follow
+			0x58, 0x20,
+			// 115792089237316195423570985008687907853269984665640564039457584007913129639935
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		})
+		require.Error(t, err)
+		assert.Equal(t, "ccf: failed to decode: failed to decode Word256: cbor: cannot decode CBOR tag type to big.Int", err.Error())
+	}
 }
 
 func TestEncodeFix64(t *testing.T) {
@@ -6093,7 +6112,23 @@ func TestEncodeEvent(t *testing.T) {
 		},
 	}
 
-	testAllEncodeAndDecode(t, simpleEvent, resourceEvent, abstractEvent)
+	testCases := []encodeTest{simpleEvent, resourceEvent, abstractEvent}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualCBOR, err := ccf.EventsEncMode.Encode(tc.val)
+			require.NoError(t, err)
+			utils.AssertEqualWithDiff(t, tc.expected, actualCBOR)
+
+			decodedVal, err := ccf.EventsDecMode.Decode(nil, actualCBOR)
+			require.NoError(t, err)
+			assert.Equal(
+				t,
+				cadence.ValueWithCachedTypeID(tc.val),
+				cadence.ValueWithCachedTypeID(decodedVal),
+			)
+		})
+	}
 }
 
 func TestEncodeContract(t *testing.T) {
@@ -7800,7 +7835,17 @@ func TestEncodeSimpleTypes(t *testing.T) {
 	} {
 		var w bytes.Buffer
 
-		encoder := ccf.CBOREncMode.NewStreamEncoder(&w)
+		cborEncMode := func() cbor.EncMode {
+			options := cbor.CoreDetEncOptions()
+			options.BigIntConvert = cbor.BigIntConvertNone
+			encMode, err := options.EncMode()
+			if err != nil {
+				panic(err)
+			}
+			return encMode
+		}()
+
+		encoder := cborEncMode.NewStreamEncoder(&w)
 
 		err := encoder.EncodeRawBytes([]byte{
 			// tag
@@ -10685,12 +10730,16 @@ func TestDecodeFix64(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := ccf.Decode(nil, tc.encodedData)
-			if tc.check != nil {
-				tc.check(t, actual, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tc.expected, actual)
+			decModes := []ccf.DecMode{ccf.EventsDecMode, deterministicDecMode}
+
+			for _, dm := range decModes {
+				actual, err := dm.Decode(nil, tc.encodedData)
+				if tc.check != nil {
+					tc.check(t, actual, err)
+				} else {
+					require.NoError(t, err)
+					assert.Equal(t, tc.expected, actual)
+				}
 			}
 		})
 	}
@@ -11572,9 +11621,14 @@ func TestDecodeInvalidType(t *testing.T) {
 			// array, 0 items follow
 			0x80,
 		}
-		_, err := ccf.Decode(nil, encodedData)
-		require.Error(t, err)
-		assert.Equal(t, "ccf: failed to decode: invalid type ID for built-in: ``", err.Error())
+
+		decModes := []ccf.DecMode{ccf.EventsDecMode, deterministicDecMode}
+
+		for _, dm := range decModes {
+			_, err := dm.Decode(nil, encodedData)
+			require.Error(t, err)
+			assert.Equal(t, "ccf: failed to decode: invalid type ID for built-in: ``", err.Error())
+		}
 	})
 
 	t.Run("invalid type ID", func(t *testing.T) {
@@ -11625,9 +11679,14 @@ func TestDecodeInvalidType(t *testing.T) {
 			// array, 0 items follow
 			0x80,
 		}
-		_, err := ccf.Decode(nil, encodedData)
-		require.Error(t, err)
-		assert.Equal(t, "ccf: failed to decode: invalid type ID `I`: invalid identifier location type ID: missing location", err.Error())
+
+		decModes := []ccf.DecMode{ccf.EventsDecMode, deterministicDecMode}
+
+		for _, dm := range decModes {
+			_, err := dm.Decode(nil, encodedData)
+			require.Error(t, err)
+			assert.Equal(t, "ccf: failed to decode: invalid type ID `I`: invalid identifier location type ID: missing location", err.Error())
+		}
 	})
 
 	t.Run("unknown location prefix", func(t *testing.T) {
@@ -11678,9 +11737,14 @@ func TestDecodeInvalidType(t *testing.T) {
 			// array, 0 items follow
 			0x80,
 		}
-		_, err := ccf.Decode(nil, encodedData)
-		require.Error(t, err)
-		assert.Equal(t, "ccf: failed to decode: invalid type ID for built-in: `N.PublicKey`", err.Error())
+
+		decModes := []ccf.DecMode{ccf.EventsDecMode, deterministicDecMode}
+
+		for _, dm := range decModes {
+			_, err := dm.Decode(nil, encodedData)
+			require.Error(t, err)
+			assert.Equal(t, "ccf: failed to decode: invalid type ID for built-in: `N.PublicKey`", err.Error())
+		}
 	})
 }
 
@@ -11696,7 +11760,7 @@ func testEncodeAndDecodeEx(t *testing.T, val cadence.Value, expectedCBOR []byte,
 }
 
 func testEncode(t *testing.T, val cadence.Value, expectedCBOR []byte) (actualCBOR []byte) {
-	actualCBOR, err := ccf.Encode(val)
+	actualCBOR, err := deterministicEncMode.Encode(val)
 	require.NoError(t, err)
 
 	utils.AssertEqualWithDiff(t, expectedCBOR, actualCBOR)
@@ -11704,7 +11768,7 @@ func testEncode(t *testing.T, val cadence.Value, expectedCBOR []byte) (actualCBO
 }
 
 func testDecode(t *testing.T, actualCBOR []byte, expectedVal cadence.Value) {
-	decodedVal, err := ccf.Decode(nil, actualCBOR)
+	decodedVal, err := deterministicDecMode.Decode(nil, actualCBOR)
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -12202,7 +12266,7 @@ func TestDeployedEvents(t *testing.T) {
 				// {"value":{"id":"A.f919ee77447b7497.FlowFees.FeesDeducted","fields":[{"value":{"value":"0.01797293","type":"UFix64"},"name":"amount"},{"value":{"value":"1.00000000","type":"UFix64"},"name":"inclusionEffort"},{"value":{"value":"0.00360123","type":"UFix64"},"name":"executionEffort"}]},"type":"Event"}
 				//
 				// language=edn, format=ccf
-				// 129([[162([h'', "A.f919ee77447b7497.FlowFees.FeesDeducted", [["amount", 137(23)], ["executionEffort", 137(23)], ["inclusionEffort", 137(23)]]])], [136(h''), [1797293, 360123, 100000000]]])
+				// 129([[162([h'', "A.f919ee77447b7497.FlowFees.FeesDeducted", [["amount", 137(23)], ["inclusionEffort", 137(23)], ["executionEffort", 137(23)]]])], [136(h''), [1797293, 100000000, 360123]]])
 				//
 				// language=cbor, format=ccf
 				// tag
@@ -12247,8 +12311,8 @@ func TestDeployedEvents(t *testing.T) {
 				0x82,
 				// text, 15 bytes follow
 				0x6f,
-				// executionEffort
-				0x65, 0x78, 0x65, 0x63, 0x75, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x66, 0x66, 0x6f, 0x72, 0x74,
+				// inclusionEffort
+				0x69, 0x6e, 0x63, 0x6c, 0x75, 0x73, 0x69, 0x6f, 0x6e, 0x45, 0x66, 0x66, 0x6f, 0x72, 0x74,
 				// tag
 				0xd8, ccf.CBORTagSimpleType,
 				// UFix64 type ID (23)
@@ -12258,8 +12322,8 @@ func TestDeployedEvents(t *testing.T) {
 				0x82,
 				// text, 15 bytes follow
 				0x6f,
-				// inclusionEffort
-				0x69, 0x6e, 0x63, 0x6c, 0x75, 0x73, 0x69, 0x6f, 0x6e, 0x45, 0x66, 0x66, 0x6f, 0x72, 0x74,
+				// executionEffort
+				0x65, 0x78, 0x65, 0x63, 0x75, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x66, 0x66, 0x6f, 0x72, 0x74,
 				// tag
 				0xd8, ccf.CBORTagSimpleType,
 				// UFix64 type ID (23)
@@ -12276,10 +12340,10 @@ func TestDeployedEvents(t *testing.T) {
 				0x83,
 				// 1797293
 				0x1a, 0x00, 0x1b, 0x6c, 0xad,
-				// 360123
-				0x1a, 0x00, 0x05, 0x7e, 0xbb,
 				// 100000000
 				0x1a, 0x05, 0xf5, 0xe1, 0x00,
+				// 360123
+				0x1a, 0x00, 0x05, 0x7e, 0xbb,
 			},
 		},
 		{
@@ -12352,7 +12416,7 @@ func TestDeployedEvents(t *testing.T) {
 				// {"value":{"id":"A.8624b52f9ddcd04a.FlowIDTableStaking.DelegatorRewardsPaid","fields":[{"value":{"value":"e52cbcd825e328acac8db6bcbdcbb6e7724862c8b89b09d85edccf41ff9981eb","type":"String"},"name":"nodeID"},{"value":{"value":"92","type":"UInt32"},"name":"delegatorID"},{"value":{"value":"4.38760261","type":"UFix64"},"name":"amount"}]},"type":"Event"}
 				//
 				// language=edn, format=ccf
-				// 129([[162([h'', "A.8624b52f9ddcd04a.FlowIDTableStaking.DelegatorRewardsPaid", [["amount", 137(23)], ["nodeID", 137(1)], ["delegatorID", 137(14)]]])], [136(h''), [438760261, "e52cbcd825e328acac8db6bcbdcbb6e7724862c8b89b09d85edccf41ff9981eb", 92]]])
+				// 129([[162([h'', "A.8624b52f9ddcd04a.FlowIDTableStaking.DelegatorRewardsPaid", [["nodeID", 137(1)], ["delegatorID", 137(14)], ["amount", 137(23)]]])], [136(h''), ["e52cbcd825e328acac8db6bcbdcbb6e7724862c8b89b09d85edccf41ff9981eb", 92, 438760261]]])
 				//
 				// language=cbor, format=ccf
 				// tag
@@ -12366,7 +12430,7 @@ func TestDeployedEvents(t *testing.T) {
 				// event type:
 				// id: []byte{}
 				// cadence-type-id: "A.8624b52f9ddcd04a.FlowIDTableStaking.DelegatorRewardsPaid"
-				// 3 field: [["amount", type(ufix64)], ["nodeID", type(string)], ["delegatorID", type(uint32)]]
+				// 3 field: [["nodeID", type(string)], ["delegatorID", type(uint32)], ["amount", type(ufix64)]]
 				// tag
 				0xd8, ccf.CBORTagEventType,
 				// array, 3 element follows
@@ -12387,24 +12451,13 @@ func TestDeployedEvents(t *testing.T) {
 				0x82,
 				// text, 6 bytes follow
 				0x66,
-				// "amount"
-				0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74,
-				// tag
-				0xd8, ccf.CBORTagSimpleType,
-				// UFix64 type ID (23)
-				0x17,
-				// field 1
-				// array, 2 element follows
-				0x82,
-				// text, 6 bytes follow
-				0x66,
 				// "nodeID"
 				0x6e, 0x6f, 0x64, 0x65, 0x49, 0x44,
 				// tag
 				0xd8, ccf.CBORTagSimpleType,
 				// String type ID (1)
 				0x01,
-				// field 2
+				// field 1
 				// array, 2 element follows
 				0x82,
 				// text, 11 bytes follow
@@ -12415,6 +12468,17 @@ func TestDeployedEvents(t *testing.T) {
 				0xd8, ccf.CBORTagSimpleType,
 				// UInt32 type ID (14)
 				0x0e,
+				// field 2
+				// array, 2 element follows
+				0x82,
+				// text, 6 bytes follow
+				0x66,
+				// "amount"
+				0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74,
+				// tag
+				0xd8, ccf.CBORTagSimpleType,
+				// UFix64 type ID (23)
+				0x17,
 
 				// element 1: type and value
 				// array, 2 element follows
@@ -12425,14 +12489,14 @@ func TestDeployedEvents(t *testing.T) {
 				0x40,
 				// array, 3 items follow
 				0x83,
-				// 438760261
-				0x1a, 0x1a, 0x26, 0xf3, 0x45,
 				// text, 64 bytes follow
 				0x78, 0x40,
 				// "e52cbcd825e328acac8db6bcbdcbb6e7724862c8b89b09d85edccf41ff9981eb"
 				0x65, 0x35, 0x32, 0x63, 0x62, 0x63, 0x64, 0x38, 0x32, 0x35, 0x65, 0x33, 0x32, 0x38, 0x61, 0x63, 0x61, 0x63, 0x38, 0x64, 0x62, 0x36, 0x62, 0x63, 0x62, 0x64, 0x63, 0x62, 0x62, 0x36, 0x65, 0x37, 0x37, 0x32, 0x34, 0x38, 0x36, 0x32, 0x63, 0x38, 0x62, 0x38, 0x39, 0x62, 0x30, 0x39, 0x64, 0x38, 0x35, 0x65, 0x64, 0x63, 0x63, 0x66, 0x34, 0x31, 0x66, 0x66, 0x39, 0x39, 0x38, 0x31, 0x65, 0x62,
 				// 92
 				0x18, 0x5c,
+				// 438760261
+				0x1a, 0x1a, 0x26, 0xf3, 0x45,
 			},
 		},
 		{
@@ -12443,7 +12507,7 @@ func TestDeployedEvents(t *testing.T) {
 				// {"value":{"id":"A.8624b52f9ddcd04a.FlowIDTableStaking.EpochTotalRewardsPaid","fields":[{"value":{"value":"1316543.00000000","type":"UFix64"},"name":"total"},{"value":{"value":"53.04112895","type":"UFix64"},"name":"fromFees"},{"value":{"value":"1316489.95887105","type":"UFix64"},"name":"minted"},{"value":{"value":"6.04080767","type":"UFix64"},"name":"feesBurned"}]},"type":"Event"}
 				//
 				// language=edn, format=ccf
-				// 129([[162([h'', "A.8624b52f9ddcd04a.FlowIDTableStaking.EpochTotalRewardsPaid", [["total", 137(23)], ["minted", 137(23)], ["fromFees", 137(23)], ["feesBurned", 137(23)]]])], [136(h''), [131654300000000, 131648995887105, 5304112895, 604080767]]])
+				// 129([[162([h'', "A.8624b52f9ddcd04a.FlowIDTableStaking.EpochTotalRewardsPaid", [["total", 137(23)], ["fromFees", 137(23)], ["minted", 137(23)], ["feesBurned", 137(23)]]])], [136(h''), [131654300000000, 5304112895, 131648995887105, 604080767]]])
 				//
 				// language=cbor, format=ccf
 				// tag
@@ -12486,10 +12550,10 @@ func TestDeployedEvents(t *testing.T) {
 				// field 1
 				// array, 2 element follows
 				0x82,
-				// text, 6 bytes follow
-				0x66,
-				// "minted"
-				0x6d, 0x69, 0x6e, 0x74, 0x65, 0x64,
+				// text, 8 bytes follow
+				0x68,
+				// "fromFees"
+				0x66, 0x72, 0x6f, 0x6d, 0x46, 0x65, 0x65, 0x73,
 				// tag
 				0xd8, ccf.CBORTagSimpleType,
 				// UFix64 type ID (23)
@@ -12497,10 +12561,10 @@ func TestDeployedEvents(t *testing.T) {
 				// field 2
 				// array, 2 element follows
 				0x82,
-				// text, 8 bytes follow
-				0x68,
-				// "fromFees"
-				0x66, 0x72, 0x6f, 0x6d, 0x46, 0x65, 0x65, 0x73,
+				// text, 6 bytes follow
+				0x66,
+				// "minted"
+				0x6d, 0x69, 0x6e, 0x74, 0x65, 0x64,
 				// tag
 				0xd8, ccf.CBORTagSimpleType,
 				// UFix64 type ID (23)
@@ -12528,10 +12592,10 @@ func TestDeployedEvents(t *testing.T) {
 				0x84,
 				// 131654300000000
 				0x1b, 0x00, 0x00, 0x77, 0xbd, 0x27, 0xc8, 0xdf, 0x00,
-				// 131648995887105
-				0x1b, 0x00, 0x00, 0x77, 0xbb, 0xeb, 0xa2, 0x88, 0x01,
 				// 5304112895
 				0x1b, 0x00, 0x00, 0x00, 0x01, 0x3c, 0x26, 0x56, 0xff,
+				// 131648995887105
+				0x1b, 0x00, 0x00, 0x77, 0xbb, 0xeb, 0xa2, 0x88, 0x01,
 				// 604080767
 				0x1a, 0x24, 0x01, 0x8a, 0x7f,
 			},
@@ -12606,7 +12670,7 @@ func TestDeployedEvents(t *testing.T) {
 				// {"value":{"id":"A.8624b52f9ddcd04a.FlowIDTableStaking.RewardsPaid","fields":[{"value":{"value":"e52cbcd825e328acac8db6bcbdcbb6e7724862c8b89b09d85edccf41ff9981eb","type":"String"},"name":"nodeID"},{"value":{"value":"1745.49955740","type":"UFix64"},"name":"amount"}]},"type":"Event"}
 				//
 				// language=edn, format=ccf
-				// 129([[162([h'', "A.8624b52f9ddcd04a.FlowIDTableStaking.RewardsPaid", [["amount", 137(23)], ["nodeID", 137(1)]]])], [136(h''), [174549955740, "e52cbcd825e328acac8db6bcbdcbb6e7724862c8b89b09d85edccf41ff9981eb"]]])
+				// 129([[162([h'', "A.8624b52f9ddcd04a.FlowIDTableStaking.RewardsPaid", [["nodeID", 137(1)], ["amount", 137(23)]]])], [136(h''), ["e52cbcd825e328acac8db6bcbdcbb6e7724862c8b89b09d85edccf41ff9981eb", 174549955740]]])
 				//
 				// language=cbor, format=ccf
 				// tag
@@ -12619,7 +12683,7 @@ func TestDeployedEvents(t *testing.T) {
 				// event type:
 				// id: []byte{}
 				// cadence-type-id: "A.8624b52f9ddcd04a.FlowIDTableStaking.RewardsPaid"
-				// 2 field: [["amount", type(ufix64)], ["nodeID", type(string)]]
+				// 2 field: [["nodeID", type(string)], ["amount", type(ufix64)]]
 				// tag
 				0xd8, ccf.CBORTagEventType,
 				// array, 3 element follows
@@ -12640,23 +12704,23 @@ func TestDeployedEvents(t *testing.T) {
 				0x82,
 				// text, 6 bytes follow
 				0x66,
-				// "amount"
-				0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74,
-				// tag
-				0xd8, ccf.CBORTagSimpleType,
-				// UFix64 type ID (23)
-				0x17,
-				// field 1
-				// array, 2 element follows
-				0x82,
-				// text, 6 bytes follow
-				0x66,
 				// "nodeID"
 				0x6e, 0x6f, 0x64, 0x65, 0x49, 0x44,
 				// tag
 				0xd8, ccf.CBORTagSimpleType,
 				// String type ID (1)
 				0x01,
+				// field 1
+				// array, 2 element follows
+				0x82,
+				// text, 6 bytes follow
+				0x66,
+				// "amount"
+				0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74,
+				// tag
+				0xd8, ccf.CBORTagSimpleType,
+				// UFix64 type ID (23)
+				0x17,
 
 				// element 1: type and value
 				// array, 2 element follows
@@ -12667,12 +12731,12 @@ func TestDeployedEvents(t *testing.T) {
 				0x40,
 				// array, 2 items follow
 				0x82,
-				// 174549955740
-				0x1b, 0x00, 0x00, 0x00, 0x28, 0xa3, 0xfc, 0xf4, 0x9c,
 				// string, 64 bytes follow
 				0x78, 0x40,
 				// "e52cbcd825e328acac8db6bcbdcbb6e7724862c8b89b09d85edccf41ff9981eb"
 				0x65, 0x35, 0x32, 0x63, 0x62, 0x63, 0x64, 0x38, 0x32, 0x35, 0x65, 0x33, 0x32, 0x38, 0x61, 0x63, 0x61, 0x63, 0x38, 0x64, 0x62, 0x36, 0x62, 0x63, 0x62, 0x64, 0x63, 0x62, 0x62, 0x36, 0x65, 0x37, 0x37, 0x32, 0x34, 0x38, 0x36, 0x32, 0x63, 0x38, 0x62, 0x38, 0x39, 0x62, 0x30, 0x39, 0x64, 0x38, 0x35, 0x65, 0x64, 0x63, 0x63, 0x66, 0x34, 0x31, 0x66, 0x66, 0x39, 0x39, 0x38, 0x31, 0x65, 0x62,
+				// 174549955740
+				0x1b, 0x00, 0x00, 0x00, 0x28, 0xa3, 0xfc, 0xf4, 0x9c,
 			},
 		},
 		{
@@ -12683,7 +12747,7 @@ func TestDeployedEvents(t *testing.T) {
 				// {"value":{"id":"A.1654653399040a61.FlowToken.TokensDeposited","fields":[{"value":{"value":"1316489.95887105","type":"UFix64"},"name":"amount"},{"value":{"value":null,"type":"Optional"},"name":"to"}]},"type":"Event"}
 				//
 				// language=edn, format=ccf
-				// 129([[162([h'', "A.1654653399040a61.FlowToken.TokensDeposited", [["to", 138(137(3))], ["amount", 137(23)]]])], [136(h''), [null, 131648995887105]]])
+				// 129([[162([h'', "A.1654653399040a61.FlowToken.TokensDeposited", [["amount", 137(23)], ["to", 138(137(3))]]])], [136(h''), [131648995887105, null]]])
 				//
 				// language=cbor, format=ccf
 				// tag
@@ -12715,6 +12779,17 @@ func TestDeployedEvents(t *testing.T) {
 				// field 0
 				// array, 2 element follows
 				0x82,
+				// text, 6 bytes follow
+				0x66,
+				// "amount"
+				0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74,
+				// tag
+				0xd8, ccf.CBORTagSimpleType,
+				// UFix64 type ID (23)
+				0x17,
+				// field 1
+				// array, 2 element follows
+				0x82,
 				// text, 2 bytes follow
 				0x62,
 				// "to"
@@ -12725,17 +12800,6 @@ func TestDeployedEvents(t *testing.T) {
 				0xd8, ccf.CBORTagSimpleType,
 				// Address type ID (3)
 				0x03,
-				// field 1
-				// array, 2 element follows
-				0x82,
-				// text, 6 bytes follow
-				0x66,
-				// "amount"
-				0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74,
-				// tag
-				0xd8, ccf.CBORTagSimpleType,
-				// UFix64 type ID (23)
-				0x17,
 
 				// element 1: type and value
 				// array, 2 element follows
@@ -12746,10 +12810,10 @@ func TestDeployedEvents(t *testing.T) {
 				0x40,
 				// array, 2 items follow
 				0x82,
-				// null
-				0xf6,
 				// 131648995887105
 				0x1b, 0x00, 0x00, 0x77, 0xbb, 0xeb, 0xa2, 0x88, 0x01,
+				// null
+				0xf6,
 			},
 		},
 		{
@@ -12760,7 +12824,7 @@ func TestDeployedEvents(t *testing.T) {
 				// {"value":{"id":"A.1654653399040a61.FlowToken.TokensDeposited","fields":[{"value":{"value":"1745.49955740","type":"UFix64"},"name":"amount"},{"value":{"value":{"value":"0x8624b52f9ddcd04a","type":"Address"},"type":"Optional"},"name":"to"}]},"type":"Event"}
 				//
 				// language=edn, format=ccf
-				// 129([[162([h'', "A.1654653399040a61.FlowToken.TokensDeposited", [["to", 138(137(3))], ["amount", 137(23)]]])], [136(h''), [h'8624B52F9DDCD04A', 174549955740]]])
+				// 129([[162([h'', "A.1654653399040a61.FlowToken.TokensDeposited", [["amount", 137(23)], ["to", 138(137(3))]]])], [136(h''), [174549955740, h'8624B52F9DDCD04A']]])
 				//
 				// language=cbor, format=ccf
 				// tag
@@ -12792,6 +12856,17 @@ func TestDeployedEvents(t *testing.T) {
 				// field 0
 				// array, 2 element follows
 				0x82,
+				// text, 6 bytes follow
+				0x66,
+				// "amount"
+				0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74,
+				// tag
+				0xd8, ccf.CBORTagSimpleType,
+				// UFix64 type ID (23)
+				0x17,
+				// field 1
+				// array, 2 element follows
+				0x82,
 				// text, 2 bytes follow
 				0x62,
 				// "to"
@@ -12802,17 +12877,6 @@ func TestDeployedEvents(t *testing.T) {
 				0xd8, ccf.CBORTagSimpleType,
 				// Address type ID (3)
 				0x03,
-				// field 1
-				// array, 2 element follows
-				0x82,
-				// text, 6 bytes follow
-				0x66,
-				// "amount"
-				0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74,
-				// tag
-				0xd8, ccf.CBORTagSimpleType,
-				// UFix64 type ID (23)
-				0x17,
 
 				// element 1: type and value
 				// array, 2 element follows
@@ -12823,12 +12887,12 @@ func TestDeployedEvents(t *testing.T) {
 				0x40,
 				// array, 2 items follow
 				0x82,
+				// 174549955740
+				0x1b, 0x00, 0x00, 0x00, 0x28, 0xa3, 0xfc, 0xf4, 0x9c,
 				// bytes, 8 bytes follow
 				0x48,
 				// 0x8624b52f9ddcd04a
 				0x86, 0x24, 0xb5, 0x2f, 0x9d, 0xdc, 0xd0, 0x4a,
-				// 174549955740
-				0x1b, 0x00, 0x00, 0x00, 0x28, 0xa3, 0xfc, 0xf4, 0x9c,
 			},
 		},
 		{
@@ -12901,7 +12965,7 @@ func TestDeployedEvents(t *testing.T) {
 				// {"value":{"id":"A.1654653399040a61.FlowToken.TokensWithdrawn","fields":[{"value":{"value":"53.04112895","type":"UFix64"},"name":"amount"},{"value":{"value":{"value":"0xf919ee77447b7497","type":"Address"},"type":"Optional"},"name":"from"}]},"type":"Event"}
 				//
 				// language=edn, format=ccf
-				// 129([[162([h'', "A.1654653399040a61.FlowToken.TokensWithdrawn", [["from", 138(137(3))], ["amount", 137(23)]]])], [136(h''), [h'F919EE77447B7497', 5304112895]]])
+				// 129([[162([h'', "A.1654653399040a61.FlowToken.TokensWithdrawn", [["amount", 137(23)], ["from", 138(137(3))]]])], [136(h''), [5304112895, h'F919EE77447B7497']]])
 				//
 				// language=cbor, format=ccf
 				// tag
@@ -12933,6 +12997,17 @@ func TestDeployedEvents(t *testing.T) {
 				// field 0
 				// array, 2 element follows
 				0x82,
+				// text, 6 bytes follow
+				0x66,
+				// "amount"
+				0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74,
+				// tag
+				0xd8, ccf.CBORTagSimpleType,
+				// UFix64 type ID (23)
+				0x17,
+				// field 1
+				// array, 2 element follows
+				0x82,
 				// text, 4 bytes follow
 				0x64,
 				// "from"
@@ -12943,17 +13018,6 @@ func TestDeployedEvents(t *testing.T) {
 				0xd8, ccf.CBORTagSimpleType,
 				// Address type ID (3)
 				0x03,
-				// field 1
-				// array, 2 element follows
-				0x82,
-				// text, 6 bytes follow
-				0x66,
-				// "amount"
-				0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74,
-				// tag
-				0xd8, ccf.CBORTagSimpleType,
-				// UFix64 type ID (23)
-				0x17,
 
 				// element 1: type and value
 				// array, 2 element follows
@@ -12964,12 +13028,12 @@ func TestDeployedEvents(t *testing.T) {
 				0x40,
 				// array, 2 items follow
 				0x82,
+				// 5304112895
+				0x1b, 0x00, 0x00, 0x00, 0x01, 0x3c, 0x26, 0x56, 0xff,
 				// bytes, 8 bytes follow
 				0x48,
 				// 0xf919ee77447b7497
 				0xf9, 0x19, 0xee, 0x77, 0x44, 0x7b, 0x74, 0x97,
-				// 5304112895
-				0x1b, 0x00, 0x00, 0x00, 0x01, 0x3c, 0x26, 0x56, 0xff,
 			},
 		},
 	}
@@ -12979,17 +13043,20 @@ func TestDeployedEvents(t *testing.T) {
 			t.Parallel()
 
 			// Encode Cadence value to CCF
-			actualCBOR, err := ccf.Encode(tc.event)
+			actualCBOR, err := ccf.EventsEncMode.Encode(tc.event)
 			require.NoError(t, err)
 			utils.AssertEqualWithDiff(t, tc.expectedCBOR, actualCBOR)
 
 			// Decode CCF to Cadence value
-			decodedEvent, err := ccf.Decode(nil, actualCBOR)
+			decodedEvent, err := ccf.EventsDecMode.Decode(nil, actualCBOR)
 			require.NoError(t, err)
 
-			// Test original event and decoded events are equal even if
-			// fields are ordered differently due to deterministic encoding.
-			testEventEquality(t, tc.event, decodedEvent.(cadence.Event))
+			// Since event encoding doesn't sort fields, make sure that input event is identical to decoded event.
+			require.Equal(
+				t,
+				cadence.ValueWithCachedTypeID(tc.event),
+				cadence.ValueWithCachedTypeID(decodedEvent),
+			)
 		})
 	}
 
@@ -13199,10 +13266,10 @@ func createFlowTokenTokensWithdrawnEvent() cadence.Event {
 	addressBytes, _ := hex.DecodeString("f919ee77447b7497")
 
 	amount, _ := cadence.NewUFix64("53.04112895")
-	to := cadence.NewOptional(cadence.BytesToAddress(addressBytes))
+	from := cadence.NewOptional(cadence.BytesToAddress(addressBytes))
 
 	return cadence.NewEvent(
-		[]cadence.Value{amount, to},
+		[]cadence.Value{amount, from},
 	).WithType(newFlowTokenTokensWithdrawnEventType())
 }
 
@@ -13363,38 +13430,17 @@ func createFlowIDTableStakingRewardsPaidEvent() cadence.Event {
 	).WithType(newFlowIDTableStakingRewardsPaidEventType())
 }
 
-func testEventEquality(t *testing.T, event1 cadence.Event, event2 cadence.Event) {
-	require.True(t, event1.Type().Equal(event2.Type()))
-	require.Equal(t, len(event1.Fields), len(event2.Fields))
-	require.Equal(t, len(event1.EventType.Fields), len(event2.EventType.Fields))
-
-	for i, event1FieldType := range event1.EventType.Fields {
-
-		foundField := false
-
-		for j, event2FieldType := range event2.EventType.Fields {
-			if event1FieldType.Identifier == event2FieldType.Identifier {
-				require.Equal(t, event1.Fields[i], event2.Fields[j])
-				foundField = true
-				break
-			}
-		}
-
-		require.True(t, foundField)
-	}
-}
-
 func TestDecodeTruncatedData(t *testing.T) {
 	t.Parallel()
 
-	data, err := ccf.Encode(createFlowTokenTokensWithdrawnEvent())
+	data, err := deterministicEncMode.Encode(createFlowTokenTokensWithdrawnEvent())
 	require.NoError(t, err)
 
-	_, err = ccf.Decode(nil, data)
+	_, err = deterministicDecMode.Decode(nil, data)
 	require.NoError(t, err)
 
 	for i := len(data) - 1; i >= 0; i-- {
-		decodedVal, err := ccf.Decode(nil, data[:i])
+		decodedVal, err := deterministicDecMode.Decode(nil, data[:i])
 		require.Nil(t, decodedVal)
 		require.Error(t, err)
 	}
@@ -14221,7 +14267,7 @@ func TestDecodeInvalidData(t *testing.T) {
 	test := func(tc testCase) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			decodedVal, err := ccf.Decode(nil, tc.data)
+			decodedVal, err := deterministicDecMode.Decode(nil, tc.data)
 			require.Nil(t, decodedVal)
 			require.Error(t, err)
 		})

--- a/encoding/ccf/decode_type.go
+++ b/encoding/ccf/decode_type.go
@@ -590,12 +590,14 @@ func (d *Decoder) decodeRestrictedType(
 			return nil, fmt.Errorf("found duplicate restricted type %s", restrictedTypeID)
 		}
 
-		// "Deterministic CCF Encoding Requirements" in CCF specs:
-		//
-		//   "restricted-type.restrictions MUST be sorted by restriction's cadence-type-id"
-		//   "restricted-type-value.restrictions MUST be sorted by restriction's cadence-type-id."
-		if !stringsAreSortedBytewise(previousRestrictedTypeID, restrictedTypeID) {
-			return nil, fmt.Errorf("restricted types are not sorted (%s, %s)", previousRestrictedTypeID, restrictedTypeID)
+		if d.dm.enforceSortRestrictedTypes == EnforceSortBytewiseLexical {
+			// "Deterministic CCF Encoding Requirements" in CCF specs:
+			//
+			//   "restricted-type.restrictions MUST be sorted by restriction's cadence-type-id"
+			//   "restricted-type-value.restrictions MUST be sorted by restriction's cadence-type-id."
+			if !stringsAreSortedBytewise(previousRestrictedTypeID, restrictedTypeID) {
+				return nil, fmt.Errorf("restricted types are not sorted (%s, %s)", previousRestrictedTypeID, restrictedTypeID)
+			}
 		}
 
 		restrictionTypeIDs[restrictedTypeID] = struct{}{}

--- a/encoding/ccf/encode.go
+++ b/encoding/ccf/encode.go
@@ -1077,7 +1077,7 @@ func (e *Encoder) encodeComposite(
 		}
 
 	default:
-		panic(fmt.Errorf("unsupported sort option for composite fields: %d", e.em.sortCompositeFields))
+		panic(cadenceErrors.NewUnexpectedError("unsupported sort option for composite fields: %d", e.em.sortCompositeFields))
 	}
 }
 
@@ -1755,7 +1755,7 @@ func (e *Encoder) encodeFieldTypeValues(fieldTypes []cadence.Field, visited ccfT
 		}
 
 	default:
-		panic(fmt.Errorf("unsupported sort option for composite field type values: %d", e.em.sortCompositeFields))
+		panic(cadenceErrors.NewUnexpectedError("unsupported sort option for composite field type values: %d", e.em.sortCompositeFields))
 	}
 }
 

--- a/encoding/ccf/encode_type.go
+++ b/encoding/ccf/encode_type.go
@@ -19,7 +19,6 @@
 package ccf
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/onflow/cadence"
@@ -448,7 +447,7 @@ func (e *Encoder) encodeRestrictedTypeWithRawTag(
 		}
 
 	default:
-		panic(fmt.Errorf("unsupported sort option for restricted types: %d", e.em.sortRestrictedTypes))
+		panic(cadenceErrors.NewUnexpectedError("unsupported sort option for restricted types: %d", e.em.sortRestrictedTypes))
 	}
 }
 

--- a/encoding/ccf/encode_type.go
+++ b/encoding/ccf/encode_type.go
@@ -404,6 +404,17 @@ func (e *Encoder) encodeRestrictedTypeWithRawTag(
 		return err
 	}
 
+	if e.em.sortRestrictedTypes == SortNone {
+		for _, res := range restrictions {
+			// Encode restriction type with given encodeTypeFn.
+			err = encodeRestrictionTypeFn(res, tids)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	switch len(restrictions) {
 	case 0:
 		// Short-circuit if there is no restriction.

--- a/encoding/ccf/encode_typedef.go
+++ b/encoding/ccf/encode_typedef.go
@@ -19,8 +19,6 @@
 package ccf
 
 import (
-	"fmt"
-
 	"github.com/onflow/cadence"
 	cadenceErrors "github.com/onflow/cadence/runtime/errors"
 )
@@ -177,7 +175,7 @@ func (e *Encoder) encodeCompositeTypeFields(typ cadence.CompositeType, tids ccfT
 		}
 
 	default:
-		panic(fmt.Errorf("unsupported sort option for composite field types: %d", e.em.sortCompositeFields))
+		panic(cadenceErrors.NewUnexpectedError("unsupported sort option for composite field types: %d", e.em.sortCompositeFields))
 	}
 }
 

--- a/encoding/ccf/encode_typedef.go
+++ b/encoding/ccf/encode_typedef.go
@@ -136,6 +136,17 @@ func (e *Encoder) encodeCompositeTypeFields(typ cadence.CompositeType, tids ccfT
 		return err
 	}
 
+	if e.em.sortCompositeFields == SortNone {
+		for _, fieldType := range fieldTypes {
+			// Encode field
+			err = e.encodeCompositeTypeField(fieldType, tids)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	switch len(fieldTypes) {
 	case 0:
 		// Short-circuit if there is no field type.

--- a/encoding/ccf/service_events_test.go
+++ b/encoding/ccf/service_events_test.go
@@ -34,6 +34,10 @@ func TestEpochSetupEvent(t *testing.T) {
 	b, err := ccf.Encode(event)
 	require.NoError(t, err)
 
+	// Test that encoded value isn't sorted.
+	_, err = deterministicDecMode.Decode(nil, b)
+	require.Error(t, err)
+
 	decodedValue, err := ccf.Decode(nil, b)
 	require.NoError(t, err)
 
@@ -327,6 +331,10 @@ func TestEpochCommitEvent(t *testing.T) {
 	b, err := ccf.Encode(event)
 	require.NoError(t, err)
 
+	// Test that encoded value isn't sorted.
+	_, err = deterministicDecMode.Decode(nil, b)
+	require.Error(t, err)
+
 	decodedValue, err := ccf.Decode(nil, b)
 	require.NoError(t, err)
 
@@ -433,6 +441,10 @@ func TestVersionBeaconEvent(t *testing.T) {
 
 	b, err := ccf.Encode(event)
 	require.NoError(t, err)
+
+	// Test that encoded value isn't sorted.
+	_, err = deterministicDecMode.Decode(nil, b)
+	require.Error(t, err)
 
 	decodedValue, err := ccf.Decode(nil, b)
 	require.NoError(t, err)

--- a/encoding/ccf/service_events_test.go
+++ b/encoding/ccf/service_events_test.go
@@ -1,60 +1,508 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ccf_test
 
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/ccf"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/stretchr/testify/require"
 )
 
-func TestVersionBeaconEvent(t *testing.T) {
-	event := createVersionBeaconEvent()
+func TestEpochSetupEvent(t *testing.T) {
+	event := createEpochSetupEvent()
+
 	b, err := ccf.Encode(event)
 	require.NoError(t, err)
 
-	decodedEvent, err := ccf.Decode(nil, b)
+	decodedValue, err := ccf.Decode(nil, b)
 	require.NoError(t, err)
 
 	// Test decoded event has unsorted fields.
-	// If field is struct (such as semver), the struct field should be unsorted as well.
+	// If field is struct (such as NodeInfo), struct fields should be unsorted as well.
 
-	evt, ok := decodedEvent.(cadence.Event)
+	evt, ok := decodedValue.(cadence.Event)
+	require.True(t, ok)
+	require.Equal(t, 9, len(evt.Fields))
+
+	evtType, ok := decodedValue.Type().(*cadence.EventType)
+	require.True(t, ok)
+	require.Equal(t, 9, len(evtType.Fields))
+
+	// field 0: counter
+	require.Equal(t, "counter", evtType.Fields[0].Identifier)
+	require.Equal(t, cadence.UInt64(1), evt.Fields[0])
+
+	// field 1: nodeInfo
+	require.Equal(t, "nodeInfo", evtType.Fields[1].Identifier)
+	nodeInfos, ok := evt.Fields[1].(cadence.Array)
+	require.True(t, ok)
+	testNodeInfos(t, nodeInfos)
+
+	// field 2: firstView
+	require.Equal(t, "firstView", evtType.Fields[2].Identifier)
+	require.Equal(t, cadence.UInt64(100), evt.Fields[2])
+
+	// field 3: finalView
+	require.Equal(t, "finalView", evtType.Fields[3].Identifier)
+	require.Equal(t, cadence.UInt64(200), evt.Fields[3])
+
+	// field 4: collectorClusters
+	require.Equal(t, "collectorClusters", evtType.Fields[4].Identifier)
+	epochCollectors, ok := evt.Fields[4].(cadence.Array)
+	require.True(t, ok)
+	testEpochCollectors(t, epochCollectors)
+
+	// field 5: randomSource
+	require.Equal(t, "randomSource", evtType.Fields[5].Identifier)
+	require.Equal(t, cadence.String("01020304"), evt.Fields[5])
+
+	// field 6: DKGPhase1FinalView
+	require.Equal(t, "DKGPhase1FinalView", evtType.Fields[6].Identifier)
+	require.Equal(t, cadence.UInt64(150), evt.Fields[6])
+
+	// field 7: DKGPhase2FinalView
+	require.Equal(t, "DKGPhase2FinalView", evtType.Fields[7].Identifier)
+	require.Equal(t, cadence.UInt64(160), evt.Fields[7])
+
+	// field 8: DKGPhase3FinalView
+	require.Equal(t, "DKGPhase3FinalView", evtType.Fields[8].Identifier)
+	require.Equal(t, cadence.UInt64(170), evt.Fields[8])
+}
+
+func testNodeInfos(t *testing.T, nodeInfos cadence.Array) {
+	require.Equal(t, 7, len(nodeInfos.Values))
+
+	// Test nodeInfo 0
+
+	node0, ok := nodeInfos.Values[0].(cadence.Struct)
+	require.True(t, ok)
+	require.Equal(t, 14, len(node0.Fields))
+
+	nodeInfoType, ok := node0.Type().(*cadence.StructType)
+	require.True(t, ok)
+	require.Equal(t, 14, len(nodeInfoType.Fields))
+
+	// field 0: id
+	require.Equal(t, "id", nodeInfoType.Fields[0].Identifier)
+	require.Equal(t, cadence.String("0000000000000000000000000000000000000000000000000000000000000001"), node0.Fields[0])
+
+	// field 1: role
+	require.Equal(t, "role", nodeInfoType.Fields[1].Identifier)
+	require.Equal(t, cadence.UInt8(1), node0.Fields[1])
+
+	// field 2: networkingAddress
+	require.Equal(t, "networkingAddress", nodeInfoType.Fields[2].Identifier)
+	require.Equal(t, cadence.String("1.flow.com"), node0.Fields[2])
+
+	// field 3: networkingKey
+	require.Equal(t, "networkingKey", nodeInfoType.Fields[3].Identifier)
+	require.Equal(t, cadence.String("378dbf45d85c614feb10d8bd4f78f4b6ef8eec7d987b937e123255444657fb3da031f232a507e323df3a6f6b8f50339c51d188e80c0e7a92420945cc6ca893fc"), node0.Fields[3])
+
+	// field 4: stakingKey
+	require.Equal(t, "stakingKey", nodeInfoType.Fields[4].Identifier)
+	require.Equal(t, cadence.String("af4aade26d76bb2ab15dcc89adcef82a51f6f04b3cb5f4555214b40ec89813c7a5f95776ea4fe449de48166d0bbc59b919b7eabebaac9614cf6f9461fac257765415f4d8ef1376a2365ec9960121888ea5383d88a140c24c29962b0a14e4e4e7"), node0.Fields[4])
+
+	// field 5: tokensStaked
+	require.Equal(t, "tokensStaked", nodeInfoType.Fields[5].Identifier)
+	require.Equal(t, ufix64FromString("0.00000000"), node0.Fields[5])
+
+	// field 6: tokensCommitted
+	require.Equal(t, "tokensCommitted", nodeInfoType.Fields[6].Identifier)
+	require.Equal(t, ufix64FromString("1350000.00000000"), node0.Fields[6])
+
+	// field 7: tokensUnstaking
+	require.Equal(t, "tokensUnstaking", nodeInfoType.Fields[7].Identifier)
+	require.Equal(t, ufix64FromString("0.00000000"), node0.Fields[7])
+
+	// field 8: tokensUnstaked
+	require.Equal(t, "tokensUnstaked", nodeInfoType.Fields[8].Identifier)
+	require.Equal(t, ufix64FromString("0.00000000"), node0.Fields[8])
+
+	// field 9: tokensRewarded
+	require.Equal(t, "tokensRewarded", nodeInfoType.Fields[9].Identifier)
+	require.Equal(t, ufix64FromString("0.00000000"), node0.Fields[9])
+
+	// field 10: delegators
+	require.Equal(t, "delegators", nodeInfoType.Fields[10].Identifier)
+	delegators, ok := node0.Fields[10].(cadence.Array)
+	require.True(t, ok)
+	require.Equal(t, 0, len(delegators.Values))
+
+	// field 11: delegatorIDCounter
+	require.Equal(t, "delegatorIDCounter", nodeInfoType.Fields[11].Identifier)
+	require.Equal(t, cadence.UInt32(0), node0.Fields[11])
+
+	// field 12: tokensRequestedToUnstake
+	require.Equal(t, "tokensRequestedToUnstake", nodeInfoType.Fields[12].Identifier)
+	require.Equal(t, ufix64FromString("0.00000000"), node0.Fields[12])
+
+	// field 13: initialWeight
+	require.Equal(t, "initialWeight", nodeInfoType.Fields[13].Identifier)
+	require.Equal(t, cadence.UInt64(100), node0.Fields[13])
+
+	// Test nodeInfo 6 (last nodeInfo struct)
+
+	node6, ok := nodeInfos.Values[6].(cadence.Struct)
+	require.True(t, ok)
+	require.Equal(t, 14, len(node6.Fields))
+
+	nodeInfoType, ok = node6.Type().(*cadence.StructType)
+	require.True(t, ok)
+	require.Equal(t, 14, len(nodeInfoType.Fields))
+
+	// field 0: id
+	require.Equal(t, "id", nodeInfoType.Fields[0].Identifier)
+	require.Equal(t, cadence.String("0000000000000000000000000000000000000000000000000000000000000031"), node6.Fields[0])
+
+	// field 1: role
+	require.Equal(t, "role", nodeInfoType.Fields[1].Identifier)
+	require.Equal(t, cadence.UInt8(4), node6.Fields[1])
+
+	// field 2: networkingAddress
+	require.Equal(t, "networkingAddress", nodeInfoType.Fields[2].Identifier)
+	require.Equal(t, cadence.String("31.flow.com"), node6.Fields[2])
+
+	// field 3: networkingKey
+	require.Equal(t, "networkingKey", nodeInfoType.Fields[3].Identifier)
+	require.Equal(t, cadence.String("697241208dcc9142b6f53064adc8ff1c95760c68beb2ba083c1d005d40181fd7a1b113274e0163c053a3addd47cd528ec6a1f190cf465aac87c415feaae011ae"), node6.Fields[3])
+
+	// field 4: stakingKey
+	require.Equal(t, "stakingKey", nodeInfoType.Fields[4].Identifier)
+	require.Equal(t, cadence.String("b1f97d0a06020eca97352e1adde72270ee713c7daf58da7e74bf72235321048b4841bdfc28227964bf18e371e266e32107d238358848bcc5d0977a0db4bda0b4c33d3874ff991e595e0f537c7b87b4ddce92038ebc7b295c9ea20a1492302aa7"), node6.Fields[4])
+
+	// field 5: tokensStaked
+	require.Equal(t, "tokensStaked", nodeInfoType.Fields[5].Identifier)
+	require.Equal(t, ufix64FromString("0.00000000"), node6.Fields[5])
+
+	// field 6: tokensCommitted
+	require.Equal(t, "tokensCommitted", nodeInfoType.Fields[6].Identifier)
+	require.Equal(t, ufix64FromString("1350000.00000000"), node6.Fields[6])
+
+	// field 7: tokensUnstaking
+	require.Equal(t, "tokensUnstaking", nodeInfoType.Fields[7].Identifier)
+	require.Equal(t, ufix64FromString("0.00000000"), node6.Fields[7])
+
+	// field 8: tokensUnstaked
+	require.Equal(t, "tokensUnstaked", nodeInfoType.Fields[8].Identifier)
+	require.Equal(t, ufix64FromString("0.00000000"), node6.Fields[8])
+
+	// field 9: tokensRewarded
+	require.Equal(t, "tokensRewarded", nodeInfoType.Fields[9].Identifier)
+	require.Equal(t, ufix64FromString("0.00000000"), node6.Fields[9])
+
+	// field 10: delegators
+	require.Equal(t, "delegators", nodeInfoType.Fields[10].Identifier)
+	delegators, ok = node6.Fields[10].(cadence.Array)
+	require.True(t, ok)
+	require.Equal(t, 0, len(delegators.Values))
+
+	// field 11: delegatorIDCounter
+	require.Equal(t, "delegatorIDCounter", nodeInfoType.Fields[11].Identifier)
+	require.Equal(t, cadence.UInt32(0), node6.Fields[11])
+
+	// field 12: tokensRequestedToUnstake
+	require.Equal(t, "tokensRequestedToUnstake", nodeInfoType.Fields[12].Identifier)
+	require.Equal(t, ufix64FromString("0.00000000"), node6.Fields[12])
+
+	// field 13: initialWeight
+	require.Equal(t, "initialWeight", nodeInfoType.Fields[13].Identifier)
+	require.Equal(t, cadence.UInt64(100), node6.Fields[13])
+}
+
+func testEpochCollectors(t *testing.T, collectors cadence.Array) {
+	require.Equal(t, 2, len(collectors.Values))
+
+	// collector 0
+	collector0, ok := collectors.Values[0].(cadence.Struct)
+	require.True(t, ok)
+
+	collectorType, ok := collector0.Type().(*cadence.StructType)
+	require.True(t, ok)
+
+	// field 0: index
+	require.Equal(t, "index", collectorType.Fields[0].Identifier)
+	require.Equal(t, cadence.UInt16(0), collector0.Fields[0])
+
+	// field 1: nodeWeights
+	require.Equal(t, "nodeWeights", collectorType.Fields[1].Identifier)
+	weights, ok := collector0.Fields[1].(cadence.Dictionary)
+	require.True(t, ok)
+	require.Equal(t, 2, len(weights.Pairs))
+	require.Equal(t,
+		cadence.KeyValuePair{
+			Key:   cadence.String("0000000000000000000000000000000000000000000000000000000000000001"),
+			Value: cadence.UInt64(100),
+		},
+		weights.Pairs[0])
+	require.Equal(t,
+		cadence.KeyValuePair{
+			Key:   cadence.String("0000000000000000000000000000000000000000000000000000000000000002"),
+			Value: cadence.UInt64(100),
+		}, weights.Pairs[1])
+
+	// field 2: totalWeight
+	require.Equal(t, "totalWeight", collectorType.Fields[2].Identifier)
+	require.Equal(t, cadence.NewUInt64(100), collector0.Fields[2])
+
+	// field 3: generatedVotes
+	require.Equal(t, "generatedVotes", collectorType.Fields[3].Identifier)
+	generatedVotes, ok := collector0.Fields[3].(cadence.Dictionary)
+	require.True(t, ok)
+	require.Equal(t, 0, len(generatedVotes.Pairs))
+
+	// field 4: uniqueVoteMessageTotalWeights
+	require.Equal(t, "uniqueVoteMessageTotalWeights", collectorType.Fields[4].Identifier)
+	uniqueVoteMessageTotalWeights, ok := collector0.Fields[4].(cadence.Dictionary)
+	require.True(t, ok)
+	require.Equal(t, 0, len(uniqueVoteMessageTotalWeights.Pairs))
+
+	// collector 1
+	collector1, ok := collectors.Values[1].(cadence.Struct)
+	require.True(t, ok)
+
+	collectorType, ok = collector1.Type().(*cadence.StructType)
+	require.True(t, ok)
+
+	// field 0: index
+	require.Equal(t, "index", collectorType.Fields[0].Identifier)
+	require.Equal(t, cadence.UInt16(1), collector1.Fields[0])
+
+	// field 1: nodeWeights
+	require.Equal(t, "nodeWeights", collectorType.Fields[1].Identifier)
+	weights, ok = collector1.Fields[1].(cadence.Dictionary)
+	require.True(t, ok)
+	require.Equal(t, 2, len(weights.Pairs))
+	require.Equal(t,
+		cadence.KeyValuePair{
+			Key:   cadence.String("0000000000000000000000000000000000000000000000000000000000000003"),
+			Value: cadence.UInt64(100),
+		},
+		weights.Pairs[0])
+	require.Equal(t,
+		cadence.KeyValuePair{
+			Key:   cadence.String("0000000000000000000000000000000000000000000000000000000000000004"),
+			Value: cadence.UInt64(100),
+		}, weights.Pairs[1])
+
+	// field 2: totalWeight
+	require.Equal(t, "totalWeight", collectorType.Fields[2].Identifier)
+	require.Equal(t, cadence.NewUInt64(0), collector1.Fields[2])
+
+	// field 3: generatedVotes
+	require.Equal(t, "generatedVotes", collectorType.Fields[3].Identifier)
+	generatedVotes, ok = collector1.Fields[3].(cadence.Dictionary)
+	require.True(t, ok)
+	require.Equal(t, 0, len(generatedVotes.Pairs))
+
+	// field 4: uniqueVoteMessageTotalWeights
+	require.Equal(t, "uniqueVoteMessageTotalWeights", collectorType.Fields[4].Identifier)
+	uniqueVoteMessageTotalWeights, ok = collector1.Fields[4].(cadence.Dictionary)
+	require.True(t, ok)
+	require.Equal(t, 0, len(uniqueVoteMessageTotalWeights.Pairs))
+}
+
+func TestEpochCommitEvent(t *testing.T) {
+	event := createEpochCommittedEvent()
+
+	b, err := ccf.Encode(event)
+	require.NoError(t, err)
+
+	decodedValue, err := ccf.Decode(nil, b)
+	require.NoError(t, err)
+
+	// Test decoded event has unsorted fields.
+	// If field is struct (such as ClusterQC), struct fields should be unsorted as well.
+
+	evt, ok := decodedValue.(cadence.Event)
+	require.True(t, ok)
+	require.Equal(t, 3, len(evt.Fields))
+
+	evtType, ok := decodedValue.Type().(*cadence.EventType)
+	require.True(t, ok)
+	require.Equal(t, 3, len(evtType.Fields))
+
+	// field 0: counter
+	require.Equal(t, "counter", evtType.Fields[0].Identifier)
+	require.Equal(t, cadence.UInt64(1), evt.Fields[0])
+
+	// field 1: clusterQCs
+	require.Equal(t, "clusterQCs", evtType.Fields[1].Identifier)
+	clusterQCs, ok := evt.Fields[1].(cadence.Array)
+	require.True(t, ok)
+	testClusterQCs(t, clusterQCs)
+
+	// field 2: dkgPubKeys
+	require.Equal(t, "dkgPubKeys", evtType.Fields[2].Identifier)
+	dkgPubKeys, ok := evt.Fields[2].(cadence.Array)
+	require.True(t, ok)
+	require.Equal(t, 2, len(dkgPubKeys.Values))
+	require.Equal(t, cadence.String("8c588266db5f5cda629e83f8aa04ae9413593fac19e4865d06d291c9d14fbdd9bdb86a7a12f9ef8590c79cb635e3163315d193087e9336092987150d0cd2b14ac6365f7dc93eec573752108b8c12368abb65f0652d9f644e5aed611c37926950"), dkgPubKeys.Values[0])
+	require.Equal(t, cadence.String("87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"), dkgPubKeys.Values[1])
+}
+
+func testClusterQCs(t *testing.T, clusterQCs cadence.Array) {
+	require.Equal(t, 2, len(clusterQCs.Values))
+
+	// Test clusterQC0
+
+	clusterQC0, ok := clusterQCs.Values[0].(cadence.Struct)
+	require.True(t, ok)
+
+	clusterQCType, ok := clusterQC0.Type().(*cadence.StructType)
+	require.True(t, ok)
+
+	// field 0: index
+	require.Equal(t, "index", clusterQCType.Fields[0].Identifier)
+	require.Equal(t, cadence.UInt16(0), clusterQC0.Fields[0])
+
+	// field 1: voteSignatures
+	require.Equal(t, "voteSignatures", clusterQCType.Fields[1].Identifier)
+	sigs, ok := clusterQC0.Fields[1].(cadence.Array)
+	require.True(t, ok)
+	require.Equal(t, 2, len(sigs.Values))
+	require.Equal(t, cadence.String("a39cd1e1bf7e2fb0609b7388ce5215a6a4c01eef2aee86e1a007faa28a6b2a3dc876e11bb97cdb26c3846231d2d01e4d"), sigs.Values[0])
+	require.Equal(t, cadence.String("91673ad9c717d396c9a0953617733c128049ac1a639653d4002ab245b121df1939430e313bcbfd06948f6a281f6bf853"), sigs.Values[1])
+
+	// field 2: voteMessage
+	require.Equal(t, "voteMessage", clusterQCType.Fields[2].Identifier)
+	require.Equal(t, cadence.String("irrelevant_for_these_purposes"), clusterQC0.Fields[2])
+
+	// field 3: voterIDs
+	require.Equal(t, "voterIDs", clusterQCType.Fields[3].Identifier)
+	ids, ok := clusterQC0.Fields[3].(cadence.Array)
+	require.True(t, ok)
+	require.Equal(t, 2, len(ids.Values))
+	require.Equal(t, cadence.String("0000000000000000000000000000000000000000000000000000000000000001"), ids.Values[0])
+	require.Equal(t, cadence.String("0000000000000000000000000000000000000000000000000000000000000002"), ids.Values[1])
+
+	// Test clusterQC1
+
+	clusterQC1, ok := clusterQCs.Values[1].(cadence.Struct)
+	require.True(t, ok)
+
+	clusterQCType, ok = clusterQC1.Type().(*cadence.StructType)
+	require.True(t, ok)
+
+	// field 0: index
+	require.Equal(t, "index", clusterQCType.Fields[0].Identifier)
+	require.Equal(t, cadence.UInt16(1), clusterQC1.Fields[0])
+
+	// field 1: voteSignatures
+	require.Equal(t, "voteSignatures", clusterQCType.Fields[1].Identifier)
+	sigs, ok = clusterQC1.Fields[1].(cadence.Array)
+	require.True(t, ok)
+	require.Equal(t, 2, len(sigs.Values))
+	require.Equal(t, cadence.String("b2bff159971852ed63e72c37991e62c94822e52d4fdcd7bf29aaf9fb178b1c5b4ce20dd9594e029f3574cb29533b857a"), sigs.Values[0])
+	require.Equal(t, cadence.String("9931562f0248c9195758da3de4fb92f24fa734cbc20c0cb80280163560e0e0348f843ac89ecbd3732e335940c1e8dccb"), sigs.Values[1])
+
+	// field 2: voteMessage
+	require.Equal(t, "voteMessage", clusterQCType.Fields[2].Identifier)
+	require.Equal(t, cadence.String("irrelevant_for_these_purposes"), clusterQC1.Fields[2])
+
+	// field 3: voterIDs
+	require.Equal(t, "voterIDs", clusterQCType.Fields[3].Identifier)
+	ids, ok = clusterQC1.Fields[3].(cadence.Array)
+	require.True(t, ok)
+	require.Equal(t, 2, len(ids.Values))
+	require.Equal(t, cadence.String("0000000000000000000000000000000000000000000000000000000000000003"), ids.Values[0])
+	require.Equal(t, cadence.String("0000000000000000000000000000000000000000000000000000000000000004"), ids.Values[1])
+}
+
+func TestVersionBeaconEvent(t *testing.T) {
+	event := createVersionBeaconEvent()
+
+	b, err := ccf.Encode(event)
+	require.NoError(t, err)
+
+	decodedValue, err := ccf.Decode(nil, b)
+	require.NoError(t, err)
+
+	// Test decoded event has unsorted fields.
+	// If field is struct (such as semver), struct fields should be unsorted as well.
+
+	evt, ok := decodedValue.(cadence.Event)
 	require.True(t, ok)
 	require.Equal(t, 2, len(evt.Fields))
 
-	// VersionBeacon.versionBoundaries
+	evtType, ok := decodedValue.Type().(*cadence.EventType)
+	require.True(t, ok)
+	require.Equal(t, 2, len(evtType.Fields))
+
+	// field 0: versionBoundaries
+	require.Equal(t, "versionBoundaries", evtType.Fields[0].Identifier)
 	versionBoundaries, ok := evt.Fields[0].(cadence.Array)
 	require.True(t, ok)
+	testVersionBoundaries(t, versionBoundaries)
+
+	// field 1: sequence
+	require.Equal(t, "sequence", evtType.Fields[1].Identifier)
+	require.Equal(t, cadence.UInt64(5), evt.Fields[1])
+}
+
+func testVersionBoundaries(t *testing.T, versionBoundaries cadence.Array) {
 	require.Equal(t, 1, len(versionBoundaries.Values))
 
 	boundary, ok := versionBoundaries.Values[0].(cadence.Struct)
 	require.True(t, ok)
 	require.Equal(t, 2, len(boundary.Fields))
 
-	// versionBoundaries.blockHeight
+	boundaryType, ok := boundary.Type().(*cadence.StructType)
+	require.True(t, ok)
+	require.Equal(t, 2, len(boundaryType.Fields))
+
+	// field 0: blockHeight
+	require.Equal(t, "blockHeight", boundaryType.Fields[0].Identifier)
 	require.Equal(t, cadence.UInt64(44), boundary.Fields[0])
 
-	// versionBoundaries.version
+	// field 1: version
+	require.Equal(t, "version", boundaryType.Fields[1].Identifier)
 	version, ok := boundary.Fields[1].(cadence.Struct)
 	require.True(t, ok)
+	testSemver(t, version)
+}
+
+func testSemver(t *testing.T, version cadence.Struct) {
 	require.Equal(t, 4, len(version.Fields))
 
-	// version.preRelease
+	semverType, ok := version.Type().(*cadence.StructType)
+	require.True(t, ok)
+	require.Equal(t, 4, len(semverType.Fields))
+
+	// field 0: preRelease
+	require.Equal(t, "preRelease", semverType.Fields[0].Identifier)
 	require.Equal(t, cadence.NewOptional(cadence.String("")), version.Fields[0])
 
-	// version.major
+	// field 1: major
+	require.Equal(t, "major", semverType.Fields[1].Identifier)
 	require.Equal(t, cadence.UInt8(2), version.Fields[1])
 
-	// version.minor
+	// field 2: minor
+	require.Equal(t, "minor", semverType.Fields[2].Identifier)
 	require.Equal(t, cadence.UInt8(13), version.Fields[2])
 
-	// version.patch
+	// field 3: patch
+	require.Equal(t, "patch", semverType.Fields[3].Identifier)
 	require.Equal(t, cadence.UInt8(7), version.Fields[3])
-
-	// VersionBeacon.sequence
-	require.Equal(t, cadence.UInt64(5), evt.Fields[1])
 }
 
 func createEpochSetupEvent() cadence.Event {
@@ -543,9 +991,9 @@ func createVersionBeaconEvent() cadence.Event {
 	semverType := newNodeVersionBeaconSemverStructType()
 
 	semver := cadence.NewStruct([]cadence.Value{
-
 		// preRelease
 		cadence.NewOptional(cadence.String("")),
+
 		// major
 		cadence.UInt8(2),
 

--- a/encoding/ccf/service_events_test.go
+++ b/encoding/ccf/service_events_test.go
@@ -1,0 +1,911 @@
+package ccf_test
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/ccf"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionBeaconEvent(t *testing.T) {
+	event := createVersionBeaconEvent()
+	b, err := ccf.Encode(event)
+	require.NoError(t, err)
+
+	decodedEvent, err := ccf.Decode(nil, b)
+	require.NoError(t, err)
+
+	// Test decoded event has unsorted fields.
+	// If field is struct (such as semver), the struct field should be unsorted as well.
+
+	evt, ok := decodedEvent.(cadence.Event)
+	require.True(t, ok)
+	require.Equal(t, 2, len(evt.Fields))
+
+	// VersionBeacon.versionBoundaries
+	versionBoundaries, ok := evt.Fields[0].(cadence.Array)
+	require.True(t, ok)
+	require.Equal(t, 1, len(versionBoundaries.Values))
+
+	boundary, ok := versionBoundaries.Values[0].(cadence.Struct)
+	require.True(t, ok)
+	require.Equal(t, 2, len(boundary.Fields))
+
+	// versionBoundaries.blockHeight
+	require.Equal(t, cadence.UInt64(44), boundary.Fields[0])
+
+	// versionBoundaries.version
+	version, ok := boundary.Fields[1].(cadence.Struct)
+	require.True(t, ok)
+	require.Equal(t, 4, len(version.Fields))
+
+	// version.preRelease
+	require.Equal(t, cadence.NewOptional(cadence.String("")), version.Fields[0])
+
+	// version.major
+	require.Equal(t, cadence.UInt8(2), version.Fields[1])
+
+	// version.minor
+	require.Equal(t, cadence.UInt8(13), version.Fields[2])
+
+	// version.patch
+	require.Equal(t, cadence.UInt8(7), version.Fields[3])
+
+	// VersionBeacon.sequence
+	require.Equal(t, cadence.UInt64(5), evt.Fields[1])
+}
+
+func createEpochSetupEvent() cadence.Event {
+	return cadence.NewEvent([]cadence.Value{
+		// counter
+		cadence.NewUInt64(1),
+
+		// nodeInfo
+		createEpochNodes(),
+
+		// firstView
+		cadence.NewUInt64(100),
+
+		// finalView
+		cadence.NewUInt64(200),
+
+		// collectorClusters
+		createEpochCollectors(),
+
+		// randomSource
+		cadence.String("01020304"),
+
+		// DKGPhase1FinalView
+		cadence.UInt64(150),
+
+		// DKGPhase2FinalView
+		cadence.UInt64(160),
+
+		// DKGPhase3FinalView
+		cadence.UInt64(170),
+	}).WithType(newFlowEpochEpochSetupEventType())
+}
+
+func createEpochNodes() cadence.Array {
+
+	nodeInfoType := newFlowIDTableStakingNodeInfoStructType()
+
+	nodeInfo1 := cadence.NewStruct([]cadence.Value{
+		// id
+		cadence.String("0000000000000000000000000000000000000000000000000000000000000001"),
+
+		// role
+		cadence.UInt8(1),
+
+		// networkingAddress
+		cadence.String("1.flow.com"),
+
+		// networkingKey
+		cadence.String("378dbf45d85c614feb10d8bd4f78f4b6ef8eec7d987b937e123255444657fb3da031f232a507e323df3a6f6b8f50339c51d188e80c0e7a92420945cc6ca893fc"),
+
+		// stakingKey
+		cadence.String("af4aade26d76bb2ab15dcc89adcef82a51f6f04b3cb5f4555214b40ec89813c7a5f95776ea4fe449de48166d0bbc59b919b7eabebaac9614cf6f9461fac257765415f4d8ef1376a2365ec9960121888ea5383d88a140c24c29962b0a14e4e4e7"),
+
+		// tokensStaked
+		ufix64FromString("0.00000000"),
+
+		// tokensCommitted
+		ufix64FromString("1350000.00000000"),
+
+		// tokensUnstaking
+		ufix64FromString("0.00000000"),
+
+		// tokensUnstaked
+		ufix64FromString("0.00000000"),
+
+		// tokensRewarded
+		ufix64FromString("0.00000000"),
+
+		// delegators
+		cadence.NewArray([]cadence.Value{}).WithType(cadence.NewVariableSizedArrayType(cadence.NewUInt32Type())),
+
+		// delegatorIDCounter
+		cadence.UInt32(0),
+
+		// tokensRequestedToUnstake
+		ufix64FromString("0.00000000"),
+
+		// initialWeight
+		cadence.UInt64(100),
+	}).WithType(nodeInfoType)
+
+	nodeInfo2 := cadence.NewStruct([]cadence.Value{
+		// id
+		cadence.String("0000000000000000000000000000000000000000000000000000000000000002"),
+
+		// role
+		cadence.UInt8(1),
+
+		// networkingAddress
+		cadence.String("2.flow.com"),
+
+		// networkingKey
+		cadence.String("378dbf45d85c614feb10d8bd4f78f4b6ef8eec7d987b937e123255444657fb3da031f232a507e323df3a6f6b8f50339c51d188e80c0e7a92420945cc6ca893fc"),
+
+		// stakingKey
+		cadence.String("af4aade26d76bb2ab15dcc89adcef82a51f6f04b3cb5f4555214b40ec89813c7a5f95776ea4fe449de48166d0bbc59b919b7eabebaac9614cf6f9461fac257765415f4d8ef1376a2365ec9960121888ea5383d88a140c24c29962b0a14e4e4e7"),
+
+		// tokensStaked
+		ufix64FromString("0.00000000"),
+
+		// tokensCommitted
+		ufix64FromString("1350000.00000000"),
+
+		// tokensUnstaking
+		ufix64FromString("0.00000000"),
+
+		// tokensUnstaked
+		ufix64FromString("0.00000000"),
+
+		// tokensRewarded
+		ufix64FromString("0.00000000"),
+
+		// delegators
+		cadence.NewArray([]cadence.Value{}).WithType(cadence.NewVariableSizedArrayType(cadence.NewUInt32Type())),
+
+		// delegatorIDCounter
+		cadence.UInt32(0),
+
+		// tokensRequestedToUnstake
+		ufix64FromString("0.00000000"),
+
+		// initialWeight
+		cadence.UInt64(100),
+	}).WithType(nodeInfoType)
+
+	nodeInfo3 := cadence.NewStruct([]cadence.Value{
+		// id
+		cadence.String("0000000000000000000000000000000000000000000000000000000000000003"),
+
+		// role
+		cadence.UInt8(1),
+
+		// networkingAddress
+		cadence.String("3.flow.com"),
+
+		// networkingKey
+		cadence.String("378dbf45d85c614feb10d8bd4f78f4b6ef8eec7d987b937e123255444657fb3da031f232a507e323df3a6f6b8f50339c51d188e80c0e7a92420945cc6ca893fc"),
+
+		// stakingKey
+		cadence.String("af4aade26d76bb2ab15dcc89adcef82a51f6f04b3cb5f4555214b40ec89813c7a5f95776ea4fe449de48166d0bbc59b919b7eabebaac9614cf6f9461fac257765415f4d8ef1376a2365ec9960121888ea5383d88a140c24c29962b0a14e4e4e7"),
+
+		// tokensStaked
+		ufix64FromString("0.00000000"),
+
+		// tokensCommitted
+		ufix64FromString("1350000.00000000"),
+
+		// tokensUnstaking
+		ufix64FromString("0.00000000"),
+
+		// tokensUnstaked
+		ufix64FromString("0.00000000"),
+
+		// tokensRewarded
+		ufix64FromString("0.00000000"),
+
+		// delegators
+		cadence.NewArray([]cadence.Value{}).WithType(cadence.NewVariableSizedArrayType(cadence.NewUInt32Type())),
+
+		// delegatorIDCounter
+		cadence.UInt32(0),
+
+		// tokensRequestedToUnstake
+		ufix64FromString("0.00000000"),
+
+		// initialWeight
+		cadence.UInt64(100),
+	}).WithType(nodeInfoType)
+
+	nodeInfo4 := cadence.NewStruct([]cadence.Value{
+		// id
+		cadence.String("0000000000000000000000000000000000000000000000000000000000000004"),
+
+		// role
+		cadence.UInt8(1),
+
+		// networkingAddress
+		cadence.String("4.flow.com"),
+
+		// networkingKey
+		cadence.String("378dbf45d85c614feb10d8bd4f78f4b6ef8eec7d987b937e123255444657fb3da031f232a507e323df3a6f6b8f50339c51d188e80c0e7a92420945cc6ca893fc"),
+
+		// stakingKey
+		cadence.String("af4aade26d76bb2ab15dcc89adcef82a51f6f04b3cb5f4555214b40ec89813c7a5f95776ea4fe449de48166d0bbc59b919b7eabebaac9614cf6f9461fac257765415f4d8ef1376a2365ec9960121888ea5383d88a140c24c29962b0a14e4e4e7"),
+
+		// tokensStaked
+		ufix64FromString("0.00000000"),
+
+		// tokensCommitted
+		ufix64FromString("1350000.00000000"),
+
+		// tokensUnstaking
+		ufix64FromString("0.00000000"),
+
+		// tokensUnstaked
+		ufix64FromString("0.00000000"),
+
+		// tokensRewarded
+		ufix64FromString("0.00000000"),
+
+		// delegators
+		cadence.NewArray([]cadence.Value{}).WithType(cadence.NewVariableSizedArrayType(cadence.NewUInt32Type())),
+
+		// delegatorIDCounter
+		cadence.UInt32(0),
+
+		// tokensRequestedToUnstake
+		ufix64FromString("0.00000000"),
+
+		// initialWeight
+		cadence.UInt64(100),
+	}).WithType(nodeInfoType)
+
+	nodeInfo5 := cadence.NewStruct([]cadence.Value{
+		// id
+		cadence.String("0000000000000000000000000000000000000000000000000000000000000011"),
+
+		// role
+		cadence.UInt8(2),
+
+		// networkingAddress
+		cadence.String("11.flow.com"),
+
+		// networkingKey
+		cadence.String("cfdfe8e4362c8f79d11772cb7277ab16e5033a63e8dd5d34caf1b041b77e5b2d63c2072260949ccf8907486e4cfc733c8c42ca0e4e208f30470b0d950856cd47"),
+
+		// stakingKey
+		cadence.String("8207559cd7136af378bba53a8f0196dee3849a3ab02897c1995c3e3f6ca0c4a776c3ae869d1ddbb473090054be2400ad06d7910aa2c5d1780220fdf3765a3c1764bce10c6fe66a5a2be51a422e878518bd750424bb56b8a0ecf0f8ad2057e83f"),
+
+		// tokensStaked
+		ufix64FromString("0.00000000"),
+
+		// tokensCommitted
+		ufix64FromString("1350000.00000000"),
+
+		// tokensUnstaking
+		ufix64FromString("0.00000000"),
+
+		// tokensUnstaked
+		ufix64FromString("0.00000000"),
+
+		// tokensRewarded
+		ufix64FromString("0.00000000"),
+
+		// delegators
+		cadence.NewArray([]cadence.Value{}).WithType(cadence.NewVariableSizedArrayType(cadence.NewUInt32Type())),
+
+		// delegatorIDCounter
+		cadence.UInt32(0),
+
+		// tokensRequestedToUnstake
+		ufix64FromString("0.00000000"),
+
+		// initialWeight
+		cadence.UInt64(100),
+	}).WithType(nodeInfoType)
+
+	nodeInfo6 := cadence.NewStruct([]cadence.Value{
+		// id
+		cadence.String("0000000000000000000000000000000000000000000000000000000000000021"),
+
+		// role
+		cadence.UInt8(3),
+
+		// networkingAddress
+		cadence.String("21.flow.com"),
+
+		// networkingKey
+		cadence.String("d64318ba0dbf68f3788fc81c41d507c5822bf53154530673127c66f50fe4469ccf1a054a868a9f88506a8999f2386d86fcd2b901779718cba4fb53c2da258f9e"),
+
+		// stakingKey
+		cadence.String("880b162b7ec138b36af401d07868cb08d25746d905395edbb4625bdf105d4bb2b2f4b0f4ae273a296a6efefa7ce9ccb914e39947ce0e83745125cab05d62516076ff0173ed472d3791ccef937597c9ea12381d76f547a092a4981d77ff3fba83"),
+
+		// tokensStaked
+		ufix64FromString("0.00000000"),
+
+		// tokensCommitted
+		ufix64FromString("1350000.00000000"),
+
+		// tokensUnstaking
+		ufix64FromString("0.00000000"),
+
+		// tokensUnstaked
+		ufix64FromString("0.00000000"),
+
+		// tokensRewarded
+		ufix64FromString("0.00000000"),
+
+		// delegators
+		cadence.NewArray([]cadence.Value{}).WithType(cadence.NewVariableSizedArrayType(cadence.NewUInt32Type())),
+
+		// delegatorIDCounter
+		cadence.UInt32(0),
+
+		// tokensRequestedToUnstake
+		ufix64FromString("0.00000000"),
+
+		// initialWeight
+		cadence.UInt64(100),
+	}).WithType(nodeInfoType)
+
+	nodeInfo7 := cadence.NewStruct([]cadence.Value{
+		// id
+		cadence.String("0000000000000000000000000000000000000000000000000000000000000031"),
+
+		// role
+		cadence.UInt8(4),
+
+		// networkingAddress
+		cadence.String("31.flow.com"),
+
+		// networkingKey
+		cadence.String("697241208dcc9142b6f53064adc8ff1c95760c68beb2ba083c1d005d40181fd7a1b113274e0163c053a3addd47cd528ec6a1f190cf465aac87c415feaae011ae"),
+
+		// stakingKey
+		cadence.String("b1f97d0a06020eca97352e1adde72270ee713c7daf58da7e74bf72235321048b4841bdfc28227964bf18e371e266e32107d238358848bcc5d0977a0db4bda0b4c33d3874ff991e595e0f537c7b87b4ddce92038ebc7b295c9ea20a1492302aa7"),
+
+		// tokensStaked
+		ufix64FromString("0.00000000"),
+
+		// tokensCommitted
+		ufix64FromString("1350000.00000000"),
+
+		// tokensUnstaking
+		ufix64FromString("0.00000000"),
+
+		// tokensUnstaked
+		ufix64FromString("0.00000000"),
+
+		// tokensRewarded
+		ufix64FromString("0.00000000"),
+
+		// delegators
+		cadence.NewArray([]cadence.Value{}).WithType(cadence.NewVariableSizedArrayType(cadence.NewUInt32Type())),
+
+		// delegatorIDCounter
+		cadence.UInt32(0),
+
+		// tokensRequestedToUnstake
+		ufix64FromString("0.00000000"),
+
+		// initialWeight
+		cadence.UInt64(100),
+	}).WithType(nodeInfoType)
+
+	return cadence.NewArray([]cadence.Value{
+		nodeInfo1,
+		nodeInfo2,
+		nodeInfo3,
+		nodeInfo4,
+		nodeInfo5,
+		nodeInfo6,
+		nodeInfo7,
+	}).WithType(cadence.NewVariableSizedArrayType(nodeInfoType))
+}
+
+func createEpochCollectors() cadence.Array {
+
+	clusterType := newFlowClusterQCClusterStructType()
+
+	voteType := newFlowClusterQCVoteStructType()
+
+	cluster1 := cadence.NewStruct([]cadence.Value{
+		// index
+		cadence.NewUInt16(0),
+
+		// nodeWeights
+		cadence.NewDictionary([]cadence.KeyValuePair{
+			{
+				Key:   cadence.String("0000000000000000000000000000000000000000000000000000000000000001"),
+				Value: cadence.UInt64(100),
+			},
+			{
+				Key:   cadence.String("0000000000000000000000000000000000000000000000000000000000000002"),
+				Value: cadence.UInt64(100),
+			},
+		}).WithType(cadence.NewMeteredDictionaryType(nil, cadence.StringType{}, cadence.UInt64Type{})),
+
+		// totalWeight
+		cadence.NewUInt64(100),
+
+		// generatedVotes
+		cadence.NewDictionary(nil).WithType(cadence.NewDictionaryType(cadence.StringType{}, voteType)),
+
+		// uniqueVoteMessageTotalWeights
+		cadence.NewDictionary(nil).WithType(cadence.NewDictionaryType(cadence.StringType{}, cadence.UInt64Type{})),
+	}).WithType(clusterType)
+
+	cluster2 := cadence.NewStruct([]cadence.Value{
+		// index
+		cadence.NewUInt16(1),
+
+		// nodeWeights
+		cadence.NewDictionary([]cadence.KeyValuePair{
+			{
+				Key:   cadence.String("0000000000000000000000000000000000000000000000000000000000000003"),
+				Value: cadence.UInt64(100),
+			},
+			{
+				Key:   cadence.String("0000000000000000000000000000000000000000000000000000000000000004"),
+				Value: cadence.UInt64(100),
+			},
+		}).WithType(cadence.NewMeteredDictionaryType(nil, cadence.StringType{}, cadence.UInt64Type{})),
+
+		// totalWeight
+		cadence.NewUInt64(0),
+
+		// generatedVotes
+		cadence.NewDictionary(nil).WithType(cadence.NewDictionaryType(cadence.StringType{}, voteType)),
+
+		// uniqueVoteMessageTotalWeights
+		cadence.NewDictionary(nil).WithType(cadence.NewDictionaryType(cadence.StringType{}, cadence.UInt64Type{})),
+	}).WithType(clusterType)
+
+	return cadence.NewArray([]cadence.Value{
+		cluster1,
+		cluster2,
+	}).WithType(cadence.NewVariableSizedArrayType(clusterType))
+}
+
+func createEpochCommittedEvent() cadence.Event {
+
+	clusterQCType := newFlowClusterQCClusterQCStructType()
+
+	cluster1 := cadence.NewStruct([]cadence.Value{
+		// index
+		cadence.UInt16(0),
+
+		// voteSignatures
+		cadence.NewArray([]cadence.Value{
+			cadence.String("a39cd1e1bf7e2fb0609b7388ce5215a6a4c01eef2aee86e1a007faa28a6b2a3dc876e11bb97cdb26c3846231d2d01e4d"),
+			cadence.String("91673ad9c717d396c9a0953617733c128049ac1a639653d4002ab245b121df1939430e313bcbfd06948f6a281f6bf853"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType{})),
+
+		// voteMessage
+		cadence.String("irrelevant_for_these_purposes"),
+
+		// voterIDs
+		cadence.NewArray([]cadence.Value{
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000001"),
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000002"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType{})),
+	}).WithType(clusterQCType)
+
+	cluster2 := cadence.NewStruct([]cadence.Value{
+		// index
+		cadence.UInt16(1),
+
+		// voteSignatures
+		cadence.NewArray([]cadence.Value{
+			cadence.String("b2bff159971852ed63e72c37991e62c94822e52d4fdcd7bf29aaf9fb178b1c5b4ce20dd9594e029f3574cb29533b857a"),
+			cadence.String("9931562f0248c9195758da3de4fb92f24fa734cbc20c0cb80280163560e0e0348f843ac89ecbd3732e335940c1e8dccb"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType{})),
+
+		// voteMessage
+		cadence.String("irrelevant_for_these_purposes"),
+
+		// voterIDs
+		cadence.NewArray([]cadence.Value{
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000003"),
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000004"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType{})),
+	}).WithType(clusterQCType)
+
+	return cadence.NewEvent([]cadence.Value{
+		// counter
+		cadence.NewUInt64(1),
+
+		// clusterQCs
+		cadence.NewArray([]cadence.Value{
+			cluster1,
+			cluster2,
+		}).WithType(cadence.NewVariableSizedArrayType(clusterQCType)),
+
+		// dkgPubKeys
+		cadence.NewArray([]cadence.Value{
+			cadence.String("8c588266db5f5cda629e83f8aa04ae9413593fac19e4865d06d291c9d14fbdd9bdb86a7a12f9ef8590c79cb635e3163315d193087e9336092987150d0cd2b14ac6365f7dc93eec573752108b8c12368abb65f0652d9f644e5aed611c37926950"),
+			cadence.String("87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType{})),
+	}).WithType(newFlowEpochEpochCommittedEventType())
+}
+
+func createVersionBeaconEvent() cadence.Event {
+	versionBoundaryType := newNodeVersionBeaconVersionBoundaryStructType()
+
+	semverType := newNodeVersionBeaconSemverStructType()
+
+	semver := cadence.NewStruct([]cadence.Value{
+
+		// preRelease
+		cadence.NewOptional(cadence.String("")),
+		// major
+		cadence.UInt8(2),
+
+		// minor
+		cadence.UInt8(13),
+
+		// patch
+		cadence.UInt8(7),
+	}).WithType(semverType)
+
+	versionBoundary := cadence.NewStruct([]cadence.Value{
+		// blockHeight
+		cadence.UInt64(44),
+
+		// version
+		semver,
+	}).WithType(versionBoundaryType)
+
+	return cadence.NewEvent([]cadence.Value{
+		// versionBoundaries
+		cadence.NewArray([]cadence.Value{
+			versionBoundary,
+		}).WithType(cadence.NewVariableSizedArrayType(versionBoundaryType)),
+
+		// sequence
+		cadence.UInt64(5),
+	}).WithType(newNodeVersionBeaconVersionBeaconEventType())
+}
+
+func newFlowClusterQCVoteStructType() cadence.Type {
+
+	// A.01cf0e2f2f715450.FlowClusterQC.Vote
+
+	address, _ := common.HexToAddress("01cf0e2f2f715450")
+	location := common.NewAddressLocation(nil, address, "FlowClusterQC")
+
+	return &cadence.StructType{
+		Location:            location,
+		QualifiedIdentifier: "FlowClusterQC.Vote",
+		Fields: []cadence.Field{
+			{
+				Identifier: "nodeID",
+				Type:       cadence.StringType{},
+			},
+			{
+				Identifier: "signature",
+				Type:       cadence.NewOptionalType(cadence.StringType{}),
+			},
+			{
+				Identifier: "message",
+				Type:       cadence.NewOptionalType(cadence.StringType{}),
+			},
+			{
+				Identifier: "clusterIndex",
+				Type:       cadence.UInt16Type{},
+			},
+			{
+				Identifier: "weight",
+				Type:       cadence.UInt64Type{},
+			},
+		},
+	}
+}
+
+func newFlowClusterQCClusterStructType() *cadence.StructType {
+
+	// A.01cf0e2f2f715450.FlowClusterQC.Cluster
+
+	address, _ := common.HexToAddress("01cf0e2f2f715450")
+	location := common.NewAddressLocation(nil, address, "FlowClusterQC")
+
+	return &cadence.StructType{
+		Location:            location,
+		QualifiedIdentifier: "FlowClusterQC.Cluster",
+		Fields: []cadence.Field{
+			{
+				Identifier: "index",
+				Type:       cadence.UInt16Type{},
+			},
+			{
+				Identifier: "nodeWeights",
+				Type:       cadence.NewDictionaryType(cadence.StringType{}, cadence.UInt64Type{}),
+			},
+			{
+				Identifier: "totalWeight",
+				Type:       cadence.UInt64Type{},
+			},
+			{
+				Identifier: "generatedVotes",
+				Type:       cadence.NewDictionaryType(cadence.StringType{}, newFlowClusterQCVoteStructType()),
+			},
+			{
+				Identifier: "uniqueVoteMessageTotalWeights",
+				Type:       cadence.NewDictionaryType(cadence.StringType{}, cadence.UInt64Type{}),
+			},
+		},
+	}
+}
+
+func newFlowIDTableStakingNodeInfoStructType() *cadence.StructType {
+
+	// A.01cf0e2f2f715450.FlowIDTableStaking.NodeInfo
+
+	address, _ := common.HexToAddress("01cf0e2f2f715450")
+	location := common.NewAddressLocation(nil, address, "FlowIDTableStaking")
+
+	return &cadence.StructType{
+		Location:            location,
+		QualifiedIdentifier: "FlowIDTableStaking.NodeInfo",
+		Fields: []cadence.Field{
+			{
+				Identifier: "id",
+				Type:       cadence.StringType{},
+			},
+			{
+				Identifier: "role",
+				Type:       cadence.UInt8Type{},
+			},
+			{
+				Identifier: "networkingAddress",
+				Type:       cadence.StringType{},
+			},
+			{
+				Identifier: "networkingKey",
+				Type:       cadence.StringType{},
+			},
+			{
+				Identifier: "stakingKey",
+				Type:       cadence.StringType{},
+			},
+			{
+				Identifier: "tokensStaked",
+				Type:       cadence.UFix64Type{},
+			},
+			{
+				Identifier: "tokensCommitted",
+				Type:       cadence.UFix64Type{},
+			},
+			{
+				Identifier: "tokensUnstaking",
+				Type:       cadence.UFix64Type{},
+			},
+			{
+				Identifier: "tokensUnstaked",
+				Type:       cadence.UFix64Type{},
+			},
+			{
+				Identifier: "tokensRewarded",
+				Type:       cadence.UFix64Type{},
+			},
+			{
+				Identifier: "delegators",
+				Type:       cadence.NewVariableSizedArrayType(cadence.NewUInt32Type()),
+			},
+			{
+				Identifier: "delegatorIDCounter",
+				Type:       cadence.UInt32Type{},
+			},
+			{
+				Identifier: "tokensRequestedToUnstake",
+				Type:       cadence.UFix64Type{},
+			},
+			{
+				Identifier: "initialWeight",
+				Type:       cadence.UInt64Type{},
+			},
+		},
+	}
+}
+
+func newFlowEpochEpochSetupEventType() *cadence.EventType {
+
+	// A.01cf0e2f2f715450.FlowEpoch.EpochSetup
+
+	address, _ := common.HexToAddress("01cf0e2f2f715450")
+	location := common.NewAddressLocation(nil, address, "FlowEpoch")
+
+	return &cadence.EventType{
+		Location:            location,
+		QualifiedIdentifier: "FlowEpoch.EpochSetup",
+		Fields: []cadence.Field{
+			{
+				Identifier: "counter",
+				Type:       cadence.UInt64Type{},
+			},
+			{
+				Identifier: "nodeInfo",
+				Type:       cadence.NewVariableSizedArrayType(newFlowIDTableStakingNodeInfoStructType()),
+			},
+			{
+				Identifier: "firstView",
+				Type:       cadence.UInt64Type{},
+			},
+			{
+				Identifier: "finalView",
+				Type:       cadence.UInt64Type{},
+			},
+			{
+				Identifier: "collectorClusters",
+				Type:       cadence.NewVariableSizedArrayType(newFlowClusterQCClusterStructType()),
+			},
+			{
+				Identifier: "randomSource",
+				Type:       cadence.StringType{},
+			},
+			{
+				Identifier: "DKGPhase1FinalView",
+				Type:       cadence.UInt64Type{},
+			},
+			{
+				Identifier: "DKGPhase2FinalView",
+				Type:       cadence.UInt64Type{},
+			},
+			{
+				Identifier: "DKGPhase3FinalView",
+				Type:       cadence.UInt64Type{},
+			},
+		},
+	}
+}
+
+func newFlowEpochEpochCommittedEventType() *cadence.EventType {
+
+	// A.01cf0e2f2f715450.FlowEpoch.EpochCommitted
+
+	address, _ := common.HexToAddress("01cf0e2f2f715450")
+	location := common.NewAddressLocation(nil, address, "FlowEpoch")
+
+	return &cadence.EventType{
+		Location:            location,
+		QualifiedIdentifier: "FlowEpoch.EpochCommitted",
+		Fields: []cadence.Field{
+			{
+				Identifier: "counter",
+				Type:       cadence.UInt64Type{},
+			},
+			{
+				Identifier: "clusterQCs",
+				Type:       cadence.NewVariableSizedArrayType(newFlowClusterQCClusterQCStructType()),
+			},
+			{
+				Identifier: "dkgPubKeys",
+				Type:       cadence.NewVariableSizedArrayType(cadence.StringType{}),
+			},
+		},
+	}
+}
+
+func newFlowClusterQCClusterQCStructType() *cadence.StructType {
+
+	// A.01cf0e2f2f715450.FlowClusterQC.ClusterQC"
+
+	address, _ := common.HexToAddress("01cf0e2f2f715450")
+	location := common.NewAddressLocation(nil, address, "FlowClusterQC")
+
+	return &cadence.StructType{
+		Location:            location,
+		QualifiedIdentifier: "FlowClusterQC.ClusterQC",
+		Fields: []cadence.Field{
+			{
+				Identifier: "index",
+				Type:       cadence.UInt16Type{},
+			},
+			{
+				Identifier: "voteSignatures",
+				Type:       cadence.NewVariableSizedArrayType(cadence.StringType{}),
+			},
+			{
+				Identifier: "voteMessage",
+				Type:       cadence.StringType{},
+			},
+			{
+				Identifier: "voterIDs",
+				Type:       cadence.NewVariableSizedArrayType(cadence.StringType{}),
+			},
+		},
+	}
+}
+
+func newNodeVersionBeaconVersionBeaconEventType() *cadence.EventType {
+
+	// A.01cf0e2f2f715450.NodeVersionBeacon.VersionBeacon
+
+	address, _ := common.HexToAddress("01cf0e2f2f715450")
+	location := common.NewAddressLocation(nil, address, "NodeVersionBeacon")
+
+	return &cadence.EventType{
+		Location:            location,
+		QualifiedIdentifier: "NodeVersionBeacon.VersionBeacon",
+		Fields: []cadence.Field{
+			{
+				Identifier: "versionBoundaries",
+				Type:       cadence.NewVariableSizedArrayType(newNodeVersionBeaconVersionBoundaryStructType()),
+			},
+			{
+				Identifier: "sequence",
+				Type:       cadence.UInt64Type{},
+			},
+		},
+	}
+}
+
+func newNodeVersionBeaconVersionBoundaryStructType() *cadence.StructType {
+
+	// A.01cf0e2f2f715450.NodeVersionBeacon.VersionBoundary
+
+	address, _ := common.HexToAddress("01cf0e2f2f715450")
+	location := common.NewAddressLocation(nil, address, "NodeVersionBeacon")
+
+	return &cadence.StructType{
+		Location:            location,
+		QualifiedIdentifier: "NodeVersionBeacon.VersionBoundary",
+		Fields: []cadence.Field{
+			{
+				Identifier: "blockHeight",
+				Type:       cadence.UInt64Type{},
+			},
+			{
+				Identifier: "version",
+				Type:       newNodeVersionBeaconSemverStructType(),
+			},
+		},
+	}
+}
+
+func newNodeVersionBeaconSemverStructType() *cadence.StructType {
+
+	// A.01cf0e2f2f715450.NodeVersionBeacon.Semver
+
+	address, _ := common.HexToAddress("01cf0e2f2f715450")
+	location := common.NewAddressLocation(nil, address, "NodeVersionBeacon")
+
+	return &cadence.StructType{
+		Location:            location,
+		QualifiedIdentifier: "NodeVersionBeacon.Semver",
+		Fields: []cadence.Field{
+			{
+				Identifier: "preRelease",
+				Type:       cadence.NewOptionalType(cadence.StringType{}),
+			},
+			{
+				Identifier: "major",
+				Type:       cadence.UInt8Type{},
+			},
+			{
+				Identifier: "minor",
+				Type:       cadence.UInt8Type{},
+			},
+			{
+				Identifier: "patch",
+				Type:       cadence.UInt8Type{},
+			},
+		},
+	}
+}
+
+func ufix64FromString(s string) cadence.UFix64 {
+	f, err := cadence.NewUFix64(s)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}


### PR DESCRIPTION
Closes #2558 #2449 
Updates #2283 #2157 

## Description

Add CCF options which can be used to specify encoding and decoding settings.

Add CCF modes to have immutable CCF options and be safe for concurrent use.

Create CCF event encoding and decoding mode with CCF presets at startup. Calling `ccf.EventsEncMode.Encode()` or `ccf.EventsDecMode.Decode()` is safe for concurrent use and uses appropriate settings for events.

For now, the default CCF settings match the presets for events. So calling `ccf.Encode()` is like calling `ccf.EventsEncMode.Encode()`. However, it is safer to use a separate explicit mode for each CCF-based protocol.

### TODO:

- [x] Add more tests.  This PR can be reviewed while I add more tests.
- [ ] Fuzz test.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
