### PR TITLE
Prevent function invocation on destroyed resource

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -5116,6 +5116,17 @@ func (interpreter *Interpreter) trackReferencedResourceKindedValue(
 	values[value] = struct{}{}
 }
 
+func (interpreter *Interpreter) untrackReferencedResourceKindedValue(
+	id atree.StorageID,
+	value ReferenceTrackedResourceKindedValue,
+) {
+	values := interpreter.SharedState.referencedResourceKindedValues[id]
+	if values == nil {
+		return
+	}
+	delete(values, value)
+}
+
 func (interpreter *Interpreter) updateReferencedResource(
 	currentStorageID atree.StorageID,
 	newStorageID atree.StorageID,

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -933,6 +933,16 @@ func (interpreter *Interpreter) visitInvocationExpressionWithImplicitArgument(in
 		panic(errors.NewUnreachableError())
 	}
 
+	// Bound functions
+	if boundFunction, ok := function.(BoundFunctionValue); ok && boundFunction.Self != nil {
+		self := *boundFunction.Self
+		if resource, ok := self.(ReferenceTrackedResourceKindedValue); ok {
+			storageID := resource.StorageID()
+			interpreter.trackReferencedResourceKindedValue(storageID, resource)
+			defer interpreter.untrackReferencedResourceKindedValue(storageID, resource)
+		}
+	}
+
 	// NOTE: evaluate all argument expressions in call-site scope, not in function body
 
 	var argumentExpressions []ast.Expression

--- a/runtime/interpreter/value_function.go
+++ b/runtime/interpreter/value_function.go
@@ -383,7 +383,15 @@ func (f BoundFunctionValue) FunctionType() *sema.FunctionType {
 }
 
 func (f BoundFunctionValue) invoke(invocation Invocation) Value {
-	invocation.Self = f.Self
+	self := f.Self
+	invocation.Self = self
+	if self != nil {
+		if resource, ok := (*self).(ResourceKindedValue); ok && resource.IsDestroyed() {
+			panic(DestroyedResourceError{
+				LocationRange: invocation.LocationRange,
+			})
+		}
+	}
 	invocation.Base = f.Base
 	return f.Function.invoke(invocation)
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -8239,3 +8239,203 @@ func TestRuntimeFlowEventTypes(t *testing.T) {
 		result,
 	)
 }
+
+func TestInvalidatedResourceUse(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := newTestInterpreterRuntime()
+
+	signerAccount := common.MustBytesToAddress([]byte{0x1})
+
+	signers := []Address{signerAccount}
+
+	accountCodes := map[Location][]byte{}
+	var events []cadence.Event
+
+	runtimeInterface := &testRuntimeInterface{
+		getCode: func(location Location) (bytes []byte, err error) {
+			return accountCodes[location], nil
+		},
+		storage: newTestLedger(nil, nil),
+		getSigningAccounts: func() ([]Address, error) {
+			return signers, nil
+		},
+		resolveLocation: singleIdentifierLocationResolver(t),
+		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			return accountCodes[location], nil
+		},
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
+			accountCodes[location] = code
+			return nil
+		},
+		emitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
+		},
+		log: func(s string) {
+			fmt.Println(s)
+		},
+	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	attacker := []byte(fmt.Sprintf(`
+		import VictimContract from %s
+
+		pub contract AttackerContract {
+
+			pub resource AttackerResource {
+				pub var vault: @VictimContract.Vault
+				pub var firstCopy: @VictimContract.Vault
+
+				init(vault: @VictimContract.Vault) {
+					self.vault <- vault
+					self.firstCopy <- self.vault.withdraw(amount: 0.0)
+				}
+
+				pub fun shenanigans(): UFix64{
+					let fullBalance = self.vault.balance
+
+					var withdrawn <- self.vault.withdraw(amount: 0.0)
+
+					// "Rug pull" the vault from under the in-flight
+					// withdrawal and deposit it into our "first copy" wallet
+					self.vault <-> withdrawn
+					self.firstCopy.deposit(from: <- withdrawn)
+
+					// Return the pre-deposit balance for caller to withdraw
+					return fullBalance
+				}
+
+				pub fun fetchfirstCopy(): @VictimContract.Vault {
+					var withdrawn <- self.firstCopy.withdraw(amount: 0.0)
+					self.firstCopy <-> withdrawn
+					return <- withdrawn
+				}
+
+				destroy() {
+					destroy self.vault
+					destroy self.firstCopy
+				}
+			}
+
+			pub fun doubleBalanceOfVault(_ victim: @VictimContract.Vault): @VictimContract.Vault {
+				var r <- create AttackerResource(vault: <- victim)
+
+				// The magic happens during the execution of the following line of code
+				// var withdrawAmmount = r.shenanigans()
+				var secondCopy <- r.vault.withdraw(amount: r.shenanigans())
+
+				// Deposit the second copy of the funds as retained by the AttackerResource instance
+				secondCopy.deposit(from: <- r.fetchfirstCopy())
+
+				destroy r
+				return <- secondCopy
+			}
+
+			pub fun attack() {
+				var v1 <- VictimContract.faucet()
+				log("Balance at the beginning: ".concat(v1.balance.toString()))
+
+				var v2<- AttackerContract.doubleBalanceOfVault(<- v1)
+				// var v3 <- AttackerContract.doubleBalanceOfVault(<- v2)
+				log("Balance at the end: ".concat(v2.balance.toString()))
+
+				destroy v2
+		   }
+		}`,
+		signerAccount.HexWithPrefix(),
+	))
+
+	victim := []byte(`
+        pub contract VictimContract {
+            pub resource Vault {
+
+                // Balance of a user's Vault
+                // we use unsigned fixed point numbers for balances
+                // because they can represent decimals and do not allow negative values
+                pub var balance: UFix64
+
+                init(balance: UFix64) {
+                    self.balance = balance
+                }
+
+                pub fun withdraw(amount: UFix64): @Vault {
+                    self.balance = self.balance - amount
+                    return <-create Vault(balance: amount)
+                }
+
+                pub fun deposit(from: @Vault) {
+                    self.balance = self.balance + from.balance
+                    destroy from
+                }
+            }
+
+            pub fun faucet(): @VictimContract.Vault {
+                return <- create VictimContract.Vault(balance: 5.0)
+            }
+        }
+    `)
+
+	// Deploy Victim
+
+	deployVictim := DeploymentTransaction("VictimContract", victim)
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deployVictim,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+
+	// Deploy Attacker
+
+	deployAttacker := DeploymentTransaction("AttackerContract", attacker)
+
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: deployAttacker,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+
+	// Attack
+
+	attackTransaction := []byte(fmt.Sprintf(`
+        import VictimContract from %s
+        import AttackerContract from %s
+
+        transaction {
+            execute {
+                AttackerContract.attack()
+            }
+        }`,
+		signerAccount.HexWithPrefix(),
+		signerAccount.HexWithPrefix(),
+	))
+
+	signers = nil
+
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: attackTransaction,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	RequireError(t, err)
+
+	var destroyedResourceErr interpreter.DestroyedResourceError
+	require.ErrorAs(t, err, &destroyedResourceErr)
+
+}


### PR DESCRIPTION
## Description

Port of https://github.com/dapperlabs/cadence-internal/pull/123

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
