### PR TITLE
Populate `Message`, `LocationRange` fields for `AssertionError` on `Test.expect` function

### DIFF
--- a/runtime/stdlib/test_contract.go
+++ b/runtime/stdlib/test_contract.go
@@ -280,7 +280,14 @@ func newTestTypeExpectFunction(functionType *sema.FunctionType) interpreter.Func
 			)
 
 			if !result {
-				panic(AssertionError{})
+				message := fmt.Sprintf(
+					"given value is: %s",
+					value,
+				)
+				panic(AssertionError{
+					Message:       message,
+					LocationRange: invocation.LocationRange,
+				})
 			}
 
 			return interpreter.Void

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -1613,7 +1613,12 @@ func TestTestExpect(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
-		assert.ErrorAs(t, err, &AssertionError{})
+
+		assertionErr := &AssertionError{}
+		assert.ErrorAs(t, err, assertionErr)
+		assert.Equal(t, "given value is: \"this string\"", assertionErr.Message)
+		assert.Equal(t, "test", assertionErr.LocationRange.Location.String())
+		assert.Equal(t, 5, assertionErr.LocationRange.StartPosition().Line)
 	})
 
 	t.Run("different types", func(t *testing.T) {


### PR DESCRIPTION
## Description

Without `LocationRange`, this function crashes when used through the `flow-cli`, to run tests. This is because the `LocationRange` is needed to show in which line the error occurred.

Stack trace:
```bash
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xb80405]

goroutine 1 [running]:
github.com/onflow/cadence/runtime/pretty.ErrorPrettyPrinter.PrettyPrintError.func1()
	github.com/onflow/cadence@v0.39.12/runtime/pretty/print.go:160 +0x106
panic({0x1c35320, 0x338e1c0})
	runtime/panic.go:884 +0x213
github.com/onflow/cadence/runtime/stdlib.(*AssertionError).StartPosition(0x1a68ef2?)
```

With the fix:

```bash
Test results: "tests/test_foo_contract.cdc"
- PASS: testGetIntegerTrait
- FAIL: testAddSpecialNumber
		Execution failed:
			error: assertion failed: given value is: "this string"
			  --> 7465737400000000000000000000000000000000000000000000000000000000:37:4
			
Coverage: 95.8% of statements
```
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
