### PR TITLE
Set permissions in backward compatibility check

### DIFF
--- a/.github/workflows/compatibility-check-template.yml
+++ b/.github/workflows/compatibility-check-template.yml
@@ -76,6 +76,12 @@ jobs:
           path: tmp/contracts.csv
           key: ${{ steps.cache-key-generator.outputs.cache-key }}-contracts
 
+      - name: Configure permissions
+        if: github.repository != 'onflow/cadence'
+        run: |
+          echo "GOPRIVATE=github.com/${{ inputs.repo }}" >> "$GITHUB_ENV"
+          git config --global url."https://${{ github.actor }}:${{ github.token }}@github.com".insteadOf "https://github.com"
+
       # Check contracts using current branch
 
       - name: Check contracts using ${{ inputs.current-branch }}

--- a/.github/workflows/compatibility-check.yml
+++ b/.github/workflows/compatibility-check.yml
@@ -61,7 +61,7 @@ jobs:
     needs: setup
     uses: ./.github/workflows/compatibility-check-template.yml
     with:
-      repo: ${{ inputs.repo }}
+      repo: ${{ needs.setup.outputs.repo }}
       base-branch: ${{ needs.setup.outputs.base }}
       current-branch: ${{ needs.setup.outputs.branch }}
       chain: flow-mainnet


### PR DESCRIPTION
## Description

#2612 added support for running backward compatibility check from forks.

Add support for private forks.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
