### PR TITLE
Update reference invalidation check to consider optional resources

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -5350,18 +5350,20 @@ func (interpreter *Interpreter) checkReferencedResourceNotMovedOrDestroyed(
 	referencedValue Value,
 	locationRange LocationRange,
 ) {
-	resourceKindedValue, ok := referencedValue.(ReferenceTrackedResourceKindedValue)
-	if !ok {
-		return
-	}
 
-	if resourceKindedValue.IsDestroyed() {
+	// First check if the referencedValue is a resource.
+	// This is to handle optionals, since optionals does not
+	// belong to `ReferenceTrackedResourceKindedValue`
+
+	resourceKindedValue, ok := referencedValue.(ResourceKindedValue)
+	if ok && resourceKindedValue.IsDestroyed() {
 		panic(DestroyedResourceError{
 			LocationRange: locationRange,
 		})
 	}
 
-	if resourceKindedValue.IsStaleResource(interpreter) {
+	referenceTrackedResourceKindedValue, ok := referencedValue.(ReferenceTrackedResourceKindedValue)
+	if ok && referenceTrackedResourceKindedValue.IsStaleResource(interpreter) {
 		panic(InvalidatedResourceReferenceError{
 			LocationRange: locationRange,
 		})

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -9037,7 +9037,7 @@ func TestRuntimeReturnDestroyedOptional(t *testing.T) {
 			Location:  common.ScriptLocation{},
 		},
 	)
-	RequireError(t, err)
 
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+	RequireError(t, err)
+	require.ErrorAs(t, err, &interpreter.DestroyedResourceError{})
 }


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-internal/issues/140

## Description

Update the reference invalidation to consider references to optionals. This allows catching the invalidated references early as possible, rather than later failing with an internal error.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
