### PR TITLE
add suggestions for missing entitlements in access errors

### DIFF
--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -294,11 +294,12 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (accessedT
 		}
 		checker.report(
 			&InvalidAccessError{
-				Name:              member.Identifier.Identifier,
-				RestrictingAccess: member.Access,
-				PossessedAccess:   possessedAccess,
-				DeclarationKind:   member.DeclarationKind,
-				Range:             accessRange(),
+				Name:                member.Identifier.Identifier,
+				RestrictingAccess:   member.Access,
+				PossessedAccess:     possessedAccess,
+				DeclarationKind:     member.DeclarationKind,
+				suggestEntitlements: checker.Config.SuggestionsEnabled,
+				Range:               accessRange(),
 			},
 		)
 	}

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -3039,7 +3039,7 @@ func (e *InvalidAccessError) SecondaryError() string {
 	if !possessedOk && e.PossessedAccess.Equal(UnauthorizedAccess) {
 		possessedOk = true
 		// for this error reporting, model UnauthorizedAccess as an empty entitlement set
-		possessedEntitlements = NewEntitlementSetAccess([]*EntitlementType{}, Conjunction)
+		possessedEntitlements = NewEntitlementSetAccess(nil, Conjunction)
 	}
 	if !possessedOk || !requiredOk || possessedEntitlements.SetKind != Conjunction {
 		return ""

--- a/runtime/tests/checker/attachments_test.go
+++ b/runtime/tests/checker/attachments_test.go
@@ -3812,7 +3812,7 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheck(t,
+		_, err := ParseAndCheckWithOptions(t,
 			`
 				access(all) resource R {}
 				access(all) attachment A for R {
@@ -3827,6 +3827,10 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 					destroy r
 				}
 				`,
+			ParseAndCheckOptions{Config: &sema.Config{
+				SuggestionsEnabled: true,
+				AttachmentsEnabled: true,
+			}},
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -3888,7 +3892,7 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheck(t,
+		_, err := ParseAndCheckWithOptions(t,
 			`
 				access(all) resource R {
 					access(all) fun foo() {
@@ -3903,6 +3907,10 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 				}
 				
 				`,
+			ParseAndCheckOptions{Config: &sema.Config{
+				SuggestionsEnabled: true,
+				AttachmentsEnabled: true,
+			}},
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -3962,7 +3970,7 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheck(t,
+		_, err := ParseAndCheckWithOptions(t,
 			`
 				access(all) resource R {}
 				access(all) attachment A for R {
@@ -3976,6 +3984,10 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 				}
 				
 				`,
+			ParseAndCheckOptions{Config: &sema.Config{
+				SuggestionsEnabled: true,
+				AttachmentsEnabled: true,
+			}},
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)

--- a/runtime/tests/checker/attachments_test.go
+++ b/runtime/tests/checker/attachments_test.go
@@ -3847,6 +3847,11 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 			errs[0].(*sema.InvalidAccessError).PossessedAccess,
 			sema.UnauthorizedAccess,
 		)
+		assert.Equal(
+			t,
+			errs[0].(*sema.InvalidAccessError).SecondaryError(),
+			"reference needs one of entitlements `Insert` or `Mutate`",
+		)
 	})
 
 	t.Run("basic, with entitlements", func(t *testing.T) {
@@ -3918,6 +3923,11 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 			errs[0].(*sema.InvalidAccessError).PossessedAccess,
 			sema.UnauthorizedAccess,
 		)
+		assert.Equal(
+			t,
+			errs[0].(*sema.InvalidAccessError).SecondaryError(),
+			"reference needs one of entitlements `Insert` or `Mutate`",
+		)
 	})
 
 	t.Run("in base, with entitlements", func(t *testing.T) {
@@ -3985,6 +3995,11 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 			t,
 			errs[0].(*sema.InvalidAccessError).PossessedAccess,
 			sema.UnauthorizedAccess,
+		)
+		assert.Equal(
+			t,
+			errs[0].(*sema.InvalidAccessError).SecondaryError(),
+			"reference needs one of entitlements `Insert` or `Mutate`",
 		)
 	})
 }

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -5761,15 +5761,23 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 		entitlement Z
 		entitlement A
 		entitlement B
+
 		struct S {
 			view access(X, Y, Z) fun foo(): Bool {
 				return true
 			}
 		}
+
 		fun bar(r: auth(A, B) &S) {
 			r.foo()
 		}
-	`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
+	`,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					SuggestionsEnabled: true,
+				},
+			},
+		)
 
 		errs := RequireCheckerErrors(t, err, 1)
 		require.IsType(t, &sema.InvalidAccessError{}, errs[0])
@@ -5811,15 +5819,23 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 		entitlement Z
 		entitlement A
 		entitlement B
+
 		struct S {
 			view access(X, Y, Z) fun foo(): Bool {
 				return true
 			}
 		}
+
 		fun bar(r: auth(A, B, Y) &S) {
 			r.foo()
 		}
-	`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
+	`,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					SuggestionsEnabled: true,
+				},
+			},
+		)
 
 		errs := RequireCheckerErrors(t, err, 1)
 		require.IsType(t, &sema.InvalidAccessError{}, errs[0])
@@ -5862,15 +5878,23 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 		entitlement Z
 		entitlement A
 		entitlement B
+
 		struct S {
 			view access(X | Y | Z) fun foo(): Bool {
 				return true
 			}
 		}
+
 		fun bar(r: auth(A, B) &S) {
 			r.foo()
 		}
-	`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
+	`,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					SuggestionsEnabled: true,
+				},
+			},
+		)
 
 		errs := RequireCheckerErrors(t, err, 1)
 		require.IsType(t, &sema.InvalidAccessError{}, errs[0])
@@ -5912,15 +5936,23 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 		entitlement Z
 		entitlement A
 		entitlement B
+
 		struct S {
 			view access(X | Y | Z) fun foo(): Bool {
 				return true
 			}
 		}
+
 		fun bar(r: auth(A | B) &S) {
 			r.foo()
 		}
-	`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
+	`,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					SuggestionsEnabled: true,
+				},
+			},
+		)
 
 		errs := RequireCheckerErrors(t, err, 1)
 		require.IsType(t, &sema.InvalidAccessError{}, errs[0])
@@ -5959,15 +5991,23 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 		_, err := ParseAndCheckWithOptions(t, `
 		entitlement A
 		entitlement B
+		
 		struct S {
 			view access(self) fun foo(): Bool {
 				return true
 			}
 		}
+
 		fun bar(r: auth(A, B) &S) {
 			r.foo()
 		}
-	`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
+	`,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					SuggestionsEnabled: true,
+				},
+			},
+		)
 
 		errs := RequireCheckerErrors(t, err, 1)
 		require.IsType(t, &sema.InvalidAccessError{}, errs[0])

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -898,7 +898,7 @@ func TestCheckBasicEntitlementMappingAccess(t *testing.T) {
 
 	t.Run("accessor function with no downcast impl", func(t *testing.T) {
 		t.Parallel()
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithOptions(t, `
 			entitlement X
 			entitlement Y
 			entitlement mapping M {
@@ -914,7 +914,7 @@ func TestCheckBasicEntitlementMappingAccess(t *testing.T) {
 					return x
 				}
 			}
-		`)
+		`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
 
 		errs := RequireCheckerErrors(t, err, 1)
 
@@ -968,7 +968,7 @@ func TestCheckBasicEntitlementMappingAccess(t *testing.T) {
 
 	t.Run("accessor function with invalid object access impl", func(t *testing.T) {
 		t.Parallel()
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithOptions(t, `
 			entitlement X
 			entitlement Y
 			entitlement Z
@@ -990,7 +990,7 @@ func TestCheckBasicEntitlementMappingAccess(t *testing.T) {
 					self.t = &T() as auth(Y) &T
 				}
 			}
-		`)
+		`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
 
 		errs := RequireCheckerErrors(t, err, 1)
 
@@ -4648,7 +4648,7 @@ func TestCheckEntitlementConditions(t *testing.T) {
 
 	t.Run("use of function on unentitled referenced value", func(t *testing.T) {
 		t.Parallel()
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithOptions(t, `
 		entitlement X
 		struct S {
 			view access(X) fun foo(): Bool {
@@ -4664,7 +4664,7 @@ func TestCheckEntitlementConditions(t *testing.T) {
 			}
 			r.foo()
 		}
-		`)
+		`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
 
 		errs := RequireCheckerErrors(t, err, 3)
 		require.IsType(t, &sema.InvalidAccessError{}, errs[0])
@@ -4715,7 +4715,7 @@ func TestCheckEntitlementConditions(t *testing.T) {
 
 	t.Run("result value usage reference", func(t *testing.T) {
 		t.Parallel()
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithOptions(t, `
 		entitlement X
 		struct S {
 			view access(X) fun foo(): Bool {
@@ -4728,7 +4728,7 @@ func TestCheckEntitlementConditions(t *testing.T) {
 			}
 			return &r as auth(X) &S
 		}
-		`)
+		`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
 
 		errs := RequireCheckerErrors(t, err, 1)
 		require.IsType(t, &sema.InvalidAccessError{}, errs[0])
@@ -5047,7 +5047,7 @@ func TestCheckEntitledWriteAndMutateNotAllowed(t *testing.T) {
 
 	t.Run("basic authorized", func(t *testing.T) {
 		t.Parallel()
-		_, err := ParseAndCheck(t, `
+		_, err := ParseAndCheckWithOptions(t, `
 			entitlement E
 			struct S {
 				access(E) var x: [Int]
@@ -5060,7 +5060,7 @@ func TestCheckEntitledWriteAndMutateNotAllowed(t *testing.T) {
 				let ref = &s as auth(E) &S
 				ref.x.append(3)
 			}
-		`)
+		`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
 
 		errs := RequireCheckerErrors(t, err, 1)
 		require.IsType(t, &sema.InvalidAccessError{}, errs[0])
@@ -5755,7 +5755,7 @@ func TestCheckIdentityMapping(t *testing.T) {
 func TestCheckEntitlementErrorReporting(t *testing.T) {
 	t.Run("three or more conjunction", func(t *testing.T) {
 		t.Parallel()
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithOptions(t, `
 		entitlement X
 		entitlement Y
 		entitlement Z
@@ -5769,7 +5769,7 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 		fun bar(r: auth(A, B) &S) {
 			r.foo()
 		}
-	`)
+	`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
 
 		errs := RequireCheckerErrors(t, err, 1)
 		require.IsType(t, &sema.InvalidAccessError{}, errs[0])
@@ -5799,13 +5799,13 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 		assert.Equal(
 			t,
 			errs[0].(*sema.InvalidAccessError).SecondaryError(),
-			"reference needs all of entitlements `X`, `Y` and `Z`",
+			"reference needs all of entitlements `X`, `Y`, and `Z`",
 		)
 	})
 
 	t.Run("has one entitlement of three", func(t *testing.T) {
 		t.Parallel()
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithOptions(t, `
 		entitlement X
 		entitlement Y
 		entitlement Z
@@ -5819,7 +5819,7 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 		fun bar(r: auth(A, B, Y) &S) {
 			r.foo()
 		}
-	`)
+	`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
 
 		errs := RequireCheckerErrors(t, err, 1)
 		require.IsType(t, &sema.InvalidAccessError{}, errs[0])
@@ -5856,7 +5856,7 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 
 	t.Run("has one entitlement of three", func(t *testing.T) {
 		t.Parallel()
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithOptions(t, `
 		entitlement X
 		entitlement Y
 		entitlement Z
@@ -5870,7 +5870,7 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 		fun bar(r: auth(A, B) &S) {
 			r.foo()
 		}
-	`)
+	`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
 
 		errs := RequireCheckerErrors(t, err, 1)
 		require.IsType(t, &sema.InvalidAccessError{}, errs[0])
@@ -5900,13 +5900,13 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 		assert.Equal(
 			t,
 			errs[0].(*sema.InvalidAccessError).SecondaryError(),
-			"reference needs one of entitlements `X`, `Y` or `Z`",
+			"reference needs one of entitlements `X`, `Y`, or `Z`",
 		)
 	})
 
 	t.Run("no suggestion for disjoint possession set", func(t *testing.T) {
 		t.Parallel()
-		checker, err := ParseAndCheck(t, `
+		checker, err := ParseAndCheckWithOptions(t, `
 		entitlement X
 		entitlement Y
 		entitlement Z
@@ -5920,7 +5920,7 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 		fun bar(r: auth(A | B) &S) {
 			r.foo()
 		}
-	`)
+	`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
 
 		errs := RequireCheckerErrors(t, err, 1)
 		require.IsType(t, &sema.InvalidAccessError{}, errs[0])
@@ -5956,7 +5956,7 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 
 	t.Run("no suggestion for self access requirement", func(t *testing.T) {
 		t.Parallel()
-		_, err := ParseAndCheck(t, `
+		_, err := ParseAndCheckWithOptions(t, `
 		entitlement A
 		entitlement B
 		struct S {
@@ -5967,7 +5967,7 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
 		fun bar(r: auth(A, B) &S) {
 			r.foo()
 		}
-	`)
+	`, ParseAndCheckOptions{Config: &sema.Config{SuggestionsEnabled: true}})
 
 		errs := RequireCheckerErrors(t, err, 1)
 		require.IsType(t, &sema.InvalidAccessError{}, errs[0])


### PR DESCRIPTION
Further improves entitlement access errors by making concrete suggestions about which entitlements users can add to their references to gain the access they want, in cases where this makes sense. 

This same principle can be later extended to a lint, which, in combination with an analysis that can figure out all the entitlements that a certain section of code uses, to suggest which entitlements on a type are unnecessary or redundant and can be removed from an annotation. 
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
