### PR TITLE
Improve formatting of access modifiers

### DIFF
--- a/runtime/ast/attachment.go
+++ b/runtime/ast/attachment.go
@@ -135,7 +135,7 @@ func (d *AttachmentDeclaration) Doc() prettier.Doc {
 		doc = append(
 			doc,
 			prettier.Text(d.Access.Keyword()),
-			prettier.Space,
+			prettier.HardLine{},
 		)
 	}
 

--- a/runtime/ast/attachment_test.go
+++ b/runtime/ast/attachment_test.go
@@ -207,7 +207,7 @@ func TestAttachmentDeclaration_Doc(t *testing.T) {
 		t,
 		prettier.Concat{
 			prettier.Text("access(all)"),
-			prettier.Text(" "),
+			prettier.HardLine{},
 			prettier.Text("attachment"),
 			prettier.Text(" "),
 			prettier.Text("Foo"),
@@ -258,7 +258,14 @@ func TestAttachmentDeclaration_Doc(t *testing.T) {
 		decl.Doc(),
 	)
 
-	require.Equal(t, "access(all) attachment Foo for Bar: Baz {\nrequire entitlement X\nrequire entitlement Y\n}", decl.String())
+	require.Equal(t,
+		`access(all)
+attachment Foo for Bar: Baz {
+require entitlement X
+require entitlement Y
+}`,
+		decl.String(),
+	)
 }
 
 func TestAttachExpressionMarshallJSON(t *testing.T) {

--- a/runtime/ast/block_test.go
+++ b/runtime/ast/block_test.go
@@ -137,10 +137,10 @@ func TestBlock_String(t *testing.T) {
 
 	require.Equal(
 		t,
-		"{\n"+
-			"    false\n"+
-			`    "test"`+"\n"+
-			"}",
+		`{
+    false
+    "test"
+}`,
 		block.String(),
 	)
 }

--- a/runtime/ast/composite.go
+++ b/runtime/ast/composite.go
@@ -151,7 +151,7 @@ func (d *CompositeDeclaration) EventDoc() prettier.Doc {
 		doc = append(
 			doc,
 			prettier.Text(d.Access.Keyword()),
-			prettier.Space,
+			prettier.HardLine{},
 		)
 	}
 
@@ -199,7 +199,7 @@ func CompositeDocument(
 		doc = append(
 			doc,
 			prettier.Text(access.Keyword()),
-			prettier.Space,
+			prettier.HardLine{},
 		)
 	}
 
@@ -415,13 +415,6 @@ func (d *FieldDeclaration) Doc() prettier.Doc {
 
 	var docs []prettier.Doc
 
-	if d.Access != AccessNotSpecified {
-		docs = append(
-			docs,
-			prettier.Text(d.Access.Keyword()),
-		)
-	}
-
 	if d.IsStatic() {
 		docs = append(
 			docs,
@@ -458,6 +451,14 @@ func (d *FieldDeclaration) Doc() prettier.Doc {
 		doc = prettier.Join(prettier.Space, docs...)
 	} else {
 		doc = identifierTypeDoc
+	}
+
+	if d.Access != AccessNotSpecified {
+		doc = prettier.Concat{
+			prettier.Text(d.Access.Keyword()),
+			prettier.HardLine{},
+			doc,
+		}
 	}
 
 	return prettier.Group{
@@ -566,7 +567,7 @@ func (d *EnumCaseDeclaration) Doc() prettier.Doc {
 		doc = append(
 			doc,
 			prettier.Text(d.Access.Keyword()),
-			prettier.Space,
+			prettier.HardLine{},
 		)
 	}
 

--- a/runtime/ast/composite_test.go
+++ b/runtime/ast/composite_test.go
@@ -129,20 +129,22 @@ func TestFieldDeclaration_Doc(t *testing.T) {
 			prettier.Group{
 				Doc: prettier.Concat{
 					prettier.Text("access(all)"),
-					prettier.Text(" "),
-					prettier.Text("static"),
-					prettier.Text(" "),
-					prettier.Text("native"),
-					prettier.Text(" "),
-					prettier.Text("let"),
-					prettier.Text(" "),
-					prettier.Group{
-						Doc: prettier.Concat{
-							prettier.Text("xyz"),
-							prettier.Text(": "),
-							prettier.Concat{
-								prettier.Text("@"),
-								prettier.Text("CD"),
+					prettier.HardLine{},
+					prettier.Concat{
+						prettier.Text("static"),
+						prettier.Text(" "),
+						prettier.Text("native"),
+						prettier.Text(" "),
+						prettier.Text("let"),
+						prettier.Text(" "),
+						prettier.Group{
+							Doc: prettier.Concat{
+								prettier.Text("xyz"),
+								prettier.Text(": "),
+								prettier.Concat{
+									prettier.Text("@"),
+									prettier.Text("CD"),
+								},
 							},
 						},
 					},
@@ -218,15 +220,13 @@ func TestFieldDeclaration_Doc(t *testing.T) {
 			prettier.Group{
 				Doc: prettier.Concat{
 					prettier.Text("access(all)"),
-					prettier.Text(" "),
-					prettier.Group{
-						Doc: prettier.Concat{
-							prettier.Text("xyz"),
-							prettier.Text(": "),
-							prettier.Concat{
-								prettier.Text("@"),
-								prettier.Text("CD"),
-							},
+					prettier.HardLine{},
+					prettier.Concat{
+						prettier.Text("xyz"),
+						prettier.Text(": "),
+						prettier.Concat{
+							prettier.Text("@"),
+							prettier.Text("CD"),
 						},
 					},
 				},
@@ -298,7 +298,8 @@ func TestFieldDeclaration_String(t *testing.T) {
 
 		require.Equal(
 			t,
-			"access(all) let xyz: @CD",
+			`access(all)
+let xyz: @CD`,
 			decl.String(),
 		)
 	})
@@ -351,7 +352,8 @@ func TestFieldDeclaration_String(t *testing.T) {
 
 		require.Equal(
 			t,
-			"access(all) xyz: @CD",
+			`access(all)
+xyz: @CD`,
 			decl.String(),
 		)
 
@@ -484,7 +486,7 @@ func TestCompositeDeclaration_Doc(t *testing.T) {
 			t,
 			prettier.Concat{
 				prettier.Text("access(all)"),
-				prettier.Text(" "),
+				prettier.HardLine{},
 				prettier.Text("resource"),
 				prettier.Text(" "),
 				prettier.Text("AB"),
@@ -556,7 +558,7 @@ func TestCompositeDeclaration_Doc(t *testing.T) {
 			t,
 			prettier.Concat{
 				prettier.Text("access(all)"),
-				prettier.Text(" "),
+				prettier.HardLine{},
 				prettier.Text("resource"),
 				prettier.Text(" "),
 				prettier.Text("AB"),
@@ -637,7 +639,7 @@ func TestCompositeDeclaration_Doc(t *testing.T) {
 			t,
 			prettier.Concat{
 				prettier.Text("access(all)"),
-				prettier.Text(" "),
+				prettier.HardLine{},
 				prettier.Text("event"),
 				prettier.Text(" "),
 				prettier.Text("AB"),
@@ -694,7 +696,7 @@ func TestCompositeDeclaration_Doc(t *testing.T) {
 			t,
 			prettier.Concat{
 				prettier.Text("access(all)"),
-				prettier.Text(" "),
+				prettier.HardLine{},
 				prettier.Text("enum"),
 				prettier.Text(" "),
 				prettier.Text("AB"),
@@ -763,7 +765,8 @@ func TestCompositeDeclaration_String(t *testing.T) {
 
 		require.Equal(
 			t,
-			"access(all) resource AB: CD, EF {}",
+			`access(all)
+resource AB: CD, EF {}`,
 			decl.String(),
 		)
 	})
@@ -809,9 +812,10 @@ func TestCompositeDeclaration_String(t *testing.T) {
 
 		require.Equal(
 			t,
-			"access(all) resource AB: CD, EF {\n"+
-				"    x: X\n"+
-				"}",
+			`access(all)
+resource AB: CD, EF {
+    x: X
+}`,
 			decl.String(),
 		)
 	})
@@ -850,7 +854,8 @@ func TestCompositeDeclaration_String(t *testing.T) {
 
 		require.Equal(
 			t,
-			"access(all) event AB(e: E)",
+			`access(all)
+event AB(e: E)`,
 			decl.String(),
 		)
 	})
@@ -884,9 +889,10 @@ func TestCompositeDeclaration_String(t *testing.T) {
 
 		require.Equal(
 			t,
-			"access(all) enum AB: CD {\n"+
-				"    case x\n"+
-				"}",
+			`access(all)
+enum AB: CD {
+    case x
+}`,
 			decl.String(),
 		)
 	})

--- a/runtime/ast/entitlement_declaration.go
+++ b/runtime/ast/entitlement_declaration.go
@@ -108,7 +108,7 @@ func (d *EntitlementDeclaration) Doc() prettier.Doc {
 		doc = append(
 			doc,
 			prettier.Text(d.Access.Keyword()),
-			prettier.Space,
+			prettier.HardLine{},
 		)
 	}
 
@@ -242,7 +242,7 @@ func (d *EntitlementMappingDeclaration) Doc() prettier.Doc {
 		doc = append(
 			doc,
 			prettier.Text(d.Access.Keyword()),
-			prettier.Space,
+			prettier.HardLine{},
 		)
 	}
 

--- a/runtime/ast/entitlement_declaration_test.go
+++ b/runtime/ast/entitlement_declaration_test.go
@@ -86,7 +86,7 @@ func TestEntitlementDeclaration_Doc(t *testing.T) {
 			t,
 			prettier.Concat{
 				prettier.Text("access(all)"),
-				prettier.Text(" "),
+				prettier.HardLine{},
 				prettier.Text("entitlement "),
 				prettier.Text("AB"),
 			},
@@ -113,7 +113,8 @@ func TestEntitlementDeclaration_String(t *testing.T) {
 
 		require.Equal(
 			t,
-			"access(all) entitlement AB",
+			`access(all)
+entitlement AB`,
 			decl.String(),
 		)
 
@@ -237,7 +238,7 @@ func TestEntitlementMappingDeclaration_Doc(t *testing.T) {
 		t,
 		prettier.Concat{
 			prettier.Text("access(all)"),
-			prettier.Text(" "),
+			prettier.HardLine{},
 			prettier.Text("entitlement "),
 			prettier.Text("mapping "),
 			prettier.Text("AB"),
@@ -296,7 +297,8 @@ func TestEntitlementMappingDeclaration_String(t *testing.T) {
 
 	require.Equal(
 		t,
-		`access(all) entitlement mapping AB {
+		`access(all)
+entitlement mapping AB {
     X -> Y
 }`,
 		decl.String(),

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -1443,7 +1443,7 @@ func FunctionDocument(
 		doc = append(
 			doc,
 			prettier.Text(access.Keyword()),
-			prettier.Space,
+			prettier.HardLine{},
 		)
 	}
 

--- a/runtime/ast/function_declaration_test.go
+++ b/runtime/ast/function_declaration_test.go
@@ -331,7 +331,7 @@ func TestFunctionDeclaration_Doc(t *testing.T) {
 	require.Equal(t,
 		prettier.Concat{
 			prettier.Text("access(all)"),
-			prettier.Space,
+			prettier.HardLine{},
 			prettier.Text("view"),
 			prettier.Space,
 			prettier.Text("static"),
@@ -420,7 +420,8 @@ func TestFunctionDeclaration_String(t *testing.T) {
 		}
 
 		require.Equal(t,
-			"access(all) fun xyz(ok foobar: AB): @CD {}",
+			`access(all)
+fun xyz(ok foobar: AB): @CD {}`,
 			decl.String(),
 		)
 
@@ -488,7 +489,8 @@ func TestFunctionDeclaration_String(t *testing.T) {
 		}
 
 		require.Equal(t,
-			"access(all) fun xyz<A, B: C>(ok foobar: AB): @CD {}",
+			`access(all)
+fun xyz<A, B: C>(ok foobar: AB): @CD {}`,
 			decl.String(),
 		)
 	})

--- a/runtime/ast/interface_test.go
+++ b/runtime/ast/interface_test.go
@@ -163,7 +163,7 @@ func TestInterfaceDeclaration_Doc(t *testing.T) {
 			t,
 			prettier.Concat{
 				prettier.Text("access(all)"),
-				prettier.Text(" "),
+				prettier.HardLine{},
 				prettier.Text("resource"),
 				prettier.Text(" "),
 				prettier.Text("interface "),
@@ -207,7 +207,7 @@ func TestInterfaceDeclaration_Doc(t *testing.T) {
 			t,
 			prettier.Concat{
 				prettier.Text("access(all)"),
-				prettier.Text(" "),
+				prettier.HardLine{},
 				prettier.Text("resource"),
 				prettier.Text(" "),
 				prettier.Text("interface "),
@@ -256,7 +256,8 @@ func TestInterfaceDeclaration_String(t *testing.T) {
 
 		require.Equal(
 			t,
-			"access(all) resource interface AB {}",
+			`access(all)
+resource interface AB {}`,
 			decl.String(),
 		)
 
@@ -291,9 +292,10 @@ func TestInterfaceDeclaration_String(t *testing.T) {
 
 		require.Equal(
 			t,
-			"access(all) resource interface AB {\n"+
-				"    x: X\n"+
-				"}",
+			`access(all)
+resource interface AB {
+    x: X
+}`,
 			decl.String(),
 		)
 

--- a/runtime/ast/transaction_declaration_test.go
+++ b/runtime/ast/transaction_declaration_test.go
@@ -211,16 +211,18 @@ func TestTransactionDeclaration_Doc(t *testing.T) {
 						prettier.Group{
 							Doc: prettier.Concat{
 								prettier.Text("access(all)"),
-								prettier.Text(" "),
-								prettier.Text("let"),
-								prettier.Text(" "),
-								prettier.Group{
-									Doc: prettier.Concat{
-										prettier.Text("f"),
-										prettier.Text(": "),
-										prettier.Concat{
-											prettier.Text("@"),
-											prettier.Text("F"),
+								prettier.HardLine{},
+								prettier.Concat{
+									prettier.Text("let"),
+									prettier.Text(" "),
+									prettier.Group{
+										Doc: prettier.Concat{
+											prettier.Text("f"),
+											prettier.Text(": "),
+											prettier.Concat{
+												prettier.Text("@"),
+												prettier.Text("F"),
+											},
 										},
 									},
 								},
@@ -447,25 +449,26 @@ func TestTransactionDeclaration_String(t *testing.T) {
 
 	require.Equal(
 		t,
-		"transaction(x: X) {\n"+
-			"    access(all) let f: @F\n"+
-			"    \n"+
-			"    prepare(signer: AuthAccount) {}\n"+
-			"    \n"+
-			"    pre {\n"+
-			"        true:\n"+
-			"            \"pre\"\n"+
-			"    }\n"+
-			"    \n"+
-			"    execute {\n"+
-			"        \"xyz\"\n"+
-			"    }\n"+
-			"    \n"+
-			"    post {\n"+
-			"        false:\n"+
-			"            \"post\"\n"+
-			"    }\n"+
-			"}",
+		`transaction(x: X) {
+    access(all)
+    let f: @F
+    
+    prepare(signer: AuthAccount) {}
+    
+    pre {
+        true:
+            "pre"
+    }
+    
+    execute {
+        "xyz"
+    }
+    
+    post {
+        false:
+            "post"
+    }
+}`,
 		decl.String(),
 	)
 }

--- a/runtime/ast/variable_declaration.go
+++ b/runtime/ast/variable_declaration.go
@@ -206,7 +206,7 @@ func (d *VariableDeclaration) Doc() prettier.Doc {
 		doc = append(
 			doc,
 			prettier.Text(d.Access.Keyword()),
-			prettier.Space,
+			prettier.HardLine{},
 		)
 	}
 

--- a/runtime/ast/variable_declaration_test.go
+++ b/runtime/ast/variable_declaration_test.go
@@ -171,7 +171,7 @@ func TestVariableDeclaration_Doc(t *testing.T) {
 			prettier.Group{
 				Doc: prettier.Concat{
 					prettier.Text("access(all)"),
-					prettier.Text(" "),
+					prettier.HardLine{},
 					prettier.Text("let"),
 					prettier.Text(" "),
 					prettier.Group{
@@ -240,7 +240,7 @@ func TestVariableDeclaration_Doc(t *testing.T) {
 			prettier.Group{
 				Doc: prettier.Concat{
 					prettier.Text("access(all)"),
-					prettier.Text(" "),
+					prettier.HardLine{},
 					prettier.Text("let"),
 					prettier.Text(" "),
 					prettier.Group{
@@ -309,7 +309,8 @@ func TestVariableDeclaration_String(t *testing.T) {
 		}
 
 		require.Equal(t,
-			"access(all) let foo: @AB <- true",
+			`access(all)
+let foo: @AB <- true`,
 			decl.String(),
 		)
 	})
@@ -347,7 +348,8 @@ func TestVariableDeclaration_String(t *testing.T) {
 		}
 
 		require.Equal(t,
-			"access(all) let foo: @AB <- true <- false",
+			`access(all)
+let foo: @AB <- true <- false`,
 			decl.String(),
 		)
 	})


### PR DESCRIPTION
## Description

When formatting access modifiers, put the access modifier on a separate line, by appending a line break instead of a space.

This makes access modifiers more readable, as they are long now, especially when entitlements are involved.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
