### PR TITLE
Use atree orderd map's Has function to test for existence

### DIFF
--- a/runtime/interpreter/storagemap.go
+++ b/runtime/interpreter/storagemap.go
@@ -67,20 +67,16 @@ func NewStorageMapWithRootID(storage atree.SlabStorage, storageID atree.StorageI
 
 // ValueExists returns true if the given key exists in the storage map.
 func (s StorageMap) ValueExists(key StorageMapKey) bool {
-	_, err := s.orderedMap.Get(
+	exists, err := s.orderedMap.Has(
 		key.AtreeValueCompare,
 		key.AtreeValueHashInput,
 		key.AtreeValue(),
 	)
 	if err != nil {
-		var keyNotFoundError *atree.KeyNotFoundError
-		if goerrors.As(err, &keyNotFoundError) {
-			return false
-		}
 		panic(errors.NewExternalError(err))
 	}
 
-	return true
+	return exists
 }
 
 // ReadValue returns the value for the given key.

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -16925,20 +16925,15 @@ func (v *DictionaryValue) ContainsKey(
 	valueComparator := newValueComparator(interpreter, locationRange)
 	hashInputProvider := newHashInputProvider(interpreter, locationRange)
 
-	_, err := v.dictionary.Get(
+	exists, err := v.dictionary.Has(
 		valueComparator,
 		hashInputProvider,
 		keyValue,
 	)
 	if err != nil {
-		var keyNotFoundError *atree.KeyNotFoundError
-		if goerrors.As(err, &keyNotFoundError) {
-			return FalseValue
-		}
 		panic(errors.NewExternalError(err))
 	}
-
-	return TrueValue
+	return AsBoolValue(exists)
 }
 
 func (v *DictionaryValue) Get(


### PR DESCRIPTION

## Description

Triggered by onflow/atree#318: Atree's ordered map provides a high-level `Has` function to check for key existence. Use it instead of `Get` to prevent a future unnecessary value conversion in the case where the key exists.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
