### PR TITLE
Add capability field to capabilitity controllers

### DIFF
--- a/runtime/capabilitycontrollers_test.go
+++ b/runtime/capabilitycontrollers_test.go
@@ -2500,6 +2500,43 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 		t.Parallel()
 
+		t.Run("capability", func(t *testing.T) {
+			t.Parallel()
+
+			err, _ := test(
+				// language=cadence
+				`
+                  import Test from 0x1
+
+                  transaction {
+                      prepare(signer: AuthAccount) {
+                          let storagePath = /storage/r
+                          let resourceID = 42
+
+						  // Arrange
+						  Test.createAndSaveR(id: resourceID, storagePath: storagePath)
+
+                          let issuedCap: Capability<&Test.R> =
+                              signer.capabilities.storage.issue<&Test.R>(storagePath)
+                          let controller1: &StorageCapabilityController =
+                              signer.capabilities.storage.getController(byCapabilityID: issuedCap.id)!
+                          let controller2: &StorageCapabilityController =
+                              signer.capabilities.storage.getController(byCapabilityID: issuedCap.id)!
+
+                          // Act
+                          let controller1Cap = controller1.capability
+                          let controller2Cap = controller2.capability
+
+                          // Assert
+                          assert(controller1Cap.borrow<&Test.R>() != nil)
+                          assert(controller2Cap.borrow<&Test.R>() != nil)
+                      }
+                  }
+                `,
+			)
+			require.NoError(t, err)
+		})
+
 		t.Run("tag", func(t *testing.T) {
 			t.Parallel()
 
@@ -2980,6 +3017,39 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 	t.Run("AccountCapabilityController", func(t *testing.T) {
 
 		t.Parallel()
+
+		t.Run("capability", func(t *testing.T) {
+			t.Parallel()
+
+			err, _ := test(
+				// language=cadence
+				`
+                  import Test from 0x1
+
+                  transaction {
+                      prepare(signer: AuthAccount) {
+
+						  // Arrange
+                          let issuedCap: Capability<&AuthAccount> =
+                              signer.capabilities.account.issue<&AuthAccount>()
+                          let controller1: &AccountCapabilityController =
+                              signer.capabilities.account.getController(byCapabilityID: issuedCap.id)!
+                          let controller2: &AccountCapabilityController =
+                              signer.capabilities.account.getController(byCapabilityID: issuedCap.id)!
+
+                          // Act
+                          let controller1Cap = controller1.capability
+                          let controller2Cap = controller2.capability
+
+                          // Assert
+                          assert(controller1Cap.borrow<&AuthAccount>() != nil)
+                          assert(controller2Cap.borrow<&AuthAccount>() != nil)
+                      }
+                  }
+                `,
+			)
+			require.NoError(t, err)
+		})
 
 		t.Run("tag", func(t *testing.T) {
 			t.Parallel()

--- a/runtime/interpreter/value_accountcapabilitycontroller.go
+++ b/runtime/interpreter/value_accountcapabilitycontroller.go
@@ -41,6 +41,7 @@ type AccountCapabilityControllerValue struct {
 	// Tags are not stored directly inside the controller
 	// to avoid unnecessary storage reads
 	// when the controller is loaded for borrowing/checking
+	GetCapability  func() *IDCapabilityValue
 	GetTag         func() *StringValue
 	SetTag         func(*StringValue)
 	DeleteFunction FunctionValue
@@ -110,7 +111,10 @@ func (v *AccountCapabilityControllerValue) RecursiveString(seenReferences SeenRe
 	)
 }
 
-func (v *AccountCapabilityControllerValue) MeteredString(memoryGauge common.MemoryGauge, seenReferences SeenReferences) string {
+func (v *AccountCapabilityControllerValue) MeteredString(
+	memoryGauge common.MemoryGauge,
+	seenReferences SeenReferences,
+) string {
 	common.UseMemory(memoryGauge, common.AccountCapabilityControllerValueStringMemoryUsage)
 
 	return format.AccountCapabilityController(
@@ -127,7 +131,11 @@ func (v *AccountCapabilityControllerValue) ConformsToStaticType(
 	return true
 }
 
-func (v *AccountCapabilityControllerValue) Equal(interpreter *Interpreter, locationRange LocationRange, other Value) bool {
+func (v *AccountCapabilityControllerValue) Equal(
+	interpreter *Interpreter,
+	locationRange LocationRange,
+	other Value,
+) bool {
 	otherController, ok := other.(*AccountCapabilityControllerValue)
 	if !ok {
 		return false
@@ -141,7 +149,14 @@ func (*AccountCapabilityControllerValue) IsStorable() bool {
 	return true
 }
 
-func (v *AccountCapabilityControllerValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
+func (v *AccountCapabilityControllerValue) Storable(
+	storage atree.SlabStorage,
+	address atree.Address,
+	maxInlineSize uint64,
+) (
+	atree.Storable,
+	error,
+) {
 	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
@@ -212,6 +227,9 @@ func (v *AccountCapabilityControllerValue) GetMember(inter *Interpreter, _ Locat
 
 	case sema.AccountCapabilityControllerTypeDeleteFunctionName:
 		return v.DeleteFunction
+
+	case sema.AccountCapabilityControllerTypeCapabilityFieldName:
+		return v.GetCapability()
 	}
 
 	return nil
@@ -222,7 +240,12 @@ func (*AccountCapabilityControllerValue) RemoveMember(_ *Interpreter, _ Location
 	panic(errors.NewUnreachableError())
 }
 
-func (v *AccountCapabilityControllerValue) SetMember(_ *Interpreter, _ LocationRange, identifier string, value Value) bool {
+func (v *AccountCapabilityControllerValue) SetMember(
+	_ *Interpreter,
+	_ LocationRange,
+	identifier string,
+	value Value,
+) bool {
 	switch identifier {
 	case sema.AccountCapabilityControllerTypeTagFieldName:
 		stringValue, ok := value.(*StringValue)
@@ -235,6 +258,10 @@ func (v *AccountCapabilityControllerValue) SetMember(_ *Interpreter, _ LocationR
 	}
 
 	panic(errors.NewUnreachableError())
+}
+
+func (v *AccountCapabilityControllerValue) ControllerCapabilityID() UInt64Value {
+	return v.CapabilityID
 }
 
 func (v *AccountCapabilityControllerValue) ReferenceValue(

--- a/runtime/sema/account_capability_controller.cdc
+++ b/runtime/sema/account_capability_controller.cdc
@@ -1,5 +1,9 @@
 pub struct AccountCapabilityController {
 
+    /// The capability that is controlled by this controller.
+    access(all)
+    let capability: Capability
+
     /// An arbitrary "tag" for the controller.
     /// For example, it could be used to describe the purpose of the capability.
     /// Empty by default.

--- a/runtime/sema/account_capability_controller.gen.go
+++ b/runtime/sema/account_capability_controller.gen.go
@@ -21,6 +21,14 @@ package sema
 
 import "github.com/onflow/cadence/runtime/ast"
 
+const AccountCapabilityControllerTypeCapabilityFieldName = "capability"
+
+var AccountCapabilityControllerTypeCapabilityFieldType = &CapabilityType{}
+
+const AccountCapabilityControllerTypeCapabilityFieldDocString = `
+The capability that is controlled by this controller.
+`
+
 const AccountCapabilityControllerTypeTagFieldName = "tag"
 
 var AccountCapabilityControllerTypeTagFieldType = StringType
@@ -87,6 +95,14 @@ var AccountCapabilityControllerType = &SimpleType{
 func init() {
 	AccountCapabilityControllerType.Members = func(t *SimpleType) map[string]MemberResolver {
 		return MembersAsResolvers([]*Member{
+			NewUnmeteredFieldMember(
+				t,
+				ast.AccessPublic,
+				ast.VariableKindConstant,
+				AccountCapabilityControllerTypeCapabilityFieldName,
+				AccountCapabilityControllerTypeCapabilityFieldType,
+				AccountCapabilityControllerTypeCapabilityFieldDocString,
+			),
 			NewUnmeteredFieldMember(
 				t,
 				ast.AccessPublicSettable,

--- a/runtime/sema/storage_capability_controller.cdc
+++ b/runtime/sema/storage_capability_controller.cdc
@@ -1,5 +1,9 @@
 pub struct StorageCapabilityController {
 
+    /// The capability that is controlled by this controller.
+    access(all)
+    let capability: Capability
+
     /// An arbitrary "tag" for the controller.
     /// For example, it could be used to describe the purpose of the capability.
     /// Empty by default.

--- a/runtime/sema/storage_capability_controller.gen.go
+++ b/runtime/sema/storage_capability_controller.gen.go
@@ -21,6 +21,14 @@ package sema
 
 import "github.com/onflow/cadence/runtime/ast"
 
+const StorageCapabilityControllerTypeCapabilityFieldName = "capability"
+
+var StorageCapabilityControllerTypeCapabilityFieldType = &CapabilityType{}
+
+const StorageCapabilityControllerTypeCapabilityFieldDocString = `
+The capability that is controlled by this controller.
+`
+
 const StorageCapabilityControllerTypeTagFieldName = "tag"
 
 var StorageCapabilityControllerTypeTagFieldType = StringType
@@ -119,6 +127,14 @@ var StorageCapabilityControllerType = &SimpleType{
 func init() {
 	StorageCapabilityControllerType.Members = func(t *SimpleType) map[string]MemberResolver {
 		return MembersAsResolvers([]*Member{
+			NewUnmeteredFieldMember(
+				t,
+				ast.AccessPublic,
+				ast.VariableKindConstant,
+				StorageCapabilityControllerTypeCapabilityFieldName,
+				StorageCapabilityControllerTypeCapabilityFieldType,
+				StorageCapabilityControllerTypeCapabilityFieldDocString,
+			),
 			NewUnmeteredFieldMember(
 				t,
 				ast.AccessPublicSettable,

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -2717,10 +2717,15 @@ func getCapabilityController(
 	// Inject functions
 	switch controller := controller.(type) {
 	case *interpreter.StorageCapabilityControllerValue:
+		capabilityID := controller.CapabilityID
+
+		controller.GetCapability =
+			newCapabilityControllerGetCapabilityFunction(inter, address, controller)
+
 		controller.GetTag =
-			newCapabilityControllerGetTagFunction(inter, address, controller.CapabilityID)
+			newCapabilityControllerGetTagFunction(inter, address, capabilityID)
 		controller.SetTag =
-			newCapabilityControllerSetTagFunction(inter, address, controller.CapabilityID)
+			newCapabilityControllerSetTagFunction(inter, address, capabilityID)
 
 		controller.TargetFunction =
 			newStorageCapabilityControllerTargetFunction(inter, controller)
@@ -2730,10 +2735,15 @@ func getCapabilityController(
 			newStorageCapabilityControllerDeleteFunction(inter, address, controller)
 
 	case *interpreter.AccountCapabilityControllerValue:
+		capabilityID := controller.CapabilityID
+
+		controller.GetCapability =
+			newCapabilityControllerGetCapabilityFunction(inter, address, controller)
+
 		controller.GetTag =
-			newCapabilityControllerGetTagFunction(inter, address, controller.CapabilityID)
+			newCapabilityControllerGetTagFunction(inter, address, capabilityID)
 		controller.SetTag =
-			newCapabilityControllerSetTagFunction(inter, address, controller.CapabilityID)
+			newCapabilityControllerSetTagFunction(inter, address, capabilityID)
 
 		controller.DeleteFunction =
 			newAccountCapabilityControllerDeleteFunction(inter, address, controller)
@@ -4003,6 +4013,26 @@ func getCapabilityControllerTag(
 	}
 
 	return stringValue
+}
+
+func newCapabilityControllerGetCapabilityFunction(
+	inter *interpreter.Interpreter,
+	address common.Address,
+	controller interpreter.CapabilityControllerValue,
+) func() *interpreter.IDCapabilityValue {
+
+	addressValue := interpreter.AddressValue(address)
+	capabilityID := controller.ControllerCapabilityID()
+	borrowType := controller.CapabilityControllerBorrowType()
+
+	return func() *interpreter.IDCapabilityValue {
+		return interpreter.NewIDCapabilityValue(
+			inter,
+			capabilityID,
+			addressValue,
+			borrowType,
+		)
+	}
 }
 
 func newCapabilityControllerGetTagFunction(

--- a/runtime/tests/checker/capability_controller_test.go
+++ b/runtime/tests/checker/capability_controller_test.go
@@ -73,6 +73,7 @@ func TestCheckStorageCapabilityController(t *testing.T) {
 		t.Parallel()
 
 		_, err := parseAndCheck(t, `
+          let cap: Capability = controller.capability
           let tag: String = controller.tag
           let borrowType: Type = controller.borrowType
           let capabilityID: UInt64 = controller.capabilityID
@@ -133,6 +134,7 @@ func TestCheckAccountCapabilityController(t *testing.T) {
 		t.Parallel()
 
 		_, err := parseAndCheck(t, `
+          let cap: Capability = controller.capability
           let tag: String = controller.tag
           let borrowType: Type = controller.borrowType
           let capabilityID: UInt64 = controller.capabilityID


### PR DESCRIPTION
Closes #2711 

## Description

Add a new field `let capability: Capability` to `StorageCapabilityController` and `AccountCapabilityController`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
