### PR TITLE
Fix data race in sema/type_test.go

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3794,6 +3794,15 @@ func (t *CompositeType) ID() TypeID {
 	return t.cachedIdentifiers.TypeID
 }
 
+// clearCachedIdentifiers clears cachedIdentifiers.
+// This function currently is only used in tests.
+func (t *CompositeType) clearCachedIdentifiers() {
+	t.cachedIdentifiersLock.Lock()
+	defer t.cachedIdentifiersLock.Unlock()
+
+	t.cachedIdentifiers = nil
+}
+
 func (t *CompositeType) initializeIdentifiers() {
 	t.cachedIdentifiersLock.Lock()
 	defer t.cachedIdentifiersLock.Unlock()
@@ -4380,6 +4389,15 @@ func (t *InterfaceType) checkIdentifiersCached() {
 	if t.NestedTypes != nil {
 		t.NestedTypes.Foreach(checkIdentifiersCached)
 	}
+}
+
+// clearCachedIdentifiers clears cachedIdentifiers.
+// This function currently is only used in tests.
+func (t *InterfaceType) clearCachedIdentifiers() {
+	t.cachedIdentifiersLock.Lock()
+	defer t.cachedIdentifiersLock.Unlock()
+
+	t.cachedIdentifiers = nil
 }
 
 func (t *InterfaceType) GetCompositeKind() common.CompositeKind {

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -631,23 +631,23 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 	t.Parallel()
 
 	code := `
-          pub contract interface Test {
+      contract interface Test {
 
-              pub struct interface NestedInterface {
-                  pub fun test(): Bool
-              }
-
-              pub struct Nested: NestedInterface {}
+          struct interface NestedInterface {
+              pub fun test(): Bool
           }
 
-          pub contract TestImpl {
+          struct Nested: NestedInterface {}
+      }
 
-              pub struct Nested {
-                  pub fun test(): Bool {
-                      return true
-                  }
+      contract TestImpl {
+
+          struct Nested {
+              fun test(): Bool {
+                  return true
               }
           }
+      }
 	`
 
 	program, err := parser.ParseProgram(nil, []byte(code), parser.Config{})
@@ -658,7 +658,7 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 		common.StringLocation("test"),
 		nil,
 		&Config{
-			AccessCheckMode: AccessCheckModeStrict,
+			AccessCheckMode: AccessCheckModeNotSpecifiedUnrestricted,
 		},
 	)
 	require.NoError(t, err)
@@ -666,8 +666,10 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 	err = checker.Check()
 	require.NoError(t, err)
 
+	var typeIDs []common.TypeID
+
 	checker.typeActivations.ForEachVariableDeclaredInAndBelow(
-		0,
+		checker.valueActivations.Depth(),
 		func(_ string, value *Variable) {
 			typ := value.Type
 
@@ -698,6 +700,8 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 					assert.Equal(t, recalculatedQualifiedID, cachedQualifiedID)
 					assert.Equal(t, recalculatedID, cachedID)
 
+					typeIDs = append(typeIDs, recalculatedID)
+
 					// Recursively check for nested types
 					checkNestedTypes(semaType.NestedTypes)
 
@@ -714,13 +718,28 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 					assert.Equal(t, recalculatedQualifiedID, cachedQualifiedID)
 					assert.Equal(t, recalculatedID, cachedID)
 
+					typeIDs = append(typeIDs, recalculatedID)
+
 					// Recursively check for nested types
 					checkNestedTypes(semaType.NestedTypes)
 				}
 			}
 
 			checkIdentifiers(t, typ)
-		})
+		},
+	)
+
+	assert.Equal(t,
+		[]common.TypeID{
+			"S.test.Test",
+			"S.test.Test.NestedInterface",
+			"S.test.Test.Nested",
+			"S.test.TestImpl",
+			"S.test.TestImpl.Nested",
+		},
+		typeIDs,
+	)
+
 }
 
 func TestCommonSuperType(t *testing.T) {

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -690,7 +690,7 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 					cachedID := semaType.ID()
 
 					// clear cached identifiers for one level
-					semaType.cachedIdentifiers = nil
+					semaType.clearCachedIdentifiers()
 
 					recalculatedQualifiedID := semaType.QualifiedIdentifier()
 					recalculatedID := semaType.ID()
@@ -706,7 +706,7 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 					cachedID := semaType.ID()
 
 					// clear cached identifiers for one level
-					semaType.cachedIdentifiers = nil
+					semaType.clearCachedIdentifiers()
 
 					recalculatedQualifiedID := semaType.QualifiedIdentifier()
 					recalculatedID := semaType.ID()


### PR DESCRIPTION
Closes #2623

This PR fixes the data race in sema/type_test.go.

https://github.com/onflow/cadence/actions/runs/5424849656/jobs/9864802365?pr=2621

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
