### PR TITLE
Expose `Test.Blockchain` as a singleton through `Test.emulatorBlockchain` public field

### DIFF
--- a/runtime/stdlib/test_contract.go
+++ b/runtime/stdlib/test_contract.go
@@ -383,6 +383,8 @@ func newTestTypeReadFileFunction(testFramework TestFramework) *interpreter.HostF
 // 'Test.newEmulatorBlockchain' function
 
 const testTypeNewEmulatorBlockchainFunctionDocString = `
+**DEPRECATED**: Use the ` + "`Test.emulatorBlockchain`" + ` field instead.
+
 Creates a blockchain which is backed by a new emulator instance.
 `
 

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -865,7 +865,7 @@ func TestAssertEqual(t *testing.T) {
 		assert.ErrorContains(
 			t,
 			err,
-			"not equal: expected: {2: false, 1: true}, actual: {2: true, 1: true}",
+			"not equal: expected: {2: false, 1: true}, actual: {1: true, 2: true}",
 		)
 	})
 
@@ -2137,6 +2137,37 @@ func TestBlockchain(t *testing.T) {
 
             pub fun test() {
                 let blockchain = Test.newEmulatorBlockchain()
+                blockchain.reset(to: 5)
+            }
+		`
+
+		resetInvoked := false
+
+		testFramework := &mockedTestFramework{
+			reset: func(height uint64) {
+				resetInvoked = true
+				assert.Equal(t, uint64(5), height)
+			},
+		}
+
+		inter, err := newTestContractInterpreterWithTestFramework(t, script, testFramework)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.NoError(t, err)
+
+		assert.True(t, resetInvoked)
+	})
+
+	t.Run("emulatorBlockchain", func(t *testing.T) {
+		t.Parallel()
+
+		const script = `
+            import Test
+
+            pub fun test() {
+                let blockchain = Test.emulatorBlockchain
+                Test.assertEqual(Type<Test.Blockchain>(), blockchain.getType())
                 blockchain.reset(to: 5)
             }
 		`


### PR DESCRIPTION
Closes https://github.com/onflow/cadence-tools/issues/139

## Description

We also add a deprecation hint for `Test.newEmulatorBlockchain()`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
