### PR TITLE
Delegate storage address to Atree

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2583,11 +2583,10 @@ func (v *ArrayValue) Transfer(
 	}
 
 	currentStorageID := v.StorageID()
-	currentAddress := currentStorageID.Address
 
 	array := v.array
 
-	needsStoreTo := address != currentAddress
+	needsStoreTo := v.NeedsStoreTo(address)
 	isResourceKinded := v.IsResourceKinded(interpreter)
 
 	if needsStoreTo || !isResourceKinded {
@@ -2694,7 +2693,7 @@ func (v *ArrayValue) Clone(interpreter *Interpreter) Value {
 
 	array, err := atree.NewArrayFromBatchData(
 		config.Storage,
-		v.StorageID().Address,
+		v.StorageAddress(),
 		v.array.Type(),
 		func() (atree.Value, error) {
 			value, err := iterator.Next()
@@ -2760,8 +2759,12 @@ func (v *ArrayValue) StorageID() atree.StorageID {
 	return v.array.StorageID()
 }
 
+func (v *ArrayValue) StorageAddress() atree.Address {
+	return v.array.Address()
+}
+
 func (v *ArrayValue) GetOwner() common.Address {
-	return common.Address(v.StorageID().Address)
+	return common.Address(v.StorageAddress())
 }
 
 func (v *ArrayValue) SemaType(interpreter *Interpreter) sema.ArrayType {
@@ -2773,7 +2776,7 @@ func (v *ArrayValue) SemaType(interpreter *Interpreter) sema.ArrayType {
 }
 
 func (v *ArrayValue) NeedsStoreTo(address atree.Address) bool {
-	return address != v.StorageID().Address
+	return address != v.StorageAddress()
 }
 
 func (v *ArrayValue) IsResourceKinded(interpreter *Interpreter) bool {
@@ -15583,7 +15586,7 @@ func (v *CompositeValue) InitializeFunctions(interpreter *Interpreter) {
 }
 
 func (v *CompositeValue) OwnerValue(interpreter *Interpreter, locationRange LocationRange) OptionalValue {
-	address := v.StorageID().Address
+	address := v.StorageAddress()
 
 	if address == (atree.Address{}) {
 		return NilOptionalValue
@@ -15695,7 +15698,7 @@ func (v *CompositeValue) SetMember(
 		}()
 	}
 
-	address := v.StorageID().Address
+	address := v.StorageAddress()
 
 	value = value.Transfer(
 		interpreter,
@@ -16031,7 +16034,7 @@ func (v *CompositeValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64
 }
 
 func (v *CompositeValue) NeedsStoreTo(address atree.Address) bool {
-	return address != v.StorageID().Address
+	return address != v.StorageAddress()
 }
 
 func (v *CompositeValue) IsResourceKinded(interpreter *Interpreter) bool {
@@ -16083,11 +16086,11 @@ func (v *CompositeValue) Transfer(
 	}
 
 	currentStorageID := v.StorageID()
-	currentAddress := currentStorageID.Address
+	currentAddress := v.StorageAddress()
 
 	dictionary := v.dictionary
 
-	needsStoreTo := address != currentAddress
+	needsStoreTo := v.NeedsStoreTo(address)
 	isResourceKinded := v.IsResourceKinded(interpreter)
 
 	if needsStoreTo && v.Kind == common.CompositeKindContract {
@@ -16250,7 +16253,7 @@ func (v *CompositeValue) Clone(interpreter *Interpreter) Value {
 
 	dictionary, err := atree.NewMapFromBatchData(
 		config.Storage,
-		v.StorageID().Address,
+		v.StorageAddress(),
 		atree.NewDefaultDigesterBuilder(),
 		v.dictionary.Type(),
 		StringAtreeValueComparator,
@@ -16337,7 +16340,7 @@ func (v *CompositeValue) DeepRemove(interpreter *Interpreter) {
 }
 
 func (v *CompositeValue) GetOwner() common.Address {
-	return common.Address(v.StorageID().Address)
+	return common.Address(v.StorageAddress())
 }
 
 // ForEachField iterates over all field-name field-value pairs of the composite value.
@@ -16358,6 +16361,10 @@ func (v *CompositeValue) ForEachField(gauge common.MemoryGauge, f func(fieldName
 
 func (v *CompositeValue) StorageID() atree.StorageID {
 	return v.dictionary.StorageID()
+}
+
+func (v *CompositeValue) StorageAddress() atree.Address {
+	return v.dictionary.Address()
 }
 
 func (v *CompositeValue) RemoveField(
@@ -17579,11 +17586,10 @@ func (v *DictionaryValue) Transfer(
 	}
 
 	currentStorageID := v.StorageID()
-	currentAddress := currentStorageID.Address
 
 	dictionary := v.dictionary
 
-	needsStoreTo := address != currentAddress
+	needsStoreTo := v.NeedsStoreTo(address)
 	isResourceKinded := v.IsResourceKinded(interpreter)
 
 	if needsStoreTo || !isResourceKinded {
@@ -17705,7 +17711,7 @@ func (v *DictionaryValue) Clone(interpreter *Interpreter) Value {
 
 	dictionary, err := atree.NewMapFromBatchData(
 		config.Storage,
-		v.StorageID().Address,
+		v.StorageAddress(),
 		atree.NewDefaultDigesterBuilder(),
 		v.dictionary.Type(),
 		valueComparator,
@@ -17783,11 +17789,15 @@ func (v *DictionaryValue) DeepRemove(interpreter *Interpreter) {
 }
 
 func (v *DictionaryValue) GetOwner() common.Address {
-	return common.Address(v.StorageID().Address)
+	return common.Address(v.StorageAddress())
 }
 
 func (v *DictionaryValue) StorageID() atree.StorageID {
 	return v.dictionary.StorageID()
+}
+
+func (v *DictionaryValue) StorageAddress() atree.Address {
+	return v.dictionary.Address()
 }
 
 func (v *DictionaryValue) SemaType(interpreter *Interpreter) *sema.DictionaryType {
@@ -17799,7 +17809,7 @@ func (v *DictionaryValue) SemaType(interpreter *Interpreter) *sema.DictionaryTyp
 }
 
 func (v *DictionaryValue) NeedsStoreTo(address atree.Address) bool {
-	return address != v.StorageID().Address
+	return address != v.StorageAddress()
 }
 
 func (v *DictionaryValue) IsResourceKinded(interpreter *Interpreter) bool {


### PR DESCRIPTION
Updates https://github.com/onflow/atree/issues/292

## Description

Currently, storage address is derived from `StorageID()`.

In the future, some Atree values can be inlined so they don't have `StorageID` and address needs be derived differently.

This PR delegates storage address to its internal Atree values, by calling `Address()`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
