### PR TITLE
Introduce `filter` in Fixed/Variable sized Array types

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2989,10 +2989,8 @@ func (v *ArrayValue) Filter(
 		return invocation
 	}
 
-	iterator, err := v.array.Iterator()
-
 	i := 0
-	err = v.array.Iterate(
+	err := v.array.Iterate(
 		func(item atree.Value) (bool, error) {
 			arrayElement := MustConvertStoredValue(interpreter, item)
 
@@ -3009,6 +3007,11 @@ func (v *ArrayValue) Filter(
 			return true, nil
 		},
 	)
+	if err != nil {
+		panic(errors.NewExternalError(err))
+	}
+
+	iterator, err := v.array.Iterator()
 	if err != nil {
 		panic(errors.NewExternalError(err))
 	}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2989,7 +2989,6 @@ func (v *ArrayValue) Filter(
 		return invocation
 	}
 
-	i := 0
 	err := v.array.Iterate(
 		func(item atree.Value) (bool, error) {
 			arrayElement := MustConvertStoredValue(interpreter, item)
@@ -3003,7 +3002,6 @@ func (v *ArrayValue) Filter(
 				filteredValuesCount++
 			}
 
-			i++
 			return true, nil
 		},
 	)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2975,13 +2975,14 @@ func (v *ArrayValue) Filter(
 	procedure FunctionValue,
 ) Value {
 
+	elementTypeSlice := []sema.Type{v.semaType.ElementType(false)}
 	iterationInvocation := func(arrayElement Value) Invocation {
 		invocation := NewInvocation(
 			interpreter,
 			nil,
 			nil,
 			[]Value{arrayElement},
-			[]sema.Type{v.semaType.ElementType(false)},
+			elementTypeSlice,
 			nil,
 			locationRange,
 		)

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -1795,6 +1795,13 @@ Returns a new array with contents in the reversed order.
 Available if the array element type is not resource-kinded.
 `
 
+const ArrayTypeFilterFunctionName = "filter"
+
+const arrayTypeFilterFunctionDocString = `
+Returns a new array whose elements are filtered by applying the filter function on each element of the original array.
+Available if the array element type is not resource-kinded.
+`
+
 func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 
 	members := map[string]MemberResolver{
@@ -2083,6 +2090,32 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 				)
 			},
 		}
+
+		members[ArrayTypeFilterFunctionName] = MemberResolver{
+			Kind: common.DeclarationKindFunction,
+			Resolve: func(memoryGauge common.MemoryGauge, identifier string, targetRange ast.Range, report func(error)) *Member {
+
+				elementType := arrayType.ElementType(false)
+
+				if elementType.IsResourceType() {
+					report(
+						&InvalidResourceArrayMemberError{
+							Name:            identifier,
+							DeclarationKind: common.DeclarationKindFunction,
+							Range:           targetRange,
+						},
+					)
+				}
+
+				return NewPublicFunctionMember(
+					memoryGauge,
+					arrayType,
+					identifier,
+					ArrayFilterFunctionType(elementType),
+					arrayTypeFilterFunctionDocString,
+				)
+			},
+		}
 	}
 
 	return withBuiltinMembers(arrayType, members)
@@ -2229,6 +2262,33 @@ func ArrayReverseFunctionType(arrayType ArrayType) *FunctionType {
 	return &FunctionType{
 		Parameters:           []Parameter{},
 		ReturnTypeAnnotation: NewTypeAnnotation(arrayType),
+	}
+}
+
+func ArrayFilterFunctionType(elementType Type) *FunctionType {
+	// fun filter(_ function: ((T): Bool)): [T]
+	// funcType: elementType -> Bool
+	funcType := &FunctionType{
+		Parameters: []Parameter{
+			{
+				Identifier:     "element",
+				TypeAnnotation: NewTypeAnnotation(elementType),
+			},
+		},
+		ReturnTypeAnnotation: NewTypeAnnotation(BoolType),
+	}
+
+	return &FunctionType{
+		Parameters: []Parameter{
+			{
+				Label:          ArgumentLabelNotRequired,
+				Identifier:     "f",
+				TypeAnnotation: NewTypeAnnotation(funcType),
+			},
+		},
+		ReturnTypeAnnotation: NewTypeAnnotation(&VariableSizedType{
+			Type: elementType,
+		}),
 	}
 }
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -1920,6 +1920,31 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 				)
 			},
 		},
+		ArrayTypeFilterFunctionName: {
+			Kind: common.DeclarationKindFunction,
+			Resolve: func(memoryGauge common.MemoryGauge, identifier string, targetRange ast.Range, report func(error)) *Member {
+
+				elementType := arrayType.ElementType(false)
+
+				if elementType.IsResourceType() {
+					report(
+						&InvalidResourceArrayMemberError{
+							Name:            identifier,
+							DeclarationKind: common.DeclarationKindFunction,
+							Range:           targetRange,
+						},
+					)
+				}
+
+				return NewPublicFunctionMember(
+					memoryGauge,
+					arrayType,
+					identifier,
+					ArrayFilterFunctionType(elementType),
+					arrayTypeFilterFunctionDocString,
+				)
+			},
+		},
 	}
 
 	// TODO: maybe still return members but report a helpful error?
@@ -2087,32 +2112,6 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 					identifier,
 					ArrayRemoveLastFunctionType(elementType),
 					arrayTypeRemoveLastFunctionDocString,
-				)
-			},
-		}
-
-		members[ArrayTypeFilterFunctionName] = MemberResolver{
-			Kind: common.DeclarationKindFunction,
-			Resolve: func(memoryGauge common.MemoryGauge, identifier string, targetRange ast.Range, report func(error)) *Member {
-
-				elementType := arrayType.ElementType(false)
-
-				if elementType.IsResourceType() {
-					report(
-						&InvalidResourceArrayMemberError{
-							Name:            identifier,
-							DeclarationKind: common.DeclarationKindFunction,
-							Range:           targetRange,
-						},
-					)
-				}
-
-				return NewPublicFunctionMember(
-					memoryGauge,
-					arrayType,
-					identifier,
-					ArrayFilterFunctionType(elementType),
-					arrayTypeFilterFunctionDocString,
 				)
 			},
 		}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -1940,7 +1940,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 					memoryGauge,
 					arrayType,
 					identifier,
-					ArrayFilterFunctionType(elementType),
+					ArrayFilterFunctionType(memoryGauge, elementType),
 					arrayTypeFilterFunctionDocString,
 				)
 			},
@@ -2264,7 +2264,7 @@ func ArrayReverseFunctionType(arrayType ArrayType) *FunctionType {
 	}
 }
 
-func ArrayFilterFunctionType(elementType Type) *FunctionType {
+func ArrayFilterFunctionType(memoryGauge common.MemoryGauge, elementType Type) *FunctionType {
 	// fun filter(_ function: ((T): Bool)): [T]
 	// funcType: elementType -> Bool
 	funcType := &FunctionType{
@@ -2285,9 +2285,7 @@ func ArrayFilterFunctionType(elementType Type) *FunctionType {
 				TypeAnnotation: NewTypeAnnotation(funcType),
 			},
 		},
-		ReturnTypeAnnotation: NewTypeAnnotation(&VariableSizedType{
-			Type: elementType,
-		}),
+		ReturnTypeAnnotation: NewTypeAnnotation(NewVariableSizedType(memoryGauge, elementType)),
 	}
 }
 

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -1142,6 +1142,16 @@ func TestCheckArrayFilter(t *testing.T) {
 
 			let y = x.filter(onlyEven)
 		}
+
+		fun testFixedSize() {
+			let x : [Int; 5] = [1, 2, 3, 21, 30]
+			let onlyEvenInt =
+				fun (_ x: Int): Bool {
+					return x % 2 == 0
+				}
+
+			let y = x.filter(onlyEvenInt)
+		}
     `)
 
 	require.NoError(t, err)
@@ -1185,22 +1195,6 @@ func TestCheckArrayFilterInvalidArgs(t *testing.T) {
 	`,
 		[]sema.SemanticError{
 			&sema.TypeMismatchError{},
-		},
-	)
-
-	testInvalidArgs(`
-		fun test() {
-			let x : [Int; 5] = [1, 2, 3, 21, 30]
-			let onlyEvenInt =
-				fun (_ x: Int): Bool {
-					return x % 2 == 0
-				}
-
-			let y = x.filter(onlyEvenInt)
-		}
-	`,
-		[]sema.SemanticError{
-			&sema.NotDeclaredMemberError{},
 		},
 	)
 }

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -10745,8 +10745,8 @@ func TestInterpretArrayFilter(t *testing.T) {
 	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
-		let xs = [1, 2, 3, 100, 200]
-		let xs_fixed: [Int; 5] = [1, 2, 3, 100, 200]
+		let xs = [1, 2, 3, 100, 201]
+		let xs_fixed: [Int; 5] = [1, 2, 3, 100, 201]
 		let emptyVals: [Int] = []
 		let emptyVals_fixed: [Int; 0] = []
 
@@ -10910,7 +10910,6 @@ func TestInterpretArrayFilter(t *testing.T) {
 				common.ZeroAddress,
 				interpreter.NewUnmeteredIntValueFromInt64(2),
 				interpreter.NewUnmeteredIntValueFromInt64(100),
-				interpreter.NewUnmeteredIntValueFromInt64(200),
 			), interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
@@ -10920,7 +10919,7 @@ func TestInterpretArrayFilter(t *testing.T) {
 				interpreter.NewUnmeteredIntValueFromInt64(2),
 				interpreter.NewUnmeteredIntValueFromInt64(3),
 				interpreter.NewUnmeteredIntValueFromInt64(100),
-				interpreter.NewUnmeteredIntValueFromInt64(200),
+				interpreter.NewUnmeteredIntValueFromInt64(201),
 			))
 
 		runValidCase(t, "filtersa"+suffix, "originalsa"+suffix,


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/2605

## Description

Introduce `filter` function for creating a copy of an Array value with its entries filtered via predicate.

This function would be unavailable to resource arrays since resources cannot be copied

Will send docs PR post the merge.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
