### PR TITLE
Cadence testing framework improvements

### DIFF
--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -122,10 +122,10 @@ pub contract Test {
             return self.backend.events(type)
         }
 
-        /// Resets the state of the blockchain.
+        /// Resets the state of the blockchain at the given height.
         ///
-        pub fun reset() {
-            self.backend.reset()
+        pub fun reset(to height: UInt64) {
+            self.backend.reset(to: height)
         }
     }
 
@@ -305,9 +305,9 @@ pub contract Test {
         ///
         pub fun events(_ type: Type?): [AnyStruct]
 
-        /// Resets the state of the blockchain.
+        /// Resets the state of the blockchain at the given height.
         ///
-        pub fun reset()
+        pub fun reset(to height: UInt64)
     }
 
     /// Returns a new matcher that negates the test of the given matcher.

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -171,6 +171,10 @@ pub contract Test {
         /// The resulted status of an executed operation.
         ///
         pub let status: ResultStatus
+
+        /// The optionally resulted error of an executed operation.
+        ///
+        pub let error: Error?
     }
 
     /// The result of a transaction execution.
@@ -344,6 +348,30 @@ pub contract Test {
         return Matcher(test: fun (value: AnyStruct): Bool {
             return value == nil
         })
+    }
+
+    /// Asserts that the result of an executed operation, such as
+    /// scripts & transactions, has errored and the error message
+    /// contains the given sub-string.
+    ///
+    pub fun assertError(_ result: {Result}, errorMessage: String) {
+        pre {
+            result.status == ResultStatus.failed: "no error was found"
+        }
+
+        var found = false
+        let msg = result.error!.message
+        let msgLength = msg.length - errorMessage.length + 1
+        var i = 0
+        while i < msgLength {
+            if msg.slice(from: i, upTo: i + errorMessage.length) == errorMessage {
+                found = true
+                break
+            }
+            i = i + 1
+        }
+
+        assert(found, message: "the error message did not contain the given sub-string")
     }
 
 }

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -122,7 +122,7 @@ pub contract Test {
             return self.backend.events(type)
         }
 
-        /// Resets the state of the blockchain at the given height.
+        /// Resets the state of the blockchain to the given height.
         ///
         pub fun reset(to height: UInt64) {
             self.backend.reset(to: height)
@@ -168,11 +168,11 @@ pub contract Test {
     /// operations, such as transactions and scripts.
     ///
     pub struct interface Result {
-        /// The resulted status of an executed operation.
+        /// The result status of an executed operation.
         ///
         pub let status: ResultStatus
 
-        /// The optionally resulted error of an executed operation.
+        /// The optional error of an executed operation.
         ///
         pub let error: Error?
     }
@@ -309,7 +309,7 @@ pub contract Test {
         ///
         pub fun events(_ type: Type?): [AnyStruct]
 
-        /// Resets the state of the blockchain at the given height.
+        /// Resets the state of the blockchain to the given height.
         ///
         pub fun reset(to height: UInt64)
     }
@@ -350,9 +350,9 @@ pub contract Test {
         })
     }
 
-    /// Asserts that the result of an executed operation, such as
-    /// scripts & transactions, has errored and the error message
-    /// contains the given sub-string.
+    /// Asserts that the result status of an executed operation, such as
+    /// a script or transaction, has failed and contains the given error
+    /// message.
     ///
     pub fun assertError(_ result: {Result}, errorMessage: String) {
         pre {

--- a/runtime/stdlib/test-framework.go
+++ b/runtime/stdlib/test-framework.go
@@ -70,7 +70,7 @@ type TestFramework interface {
 		eventType interpreter.StaticType,
 	) interpreter.Value
 
-	Reset()
+	Reset(uint64)
 }
 
 type ScriptResult struct {

--- a/runtime/stdlib/test_emulatorbackend.go
+++ b/runtime/stdlib/test_emulatorbackend.go
@@ -666,16 +666,20 @@ func (t *testEmulatorBackendType) newEventsFunction(
 const testEmulatorBackendTypeResetFunctionName = "reset"
 
 const testEmulatorBackendTypeResetFunctionDocString = `
-Resets the state of the blockchain.
+Resets the state of the blockchain at the given height.
 `
 
 func (t *testEmulatorBackendType) newResetFunction(
 	testFramework TestFramework,
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewUnmeteredHostFunctionValue(
-		t.eventsFunctionType,
+		t.resetFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
-			testFramework.Reset()
+			height, ok := invocation.Arguments[0].(interpreter.UInt64Value)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+			testFramework.Reset(uint64(height))
 			return interpreter.Void
 		},
 	)

--- a/runtime/stdlib/test_emulatorbackend.go
+++ b/runtime/stdlib/test_emulatorbackend.go
@@ -666,7 +666,7 @@ func (t *testEmulatorBackendType) newEventsFunction(
 const testEmulatorBackendTypeResetFunctionName = "reset"
 
 const testEmulatorBackendTypeResetFunctionDocString = `
-Resets the state of the blockchain at the given height.
+Resets the state of the blockchain to the given height.
 `
 
 func (t *testEmulatorBackendType) newResetFunction(


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2076
**Companion PR:** https://github.com/onflow/cadence-tools/pull/181

## Description

Adding the following improvements:
- Allow **rolling back** at a specific block height
- Add helper function to **assert error message** on `ScriptResult`/`TransactionResult`

Sample usage:

```cadence
import Test

pub let blockchain = Test.newEmulatorBlockchain()
pub let account = blockchain.createAccount()

// Retrieve current block height
pub let height = getCurrentBlockHeight(blockchain: blockchain)

// Reset (rollback) the blockchain to a given block height
blockchain.reset(height)

pub let script = Test.readFile("../scripts/get_integer_traits.cdc")
pub let result = blockchain.executeScript(script, [])

// Assert that a script/transaction errored and the error message contains a specified sub-string
Test.assertError(result, errorMessage: "exceeding limit")
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
