### PR TITLE
Update to new Atree API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/fxamacker/cbor/v2 v2.4.1-0.20230228173756-c0c9f774e40c
 	github.com/go-test/deep v1.1.0
 	github.com/leanovate/gopter v0.2.9
-	github.com/onflow/atree v0.6.0
+	github.com/onflow/atree v0.6.1-0.20230629205511-5b7b45a566a9
 	github.com/rivo/uniseg v0.4.4
 	github.com/schollz/progressbar/v3 v3.13.1
-	github.com/stretchr/testify v1.8.2
+	github.com/stretchr/testify v1.8.4
 	github.com/tidwall/pretty v1.2.1
 	github.com/turbolent/prettier v0.0.0-20220320183459-661cc755135d
 	go.opentelemetry.io/otel v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/mattn/go-tty v0.0.4/go.mod h1:u5GGXBtZU6RQoKV8gY5W6UhMudbR5vXnUe7j3px
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
-github.com/onflow/atree v0.6.0 h1:j7nQ2r8npznx4NX39zPpBYHmdy45f4xwoi+dm37Jk7c=
-github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVFi0tc=
+github.com/onflow/atree v0.6.1-0.20230629205511-5b7b45a566a9 h1:mffWKRKGrBq5NhCWplOox33eW+gf2lcgjvdI8aeCjGk=
+github.com/onflow/atree v0.6.1-0.20230629205511-5b7b45a566a9/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/pkg/term v1.2.0-beta.2 h1:L3y/h2jkuBVFdWiJvNfYfKmzcCnILw7mJWm2JQuMppw=
 github.com/pkg/term v1.2.0-beta.2/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -65,14 +65,10 @@ github.com/schollz/progressbar/v3 v3.13.1 h1:o8rySDYiQ59Mwzy2FELeHY5ZARXZTVJC7iH
 github.com/schollz/progressbar/v3 v3.13.1/go.mod h1:xvrbki8kfT1fzWzBT/UZd9L6GA+jdL7HAgq2RFnO6fQ=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c h1:HelZ2kAFadG0La9d+4htN4HzQ68Bm2iM9qKMSMES6xg=
 github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c/go.mod h1:JlzghshsemAMDGZLytTFY8C1JQxQPhnatWqNwUXjggo=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
@@ -118,7 +114,6 @@ golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3j
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-lukechampine.com/blake3 v1.1.7 h1:GgRMhmdsuK8+ii6UZFDL8Nb+VyMwadAgcJyfYHxG6n0=
+lukechampine.com/blake3 v1.2.1 h1:YuqqRuaqsGV71BV/nm9xlI0MKUv4QC54jQnBChWbGnI=

--- a/runtime/interpreter/deepcopyremove_test.go
+++ b/runtime/interpreter/deepcopyremove_test.go
@@ -53,7 +53,7 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 	}
 
 	dictValueKey := NewUnmeteredStringValue(
-		strings.Repeat("x", int(atree.MaxInlineMapKeyOrValueSize+1)),
+		strings.Repeat("x", int(atree.MaxInlineMapKeySize()+1)),
 	)
 
 	dictValueValue := NewUnmeteredInt256ValueFromInt64(1)

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -242,7 +242,7 @@ func TestEncodeDecodeString(t *testing.T) {
 
 		t.Parallel()
 
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		expected := NewUnmeteredStringValue(strings.Repeat("x", int(maxInlineElementSize+1)))
 
 		testEncodeDecode(t,
@@ -304,7 +304,7 @@ func TestEncodeDecodeStringAtreeValue(t *testing.T) {
 
 		t.Parallel()
 
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		expected := StringAtreeValue(strings.Repeat("x", int(maxInlineElementSize+1)))
 
 		testEncodeDecode(t,
@@ -661,7 +661,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 
 		expected := NewUnmeteredIntValueFromInt64(1_000_000_000)
 
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		for len(expected.BigInt.Bytes()) < int(maxInlineElementSize+1) {
 			expected = expected.Mul(inter, expected, EmptyLocationRange).(IntValue)
 		}
@@ -1619,7 +1619,7 @@ func TestEncodeDecodeUIntValue(t *testing.T) {
 
 		expected := NewUnmeteredUIntValueFromUint64(1_000_000_000)
 
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		for len(expected.BigInt.Bytes()) < int(maxInlineElementSize+1) {
 			expected = expected.Mul(inter, expected, EmptyLocationRange).(UIntValue)
 		}
@@ -2811,7 +2811,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 		// It will not get inlined, but the outer value will
 
 		var str *StringValue
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		for i := uint64(0); i < maxInlineElementSize; i++ {
 			str = NewUnmeteredStringValue(strings.Repeat("x", int(maxInlineElementSize-i)))
 			size, err := StorableSize(str)
@@ -2845,7 +2845,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 		// Generate a string that has an encoding size just above the max inline element size
 
 		var str *StringValue
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		for i := uint64(0); i < maxInlineElementSize; i++ {
 			str = NewUnmeteredStringValue(strings.Repeat("x", int(maxInlineElementSize-i)))
 			size, err := StorableSize(str)
@@ -3233,7 +3233,7 @@ func TestEncodeDecodePathValue(t *testing.T) {
 
 		t.Parallel()
 
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		identifier := strings.Repeat("x", int(maxInlineElementSize+1))
 
 		expected := PathValue{
@@ -3494,7 +3494,7 @@ func TestEncodeDecodePathCapabilityValue(t *testing.T) {
 		// It will not get inlined, but the outer capability will
 
 		var path PathValue
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		for i := uint64(0); i < maxInlineElementSize; i++ {
 			identifier := strings.Repeat("x", int(maxInlineElementSize-i))
 
@@ -3538,7 +3538,7 @@ func TestEncodeDecodePathCapabilityValue(t *testing.T) {
 
 		// Generate a path that has an encoding size just above the max inline element size
 
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 
 		var path PathValue
 		for i := uint64(0); i < maxInlineElementSize; i++ {
@@ -3653,7 +3653,7 @@ func TestEncodeDecodeIDCapabilityValue(t *testing.T) {
 		t.Parallel()
 
 		// Generate an arbitrary, large static type
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		var borrowType StaticType = PrimitiveStaticTypeNever
 
 		for i := uint64(0); i < maxInlineElementSize; i++ {
@@ -4127,7 +4127,7 @@ func TestEncodeDecodePathLinkValue(t *testing.T) {
 
 		t.Parallel()
 
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		identifier := strings.Repeat("x", int(maxInlineElementSize+1))
 
 		path := PathValue{
@@ -4263,7 +4263,7 @@ func TestEncodeDecodeTypeValue(t *testing.T) {
 
 		t.Parallel()
 
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		identifier := strings.Repeat("x", int(maxInlineElementSize+1))
 
 		expected := TypeValue{
@@ -4798,7 +4798,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		t.Parallel()
 
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		identifier := strings.Repeat("x", int(maxInlineElementSize+1))
 
 		path := PathValue{
@@ -4980,7 +4980,7 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 		t.Parallel()
 
 		// Generate an arbitrary, large static type
-		maxInlineElementSize := atree.MaxInlineArrayElementSize
+		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		var borrowType StaticType = PrimitiveStaticTypeNever
 
 		for i := uint64(0); i < maxInlineElementSize; i++ {

--- a/runtime/interpreter/storagemap.go
+++ b/runtime/interpreter/storagemap.go
@@ -82,7 +82,7 @@ func (s StorageMap) ValueExists(key StorageMapKey) bool {
 // ReadValue returns the value for the given key.
 // Returns nil if the key does not exist.
 func (s StorageMap) ReadValue(gauge common.MemoryGauge, key StorageMapKey) Value {
-	storable, err := s.orderedMap.Get(
+	storedValue, err := s.orderedMap.Get(
 		key.AtreeValueCompare,
 		key.AtreeValueHashInput,
 		key.AtreeValue(),
@@ -95,7 +95,7 @@ func (s StorageMap) ReadValue(gauge common.MemoryGauge, key StorageMapKey) Value
 		panic(errors.NewExternalError(err))
 	}
 
-	return StoredValue(gauge, storable, s.orderedMap.Storage)
+	return MustConvertStoredValue(gauge, storedValue)
 }
 
 // WriteValue sets or removes a value in the storage map.

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1925,14 +1925,14 @@ func (v *ArrayValue) Get(interpreter *Interpreter, locationRange LocationRange, 
 		})
 	}
 
-	storable, err := v.array.Get(uint64(index))
+	storedValue, err := v.array.Get(uint64(index))
 	if err != nil {
 		v.handleIndexOutOfBoundsError(err, index, locationRange)
 
 		panic(errors.NewExternalError(err))
 	}
 
-	return StoredValue(interpreter, storable, interpreter.Storage())
+	return MustConvertStoredValue(interpreter, storedValue)
 }
 
 func (v *ArrayValue) SetKey(interpreter *Interpreter, locationRange LocationRange, key Value, value Value) {
@@ -15487,7 +15487,7 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, locationRange Locat
 		return builtin
 	}
 
-	storable, err := v.dictionary.Get(
+	storedValue, err := v.dictionary.Get(
 		StringAtreeValueComparator,
 		StringAtreeValueHashInput,
 		StringAtreeValue(name),
@@ -15498,8 +15498,8 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, locationRange Locat
 			panic(errors.NewExternalError(err))
 		}
 	}
-	if storable != nil {
-		return StoredValue(interpreter, storable, config.Storage)
+	if storedValue != nil {
+		return MustConvertStoredValue(interpreter, storedValue)
 	}
 
 	if v.NestedVariables != nil {
@@ -15810,7 +15810,7 @@ func (v *CompositeValue) GetField(interpreter *Interpreter, locationRange Locati
 		v.checkInvalidatedResourceUse(locationRange)
 	}
 
-	storable, err := v.dictionary.Get(
+	storedValue, err := v.dictionary.Get(
 		StringAtreeValueComparator,
 		StringAtreeValueHashInput,
 		StringAtreeValue(name),
@@ -15823,7 +15823,7 @@ func (v *CompositeValue) GetField(interpreter *Interpreter, locationRange Locati
 		panic(errors.NewExternalError(err))
 	}
 
-	return StoredValue(interpreter, storable, v.dictionary.Storage)
+	return MustConvertStoredValue(interpreter, storedValue)
 }
 
 func (v *CompositeValue) Equal(interpreter *Interpreter, locationRange LocationRange, other Value) bool {
@@ -16949,7 +16949,7 @@ func (v *DictionaryValue) Get(
 	valueComparator := newValueComparator(interpreter, locationRange)
 	hashInputProvider := newHashInputProvider(interpreter, locationRange)
 
-	storable, err := v.dictionary.Get(
+	storedValue, err := v.dictionary.Get(
 		valueComparator,
 		hashInputProvider,
 		keyValue,
@@ -16962,9 +16962,7 @@ func (v *DictionaryValue) Get(
 		panic(errors.NewExternalError(err))
 	}
 
-	storage := v.dictionary.Storage
-	value := StoredValue(interpreter, storable, storage)
-	return value, true
+	return MustConvertStoredValue(interpreter, storedValue), true
 }
 
 func (v *DictionaryValue) GetKey(interpreter *Interpreter, locationRange LocationRange, keyValue Value) Value {


### PR DESCRIPTION
Updates https://github.com/onflow/atree/issues/292

## Description

This PR updates Cadence to use new Atree API:
- Array.Get()
- OrderedMap.Get()
- MaxInlineArrayElementSize()
- MaxInlineMapKeySize()

The new Atree API is part of prep work for Atree register inlining work.

For more info, see Atree PRs:
- https://github.com/onflow/atree/pull/314
- https://github.com/onflow/atree/pull/316
- https://github.com/onflow/atree/pull/318

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
