### PR TITLE
Add support for running downstream dependencies workflow for PRs from forks

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -39,7 +39,7 @@ jobs:
         run: sh crypto_setup.sh
 
       - name: Update Cadence
-        run: go get github.com/onflow/cadence@${{ github.event.pull_request.head.sha }}
+        run: go mod edit -replace github.com/onflow/cadence=github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}
 
       - name: Tidy up
         run: go mod tidy
@@ -63,7 +63,7 @@ jobs:
           cache: true
 
       - name: Update Cadence
-        run: go get github.com/onflow/cadence@${{ github.event.pull_request.head.sha }}
+        run: go mod edit -replace github.com/onflow/cadence=github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}
 
       - name: Tidy up
         run: go mod tidy


### PR DESCRIPTION
## Description

Use go mod replace to allow PRs from forks
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
