### PR TITLE
Temporarily remove deprecations for existing capability API

### DIFF
--- a/runtime/sema/authaccount.cdc
+++ b/runtime/sema/authaccount.cdc
@@ -117,8 +117,6 @@ pub struct AuthAccount {
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
     pub fun check<T: Any>(from: StoragePath): Bool
 
-    /// **DEPRECATED**: Instead, use `capabilities.storage.issue`, and `capabilities.publish` if the path is public.
-    ///
     /// Creates a capability at the given public or private path,
     /// which targets the given public, private, or storage path.
     ///
@@ -139,26 +137,18 @@ pub struct AuthAccount {
     /// and the target value might be moved out after the link has been created.
     pub fun link<T: &Any>(_ newCapabilityPath: CapabilityPath, target: Path): Capability<T>?
 
-    /// **DEPRECATED**: Use `capabilities.account.issue` instead.
-    ///
     /// Creates a capability at the given public or private path which targets this account.
     ///
     /// Returns nil if a link for the given capability path already exists, or the newly created capability if not.
     pub fun linkAccount(_ newCapabilityPath: PrivatePath): Capability<&AuthAccount>?
 
-    /// **DEPRECATED**: Use `capabilities.get` instead.
-    ///
     /// Returns the capability at the given private or public path.
     pub fun getCapability<T: &Any>(_ path: CapabilityPath): Capability<T>
 
-    /// **DEPRECATED**: Use `capabilities.storage.getController` and `StorageCapabilityController.target()`.
-    ///
     /// Returns the target path of the capability at the given public or private path,
     /// or nil if there exists no capability at the given path.
     pub fun getLinkTarget(_ path: CapabilityPath): Path?
 
-    /// **DEPRECATED**: Use `capabilities.unpublish` instead if the path is public.
-    ///
     /// Removes the capability at the given public or private path.
     pub fun unlink(_ path: CapabilityPath)
 

--- a/runtime/sema/authaccount.gen.go
+++ b/runtime/sema/authaccount.gen.go
@@ -431,8 +431,6 @@ var AuthAccountTypeLinkFunctionType = &FunctionType{
 }
 
 const AuthAccountTypeLinkFunctionDocString = `
-**DEPRECATED**: Instead, use ` + "`capabilities.storage.issue`" + `, and ` + "`capabilities.publish`" + ` if the path is public.
-
 Creates a capability at the given public or private path,
 which targets the given public, private, or storage path.
 
@@ -476,8 +474,6 @@ var AuthAccountTypeLinkAccountFunctionType = &FunctionType{
 }
 
 const AuthAccountTypeLinkAccountFunctionDocString = `
-**DEPRECATED**: Use ` + "`capabilities.account.issue`" + ` instead.
-
 Creates a capability at the given public or private path which targets this account.
 
 Returns nil if a link for the given capability path already exists, or the newly created capability if not.
@@ -514,8 +510,6 @@ var AuthAccountTypeGetCapabilityFunctionType = &FunctionType{
 }
 
 const AuthAccountTypeGetCapabilityFunctionDocString = `
-**DEPRECATED**: Use ` + "`capabilities.get`" + ` instead.
-
 Returns the capability at the given private or public path.
 `
 
@@ -537,8 +531,6 @@ var AuthAccountTypeGetLinkTargetFunctionType = &FunctionType{
 }
 
 const AuthAccountTypeGetLinkTargetFunctionDocString = `
-**DEPRECATED**: Use ` + "`capabilities.storage.getController`" + ` and ` + "`StorageCapabilityController.target()`" + `.
-
 Returns the target path of the capability at the given public or private path,
 or nil if there exists no capability at the given path.
 `
@@ -559,8 +551,6 @@ var AuthAccountTypeUnlinkFunctionType = &FunctionType{
 }
 
 const AuthAccountTypeUnlinkFunctionDocString = `
-**DEPRECATED**: Use ` + "`capabilities.unpublish`" + ` instead if the path is public.
-
 Removes the capability at the given public or private path.
 `
 

--- a/runtime/sema/publicaccount.cdc
+++ b/runtime/sema/publicaccount.cdc
@@ -28,13 +28,9 @@ pub struct PublicAccount {
     /// All public paths of this account.
     pub let publicPaths: [PublicPath]
 
-    /// **DEPRECATED**: Use `capabilities.get` instead.
-    ///
     /// Returns the capability at the given public path.
     pub fun getCapability<T: &Any>(_ path: PublicPath): Capability<T>
 
-    /// **DEPRECATED**
-    ///
     /// Returns the target path of the capability at the given public or private path,
     /// or nil if there exists no capability at the given path.
     pub fun getLinkTarget(_ path: CapabilityPath): Path?

--- a/runtime/sema/publicaccount.gen.go
+++ b/runtime/sema/publicaccount.gen.go
@@ -129,8 +129,6 @@ var PublicAccountTypeGetCapabilityFunctionType = &FunctionType{
 }
 
 const PublicAccountTypeGetCapabilityFunctionDocString = `
-**DEPRECATED**: Use ` + "`capabilities.get`" + ` instead.
-
 Returns the capability at the given public path.
 `
 
@@ -152,8 +150,6 @@ var PublicAccountTypeGetLinkTargetFunctionType = &FunctionType{
 }
 
 const PublicAccountTypeGetLinkTargetFunctionDocString = `
-**DEPRECATED**
-
 Returns the target path of the capability at the given public or private path,
 or nil if there exists no capability at the given path.
 `


### PR DESCRIPTION
Closes https://github.com/onflow/vscode-cadence/issues/400

## Description

This is causing some confusion to developers, as CapCons is not yet live on Mainnet. The changes affect both `AuthAccount` & `PublicAccount`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
