### PR TITLE
Add utility function `ccf.HasMsgPrefix`

### DIFF
--- a/encoding/ccf/decode.go
+++ b/encoding/ccf/decode.go
@@ -32,12 +32,6 @@ import (
 	cadenceErrors "github.com/onflow/cadence/runtime/errors"
 )
 
-const (
-	// Top level CCF messages are CBOR tag (tag number: CBORTagTypeDefAndValue | CBORTagTypeAndValue, content: array of 2 elements).
-	// Minimum size is 5 bytes: top level tag number (2 bytes) + min size for array of 2 elements (3 bytes).
-	minTopLevelMsgSize = 5
-)
-
 // HasMsgPrefix returns true if the msg prefix (first few bytes)
 // matches currently implemented top-level CCF messages:
 // -  ccf-typedef-and-value-message
@@ -45,6 +39,11 @@ const (
 // WARNING: For simplicity and performance, this does not check
 // if msg is actually a CCF message, or well-formed, or valid.
 func HasMsgPrefix(msg []byte) bool {
+
+	// Top level CCF messages are CBOR tag (tag number: CBORTagTypeDefAndValue | CBORTagTypeAndValue, content: array of 2 elements).
+	// Minimum size is 5 bytes: top level tag number (2 bytes) + min size for array of 2 elements (3 bytes).
+	const minTopLevelMsgSize = 5
+
 	if len(msg) < minTopLevelMsgSize {
 		return false
 	}
@@ -62,7 +61,7 @@ func HasMsgPrefix(msg []byte) bool {
 	// - ccf-typedef-and-value-message
 	// - ccf-type-and-valu8e-message
 
-	return msg[0] == 0xd8 &&
+	return msg[0] == 0xd8 && // 0xd8 is major type 6, semantic tag
 		(msg[1] == CBORTagTypeDefAndValue || msg[1] == CBORTagTypeAndValue) &&
 		msg[2] == 0x82 // 0x82 is CBOR array head of 2 elements
 }

--- a/encoding/ccf/decode.go
+++ b/encoding/ccf/decode.go
@@ -32,6 +32,41 @@ import (
 	cadenceErrors "github.com/onflow/cadence/runtime/errors"
 )
 
+const (
+	// Top level CCF messages are CBOR tag (tag number: CBORTagTypeDefAndValue | CBORTagTypeAndValue, content: array of 2 elements).
+	// Minimum size is 5 bytes: top level tag number (2 bytes) + min size for array of 2 elements (3 bytes).
+	minTopLevelMsgSize = 5
+)
+
+// HasMsgPrefix returns true if the msg prefix (first few bytes)
+// matches currently implemented top-level CCF messages:
+// -  ccf-typedef-and-value-message
+// -  ccf-type-and-value-message
+// WARNING: For simplicity and performance, this does not check
+// if msg is actually a CCF message, or well-formed, or valid.
+func HasMsgPrefix(msg []byte) bool {
+	if len(msg) < minTopLevelMsgSize {
+		return false
+	}
+
+	// There are 3 top messages defined in CCF specs:
+	// language=CDDL
+	// ccf-message = (
+	//   ccf-typedef-message
+	//   / ccf-typedef-and-value-message
+	//   / ccf-type-and-value-message
+	// )
+	//
+	// Since ccf-typedef-message isn't implemented yet,
+	// check for these two messages:
+	// - ccf-typedef-and-value-message
+	// - ccf-type-and-valu8e-message
+
+	return msg[0] == 0xd8 &&
+		(msg[1] == CBORTagTypeDefAndValue || msg[1] == CBORTagTypeAndValue) &&
+		msg[2] == 0x82 // 0x82 is CBOR array head of 2 elements
+}
+
 // defaultCBORDecMode
 //
 // See https://github.com/fxamacker/cbor:


### PR DESCRIPTION
Closes #2608 

## Description

`HasMsgPrefix` returns `true` if the msg prefix (first few bytes) matches currently implemented top-level CCF messages.

For simplicity and performance, `HasMsgPrefix` does not check if msg is actually a CCF message, or well-formed, or valid.

cc: @peterargue 
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
