### PR TITLE
Fix error on reference creation with invalid type

### DIFF
--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -92,7 +92,9 @@ func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.Refere
 		// If the reference type was a non-optional type,
 		// check that the referenced expression does not have an optional type
 
-		if _, ok := actualType.(*OptionalType); ok != isOpt {
+		// Do not report an error if the `expectedLeftType` is unknown
+
+		if _, ok := actualType.(*OptionalType); ok != isOpt && expectedLeftType != nil {
 			checker.report(&TypeMismatchError{
 				ExpectedType: expectedLeftType,
 				ActualType:   actualType,

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -1304,3 +1304,40 @@ func TestCheckReferenceTypeImplicitConformance(t *testing.T) {
 		require.IsType(t, &sema.TypeMismatchError{}, errs[0])
 	})
 }
+
+func TestCheckReferenceCreationWithInvalidType(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("invalid reference type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            let foo: AnyStruct? = nil
+            let x = &foo as &Foo
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		var notDeclaredError *sema.NotDeclaredError
+		require.ErrorAs(t, errs[0], &notDeclaredError)
+	})
+
+	t.Run("valid non-reference type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct Foo {}
+
+            let foo: AnyStruct? = nil
+            let x = &foo as Foo
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		var nonReferenceTypeReferenceError *sema.NonReferenceTypeReferenceError
+		require.ErrorAs(t, errs[0], &nonReferenceTypeReferenceError)
+	})
+}


### PR DESCRIPTION
Closes #2685

## Description

If the RHS type of the reference expression was an invalid type, then the reported error has a `nil` expected type.

It is OK to skip reporting this error, if the type is invalid.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
