### PR TITLE
Allow external mutation for owned values

### DIFF
--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -318,23 +318,6 @@ func (checker *Checker) visitIndexExpressionAssignment(
 
 	elementType = checker.visitIndexExpression(indexExpression, true)
 
-	if targetExpression, ok := indexExpression.TargetExpression.(*ast.MemberExpression); ok {
-		// visitMember caches its result, so visiting the target expression again,
-		// after it had been previously visited by visiting the outer index expression,
-		// performs no computation
-		_, _, member, _ := checker.visitMember(targetExpression)
-		if member != nil && !checker.isMutatableMember(member) {
-			checker.report(
-				&ExternalMutationError{
-					Name:            member.Identifier.Identifier,
-					DeclarationKind: member.DeclarationKind,
-					Range:           ast.NewRangeFromPositioned(checker.memoryGauge, targetExpression),
-					ContainerType:   member.ContainerType,
-				},
-			)
-		}
-	}
-
 	if elementType == nil {
 		return InvalidType
 	}

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -222,24 +222,6 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (accessedT
 		targetRange := ast.NewRangeFromPositioned(checker.memoryGauge, expression.Expression)
 		member = resolver.Resolve(checker.memoryGauge, identifier, targetRange, checker.report)
 		resultingType = member.TypeAnnotation.Type
-		if resolver.Mutating {
-			if targetExpression, ok := accessedExpression.(*ast.MemberExpression); ok {
-				// visitMember caches its result, so visiting the target expression again,
-				// after it had been previously visited to get the resolver,
-				// performs no computation
-				_, _, subMember, _ := checker.visitMember(targetExpression)
-				if subMember != nil && !checker.isMutatableMember(subMember) {
-					checker.report(
-						&ExternalMutationError{
-							Name:            subMember.Identifier.Identifier,
-							DeclarationKind: subMember.DeclarationKind,
-							Range:           ast.NewRangeFromPositioned(checker.memoryGauge, targetRange),
-							ContainerType:   subMember.ContainerType,
-						},
-					)
-				}
-			}
-		}
 	}
 
 	// Get the member from the accessed value based
@@ -489,13 +471,6 @@ func (checker *Checker) isReadableMember(accessedType Type, member *Member, acce
 func (checker *Checker) isWriteableMember(member *Member) bool {
 	return checker.Config.AccessCheckMode.IsWriteableAccess(member.Access) ||
 		checker.containerTypes[member.ContainerType]
-}
-
-// isMutatableMember returns true if the given member can be mutated
-// in the current location of the checker. Currently equivalent to
-// isWriteableMember above, but separate in case this changes
-func (checker *Checker) isMutatableMember(member *Member) bool {
-	return checker.isWriteableMember(member)
 }
 
 // containingContractKindedType returns the containing contract-kinded type

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -3926,40 +3926,6 @@ func (e *InvalidEntryPointTypeError) Error() string {
 	)
 }
 
-// ExternalMutationError
-
-type ExternalMutationError struct {
-	ContainerType Type
-	Name          string
-	ast.Range
-	DeclarationKind common.DeclarationKind
-}
-
-var _ SemanticError = &ExternalMutationError{}
-var _ errors.UserError = &ExternalMutationError{}
-var _ errors.SecondaryError = &ExternalMutationError{}
-
-func (*ExternalMutationError) isSemanticError() {}
-
-func (*ExternalMutationError) IsUserError() {}
-
-func (e *ExternalMutationError) Error() string {
-	return fmt.Sprintf(
-		"cannot mutate `%s`: %s is only mutable inside `%s`",
-		e.Name,
-		e.DeclarationKind.Name(),
-		e.ContainerType.QualifiedString(),
-	)
-}
-
-func (e *ExternalMutationError) SecondaryError() string {
-	return fmt.Sprintf(
-		"Consider adding a setter for `%s` to `%s`",
-		e.Name,
-		e.ContainerType.QualifiedString(),
-	)
-}
-
 type PurityError struct {
 	ast.Range
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -204,8 +204,7 @@ type MemberResolver struct {
 		targetRange ast.Range,
 		report func(error),
 	) *Member
-	Kind     common.DeclarationKind
-	Mutating bool
+	Kind common.DeclarationKind
 }
 
 // supertype of interfaces and composites
@@ -1996,8 +1995,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 	if _, ok := arrayType.(*VariableSizedType); ok {
 
 		members["append"] = MemberResolver{
-			Kind:     common.DeclarationKindFunction,
-			Mutating: true,
+			Kind: common.DeclarationKindFunction,
 			Resolve: func(memoryGauge common.MemoryGauge, identifier string, targetRange ast.Range, report func(error)) *Member {
 				elementType := arrayType.ElementType(false)
 				return NewFunctionMember(
@@ -2012,8 +2010,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 		}
 
 		members["appendAll"] = MemberResolver{
-			Kind:     common.DeclarationKindFunction,
-			Mutating: true,
+			Kind: common.DeclarationKindFunction,
 			Resolve: func(memoryGauge common.MemoryGauge, identifier string, targetRange ast.Range, report func(error)) *Member {
 
 				elementType := arrayType.ElementType(false)
@@ -2094,8 +2091,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 		}
 
 		members["insert"] = MemberResolver{
-			Kind:     common.DeclarationKindFunction,
-			Mutating: true,
+			Kind: common.DeclarationKindFunction,
 			Resolve: func(memoryGauge common.MemoryGauge, identifier string, _ ast.Range, _ func(error)) *Member {
 
 				elementType := arrayType.ElementType(false)
@@ -2112,8 +2108,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 		}
 
 		members["remove"] = MemberResolver{
-			Kind:     common.DeclarationKindFunction,
-			Mutating: true,
+			Kind: common.DeclarationKindFunction,
 			Resolve: func(memoryGauge common.MemoryGauge, identifier string, _ ast.Range, _ func(error)) *Member {
 
 				elementType := arrayType.ElementType(false)
@@ -2130,8 +2125,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 		}
 
 		members["removeFirst"] = MemberResolver{
-			Kind:     common.DeclarationKindFunction,
-			Mutating: true,
+			Kind: common.DeclarationKindFunction,
 			Resolve: func(memoryGauge common.MemoryGauge, identifier string, _ ast.Range, _ func(error)) *Member {
 
 				elementType := arrayType.ElementType(false)
@@ -2148,8 +2142,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 		}
 
 		members["removeLast"] = MemberResolver{
-			Kind:     common.DeclarationKindFunction,
-			Mutating: true,
+			Kind: common.DeclarationKindFunction,
 			Resolve: func(memoryGauge common.MemoryGauge, identifier string, _ ast.Range, _ func(error)) *Member {
 
 				elementType := arrayType.ElementType(false)
@@ -5307,8 +5300,7 @@ func (t *DictionaryType) initializeMemberResolvers() {
 				},
 			},
 			"insert": {
-				Kind:     common.DeclarationKindFunction,
-				Mutating: true,
+				Kind: common.DeclarationKindFunction,
 				Resolve: func(memoryGauge common.MemoryGauge, identifier string, _ ast.Range, _ func(error)) *Member {
 					return NewFunctionMember(
 						memoryGauge,
@@ -5321,8 +5313,7 @@ func (t *DictionaryType) initializeMemberResolvers() {
 				},
 			},
 			"remove": {
-				Kind:     common.DeclarationKindFunction,
-				Mutating: true,
+				Kind: common.DeclarationKindFunction,
 				Resolve: func(memoryGauge common.MemoryGauge, identifier string, _ ast.Range, _ func(error)) *Member {
 					return NewFunctionMember(
 						memoryGauge,

--- a/runtime/tests/checker/attachments_test.go
+++ b/runtime/tests/checker/attachments_test.go
@@ -4165,9 +4165,8 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 				`,
 		)
 
-		errs := RequireCheckerErrors(t, err, 2)
-		assert.IsType(t, &sema.ExternalMutationError{}, errs[0])
-		assert.IsType(t, &sema.InvalidAccessError{}, errs[1])
+		errs := RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.InvalidAccessError{}, errs[0])
 	})
 
 	t.Run("basic, with entitlements", func(t *testing.T) {
@@ -4221,9 +4220,8 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 				`,
 		)
 
-		errs := RequireCheckerErrors(t, err, 2)
-		assert.IsType(t, &sema.ExternalMutationError{}, errs[0])
-		assert.IsType(t, &sema.InvalidAccessError{}, errs[1])
+		errs := RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.InvalidAccessError{}, errs[0])
 	})
 
 	t.Run("in base, with entitlements", func(t *testing.T) {

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -4748,8 +4748,7 @@ func TestCheckEntitledWriteAndMutateNotAllowed(t *testing.T) {
 			}
 		`)
 
-		errs := RequireCheckerErrors(t, err, 1)
-		require.IsType(t, &sema.ExternalMutationError{}, errs[0])
+		assert.NoError(t, err)
 	})
 
 	t.Run("basic authorized", func(t *testing.T) {
@@ -4769,9 +4768,8 @@ func TestCheckEntitledWriteAndMutateNotAllowed(t *testing.T) {
 			}
 		`)
 
-		errs := RequireCheckerErrors(t, err, 2)
-		require.IsType(t, &sema.ExternalMutationError{}, errs[0])
-		assert.IsType(t, &sema.InvalidAccessError{}, errs[1])
+		errs := RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.InvalidAccessError{}, errs[0])
 	})
 }
 

--- a/runtime/tests/checker/external_mutation_test.go
+++ b/runtime/tests/checker/external_mutation_test.go
@@ -84,9 +84,7 @@ func TestCheckArrayUpdateIndexAccess(t *testing.T) {
             `, valueKind.Keyword(), access.Keyword(), declaration.Keywords(), assignmentOp, destroyStatement),
 			)
 
-			errs := RequireCheckerErrors(t, err, 1)
-			var externalMutationError *sema.ExternalMutationError
-			require.ErrorAs(t, errs[0], &externalMutationError)
+			require.NoError(t, err)
 		})
 	}
 
@@ -153,9 +151,7 @@ func TestCheckDictionaryUpdateIndexAccess(t *testing.T) {
             `, valueKind.Keyword(), access.Keyword(), declaration.Keywords(), assignmentOp, destroyStatement),
 			)
 
-			errs := RequireCheckerErrors(t, err, 1)
-			var externalMutationError *sema.ExternalMutationError
-			require.ErrorAs(t, errs[0], &externalMutationError)
+			require.NoError(t, err)
 		})
 	}
 
@@ -216,9 +212,7 @@ func TestCheckNestedArrayUpdateIndexAccess(t *testing.T) {
             `, access.Keyword(), declaration.Keywords()),
 			)
 
-			errs := RequireCheckerErrors(t, err, 1)
-			var externalMutationError *sema.ExternalMutationError
-			require.ErrorAs(t, errs[0], &externalMutationError)
+			require.NoError(t, err)
 		})
 	}
 
@@ -277,9 +271,7 @@ func TestCheckNestedDictionaryUpdateIndexAccess(t *testing.T) {
             `, access.Keyword(), declaration.Keywords()),
 			)
 
-			errs := RequireCheckerErrors(t, err, 1)
-			var externalMutationError *sema.ExternalMutationError
-			require.ErrorAs(t, errs[0], &externalMutationError)
+			require.NoError(t, err)
 		})
 	}
 
@@ -328,18 +320,15 @@ func TestCheckMutateContractIndexAccess(t *testing.T) {
             `, access.Keyword(), declaration.Keywords()),
 			)
 
-			expectedErrors := 1
-			if access == ast.AccessContract {
-				expectedErrors++
-			}
+			expectError := access == ast.AccessContract
 
-			errs := RequireCheckerErrors(t, err, expectedErrors)
-			if expectedErrors > 1 {
+			if expectError {
+				errs := RequireCheckerErrors(t, err, 1)
 				var accessError *sema.InvalidAccessError
-				require.ErrorAs(t, errs[expectedErrors-2], &accessError)
+				require.ErrorAs(t, errs[0], &accessError)
+			} else {
+				require.NoError(t, err)
 			}
-			var externalMutationError *sema.ExternalMutationError
-			require.ErrorAs(t, errs[expectedErrors-1], &externalMutationError)
 		})
 	}
 
@@ -395,18 +384,15 @@ func TestCheckContractNestedStructIndexAccess(t *testing.T) {
             `, access.Keyword(), declaration.Keywords()),
 			)
 
-			expectedErrors := 1
-			if access == ast.AccessContract {
-				expectedErrors++
-			}
+			expectError := access == ast.AccessContract
 
-			errs := RequireCheckerErrors(t, err, expectedErrors)
-			if expectedErrors > 1 {
+			if expectError {
+				errs := RequireCheckerErrors(t, err, 1)
 				var accessError *sema.InvalidAccessError
-				require.ErrorAs(t, errs[expectedErrors-2], &accessError)
+				require.ErrorAs(t, errs[0], &accessError)
+			} else {
+				require.NoError(t, err)
 			}
-			var externalMutationError *sema.ExternalMutationError
-			require.ErrorAs(t, errs[expectedErrors-1], &externalMutationError)
 		})
 	}
 
@@ -459,9 +445,7 @@ func TestCheckContractStructInitIndexAccess(t *testing.T) {
             `, access.Keyword(), declaration.Keywords()),
 			)
 
-			errs := RequireCheckerErrors(t, err, 1)
-			var externalMutationError *sema.ExternalMutationError
-			require.ErrorAs(t, errs[0], &externalMutationError)
+			require.NoError(t, err)
 		})
 	}
 
@@ -544,13 +528,7 @@ func TestCheckArrayUpdateMethodCall(t *testing.T) {
             `, valueKind.Keyword(), access.Keyword(), declaration.Keywords(), assignmentOp, member.Code, destroyStatement),
 			)
 
-			if member.Mutating {
-				errs := RequireCheckerErrors(t, err, 1)
-				var externalMutationError *sema.ExternalMutationError
-				require.ErrorAs(t, errs[0], &externalMutationError)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, err)
 		})
 	}
 
@@ -633,13 +611,7 @@ func TestCheckDictionaryUpdateMethodCall(t *testing.T) {
             `, valueKind.Keyword(), access.Keyword(), declaration.Keywords(), assignmentOp, member.Code, destroyStatement),
 			)
 
-			if member.Mutating {
-				errs := RequireCheckerErrors(t, err, 1)
-				var externalMutationError *sema.ExternalMutationError
-				require.ErrorAs(t, errs[0], &externalMutationError)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, err)
 		})
 	}
 
@@ -782,11 +754,8 @@ func TestCheckMutationThroughReference(t *testing.T) {
               }
         `,
 		)
-		errs := RequireCheckerErrors(t, err, 2)
-		var externalMutationError *sema.ExternalMutationError
-		require.ErrorAs(t, errs[0], &externalMutationError)
-
-		assert.IsType(t, &sema.InvalidAccessError{}, errs[1])
+		errs := RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.InvalidAccessError{}, errs[0])
 	})
 }
 
@@ -860,8 +829,6 @@ func TestCheckMutationThroughAccess(t *testing.T) {
             }
         `,
 		)
-		errs := RequireCheckerErrors(t, err, 1)
-		var externalMutationError *sema.ExternalMutationError
-		require.ErrorAs(t, errs[0], &externalMutationError)
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Work towards #2535

⚠️ depends on #2598

## Description

Reverts the changes introduced in https://github.com/onflow/cadence/pull/1267
(Will send the doc changes separately)

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
