### PR TITLE
Add tests for resource tracking in bound function invocations

### DIFF
--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -894,3 +894,44 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
 		require.IsType(t, &interpreter.EphemeralReferenceValue{}, innerValue)
 	})
 }
+
+func TestInterpretReferenceTrackingOnInvocation(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("simple resource", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            pub resource Foo {
+
+                pub let id: UInt8
+
+                init() {
+                    self.id = 12
+                }
+
+                pub fun something() {}
+            }
+
+            fun main() {
+                var foo <- create Foo()
+                var fooRef = &foo as &Foo
+
+                // Invocation should not un-track the reference
+                fooRef.something()
+
+                // Moving the resource should update the tracking
+                var newFoo <- foo
+
+            	fooRef.id
+
+            	destroy newFoo
+            }
+        `)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Description

Adding a test case for the fix https://github.com/onflow/cadence/pull/2568

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
