### PR TITLE
Update randomness runtime interface method

### DIFF
--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -219,8 +219,8 @@ func (e *interpreterEnvironment) ProgramLog(message string) error {
 	return e.runtimeInterface.ProgramLog(message)
 }
 
-func (e *interpreterEnvironment) UnsafeRandom() (uint64, error) {
-	return e.runtimeInterface.UnsafeRandom()
+func (e *interpreterEnvironment) ReadRandom(buffer []byte) error {
+	return e.runtimeInterface.ReadRandom(buffer)
 }
 
 func (e *interpreterEnvironment) GetBlockAtHeight(height uint64) (block stdlib.Block, exists bool, err error) {

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -102,9 +102,8 @@ type Interface interface {
 	GetCurrentBlockHeight() (uint64, error)
 	// GetBlockAtHeight returns the block at the given height.
 	GetBlockAtHeight(height uint64) (block Block, exists bool, err error)
-	// UnsafeRandom returns a random uint64, where the process of random number derivation is not cryptographically
-	// secure.
-	UnsafeRandom() (uint64, error)
+	// ReadRandom reads pseudo-random bytes into the input slice, using distributed randomness.
+	ReadRandom([]byte) error
 	// VerifySignature returns true if the given signature was produced by signing the given tag + data
 	// using the given public key, signature algorithm, and hash algorithm.
 	VerifySignature(

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -198,7 +198,7 @@ type testRuntimeInterface struct {
 	programParsed      func(location Location, duration time.Duration)
 	programChecked     func(location Location, duration time.Duration)
 	programInterpreted func(location Location, duration time.Duration)
-	unsafeRandom       func() (uint64, error)
+	readRandom         func([]byte) error
 	verifySignature    func(
 		signature []byte,
 		tag string,
@@ -513,11 +513,11 @@ func (i *testRuntimeInterface) GetBlockAtHeight(height uint64) (block stdlib.Blo
 	return block, true, nil
 }
 
-func (i *testRuntimeInterface) UnsafeRandom() (uint64, error) {
-	if i.unsafeRandom == nil {
-		return 0, nil
+func (i *testRuntimeInterface) ReadRandom(buffer []byte) error {
+	if i.readRandom == nil {
+		return nil
 	}
-	return i.unsafeRandom()
+	return i.readRandom(buffer)
 }
 
 func (i *testRuntimeInterface) VerifySignature(
@@ -4752,8 +4752,9 @@ func TestRuntimeUnsafeRandom(t *testing.T) {
 	var loggedMessages []string
 
 	runtimeInterface := &testRuntimeInterface{
-		unsafeRandom: func() (uint64, error) {
-			return 7558174677681708339, nil
+		readRandom: func(buffer []byte) error {
+			binary.LittleEndian.PutUint64(buffer, 7558174677681708339)
+			return nil
 		},
 		log: func(message string) {
 			loggedMessages = append(loggedMessages, message)

--- a/runtime/stdlib/random.go
+++ b/runtime/stdlib/random.go
@@ -19,6 +19,8 @@
 package stdlib
 
 import (
+	"encoding/binary"
+
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -39,9 +41,8 @@ var unsafeRandomFunctionType = &sema.FunctionType{
 }
 
 type UnsafeRandomGenerator interface {
-	// UnsafeRandom returns a random uint64,
-	// where the process of random number derivation is not cryptographically secure.
-	UnsafeRandom() (uint64, error)
+	// ReadRandom reads pseudo-random bytes into the input slice, using distributed randomness.
+	ReadRandom([]byte) error
 }
 
 func NewUnsafeRandomFunction(generator UnsafeRandomGenerator) StandardLibraryValue {
@@ -53,14 +54,15 @@ func NewUnsafeRandomFunction(generator UnsafeRandomGenerator) StandardLibraryVal
 			return interpreter.NewUInt64Value(
 				invocation.Interpreter,
 				func() uint64 {
-					var rand uint64
+					buffer := make([]byte, 8)
 					var err error
 					errors.WrapPanic(func() {
-						rand, err = generator.UnsafeRandom()
+						err = generator.ReadRandom(buffer)
 					})
 					if err != nil {
 						panic(interpreter.WrappedExternalError(err))
 					}
+					rand := binary.LittleEndian.Uint64(buffer)
 					return rand
 				},
 			)

--- a/runtime/stdlib/random.go
+++ b/runtime/stdlib/random.go
@@ -62,8 +62,7 @@ func NewUnsafeRandomFunction(generator UnsafeRandomGenerator) StandardLibraryVal
 					if err != nil {
 						panic(interpreter.WrappedExternalError(err))
 					}
-					rand := binary.LittleEndian.Uint64(buffer[:])
-					return rand
+					return binary.LittleEndian.Uint64(buffer[:])
 				},
 			)
 		},

--- a/runtime/stdlib/random.go
+++ b/runtime/stdlib/random.go
@@ -54,15 +54,15 @@ func NewUnsafeRandomFunction(generator UnsafeRandomGenerator) StandardLibraryVal
 			return interpreter.NewUInt64Value(
 				invocation.Interpreter,
 				func() uint64 {
-					buffer := make([]byte, 8)
+					var buffer [8]byte
 					var err error
 					errors.WrapPanic(func() {
-						err = generator.ReadRandom(buffer)
+						err = generator.ReadRandom(buffer[:])
 					})
 					if err != nil {
 						panic(interpreter.WrappedExternalError(err))
 					}
-					rand := binary.LittleEndian.Uint64(buffer)
+					rand := binary.LittleEndian.Uint64(buffer[:])
 					return rand
 				},
 			)


### PR DESCRIPTION
This PR is part of implementing FLIP https://github.com/onflow/flips/pull/120, specifically the type-generalized random function. 
There are no changes in Cadence for now, this is a small internal refactor without impact on Cadence language. However, this is a breaking change for dependencies implementing the runtime `Interface` (flow-go FVM, emulator FVM).

## Description

- This PR does NOT rename `unsafeRandom` to `random`
- `unsafeRandom` still returns 64 bits
- It updates the internal `Interface` method  `UnsafeRandom() (uint64, error)` to `ReadRandom([]byte) error` to allow future flexible implementations of randomness tools.

Providing randomness functions with other Cadence types can be built on top of this PR or in a separate PR. 

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
