### PR TITLE
Add utility to decode fields into struct based on field tags

### DIFF
--- a/types.go
+++ b/types.go
@@ -1128,13 +1128,13 @@ func DecodeFields(hasFields HasFields, s interface{}) error {
 		tag := structField.Tag
 		fieldValue := v.Field(i)
 
-		if !fieldValue.IsValid() || !fieldValue.CanSet() {
+		cadenceFieldNameTag := tag.Get("cadence")
+		if cadenceFieldNameTag == "" {
 			continue
 		}
 
-		cadenceFieldNameTag := tag.Get("cadenceFieldName")
-		if cadenceFieldNameTag == "" {
-			continue
+		if !fieldValue.IsValid() || !fieldValue.CanSet() {
+			return fmt.Errorf("cannot set field %s", structField.Name)
 		}
 
 		cadenceField := fieldsMap[cadenceFieldNameTag]

--- a/types_test.go
+++ b/types_test.go
@@ -1989,7 +1989,7 @@ func TestDecodeFields(t *testing.T) {
 	assert.Errorf(t, err, "should err when mapping to invalid type")
 
 	type eventStructPrivateField struct {
-		a Int `cadence:"a"`
+		a Int `cadence:"a"` // nolint: unused
 	}
 	err = DecodeFields(simpleEvent, &eventStructPrivateField{})
 	assert.Errorf(t, err, "should err when mapping to private field")

--- a/types_test.go
+++ b/types_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/tests/utils"
@@ -1938,5 +1939,43 @@ func TestTypeEquality(t *testing.T) {
 			assert.False(t, source.Equal(target))
 		})
 	})
+
+}
+
+func TestDecodeFields(t *testing.T) {
+	simpleEvent := NewEvent(
+		[]Value{
+			NewInt(1),
+			String("foo"),
+		},
+	).WithType(&EventType{
+		Location:            utils.TestLocation,
+		QualifiedIdentifier: "SimpleEvent",
+		Fields: []Field{
+			{
+				Identifier: "a",
+				Type:       IntType{},
+			},
+			{
+				Identifier: "b",
+				Type:       StringType{},
+			},
+		},
+	})
+
+	type eventStruct struct {
+		A               Int    `cadenceFieldName:"a"`
+		B               String `cadenceFieldName:"b"`
+		NonCadenceField Int
+	}
+
+	evt := &eventStruct{}
+	err := DecodeFields(simpleEvent, evt)
+	require.NoError(t, err)
+	assert.EqualValues(t, eventStruct{
+		A:               NewInt(1),
+		B:               "foo",
+		NonCadenceField: Int{},
+	}, *evt)
 
 }


### PR DESCRIPTION
## Description

Added a new method `DecodeFields` that decodes fields into a struct basing on the tag `cadenceFieldName`

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
