### PR TITLE
Hex encode user input in error to avoid invalid UTF-8

### DIFF
--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -301,7 +301,7 @@ func (d *Decoder) decodeAddress(valueJSON any) cadence.Address {
 	actualPrefix := v[:prefixLength]
 	if actualPrefix != addressPrefix {
 		panic(errors.NewDefaultUserError(
-			"invalid address prefix: expected `%s`, got `%s`",
+			"invalid address prefix: (shown as hex) expected %x, got %x", // hex encoding user input (actualPrefix) avoids invalid UTF-8.
 			addressPrefix,
 			actualPrefix,
 		))

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -197,6 +197,16 @@ func TestEncodeAddress(t *testing.T) {
 	)
 }
 
+func TestDecodeInvalidAddress(t *testing.T) {
+
+	t.Parallel()
+
+	msg := `{"type":"Address","value":"000000000102030405"}`
+
+	_, err := json.Decode(nil, []byte(msg))
+	require.ErrorContains(t, err, "invalid address prefix: (shown as hex) expected 3078, got 3030")
+}
+
 func TestEncodeInt(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
Closes #2703 

Currently, error message can include invalid UTF-8 when it shows content of actualPrefix (user input).

This PR hex encodes actualPrefix in the error message.

https://flowscan.org/transaction/f6c8e65646a3b140902aa7559ae2e740bbe92fbef65f414a441c141340a5756f

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
