### PR TITLE
Introduce `map` in Fixed/Variable sized Array types

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -3111,18 +3111,19 @@ func (v *ArrayValue) Map(
 	if !ok {
 		panic(errors.NewUnreachableError())
 	}
+	returnType := procedureStaticType.ReturnType(interpreter)
 
 	var returnArrayStaticType ArrayStaticType
 	switch v.Type.(type) {
 	case VariableSizedStaticType:
 		returnArrayStaticType = NewVariableSizedStaticType(
 			interpreter,
-			procedureStaticType.ReturnType(interpreter),
+			returnType,
 		)
 	case ConstantSizedStaticType:
 		returnArrayStaticType = NewConstantSizedStaticType(
 			interpreter,
-			procedureStaticType.ReturnType(interpreter),
+			returnType,
 			int64(v.Count()),
 		)
 	default:
@@ -3148,12 +3149,10 @@ func (v *ArrayValue) Map(
 				panic(errors.NewExternalError(err))
 			}
 
-			// Also handles the end of array case since iterator.Next() returns nil for that.
-			if atreeValue == nil {
-				return nil
+			if atreeValue != nil {
+				value = MustConvertStoredValue(interpreter, atreeValue)
 			}
 
-			value = MustConvertStoredValue(interpreter, atreeValue)
 			if value == nil {
 				return nil
 			}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -3142,20 +3142,16 @@ func (v *ArrayValue) Map(
 		uint64(v.Count()),
 		func() Value {
 
-			var value Value
-
 			atreeValue, err := iterator.Next()
 			if err != nil {
 				panic(errors.NewExternalError(err))
 			}
 
-			if atreeValue != nil {
-				value = MustConvertStoredValue(interpreter, atreeValue)
-			}
-
-			if value == nil {
+			if atreeValue == nil {
 				return nil
 			}
+
+			value := MustConvertStoredValue(interpreter, atreeValue)
 
 			mappedValue := procedure.invoke(iterationInvocation(value))
 			return mappedValue.Transfer(

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -3096,7 +3096,7 @@ func (v *ArrayValue) Map(
 
 	elementTypeSlice := []sema.Type{v.semaType.ElementType(false)}
 	iterationInvocation := func(arrayElement Value) Invocation {
-		invocation := NewInvocation(
+		return NewInvocation(
 			interpreter,
 			nil,
 			nil,
@@ -3105,7 +3105,6 @@ func (v *ArrayValue) Map(
 			nil,
 			locationRange,
 		)
-		return invocation
 	}
 
 	procedureStaticType, ok := ConvertSemaToStaticType(interpreter, transformFunctionType).(FunctionStaticType)

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -1225,6 +1225,104 @@ func TestCheckResourceArrayFilterInvalid(t *testing.T) {
 	assert.IsType(t, &sema.InvalidResourceArrayMemberError{}, errs[0])
 }
 
+func TestCheckArrayMap(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		fun test() {
+			let x = [1, 2, 3]
+			let trueForEven =
+				fun (_ x: Int): Bool {
+					return x % 2 == 0
+				}
+
+			let y = x.map(trueForEven)
+		}
+
+		fun testFixedSize() {
+			let x : [Int; 5] = [1, 2, 3, 21, 30]
+			let trueForEvenInt =
+				fun (_ x: Int): Bool {
+					return x % 2 == 0
+				}
+
+			let y = x.map(trueForEvenInt)
+		}
+	`)
+
+	require.NoError(t, err)
+}
+
+func TestCheckArrayMapInvalidArgs(t *testing.T) {
+
+	t.Parallel()
+
+	testInvalidArgs := func(code string, expectedErrors []sema.SemanticError) {
+		_, err := ParseAndCheck(t, code)
+
+		errs := RequireCheckerErrors(t, err, len(expectedErrors))
+
+		for i, e := range expectedErrors {
+			assert.IsType(t, e, errs[i])
+		}
+	}
+
+	testInvalidArgs(`
+		fun test() {
+			let x = [1, 2, 3]
+			let y = x.map(100)
+		}
+	`,
+		[]sema.SemanticError{
+			&sema.TypeMismatchError{},
+			&sema.TypeParameterTypeInferenceError{}, // since we're not passing a function.
+		},
+	)
+
+	testInvalidArgs(`
+		fun test() {
+			let x = [1, 2, 3]
+			let trueForEvenInt16 =
+				fun (_ x: Int16): Bool {
+					return x % 2 == 0
+				}
+
+			let y = x.map(trueForEvenInt16)
+		}
+	`,
+		[]sema.SemanticError{
+			&sema.TypeMismatchError{},
+		},
+	)
+}
+
+func TestCheckResourceArrayMapInvalid(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		resource X {}
+
+		fun test(): [Bool] {
+			let xs <- [<-create X()]
+			let allResources =
+				fun (_ x: @X): Bool {
+					destroy x
+					return true
+				}
+
+			let mappedXs = xs.map(allResources)
+			destroy xs
+			return mappedXs
+		}
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.InvalidResourceArrayMemberError{}, errs[0])
+}
+
 func TestCheckArrayContains(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -1237,7 +1237,7 @@ func TestCheckArrayMap(t *testing.T) {
 					return x % 2 == 0
 				}
 
-			let y = x.map(trueForEven)
+			let y: [Bool] = x.map(trueForEven)
 		}
 
 		fun testFixedSize() {
@@ -1247,7 +1247,7 @@ func TestCheckArrayMap(t *testing.T) {
 					return x % 2 == 0
 				}
 
-			let y = x.map(trueForEvenInt)
+			let y: [Bool; 5] = x.map(trueForEvenInt)
 		}
 	`)
 
@@ -1288,7 +1288,7 @@ func TestCheckArrayMapInvalidArgs(t *testing.T) {
 					return x % 2 == 0
 				}
 
-			let y = x.map(trueForEvenInt16)
+			let y: [Bool] = x.map(trueForEvenInt16)
 		}
 	`,
 		[]sema.SemanticError{
@@ -1312,7 +1312,7 @@ func TestCheckResourceArrayMapInvalid(t *testing.T) {
 					return true
 				}
 
-			let mappedXs = xs.map(allResources)
+			let mappedXs: [Bool] = xs.map(allResources)
 			destroy xs
 			return mappedXs
 		}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -11086,6 +11086,7 @@ func TestInterpretArrayFilter(t *testing.T) {
 }
 
 func TestInterpretArrayMap(t *testing.T) {
+	t.Parallel()
 
 	runValidCase := func(
 		t *testing.T,


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/2605

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Introduce `map` function for creating a copy of an Array value with its entries transformed by a transformation function.

This function would be unavailable to resource arrays. It can be enabled for resources as a reference in the future.

Will send docs PR post the merge.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
