### PR TITLE
decode complex fields into more primitive types

### DIFF
--- a/types.go
+++ b/types.go
@@ -1287,9 +1287,10 @@ func decodeSlice(valueType reflect.Type, cadenceField Value) (*reflect.Value, er
 				return nil, err
 			}
 			if valueOptional == nil {
-				continue
+				elementValue = reflect.Zero(valueType.Elem())
+			} else {
+				elementValue = *valueOptional
 			}
-			elementValue = *valueOptional
 		} else {
 			elementValue = reflect.ValueOf(value)
 		}

--- a/types_test.go
+++ b/types_test.go
@@ -2054,7 +2054,7 @@ func TestDecodeFields(t *testing.T) {
 
 	assert.EqualValues(t, map[String]Int{"k": NewInt(3)}, evt.Dict)
 
-	assert.EqualValues(t, map[String]*Int{"k": &int4}, evt.DictOptional)
+	assert.EqualValues(t, map[String]*Int{"k": &int4, "nilK": nil}, evt.DictOptional)
 
 	assert.EqualValues(t, map[String]interface{}{
 		"k":  NewInt(3),
@@ -2105,19 +2105,19 @@ func TestDecodeFields(t *testing.T) {
 		{Struct: &struct {
 			O *String `cadence:"optionalIntField"`
 		}{},
-			ExpectedErr: "cannot decode optional field O: cannot set field: expected cadence.String, got cadence.Int",
+			ExpectedErr: "cannot decode ptr field O: cannot set field: expected cadence.String, got cadence.Int",
 			Description: "should err when mapping to optional field with wrong type",
 		},
 		{Struct: &struct {
 			DOptional map[*String]*Int `cadence:"dictOptionalField"`
 		}{},
-			ExpectedErr: "cannot decode dictionary field DOptional: map key cannot be a pointer (optional) type",
+			ExpectedErr: "cannot decode map field DOptional: map key cannot be a pointer (optional) type",
 			Description: "should err when mapping to dictionary field with ptr key type",
 		},
 		{Struct: &struct {
 			D map[String]String `cadence:"dictField"`
 		}{},
-			ExpectedErr: "cannot decode dictionary field D: map value type mismatch: expected cadence.String, got cadence.Int",
+			ExpectedErr: "cannot decode map field D: map value type mismatch: expected cadence.String, got cadence.Int",
 			Description: "should err when mapping to dictionary field with wrong value type",
 		},
 		{Struct: &struct {
@@ -2141,31 +2141,30 @@ func TestDecodeFields(t *testing.T) {
 		{Struct: &struct {
 			A map[Int]Int `cadence:"dictField"`
 		}{},
-			ExpectedErr: "cannot decode dictionary field A: map key type mismatch: expected cadence.Int, got cadence.String",
+			ExpectedErr: "cannot decode map field A: map key type mismatch: expected cadence.Int, got cadence.String",
 			Description: "should err when mapping to map field with mismatching key type",
 		},
 		{Struct: &struct {
 			A map[String]*String `cadence:"dictOptionalField"`
 		}{},
-			ExpectedErr: "cannot decode dictionary field A: cannot decode optional map value for key \"k\": cannot set field: expected cadence.String, got cadence.Int",
+			ExpectedErr: "cannot decode map field A: cannot decode optional map value for key \"k\": cannot set field: expected cadence.String, got cadence.Int",
 			Description: "should err when mapping to map field with mismatching value type",
 		},
 		{Struct: &struct {
 			A map[String]Int `cadence:"intField"`
 		}{},
-			ExpectedErr: "cannot decode dictionary field A: field is not a dictionary",
+			ExpectedErr: "cannot decode map field A: field is not a dictionary",
 			Description: "should err when mapping to map with mismatching field type",
 		},
 		{Struct: &struct {
 			A *Int `cadence:"intField"`
 		}{},
-			ExpectedErr: "cannot decode optional field A: field is not an optional",
+			ExpectedErr: "cannot decode ptr field A: field is not an optional",
 			Description: "should err when mapping to optional field with mismatching type",
 		},
 	}
 	for _, errCase := range errCases {
 		t.Run(errCase.Description, func(t *testing.T) {
-			t.Parallel()
 			err := DecodeFields(simpleEvent, errCase.Struct)
 			assert.Equal(t, errCase.ExpectedErr, err.Error())
 		})

--- a/types_test.go
+++ b/types_test.go
@@ -2165,7 +2165,7 @@ func TestDecodeFields(t *testing.T) {
 	}
 	for _, errCase := range errCases {
 		t.Run(errCase.Description, func(t *testing.T) {
-			//t.Parallel()
+			t.Parallel()
 			err := DecodeFields(simpleEvent, errCase.Struct)
 			assert.Equal(t, errCase.ExpectedErr, err.Error())
 		})


### PR DESCRIPTION
## Description

Added the ability to decode fields into more primitive types
- pointers are decoded from optional
- maps are decoded from dictionary
- `interface{}` are decoded from anystruct
- `*interface{}*` are decoded from optional anystruct
- slices are decoded from VariableArray
- arrays are decoded from FixedArray
- anystruct/optional anystruct are supported as array/dict elements

```
	type eventStruct struct {
		OptionalInt                    *Int                    `cadence:"optionalIntField"`
		DictAnyStruct                  map[String]interface{}  `cadence:"dictAnyStructField"`
		DictOptionalAnyStruct          map[String]*interface{} `cadence:"dictOptionalAnyStructField"`
		Dict                           map[String]Int          `cadence:"dictField"`
		DictOptional                   map[String]*Int         `cadence:"dictOptionalField"`
		OptionalAnyStruct              *interface{}            `cadence:"optionalAnyStructField"`
		AnyStructString                interface{}             `cadence:"anyStructField"`
		ArrayInt                       []Int                   `cadence:"variableArrayIntField"`
		VariableArrayOptional          []*Int                  `cadence:"variableArrayOptionalIntField"`
		FixedArrayInt                  [2]Int                  `cadence:"fixedArrayIntField"`
		VariableArrayAnyStruct         []interface{}           `cadence:"variableArrayAnyStructField"`
		VariableArrayOptionalAnyStruct []*interface{}          `cadence:"variableArrayOptionalAnyStructField"`
	}
```
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
