### PR TITLE
Sync Stable Cadence

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,12 +23,11 @@ jobs:
   benchmark:
     name: Performance regression check
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Set benchmark repetitions
         # reducing repetition will speed up execution,
         # but will be more inaccurate at detecting change
-        run: echo "::set-output name=benchmark_repetitions::7"
+        run: echo "benchmark_repetitions=7" >> "$GITHUB_OUTPUT"
         id: settings
 
       - name: Install dependencies

--- a/.github/workflows/compatibility-check-template.yml
+++ b/.github/workflows/compatibility-check-template.yml
@@ -3,6 +3,10 @@ name: BackwardCompatibilityCheckTemplate
 on:
   workflow_call:
     inputs:
+      repo:
+        required: true
+        type: string
+        default: onflow/cadence
       current-branch:
         required: true
         type: string
@@ -72,12 +76,18 @@ jobs:
           path: tmp/contracts.csv
           key: ${{ steps.cache-key-generator.outputs.cache-key }}-contracts
 
+      - name: Configure permissions
+        if: github.repository != 'onflow/cadence'
+        run: |
+          echo "GOPRIVATE=github.com/${{ inputs.repo }}" >> "$GITHUB_ENV"
+          git config --global url."https://${{ github.actor }}:${{ github.token }}@github.com".insteadOf "https://github.com"
+
       # Check contracts using current branch
 
       - name: Check contracts using ${{ inputs.current-branch }}
         working-directory: ./tools/compatibility-check
         run: |
-          GOPROXY=direct go get github.com/onflow/cadence@${{ inputs.current-branch }}
+          GOPROXY=direct go mod edit -replace github.com/onflow/cadence=github.com/${{ inputs.repo }}@${{ inputs.current-branch }}
           go mod tidy
           go run ./cmd/check_contracts/main.go ../../tmp/contracts.csv ../../tmp/output-new.txt
 
@@ -86,7 +96,7 @@ jobs:
       - name: Check contracts using ${{ inputs.base-branch }}
         working-directory: ./tools/compatibility-check
         run: |
-          GOPROXY=direct go get github.com/onflow/cadence@${{ inputs.base-branch }}
+          GOPROXY=direct go mod edit -replace github.com/onflow/cadence=github.com/${{ inputs.repo }}@${{ inputs.base-branch }}
           go mod tidy
           go run ./cmd/check_contracts/main.go ../../tmp/contracts.csv ../../tmp/output-old.txt
 

--- a/.github/workflows/compatibility-check.yml
+++ b/.github/workflows/compatibility-check.yml
@@ -3,6 +3,8 @@ name: BackwardCompatibilityCheck
 on:
   workflow_dispatch:
     inputs:
+      repo:
+        description: Repository (defaults to 'onflow/cadence')
       branch:
         description: 'Current branch/tag'
         required: true
@@ -32,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # Map step output to the job output, so that next job can use these values.
+      repo: ${{ steps.setup.outputs.repo }}
       branch: ${{ steps.setup.outputs.branch }}
       base: ${{ steps.setup.outputs.base }}
     steps:
@@ -44,12 +47,13 @@ jobs:
         # instead of the branch name, since 'go get' command does not support all kinds of branch names.
         #
         # Here there also is a limitation that we can't use the 'merge-branch' because it is not visible to 'go get'.
-        # So the workflow will not work across forks.
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "repo=`(echo "${{ github.event.pull_request.head.repo.full_name }}")`" >> $GITHUB_OUTPUT
             echo "branch=`(echo "${{ github.event.pull_request.head.sha }}")`" >> $GITHUB_OUTPUT
             echo "base=`(echo "${{ github.base_ref }}")`" >> $GITHUB_OUTPUT
           else
+            echo "repo=`(echo "${{ inputs.repo || 'onflow/cadence' }}")`" >> $GITHUB_OUTPUT
             echo "branch=`(echo "${{ inputs.branch }}")`" >> $GITHUB_OUTPUT
             echo "base=`(echo "${{ inputs.base }}")`" >> $GITHUB_OUTPUT
           fi
@@ -57,6 +61,7 @@ jobs:
     needs: setup
     uses: ./.github/workflows/compatibility-check-template.yml
     with:
+      repo: ${{ needs.setup.outputs.repo }}
       base-branch: ${{ needs.setup.outputs.base }}
       current-branch: ${{ needs.setup.outputs.branch }}
       chain: flow-mainnet
@@ -66,6 +71,7 @@ jobs:
     needs: setup
     uses: ./.github/workflows/compatibility-check-template.yml
     with:
+      repo: ${{ needs.setup.outputs.repo }}
       base-branch:  ${{ needs.setup.outputs.base }}
       current-branch: ${{ needs.setup.outputs.branch }}
       chain: flow-testnet

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Bastian Müller <bastian@turbolent.com> <bastian@axiomzen.co>
+Bastian Müller <bastian@turbolent.com> <bastian@dapperlabs.com>

--- a/encoding/ccf/ccf_test.go
+++ b/encoding/ccf/ccf_test.go
@@ -11915,6 +11915,8 @@ func testEncode(t *testing.T, val cadence.Value, expectedCBOR []byte) (actualCBO
 }
 
 func testDecode(t *testing.T, actualCBOR []byte, expectedVal cadence.Value) {
+	require.True(t, ccf.HasMsgPrefix(actualCBOR))
+
 	decodedVal, err := deterministicDecMode.Decode(nil, actualCBOR)
 	require.NoError(t, err)
 	assert.Equal(
@@ -15606,4 +15608,33 @@ func TestInvalidDecodingOptions(t *testing.T) {
 	}
 	_, err = opts.DecMode()
 	require.Error(t, err)
+}
+
+func TestHasMsgPrefix(t *testing.T) {
+
+	t.Parallel()
+
+	type testCase struct {
+		name     string
+		msg      []byte
+		expected bool
+	}
+
+	testCases := []testCase{
+		{name: "empty", msg: nil, expected: false},
+		{name: "too short", msg: []byte{0x00}, expected: false},
+		{name: "too short", msg: []byte{0x18, 0x18}, expected: false},
+		{name: "not CCF", msg: []byte{'a', 'b', 'c', 'd', 'e'}, expected: false},
+		{name: "not CCF", msg: []byte{0x1a, 0x00, 0x0f, 0x42, 0x40}, expected: false},
+		{name: "not CCF", msg: []byte{0xd8, 0x01, 0x82, 0x00, 0x00}, expected: false},
+		{name: "not implemented", msg: []byte{0xd8, ccf.CBORTagTypeDef, 0x82, 0x00, 0x00}, expected: false},
+		{name: "ccf-typedef-and-value-message", msg: []byte{0xd8, ccf.CBORTagTypeDefAndValue, 0x82, 0x00, 0x00}, expected: true},
+		{name: "ccf-type-and-value-message", msg: []byte{0xd8, ccf.CBORTagTypeAndValue, 0x82, 0xd8, ccf.CBORTagSimpleType, 0x18, 0x32, 0xf6}, expected: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, ccf.HasMsgPrefix(tc.msg))
+		})
+	}
 }

--- a/encoding/ccf/decode.go
+++ b/encoding/ccf/decode.go
@@ -32,6 +32,40 @@ import (
 	cadenceErrors "github.com/onflow/cadence/runtime/errors"
 )
 
+// HasMsgPrefix returns true if the msg prefix (first few bytes)
+// matches currently implemented top-level CCF messages:
+// -  ccf-typedef-and-value-message
+// -  ccf-type-and-value-message
+// WARNING: For simplicity and performance, this does not check
+// if msg is actually a CCF message, or well-formed, or valid.
+func HasMsgPrefix(msg []byte) bool {
+
+	// Top level CCF messages are CBOR tag (tag number: CBORTagTypeDefAndValue | CBORTagTypeAndValue, content: array of 2 elements).
+	// Minimum size is 5 bytes: top level tag number (2 bytes) + min size for array of 2 elements (3 bytes).
+	const minTopLevelMsgSize = 5
+
+	if len(msg) < minTopLevelMsgSize {
+		return false
+	}
+
+	// There are 3 top messages defined in CCF specs:
+	// language=CDDL
+	// ccf-message = (
+	//   ccf-typedef-message
+	//   / ccf-typedef-and-value-message
+	//   / ccf-type-and-value-message
+	// )
+	//
+	// Since ccf-typedef-message isn't implemented yet,
+	// check for these two messages:
+	// - ccf-typedef-and-value-message
+	// - ccf-type-and-valu8e-message
+
+	return msg[0] == 0xd8 && // 0xd8 is major type 6, semantic tag
+		(msg[1] == CBORTagTypeDefAndValue || msg[1] == CBORTagTypeAndValue) &&
+		msg[2] == 0x82 // 0x82 is CBOR array head of 2 elements
+}
+
 // defaultCBORDecMode
 //
 // See https://github.com/fxamacker/cbor:

--- a/runtime/ast/access.go
+++ b/runtime/ast/access.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 )
 
@@ -192,9 +193,12 @@ var BasicAccesses = []PrimitiveAccess{
 	AccessAll,
 }
 
-var AllAccesses = append(BasicAccesses[:],
-	AccessContract,
-	AccessAccount,
+var AllAccesses = common.Concat(
+	BasicAccesses,
+	[]PrimitiveAccess{
+		AccessContract,
+		AccessAccount,
+	},
 )
 
 func (a PrimitiveAccess) Keyword() string {

--- a/runtime/common/concat.go
+++ b/runtime/common/concat.go
@@ -1,0 +1,36 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+func Concat[T any](slices ...[]T) []T {
+	var length int
+
+	for _, slice := range slices {
+		length += len(slice)
+	}
+
+	result := make([]T, length)
+
+	var offset int
+	for _, slice := range slices {
+		offset += copy(result[offset:], slice)
+	}
+
+	return result
+}

--- a/runtime/interpreter/storagemap.go
+++ b/runtime/interpreter/storagemap.go
@@ -67,20 +67,16 @@ func NewStorageMapWithRootID(storage atree.SlabStorage, storageID atree.StorageI
 
 // ValueExists returns true if the given key exists in the storage map.
 func (s StorageMap) ValueExists(key StorageMapKey) bool {
-	_, err := s.orderedMap.Get(
+	exists, err := s.orderedMap.Has(
 		key.AtreeValueCompare,
 		key.AtreeValueHashInput,
 		key.AtreeValue(),
 	)
 	if err != nil {
-		var keyNotFoundError *atree.KeyNotFoundError
-		if goerrors.As(err, &keyNotFoundError) {
-			return false
-		}
 		panic(errors.NewExternalError(err))
 	}
 
-	return true
+	return exists
 }
 
 // ReadValue returns the value for the given key.

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -985,6 +985,10 @@ func (v CharacterValue) GetMember(interpreter *Interpreter, _ LocationRange, nam
 				)
 			},
 		)
+
+	case sema.CharacterTypeUtf8FieldName:
+		common.UseMemory(interpreter, common.NewBytesMemoryUsage(len(v)))
+		return ByteSliceToByteArrayValue(interpreter, []byte(v))
 	}
 	return nil
 }
@@ -17093,20 +17097,15 @@ func (v *DictionaryValue) ContainsKey(
 	valueComparator := newValueComparator(interpreter, locationRange)
 	hashInputProvider := newHashInputProvider(interpreter, locationRange)
 
-	_, err := v.dictionary.Get(
+	exists, err := v.dictionary.Has(
 		valueComparator,
 		hashInputProvider,
 		keyValue,
 	)
 	if err != nil {
-		var keyNotFoundError *atree.KeyNotFoundError
-		if goerrors.As(err, &keyNotFoundError) {
-			return FalseValue
-		}
 		panic(errors.NewExternalError(err))
 	}
-
-	return TrueValue
+	return AsBoolValue(exists)
 }
 
 func (v *DictionaryValue) Get(

--- a/runtime/literal_test.go
+++ b/runtime/literal_test.go
@@ -643,10 +643,12 @@ func TestParseLiteral(t *testing.T) {
 		)
 	}
 
-	for _, signedIntegerType := range append(
-		sema.AllSignedIntegerTypes[:],
-		sema.IntegerType,
-		sema.SignedIntegerType,
+	for _, signedIntegerType := range common.Concat(
+		sema.AllSignedIntegerTypes,
+		[]sema.Type{
+			sema.IntegerType,
+			sema.SignedIntegerType,
+		},
 	) {
 
 		t.Run(

--- a/runtime/sema/character.cdc
+++ b/runtime/sema/character.cdc
@@ -1,6 +1,12 @@
 
-access(all) struct Character: Storable, Equatable, Comparable, Exportable, Importable {
+access(all)
+struct Character: Storable, Equatable, Comparable, Exportable, Importable {
+
+    /// The byte array of the UTF-8 encoding
+    access(all)
+    let utf8: [UInt8]
 
     /// Returns this character as a String
-    access(all) fun toString(): String
+    access(all)
+    fun toString(): String
 }

--- a/runtime/sema/character.gen.go
+++ b/runtime/sema/character.gen.go
@@ -21,6 +21,16 @@ package sema
 
 import "github.com/onflow/cadence/runtime/ast"
 
+const CharacterTypeUtf8FieldName = "utf8"
+
+var CharacterTypeUtf8FieldType = &VariableSizedType{
+	Type: UInt8Type,
+}
+
+const CharacterTypeUtf8FieldDocString = `
+The byte array of the UTF-8 encoding
+`
+
 const CharacterTypeToStringFunctionName = "toString"
 
 var CharacterTypeToStringFunctionType = &FunctionType{
@@ -51,6 +61,14 @@ var CharacterType = &SimpleType{
 func init() {
 	CharacterType.Members = func(t *SimpleType) map[string]MemberResolver {
 		return MembersAsResolvers([]*Member{
+			NewUnmeteredFieldMember(
+				t,
+				ast.AccessAll,
+				ast.VariableKindConstant,
+				CharacterTypeUtf8FieldName,
+				CharacterTypeUtf8FieldType,
+				CharacterTypeUtf8FieldDocString,
+			),
 			NewUnmeteredFunctionMember(
 				t,
 				ast.AccessAll,

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -651,23 +651,24 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 	t.Parallel()
 
 	code := `
-          access(all) contract interface Test {
 
-              access(all) struct interface NestedInterface {
-                  access(all) fun test(): Bool
-              }
+      contract interface Test {
 
-              access(all) struct Nested: NestedInterface {}
+          struct interface NestedInterface {
+              fun test(): Bool
           }
 
-          access(all) contract TestImpl {
+          struct Nested: NestedInterface {}
+      }
 
-              access(all) struct Nested {
-                  access(all) fun test(): Bool {
-                      return true
-                  }
+      contract TestImpl {
+
+          struct Nested {
+              fun test(): Bool {
+                  return true
               }
           }
+      }
 	`
 
 	program, err := parser.ParseProgram(nil, []byte(code), parser.Config{})
@@ -678,7 +679,7 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 		common.StringLocation("test"),
 		nil,
 		&Config{
-			AccessCheckMode: AccessCheckModeStrict,
+			AccessCheckMode: AccessCheckModeNotSpecifiedUnrestricted,
 		},
 	)
 	require.NoError(t, err)
@@ -686,8 +687,10 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 	err = checker.Check()
 	require.NoError(t, err)
 
+	var typeIDs []common.TypeID
+
 	checker.typeActivations.ForEachVariableDeclaredInAndBelow(
-		0,
+		checker.valueActivations.Depth(),
 		func(_ string, value *Variable) {
 			typ := value.Type
 
@@ -710,13 +713,15 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 					cachedID := semaType.ID()
 
 					// clear cached identifiers for one level
-					semaType.cachedIdentifiers = nil
+					semaType.clearCachedIdentifiers()
 
 					recalculatedQualifiedID := semaType.QualifiedIdentifier()
 					recalculatedID := semaType.ID()
 
 					assert.Equal(t, recalculatedQualifiedID, cachedQualifiedID)
 					assert.Equal(t, recalculatedID, cachedID)
+
+					typeIDs = append(typeIDs, recalculatedID)
 
 					// Recursively check for nested types
 					checkNestedTypes(semaType.NestedTypes)
@@ -726,7 +731,7 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 					cachedID := semaType.ID()
 
 					// clear cached identifiers for one level
-					semaType.cachedIdentifiers = nil
+					semaType.clearCachedIdentifiers()
 
 					recalculatedQualifiedID := semaType.QualifiedIdentifier()
 					recalculatedID := semaType.ID()
@@ -734,13 +739,28 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 					assert.Equal(t, recalculatedQualifiedID, cachedQualifiedID)
 					assert.Equal(t, recalculatedID, cachedID)
 
+					typeIDs = append(typeIDs, recalculatedID)
+
 					// Recursively check for nested types
 					checkNestedTypes(semaType.NestedTypes)
 				}
 			}
 
 			checkIdentifiers(t, typ)
-		})
+		},
+	)
+
+	assert.Equal(t,
+		[]common.TypeID{
+			"S.test.Test",
+			"S.test.Test.NestedInterface",
+			"S.test.Test.Nested",
+			"S.test.TestImpl",
+			"S.test.TestImpl.Nested",
+		},
+		typeIDs,
+	)
+
 }
 
 func TestCommonSuperType(t *testing.T) {

--- a/runtime/stdlib/contracts/crypto_test.cdc
+++ b/runtime/stdlib/contracts/crypto_test.cdc
@@ -1,84 +1,97 @@
 import Test
 
-access(self) var blockchain = Test.newEmulatorBlockchain()
-access(self) var account = blockchain.createAccount()
+access(all) let blockchain = Test.newEmulatorBlockchain()
+access(all) let account = blockchain.createAccount()
 
-access(self) fun setup() {
+access(all)
+fun setup() {
     blockchain.useConfiguration(Test.Configuration({
         "Crypto": account.address
     }))
 
-    var crypto = Test.readFile("crypto.cdc")
-    var err = blockchain.deployContract(
+    let crypto = Test.readFile("crypto.cdc")
+    let err = blockchain.deployContract(
         name: "Crypto",
         code: crypto,
         account: account,
         arguments: []
     )
 
-    Test.assert(err == nil)
+    Test.expect(err, Test.beNil())
 }
 
-access(self) fun testCryptoHash() {
+access(all)
+fun testCryptoHash() {
     let returnedValue = executeScript("./scripts/crypto_hash.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    Test.assertEqual(true, returnedValue)
 }
 
-access(self) fun testCryptoHashWithTag() {
+access(all)
+fun testCryptoHashWithTag() {
     let returnedValue = executeScript("./scripts/crypto_hash_with_tag.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    Test.assertEqual(true, returnedValue)
 }
 
-access(self) fun testAddKeyToKeyList() {
+access(all)
+fun testAddKeyToKeyList() {
     let returnedValue = executeScript("./scripts/crypto_key_list_add.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    Test.assertEqual(true, returnedValue)
 }
 
-access(self) fun testGetKeyFromList() {
+access(all)
+fun testGetKeyFromList() {
     let returnedValue = executeScript("./scripts/crypto_get_key_from_list.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    Test.assertEqual(true, returnedValue)
 }
 
-access(self) fun testRevokeKeyFromList() {
+access(all)
+fun testRevokeKeyFromList() {
     let returnedValue = executeScript("./scripts/crypto_revoke_key_from_list.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    Test.assertEqual(true, returnedValue)
 }
 
-access(self) fun testKeyListVerify() {
+access(all)
+fun testKeyListVerify() {
     let returnedValue = executeScript("./scripts/crypto_key_list_verify.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    Test.assertEqual(true, returnedValue)
 }
 
-access(self) fun testKeyListVerifyInsufficientWeights() {
+access(all)
+fun testKeyListVerifyInsufficientWeights() {
     let returnedValue = executeScript("./scripts/crypto_key_list_verify_insufficient_weights.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    Test.assertEqual(true, returnedValue)
 }
 
-access(self) fun testKeyListVerifyWithRevokedKey() {
+access(all)
+fun testKeyListVerifyWithRevokedKey() {
     let returnedValue = executeScript("./scripts/crypto_key_list_verify_revoked.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    Test.assertEqual(true, returnedValue)
 }
 
-access(self) fun testKeyListVerifyWithMissingSignature() {
+access(all)
+fun testKeyListVerifyWithMissingSignature() {
     let returnedValue = executeScript("./scripts/crypto_key_list_verify_missing_signature.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    Test.assertEqual(true, returnedValue)
 }
 
-access(self) fun testKeyListVerifyDuplicateSignature() {
+access(all)
+fun testKeyListVerifyDuplicateSignature() {
     let returnedValue = executeScript("./scripts/crypto_key_list_verify_duplicate_signature.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    Test.assertEqual(true, returnedValue)
 }
 
-access(self) fun testKeyListVerifyInvalidSignature() {
+access(all)
+fun testKeyListVerifyInvalidSignature() {
     let returnedValue = executeScript("./scripts/crypto_key_list_verify_invalid_signature.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    Test.assertEqual(true, returnedValue)
 }
 
-priv fun executeScript(_ scriptPath: String): Bool {
-    var script = Test.readFile(scriptPath)
-    let value = blockchain.executeScript(script, [])
+access(self)
+fun executeScript(_ scriptPath: String): Bool {
+    let script = Test.readFile(scriptPath)
+    let scriptResult = blockchain.executeScript(script, [])
 
-    Test.assert(value.status == Test.ResultStatus.succeeded)
+    Test.expect(scriptResult, Test.beSucceeded())
 
-    return value.returnValue! as! Bool
+    return scriptResult.returnValue! as! Bool
 }

--- a/runtime/stdlib/contracts/scripts/crypto_get_key_from_list.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_get_key_from_list.cdc
@@ -1,4 +1,4 @@
-import Crypto from "Crypto"
+import "Crypto"
 
 access(self) fun main(): Bool {
     let keyList = Crypto.KeyList()

--- a/runtime/stdlib/contracts/scripts/crypto_hash.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_hash.cdc
@@ -1,4 +1,4 @@
-import Crypto from "Crypto"
+import "Crypto"
 
 access(self) fun main(): Bool {
     let hash = Crypto.hash([1, 2, 3], algorithm: HashAlgorithm.SHA3_256)

--- a/runtime/stdlib/contracts/scripts/crypto_hash_with_tag.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_hash_with_tag.cdc
@@ -1,4 +1,4 @@
-import Crypto from "Crypto"
+import "Crypto"
 
 access(self) fun main(): Bool {
     let hash = Crypto.hashWithTag(

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_add.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_add.cdc
@@ -1,4 +1,4 @@
-import Crypto from "Crypto"
+import "Crypto"
 
 access(self) fun main(): Bool {
     let keyList = Crypto.KeyList()

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_verify.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_verify.cdc
@@ -1,4 +1,4 @@
-import Crypto from "Crypto"
+import "Crypto"
 
 access(self) fun main(): Bool {
     let keyList = Crypto.KeyList()

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_verify_duplicate_signature.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_verify_duplicate_signature.cdc
@@ -1,4 +1,4 @@
-import Crypto from "Crypto"
+import "Crypto"
 
 access(self) fun main(): Bool {
     let keyList = Crypto.KeyList()

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_verify_insufficient_weights.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_verify_insufficient_weights.cdc
@@ -1,4 +1,4 @@
-import Crypto from "Crypto"
+import "Crypto"
 
 access(self) fun main(): Bool {
     let keyList = Crypto.KeyList()

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_verify_invalid_signature.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_verify_invalid_signature.cdc
@@ -1,4 +1,4 @@
-import Crypto from "Crypto"
+import "Crypto"
 
 access(self) fun main(): Bool {
     let keyList = Crypto.KeyList()

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_verify_missing_signature.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_verify_missing_signature.cdc
@@ -1,4 +1,4 @@
-import Crypto from "Crypto"
+import "Crypto"
 
 access(self) fun main(): Bool {
     let keyList = Crypto.KeyList()

--- a/runtime/stdlib/contracts/scripts/crypto_key_list_verify_revoked.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_key_list_verify_revoked.cdc
@@ -1,4 +1,4 @@
-import Crypto from "Crypto"
+import "Crypto"
 
 access(self) fun main(): Bool {
     let keyList = Crypto.KeyList()

--- a/runtime/stdlib/contracts/scripts/crypto_revoke_key_from_list.cdc
+++ b/runtime/stdlib/contracts/scripts/crypto_revoke_key_from_list.cdc
@@ -1,4 +1,4 @@
-import Crypto from "Crypto"
+import "Crypto"
 
 access(self) fun main(): Bool {
     let keyList = Crypto.KeyList()

--- a/runtime/stdlib/test_contract.go
+++ b/runtime/stdlib/test_contract.go
@@ -270,7 +270,12 @@ func newTestTypeExpectFunction(functionType *sema.FunctionType) interpreter.Func
 			)
 
 			if !result {
+				message := fmt.Sprintf(
+					"given value is: %s",
+					value,
+				)
 				panic(AssertionError{
+					Message:       message,
 					LocationRange: locationRange,
 				})
 			}

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -1631,7 +1631,12 @@ func TestTestExpect(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
-		assert.ErrorAs(t, err, &AssertionError{})
+
+		assertionErr := &AssertionError{}
+		assert.ErrorAs(t, err, assertionErr)
+		assert.Equal(t, "given value is: \"this string\"", assertionErr.Message)
+		assert.Equal(t, "test", assertionErr.LocationRange.Location.String())
+		assert.Equal(t, 5, assertionErr.LocationRange.StartPosition().Line)
 	})
 
 	t.Run("different types", func(t *testing.T) {

--- a/runtime/tests/checker/builtinfunctions_test.go
+++ b/runtime/tests/checker/builtinfunctions_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
@@ -32,9 +33,11 @@ func TestCheckToString(t *testing.T) {
 
 	t.Parallel()
 
-	for _, numberOrAddressType := range append(
-		sema.AllNumberTypes[:],
-		sema.TheAddressType,
+	for _, numberOrAddressType := range common.Concat(
+		sema.AllNumberTypes,
+		[]sema.Type{
+			sema.TheAddressType,
+		},
 	) {
 
 		ty := numberOrAddressType

--- a/runtime/tests/checker/character_test.go
+++ b/runtime/tests/checker/character_test.go
@@ -57,3 +57,20 @@ func TestCheckInvalidCharacterLiteral(t *testing.T) {
 
 	assert.IsType(t, &sema.InvalidCharacterLiteralError{}, errs[0])
 }
+
+func TestCheckCharacterUtf8Field(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+		let a: Character = "a"
+        let x = a.utf8
+	`)
+
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		sema.ByteArrayType,
+		RequireGlobalValue(t, checker.Elaboration, "x"),
+	)
+}

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -107,7 +107,8 @@ func TestCheckEventDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		validTypes := append(
+		validTypes := common.Concat(
+			sema.AllNumberTypes,
 			[]sema.Type{
 				sema.StringType,
 				sema.CharacterType,
@@ -120,7 +121,6 @@ func TestCheckEventDeclaration(t *testing.T) {
 				sema.PrivatePathType,
 				sema.CapabilityPathType,
 			},
-			sema.AllNumberTypes...,
 		)
 
 		tests := validTypes[:]

--- a/runtime/tests/checker/integer_test.go
+++ b/runtime/tests/checker/integer_test.go
@@ -26,12 +26,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-var allIntegerTypesAndAddressType = append(
-	sema.AllIntegerTypes[:],
-	sema.TheAddressType,
+var allIntegerTypesAndAddressType = common.Concat(
+	sema.AllIntegerTypes,
+	[]sema.Type{
+		sema.TheAddressType,
+	},
 )
 
 func TestCheckIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T) {

--- a/runtime/tests/checker/operations_test.go
+++ b/runtime/tests/checker/operations_test.go
@@ -426,9 +426,9 @@ func TestCheckSaturatedArithmeticFunctions(t *testing.T) {
 		},
 	}
 
-	for _, ty := range append(
-		sema.AllSignedIntegerTypes[:],
-		sema.AllSignedFixedPointTypes...,
+	for _, ty := range common.Concat(
+		sema.AllSignedIntegerTypes,
+		sema.AllSignedFixedPointTypes,
 	) {
 
 		if ty == sema.IntType {
@@ -444,9 +444,9 @@ func TestCheckSaturatedArithmeticFunctions(t *testing.T) {
 		})
 	}
 
-	for _, ty := range append(
-		sema.AllUnsignedIntegerTypes[:],
-		sema.AllUnsignedFixedPointTypes...,
+	for _, ty := range common.Concat(
+		sema.AllUnsignedIntegerTypes,
+		sema.AllUnsignedFixedPointTypes,
 	) {
 
 		if ty == sema.UIntType || strings.HasPrefix(ty.String(), "Word") {

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	. "github.com/onflow/cadence/runtime/tests/utils"
@@ -723,9 +724,9 @@ func TestInterpretSaturatedArithmeticFunctions(t *testing.T) {
 
 	// Verify all test cases exist
 
-	for _, ty := range append(
-		sema.AllSignedIntegerTypes[:],
-		sema.AllSignedFixedPointTypes...,
+	for _, ty := range common.Concat(
+		sema.AllSignedIntegerTypes,
+		sema.AllSignedFixedPointTypes,
 	) {
 
 		testCase, ok := testCases[ty]
@@ -749,9 +750,9 @@ func TestInterpretSaturatedArithmeticFunctions(t *testing.T) {
 		}
 	}
 
-	for _, ty := range append(
-		sema.AllUnsignedIntegerTypes[:],
-		sema.AllUnsignedFixedPointTypes...,
+	for _, ty := range common.Concat(
+		sema.AllUnsignedIntegerTypes,
+		sema.AllUnsignedFixedPointTypes,
 	) {
 
 		if strings.HasPrefix(ty.String(), "Word") {

--- a/runtime/tests/interpreter/character_test.go
+++ b/runtime/tests/interpreter/character_test.go
@@ -1,0 +1,77 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	. "github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func TestInterpretCharacterUtf8Field(t *testing.T) {
+
+	t.Parallel()
+
+	runTest := func(t *testing.T, code string, expectedValues ...interpreter.Value) {
+		inter := parseCheckAndInterpret(t, fmt.Sprintf(`
+		fun test(): [UInt8] {
+			let c: Character = "%s"
+			return c.utf8
+		}
+	  `, code))
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		RequireValuesEqual(
+			t,
+			inter,
+			interpreter.NewArrayValue(
+				inter,
+				interpreter.EmptyLocationRange,
+				interpreter.VariableSizedStaticType{
+					Type: interpreter.PrimitiveStaticTypeUInt8,
+				},
+				common.ZeroAddress,
+				expectedValues...,
+			),
+			result,
+		)
+	}
+
+	runTest(t, `a`, interpreter.NewUnmeteredUInt8Value(97))
+	runTest(t, `F`, interpreter.NewUnmeteredUInt8Value(70))
+	runTest(t, `\u{1F490}`,
+		interpreter.NewUnmeteredUInt8Value(240),
+		interpreter.NewUnmeteredUInt8Value(159),
+		interpreter.NewUnmeteredUInt8Value(146),
+		interpreter.NewUnmeteredUInt8Value(144),
+	)
+	runTest(t, "👪",
+		interpreter.NewUnmeteredUInt8Value(240),
+		interpreter.NewUnmeteredUInt8Value(159),
+		interpreter.NewUnmeteredUInt8Value(145),
+		interpreter.NewUnmeteredUInt8Value(170),
+	)
+}

--- a/tools/update/config.yaml
+++ b/tools/update/config.yaml
@@ -7,6 +7,14 @@ repos:
       deps:
         - onflow/cadence
 
+- repo: onflow/cadence-tools
+  needsRelease: true
+  mods:
+    - path: lint
+      deps:
+        - onflow/cadence
+        - onflow/flow-go-sdk
+
 - repo: onflow/flow-go
   needsRelease: false
   mods:
@@ -55,14 +63,6 @@ repos:
 - repo: onflow/cadence-tools
   needsRelease: true
   mods:
-    - path: lint
-      deps:
-        - onflow/cadence
-        - onflow/flow-go-sdk
-
-- repo: onflow/cadence-tools
-  needsRelease: true
-  mods:
     - path: languageserver
       deps:
         - onflow/cadence
@@ -70,6 +70,7 @@ repos:
         - onflow/flow-go
         - onflow/flow-emulator
         - onflow/cadence-tools/lint
+        - onflow/flow-cli/flowkit
 
 - repo: onflow/flow-cli
   needsRelease: true


### PR DESCRIPTION

<details>
<summary>Conflict resolution:</summary>

```sh
git log -1 -p -w --remerge-diff 6e8bc51849a762230bfb6de0f11f9afd4e906c20
```

```diff
diff --git a/runtime/ast/access.go b/runtime/ast/access.go
index a2b85023f..d61aa75d1 100644
--- a/runtime/ast/access.go
+++ b/runtime/ast/access.go
@@ -195,7 +195,7 @@ var BasicAccesses = []PrimitiveAccess{
 
 var AllAccesses = common.Concat(
 	BasicAccesses,
-	[]Access{
+	[]PrimitiveAccess{
 		AccessContract,
 		AccessAccount,
 	},
diff --git a/runtime/sema/character.cdc b/runtime/sema/character.cdc
index 3e059720f..7db30455e 100644
--- a/runtime/sema/character.cdc
+++ b/runtime/sema/character.cdc
@@ -1,9 +1,12 @@
 
-access(all) struct Character: Storable, Equatable, Comparable, Exportable, Importable {
+access(all)
+struct Character: Storable, Equatable, Comparable, Exportable, Importable {
 
     /// The byte array of the UTF-8 encoding
-    pub let utf8: [UInt8]
+    access(all)
+    let utf8: [UInt8]
 
     /// Returns this character as a String
-    access(all) fun toString(): String
+    access(all)
+    fun toString(): String
 }
diff --git a/runtime/sema/character.gen.go b/runtime/sema/character.gen.go
index effa9a13a..14ca517ea 100644
--- a/runtime/sema/character.gen.go
+++ b/runtime/sema/character.gen.go
@@ -63,7 +63,7 @@ func init() {
 		return MembersAsResolvers([]*Member{
 			NewUnmeteredFieldMember(
 				t,
-				ast.AccessPublic,
+				ast.AccessAll,
 				ast.VariableKindConstant,
 				CharacterTypeUtf8FieldName,
 				CharacterTypeUtf8FieldType,
diff --git a/runtime/sema/type.go b/runtime/sema/type.go
remerge CONFLICT (content): Merge conflict in runtime/sema/type.go
index e60f8c596..6f51b77b2 100644
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -958,37 +958,22 @@ self / other, saturating at the numeric bounds instead of overflowing.
 `
 
 var SaturatingArithmeticTypeFunctionTypes = map[Type]*FunctionType{}
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
 
-func addSaturatingArithmeticFunctions(t SaturatingArithmeticType, members map[string]MemberResolver) {
-
-	arithmeticFunctionType := NewSimpleFunctionType(
+func registerSaturatingArithmeticType(t Type) {
+	SaturatingArithmeticTypeFunctionTypes[t] = NewSimpleFunctionType(
 		FunctionPurityView,
 		[]Parameter{
-=======
-
-func registerSaturatingArithmeticType(t Type) {
-	SaturatingArithmeticTypeFunctionTypes[t] = &FunctionType{
-		Parameters: []Parameter{
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
 			{
 				Label:          ArgumentLabelNotRequired,
 				Identifier:     "other",
 				TypeAnnotation: NewTypeAnnotation(t),
 			},
 		},
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
 		NewTypeAnnotation(t),
 	)
-
-	SaturatingArithmeticTypeFunctionTypes[t] = arithmeticFunctionType
-=======
-		ReturnTypeAnnotation: NewTypeAnnotation(t),
-	}
 }
 
 func addSaturatingArithmeticFunctions(t SaturatingArithmeticType, members map[string]MemberResolver) {
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
 
 	addArithmeticFunction := func(name string, docString string) {
 		members[name] = MemberResolver{
@@ -1692,19 +1677,13 @@ var (
 			WithIntRange(UFix64TypeMinIntBig, UFix64TypeMaxIntBig).
 			WithFractionalRange(UFix64TypeMinFractionalBig, UFix64TypeMaxFractionalBig).
 			WithScale(Fix64Scale).
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-			WithSaturatingAdd().
-			WithSaturatingSubtract().
-			WithSaturatingMultiply()
-
-	UFix64TypeAnnotation = NewTypeAnnotation(UFix64Type)
-=======
 			WithSaturatingFunctions(SaturatingArithmeticSupport{
 			Add:      true,
 			Subtract: true,
 			Multiply: true,
 		})
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
+
+	UFix64TypeAnnotation = NewTypeAnnotation(UFix64Type)
 )
 
 // Numeric type ranges
diff --git a/runtime/sema/type_test.go b/runtime/sema/type_test.go
remerge CONFLICT (content): Merge conflict in runtime/sema/type_test.go
index e7e749fdf..29a8af15f 100644
--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -651,27 +651,11 @@ func TestIdentifierCacheUpdate(t *testing.T) {
 	t.Parallel()
 
 	code := `
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-          access(all) contract interface Test {
 
-              access(all) struct interface NestedInterface {
-                  access(all) fun test(): Bool
-              }
-
-              access(all) struct Nested: NestedInterface {}
-          }
-
-          access(all) contract TestImpl {
-
-              access(all) struct Nested {
-                  access(all) fun test(): Bool {
-                      return true
-                  }
-=======
       contract interface Test {
 
           struct interface NestedInterface {
-              pub fun test(): Bool
+              fun test(): Bool
           }
 
           struct Nested: NestedInterface {}
@@ -682,7 +666,6 @@ func TestIdentifierCacheUpdate(t *testing.T) {
           struct Nested {
               fun test(): Bool {
                   return true
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
               }
           }
       }
diff --git a/runtime/stdlib/contracts/crypto_test.cdc b/runtime/stdlib/contracts/crypto_test.cdc
remerge CONFLICT (content): Merge conflict in runtime/stdlib/contracts/crypto_test.cdc
index 5c9e41949..b4ce834ff 100644
--- a/runtime/stdlib/contracts/crypto_test.cdc
+++ b/runtime/stdlib/contracts/crypto_test.cdc
@@ -1,17 +1,10 @@
 import Test
 
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-access(self) var blockchain = Test.newEmulatorBlockchain()
-access(self) var account = blockchain.createAccount()
-
-access(self) fun setup() {
-=======
 access(all) let blockchain = Test.newEmulatorBlockchain()
 access(all) let account = blockchain.createAccount()
 
 access(all)
 fun setup() {
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
     blockchain.useConfiguration(Test.Configuration({
         "Crypto": account.address
     }))
@@ -27,112 +20,68 @@ fun setup() {
     Test.expect(err, Test.beNil())
 }
 
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-access(self) fun testCryptoHash() {
-=======
 access(all)
 fun testCryptoHash() {
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
     let returnedValue = executeScript("./scripts/crypto_hash.cdc")
     Test.assertEqual(true, returnedValue)
 }
 
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-access(self) fun testCryptoHashWithTag() {
-=======
 access(all)
 fun testCryptoHashWithTag() {
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
     let returnedValue = executeScript("./scripts/crypto_hash_with_tag.cdc")
     Test.assertEqual(true, returnedValue)
 }
 
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-access(self) fun testAddKeyToKeyList() {
-=======
 access(all)
 fun testAddKeyToKeyList() {
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
     let returnedValue = executeScript("./scripts/crypto_key_list_add.cdc")
     Test.assertEqual(true, returnedValue)
 }
 
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-access(self) fun testGetKeyFromList() {
-=======
 access(all)
 fun testGetKeyFromList() {
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
     let returnedValue = executeScript("./scripts/crypto_get_key_from_list.cdc")
     Test.assertEqual(true, returnedValue)
 }
 
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-access(self) fun testRevokeKeyFromList() {
-=======
 access(all)
 fun testRevokeKeyFromList() {
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
     let returnedValue = executeScript("./scripts/crypto_revoke_key_from_list.cdc")
     Test.assertEqual(true, returnedValue)
 }
 
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-access(self) fun testKeyListVerify() {
-=======
 access(all)
 fun testKeyListVerify() {
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
     let returnedValue = executeScript("./scripts/crypto_key_list_verify.cdc")
     Test.assertEqual(true, returnedValue)
 }
 
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-access(self) fun testKeyListVerifyInsufficientWeights() {
-=======
 access(all)
 fun testKeyListVerifyInsufficientWeights() {
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
     let returnedValue = executeScript("./scripts/crypto_key_list_verify_insufficient_weights.cdc")
     Test.assertEqual(true, returnedValue)
 }
 
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-access(self) fun testKeyListVerifyWithRevokedKey() {
-=======
 access(all)
 fun testKeyListVerifyWithRevokedKey() {
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
     let returnedValue = executeScript("./scripts/crypto_key_list_verify_revoked.cdc")
     Test.assertEqual(true, returnedValue)
 }
 
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-access(self) fun testKeyListVerifyWithMissingSignature() {
-=======
 access(all)
 fun testKeyListVerifyWithMissingSignature() {
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
     let returnedValue = executeScript("./scripts/crypto_key_list_verify_missing_signature.cdc")
     Test.assertEqual(true, returnedValue)
 }
 
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-access(self) fun testKeyListVerifyDuplicateSignature() {
-=======
 access(all)
 fun testKeyListVerifyDuplicateSignature() {
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
     let returnedValue = executeScript("./scripts/crypto_key_list_verify_duplicate_signature.cdc")
     Test.assertEqual(true, returnedValue)
 }
 
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-access(self) fun testKeyListVerifyInvalidSignature() {
-=======
 access(all)
 fun testKeyListVerifyInvalidSignature() {
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
     let returnedValue = executeScript("./scripts/crypto_key_list_verify_invalid_signature.cdc")
     Test.assertEqual(true, returnedValue)
 }
diff --git a/runtime/stdlib/test_contract.go b/runtime/stdlib/test_contract.go
remerge CONFLICT (content): Merge conflict in runtime/stdlib/test_contract.go
index 5d344131a..5cfa7ff75 100644
--- a/runtime/stdlib/test_contract.go
+++ b/runtime/stdlib/test_contract.go
@@ -270,18 +270,13 @@ func newTestTypeExpectFunction(functionType *sema.FunctionType) interpreter.Func
 			)
 
 			if !result {
-<<<<<<< 6111b6db8 (Merge pull request #2629 from onflow/supun/cyclic-imports)
-				panic(AssertionError{
-					LocationRange: locationRange,
-=======
 				message := fmt.Sprintf(
 					"given value is: %s",
 					value,
 				)
 				panic(AssertionError{
 					Message:       message,
-					LocationRange: invocation.LocationRange,
->>>>>>> 1173380ad (Merge pull request #2633 from onflow/bastian/fix-races)
+					LocationRange: locationRange,
 				})
 			}
 

```

</details>




______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
