### PR TITLE
Return a reference with all entitlements, when access through owned values

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -5251,7 +5251,7 @@ func (interpreter *Interpreter) getMemberWithAuthMapping(self Value, locationRan
 		return nil
 	}
 	// once we have obtained the member, if it was declared with entitlement-mapped access, we must compute the output of the map based
-	// on the runtime authorizations of the acccessing reference or composite
+	// on the runtime authorizations of the accessing reference or composite
 	memberAccess := interpreter.getAccessOfMember(self, identifier)
 	return interpreter.mapMemberValueAuthorization(self, memberAccess, result)
 }

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -202,8 +202,9 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *a
 			if isNestedResourceMove {
 				resultValue = target.(MemberAccessibleValue).RemoveMember(interpreter, locationRange, identifier)
 			} else {
-				resultValue = interpreter.getMemberWithAuthMapping(target, locationRange, identifier)
+				resultValue = interpreter.getMemberWithAuthMapping(target, locationRange, identifier, memberAccessInfo)
 			}
+
 			if resultValue == nil && !allowMissing {
 				panic(UseBeforeInitializationError{
 					Name:          identifier,

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -283,19 +283,19 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (accessedT
 		)
 	}
 
-		// Check access and report if inaccessible
-		accessRange := func() ast.Range { return ast.NewRangeFromPositioned(checker.memoryGauge, expression) }
-		isReadable, resultingAuthorization := checker.isReadableMember(accessedType, member, resultingType, accessRange)
-		if !isReadable {
-			checker.report(
-				&InvalidAccessError{
-					Name:              member.Identifier.Identifier,
-					RestrictingAccess: member.Access,
-					DeclarationKind:   member.DeclarationKind,
-					Range:             accessRange(),
-				},
-			)
-		}
+	// Check access and report if inaccessible
+	accessRange := func() ast.Range { return ast.NewRangeFromPositioned(checker.memoryGauge, expression) }
+	isReadable, resultingAuthorization := checker.isReadableMember(accessedType, member, resultingType, accessRange)
+	if !isReadable {
+		checker.report(
+			&InvalidAccessError{
+				Name:              member.Identifier.Identifier,
+				RestrictingAccess: member.Access,
+				DeclarationKind:   member.DeclarationKind,
+				Range:             accessRange(),
+			},
+		)
+	}
 
 	// the resulting authorization was mapped through an entitlement map, so we need to substitute this new authorization into the resulting type
 	// i.e. if the field was declared with `access(M) let x: auth(M) &T?`, and we computed that the output of the map would give entitlement `E`,
@@ -451,7 +451,7 @@ func (checker *Checker) mapAccess(
 
 	default:
 		if mappedAccess.Type == IdentityMappingType {
-			access := allSupportedEntitlements(resultingType)
+			access := AllSupportedEntitlements(resultingType)
 			if access != nil {
 				return true, access
 			}
@@ -463,14 +463,14 @@ func (checker *Checker) mapAccess(
 	}
 }
 
-func allSupportedEntitlements(typ Type) Access {
+func AllSupportedEntitlements(typ Type) Access {
 	switch typ := typ.(type) {
 	case *ReferenceType:
-		return allSupportedEntitlements(typ.Type)
+		return AllSupportedEntitlements(typ.Type)
 	case *OptionalType:
-		return allSupportedEntitlements(typ.Type)
+		return AllSupportedEntitlements(typ.Type)
 	case *FunctionType:
-		return allSupportedEntitlements(typ.ReturnTypeAnnotation.Type)
+		return AllSupportedEntitlements(typ.ReturnTypeAnnotation.Type)
 	case EntitlementSupportingType:
 		supportedEntitlements := typ.SupportedEntitlements()
 		if supportedEntitlements != nil && supportedEntitlements.Len() > 0 {

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -5505,11 +5505,11 @@ func TestCheckIdentityMapping(t *testing.T) {
 
                 let ref1: auth(A, B, C) &X = y.x1
 
-                //let ref2: auth(A, B, C) &X? = y.x2
+                let ref2: auth(A, B, C) &X? = y.x2
 
-                //let ref3: auth(A, B, C) &X = y.getX()
+                let ref3: auth(A, B, C) &X = y.getX()
 
-                //let ref4: auth(A, B, C) &X? = y.getOptionalX()
+                let ref4: auth(A, B, C) &X? = y.getOptionalX()
             }
         `)
 

--- a/runtime/tests/interpreter/entitlements_test.go
+++ b/runtime/tests/interpreter/entitlements_test.go
@@ -3079,4 +3079,66 @@ func TestInterpretIdentityMapping(t *testing.T) {
 		_, err := inter.Invoke("main")
 		assert.NoError(t, err)
 	})
+
+	t.Run("owned value, with entitlements", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            entitlement A
+            entitlement B
+            entitlement C
+
+            struct X {
+               access(A | B) var s: String
+
+               init() {
+                   self.s = "hello"
+               }
+
+               access(C) fun foo() {}
+            }
+
+            struct Y {
+
+                // Reference
+                access(Identity) var x1: auth(Identity) &X
+
+                // Optional reference
+                access(Identity) var x2: auth(Identity) &X?
+
+                // Function returning a reference
+                access(Identity) fun getX(): auth(Identity) &X {
+                    let x = X()
+                    return &x as auth(Identity) &X
+                }
+
+                // Function returning an optional reference
+                access(Identity) fun getOptionalX(): auth(Identity) &X? {
+                    let x: X? = X()
+                    return &x as auth(Identity) &X?
+                }
+
+                init() {
+                    let x = X()
+                    self.x1 = &x as auth(A, B, C) &X
+                    self.x2 = nil
+                }
+            }
+
+            fun main() {
+                let y = Y()
+
+                let ref1: auth(A, B, C) &X = y.x1
+
+                let ref2: auth(A, B, C) &X? = y.x2
+
+                let ref3: auth(A, B, C) &X = y.getX()
+
+                let ref4: auth(A, B, C) &X? = y.getOptionalX()
+            }
+        `)
+
+		_, err := inter.Invoke("main")
+		assert.NoError(t, err)
+	})
 }

--- a/runtime/tests/interpreter/entitlements_test.go
+++ b/runtime/tests/interpreter/entitlements_test.go
@@ -3090,11 +3090,9 @@ func TestInterpretIdentityMapping(t *testing.T) {
 
             struct X {
                access(A | B) var s: String
-
                init() {
                    self.s = "hello"
                }
-
                access(C) fun foo() {}
             }
 


### PR DESCRIPTION
Work towards #2638
Work towards onflow/flips#94
Closes #2536

## Description

Adds the improvement discussed in https://github.com/onflow/cadence/pull/2588#discussion_r1237203195

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
