### PR TITLE
Allow `moveTime` function to accept negative time deltas for going backwards in time

### DIFF
--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -131,7 +131,7 @@ pub contract Test {
         /// Moves the time of the blockchain by the given delta,
         /// which should be passed in the form of seconds.
         ///
-        pub fun moveTime(by delta: UFix64) {
+        pub fun moveTime(by delta: Fix64) {
             self.backend.moveTime(by: delta)
         }
     }
@@ -323,7 +323,7 @@ pub contract Test {
         /// Moves the time of the blockchain by the given delta,
         /// which should be passed in the form of seconds.
         ///
-        pub fun moveTime(by delta: UFix64)
+        pub fun moveTime(by delta: Fix64)
     }
 
     /// Returns a new matcher that negates the test of the given matcher.

--- a/runtime/stdlib/test_emulatorbackend.go
+++ b/runtime/stdlib/test_emulatorbackend.go
@@ -713,7 +713,7 @@ func (t *testEmulatorBackendType) newMoveTimeFunction(
 	return interpreter.NewUnmeteredHostFunctionValue(
 		t.moveTimeFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
-			timeDelta, ok := invocation.Arguments[0].(interpreter.UFix64Value)
+			timeDelta, ok := invocation.Arguments[0].(interpreter.Fix64Value)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}


### PR DESCRIPTION
**Companion PR:** https://github.com/onflow/cadence-tools/pull/196

## Description

Change the `delta` argument type from `UFix64` to `Fix64`.

```cadence
import Test

pub fun testMoveBackward() {
    let blockchain = Test.newEmulatorBlockchain()
    // timeDelta is the representation of 35 days,
    // in the form of seconds. A negative time delta
    // signifies going back in time.
    let timeDelta = Fix64(35 * 24 * 60 * 60) * -1.0
    blockchain.moveTime(by: timeDelta)
}
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
