### PR TITLE
[v0.39] Add support for max parameter count (internal #128)

### DIFF
--- a/.github/workflows/compatibility-check-template.yml
+++ b/.github/workflows/compatibility-check-template.yml
@@ -3,6 +3,10 @@ name: BackwardCompatibilityCheckTemplate
 on:
   workflow_call:
     inputs:
+      repo:
+        required: true
+        type: string
+        default: onflow/cadence
       current-branch:
         required: true
         type: string
@@ -77,7 +81,7 @@ jobs:
       - name: Check contracts using ${{ inputs.current-branch }}
         working-directory: ./tools/compatibility-check
         run: |
-          GOPROXY=direct go get github.com/onflow/cadence@${{ inputs.current-branch }}
+          GOPROXY=direct go mod edit -replace github.com/onflow/cadence=github.com/${{ inputs.repo }}@${{ inputs.current-branch }}
           go mod tidy
           go run ./cmd/check_contracts/main.go ../../tmp/contracts.csv ../../tmp/output-new.txt
 
@@ -86,7 +90,7 @@ jobs:
       - name: Check contracts using ${{ inputs.base-branch }}
         working-directory: ./tools/compatibility-check
         run: |
-          GOPROXY=direct go get github.com/onflow/cadence@${{ inputs.base-branch }}
+          GOPROXY=direct go mod edit -replace github.com/onflow/cadence=github.com/${{ inputs.repo }}@${{ inputs.base-branch }}
           go mod tidy
           go run ./cmd/check_contracts/main.go ../../tmp/contracts.csv ../../tmp/output-old.txt
 

--- a/.github/workflows/compatibility-check-template.yml
+++ b/.github/workflows/compatibility-check-template.yml
@@ -76,6 +76,12 @@ jobs:
           path: tmp/contracts.csv
           key: ${{ steps.cache-key-generator.outputs.cache-key }}-contracts
 
+      - name: Configure permissions
+        if: github.repository != 'onflow/cadence'
+        run: |
+          echo "GOPRIVATE=github.com/${{ inputs.repo }}" >> "$GITHUB_ENV"
+          git config --global url."https://${{ github.actor }}:${{ github.token }}@github.com".insteadOf "https://github.com"
+
       # Check contracts using current branch
 
       - name: Check contracts using ${{ inputs.current-branch }}

--- a/.github/workflows/compatibility-check.yml
+++ b/.github/workflows/compatibility-check.yml
@@ -3,6 +3,8 @@ name: BackwardCompatibilityCheck
 on:
   workflow_dispatch:
     inputs:
+      repo:
+        description: Repository (defaults to 'onflow/cadence')
       branch:
         description: 'Current branch/tag'
         required: true
@@ -32,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # Map step output to the job output, so that next job can use these values.
+      repo: ${{ steps.setup.outputs.repo }}
       branch: ${{ steps.setup.outputs.branch }}
       base: ${{ steps.setup.outputs.base }}
     steps:
@@ -44,12 +47,13 @@ jobs:
         # instead of the branch name, since 'go get' command does not support all kinds of branch names.
         #
         # Here there also is a limitation that we can't use the 'merge-branch' because it is not visible to 'go get'.
-        # So the workflow will not work across forks.
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "repo=`(echo "${{ github.event.pull_request.head.repo.full_name }}")`" >> $GITHUB_OUTPUT
             echo "branch=`(echo "${{ github.event.pull_request.head.sha }}")`" >> $GITHUB_OUTPUT
             echo "base=`(echo "${{ github.base_ref }}")`" >> $GITHUB_OUTPUT
           else
+            echo "repo=`(echo "${{ inputs.repo || 'onflow/cadence' }}")`" >> $GITHUB_OUTPUT
             echo "branch=`(echo "${{ inputs.branch }}")`" >> $GITHUB_OUTPUT
             echo "base=`(echo "${{ inputs.base }}")`" >> $GITHUB_OUTPUT
           fi
@@ -57,6 +61,7 @@ jobs:
     needs: setup
     uses: ./.github/workflows/compatibility-check-template.yml
     with:
+      repo: ${{ inputs.repo }}
       base-branch: ${{ needs.setup.outputs.base }}
       current-branch: ${{ needs.setup.outputs.branch }}
       chain: flow-mainnet
@@ -66,6 +71,7 @@ jobs:
     needs: setup
     uses: ./.github/workflows/compatibility-check-template.yml
     with:
+      repo: ${{ needs.setup.outputs.repo }}
       base-branch:  ${{ needs.setup.outputs.base }}
       current-branch: ${{ needs.setup.outputs.branch }}
       chain: flow-testnet

--- a/.github/workflows/compatibility-check.yml
+++ b/.github/workflows/compatibility-check.yml
@@ -61,7 +61,7 @@ jobs:
     needs: setup
     uses: ./.github/workflows/compatibility-check-template.yml
     with:
-      repo: ${{ inputs.repo }}
+      repo: ${{ needs.setup.outputs.repo }}
       base-branch: ${{ needs.setup.outputs.base }}
       current-branch: ${{ needs.setup.outputs.branch }}
       chain: flow-mainnet

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -2361,7 +2361,7 @@ func TestGetAuthAccount(t *testing.T) {
 
 		errs := checker.RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.ArgumentCountError{}, errs[0])
+		assert.IsType(t, &sema.InsufficientArgumentsError{}, errs[0])
 	})
 
 	t.Run("too many args", func(t *testing.T) {
@@ -2388,7 +2388,7 @@ func TestGetAuthAccount(t *testing.T) {
 		)
 		errs := checker.RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.ArgumentCountError{}, errs[0])
+		assert.IsType(t, &sema.ExcessiveArgumentsError{}, errs[0])
 	})
 
 	t.Run("transaction", func(t *testing.T) {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -423,12 +423,15 @@ func (interpreter *Interpreter) InvokeExternally(
 
 	if argumentCount != parameterCount {
 
-		// if the function has defined optional parameters,
-		// then the provided arguments must be equal to or greater than
-		// the number of required parameters.
-		if functionType.RequiredArgumentCount == nil ||
-			argumentCount < *functionType.RequiredArgumentCount {
+		if argumentCount < functionType.Arity.MinCount(parameterCount) {
+			return nil, ArgumentCountError{
+				ParameterCount: parameterCount,
+				ArgumentCount:  argumentCount,
+			}
+		}
 
+		maxCount := functionType.Arity.MaxCount(parameterCount)
+		if maxCount != nil && argumentCount > *maxCount {
 			return nil, ArgumentCountError{
 				ParameterCount: parameterCount,
 				ArgumentCount:  argumentCount,
@@ -1065,7 +1068,6 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 		ReturnTypeAnnotation: sema.TypeAnnotation{
 			Type: compositeType,
 		},
-		RequiredArgumentCount: nil,
 	}
 
 	var initializerFunction FunctionValue

--- a/runtime/sema/authaccount.go
+++ b/runtime/sema/authaccount.go
@@ -23,7 +23,7 @@ package sema
 var AuthAccountTypeLinkAccountFunctionTypePathParameterTypeAnnotation = AuthAccountTypeLinkAccountFunctionType.Parameters[0].TypeAnnotation
 
 func init() {
-	AuthAccountContractsTypeAddFunctionType.RequiredArgumentCount = RequiredArgumentCount(2)
+	AuthAccountContractsTypeAddFunctionType.Arity = &Arity{Min: 2}
 	AuthAccountTypeGetCapabilityFunctionTypeParameterT.Optional = true
 	PublicAccountTypeGetCapabilityFunctionTypeParameterT.Optional = true
 }

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2430,4 +2430,3 @@ func (checker *Checker) isAvailableMember(expressionType Type, identifier string
 
 	return true
 }
-

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2430,3 +2430,4 @@ func (checker *Checker) isAvailableMember(expressionType Type, identifier string
 
 	return true
 }
+

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -411,31 +411,59 @@ func (e *NotCallableError) Error() string {
 	)
 }
 
-// ArgumentCountError
+// InsufficientArgumentsError
 
-type ArgumentCountError struct {
-	ParameterCount int
-	ArgumentCount  int
+type InsufficientArgumentsError struct {
+	MinCount    int
+	ActualCount int
 	ast.Range
 }
 
-var _ SemanticError = &ArgumentCountError{}
-var _ errors.UserError = &ArgumentCountError{}
-var _ errors.SecondaryError = &ArgumentCountError{}
+var _ SemanticError = &InsufficientArgumentsError{}
+var _ errors.UserError = &InsufficientArgumentsError{}
+var _ errors.SecondaryError = &InsufficientArgumentsError{}
 
-func (*ArgumentCountError) isSemanticError() {}
+func (*InsufficientArgumentsError) isSemanticError() {}
 
-func (*ArgumentCountError) IsUserError() {}
+func (*InsufficientArgumentsError) IsUserError() {}
 
-func (e *ArgumentCountError) Error() string {
-	return "incorrect number of arguments"
+func (e *InsufficientArgumentsError) Error() string {
+	return "too few arguments"
 }
 
-func (e *ArgumentCountError) SecondaryError() string {
+func (e *InsufficientArgumentsError) SecondaryError() string {
 	return fmt.Sprintf(
-		"expected %d, got %d",
-		e.ParameterCount,
-		e.ArgumentCount,
+		"expected at least %d, got %d",
+		e.MinCount,
+		e.ActualCount,
+	)
+}
+
+// ExcessiveArgumentsError
+
+type ExcessiveArgumentsError struct {
+	MaxCount    int
+	ActualCount int
+	ast.Range
+}
+
+var _ SemanticError = &ExcessiveArgumentsError{}
+var _ errors.UserError = &ExcessiveArgumentsError{}
+var _ errors.SecondaryError = &ExcessiveArgumentsError{}
+
+func (*ExcessiveArgumentsError) isSemanticError() {}
+
+func (*ExcessiveArgumentsError) IsUserError() {}
+
+func (e *ExcessiveArgumentsError) Error() string {
+	return "too many arguments"
+}
+
+func (e *ExcessiveArgumentsError) SecondaryError() string {
+	return fmt.Sprintf(
+		"expected up to %d, got %d",
+		e.MaxCount,
+		e.ActualCount,
 	)
 }
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2639,10 +2639,38 @@ func formatFunctionType(
 	return builder.String()
 }
 
+//
+
+type Arity struct {
+	Min int
+	Max int
+}
+
+func (arity *Arity) MinCount(parameterCount int) int {
+	minCount := parameterCount
+	if arity != nil {
+		minCount = arity.Min
+	}
+
+	return minCount
+}
+
+func (arity *Arity) MaxCount(parameterCount int) *int {
+	maxCount := parameterCount
+	if arity != nil {
+		if arity.Max < parameterCount {
+			return nil
+		}
+		maxCount = arity.Max
+	}
+
+	return &maxCount
+}
+
 // FunctionType
 type FunctionType struct {
 	ReturnTypeAnnotation     TypeAnnotation
-	RequiredArgumentCount    *int
+	Arity                    *Arity
 	ArgumentExpressionsCheck ArgumentExpressionsCheck
 	Members                  *StringMemberOrderedMap
 	TypeParameters           []*TypeParameter
@@ -2653,10 +2681,6 @@ type FunctionType struct {
 }
 
 var _ Type = &FunctionType{}
-
-func RequiredArgumentCount(count int) *int {
-	return &count
-}
 
 func (*FunctionType) IsType() {}
 
@@ -2978,10 +3002,10 @@ func (t *FunctionType) RewriteWithRestrictedTypes() (Type, bool) {
 		}
 
 		return &FunctionType{
-			TypeParameters:        rewrittenTypeParameters,
-			Parameters:            rewrittenParameters,
-			ReturnTypeAnnotation:  NewTypeAnnotation(rewrittenReturnType),
-			RequiredArgumentCount: t.RequiredArgumentCount,
+			TypeParameters:       rewrittenTypeParameters,
+			Parameters:           rewrittenParameters,
+			ReturnTypeAnnotation: NewTypeAnnotation(rewrittenReturnType),
+			Arity:                t.Arity,
 		}, true
 	} else {
 		return t, false
@@ -3090,9 +3114,9 @@ func (t *FunctionType) Resolve(typeArguments *TypeParameterTypeOrderedMap) Type 
 	}
 
 	return &FunctionType{
-		Parameters:            newParameters,
-		ReturnTypeAnnotation:  NewTypeAnnotation(newReturnType),
-		RequiredArgumentCount: t.RequiredArgumentCount,
+		Parameters:           newParameters,
+		ReturnTypeAnnotation: NewTypeAnnotation(newReturnType),
+		Arity:                t.Arity,
 	}
 
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2639,7 +2639,7 @@ func formatFunctionType(
 	return builder.String()
 }
 
-//
+// Arity
 
 type Arity struct {
 	Min int

--- a/runtime/stdlib/assert.go
+++ b/runtime/stdlib/assert.go
@@ -50,7 +50,8 @@ var assertFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(
 		sema.VoidType,
 	),
-	RequiredArgumentCount: sema.RequiredArgumentCount(1),
+	// `message` parameter is optional
+	Arity: &sema.Arity{Min: 1, Max: 2},
 }
 
 var AssertFunction = NewStandardLibraryFunction(

--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/onflow/cadence/runtime/activations"
+	"github.com/onflow/cadence/runtime/tests/checker"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,9 +87,80 @@ func newInterpreter(t *testing.T, code string, valueDeclarations ...StandardLibr
 	return inter
 }
 
-func TestAssert(t *testing.T) {
+func TestCheckAssert(t *testing.T) {
 
 	t.Parallel()
+
+	baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+	baseValueActivation.DeclareValue(AssertFunction)
+
+	parseAndCheck := func(t *testing.T, code string) (*sema.Checker, error) {
+		return checker.ParseAndCheckWithOptions(t,
+			code,
+			checker.ParseAndCheckOptions{
+				Config: &sema.Config{
+					BaseValueActivation: baseValueActivation,
+				},
+			},
+		)
+	}
+
+	t.Run("too few arguments", func(t *testing.T) {
+
+		_, err := parseAndCheck(t, `let _ = assert()`)
+
+		errs := checker.RequireCheckerErrors(t, err, 1)
+		require.IsType(t, errs[0], &sema.InsufficientArgumentsError{})
+	})
+
+	t.Run("invalid first argument", func(t *testing.T) {
+
+		_, err := parseAndCheck(t, `let _ = assert(1)`)
+
+		errs := checker.RequireCheckerErrors(t, err, 1)
+		require.IsType(t, errs[0], &sema.TypeMismatchError{})
+	})
+
+	t.Run("no message", func(t *testing.T) {
+
+		_, err := parseAndCheck(t, `let _ = assert(true)`)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("with message", func(t *testing.T) {
+
+		_, err := parseAndCheck(t, `let _ = assert(true, message: "foo")`)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid message", func(t *testing.T) {
+
+		_, err := parseAndCheck(t, `let _ = assert(true, message: 1)`)
+
+		errs := checker.RequireCheckerErrors(t, err, 1)
+		require.IsType(t, errs[0], &sema.TypeMismatchError{})
+	})
+
+	t.Run("missing argument label for message", func(t *testing.T) {
+
+		_, err := parseAndCheck(t, `let _ = assert(true, "")`)
+
+		errs := checker.RequireCheckerErrors(t, err, 1)
+		require.IsType(t, errs[0], &sema.MissingArgumentLabelError{})
+	})
+
+	t.Run("too many arguments", func(t *testing.T) {
+
+		_, err := parseAndCheck(t, `let _ = assert(true, message: "foo", true)`)
+
+		errs := checker.RequireCheckerErrors(t, err, 1)
+		require.IsType(t, errs[0], &sema.ExcessiveArgumentsError{})
+	})
+}
+
+func TestInterpretAssert(t *testing.T) {
 
 	inter := newInterpreter(t,
 		`pub let test = assert`,
@@ -131,7 +203,58 @@ func TestAssert(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestPanic(t *testing.T) {
+func TestCheckPanic(t *testing.T) {
+
+	t.Parallel()
+
+	baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+	baseValueActivation.DeclareValue(PanicFunction)
+
+	parseAndCheck := func(t *testing.T, code string) (*sema.Checker, error) {
+		return checker.ParseAndCheckWithOptions(t,
+			code,
+			checker.ParseAndCheckOptions{
+				Config: &sema.Config{
+					BaseValueActivation: baseValueActivation,
+				},
+			},
+		)
+	}
+
+	t.Run("too few arguments", func(t *testing.T) {
+
+		_, err := parseAndCheck(t, `let _ = panic()`)
+
+		errs := checker.RequireCheckerErrors(t, err, 1)
+		require.IsType(t, errs[0], &sema.InsufficientArgumentsError{})
+	})
+
+	t.Run("message", func(t *testing.T) {
+
+		_, err := parseAndCheck(t, `let _ = panic("test")`)
+
+		require.NoError(t, err)
+
+	})
+
+	t.Run("invalid message", func(t *testing.T) {
+
+		_, err := parseAndCheck(t, `let _ = panic(true)`)
+
+		errs := checker.RequireCheckerErrors(t, err, 1)
+		require.IsType(t, errs[0], &sema.TypeMismatchError{})
+	})
+
+	t.Run("too many arguments", func(t *testing.T) {
+
+		_, err := parseAndCheck(t, `let _ = panic("test", 1)`)
+
+		errs := checker.RequireCheckerErrors(t, err, 1)
+		require.IsType(t, errs[0], &sema.ExcessiveArgumentsError{})
+	})
+}
+
+func TestInterpretPanic(t *testing.T) {
 
 	t.Parallel()
 

--- a/runtime/stdlib/test_contract.go
+++ b/runtime/stdlib/test_contract.go
@@ -75,7 +75,8 @@ var testTypeAssertFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(
 		sema.VoidType,
 	),
-	RequiredArgumentCount: sema.RequiredArgumentCount(1),
+	// `message` parameter is optional
+	Arity: &sema.Arity{Min: 1, Max: 2},
 }
 
 var testTypeAssertFunction = interpreter.NewUnmeteredHostFunctionValue(
@@ -195,7 +196,8 @@ var testTypeFailFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(
 		sema.VoidType,
 	),
-	RequiredArgumentCount: sema.RequiredArgumentCount(0),
+	// `message` parameter is optional
+	Arity: &sema.Arity{Min: 0, Max: 1},
 }
 
 var testTypeFailFunction = interpreter.NewUnmeteredHostFunctionValue(
@@ -903,7 +905,6 @@ func newTestTypeExpectFailureFunctionType() *sema.FunctionType {
 		ReturnTypeAnnotation: sema.NewTypeAnnotation(
 			sema.VoidType,
 		),
-		RequiredArgumentCount: sema.RequiredArgumentCount(2),
 	}
 }
 

--- a/runtime/stdlib/test_contract.go
+++ b/runtime/stdlib/test_contract.go
@@ -133,7 +133,6 @@ var testTypeAssertEqualFunctionType = &sema.FunctionType{
 			),
 		},
 	},
-	RequiredArgumentCount: sema.RequiredArgumentCount(2),
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(
 		sema.VoidType,
 	),

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -963,7 +963,7 @@ func TestCheckInvalidArrayRemoveFirst(t *testing.T) {
 
 	errs := RequireCheckerErrors(t, err, 1)
 
-	assert.IsType(t, &sema.ArgumentCountError{}, errs[0])
+	assert.IsType(t, &sema.ExcessiveArgumentsError{}, errs[0])
 }
 
 func TestCheckInvalidArrayRemoveFirstFromConstantSized(t *testing.T) {

--- a/runtime/tests/checker/builtinfunctions_test.go
+++ b/runtime/tests/checker/builtinfunctions_test.go
@@ -127,8 +127,8 @@ func TestCheckAddressFromBytes(t *testing.T) {
 
 	runInvalidCase(t, "[\"abc\"]", &sema.TypeMismatchError{})
 	runInvalidCase(t, "1", &sema.TypeMismatchError{})
-	runInvalidCase(t, "[1], [2, 3, 4]", &sema.ArgumentCountError{})
-	runInvalidCase(t, "", &sema.ArgumentCountError{})
+	runInvalidCase(t, "[1], [2, 3, 4]", &sema.ExcessiveArgumentsError{})
+	runInvalidCase(t, "", &sema.InsufficientArgumentsError{})
 	runInvalidCase(t, "typo: [1]", &sema.IncorrectArgumentLabelError{})
 }
 
@@ -177,8 +177,8 @@ func TestCheckAddressFromString(t *testing.T) {
 
 	runInvalidCase(t, "[1232]", &sema.TypeMismatchError{})
 	runInvalidCase(t, "1", &sema.TypeMismatchError{})
-	runInvalidCase(t, "\"0x1\", \"0x2\"", &sema.ArgumentCountError{})
-	runInvalidCase(t, "", &sema.ArgumentCountError{})
+	runInvalidCase(t, "\"0x1\", \"0x2\"", &sema.ExcessiveArgumentsError{})
+	runInvalidCase(t, "", &sema.InsufficientArgumentsError{})
 	runInvalidCase(t, "typo: \"0x1\"", &sema.IncorrectArgumentLabelError{})
 }
 
@@ -259,8 +259,8 @@ func TestCheckFromBigEndianBytes(t *testing.T) {
 			runValidCase(t, ty, "[1, 2, 100, 4, 45, 12]")
 
 			runInvalidCase(t, ty, "\"abcd\"", &sema.TypeMismatchError{})
-			runInvalidCase(t, ty, "", &sema.ArgumentCountError{})
-			runInvalidCase(t, ty, "[1], [2, 4]", &sema.ArgumentCountError{})
+			runInvalidCase(t, ty, "", &sema.InsufficientArgumentsError{})
+			runInvalidCase(t, ty, "[1], [2, 4]", &sema.ExcessiveArgumentsError{})
 			runInvalidCase(t, ty, "typo: [1]", &sema.IncorrectArgumentLabelError{})
 		}
 	}

--- a/runtime/tests/checker/casting_test.go
+++ b/runtime/tests/checker/casting_test.go
@@ -6050,7 +6050,6 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 						},
 					},
 					ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-					RequiredArgumentCount: nil,
 				},
 			)
 

--- a/runtime/tests/checker/casting_test.go
+++ b/runtime/tests/checker/casting_test.go
@@ -6049,7 +6049,7 @@ func TestCheckStaticCastElaboration(t *testing.T) {
 							),
 						},
 					},
-					ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
+					ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 				},
 			)
 

--- a/runtime/tests/checker/conditions_test.go
+++ b/runtime/tests/checker/conditions_test.go
@@ -145,7 +145,7 @@ func TestCheckInvalidFunctionPostConditionWithBeforeAndNoArgument(t *testing.T) 
 
 	errs := RequireCheckerErrors(t, err, 2)
 
-	assert.IsType(t, &sema.ArgumentCountError{}, errs[0])
+	assert.IsType(t, &sema.InsufficientArgumentsError{}, errs[0])
 	assert.IsType(t, &sema.TypeParameterTypeInferenceError{}, errs[1])
 }
 

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -66,10 +66,7 @@ func TestCheckGenericFunction(t *testing.T) {
 					variant,
 				),
 				&sema.FunctionType{
-					TypeParameters:        nil,
-					Parameters:            nil,
-					ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-					RequiredArgumentCount: nil,
+					ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 				},
 			)
 
@@ -91,10 +88,7 @@ func TestCheckGenericFunction(t *testing.T) {
               let res = test<X>()
             `,
 			&sema.FunctionType{
-				TypeParameters:        nil,
-				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -120,9 +114,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -148,9 +140,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -200,7 +190,6 @@ func TestCheckGenericFunction(t *testing.T) {
 					},
 				},
 				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
 			},
 		)
 
@@ -249,14 +238,13 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
 		errs := RequireCheckerErrors(t, err, 2)
 
-		assert.IsType(t, &sema.ArgumentCountError{}, errs[0])
+		assert.IsType(t, &sema.InsufficientArgumentsError{}, errs[0])
 		assert.IsType(t, &sema.TypeParameterTypeInferenceError{}, errs[1])
 	})
 
@@ -288,8 +276,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -328,7 +315,6 @@ func TestCheckGenericFunction(t *testing.T) {
 					},
 				},
 				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
 			},
 		)
 
@@ -372,8 +358,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -431,8 +416,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -459,13 +443,11 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				Parameters: nil,
 				ReturnTypeAnnotation: sema.NewTypeAnnotation(
 					&sema.GenericType{
 						TypeParameter: typeParameter,
 					},
 				),
-				RequiredArgumentCount: nil,
 			},
 		)
 
@@ -491,13 +473,11 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				Parameters: nil,
 				ReturnTypeAnnotation: sema.NewTypeAnnotation(
 					&sema.GenericType{
 						TypeParameter: typeParameter,
 					},
 				),
-				RequiredArgumentCount: nil,
 			},
 		)
 
@@ -556,7 +536,6 @@ func TestCheckGenericFunction(t *testing.T) {
 						TypeParameter: typeParameter,
 					},
 				),
-				RequiredArgumentCount: nil,
 			},
 		)
 
@@ -599,9 +578,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				Parameters:            nil,
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -639,9 +616,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				Parameters:            nil,
 				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
 			},
 		)
 
@@ -678,8 +653,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -757,7 +731,6 @@ func TestCheckGenericFunction(t *testing.T) {
 								},
 							),
 						),
-						RequiredArgumentCount: nil,
 					},
 				)
 
@@ -865,7 +838,6 @@ func TestCheckGenericFunction(t *testing.T) {
 								},
 							),
 						),
-						RequiredArgumentCount: nil,
 					},
 				)
 
@@ -906,7 +878,6 @@ func TestCheckGenericFunctionIsInvalid(t *testing.T) {
 			},
 		},
 		ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-		RequiredArgumentCount: nil,
 	}
 
 	assert.False(t, genericFunctionType.IsInvalidType())

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -189,7 +189,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -314,7 +314,7 @@ func TestCheckGenericFunction(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -616,7 +616,7 @@ func TestCheckGenericFunction(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					typeParameter,
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 
@@ -877,7 +877,7 @@ func TestCheckGenericFunctionIsInvalid(t *testing.T) {
 				),
 			},
 		},
-		ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
+		ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 	}
 
 	assert.False(t, genericFunctionType.IsInvalidType())

--- a/runtime/tests/checker/integer_test.go
+++ b/runtime/tests/checker/integer_test.go
@@ -472,7 +472,7 @@ func TestCheckInvalidIntegerConversionFunctionWithoutArgs(t *testing.T) {
 
 			errs := RequireCheckerErrors(t, err, 1)
 
-			assert.IsType(t, &sema.ArgumentCountError{}, errs[0])
+			assert.IsType(t, &sema.InsufficientArgumentsError{}, errs[0])
 
 		})
 	}

--- a/runtime/tests/checker/invocation_test.go
+++ b/runtime/tests/checker/invocation_test.go
@@ -44,7 +44,7 @@ func TestCheckInvalidFunctionCallWithTooFewArguments(t *testing.T) {
 
 	errs := RequireCheckerErrors(t, err, 1)
 
-	assert.IsType(t, &sema.ArgumentCountError{}, errs[0])
+	assert.IsType(t, &sema.InsufficientArgumentsError{}, errs[0])
 }
 
 func TestCheckFunctionCallWithArgumentLabel(t *testing.T) {
@@ -172,8 +172,7 @@ func TestCheckInvalidFunctionCallWithTooManyArguments(t *testing.T) {
 
 	errs := RequireCheckerErrors(t, err, 2)
 
-	assert.IsType(t, &sema.ArgumentCountError{}, errs[0])
-
+	assert.IsType(t, &sema.ExcessiveArgumentsError{}, errs[0])
 	assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[1])
 }
 
@@ -319,11 +318,7 @@ func TestCheckInvocationWithOnlyVarargs(t *testing.T) {
 			ReturnTypeAnnotation: sema.TypeAnnotation{
 				Type: sema.VoidType,
 			},
-			RequiredArgumentCount: func() *int {
-				// NOTE: important to check *all* arguments are optional
-				var count = 0
-				return &count
-			}(),
+			Arity: &sema.Arity{Max: -1},
 		},
 		"",
 		nil,

--- a/runtime/tests/checker/metatype_test.go
+++ b/runtime/tests/checker/metatype_test.go
@@ -134,7 +134,7 @@ func TestCheckIsInstance(t *testing.T) {
 			code: `
               let result = (1).isInstance(Type<Int>(), Type<Int>())
             `,
-			expectedErrorType: &sema.ArgumentCountError{},
+			expectedErrorType: &sema.ExcessiveArgumentsError{},
 		},
 	}
 
@@ -209,7 +209,7 @@ func TestCheckIsSubtype(t *testing.T) {
 			code: `
               let result = Type<Int>().isSubtype()
             `,
-			expectedErrorType: &sema.ArgumentCountError{},
+			expectedErrorType: &sema.InsufficientArgumentsError{},
 		},
 		{
 			name: "isSubtype argument must be named",
@@ -223,7 +223,7 @@ func TestCheckIsSubtype(t *testing.T) {
 			code: `
               let result = Type<Int>().isSubtype(of: Type<Int?>(), Type<Int?>())
             `,
-			expectedErrorType: &sema.ArgumentCountError{},
+			expectedErrorType: &sema.ExcessiveArgumentsError{},
 		},
 	}
 

--- a/runtime/tests/checker/runtimetype_test.go
+++ b/runtime/tests/checker/runtimetype_test.go
@@ -70,14 +70,14 @@ func TestCheckOptionalTypeConstructor(t *testing.T) {
 			code: `
               let result = OptionalType(Type<Int>(), Type<Int>())
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.ExcessiveArgumentsError{},
 		},
 		{
 			name: "too few args",
 			code: `
               let result = OptionalType()
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 	}
 
@@ -142,14 +142,14 @@ func TestCheckVariableSizedArrayTypeConstructor(t *testing.T) {
 			code: `
               let result = VariableSizedArrayType(Type<Int>(), Type<Int>())
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.ExcessiveArgumentsError{},
 		},
 		{
 			name: "too few args",
 			code: `
               let result = VariableSizedArrayType()
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 	}
 
@@ -221,21 +221,21 @@ func TestCheckConstantSizedArrayTypeConstructor(t *testing.T) {
 			code: `
               let result = ConstantSizedArrayType(type:Type<Int>(), size: 3, 4)
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.ExcessiveArgumentsError{},
 		},
 		{
 			name: "one arg",
 			code: `
               let result = ConstantSizedArrayType(type: Type<Int>())
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 		{
 			name: "no args",
 			code: `
               let result = ConstantSizedArrayType()
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 		{
 			name: "second label missing",
@@ -322,21 +322,21 @@ func TestCheckDictionaryTypeConstructor(t *testing.T) {
 			code: `
               let result = DictionaryType(key: Type<Int>(), value: Type<Int>(), 4)
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.ExcessiveArgumentsError{},
 		},
 		{
 			name: "one arg",
 			code: `
               let result = DictionaryType(key: Type<Int>())
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 		{
 			name: "no args",
 			code: `
               let result = DictionaryType()
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 		{
 			name: "first label missing",
@@ -400,14 +400,14 @@ func TestCheckCompositeTypeConstructor(t *testing.T) {
 			code: `
               let result = CompositeType("", 3)
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.ExcessiveArgumentsError{},
 		},
 		{
 			name: "no args",
 			code: `
               let result = CompositeType()
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 	}
 
@@ -457,14 +457,14 @@ func TestCheckInterfaceTypeConstructor(t *testing.T) {
 			code: `
               let result = InterfaceType("", 3)
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.ExcessiveArgumentsError{},
 		},
 		{
 			name: "no args",
 			code: `
               let result = InterfaceType()
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 	}
 
@@ -535,21 +535,21 @@ func TestCheckFunctionTypeConstructor(t *testing.T) {
 			code: `
               let result = FunctionType(parameters: [Type<String>(), Type<Int>()], return: Type<String>(), 4)
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.ExcessiveArgumentsError{},
 		},
 		{
 			name: "one arg",
 			code: `
               let result = FunctionType(parameters: [Type<String>(), Type<Int>()])
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 		{
 			name: "no args",
 			code: `
               let result = FunctionType()
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 		{
 			name: "first label missing",
@@ -628,21 +628,21 @@ func TestCheckReferenceTypeConstructor(t *testing.T) {
 			code: `
               let result = ReferenceType(authorized: true, type: Type<String>(), Type<Int>())
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.ExcessiveArgumentsError{},
 		},
 		{
 			name: "one arg",
 			code: `
               let result = ReferenceType(authorized: true)
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 		{
 			name: "no args",
 			code: `
               let result = ReferenceType()
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 		{
 			name: "first label missing",
@@ -731,21 +731,21 @@ func TestCheckRestrictedTypeConstructor(t *testing.T) {
 			code: `
               let result = RestrictedType(identifier: "A", restrictions: ["I1"], ["I2"])
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.ExcessiveArgumentsError{},
 		},
 		{
 			name: "one arg",
 			code: `
               let result = RestrictedType(identifier: "A")
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 		{
 			name: "no args",
 			code: `
               let result = RestrictedType()
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 		{
 			name: "missing first label",
@@ -824,14 +824,14 @@ func TestCheckCapabilityTypeConstructor(t *testing.T) {
 			code: `
               let result = CapabilityType(Type<Int>(), Type<Int>())
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.ExcessiveArgumentsError{},
 		},
 		{
 			name: "too few args",
 			code: `
               let result = CapabilityType()
             `,
-			expectedError: &sema.ArgumentCountError{},
+			expectedError: &sema.InsufficientArgumentsError{},
 		},
 	}
 

--- a/runtime/tests/checker/type_inference_test.go
+++ b/runtime/tests/checker/type_inference_test.go
@@ -363,8 +363,7 @@ func TestCheckFunctionArgumentTypeInference(t *testing.T) {
 						),
 					},
 				},
-				ReturnTypeAnnotation:  sema.NewTypeAnnotation(sema.VoidType),
-				RequiredArgumentCount: nil,
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 			},
 		)
 


### PR DESCRIPTION
Port https://github.com/dapperlabs/cadence-internal/pull/128
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
