### PR TITLE
Track resources with atree.ValueID instead of SlabID

### DIFF
--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -937,8 +937,8 @@ func (interpreter *Interpreter) visitInvocationExpressionWithImplicitArgument(in
 	if boundFunction, ok := function.(BoundFunctionValue); ok && boundFunction.Self != nil {
 		self := *boundFunction.Self
 		if resource, ok := self.(ReferenceTrackedResourceKindedValue); ok {
-			slabID := resource.SlabID()
-			interpreter.trackReferencedResourceKindedValue(slabID, resource)
+			valueID := resource.ValueID()
+			interpreter.trackReferencedResourceKindedValue(valueID, resource)
 		}
 	}
 
@@ -1290,7 +1290,7 @@ func (interpreter *Interpreter) VisitAttachExpression(attachExpression *ast.Atta
 		base,
 		interpreter.MustSemaTypeOfValue(base).(*sema.CompositeType),
 	)
-	interpreter.trackReferencedResourceKindedValue(base.SlabID(), base)
+	interpreter.trackReferencedResourceKindedValue(base.ValueID(), base)
 
 	attachment, ok := interpreter.visitInvocationExpressionWithImplicitArgument(
 		attachExpression.Attachment,
@@ -1302,7 +1302,7 @@ func (interpreter *Interpreter) VisitAttachExpression(attachExpression *ast.Atta
 	}
 
 	// Because `self` in attachments is a reference, we need to track the attachment if it's a resource
-	interpreter.trackReferencedResourceKindedValue(attachment.SlabID(), attachment)
+	interpreter.trackReferencedResourceKindedValue(attachment.ValueID(), attachment)
 
 	base = base.Transfer(
 		interpreter,

--- a/runtime/interpreter/sharedstate.go
+++ b/runtime/interpreter/sharedstate.go
@@ -43,8 +43,8 @@ type SharedState struct {
 	storageMutatedDuringIteration               bool
 	CapabilityControllerIterations              map[AddressPath]int
 	MutationDuringCapabilityControllerIteration bool
-	containerValueIteration                     map[atree.SlabID]struct{}
-	destroyedResources                          map[atree.SlabID]struct{}
+	containerValueIteration                     map[atree.ValueID]struct{}
+	destroyedResources                          map[atree.ValueID]struct{}
 }
 
 func NewSharedState(config *Config) *SharedState {
@@ -59,11 +59,11 @@ func NewSharedState(config *Config) *SharedState {
 		},
 		inStorageIteration:             false,
 		storageMutatedDuringIteration:  false,
-		referencedResourceKindedValues: map[atree.SlabID]map[ReferenceTrackedResourceKindedValue]struct{}{},
+		referencedResourceKindedValues: map[atree.ValueID]map[ReferenceTrackedResourceKindedValue]struct{}{},
 		resourceVariables:              map[ResourceKindedValue]*Variable{},
 		CapabilityControllerIterations: map[AddressPath]int{},
-		containerValueIteration:        map[atree.SlabID]struct{}{},
-		destroyedResources:             map[atree.SlabID]struct{}{},
+		containerValueIteration:        map[atree.ValueID]struct{}{},
+		destroyedResources:             map[atree.ValueID]struct{}{},
 	}
 }
 


### PR DESCRIPTION
Updates https://github.com/onflow/atree/issues/292

## Description

Currently, `Array.SlabID()` and `OrderedMap.SlabID()` are used as identifier to track resources, etc because slab IDs are guaranteed to unique. However, atree slab ID should be only used to retrieve slabs (registers) from storage.

Also, when Atree register inlining is implemented in the future, some resources may not be stored in separate slabs, so they will not have slab IDs anymore.

This commit uses `Array.ValueID()` and `OrderedMap.ValueID()` to uniquely identify resources.

More details at 
- https://github.com/onflow/atree/pull/321
- https://github.com/onflow/atree/pull/325

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
