### PR TITLE
Improve view annotations for account type functions

### DIFF
--- a/runtime/sema/authaccount.cdc
+++ b/runtime/sema/authaccount.cdc
@@ -1,41 +1,54 @@
 
-access(all) struct AuthAccount {
+access(all)
+struct AuthAccount {
 
     /// The address of the account.
-    access(all) let address: Address
+    access(all)
+    let address: Address
 
     /// The FLOW balance of the default vault of this account.
-    access(all) let balance: UFix64
+    access(all)
+    let balance: UFix64
 
     /// The FLOW balance of the default vault of this account that is available to be moved.
-    access(all) let availableBalance: UFix64
+    access(all)
+    let availableBalance: UFix64
 
     /// The current amount of storage used by the account in bytes.
-    access(all) let storageUsed: UInt64
+    access(all)
+    let storageUsed: UInt64
 
     /// The storage capacity of the account in bytes.
-    access(all) let storageCapacity: UInt64
+    access(all)
+    let storageCapacity: UInt64
 
     /// The contracts deployed to the account.
-    access(all) let contracts: AuthAccount.Contracts
+    access(all)
+    let contracts: AuthAccount.Contracts
 
     /// The keys assigned to the account.
-    access(all) let keys: AuthAccount.Keys
+    access(all)
+    let keys: AuthAccount.Keys
 
     /// The inbox allows bootstrapping (sending and receiving) capabilities.
-    access(all) let inbox: AuthAccount.Inbox
+    access(all)
+    let inbox: AuthAccount.Inbox
 
     /// The capabilities of the account.
-    access(all) let capabilities: AuthAccount.Capabilities
+    access(all)
+    let capabilities: AuthAccount.Capabilities
 
     /// All public paths of this account.
-    access(all) let publicPaths: [PublicPath]
+    access(all)
+    let publicPaths: [PublicPath]
 
     /// All private paths of this account.
-    access(all) let privatePaths: [PrivatePath]
+    access(all)
+    let privatePaths: [PrivatePath]
 
     /// All storage paths of this account.
-    access(all) let storagePaths: [StoragePath]
+    access(all)
+    let storagePaths: [StoragePath]
 
     /// Saves the given object into the account's storage at the given path.
     ///
@@ -44,7 +57,8 @@ access(all) struct AuthAccount {
     /// If there is already an object stored under the given path, the program aborts.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
-    access(all) fun save<T: Storable>(_ value: T, to: StoragePath)
+    access(all)
+    fun save<T: Storable>(_ value: T, to: StoragePath)
 
     /// Reads the type of an object from the account's storage which is stored under the given path,
     /// or nil if no object is stored under the given path.
@@ -52,7 +66,8 @@ access(all) struct AuthAccount {
     /// If there is an object stored, the type of the object is returned without modifying the stored object.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
-    access(all) view fun type(at path: StoragePath): Type?
+    access(all)
+    view fun type(at path: StoragePath): Type?
 
     /// Loads an object from the account's storage which is stored under the given path,
     /// or nil if no object is stored under the given path.
@@ -68,7 +83,8 @@ access(all) struct AuthAccount {
     /// The given type must not necessarily be exactly the same as the type of the loaded object.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
-    access(all) fun load<T: Storable>(from: StoragePath): T?
+    access(all)
+    fun load<T: Storable>(from: StoragePath): T?
 
     /// Returns a copy of a structure stored in account storage under the given path,
     /// without removing it from storage,
@@ -83,7 +99,8 @@ access(all) struct AuthAccount {
     /// The given type must not necessarily be exactly the same as the type of the copied structure.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
-    access(all) view fun copy<T: AnyStruct>(from: StoragePath): T?
+    access(all)
+    view fun copy<T: AnyStruct>(from: StoragePath): T?
 
     /// Returns a reference to an object in storage without removing it from storage.
     ///
@@ -95,7 +112,8 @@ access(all) struct AuthAccount {
     /// The given type must not necessarily be exactly the same as the type of the borrowed object.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed
-    access(all) view fun borrow<T: &Any>(from: StoragePath): T?
+    access(all)
+    view fun borrow<T: &Any>(from: StoragePath): T?
 
     /// Returns true if the object in account storage under the given path satisfies the given type,
     /// i.e. could be borrowed using the given type.
@@ -103,7 +121,8 @@ access(all) struct AuthAccount {
     /// The given type must not necessarily be exactly the same as the type of the borrowed object.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
-    access(all) view fun check<T: Any>(from: StoragePath): Bool
+    access(all)
+    view fun check<T: Any>(from: StoragePath): Bool
 
     /// Iterate over all the public paths of an account,
     /// passing each path and type in turn to the provided callback function.
@@ -121,7 +140,8 @@ access(all) struct AuthAccount {
     /// then the callback must stop iteration by returning false.
     /// Otherwise, iteration aborts.
     ///
-    access(all) fun forEachPublic(_ function: fun(PublicPath, Type): Bool)
+    access(all)
+    fun forEachPublic(_ function: fun(PublicPath, Type): Bool)
 
     /// Iterate over all the private paths of an account,
     /// passing each path and type in turn to the provided callback function.
@@ -139,7 +159,8 @@ access(all) struct AuthAccount {
     /// or an existing object is removed from a private path,
     /// then the callback must stop iteration by returning false.
     /// Otherwise, iteration aborts.
-    access(all) fun forEachPrivate(_ function: fun(PrivatePath, Type): Bool)
+    access(all)
+    fun forEachPrivate(_ function: fun(PrivatePath, Type): Bool)
 
     /// Iterate over all the stored paths of an account,
     /// passing each path and type in turn to the provided callback function.
@@ -155,12 +176,15 @@ access(all) struct AuthAccount {
     /// or an existing object is removed from a storage path,
     /// then the callback must stop iteration by returning false.
     /// Otherwise, iteration aborts.
-    access(all) fun forEachStored(_ function: fun(StoragePath, Type): Bool)
+    access(all)
+    fun forEachStored(_ function: fun(StoragePath, Type): Bool)
 
-    access(all) struct Contracts {
+    access(all)
+    struct Contracts {
 
         /// The names of all contracts deployed in the account.
-        access(all) let names: [String]
+        access(all)
+        let names: [String]
 
         /// Adds the given contract to the account.
         ///
@@ -176,7 +200,8 @@ access(all) struct AuthAccount {
         /// or if the given name does not match the name of the contract/contract interface declaration in the code.
         ///
         /// Returns the deployed contract.
-        access(all) fun add(
+        access(all)
+        fun add(
             name: String,
             code: [UInt8]
         ): DeployedContract
@@ -197,33 +222,39 @@ access(all) struct AuthAccount {
         /// or if the given name does not match the name of the contract/contract interface declaration in the code.
         ///
         /// Returns the deployed contract for the updated contract.
-        access(all) fun update__experimental(name: String, code: [UInt8]): DeployedContract
+        access(all)
+        fun update__experimental(name: String, code: [UInt8]): DeployedContract
 
         /// Returns the deployed contract for the contract/contract interface with the given name in the account, if any.
         ///
         /// Returns nil if no contract/contract interface with the given name exists in the account.
-        access(all) view fun get(name: String): DeployedContract?
+        access(all)
+        view fun get(name: String): DeployedContract?
 
         /// Removes the contract/contract interface from the account which has the given name, if any.
         ///
         /// Returns the removed deployed contract, if any.
         ///
         /// Returns nil if no contract/contract interface with the given name exists in the account.
-        access(all) fun remove(name: String): DeployedContract?
+        access(all)
+        fun remove(name: String): DeployedContract?
 
         /// Returns a reference of the given type to the contract with the given name in the account, if any.
         ///
         /// Returns nil if no contract with the given name exists in the account,
         /// or if the contract does not conform to the given type.
-        access(all) view fun borrow<T: &Any>(name: String): T?
+        access(all)
+        view fun borrow<T: &Any>(name: String): T?
     }
 
-    access(all) struct Keys {
+    access(all)
+    struct Keys {
 
         /// Adds a new key with the given hashing algorithm and a weight.
         ///
         /// Returns the added key.
-        access(all) fun add(
+        access(all)
+        fun add(
             publicKey: PublicKey,
             hashAlgorithm: HashAlgorithm,
             weight: UFix64
@@ -232,12 +263,14 @@ access(all) struct AuthAccount {
         /// Returns the key at the given index, if it exists, or nil otherwise.
         ///
         /// Revoked keys are always returned, but they have `isRevoked` field set to true.
-        access(all) view fun get(keyIndex: Int): AccountKey?
+        access(all)
+        view fun get(keyIndex: Int): AccountKey?
 
         /// Marks the key at the given index revoked, but does not delete it.
         ///
         /// Returns the revoked key if it exists, or nil otherwise.
-        access(all) fun revoke(keyIndex: Int): AccountKey?
+        access(all)
+        fun revoke(keyIndex: Int): AccountKey?
 
         /// Iterate over all unrevoked keys in this account,
         /// passing each key in turn to the provided function.
@@ -245,24 +278,29 @@ access(all) struct AuthAccount {
         /// Iteration is stopped early if the function returns `false`.
         ///
         /// The order of iteration is undefined.
-        access(all) fun forEach(_ function: fun(AccountKey): Bool)
+        access(all)
+        fun forEach(_ function: fun(AccountKey): Bool)
 
         /// The total number of unrevoked keys in this account.
-        access(all) let count: UInt64
+        access(all)
+        let count: UInt64
     }
 
-    access(all) struct Inbox {
+    access(all)
+    struct Inbox {
 
         /// Publishes a new Capability under the given name,
         /// to be claimed by the specified recipient.
-        access(all) fun publish(_ value: Capability, name: String, recipient: Address)
+        access(all)
+        fun publish(_ value: Capability, name: String, recipient: Address)
 
         /// Unpublishes a Capability previously published by this account.
         ///
         /// Returns `nil` if no Capability is published under the given name.
         ///
         /// Errors if the Capability under that name does not match the provided type.
-        access(all) fun unpublish<T: &Any>(_ name: String): Capability<T>?
+        access(all)
+        fun unpublish<T: &Any>(_ name: String): Capability<T>?
 
         /// Claims a Capability previously published by the specified provider.
         ///
@@ -270,50 +308,61 @@ access(all) struct AuthAccount {
         /// or if this account is not its intended recipient.
         ///
         /// Errors if the Capability under that name does not match the provided type.
-        access(all) fun claim<T: &Any>(_ name: String, provider: Address): Capability<T>?
+        access(all)
+        fun claim<T: &Any>(_ name: String, provider: Address): Capability<T>?
     }
 
-    access(all) struct Capabilities {
+    access(all)
+    struct Capabilities {
 
         /// The storage capabilities of the account.
-        access(all) let storage: AuthAccount.StorageCapabilities
+        access(all)
+        let storage: AuthAccount.StorageCapabilities
 
         /// The account capabilities of the account.
-        access(all) let account: AuthAccount.AccountCapabilities
+        access(all)
+        let account: AuthAccount.AccountCapabilities
 
         /// Returns the capability at the given public path.
         /// Returns nil if the capability does not exist,
         /// or if the given type is not a supertype of the capability's borrow type.
-        access(all) view fun get<T: &Any>(_ path: PublicPath): Capability<T>?
+        access(all)
+        view fun get<T: &Any>(_ path: PublicPath): Capability<T>?
 
         /// Borrows the capability at the given public path.
         /// Returns nil if the capability does not exist, or cannot be borrowed using the given type.
         /// The function is equivalent to `get(path)?.borrow()`.
-        access(all) fun borrow<T: &Any>(_ path: PublicPath): T?
+        access(all)
+        view fun borrow<T: &Any>(_ path: PublicPath): T?
 
         /// Publish the capability at the given public path.
         ///
         /// If there is already a capability published under the given path, the program aborts.
         ///
         /// The path must be a public path, i.e., only the domain `public` is allowed.
-        access(all) fun publish(_ capability: Capability, at: PublicPath)
+        access(all)
+        fun publish(_ capability: Capability, at: PublicPath)
 
         /// Unpublish the capability published at the given path.
         ///
         /// Returns the capability if one was published at the path.
         /// Returns nil if no capability was published at the path.
-        access(all) fun unpublish(_ path: PublicPath): Capability?
+        access(all)
+        fun unpublish(_ path: PublicPath): Capability?
     }
 
-    access(all) struct StorageCapabilities {
+    access(all)
+    struct StorageCapabilities {
 
         /// Get the storage capability controller for the capability with the specified ID.
         ///
         /// Returns nil if the ID does not reference an existing storage capability.
-        access(all) view fun getController(byCapabilityID: UInt64): &StorageCapabilityController?
+        access(all)
+        view fun getController(byCapabilityID: UInt64): &StorageCapabilityController?
 
         /// Get all storage capability controllers for capabilities that target this storage path
-        access(all) view fun getControllers(forPath: StoragePath): [&StorageCapabilityController]
+        access(all)
+        view fun getControllers(forPath: StoragePath): [&StorageCapabilityController]
 
         /// Iterate over all storage capability controllers for capabilities that target this storage path,
         /// passing a reference to each controller to the provided callback function.
@@ -325,20 +374,28 @@ access(all) struct AuthAccount {
         /// or a storage capability controller is retargeted from or to the path,
         /// then the callback must stop iteration by returning false.
         /// Otherwise, iteration aborts.
-        access(all) fun forEachController(forPath: StoragePath, _ function: fun(&StorageCapabilityController): Bool)
+        access(all)
+        fun forEachController(
+            forPath: StoragePath,
+            _ function: fun(&StorageCapabilityController): Bool
+        )
 
         /// Issue/create a new storage capability.
-        access(all) fun issue<T: &Any>(_ path: StoragePath): Capability<T>
+        access(all)
+        fun issue<T: &Any>(_ path: StoragePath): Capability<T>
     }
 
-    access(all) struct AccountCapabilities {
+    access(all)
+    struct AccountCapabilities {
         /// Get capability controller for capability with the specified ID.
         ///
         /// Returns nil if the ID does not reference an existing account capability.
-        access(all) view fun getController(byCapabilityID: UInt64): &AccountCapabilityController?
+        access(all)
+        view fun getController(byCapabilityID: UInt64): &AccountCapabilityController?
 
         /// Get all capability controllers for all account capabilities.
-        access(all) view fun getControllers(): [&AccountCapabilityController]
+        access(all)
+        view fun getControllers(): [&AccountCapabilityController]
 
         /// Iterate over all account capability controllers for all account capabilities,
         /// passing a reference to each controller to the provided callback function.
@@ -349,9 +406,11 @@ access(all) struct AuthAccount {
         /// or an existing account capability controller for the account is deleted,
         /// then the callback must stop iteration by returning false.
         /// Otherwise, iteration aborts.
-        access(all) fun forEachController(_ function: fun(&AccountCapabilityController): Bool)
+        access(all)
+        fun forEachController(_ function: fun(&AccountCapabilityController): Bool)
 
         /// Issue/create a new account capability.
-        access(all) fun issue<T: &AuthAccount>(): Capability<T>
+        access(all)
+        fun issue<T: &AuthAccount>(): Capability<T>
     }
 }

--- a/runtime/sema/authaccount.gen.go
+++ b/runtime/sema/authaccount.gen.go
@@ -1115,6 +1115,7 @@ var AuthAccountCapabilitiesTypeBorrowFunctionTypeParameterT = &TypeParameter{
 }
 
 var AuthAccountCapabilitiesTypeBorrowFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	TypeParameters: []*TypeParameter{
 		AuthAccountCapabilitiesTypeBorrowFunctionTypeParameterT,
 	},

--- a/runtime/sema/publicaccount.cdc
+++ b/runtime/sema/publicaccount.cdc
@@ -1,32 +1,42 @@
 
-access(all) struct PublicAccount {
+access(all)
+struct PublicAccount {
 
     /// The address of the account.
-    access(all) let address: Address
+    access(all)
+    let address: Address
 
     /// The FLOW balance of the default vault of this account.
-    access(all) let balance: UFix64
+    access(all)
+    let balance: UFix64
 
     /// The FLOW balance of the default vault of this account that is available to be moved.
-    access(all) let availableBalance: UFix64
+    access(all)
+    let availableBalance: UFix64
 
     /// The current amount of storage used by the account in bytes.
-    access(all) let storageUsed: UInt64
+    access(all)
+    let storageUsed: UInt64
 
     /// The storage capacity of the account in bytes.
-    access(all) let storageCapacity: UInt64
+    access(all)
+    let storageCapacity: UInt64
 
     /// The contracts deployed to the account.
-    access(all) let contracts: PublicAccount.Contracts
+    access(all)
+    let contracts: PublicAccount.Contracts
 
     /// The keys assigned to the account.
-    access(all) let keys: PublicAccount.Keys
+    access(all)
+    let keys: PublicAccount.Keys
 
     /// The capabilities of the account.
-    access(all) let capabilities: PublicAccount.Capabilities
+    access(all)
+    let capabilities: PublicAccount.Capabilities
 
     /// All public paths of this account.
-    access(all) let publicPaths: [PublicPath]
+    access(all)
+    let publicPaths: [PublicPath]
 
     /// Iterate over all the public paths of an account.
     /// passing each path and type in turn to the provided callback function.
@@ -39,51 +49,63 @@ access(all) struct PublicAccount {
     ///
     /// The order of iteration, as well as the behavior of adding or removing objects from storage during iteration,
     /// is undefined.
-    access(all) fun forEachPublic(_ function: fun(PublicPath, Type): Bool)
+    access(all)
+    fun forEachPublic(_ function: fun(PublicPath, Type): Bool)
 
-    access(all) struct Contracts {
+    access(all)
+    struct Contracts {
 
         /// The names of all contracts deployed in the account.
-        access(all) let names: [String]
+        access(all)
+        let names: [String]
 
         /// Returns the deployed contract for the contract/contract interface with the given name in the account, if any.
         ///
         /// Returns nil if no contract/contract interface with the given name exists in the account.
-        access(all) fun get(name: String): DeployedContract?
+        access(all)
+        view fun get(name: String): DeployedContract?
 
         /// Returns a reference of the given type to the contract with the given name in the account, if any.
         ///
         /// Returns nil if no contract with the given name exists in the account,
         /// or if the contract does not conform to the given type.
-        access(all) fun borrow<T: &Any>(name: String): T?
+        access(all)
+        view fun borrow<T: &Any>(name: String): T?
     }
 
-    access(all) struct Keys {
+    access(all)
+    struct Keys {
 
         /// Returns the key at the given index, if it exists, or nil otherwise.
         ///
         /// Revoked keys are always returned, but they have `isRevoked` field set to true.
-        access(all) fun get(keyIndex: Int): AccountKey?
+        access(all)
+        view fun get(keyIndex: Int): AccountKey?
 
         /// Iterate over all unrevoked keys in this account,
         /// passing each key in turn to the provided function.
         ///
         /// Iteration is stopped early if the function returns `false`.
         /// The order of iteration is undefined.
-        access(all) fun forEach(_ function: fun(AccountKey): Bool)
+        access(all)
+        fun forEach(_ function: fun(AccountKey): Bool)
 
         /// The total number of unrevoked keys in this account.
-        access(all) let count: UInt64
+        access(all)
+        let count: UInt64
     }
 
-    access(all) struct Capabilities {
+    access(all)
+    struct Capabilities {
         /// get returns the storage capability at the given path, if one was stored there.
-        access(all) fun get<T: &Any>(_ path: PublicPath): Capability<T>?
+        access(all)
+        view fun get<T: &Any>(_ path: PublicPath): Capability<T>?
 
         /// borrow gets the storage capability at the given path, and borrows the capability if it exists.
         ///
         /// Returns nil if the capability does not exist or cannot be borrowed using the given type.
         /// The function is equivalent to `get(path)?.borrow()`.
-        access(all) fun borrow<T: &Any>(_ path: PublicPath): T?
+        access(all)
+        view fun borrow<T: &Any>(_ path: PublicPath): T?
     }
 }

--- a/runtime/sema/publicaccount.gen.go
+++ b/runtime/sema/publicaccount.gen.go
@@ -152,6 +152,7 @@ The names of all contracts deployed in the account.
 const PublicAccountContractsTypeGetFunctionName = "get"
 
 var PublicAccountContractsTypeGetFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	Parameters: []Parameter{
 		{
 			Identifier:     "name",
@@ -182,6 +183,7 @@ var PublicAccountContractsTypeBorrowFunctionTypeParameterT = &TypeParameter{
 }
 
 var PublicAccountContractsTypeBorrowFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	TypeParameters: []*TypeParameter{
 		PublicAccountContractsTypeBorrowFunctionTypeParameterT,
 	},
@@ -253,6 +255,7 @@ func init() {
 const PublicAccountKeysTypeGetFunctionName = "get"
 
 var PublicAccountKeysTypeGetFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	Parameters: []Parameter{
 		{
 			Identifier:     "keyIndex",
@@ -366,6 +369,7 @@ var PublicAccountCapabilitiesTypeGetFunctionTypeParameterT = &TypeParameter{
 }
 
 var PublicAccountCapabilitiesTypeGetFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	TypeParameters: []*TypeParameter{
 		PublicAccountCapabilitiesTypeGetFunctionTypeParameterT,
 	},
@@ -403,6 +407,7 @@ var PublicAccountCapabilitiesTypeBorrowFunctionTypeParameterT = &TypeParameter{
 }
 
 var PublicAccountCapabilitiesTypeBorrowFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
 	TypeParameters: []*TypeParameter{
 		PublicAccountCapabilitiesTypeBorrowFunctionTypeParameterT,
 	},

--- a/runtime/tests/checker/purity_test.go
+++ b/runtime/tests/checker/purity_test.go
@@ -238,7 +238,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -264,7 +264,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -306,7 +306,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -333,7 +333,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -344,243 +344,10 @@ func TestCheckPurityEnforcement(t *testing.T) {
 		)
 	})
 
-	t.Run("copy", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              authAccount.copy<Int>(from: /storage/foo)
-          }
-        `)
-		require.NoError(t, err)
-	})
-
-	t.Run("borrow", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              authAccount.borrow<&Int>(from: /storage/foo)
-          }
-        `)
-		require.NoError(t, err)
-	})
-
-	t.Run("check", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              authAccount.check<Int>(from: /storage/foo)
-          }
-        `)
-		require.NoError(t, err)
-	})
-
-	t.Run("get contract", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              authAccount.contracts.get(name: "")
-          }
-        `)
-
-		require.NoError(t, err)
-	})
-
-	t.Run("borrow contract", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              authAccount.contracts.borrow<&Int>(name: "")
-          }
-        `)
-		require.NoError(t, err)
-	})
-
-	t.Run("get keys", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              authAccount.keys.get(keyIndex: 0)
-          }
-        `)
-		require.NoError(t, err)
-	})
-
-	t.Run("save", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              authAccount.save(3, to: /storage/foo)
-          }
-        `)
-
-		errs := RequireCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.PurityError{}, errs[0])
-		assert.Equal(
-			t,
-			ast.Range{
-				StartPos: ast.Position{Offset: 42, Line: 3, Column: 14},
-				EndPos:   ast.Position{Offset: 78, Line: 3, Column: 50},
-			},
-			errs[0].(*sema.PurityError).Range,
-		)
-	})
-
-	t.Run("load", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              authAccount.load<Int>(from: /storage/foo)
-          }
-        `)
-
-		errs := RequireCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.PurityError{}, errs[0])
-		assert.Equal(
-			t,
-			ast.Range{
-				StartPos: ast.Position{Offset: 42, Line: 3, Column: 14},
-				EndPos:   ast.Position{Offset: 82, Line: 3, Column: 54},
-			},
-			errs[0].(*sema.PurityError).Range,
-		)
-	})
-
-	t.Run("type", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              authAccount.type(at: /storage/foo)
-          }
-        `)
-		require.NoError(t, err)
-	})
-
-	t.Run("add contract", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              authAccount.contracts.add(name: "", code: [])
-          }
-        `)
-
-		errs := RequireCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.PurityError{}, errs[0])
-		assert.Equal(
-			t,
-			ast.Range{
-				StartPos: ast.Position{Offset: 42, Line: 3, Column: 14},
-				EndPos:   ast.Position{Offset: 86, Line: 3, Column: 58},
-			},
-			errs[0].(*sema.PurityError).Range,
-		)
-	})
-
-	t.Run("update contract", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              authAccount.contracts.update__experimental(name: "", code: [])
-          }
-        `)
-
-		errs := RequireCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.PurityError{}, errs[0])
-		assert.Equal(
-			t,
-			ast.Range{
-				StartPos: ast.Position{Offset: 42, Line: 3, Column: 14},
-				EndPos:   ast.Position{Offset: 103, Line: 3, Column: 75},
-			},
-			errs[0].(*sema.PurityError).Range,
-		)
-	})
-
-	t.Run("remove contract", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              authAccount.contracts.remove(name: "")
-          }
-        `)
-
-		errs := RequireCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.PurityError{}, errs[0])
-		assert.Equal(
-			t,
-			ast.Range{
-				StartPos: ast.Position{Offset: 42, Line: 3, Column: 14},
-				EndPos:   ast.Position{Offset: 79, Line: 3, Column: 51},
-			},
-			errs[0].(*sema.PurityError).Range,
-		)
-	})
-
-	t.Run("revoke key", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              authAccount.keys.revoke(keyIndex: 0)
-          }
-        `)
-
-		errs := RequireCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.PurityError{}, errs[0])
-		assert.Equal(
-			t,
-			ast.Range{
-				StartPos: ast.Position{Offset: 42, Line: 3, Column: 14},
-				EndPos:   ast.Position{Offset: 77, Line: 3, Column: 49},
-			},
-			errs[0].(*sema.PurityError).Range,
-		)
-	})
-
-	t.Run("alias", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheckAccount(t, `
-          view fun foo() {
-              let f = authAccount.contracts.remove
-              f(name: "")
-          }
-        `)
-
-		errs := RequireCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.PurityError{}, errs[0])
-		assert.Equal(
-			t,
-			ast.Range{
-				StartPos: ast.Position{Offset: 93, Line: 4, Column: 14},
-				EndPos:   ast.Position{Offset: 103, Line: 4, Column: 24},
-			},
-			errs[0].(*sema.PurityError).Range,
-		)
-	})
-
 	t.Run("emit", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := ParseAndCheckAccount(t, `
+		_, err := ParseAndCheck(t, `
           event FooEvent()
 
           view fun foo() {
@@ -602,7 +369,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -626,7 +393,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -696,7 +463,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -781,7 +548,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -808,7 +575,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -866,7 +633,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -895,7 +662,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -925,7 +692,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 		errs := RequireCheckerErrors(t, err, 2)
 
 		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
-		assert.IsType(t, &sema.PurityError{}, errs[1])
+		require.IsType(t, &sema.PurityError{}, errs[1])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -934,6 +701,50 @@ func TestCheckPurityEnforcement(t *testing.T) {
 			},
 			errs[1].(*sema.PurityError).Range,
 		)
+	})
+
+	t.Run("bound function", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheckAccount(t, `
+          struct S {
+              fun f() {}
+          }
+
+          view fun foo() {
+              let f = S().f
+              f()
+          }
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.PurityError{}, errs[0])
+		assert.Equal(
+			t,
+			ast.Range{
+				StartPos: ast.Position{Offset: 129, Line: 8, Column: 14},
+				EndPos:   ast.Position{Offset: 131, Line: 8, Column: 16},
+			},
+			errs[0].(*sema.PurityError).Range,
+		)
+	})
+
+	t.Run("bound function, view", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheckAccount(t, `
+          struct S {
+              view fun f() {}
+          }
+
+          view fun foo() {
+              let f = S().f
+              f()
+          }
+        `)
+
+		require.NoError(t, err)
 	})
 }
 
@@ -960,7 +771,7 @@ func TestCheckResourceWritePurity(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -984,7 +795,7 @@ func TestCheckResourceWritePurity(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -1019,7 +830,7 @@ func TestCheckResourceWritePurity(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -1051,7 +862,7 @@ func TestCheckResourceWritePurity(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -1083,7 +894,7 @@ func TestCheckResourceWritePurity(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -1114,7 +925,7 @@ func TestCheckResourceWritePurity(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -1145,7 +956,7 @@ func TestCheckResourceWritePurity(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -1199,7 +1010,7 @@ func TestCheckCompositeWritePurity(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -1289,7 +1100,7 @@ func TestCheckCompositeWritePurity(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(
 			t,
 			ast.Range{
@@ -1322,7 +1133,7 @@ func TestCheckCompositeWritePurity(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.PurityError{}, errs[0])
+		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(t,
 			ast.Range{
 				StartPos: ast.Position{Offset: 126, Line: 8, Column: 19},
@@ -1603,5 +1414,769 @@ func TestCheckConditionPurity(t *testing.T) {
 		errs := RequireCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.PurityError{}, errs[0])
+	})
+}
+
+func TestCheckAuthAccountPurity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("save", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheckAccount(t, `
+          view fun foo() {
+              authAccount.save(3, to: /storage/foo)
+          }
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.PurityError{}, errs[0])
+		assert.Equal(
+			t,
+			ast.Range{
+				StartPos: ast.Position{Offset: 42, Line: 3, Column: 14},
+				EndPos:   ast.Position{Offset: 78, Line: 3, Column: 50},
+			},
+			errs[0].(*sema.PurityError).Range,
+		)
+	})
+
+	t.Run("type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheckAccount(t, `
+          view fun foo() {
+              authAccount.type(at: /storage/foo)
+          }
+        `)
+		require.NoError(t, err)
+	})
+
+	t.Run("load", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheckAccount(t, `
+          view fun foo() {
+              authAccount.load<Int>(from: /storage/foo)
+          }
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.PurityError{}, errs[0])
+		assert.Equal(
+			t,
+			ast.Range{
+				StartPos: ast.Position{Offset: 42, Line: 3, Column: 14},
+				EndPos:   ast.Position{Offset: 82, Line: 3, Column: 54},
+			},
+			errs[0].(*sema.PurityError).Range,
+		)
+	})
+
+	t.Run("copy", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheckAccount(t, `
+          view fun foo() {
+              authAccount.copy<Int>(from: /storage/foo)
+          }
+        `)
+		require.NoError(t, err)
+	})
+
+	t.Run("borrow", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheckAccount(t, `
+          view fun foo() {
+              authAccount.borrow<&Int>(from: /storage/foo)
+          }
+        `)
+		require.NoError(t, err)
+	})
+
+	t.Run("check", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheckAccount(t, `
+          view fun foo() {
+              authAccount.check<Int>(from: /storage/foo)
+          }
+        `)
+		require.NoError(t, err)
+	})
+
+	t.Run("forEachPublic", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheckAccount(t, `
+          view fun foo() {
+              authAccount.forEachPublic(fun (path: PublicPath, type: Type): Bool {
+                  return true
+              })
+          }
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.PurityError{}, errs[0])
+		assert.Equal(
+			t,
+			ast.Range{
+				StartPos: ast.Position{Offset: 42, Line: 3, Column: 14},
+				EndPos:   ast.Position{Offset: 156, Line: 5, Column: 15},
+			},
+			errs[0].(*sema.PurityError).Range,
+		)
+	})
+
+	t.Run("forEachPrivate", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheckAccount(t, `
+          view fun foo() {
+              authAccount.forEachPrivate(fun (path: PrivatePath, type: Type): Bool {
+                  return true
+              })
+          }
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.PurityError{}, errs[0])
+		assert.Equal(
+			t,
+			ast.Range{
+				StartPos: ast.Position{Offset: 42, Line: 3, Column: 14},
+				EndPos:   ast.Position{Offset: 158, Line: 5, Column: 15},
+			},
+			errs[0].(*sema.PurityError).Range,
+		)
+	})
+
+	t.Run("forEachStored", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheckAccount(t, `
+          view fun foo() {
+              authAccount.forEachStored(fun (path: StoragePath, type: Type): Bool {
+                  return true
+              })
+          }
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.PurityError{}, errs[0])
+		assert.Equal(
+			t,
+			ast.Range{
+				StartPos: ast.Position{Offset: 42, Line: 3, Column: 14},
+				EndPos:   ast.Position{Offset: 157, Line: 5, Column: 15},
+			},
+			errs[0].(*sema.PurityError).Range,
+		)
+	})
+
+	t.Run("contracts", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("add", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.contracts.add(name: "", code: [])
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 1)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 94, Line: 3, Column: 62},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+		})
+
+		t.Run("update__experimental", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.contracts.update__experimental(name: "", code: [])
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 1)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 111, Line: 3, Column: 79},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+		})
+
+		t.Run("get", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.contracts.get(name: "")
+              }
+            `)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("remove", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.contracts.remove(name: "")
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 1)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 87, Line: 3, Column: 55},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+		})
+
+		t.Run("borrow", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.contracts.borrow<&Int>(name: "")
+              }
+            `)
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("keys", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("add", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.keys.add(
+                      publicKey: key,
+                      hashAlgorithm: algo,
+                      weight: 100.0
+                  )
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 3)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 207, Line: 7, Column: 18},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+			assert.IsType(t, &sema.NotDeclaredError{}, errs[1])
+			assert.IsType(t, &sema.NotDeclaredError{}, errs[2])
+		})
+
+		t.Run("get", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.keys.get(keyIndex: 0)
+              }
+            `)
+			require.NoError(t, err)
+		})
+
+		t.Run("revoke", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.keys.revoke(keyIndex: 0)
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 1)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 85, Line: 3, Column: 53},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+		})
+
+		t.Run("forEach", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.keys.forEach(fun(key: AccountKey): Bool {
+                      return true
+                  })
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 1)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 157, Line: 5, Column: 19},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+		})
+	})
+
+	t.Run("inbox", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("publish", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.inbox.publish(
+                      cap,
+                      name: "cap",
+                      recipient: 0x1
+                  )
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 2)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 194, Line: 7, Column: 18},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+			assert.IsType(t, &sema.NotDeclaredError{}, errs[1])
+		})
+
+		t.Run("unpublish", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.inbox.unpublish<&Int>("cap")
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 1)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 89, Line: 3, Column: 57},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+		})
+
+		t.Run("claim", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.inbox.claim<&Int>("cap", provider: 0x1)
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 1)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 100, Line: 3, Column: 68},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+		})
+	})
+
+	t.Run("capabilities", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("get", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.capabilities.get<&Int>(/public/foo)
+              }
+            `)
+			require.NoError(t, err)
+		})
+
+		t.Run("borrow", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.capabilities.borrow<&Int>(/public/foo)
+              }
+            `)
+			require.NoError(t, err)
+		})
+
+		t.Run("publish", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.capabilities.publish(
+                      cap,
+                      at: /public/foo
+                  )
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 2)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 167, Line: 6, Column: 18},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+			assert.IsType(t, &sema.NotDeclaredError{}, errs[1])
+		})
+
+		t.Run("unpublish", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.capabilities.unpublish(/public/foo)
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 1)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 96, Line: 3, Column: 64},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+		})
+	})
+
+	t.Run("capabilities.storage", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("getController", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.capabilities.storage.getController(byCapabilityID: 1)
+              }
+            `)
+			require.NoError(t, err)
+		})
+
+		t.Run("getControllers", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.capabilities.storage.getControllers(forPath: /storage/foo)
+              }
+            `)
+			require.NoError(t, err)
+		})
+
+		t.Run("forEachController", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.capabilities.storage.forEachController(
+                      forPath: /storage/foo,
+                      fun (controller: &StorageCapabilityController): Bool {
+                          return true
+                      }
+                  )
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 1)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 304, Line: 8, Column: 18},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+		})
+
+		t.Run("issue", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.capabilities.storage.issue<&Int>(/storage/foo)
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 1)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 107, Line: 3, Column: 75},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+		})
+	})
+
+	t.Run("capabilities.account", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("getController", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.capabilities.account.getController(byCapabilityID: 1)
+              }
+            `)
+			require.NoError(t, err)
+		})
+
+		t.Run("getControllers", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.capabilities.account.getControllers()
+              }
+            `)
+			require.NoError(t, err)
+		})
+
+		t.Run("forEachController", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.capabilities.account.forEachController(
+                      fun (controller: &AccountCapabilityController): Bool {
+                          return true
+                      }
+                  )
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 1)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 259, Line: 7, Column: 18},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+		})
+
+		t.Run("issue", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  authAccount.capabilities.account.issue<&AuthAccount>()
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 1)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 103, Line: 3, Column: 71},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+		})
+	})
+}
+
+func TestCheckPublicAccountPurity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("forEachPublic", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheckAccount(t, `
+          view fun foo() {
+              publicAccount.forEachPublic(fun (path: PublicPath, type: Type): Bool {
+                  return true
+              })
+          }
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.PurityError{}, errs[0])
+		assert.Equal(
+			t,
+			ast.Range{
+				StartPos: ast.Position{Offset: 42, Line: 3, Column: 14},
+				EndPos:   ast.Position{Offset: 158, Line: 5, Column: 15},
+			},
+			errs[0].(*sema.PurityError).Range,
+		)
+	})
+
+	t.Run("contracts", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("get", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  publicAccount.contracts.get(name: "")
+              }
+            `)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("borrow", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  publicAccount.contracts.borrow<&Int>(name: "")
+              }
+            `)
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("keys", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("get", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  publicAccount.keys.get(keyIndex: 0)
+              }
+            `)
+			require.NoError(t, err)
+		})
+
+		t.Run("forEach", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  publicAccount.keys.forEach(fun(key: AccountKey): Bool {
+                      return true
+                  })
+              }
+            `)
+
+			errs := RequireCheckerErrors(t, err, 1)
+
+			require.IsType(t, &sema.PurityError{}, errs[0])
+			assert.Equal(
+				t,
+				ast.Range{
+					StartPos: ast.Position{Offset: 50, Line: 3, Column: 18},
+					EndPos:   ast.Position{Offset: 159, Line: 5, Column: 19},
+				},
+				errs[0].(*sema.PurityError).Range,
+			)
+		})
+	})
+
+	t.Run("capabilities", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("get", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  publicAccount.capabilities.get<&Int>(/public/foo)
+              }
+            `)
+			require.NoError(t, err)
+		})
+
+		t.Run("borrow", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseAndCheckAccount(t, `
+              view fun foo() {
+                  publicAccount.capabilities.borrow<&Int>(/public/foo)
+              }
+            `)
+			require.NoError(t, err)
+		})
 	})
 }


### PR DESCRIPTION
Closes #2698 

## Description

Complete work started in #2666:

- Add `view` annotation to `AuthAccount.capabilities.borrow` function  
- Add `view` annotations to `PublicAccount` functions
- Improve and add purity tests for `AuthAccount`/`PublicAccount` functions 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
