### PR TITLE
Introduce the `Test.assertEqual` function

### DIFF
--- a/runtime/stdlib/test_contract.go
+++ b/runtime/stdlib/test_contract.go
@@ -106,6 +106,75 @@ var testTypeAssertFunction = interpreter.NewUnmeteredHostFunctionValue(
 	},
 )
 
+// 'Test.assertEqual' function
+
+const testTypeAssertEqualFunctionDocString = `
+Fails the test-case if the given values are not equal, and
+reports a message which explains how the two values differ.
+`
+
+const testTypeAssertEqualFunctionName = "assertEqual"
+
+var testTypeAssertEqualFunctionType = &sema.FunctionType{
+	Parameters: []sema.Parameter{
+		{
+			Label:      sema.ArgumentLabelNotRequired,
+			Identifier: "expected",
+			TypeAnnotation: sema.NewTypeAnnotation(
+				sema.AnyStructType,
+			),
+		},
+		{
+			Label:      sema.ArgumentLabelNotRequired,
+			Identifier: "actual",
+			TypeAnnotation: sema.NewTypeAnnotation(
+				sema.AnyStructType,
+			),
+		},
+	},
+	RequiredArgumentCount: sema.RequiredArgumentCount(2),
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		sema.VoidType,
+	),
+}
+
+var testTypeAssertEqualFunction = interpreter.NewUnmeteredHostFunctionValue(
+	testTypeAssertEqualFunctionType,
+	func(invocation interpreter.Invocation) interpreter.Value {
+		expected, ok := invocation.Arguments[0].(interpreter.EquatableValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		inter := invocation.Interpreter
+
+		actual, ok := invocation.Arguments[1].(interpreter.EquatableValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		equal := expected.Equal(
+			inter,
+			invocation.LocationRange,
+			actual,
+		)
+
+		if !equal {
+			message := fmt.Sprintf(
+				"not equal: expected: %s, actual: %s",
+				expected,
+				actual,
+			)
+			panic(AssertionError{
+				Message:       message,
+				LocationRange: invocation.LocationRange,
+			})
+		}
+
+		return interpreter.Void
+	},
+)
+
 // 'Test.fail' function
 
 const testTypeFailFunctionDocString = `
@@ -1007,6 +1076,17 @@ func newTestContractType() *TestContractType {
 		),
 	)
 
+	// Test.assertEqual()
+	compositeType.Members.Set(
+		testTypeAssertEqualFunctionName,
+		sema.NewUnmeteredPublicFunctionMember(
+			compositeType,
+			testTypeAssertEqualFunctionName,
+			testTypeAssertEqualFunctionType,
+			testTypeAssertEqualFunctionDocString,
+		),
+	)
+
 	// Test.fail()
 	compositeType.Members.Set(
 		testTypeFailFunctionName,
@@ -1263,6 +1343,7 @@ func (t *TestContractType) NewTestContract(
 
 	// Inject natively implemented function values
 	compositeValue.Functions[testTypeAssertFunctionName] = testTypeAssertFunction
+	compositeValue.Functions[testTypeAssertEqualFunctionName] = testTypeAssertEqualFunction
 	compositeValue.Functions[testTypeFailFunctionName] = testTypeFailFunction
 	compositeValue.Functions[testTypeExpectFunctionName] = t.expectFunction
 	compositeValue.Functions[testTypeNewEmulatorBlockchainFunctionName] =


### PR DESCRIPTION
Closes https://github.com/onflow/cadence-tools/issues/93

## Description

This function has built-in support for showing the difference between the expected and the actual value. For example:

```bash
Test results: "tests/test_foo_contract.cdc"
- FAIL: testGetIntegerTrait
		Execution failed:
			error: assertion failed: not equal: expected: "Hugee", actual: "Huge"
			  --> 7465737400000000000000000000000000000000000000000000000000000000:27:8
			
- PASS: testAddSpecialNumber
Coverage: 95.7% of statements
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
