### PR TITLE
Make more `AuthAccount` functions `view`

### DIFF
--- a/runtime/sema/authaccount.cdc
+++ b/runtime/sema/authaccount.cdc
@@ -83,7 +83,7 @@ access(all) struct AuthAccount {
     /// The given type must not necessarily be exactly the same as the type of the copied structure.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
-    access(all) fun copy<T: AnyStruct>(from: StoragePath): T?
+    access(all) view fun copy<T: AnyStruct>(from: StoragePath): T?
 
     /// Returns a reference to an object in storage without removing it from storage.
     ///

--- a/runtime/sema/authaccount.cdc
+++ b/runtime/sema/authaccount.cdc
@@ -95,7 +95,7 @@ access(all) struct AuthAccount {
     /// The given type must not necessarily be exactly the same as the type of the borrowed object.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed
-    access(all) fun borrow<T: &Any>(from: StoragePath): T?
+    access(all) view fun borrow<T: &Any>(from: StoragePath): T?
 
     /// Returns true if the object in account storage under the given path satisfies the given type,
     /// i.e. could be borrowed using the given type.
@@ -103,7 +103,7 @@ access(all) struct AuthAccount {
     /// The given type must not necessarily be exactly the same as the type of the borrowed object.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
-    access(all) fun check<T: Any>(from: StoragePath): Bool
+    access(all) view fun check<T: Any>(from: StoragePath): Bool
 
     /// **DEPRECATED**: Instead, use `capabilities.storage.issue`, and `capabilities.publish` if the path is public.
     ///
@@ -137,13 +137,13 @@ access(all) struct AuthAccount {
     /// **DEPRECATED**: Use `capabilities.get` instead.
     ///
     /// Returns the capability at the given private or public path.
-    access(all) fun getCapability<T: &Any>(_ path: CapabilityPath): Capability<T>
+    access(all) view fun getCapability<T: &Any>(_ path: CapabilityPath): Capability<T>
 
     /// **DEPRECATED**: Use `capabilities.storage.getController` and `StorageCapabilityController.target()`.
     ///
     /// Returns the target path of the capability at the given public or private path,
     /// or nil if there exists no capability at the given path.
-    access(all) fun getLinkTarget(_ path: CapabilityPath): Path?
+    access(all) view fun getLinkTarget(_ path: CapabilityPath): Path?
 
     /// **DEPRECATED**: Use `capabilities.unpublish` instead if the path is public.
     ///
@@ -247,7 +247,7 @@ access(all) struct AuthAccount {
         /// Returns the deployed contract for the contract/contract interface with the given name in the account, if any.
         ///
         /// Returns nil if no contract/contract interface with the given name exists in the account.
-        access(all) fun get(name: String): DeployedContract?
+        access(all) view fun get(name: String): DeployedContract?
 
         /// Removes the contract/contract interface from the account which has the given name, if any.
         ///
@@ -260,7 +260,7 @@ access(all) struct AuthAccount {
         ///
         /// Returns nil if no contract with the given name exists in the account,
         /// or if the contract does not conform to the given type.
-        access(all) fun borrow<T: &Any>(name: String): T?
+        access(all) view fun borrow<T: &Any>(name: String): T?
     }
 
     access(all) struct Keys {
@@ -277,7 +277,7 @@ access(all) struct AuthAccount {
         /// Returns the key at the given index, if it exists, or nil otherwise.
         ///
         /// Revoked keys are always returned, but they have `isRevoked` field set to true.
-        access(all) fun get(keyIndex: Int): AccountKey?
+        access(all) view fun get(keyIndex: Int): AccountKey?
 
         /// Marks the key at the given index revoked, but does not delete it.
         ///
@@ -329,7 +329,7 @@ access(all) struct AuthAccount {
         /// Returns the capability at the given public path.
         /// Returns nil if the capability does not exist,
         /// or if the given type is not a supertype of the capability's borrow type.
-        access(all) fun get<T: &Any>(_ path: PublicPath): Capability<T>?
+        access(all) view fun get<T: &Any>(_ path: PublicPath): Capability<T>?
 
         /// Borrows the capability at the given public path.
         /// Returns nil if the capability does not exist, or cannot be borrowed using the given type.
@@ -369,10 +369,10 @@ access(all) struct AuthAccount {
         /// Get the storage capability controller for the capability with the specified ID.
         ///
         /// Returns nil if the ID does not reference an existing storage capability.
-        access(all) fun getController(byCapabilityID: UInt64): &StorageCapabilityController?
+        access(all) view fun getController(byCapabilityID: UInt64): &StorageCapabilityController?
 
         /// Get all storage capability controllers for capabilities that target this storage path
-        access(all) fun getControllers(forPath: StoragePath): [&StorageCapabilityController]
+        access(all) view fun getControllers(forPath: StoragePath): [&StorageCapabilityController]
 
         /// Iterate over all storage capability controllers for capabilities that target this storage path,
         /// passing a reference to each controller to the provided callback function.
@@ -394,10 +394,10 @@ access(all) struct AuthAccount {
         /// Get capability controller for capability with the specified ID.
         ///
         /// Returns nil if the ID does not reference an existing account capability.
-        access(all) fun getController(byCapabilityID: UInt64): &AccountCapabilityController?
+        access(all) view fun getController(byCapabilityID: UInt64): &AccountCapabilityController?
 
         /// Get all capability controllers for all account capabilities.
-        access(all) fun getControllers(): [&AccountCapabilityController]
+        access(all) view fun getControllers(): [&AccountCapabilityController]
 
         /// Iterate over all account capability controllers for all account capabilities,
         /// passing a reference to each controller to the provided callback function.

--- a/runtime/sema/authaccount.gen.go
+++ b/runtime/sema/authaccount.gen.go
@@ -243,6 +243,7 @@ var AuthAccountTypeCopyFunctionTypeParameterT = &TypeParameter{
 }
 
 var AuthAccountTypeCopyFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	TypeParameters: []*TypeParameter{
 		AuthAccountTypeCopyFunctionTypeParameterT,
 	},

--- a/runtime/sema/authaccount.gen.go
+++ b/runtime/sema/authaccount.gen.go
@@ -289,6 +289,7 @@ var AuthAccountTypeBorrowFunctionTypeParameterT = &TypeParameter{
 }
 
 var AuthAccountTypeBorrowFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	TypeParameters: []*TypeParameter{
 		AuthAccountTypeBorrowFunctionTypeParameterT,
 	},
@@ -328,6 +329,7 @@ var AuthAccountTypeCheckFunctionTypeParameterT = &TypeParameter{
 }
 
 var AuthAccountTypeCheckFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	TypeParameters: []*TypeParameter{
 		AuthAccountTypeCheckFunctionTypeParameterT,
 	},
@@ -453,6 +455,7 @@ var AuthAccountTypeGetCapabilityFunctionTypeParameterT = &TypeParameter{
 }
 
 var AuthAccountTypeGetCapabilityFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	TypeParameters: []*TypeParameter{
 		AuthAccountTypeGetCapabilityFunctionTypeParameterT,
 	},
@@ -482,6 +485,7 @@ Returns the capability at the given private or public path.
 const AuthAccountTypeGetLinkTargetFunctionName = "getLinkTarget"
 
 var AuthAccountTypeGetLinkTargetFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	Parameters: []Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,
@@ -746,6 +750,7 @@ Returns the deployed contract for the updated contract.
 const AuthAccountContractsTypeGetFunctionName = "get"
 
 var AuthAccountContractsTypeGetFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	Parameters: []Parameter{
 		{
 			Identifier:     "name",
@@ -800,6 +805,7 @@ var AuthAccountContractsTypeBorrowFunctionTypeParameterT = &TypeParameter{
 }
 
 var AuthAccountContractsTypeBorrowFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	TypeParameters: []*TypeParameter{
 		AuthAccountContractsTypeBorrowFunctionTypeParameterT,
 	},
@@ -920,6 +926,7 @@ Returns the added key.
 const AuthAccountKeysTypeGetFunctionName = "get"
 
 var AuthAccountKeysTypeGetFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	Parameters: []Parameter{
 		{
 			Identifier:     "keyIndex",
@@ -1243,6 +1250,7 @@ var AuthAccountCapabilitiesTypeGetFunctionTypeParameterT = &TypeParameter{
 }
 
 var AuthAccountCapabilitiesTypeGetFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	TypeParameters: []*TypeParameter{
 		AuthAccountCapabilitiesTypeGetFunctionTypeParameterT,
 	},
@@ -1465,6 +1473,7 @@ func init() {
 const AuthAccountStorageCapabilitiesTypeGetControllerFunctionName = "getController"
 
 var AuthAccountStorageCapabilitiesTypeGetControllerFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	Parameters: []Parameter{
 		{
 			Identifier:     "byCapabilityID",
@@ -1490,6 +1499,7 @@ Returns nil if the ID does not reference an existing storage capability.
 const AuthAccountStorageCapabilitiesTypeGetControllersFunctionName = "getControllers"
 
 var AuthAccountStorageCapabilitiesTypeGetControllersFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	Parameters: []Parameter{
 		{
 			Identifier:     "forPath",
@@ -1641,6 +1651,7 @@ func init() {
 const AuthAccountAccountCapabilitiesTypeGetControllerFunctionName = "getController"
 
 var AuthAccountAccountCapabilitiesTypeGetControllerFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	Parameters: []Parameter{
 		{
 			Identifier:     "byCapabilityID",
@@ -1666,6 +1677,7 @@ Returns nil if the ID does not reference an existing account capability.
 const AuthAccountAccountCapabilitiesTypeGetControllersFunctionName = "getControllers"
 
 var AuthAccountAccountCapabilitiesTypeGetControllersFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	ReturnTypeAnnotation: NewTypeAnnotation(
 		&VariableSizedType{
 			Type: &ReferenceType{

--- a/runtime/tests/checker/purity_test.go
+++ b/runtime/tests/checker/purity_test.go
@@ -303,6 +303,17 @@ func TestCheckPurityEnforcement(t *testing.T) {
 		})
 	})
 
+	t.Run("copy", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAndCheckAccount(t, `
+        view fun foo() {
+            authAccount.copy<Int>(from: /storage/foo)
+        }
+        `)
+
+		require.NoError(t, err)
+	})
+
 	t.Run("save", func(t *testing.T) {
 		t.Parallel()
 		_, err := ParseAndCheckAccount(t, `

--- a/runtime/tests/checker/purity_test.go
+++ b/runtime/tests/checker/purity_test.go
@@ -314,6 +314,83 @@ func TestCheckPurityEnforcement(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("borrow", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAndCheckAccount(t, `
+        view fun foo() {
+            authAccount.borrow<&Int>(from: /storage/foo)
+        }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("check", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAndCheckAccount(t, `
+        view fun foo() {
+            authAccount.check<Int>(from: /storage/foo)
+        }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("getlinktarget", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAndCheckAccount(t, `
+        view fun foo() {
+            authAccount.getLinkTarget(/public/foo)
+        }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("getcap", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAndCheckAccount(t, `
+        view fun foo() {
+            authAccount.getCapability<&Int>(/public/foo)
+        }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("get contract", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAndCheckAccount(t, `
+        view fun foo() {
+            authAccount.contracts.get(name: "")
+        }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("borrow contract", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAndCheckAccount(t, `
+        view fun foo() {
+            authAccount.contracts.borrow<&Int>(name: "")
+        }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("get keys", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAndCheckAccount(t, `
+        view fun foo() {
+            authAccount.keys.get(keyIndex: 0)
+        }
+        `)
+
+		require.NoError(t, err)
+	})
+
 	t.Run("save", func(t *testing.T) {
 		t.Parallel()
 		_, err := ParseAndCheckAccount(t, `


### PR DESCRIPTION
These functions were not marked as `view` when they could have been, causing unnecessary restrictive behavior. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
