### PR TITLE
Fix interface member inheritance

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4953,7 +4953,7 @@ func (t *InterfaceType) initializeMemberResolvers() {
 
 		// add any inherited members from up the inheritance chain
 		for _, conformance := range t.EffectiveInterfaceConformances() {
-			for name, member := range conformance.InterfaceType.GetMembers() {
+			for name, member := range conformance.InterfaceType.GetMembers() { //nolint:maprange
 				if _, ok := members[name]; !ok {
 					members[name] = member
 				}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4951,6 +4951,16 @@ func (t *InterfaceType) initializeMemberResolvers() {
 	t.memberResolversOnce.Do(func() {
 		members := MembersMapAsResolvers(t.Members)
 
+		// add any inherited members from up the inheritance chain
+		for _, conformance := range t.EffectiveInterfaceConformances() {
+			for name, member := range conformance.InterfaceType.GetMembers() {
+				if _, ok := members[name]; !ok {
+					members[name] = member
+				}
+			}
+
+		}
+
 		t.memberResolvers = withBuiltinMembers(t, members)
 	})
 }

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -4095,6 +4095,72 @@ func TestCheckInterfaceTypeDefinitionInheritance(t *testing.T) {
 
 }
 
+func TestInheritedInterfaceMembers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inherited interface field", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		resource interface A {
+			let foo: String
+		}
+		resource interface B: A {}
+		resource C: B {
+			let foo: String
+			init() {
+				self.foo = ""
+			}
+		}
+		fun test() {
+			let c: @{B} <- create C()
+			c.foo
+			destroy c
+		}
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("inherited interface function", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		resource interface A {
+			fun foo ()
+		}
+		resource interface B: A {}
+		fun test(c: @{B}) {
+			c.foo()
+			destroy c
+		}
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("doubly inherited interface function", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		resource interface A {
+			fun foo ()
+		}
+		resource interface B: A {}
+		resource interface C: B {}
+		fun test(c: @{C}) {
+			c.foo()
+			destroy c
+		}
+        `)
+
+		require.NoError(t, err)
+	})
+}
+
 func TestCheckInterfaceEventsInheritance(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/interpreter/interface_test.go
+++ b/runtime/tests/interpreter/interface_test.go
@@ -160,6 +160,40 @@ func TestInterpretInterfaceDefaultImplementation(t *testing.T) {
 			array.Get(inter, interpreter.EmptyLocationRange, 1),
 		)
 	})
+
+	t.Run("inherited interface function", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+
+          struct interface I {
+              fun test(): Int {
+				return 3
+			  }
+          }
+
+          struct interface J: I {}
+
+		  struct S: J {}
+
+		  fun foo(_ s: {J}): Int {
+			return s.test()
+		  }
+
+          fun main(): Int {
+			return foo(S())
+          }
+        `)
+
+		value, err := inter.Invoke("main")
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			value,
+		)
+	})
 }
 
 func TestInterpretInterfaceDefaultImplementationWhenOverriden(t *testing.T) {


### PR DESCRIPTION
Members from inherited interfaces were not being properly being considered when getting resolvers for interface types. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
