### PR TITLE
Fix resource tracking

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -5116,17 +5116,6 @@ func (interpreter *Interpreter) trackReferencedResourceKindedValue(
 	values[value] = struct{}{}
 }
 
-func (interpreter *Interpreter) untrackReferencedResourceKindedValue(
-	id atree.StorageID,
-	value ReferenceTrackedResourceKindedValue,
-) {
-	values := interpreter.SharedState.referencedResourceKindedValues[id]
-	if values == nil {
-		return
-	}
-	delete(values, value)
-}
-
 func (interpreter *Interpreter) updateReferencedResource(
 	currentStorageID atree.StorageID,
 	newStorageID atree.StorageID,

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -939,7 +939,6 @@ func (interpreter *Interpreter) visitInvocationExpressionWithImplicitArgument(in
 		if resource, ok := self.(ReferenceTrackedResourceKindedValue); ok {
 			storageID := resource.StorageID()
 			interpreter.trackReferencedResourceKindedValue(storageID, resource)
-			defer interpreter.untrackReferencedResourceKindedValue(storageID, resource)
 		}
 	}
 


### PR DESCRIPTION
## Description

Untracking causes resources which are not updated properly, for some reason.

For now, remove the untracking.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
