### PR TITLE
Introduce `reverse` in Variable/Fixed size Array

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2192,6 +2192,18 @@ func (v *ArrayValue) FirstIndex(interpreter *Interpreter, locationRange Location
 	return NilOptionalValue
 }
 
+func (v *ArrayValue) Reverse(interpreter *Interpreter, locationRange LocationRange) VoidValue {
+	count := v.Count()
+
+	for i := 0; i < count/2; i++ {
+		tempValue := v.Get(interpreter, locationRange, i)
+		v.Set(interpreter, locationRange, i, v.Get(interpreter, locationRange, count-i-1))
+		v.Set(interpreter, locationRange, count-i-1, tempValue)
+	}
+
+	return VoidValue{}
+}
+
 func (v *ArrayValue) Contains(
 	interpreter *Interpreter,
 	locationRange LocationRange,
@@ -2367,6 +2379,18 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationR
 					invocation.Interpreter,
 					invocation.LocationRange,
 					invocation.Arguments[0],
+				)
+			},
+		)
+
+	case "reverse":
+		return NewHostFunctionValue(
+			interpreter,
+			sema.ArrayReverseFunctionType,
+			func(invocation Invocation) Value {
+				return v.Reverse(
+					invocation.Interpreter,
+					invocation.LocationRange,
 				)
 			},
 		)

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -1714,6 +1714,10 @@ Returns the index of the first element matching the given object in the array, n
 Available if the array element type is not resource-kinded and equatable.
 `
 
+const arrayTypeReverseFunctionDocString = `
+Reverses the elements of the array.
+`
+
 const arrayTypeContainsFunctionDocString = `
 Returns true if the given object is in the array
 `
@@ -1862,6 +1866,18 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 					identifier,
 					ArrayFirstIndexFunctionType(elementType),
 					arrayTypeFirstIndexFunctionDocString,
+				)
+			},
+		},
+		"reverse": {
+			Kind: common.DeclarationKindFunction,
+			Resolve: func(memoryGauge common.MemoryGauge, identifier string, targetRange ast.Range, report func(error)) *Member {
+				return NewPublicFunctionMember(
+					memoryGauge,
+					arrayType,
+					identifier,
+					ArrayReverseFunctionType,
+					arrayTypeReverseFunctionDocString,
 				)
 			},
 		},
@@ -2116,6 +2132,12 @@ func ArrayFirstIndexFunctionType(elementType Type) *FunctionType {
 		),
 	}
 }
+
+var ArrayReverseFunctionType *FunctionType = &FunctionType{
+	Parameters:           []Parameter{},
+	ReturnTypeAnnotation: NewTypeAnnotation(VoidType),
+}
+
 func ArrayContainsFunctionType(elementType Type) *FunctionType {
 	return &FunctionType{
 		Parameters: []Parameter{

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -1078,6 +1078,36 @@ func TestCheckInvalidResourceFirstIndex(t *testing.T) {
 	assert.IsType(t, &sema.ResourceLossError{}, errs[2])
 }
 
+func TestCheckArrayReverse(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      fun test() {
+          let x = [1, 2, 3]
+          x.reverse()
+      }
+    `)
+
+	require.NoError(t, err)
+}
+
+func TestCheckInvalidArrayReverse(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      fun test() {
+          let x = [1, 2, 3]
+          x.reverse(100)
+      }
+    `)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.ArgumentCountError{}, errs[0])
+}
+
 func TestCheckArrayContains(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -10401,7 +10401,7 @@ func TestInterpretArrayReverse(t *testing.T) {
 
 	inter := parseCheckAndInterpret(t, `
       let xs = [1, 2, 3, 100, 200]
-	  let ys = [100, 467, 297, 23]
+      let ys = [100, 467, 297, 23]
 
       fun reversexs() {
           return xs.reverse()

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -10395,6 +10395,67 @@ func TestInterpretArrayFirstIndexDoesNotExist(t *testing.T) {
 	)
 }
 
+func TestInterpretArrayReverse(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+      let xs = [1, 2, 3, 100, 200]
+	  let ys = [100, 467, 297, 23]
+
+      fun reversexs() {
+          return xs.reverse()
+      }
+
+	  fun reverseys() {
+		return ys.reverse()
+	  }
+    `)
+
+	_, err := inter.Invoke("reversexs")
+	require.NoError(t, err)
+
+	AssertValuesEqual(
+		t,
+		inter,
+		interpreter.NewArrayValue(
+			inter,
+			interpreter.EmptyLocationRange,
+			interpreter.VariableSizedStaticType{
+				Type: interpreter.PrimitiveStaticTypeInt,
+			},
+			common.ZeroAddress,
+			interpreter.NewUnmeteredIntValueFromInt64(200),
+			interpreter.NewUnmeteredIntValueFromInt64(100),
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			interpreter.NewUnmeteredIntValueFromInt64(2),
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+		),
+		inter.Globals.Get("xs").GetValue(),
+	)
+
+	_, err = inter.Invoke("reverseys")
+	require.NoError(t, err)
+
+	AssertValuesEqual(
+		t,
+		inter,
+		interpreter.NewArrayValue(
+			inter,
+			interpreter.EmptyLocationRange,
+			interpreter.VariableSizedStaticType{
+				Type: interpreter.PrimitiveStaticTypeInt,
+			},
+			common.ZeroAddress,
+			interpreter.NewUnmeteredIntValueFromInt64(23),
+			interpreter.NewUnmeteredIntValueFromInt64(297),
+			interpreter.NewUnmeteredIntValueFromInt64(467),
+			interpreter.NewUnmeteredIntValueFromInt64(100),
+		),
+		inter.Globals.Get("ys").GetValue(),
+	)
+}
+
 func TestInterpretOptionalReference(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
Work towards #2605 

## Description
Introduce `reverse` function for in-place reversal of a Variable/Fixed size Array value.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
