### PR TITLE
Give `CompositeTypeHandler` higher precedence over `getUserCompositeType`

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4797,16 +4797,16 @@ func (interpreter *Interpreter) GetCompositeType(
 			return compositeType, nil
 		}
 	} else {
-		compositeType = interpreter.getUserCompositeType(location, typeID)
-		if compositeType != nil {
-			return compositeType, nil
+		config := interpreter.SharedState.Config
+		compositeTypeHandler := config.CompositeTypeHandler
+		if compositeTypeHandler != nil {
+			compositeType = compositeTypeHandler(location, typeID)
+			if compositeType != nil {
+				return compositeType, nil
+			}
 		}
-	}
 
-	config := interpreter.SharedState.Config
-	compositeTypeHandler := config.CompositeTypeHandler
-	if compositeTypeHandler != nil {
-		compositeType = compositeTypeHandler(location, typeID)
+		compositeType = interpreter.getUserCompositeType(location, typeID)
 		if compositeType != nil {
 			return compositeType, nil
 		}


### PR DESCRIPTION
Closes https://github.com/onflow/cadence-tools/issues/172

## Description

When running the following script, in the Flow Emulator:
```cadence
pub fun main(): Type? {
    return CompositeType("flow.AccountContractAdded")
}
```

The following error is returned:
```bash
error: [Error Code: 1054] location (flow) is not a valid location: expecting an AddressLocation, but other location types are passed
 --> b2b8424d1ef6de8f49bd006c8b7cbdba4a98c3be6e5834fb4ed1b281655293fe:2:4
  |
2 |     return CompositeType("flow.AccountContractAdded")
```

After the proposed change, the script runs successfully:
```bash
Result: Type<flow.AccountContractAdded>()
```

**Note:** This seemed to work in the test suite of the `cadence-tools/test` repository, however, it didn't work when I tried it in an actual Cadence test file.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
