### PR TITLE
Fix potential data races

### DIFF
--- a/runtime/ast/access.go
+++ b/runtime/ast/access.go
@@ -21,6 +21,7 @@ package ast
 import (
 	"encoding/json"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 )
 
@@ -58,9 +59,12 @@ var BasicAccesses = []Access{
 	AccessPublicSettable,
 }
 
-var AllAccesses = append(BasicAccesses[:],
-	AccessContract,
-	AccessAccount,
+var AllAccesses = common.Concat(
+	BasicAccesses,
+	[]Access{
+		AccessContract,
+		AccessAccount,
+	},
 )
 
 func (a Access) Keyword() string {

--- a/runtime/common/concat.go
+++ b/runtime/common/concat.go
@@ -1,0 +1,36 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+func Concat[T any](slices ...[]T) []T {
+	var length int
+
+	for _, slice := range slices {
+		length += len(slice)
+	}
+
+	result := make([]T, length)
+
+	var offset int
+	for _, slice := range slices {
+		offset += copy(result[offset:], slice)
+	}
+
+	return result
+}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2921,11 +2921,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 	case sema.NumericTypeSaturatingAddFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
-			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					typ,
-				),
-			},
+			sema.SaturatingArithmeticTypeFunctionTypes[typ],
 			func(invocation Invocation) Value {
 				other, ok := invocation.Arguments[0].(NumberValue)
 				if !ok {
@@ -2942,11 +2938,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 	case sema.NumericTypeSaturatingSubtractFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
-			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					typ,
-				),
-			},
+			sema.SaturatingArithmeticTypeFunctionTypes[typ],
 			func(invocation Invocation) Value {
 				other, ok := invocation.Arguments[0].(NumberValue)
 				if !ok {
@@ -2963,11 +2955,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 	case sema.NumericTypeSaturatingMultiplyFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
-			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					typ,
-				),
-			},
+			sema.SaturatingArithmeticTypeFunctionTypes[typ],
 			func(invocation Invocation) Value {
 				other, ok := invocation.Arguments[0].(NumberValue)
 				if !ok {
@@ -2984,11 +2972,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 	case sema.NumericTypeSaturatingDivideFunctionName:
 		return NewHostFunctionValue(
 			interpreter,
-			&sema.FunctionType{
-				ReturnTypeAnnotation: sema.NewTypeAnnotation(
-					typ,
-				),
-			},
+			sema.SaturatingArithmeticTypeFunctionTypes[typ],
 			func(invocation Invocation) Value {
 				other, ok := invocation.Arguments[0].(NumberValue)
 				if !ok {

--- a/runtime/literal_test.go
+++ b/runtime/literal_test.go
@@ -643,10 +643,12 @@ func TestParseLiteral(t *testing.T) {
 		)
 	}
 
-	for _, signedIntegerType := range append(
-		sema.AllSignedIntegerTypes[:],
-		sema.IntegerType,
-		sema.SignedIntegerType,
+	for _, signedIntegerType := range common.Concat(
+		sema.AllSignedIntegerTypes,
+		[]sema.Type{
+			sema.IntegerType,
+			sema.SignedIntegerType,
+		},
 	) {
 
 		t.Run(

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -913,9 +913,10 @@ const numericTypeSaturatingDivideFunctionDocString = `
 self / other, saturating at the numeric bounds instead of overflowing.
 `
 
-func addSaturatingArithmeticFunctions(t SaturatingArithmeticType, members map[string]MemberResolver) {
+var SaturatingArithmeticTypeFunctionTypes = map[Type]*FunctionType{}
 
-	arithmeticFunctionType := &FunctionType{
+func registerSaturatingArithmeticType(t Type) {
+	SaturatingArithmeticTypeFunctionTypes[t] = &FunctionType{
 		Parameters: []Parameter{
 			{
 				Label:          ArgumentLabelNotRequired,
@@ -925,13 +926,21 @@ func addSaturatingArithmeticFunctions(t SaturatingArithmeticType, members map[st
 		},
 		ReturnTypeAnnotation: NewTypeAnnotation(t),
 	}
+}
+
+func addSaturatingArithmeticFunctions(t SaturatingArithmeticType, members map[string]MemberResolver) {
 
 	addArithmeticFunction := func(name string, docString string) {
 		members[name] = MemberResolver{
 			Kind: common.DeclarationKindFunction,
-			Resolve: func(memoryGauge common.MemoryGauge, identifier string, targetRange ast.Range, report func(error)) *Member {
+			Resolve: func(memoryGauge common.MemoryGauge, _ string, _ ast.Range, _ func(error)) *Member {
 				return NewPublicFunctionMember(
-					memoryGauge, t, name, arithmeticFunctionType, docString)
+					memoryGauge,
+					t,
+					name,
+					SaturatingArithmeticTypeFunctionTypes[t],
+					docString,
+				)
 			},
 		}
 	}
@@ -965,20 +974,24 @@ func addSaturatingArithmeticFunctions(t SaturatingArithmeticType, members map[st
 	}
 }
 
+type SaturatingArithmeticSupport struct {
+	Add      bool
+	Subtract bool
+	Multiply bool
+	Divide   bool
+}
+
 // NumericType represent all the types in the integer range
 // and non-fractional ranged types.
 type NumericType struct {
-	minInt                     *big.Int
-	maxInt                     *big.Int
-	memberResolvers            map[string]MemberResolver
-	name                       string
-	tag                        TypeTag
-	memberResolversOnce        sync.Once
-	supportsSaturatingAdd      bool
-	supportsSaturatingSubtract bool
-	supportsSaturatingMultiply bool
-	supportsSaturatingDivide   bool
-	isSuperType                bool
+	minInt               *big.Int
+	maxInt               *big.Int
+	memberResolvers      map[string]MemberResolver
+	name                 string
+	tag                  TypeTag
+	memberResolversOnce  sync.Once
+	saturatingArithmetic SaturatingArithmeticSupport
+	isSuperType          bool
 }
 
 var _ Type = &NumericType{}
@@ -1004,40 +1017,28 @@ func (t *NumericType) WithIntRange(min *big.Int, max *big.Int) *NumericType {
 	return t
 }
 
-func (t *NumericType) WithSaturatingAdd() *NumericType {
-	t.supportsSaturatingAdd = true
-	return t
-}
+func (t *NumericType) WithSaturatingFunctions(saturatingArithmetic SaturatingArithmeticSupport) *NumericType {
+	t.saturatingArithmetic = saturatingArithmetic
 
-func (t *NumericType) WithSaturatingSubtract() *NumericType {
-	t.supportsSaturatingSubtract = true
-	return t
-}
+	registerSaturatingArithmeticType(t)
 
-func (t *NumericType) WithSaturatingMultiply() *NumericType {
-	t.supportsSaturatingMultiply = true
-	return t
-}
-
-func (t *NumericType) WithSaturatingDivide() *NumericType {
-	t.supportsSaturatingDivide = true
 	return t
 }
 
 func (t *NumericType) SupportsSaturatingAdd() bool {
-	return t.supportsSaturatingAdd
+	return t.saturatingArithmetic.Add
 }
 
 func (t *NumericType) SupportsSaturatingSubtract() bool {
-	return t.supportsSaturatingSubtract
+	return t.saturatingArithmetic.Subtract
 }
 
 func (t *NumericType) SupportsSaturatingMultiply() bool {
-	return t.supportsSaturatingMultiply
+	return t.saturatingArithmetic.Multiply
 }
 
 func (t *NumericType) SupportsSaturatingDivide() bool {
-	return t.supportsSaturatingDivide
+	return t.saturatingArithmetic.Divide
 }
 
 func (*NumericType) IsType() {}
@@ -1143,20 +1144,17 @@ func (t *NumericType) IsSuperType() bool {
 
 // FixedPointNumericType represents all the types in the fixed-point range.
 type FixedPointNumericType struct {
-	maxFractional              *big.Int
-	minFractional              *big.Int
-	memberResolvers            map[string]MemberResolver
-	minInt                     *big.Int
-	maxInt                     *big.Int
-	name                       string
-	tag                        TypeTag
-	scale                      uint
-	memberResolversOnce        sync.Once
-	supportsSaturatingAdd      bool
-	supportsSaturatingDivide   bool
-	supportsSaturatingMultiply bool
-	supportsSaturatingSubtract bool
-	isSuperType                bool
+	maxFractional        *big.Int
+	minFractional        *big.Int
+	memberResolvers      map[string]MemberResolver
+	minInt               *big.Int
+	maxInt               *big.Int
+	name                 string
+	tag                  TypeTag
+	scale                uint
+	memberResolversOnce  sync.Once
+	saturatingArithmetic SaturatingArithmeticSupport
+	isSuperType          bool
 }
 
 var _ Type = &FixedPointNumericType{}
@@ -1200,40 +1198,28 @@ func (t *FixedPointNumericType) WithScale(scale uint) *FixedPointNumericType {
 	return t
 }
 
-func (t *FixedPointNumericType) WithSaturatingAdd() *FixedPointNumericType {
-	t.supportsSaturatingAdd = true
-	return t
-}
+func (t *FixedPointNumericType) WithSaturatingFunctions(saturatingArithmetic SaturatingArithmeticSupport) *FixedPointNumericType {
+	t.saturatingArithmetic = saturatingArithmetic
 
-func (t *FixedPointNumericType) WithSaturatingSubtract() *FixedPointNumericType {
-	t.supportsSaturatingSubtract = true
-	return t
-}
+	registerSaturatingArithmeticType(t)
 
-func (t *FixedPointNumericType) WithSaturatingMultiply() *FixedPointNumericType {
-	t.supportsSaturatingMultiply = true
-	return t
-}
-
-func (t *FixedPointNumericType) WithSaturatingDivide() *FixedPointNumericType {
-	t.supportsSaturatingDivide = true
 	return t
 }
 
 func (t *FixedPointNumericType) SupportsSaturatingAdd() bool {
-	return t.supportsSaturatingAdd
+	return t.saturatingArithmetic.Add
 }
 
 func (t *FixedPointNumericType) SupportsSaturatingSubtract() bool {
-	return t.supportsSaturatingSubtract
+	return t.saturatingArithmetic.Subtract
 }
 
 func (t *FixedPointNumericType) SupportsSaturatingMultiply() bool {
-	return t.supportsSaturatingMultiply
+	return t.saturatingArithmetic.Multiply
 }
 
 func (t *FixedPointNumericType) SupportsSaturatingDivide() bool {
-	return t.supportsSaturatingDivide
+	return t.saturatingArithmetic.Divide
 }
 
 func (*FixedPointNumericType) IsType() {}
@@ -1381,115 +1367,141 @@ var (
 	Int8Type = NewNumericType(Int8TypeName).
 			WithTag(Int8TypeTag).
 			WithIntRange(Int8TypeMinInt, Int8TypeMaxInt).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply().
-			WithSaturatingDivide()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+			Divide:   true,
+		})
 
 	// Int16Type represents the 16-bit signed integer type `Int16`
 	Int16Type = NewNumericType(Int16TypeName).
 			WithTag(Int16TypeTag).
 			WithIntRange(Int16TypeMinInt, Int16TypeMaxInt).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply().
-			WithSaturatingDivide()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+			Divide:   true,
+		})
 
 	// Int32Type represents the 32-bit signed integer type `Int32`
 	Int32Type = NewNumericType(Int32TypeName).
 			WithTag(Int32TypeTag).
 			WithIntRange(Int32TypeMinInt, Int32TypeMaxInt).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply().
-			WithSaturatingDivide()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+			Divide:   true,
+		})
 
 	// Int64Type represents the 64-bit signed integer type `Int64`
 	Int64Type = NewNumericType(Int64TypeName).
 			WithTag(Int64TypeTag).
 			WithIntRange(Int64TypeMinInt, Int64TypeMaxInt).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply().
-			WithSaturatingDivide()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+			Divide:   true,
+		})
 
 	// Int128Type represents the 128-bit signed integer type `Int128`
 	Int128Type = NewNumericType(Int128TypeName).
 			WithTag(Int128TypeTag).
 			WithIntRange(Int128TypeMinIntBig, Int128TypeMaxIntBig).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply().
-			WithSaturatingDivide()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+			Divide:   true,
+		})
 
 	// Int256Type represents the 256-bit signed integer type `Int256`
 	Int256Type = NewNumericType(Int256TypeName).
 			WithTag(Int256TypeTag).
 			WithIntRange(Int256TypeMinIntBig, Int256TypeMaxIntBig).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply().
-			WithSaturatingDivide()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+			Divide:   true,
+		})
 
 	// UIntType represents the arbitrary-precision unsigned integer type `UInt`
 	UIntType = NewNumericType(UIntTypeName).
 			WithTag(UIntTypeTag).
 			WithIntRange(UIntTypeMin, nil).
-			WithSaturatingSubtract()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Subtract: true,
+		})
 
 	// UInt8Type represents the 8-bit unsigned integer type `UInt8`
 	// which checks for overflow and underflow
 	UInt8Type = NewNumericType(UInt8TypeName).
 			WithTag(UInt8TypeTag).
 			WithIntRange(UInt8TypeMinInt, UInt8TypeMaxInt).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+		})
 
 	// UInt16Type represents the 16-bit unsigned integer type `UInt16`
 	// which checks for overflow and underflow
 	UInt16Type = NewNumericType(UInt16TypeName).
 			WithTag(UInt16TypeTag).
 			WithIntRange(UInt16TypeMinInt, UInt16TypeMaxInt).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+		})
 
 	// UInt32Type represents the 32-bit unsigned integer type `UInt32`
 	// which checks for overflow and underflow
 	UInt32Type = NewNumericType(UInt32TypeName).
 			WithTag(UInt32TypeTag).
 			WithIntRange(UInt32TypeMinInt, UInt32TypeMaxInt).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+		})
 
 	// UInt64Type represents the 64-bit unsigned integer type `UInt64`
 	// which checks for overflow and underflow
 	UInt64Type = NewNumericType(UInt64TypeName).
 			WithTag(UInt64TypeTag).
 			WithIntRange(UInt64TypeMinInt, UInt64TypeMaxInt).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+		})
 
 	// UInt128Type represents the 128-bit unsigned integer type `UInt128`
 	// which checks for overflow and underflow
 	UInt128Type = NewNumericType(UInt128TypeName).
 			WithTag(UInt128TypeTag).
 			WithIntRange(UInt128TypeMinIntBig, UInt128TypeMaxIntBig).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+		})
 
 	// UInt256Type represents the 256-bit unsigned integer type `UInt256`
 	// which checks for overflow and underflow
 	UInt256Type = NewNumericType(UInt256TypeName).
 			WithTag(UInt256TypeTag).
 			WithIntRange(UInt256TypeMinIntBig, UInt256TypeMaxIntBig).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+		})
 
 	// Word8Type represents the 8-bit unsigned integer type `Word8`
 	// which does NOT check for overflow and underflow
@@ -1544,10 +1556,12 @@ var (
 			WithIntRange(Fix64TypeMinIntBig, Fix64TypeMaxIntBig).
 			WithFractionalRange(Fix64TypeMinFractionalBig, Fix64TypeMaxFractionalBig).
 			WithScale(Fix64Scale).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply().
-			WithSaturatingDivide()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+			Divide:   true,
+		})
 
 	// UFix64Type represents the 64-bit unsigned decimal fixed-point type `UFix64`
 	// which has a scale of 1E9, and checks for overflow and underflow
@@ -1556,9 +1570,11 @@ var (
 			WithIntRange(UFix64TypeMinIntBig, UFix64TypeMaxIntBig).
 			WithFractionalRange(UFix64TypeMinFractionalBig, UFix64TypeMaxFractionalBig).
 			WithScale(Fix64Scale).
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply()
+			WithSaturatingFunctions(SaturatingArithmeticSupport{
+			Add:      true,
+			Subtract: true,
+			Multiply: true,
+		})
 )
 
 // Numeric type ranges
@@ -3124,37 +3140,37 @@ var BaseTypeActivation = NewVariableActivation(nil)
 
 func init() {
 
-	types := AllNumberTypes[:]
-
-	types = append(
-		types,
-		MetaType,
-		VoidType,
-		AnyStructType,
-		AnyStructAttachmentType,
-		AnyResourceType,
-		AnyResourceAttachmentType,
-		NeverType,
-		BoolType,
-		CharacterType,
-		StringType,
-		TheAddressType,
-		AuthAccountType,
-		PublicAccountType,
-		PathType,
-		StoragePathType,
-		CapabilityPathType,
-		PrivatePathType,
-		PublicPathType,
-		&CapabilityType{},
-		DeployedContractType,
-		BlockType,
-		AccountKeyType,
-		PublicKeyType,
-		SignatureAlgorithmType,
-		HashAlgorithmType,
-		StorageCapabilityControllerType,
-		AccountCapabilityControllerType,
+	types := common.Concat(
+		AllNumberTypes,
+		[]Type{
+			MetaType,
+			VoidType,
+			AnyStructType,
+			AnyStructAttachmentType,
+			AnyResourceType,
+			AnyResourceAttachmentType,
+			NeverType,
+			BoolType,
+			CharacterType,
+			StringType,
+			TheAddressType,
+			AuthAccountType,
+			PublicAccountType,
+			PathType,
+			StoragePathType,
+			CapabilityPathType,
+			PrivatePathType,
+			PublicPathType,
+			&CapabilityType{},
+			DeployedContractType,
+			BlockType,
+			AccountKeyType,
+			PublicKeyType,
+			SignatureAlgorithmType,
+			HashAlgorithmType,
+			StorageCapabilityControllerType,
+			AccountCapabilityControllerType,
+		},
 	)
 
 	for _, ty := range types {
@@ -3202,13 +3218,13 @@ var AllUnsignedFixedPointTypes = []Type{
 	UFix64Type,
 }
 
-var AllFixedPointTypes = append(
-	append(
-		AllUnsignedFixedPointTypes[:],
-		AllSignedFixedPointTypes...,
-	),
-	FixedPointType,
-	SignedFixedPointType,
+var AllFixedPointTypes = common.Concat(
+	AllUnsignedFixedPointTypes,
+	AllSignedFixedPointTypes,
+	[]Type{
+		FixedPointType,
+		SignedFixedPointType,
+	},
 )
 
 var AllSignedIntegerTypes = []Type{
@@ -3239,22 +3255,22 @@ var AllUnsignedIntegerTypes = []Type{
 	Word256Type,
 }
 
-var AllIntegerTypes = append(
-	append(
-		AllUnsignedIntegerTypes[:],
-		AllSignedIntegerTypes...,
-	),
-	IntegerType,
-	SignedIntegerType,
+var AllIntegerTypes = common.Concat(
+	AllUnsignedIntegerTypes,
+	AllSignedIntegerTypes,
+	[]Type{
+		IntegerType,
+		SignedIntegerType,
+	},
 )
 
-var AllNumberTypes = append(
-	append(
-		AllIntegerTypes[:],
-		AllFixedPointTypes...,
-	),
-	NumberType,
-	SignedNumberType,
+var AllNumberTypes = common.Concat(
+	AllIntegerTypes,
+	AllFixedPointTypes,
+	[]Type{
+		NumberType,
+		SignedNumberType,
+	},
 )
 
 const NumberTypeMinFieldName = "min"

--- a/runtime/tests/checker/builtinfunctions_test.go
+++ b/runtime/tests/checker/builtinfunctions_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
@@ -32,9 +33,11 @@ func TestCheckToString(t *testing.T) {
 
 	t.Parallel()
 
-	for _, numberOrAddressType := range append(
-		sema.AllNumberTypes[:],
-		sema.TheAddressType,
+	for _, numberOrAddressType := range common.Concat(
+		sema.AllNumberTypes,
+		[]sema.Type{
+			sema.TheAddressType,
+		},
 	) {
 
 		ty := numberOrAddressType

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -107,7 +107,8 @@ func TestCheckEventDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		validTypes := append(
+		validTypes := common.Concat(
+			sema.AllNumberTypes,
 			[]sema.Type{
 				sema.StringType,
 				sema.CharacterType,
@@ -120,7 +121,6 @@ func TestCheckEventDeclaration(t *testing.T) {
 				sema.PrivatePathType,
 				sema.CapabilityPathType,
 			},
-			sema.AllNumberTypes...,
 		)
 
 		tests := validTypes[:]

--- a/runtime/tests/checker/integer_test.go
+++ b/runtime/tests/checker/integer_test.go
@@ -26,12 +26,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-var allIntegerTypesAndAddressType = append(
-	sema.AllIntegerTypes[:],
-	sema.TheAddressType,
+var allIntegerTypesAndAddressType = common.Concat(
+	sema.AllIntegerTypes,
+	[]sema.Type{
+		sema.TheAddressType,
+	},
 )
 
 func TestCheckIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T) {

--- a/runtime/tests/checker/operations_test.go
+++ b/runtime/tests/checker/operations_test.go
@@ -426,9 +426,9 @@ func TestCheckSaturatedArithmeticFunctions(t *testing.T) {
 		},
 	}
 
-	for _, ty := range append(
-		sema.AllSignedIntegerTypes[:],
-		sema.AllSignedFixedPointTypes...,
+	for _, ty := range common.Concat(
+		sema.AllSignedIntegerTypes,
+		sema.AllSignedFixedPointTypes,
 	) {
 
 		if ty == sema.IntType {
@@ -444,9 +444,9 @@ func TestCheckSaturatedArithmeticFunctions(t *testing.T) {
 		})
 	}
 
-	for _, ty := range append(
-		sema.AllUnsignedIntegerTypes[:],
-		sema.AllUnsignedFixedPointTypes...,
+	for _, ty := range common.Concat(
+		sema.AllUnsignedIntegerTypes,
+		sema.AllUnsignedFixedPointTypes,
 	) {
 
 		if ty == sema.UIntType || strings.HasPrefix(ty.String(), "Word") {

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	. "github.com/onflow/cadence/runtime/tests/utils"
@@ -723,9 +724,9 @@ func TestInterpretSaturatedArithmeticFunctions(t *testing.T) {
 
 	// Verify all test cases exist
 
-	for _, ty := range append(
-		sema.AllSignedIntegerTypes[:],
-		sema.AllSignedFixedPointTypes...,
+	for _, ty := range common.Concat(
+		sema.AllSignedIntegerTypes,
+		sema.AllSignedFixedPointTypes,
 	) {
 
 		testCase, ok := testCases[ty]
@@ -749,9 +750,9 @@ func TestInterpretSaturatedArithmeticFunctions(t *testing.T) {
 		}
 	}
 
-	for _, ty := range append(
-		sema.AllUnsignedIntegerTypes[:],
-		sema.AllUnsignedFixedPointTypes...,
+	for _, ty := range common.Concat(
+		sema.AllUnsignedIntegerTypes,
+		sema.AllUnsignedFixedPointTypes,
 	) {
 
 		if strings.HasPrefix(ty.String(), "Word") {


### PR DESCRIPTION
## Description

CI runs tests in parallel and with the race detector on. It flagged the concurrent, but non-thread safe modification of some global state.

This PR fixes two issues I could identify:

- On the Stable Cadence feature branch, https://github.com/onflow/cadence/commit/b8ee2a53d846eb552f51ffc0a0458105d5f7f436 had fixes and refactored the function types of the saturating arithmetic types. However, it modified a global map in a non-thread safe way.
- `append` mutates its first argument, so introduce a new concatenation function which avoids the mutation and just allocates and returns a new slice

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
