### PR TITLE
Add `cadence-tools/test` as a dependency to the language server

### DIFF
--- a/tools/update/config.yaml
+++ b/tools/update/config.yaml
@@ -70,6 +70,7 @@ repos:
         - onflow/flow-go
         - onflow/flow-emulator
         - onflow/cadence-tools/lint
+        - onflow/cadence-tools/test
         - onflow/flow-cli/flowkit
 
 - repo: onflow/flow-cli


### PR DESCRIPTION
## Description

In https://github.com/onflow/cadence-tools/pull/187, `cadence-tools/test` was added as a dependency to the language server. So update the update tool to reflect this change.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
