### PR TITLE
Provide suggested fixes for argument label errors

### DIFF
--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -5513,7 +5513,7 @@ func TestParseEventEmitStatement(t *testing.T) {
 										{
 											Label:         "to",
 											LabelStartPos: &ast.Position{Offset: 42, Line: 3, Column: 22},
-											LabelEndPos:   &ast.Position{Offset: 43, Line: 3, Column: 23},
+											LabelEndPos:   &ast.Position{Offset: 44, Line: 3, Column: 24},
 											Expression: &ast.IntegerExpression{
 												PositiveLiteral: []byte("1"),
 												Value:           big.NewInt(1),
@@ -5528,7 +5528,7 @@ func TestParseEventEmitStatement(t *testing.T) {
 										{
 											Label:         "from",
 											LabelStartPos: &ast.Position{Offset: 49, Line: 3, Column: 29},
-											LabelEndPos:   &ast.Position{Offset: 52, Line: 3, Column: 32},
+											LabelEndPos:   &ast.Position{Offset: 53, Line: 3, Column: 33},
 											Expression: &ast.IntegerExpression{
 												PositiveLiteral: []byte("2"),
 												Value:           big.NewInt(2),

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -1054,6 +1054,8 @@ func parseArgument(p *parser) (*ast.Argument, error) {
 
 	// If a colon follows the expression, the expression was our label.
 	if p.current.Is(lexer.TokenColon) {
+		labelEndPos = p.current.EndPos
+
 		identifier, ok := expr.(*ast.IdentifierExpression)
 		if !ok {
 			return nil, p.syntaxError(
@@ -1063,7 +1065,6 @@ func parseArgument(p *parser) (*ast.Argument, error) {
 		}
 		label = identifier.Identifier.Identifier
 		labelStartPos = expr.StartPosition()
-		labelEndPos = expr.EndPosition(p.memoryGauge)
 
 		// Skip the identifier
 		p.nextSemanticToken()

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -1478,7 +1478,7 @@ func TestParseInvocation(t *testing.T) {
 					{
 						Label:         "label",
 						LabelStartPos: &ast.Position{Offset: 2, Line: 1, Column: 2},
-						LabelEndPos:   &ast.Position{Offset: 6, Line: 1, Column: 6},
+						LabelEndPos:   &ast.Position{Offset: 7, Line: 1, Column: 7},
 						Expression: &ast.IntegerExpression{
 							PositiveLiteral: []byte("1"),
 							Value:           big.NewInt(1),
@@ -1567,7 +1567,7 @@ func TestParseInvocation(t *testing.T) {
 					{
 						Label:         "a",
 						LabelStartPos: &ast.Position{Offset: 2, Line: 1, Column: 2},
-						LabelEndPos:   &ast.Position{Offset: 2, Line: 1, Column: 2},
+						LabelEndPos:   &ast.Position{Offset: 3, Line: 1, Column: 3},
 						Expression: &ast.IntegerExpression{
 							PositiveLiteral: []byte("1"),
 							Value:           big.NewInt(1),
@@ -1582,7 +1582,7 @@ func TestParseInvocation(t *testing.T) {
 					{
 						Label:         "b",
 						LabelStartPos: &ast.Position{Offset: 6, Line: 1, Column: 6},
-						LabelEndPos:   &ast.Position{Offset: 6, Line: 1, Column: 6},
+						LabelEndPos:   &ast.Position{Offset: 7, Line: 1, Column: 7},
 						Expression: &ast.IntegerExpression{
 							PositiveLiteral: []byte("2"),
 							Value:           big.NewInt(2),
@@ -4637,7 +4637,7 @@ func TestParseInvocationExpressionWithLabels(t *testing.T) {
 	t.Parallel()
 
 	const code = `
-	    let a = b(x: 1, y: 2)
+	    let a = b(x: 1, y: 2, z : 3)
 	`
 	result, errs := testParseProgram(code)
 	require.Empty(t, errs)
@@ -4665,7 +4665,7 @@ func TestParseInvocationExpressionWithLabels(t *testing.T) {
 						{
 							Label:         "x",
 							LabelStartPos: &ast.Position{Offset: 16, Line: 2, Column: 15},
-							LabelEndPos:   &ast.Position{Offset: 16, Line: 2, Column: 15},
+							LabelEndPos:   &ast.Position{Offset: 17, Line: 2, Column: 16},
 							Expression: &ast.IntegerExpression{
 								PositiveLiteral: []byte("1"),
 								Value:           big.NewInt(1),
@@ -4680,7 +4680,7 @@ func TestParseInvocationExpressionWithLabels(t *testing.T) {
 						{
 							Label:         "y",
 							LabelStartPos: &ast.Position{Offset: 22, Line: 2, Column: 21},
-							LabelEndPos:   &ast.Position{Offset: 22, Line: 2, Column: 21},
+							LabelEndPos:   &ast.Position{Offset: 23, Line: 2, Column: 22},
 							Expression: &ast.IntegerExpression{
 								PositiveLiteral: []byte("2"),
 								Value:           big.NewInt(2),
@@ -4692,9 +4692,24 @@ func TestParseInvocationExpressionWithLabels(t *testing.T) {
 							},
 							TrailingSeparatorPos: ast.Position{Offset: 26, Line: 2, Column: 25},
 						},
+						{
+							Label:         "z",
+							LabelStartPos: &ast.Position{Offset: 28, Line: 2, Column: 27},
+							LabelEndPos:   &ast.Position{Offset: 30, Line: 2, Column: 29},
+							Expression: &ast.IntegerExpression{
+								PositiveLiteral: []byte("3"),
+								Value:           big.NewInt(3),
+								Base:            10,
+								Range: ast.Range{
+									StartPos: ast.Position{Offset: 32, Line: 2, Column: 31},
+									EndPos:   ast.Position{Offset: 32, Line: 2, Column: 31},
+								},
+							},
+							TrailingSeparatorPos: ast.Position{Offset: 33, Line: 2, Column: 32},
+						},
 					},
 					ArgumentsStartPos: ast.Position{Offset: 15, Line: 2, Column: 14},
-					EndPos:            ast.Position{Offset: 26, Line: 2, Column: 25},
+					EndPos:            ast.Position{Offset: 33, Line: 2, Column: 32},
 				},
 				StartPos: ast.Position{Offset: 6, Line: 2, Column: 5},
 			},

--- a/runtime/parser/parser_test.go
+++ b/runtime/parser/parser_test.go
@@ -791,9 +791,9 @@ func TestParseArgumentList(t *testing.T) {
 						Column: 4,
 					},
 					LabelEndPos: &ast.Position{
-						Offset: 4,
+						Offset: 5,
 						Line:   1,
-						Column: 4,
+						Column: 5,
 					},
 					Expression: &ast.BoolExpression{
 						Value: true,

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -76,6 +76,23 @@ func (e *unsupportedOperation) Error() string {
 	)
 }
 
+// SuggestedFix
+
+type HasSuggestedFixes interface {
+	SuggestFixes(code string) []SuggestedFix
+}
+
+type SuggestedFix struct {
+	Message   string
+	TextEdits []TextEdit
+}
+
+type TextEdit struct {
+	Replacement string
+	Insertion   string
+	ast.Range
+}
+
 // InvalidPragmaError
 
 type InvalidPragmaError struct {

--- a/tools/analysis/diagnostic.go
+++ b/tools/analysis/diagnostic.go
@@ -21,17 +21,12 @@ package analysis
 import (
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
 )
 
-type SuggestedFix struct {
-	Message   string
-	TextEdits []TextEdit
-}
+type SuggestedFix = sema.SuggestedFix
 
-type TextEdit struct {
-	Replacement string
-	ast.Range
-}
+type TextEdit = sema.TextEdit
 
 type Diagnostic struct {
 	Location         common.Location
@@ -40,4 +35,8 @@ type Diagnostic struct {
 	SecondaryMessage string
 	SuggestedFixes   []SuggestedFix
 	ast.Range
+}
+
+func (d Diagnostic) SuggestFixes(_ string) []SuggestedFix {
+	return d.SuggestedFixes
 }


### PR DESCRIPTION
Work towards onflow/cadence-tools#159

## Description

- Improve parsing of argument labels: Use colon position as end position
- Move support for suggested fixes from `analysis` package to `sema`. This allows providing suggested fixes for sema errors
- Add suggested fixes for missing argument label error and incorrect argument label error

Support in the LS is added in https://github.com/onflow/cadence-tools/pull/161.
You can see the feature working in action there.


______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
