### PR TITLE
Add tests for entitlement inheritance between interfaces

### DIFF
--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -2607,7 +2607,7 @@ func TestCheckEntitlementInheritance(t *testing.T) {
 		require.IsType(t, &sema.ConformanceError{}, errs[0])
 	})
 
-	t.Run("default function entitlemnts", func(t *testing.T) {
+	t.Run("default function entitlements", func(t *testing.T) {
 		t.Parallel()
 		_, err := ParseAndCheck(t, `
 			entitlement E
@@ -2632,7 +2632,7 @@ func TestCheckEntitlementInheritance(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("attachment default function entitlemnts", func(t *testing.T) {
+	t.Run("attachment default function entitlements", func(t *testing.T) {
 		t.Parallel()
 		_, err := ParseAndCheck(t, `
 			entitlement E
@@ -2661,7 +2661,37 @@ func TestCheckEntitlementInheritance(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("attachment default function entitlemnts no attachment mapping", func(t *testing.T) {
+	t.Run("attachment inherited default function entitlements", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAndCheck(t, `
+			entitlement E
+			entitlement F 
+			entitlement G
+			entitlement mapping M {
+				E -> F
+			}
+			entitlement mapping N {
+				G -> E
+			}
+			struct interface I {
+				access(M) fun foo(): auth(M) &Int {
+					return &1 as auth(M) &Int
+				}
+			}
+			struct interface I2: I {}
+			struct S {}
+			access(N) attachment A for S: I2 {}
+			fun test() {
+				let s = attach A() to S()
+				let ref = &s as auth(G) &S
+				let i: auth(F) &Int = s[A]!.foo()
+			}
+		`)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("attachment default function entitlements no attachment mapping", func(t *testing.T) {
 		t.Parallel()
 		_, err := ParseAndCheck(t, `
 			entitlement E

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -1975,6 +1975,21 @@ func TestCheckEntitlementInheritance(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("valid interface", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAndCheck(t, `
+			entitlement E
+			struct interface I {
+				access(E) fun foo() 
+			}
+			struct interface S: I {
+				access(E) fun foo() 
+			}
+		`)
+
+		assert.NoError(t, err)
+	})
+
 	t.Run("valid mapped", func(t *testing.T) {
 		t.Parallel()
 		_, err := ParseAndCheck(t, `
@@ -1991,6 +2006,25 @@ func TestCheckEntitlementInheritance(t *testing.T) {
 				init() {
 					self.x = &"foo" as auth(Y) &String
 				}
+			}
+		`)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid mapped interface", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAndCheck(t, `
+		 	entitlement X
+			entitlement Y
+			entitlement mapping M {
+				X -> Y
+			}
+			struct interface I {
+				access(M) let x: auth(M) &String
+			}
+			struct interface S: I {
+				access(M) let x: auth(M) &String
 			}
 		`)
 
@@ -2020,6 +2054,28 @@ func TestCheckEntitlementInheritance(t *testing.T) {
 		errs := RequireCheckerErrors(t, err, 1)
 
 		require.IsType(t, &sema.ConformanceError{}, errs[0])
+	})
+
+	t.Run("mismatched mapped interfaces", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAndCheck(t, `
+			entitlement X
+			entitlement Y
+			entitlement mapping M {}
+			entitlement mapping N {
+				X -> Y
+			}
+			struct interface I {
+				access(M) let x: auth(M) &String
+			}
+			struct interface S: I {
+				access(N) let x: auth(N) &String
+			}
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.InterfaceMemberConflictError{}, errs[0])
 	})
 
 	t.Run("pub subtyping invalid", func(t *testing.T) {

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -3006,7 +3006,7 @@ func TestCheckInterfaceInheritance(t *testing.T) {
 			entitlement X
 
             struct interface Foo {
-                access(X) fun hello()
+                access(X) fun hello(): String
             }
 
             struct interface Bar: Foo {

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -2998,6 +2998,30 @@ func TestCheckInterfaceInheritance(t *testing.T) {
 		assert.Equal(t, "Foo", memberConflictError.ConflictingInterfaceType.QualifiedIdentifier())
 	})
 
+	t.Run("duplicate methods mismatching entitlements", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			entitlement X
+
+            struct interface Foo {
+                access(X) fun hello()
+            }
+
+            struct interface Bar: Foo {
+                pub fun hello(): String
+            }
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		memberConflictError := &sema.InterfaceMemberConflictError{}
+		require.ErrorAs(t, errs[0], &memberConflictError)
+		assert.Equal(t, "hello", memberConflictError.MemberName)
+		assert.Equal(t, "Foo", memberConflictError.ConflictingInterfaceType.QualifiedIdentifier())
+	})
+
 	t.Run("duplicate fields matching", func(t *testing.T) {
 
 		t.Parallel()
@@ -3026,6 +3050,30 @@ func TestCheckInterfaceInheritance(t *testing.T) {
 
             struct interface Bar: Foo {
                 pub var x: Int
+            }
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		memberConflictError := &sema.InterfaceMemberConflictError{}
+		require.ErrorAs(t, errs[0], &memberConflictError)
+		assert.Equal(t, "x", memberConflictError.MemberName)
+		assert.Equal(t, "Foo", memberConflictError.ConflictingInterfaceType.QualifiedIdentifier())
+	})
+
+	t.Run("duplicate fields, mismatching entitlements", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			entitlement X
+
+            struct interface Foo {
+                pub var x: String
+            }
+
+            struct interface Bar: Foo {
+                access(X) var x: String
             }
         `)
 
@@ -3183,6 +3231,72 @@ func TestCheckInterfaceInheritance(t *testing.T) {
 
             struct interface P {
                 pub fun hello(): String
+            }
+
+            struct interface Q: P {}
+
+            struct X: B, Q {}
+        `)
+
+		errs := RequireCheckerErrors(t, err, 2)
+
+		conformanceError := &sema.ConformanceError{}
+		require.ErrorAs(t, errs[0], &conformanceError)
+		assert.Equal(t, "B", conformanceError.InterfaceType.QualifiedIdentifier())
+		assert.Equal(t, "A", conformanceError.NestedInterfaceType.QualifiedIdentifier())
+
+		require.ErrorAs(t, errs[1], &conformanceError)
+		assert.Equal(t, "Q", conformanceError.InterfaceType.QualifiedIdentifier())
+		assert.Equal(t, "P", conformanceError.NestedInterfaceType.QualifiedIdentifier())
+	})
+
+	t.Run("duplicate methods same type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct interface A {
+                pub fun hello(): Int
+            }
+
+            struct interface B: A {}
+
+            struct interface P {
+                pub fun hello(): Int
+            }
+
+            struct interface Q: P {}
+
+            struct X: B, Q {}
+        `)
+
+		errs := RequireCheckerErrors(t, err, 2)
+
+		conformanceError := &sema.ConformanceError{}
+		require.ErrorAs(t, errs[0], &conformanceError)
+		assert.Equal(t, "B", conformanceError.InterfaceType.QualifiedIdentifier())
+		assert.Equal(t, "A", conformanceError.NestedInterfaceType.QualifiedIdentifier())
+
+		require.ErrorAs(t, errs[1], &conformanceError)
+		assert.Equal(t, "Q", conformanceError.InterfaceType.QualifiedIdentifier())
+		assert.Equal(t, "P", conformanceError.NestedInterfaceType.QualifiedIdentifier())
+	})
+
+	t.Run("duplicate methods same type different entitlements", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			entitlement E
+
+            struct interface A {
+                access(E) fun hello(): Int
+            }
+
+            struct interface B: A {}
+
+            struct interface P {
+                pub fun hello(): Int
             }
 
             struct interface Q: P {}
@@ -3665,6 +3779,38 @@ func TestCheckInterfaceTypeDefinitionInheritance(t *testing.T) {
             contract interface C: B {}
 
             contract X: C {}
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.ConformanceError{}, errs[0])
+	})
+
+	t.Run("type requirement wrong entitlement", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			entitlement E
+
+            contract interface A {
+                struct Nested {
+                    pub fun test(): Int {
+                        return 3
+                    }
+                }
+            }
+
+            contract interface B: A {}
+
+            contract interface C: B {}
+
+            contract X: C {
+				struct Nested {
+                    access(E) fun test(): Int {
+                        return 3
+                    }
+                }
+			}
         `)
 
 		errs := RequireCheckerErrors(t, err, 1)


### PR DESCRIPTION
With interface inheritance and entitlements now in the same branch, we now need tests for their interaction. I think however that the implementations just work together out of the box.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
