### PR TITLE
Remove spurious resource loss errors (internal #130)

### DIFF
--- a/runtime/sema/check_return_statement.go
+++ b/runtime/sema/check_return_statement.go
@@ -25,8 +25,13 @@ func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) (_ 
 
 	defer func() {
 		// NOTE: check for resource loss before declaring the function
-		// as having definitely returned
-		checker.checkResourceLossForFunction()
+		// as having definitely returned.
+		//
+		// Check all variables declared *inside* of the function.
+		// The function activation's value activation depth is where the *function* is declared ("parent scope"),
+		// and two value activation scopes are defined for the function itself: for the parameters and the body.
+
+		checker.checkResourceLoss(functionActivation.ValueActivationDepth + 1)
 		functionActivation.ReturnInfo.MaybeReturned = true
 		functionActivation.ReturnInfo.DefinitelyReturned = true
 	}()
@@ -72,10 +77,4 @@ func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) (_ 
 	checker.checkResourceMoveOperation(statement.Expression, valueType)
 
 	return
-}
-
-func (checker *Checker) checkResourceLossForFunction() {
-	functionValueActivationDepth :=
-		checker.functionActivations.Current().ValueActivationDepth
-	checker.checkResourceLoss(functionValueActivationDepth)
 }

--- a/runtime/sema/variable_activations.go
+++ b/runtime/sema/variable_activations.go
@@ -253,7 +253,11 @@ func (a *VariableActivations) Find(name string) *Variable {
 
 // Depth returns the depth (size) of the activation stack.
 func (a *VariableActivations) Depth() int {
-	return len(a.activations)
+	current := a.Current()
+	if current == nil {
+		return 0
+	}
+	return current.Depth
 }
 
 type variableDeclaration struct {

--- a/runtime/tests/checker/function_test.go
+++ b/runtime/tests/checker/function_test.go
@@ -380,10 +380,9 @@ func TestCheckInvalidResourceCapturingJustMemberAccess(t *testing.T) {
       let test = makeKittyIdGetter()
     `)
 
-	errs := RequireCheckerErrors(t, err, 2)
+	errs := RequireCheckerErrors(t, err, 1)
 
 	assert.IsType(t, &sema.ResourceCapturingError{}, errs[0])
-	assert.IsType(t, &sema.ResourceLossError{}, errs[1])
 }
 
 func TestCheckInvalidFunctionWithResult(t *testing.T) {

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -3982,11 +3982,10 @@ func TestCheckInvalidResourceDictionaryKeysForeach(t *testing.T) {
         }
     `)
 
-	errs := RequireCheckerErrors(t, err, 3)
+	errs := RequireCheckerErrors(t, err, 2)
 
 	assert.IsType(t, &sema.InvalidDictionaryKeyTypeError{}, errs[0])
 	assert.IsType(t, &sema.InvalidResourceDictionaryMemberError{}, errs[1])
-	assert.IsType(t, &sema.ResourceLossError{}, errs[2])
 }
 
 func TestCheckInvalidResourceLossAfterMoveThroughDictionaryIndexing(t *testing.T) {
@@ -9302,4 +9301,60 @@ func TestCheckInvalidUnreachableResourceInvalidation(t *testing.T) {
 	errs := RequireCheckerErrors(t, err, 1)
 
 	assert.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
+}
+
+func TestCheckResourceWithFunction(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("without return statement", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+
+          fun test() {
+              let x: @AnyResource? <- nil
+
+              fun () {}
+
+              destroy x
+          }
+        `)
+		require.NoError(t, err)
+	})
+
+	t.Run("with return statement", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+
+          fun test() {
+              let x: @AnyResource? <- nil
+
+              fun (): Bool {
+                  return true
+              }
+
+              destroy x
+          }
+        `)
+		require.NoError(t, err)
+	})
+}
+
+func TestCheckInvalidResourceDestructionInFunction(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      fun test() {
+          let x: @AnyResource? <- nil
+
+          fun () {
+              destroy x
+          }
+      }
+    `)
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.ResourceCapturingError{}, errs[0])
 }


### PR DESCRIPTION
## Description

Port of https://github.com/dapperlabs/cadence-internal/pull/130

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
