### PR TITLE
Allow default functions to co-exist with conditions in interface conformance

### DIFF
--- a/runtime/ast/block.go
+++ b/runtime/ast/block.go
@@ -223,6 +223,11 @@ func (b *FunctionBlock) HasStatements() bool {
 	return b != nil && len(b.Block.Statements) > 0
 }
 
+func (b *FunctionBlock) HasConditions() bool {
+	return b != nil &&
+		(!b.PreConditions.IsEmpty() || !b.PostConditions.IsEmpty())
+}
+
 // Condition
 
 type Condition interface {

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -573,9 +573,7 @@ func (checker *Checker) checkInterfaceConformance(
 					conformanceMember,
 					conflictingInterface,
 					conflictingMember,
-					func() ast.Range {
-						return ast.NewRangeFromPositioned(checker.memoryGauge, interfaceDeclaration.Identifier)
-					},
+					interfaceDeclaration.Identifier,
 				)
 			}
 		}
@@ -588,9 +586,7 @@ func (checker *Checker) checkInterfaceConformance(
 				declarationMember,
 				conformance,
 				conformanceMember,
-				func() ast.Range {
-					return ast.NewRangeFromPositioned(checker.memoryGauge, declarationMember.Identifier)
-				},
+				declarationMember.Identifier,
 			)
 		}
 
@@ -656,7 +652,7 @@ func (checker *Checker) checkDuplicateInterfaceMember(
 	interfaceMember *Member,
 	conflictingInterfaceType *InterfaceType,
 	conflictingMember *Member,
-	getRange func() ast.Range,
+	hasPosition ast.HasPosition,
 ) (isDuplicate bool) {
 
 	reportMemberConflictError := func() {
@@ -666,7 +662,7 @@ func (checker *Checker) checkDuplicateInterfaceMember(
 			MemberName:               interfaceMember.Identifier.Identifier,
 			MemberKind:               interfaceMember.DeclarationKind,
 			ConflictingMemberKind:    conflictingMember.DeclarationKind,
-			Range:                    getRange(),
+			Range:                    ast.NewRangeFromPositioned(checker.memoryGauge, hasPosition),
 		})
 
 		isDuplicate = true

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4548,6 +4548,7 @@ type Member struct {
 	// Predeclared fields can be considered initialized
 	Predeclared       bool
 	HasImplementation bool
+	HasConditions     bool
 	// IgnoreInSerialization determines if the field is ignored in serialization
 	IgnoreInSerialization bool
 }

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -3419,12 +3419,30 @@ func TestCheckInterfaceDefaultMethodsInheritance(t *testing.T) {
             }
         `)
 
-		errs := RequireCheckerErrors(t, err, 1)
+		require.NoError(t, err)
+	})
 
-		memberConflictError := &sema.InterfaceMemberConflictError{}
-		require.ErrorAs(t, errs[0], &memberConflictError)
-		assert.Equal(t, "hello", memberConflictError.MemberName)
-		assert.Equal(t, "A", memberConflictError.ConflictingInterfaceType.QualifiedIdentifier())
+	t.Run("default impl in super, condition in child, concrete type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct interface A {
+                access(all) fun hello() {
+                    var a = 1
+                }
+            }
+
+            struct interface B: A {
+                access(all) fun hello() {
+                    pre { true }
+                }
+            }
+
+            struct C: B {}
+        `)
+
+		require.NoError(t, err)
 	})
 
 	t.Run("default impl in super, declaration in child", func(t *testing.T) {
@@ -3494,12 +3512,30 @@ func TestCheckInterfaceDefaultMethodsInheritance(t *testing.T) {
             }
         `)
 
-		errs := RequireCheckerErrors(t, err, 1)
+		require.NoError(t, err)
+	})
 
-		memberConflictError := &sema.InterfaceMemberConflictError{}
-		require.ErrorAs(t, errs[0], &memberConflictError)
-		assert.Equal(t, "hello", memberConflictError.MemberName)
-		assert.Equal(t, "A", memberConflictError.ConflictingInterfaceType.QualifiedIdentifier())
+	t.Run("default impl in child, condition in parent, concrete type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct interface A {
+                access(all) fun hello() {
+                    pre { true }
+                }
+            }
+
+            struct interface B: A {
+                access(all) fun hello() {
+                    var a = 1
+                }
+            }
+
+            struct C: B {}
+        `)
+
+		require.NoError(t, err)
 	})
 
 	t.Run("default impl in child, declaration in parent", func(t *testing.T) {
@@ -3673,14 +3709,10 @@ func TestCheckInterfaceDefaultMethodsInheritance(t *testing.T) {
             struct interface C: A, B {}
         `)
 
-		// TODO: Should be no error once https://github.com/onflow/flips/pull/83 is added.
-		errs := RequireCheckerErrors(t, err, 1)
-
-		interfaceMemberConflictError := &sema.InterfaceMemberConflictError{}
-		require.ErrorAs(t, errs[0], &interfaceMemberConflictError)
+		require.NoError(t, err)
 	})
 
-	t.Run("default impl in one path and condition in another, in concrete type", func(t *testing.T) {
+	t.Run("default impl in first and condition in second, in concrete type", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -3702,14 +3734,143 @@ func TestCheckInterfaceDefaultMethodsInheritance(t *testing.T) {
             struct D: C {}
         `)
 
-		// TODO: Should be no error once https://github.com/onflow/flips/pull/83 is added.
-		errs := RequireCheckerErrors(t, err, 2)
+		require.NoError(t, err)
+	})
 
-		interfaceMemberConflictError := &sema.InterfaceMemberConflictError{}
-		require.ErrorAs(t, errs[0], &interfaceMemberConflictError)
+	t.Run("condition in first and default impl in second, in concrete type", func(t *testing.T) {
 
-		defaultFunctionConflictError := &sema.DefaultFunctionConflictError{}
-		require.ErrorAs(t, errs[1], &defaultFunctionConflictError)
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct interface A {
+                access(all) fun hello() {
+                    var a = 1
+                }
+            }
+
+            struct interface B {
+                access(all) fun hello() {
+                    pre { true }
+                }
+            }
+
+            struct interface C: B, A {}
+
+            struct D: C {}
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("conditions in both parent and child", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct interface Foo {
+                access(all) fun hello() {
+                    pre { true }
+                }
+            }
+
+            struct interface Bar: Foo {
+                access(all) fun hello() {
+                    pre { true }
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("condition in parent", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct interface Foo {
+                access(all) fun hello() {
+                    pre { true }
+                }
+            }
+
+            struct interface Bar: Foo {
+                access(all) fun hello()
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("condition in child", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct interface Foo {
+                access(all) fun hello()
+            }
+
+            struct interface Bar: Foo {
+                access(all) fun hello() {
+                    pre { true }
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("conditions from two paths", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct interface A {
+                access(all) fun hello() {
+                    pre { true }
+                }
+            }
+
+            struct interface B {
+                access(all) fun hello() {
+                    pre { true }
+                }
+            }
+
+            struct interface C: A, B {}
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("conditions from two paths, concrete type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct interface A {
+                access(all) fun hello() {
+                    pre { true }
+                }
+            }
+
+            struct interface B {
+                access(all) fun hello() {
+                    pre { true }
+                }
+            }
+
+            struct interface C: A, B {}
+
+            struct D: C {
+                access(all) fun hello() {
+                    var a = 1
+                }
+            }
+        `)
+
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
Closes #2471
Closes #2537

## Description

Implementation of https://github.com/onflow/flips/pull/83

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
