### PR TITLE
Use thread safe data structures for entitlement maps

### DIFF
--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -479,7 +479,7 @@ func exportAuthorization(
 		if access.Equal(sema.UnauthorizedAccess) {
 			return cadence.UnauthorizedAccess
 		}
-	case sema.EntitlementMapAccess:
+	case *sema.EntitlementMapAccess:
 		common.UseMemory(gauge, common.NewConstantMemoryUsage(common.MemoryKindCadenceEntitlementMapAccess))
 		return cadence.EntitlementMapAuthorization{
 			TypeID: access.Type.ID(),

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1730,7 +1730,7 @@ func (interpreter *Interpreter) substituteMappedEntitlements(ty sema.Type) sema.
 	return ty.Map(interpreter, make(map[*sema.TypeParameter]*sema.TypeParameter), func(t sema.Type) sema.Type {
 		switch refType := t.(type) {
 		case *sema.ReferenceType:
-			if _, isMappedAuth := refType.Authorization.(sema.EntitlementMapAccess); isMappedAuth {
+			if _, isMappedAuth := refType.Authorization.(*sema.EntitlementMapAccess); isMappedAuth {
 				return sema.NewReferenceType(
 					interpreter,
 					refType.Type,
@@ -4715,7 +4715,7 @@ func (interpreter *Interpreter) mapMemberValueAuthorization(
 		return resultValue
 	}
 
-	if mappedAccess, isMappedAccess := (*memberAccess).(sema.EntitlementMapAccess); isMappedAccess {
+	if mappedAccess, isMappedAccess := (*memberAccess).(*sema.EntitlementMapAccess); isMappedAccess {
 		var auth Authorization
 		switch selfValue := self.(type) {
 		case AuthorizedValue:

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -268,7 +268,7 @@ func (interpreter *Interpreter) getReferenceValue(value Value, resultType sema.T
 }
 
 func (interpreter *Interpreter) getEffectiveAuthorization(referenceType *sema.ReferenceType) Authorization {
-	_, isMapped := referenceType.Authorization.(sema.EntitlementMapAccess)
+	_, isMapped := referenceType.Authorization.(*sema.EntitlementMapAccess)
 
 	if isMapped && interpreter.SharedState.currentEntitlementMappedValue != nil {
 		return interpreter.SharedState.currentEntitlementMappedValue

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -835,7 +835,7 @@ func ConvertSemaAccessToStaticAuthorization(
 		})
 		return NewEntitlementSetAuthorization(memoryGauge, entitlements, access.SetKind)
 
-	case sema.EntitlementMapAccess:
+	case *sema.EntitlementMapAccess:
 		typeId := access.Type.ID()
 		return NewEntitlementMapAuthorization(memoryGauge, typeId)
 	}

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -21,6 +21,7 @@ package sema
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -196,52 +197,54 @@ func (e EntitlementSetAccess) IsLessPermissiveThan(other Access) bool {
 }
 
 type EntitlementMapAccess struct {
-	Type     *EntitlementMapType
-	domain   EntitlementSetAccess
-	codomain EntitlementSetAccess
-	images   map[*EntitlementType]*EntitlementOrderedSet
+	Type         *EntitlementMapType
+	domain       EntitlementSetAccess
+	domainOnce   sync.Once
+	codomain     EntitlementSetAccess
+	codomainOnce sync.Once
+	images       sync.Map
 }
 
-var _ Access = EntitlementMapAccess{}
+var _ Access = &EntitlementMapAccess{}
 
-func NewEntitlementMapAccess(mapType *EntitlementMapType) EntitlementMapAccess {
-	return EntitlementMapAccess{
+func NewEntitlementMapAccess(mapType *EntitlementMapType) *EntitlementMapAccess {
+	return &EntitlementMapAccess{
 		Type:   mapType,
-		images: make(map[*EntitlementType]*EntitlementOrderedSet),
+		images: sync.Map{},
 	}
 }
 
-func (EntitlementMapAccess) isAccess() {}
+func (*EntitlementMapAccess) isAccess() {}
 
-func (e EntitlementMapAccess) string(typeFormatter func(ty Type) string) string {
+func (e *EntitlementMapAccess) string(typeFormatter func(ty Type) string) string {
 	return typeFormatter(e.Type)
 }
 
-func (a EntitlementMapAccess) Description() string {
+func (a *EntitlementMapAccess) Description() string {
 	return a.AccessKeyword()
 }
 
-func (a EntitlementMapAccess) AccessKeyword() string {
+func (a *EntitlementMapAccess) AccessKeyword() string {
 	return a.string(func(ty Type) string { return ty.String() })
 }
 
-func (a EntitlementMapAccess) AuthKeyword() string {
+func (a *EntitlementMapAccess) AuthKeyword() string {
 	return fmt.Sprintf("auth(%s)", a.AccessKeyword())
 }
 
-func (e EntitlementMapAccess) Equal(other Access) bool {
+func (e *EntitlementMapAccess) Equal(other Access) bool {
 	switch otherAccess := other.(type) {
-	case EntitlementMapAccess:
+	case *EntitlementMapAccess:
 		return e.Type.Equal(otherAccess.Type)
 	}
 	return false
 }
 
-func (e EntitlementMapAccess) PermitsAccess(other Access) bool {
+func (e *EntitlementMapAccess) PermitsAccess(other Access) bool {
 	switch otherAccess := other.(type) {
 	case PrimitiveAccess:
 		return otherAccess == PrimitiveAccess(ast.AccessSelf)
-	case EntitlementMapAccess:
+	case *EntitlementMapAccess:
 		return e.Type.Equal(otherAccess.Type)
 	// if we are initializing a field that was declared with an entitlement-mapped reference type,
 	// the type we are using to initialize that member must be fully authorized for the entire codomain
@@ -274,11 +277,11 @@ func (e EntitlementMapAccess) PermitsAccess(other Access) bool {
 	}
 }
 
-func (e EntitlementMapAccess) IsLessPermissiveThan(other Access) bool {
+func (e *EntitlementMapAccess) IsLessPermissiveThan(other Access) bool {
 	switch otherAccess := other.(type) {
 	case PrimitiveAccess:
 		return ast.PrimitiveAccess(otherAccess) != ast.AccessSelf
-	case EntitlementMapAccess:
+	case *EntitlementMapAccess:
 		// this should be false on equality
 		return !e.Type.Equal(otherAccess.Type)
 	default:
@@ -286,59 +289,56 @@ func (e EntitlementMapAccess) IsLessPermissiveThan(other Access) bool {
 	}
 }
 
-func (e EntitlementMapAccess) Domain() EntitlementSetAccess {
-	if e.domain.Entitlements != nil {
-		return e.domain
-	}
-
-	domain := common.MappedSliceWithNoDuplicates(
-		e.Type.Relations,
-		func(r EntitlementRelation) *EntitlementType {
-			return r.Input
-		},
-	)
-	e.domain = NewEntitlementSetAccess(domain, Conjunction)
+func (e *EntitlementMapAccess) Domain() EntitlementSetAccess {
+	e.domainOnce.Do(func() {
+		domain := common.MappedSliceWithNoDuplicates(
+			e.Type.Relations,
+			func(r EntitlementRelation) *EntitlementType {
+				return r.Input
+			},
+		)
+		e.domain = NewEntitlementSetAccess(domain, Conjunction)
+	})
 	return e.domain
 }
 
-func (e EntitlementMapAccess) Codomain() EntitlementSetAccess {
-	if e.codomain.Entitlements != nil {
-		return e.codomain
-	}
-
-	codomain := common.MappedSliceWithNoDuplicates(
-		e.Type.Relations,
-		func(r EntitlementRelation) *EntitlementType {
-			return r.Output
-		},
-	)
-	e.codomain = NewEntitlementSetAccess(codomain, Conjunction)
+func (e *EntitlementMapAccess) Codomain() EntitlementSetAccess {
+	e.codomainOnce.Do(func() {
+		codomain := common.MappedSliceWithNoDuplicates(
+			e.Type.Relations,
+			func(r EntitlementRelation) *EntitlementType {
+				return r.Output
+			},
+		)
+		e.codomain = NewEntitlementSetAccess(codomain, Conjunction)
+	})
 	return e.codomain
 }
 
 // produces the image set of a single entitlement through a map
 // the image set of one element is always a conjunction
-func (e EntitlementMapAccess) entitlementImage(entitlement *EntitlementType) (output *EntitlementOrderedSet) {
-	image := e.images[entitlement]
-	if image != nil {
-		return image
+func (e *EntitlementMapAccess) entitlementImage(entitlement *EntitlementType) *EntitlementOrderedSet {
+	image, ok := e.images.Load(entitlement)
+
+	if ok {
+		return image.(*EntitlementOrderedSet)
 	}
 
-	output = orderedmap.New[EntitlementOrderedSet](0)
+	imageMap := orderedmap.New[EntitlementOrderedSet](0)
 	for _, relation := range e.Type.Relations {
 		if relation.Input.Equal(entitlement) {
-			output.Set(relation.Output, struct{}{})
+			imageMap.Set(relation.Output, struct{}{})
 		}
 	}
 
-	e.images[entitlement] = output
-	return
+	e.images.Store(entitlement, imageMap)
+	return imageMap
 }
 
 // Image applies all the entitlements in the `argumentAccess` to the function
 // defined by the map in `e`, producing a new entitlement set of the image of the
 // arguments.
-func (e EntitlementMapAccess) Image(inputs Access, astRange func() ast.Range) (Access, error) {
+func (e *EntitlementMapAccess) Image(inputs Access, astRange func() ast.Range) (Access, error) {
 
 	if e.Type == IdentityMappingType {
 		return inputs, nil

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -95,10 +95,10 @@ func (checker *Checker) checkAttachmentMembersAccess(attachmentType *CompositeTy
 	// while the definition of `qux` is not.
 	var attachmentAccess Access = UnauthorizedAccess
 	if attachmentType.AttachmentEntitlementAccess != nil {
-		attachmentAccess = *attachmentType.AttachmentEntitlementAccess
+		attachmentAccess = attachmentType.AttachmentEntitlementAccess
 	}
 
-	if attachmentAccess, ok := attachmentAccess.(EntitlementMapAccess); ok {
+	if attachmentAccess, ok := attachmentAccess.(*EntitlementMapAccess); ok {
 		codomain := attachmentAccess.Codomain()
 		attachmentType.Members.Foreach(func(_ string, member *Member) {
 			if memberAccess, ok := member.Access.(EntitlementSetAccess); ok {
@@ -655,8 +655,8 @@ func (checker *Checker) declareAttachmentType(declaration *ast.AttachmentDeclara
 	composite.baseType = checker.convertNominalType(declaration.BaseType)
 
 	attachmentAccess := checker.accessFromAstAccess(declaration.Access)
-	if attachmentAccess, ok := attachmentAccess.(EntitlementMapAccess); ok {
-		composite.AttachmentEntitlementAccess = &attachmentAccess
+	if attachmentAccess, ok := attachmentAccess.(*EntitlementMapAccess); ok {
+		composite.AttachmentEntitlementAccess = attachmentAccess
 	}
 
 	// add all the required entitlements to a set for this attachment
@@ -2042,7 +2042,7 @@ func (checker *Checker) defaultMembersAndOrigins(
 
 		fieldAccess := checker.accessFromAstAccess(field.Access)
 
-		if entitlementMapAccess, ok := fieldAccess.(EntitlementMapAccess); ok {
+		if entitlementMapAccess, ok := fieldAccess.(*EntitlementMapAccess); ok {
 			checker.entitlementMappingInScope = entitlementMapAccess.Type
 		}
 		fieldTypeAnnotation := checker.ConvertTypeAnnotation(field.TypeAnnotation)

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -187,7 +187,7 @@ func (checker *Checker) checkFunction(
 			functionActivation.InitializationInfo = initializationInfo
 
 			if functionBlock != nil {
-				if mappedAccess, isMappedAccess := access.(EntitlementMapAccess); isMappedAccess {
+				if mappedAccess, isMappedAccess := access.(*EntitlementMapAccess); isMappedAccess {
 					checker.entitlementMappingInScope = mappedAccess.Type
 				}
 

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -373,7 +373,7 @@ func (checker *Checker) isReadableMember(accessedType Type, member *Member, resu
 	if checker.Config.AccessCheckMode.IsReadableAccess(member.Access) ||
 		checker.containerTypes[member.ContainerType] {
 
-		if mappedAccess, isMappedAccess := member.Access.(EntitlementMapAccess); isMappedAccess {
+		if mappedAccess, isMappedAccess := member.Access.(*EntitlementMapAccess); isMappedAccess {
 			return checker.mapAccess(mappedAccess, accessedType, resultingType, accessRange)
 		}
 
@@ -417,7 +417,7 @@ func (checker *Checker) isReadableMember(accessedType Type, member *Member, resu
 			// allowed as an owned value is considered fully authorized
 			return true, member.Access
 		}
-	case EntitlementMapAccess:
+	case *EntitlementMapAccess:
 		return checker.mapAccess(access, accessedType, resultingType, accessRange)
 	}
 
@@ -425,7 +425,7 @@ func (checker *Checker) isReadableMember(accessedType Type, member *Member, resu
 }
 
 func (checker *Checker) mapAccess(
-	mappedAccess EntitlementMapAccess,
+	mappedAccess *EntitlementMapAccess,
 	accessedType Type,
 	resultingType Type,
 	accessRange func() ast.Range,

--- a/runtime/sema/checker_test.go
+++ b/runtime/sema/checker_test.go
@@ -309,7 +309,7 @@ func TestReferenceSubtyping(t *testing.T) {
 		Identifier: "Z",
 	}
 
-	mapAccess := EntitlementMapAccess{
+	mapAccess := &EntitlementMapAccess{
 		Type: &EntitlementMapType{
 			Location:   testLocation,
 			Identifier: "M",
@@ -329,7 +329,7 @@ func TestReferenceSubtyping(t *testing.T) {
 		Identifier: "X",
 	}
 
-	containedMapAccess := EntitlementMapAccess{
+	containedMapAccess := &EntitlementMapAccess{
 		Type: &EntitlementMapType{
 			Location: testLocation,
 			containerType: &InterfaceType{

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -4580,7 +4580,7 @@ func (e *InvalidAttachmentEntitlementError) SecondaryError() string {
 	switch access := e.AttachmentAccessModifier.(type) {
 	case PrimitiveAccess:
 		return "attachments declared with `access(all)` access do not support entitlements on their members"
-	case EntitlementMapAccess:
+	case *EntitlementMapAccess:
 		return fmt.Sprintf("`%s` must appear in the output of the entitlement mapping `%s`",
 			e.InvalidEntitlement.QualifiedIdentifier(),
 			access.Type.QualifiedIdentifier())

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4296,7 +4296,7 @@ func (t *CompositeType) SupportedEntitlements() (set *EntitlementOrderedSet) {
 	set = orderedmap.New[EntitlementOrderedSet](t.Members.Len())
 	t.Members.Foreach(func(_ string, member *Member) {
 		switch access := member.Access.(type) {
-		case EntitlementMapAccess:
+		case *EntitlementMapAccess:
 			set.SetAll(access.Domain().Entitlements)
 		case EntitlementSetAccess:
 			set.SetAll(access.Entitlements)
@@ -5022,7 +5022,7 @@ func (t *InterfaceType) SupportedEntitlements() (set *EntitlementOrderedSet) {
 	set = orderedmap.New[EntitlementOrderedSet](t.Members.Len())
 	t.Members.Foreach(func(_ string, member *Member) {
 		switch access := member.Access.(type) {
-		case EntitlementMapAccess:
+		case *EntitlementMapAccess:
 			access.Domain().Entitlements.Foreach(func(entitlement *EntitlementType, _ struct{}) {
 				set.Set(entitlement, struct{}{})
 			})


### PR DESCRIPTION
Fix data race

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
