### PR TITLE
Improve cyclic import handling

### DIFF
--- a/runtime/sema/check_import_declaration.go
+++ b/runtime/sema/check_import_declaration.go
@@ -45,7 +45,7 @@ func (checker *Checker) VisitImportDeclaration(declaration *ast.ImportDeclaratio
 	})
 }
 
-func (checker *Checker) declareImportDeclaration(declaration *ast.ImportDeclaration) Type {
+func (checker *Checker) declareImportDeclaration(declaration *ast.ImportDeclaration) {
 	locationRange := ast.NewRange(
 		checker.memoryGauge,
 		declaration.LocationPos,
@@ -58,7 +58,7 @@ func (checker *Checker) declareImportDeclaration(declaration *ast.ImportDeclarat
 	resolvedLocations, err := checker.resolveLocation(identifiers, declaration.Location)
 	if err != nil {
 		checker.report(err)
-		return nil
+		return
 	}
 
 	// 1) If the import is just for an address (e.g. `import 0x01`) without specifying any contracts, AND
@@ -80,7 +80,7 @@ func (checker *Checker) declareImportDeclaration(declaration *ast.ImportDeclarat
 						},
 					)
 
-					return nil
+					return
 				}
 			}
 		}
@@ -91,8 +91,6 @@ func (checker *Checker) declareImportDeclaration(declaration *ast.ImportDeclarat
 	for _, resolvedLocation := range resolvedLocations {
 		checker.importResolvedLocation(resolvedLocation, locationRange)
 	}
-
-	return nil
 }
 
 func (checker *Checker) resolveLocation(identifiers []ast.Identifier, location common.Location) ([]ResolvedLocation, error) {


### PR DESCRIPTION
Closes #2631

## Description

When a contract imports an address that is the same address as the contract is deployed to, it creates a cycle right after the deployment.

e.g:
Assume the below contract is deployed to `0x01`.

```cadence
import 0x01

access(all) contract Foo {}
```

Since there are no contracts existing in `0x01`, there is no cycle before the deployment. 
But as soon as `Foo` is delpoyed, then importing the same address as itself, would be equivalent to importing `Foo` itself.

This PR reject such deployments.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
