### PR TITLE
Add a utility method to the `Test.Blockchain` struct for moving the blockchain time

### DIFF
--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -127,6 +127,13 @@ pub contract Test {
         pub fun reset(to height: UInt64) {
             self.backend.reset(to: height)
         }
+
+        /// Moves the time of the blockchain by the given delta,
+        /// which should be passed in the form of seconds.
+        ///
+        pub fun moveTime(by delta: UFix64) {
+            self.backend.moveTime(by: delta)
+        }
     }
 
     pub struct Matcher {
@@ -312,6 +319,11 @@ pub contract Test {
         /// Resets the state of the blockchain to the given height.
         ///
         pub fun reset(to height: UInt64)
+
+        /// Moves the time of the blockchain by the given delta,
+        /// which should be passed in the form of seconds.
+        ///
+        pub fun moveTime(by delta: UFix64)
     }
 
     /// Returns a new matcher that negates the test of the given matcher.

--- a/runtime/stdlib/test-framework.go
+++ b/runtime/stdlib/test-framework.go
@@ -71,6 +71,8 @@ type TestFramework interface {
 	) interpreter.Value
 
 	Reset(uint64)
+
+	MoveTime(int64)
 }
 
 type ScriptResult struct {

--- a/runtime/stdlib/test_emulatorbackend.go
+++ b/runtime/stdlib/test_emulatorbackend.go
@@ -46,6 +46,7 @@ type testEmulatorBackendType struct {
 	serviceAccountFunctionType         *sema.FunctionType
 	eventsFunctionType                 *sema.FunctionType
 	resetFunctionType                  *sema.FunctionType
+	moveTimeFunctionType               *sema.FunctionType
 }
 
 func newTestEmulatorBackendType(blockchainBackendInterfaceType *sema.InterfaceType) *testEmulatorBackendType {
@@ -102,6 +103,11 @@ func newTestEmulatorBackendType(blockchainBackendInterfaceType *sema.InterfaceTy
 	resetFunctionType := interfaceFunctionType(
 		blockchainBackendInterfaceType,
 		testEmulatorBackendTypeResetFunctionName,
+	)
+
+	moveTimeFunctionType := interfaceFunctionType(
+		blockchainBackendInterfaceType,
+		testEmulatorBackendTypeMoveTimeFunctionName,
 	)
 
 	compositeType := &sema.CompositeType{
@@ -180,6 +186,12 @@ func newTestEmulatorBackendType(blockchainBackendInterfaceType *sema.InterfaceTy
 			resetFunctionType,
 			testEmulatorBackendTypeResetFunctionDocString,
 		),
+		sema.NewUnmeteredPublicFunctionMember(
+			compositeType,
+			testEmulatorBackendTypeMoveTimeFunctionName,
+			moveTimeFunctionType,
+			testEmulatorBackendTypeMoveTimeFunctionDocString,
+		),
 	}
 
 	compositeType.Members = sema.MembersAsMap(members)
@@ -198,6 +210,7 @@ func newTestEmulatorBackendType(blockchainBackendInterfaceType *sema.InterfaceTy
 		serviceAccountFunctionType:         serviceAccountFunctionType,
 		eventsFunctionType:                 eventsFunctionType,
 		resetFunctionType:                  resetFunctionType,
+		moveTimeFunctionType:               moveTimeFunctionType,
 	}
 }
 
@@ -685,6 +698,31 @@ func (t *testEmulatorBackendType) newResetFunction(
 	)
 }
 
+// 'Emulator.moveTime' function
+
+const testEmulatorBackendTypeMoveTimeFunctionName = "moveTime"
+
+const testEmulatorBackendTypeMoveTimeFunctionDocString = `
+Moves the time of the blockchain by the given delta,
+which should be passed in the form of seconds.
+`
+
+func (t *testEmulatorBackendType) newMoveTimeFunction(
+	testFramework TestFramework,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewUnmeteredHostFunctionValue(
+		t.moveTimeFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			timeDelta, ok := invocation.Arguments[0].(interpreter.UFix64Value)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+			testFramework.MoveTime(int64(timeDelta.ToInt(invocation.LocationRange)))
+			return interpreter.Void
+		},
+	)
+}
+
 func (t *testEmulatorBackendType) newEmulatorBackend(
 	inter *interpreter.Interpreter,
 	testFramework TestFramework,
@@ -733,6 +771,10 @@ func (t *testEmulatorBackendType) newEmulatorBackend(
 		{
 			Name:  testEmulatorBackendTypeResetFunctionName,
 			Value: t.newResetFunction(testFramework),
+		},
+		{
+			Name:  testEmulatorBackendTypeMoveTimeFunctionName,
+			Value: t.newMoveTimeFunction(testFramework),
 		},
 	}
 


### PR DESCRIPTION
**Companion PR:** https://github.com/onflow/cadence-tools/pull/196

## Description

Add the `TestFramework.MoveTime(int64)`, so that test providers can allow the manipulation of blockchain's time.

Example usage:
```cadence
import Test

pub fun test() {
    let blockchain = Test.newEmulatorBlockchain()
    // timeDelta is the representation of 35 days,
    // in the form of seconds.
    let timeDelta = UFix64(35 * 24 * 60 * 60)
    blockchain.moveTime(by: timeDelta)
}
```
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
