### PR TITLE
Composition of entitlement mappings

### DIFF
--- a/runtime/ast/entitlement_declaration.go
+++ b/runtime/ast/entitlement_declaration.go
@@ -165,8 +165,6 @@ func (d *EntitlementMapRelation) Doc() prettier.Doc {
 	)
 }
 
-func (*NominalType) isEntitlementMapElement() {}
-
 // EntitlementMappingDeclaration
 type EntitlementMappingDeclaration struct {
 	Access     Access

--- a/runtime/ast/entitlement_declaration.go
+++ b/runtime/ast/entitlement_declaration.go
@@ -162,6 +162,7 @@ type EntitlementMappingDeclaration struct {
 	DocString    string
 	Identifier   Identifier
 	Associations []*EntitlementMapElement
+	Inclusions   []*NominalType
 	Range
 }
 
@@ -174,6 +175,7 @@ func NewEntitlementMappingDeclaration(
 	access Access,
 	identifier Identifier,
 	associations []*EntitlementMapElement,
+	inclusions []*NominalType,
 	docString string,
 	declRange Range,
 ) *EntitlementMappingDeclaration {
@@ -183,6 +185,7 @@ func NewEntitlementMappingDeclaration(
 		Access:       access,
 		Identifier:   identifier,
 		Associations: associations,
+		Inclusions:   inclusions,
 		DocString:    docString,
 		Range:        declRange,
 	}
@@ -232,6 +235,7 @@ func (d *EntitlementMappingDeclaration) MarshalJSON() ([]byte, error) {
 }
 
 var mappingKeywordSpaceDoc = prettier.Text("mapping ")
+var includeKeywordSpaceDoc = prettier.Text("include ")
 var mappingStartDoc prettier.Doc = prettier.Text("{")
 var mappingEndDoc prettier.Doc = prettier.Text("}")
 
@@ -243,6 +247,19 @@ func (d *EntitlementMappingDeclaration) Doc() prettier.Doc {
 			doc,
 			prettier.Text(d.Access.Keyword()),
 			prettier.HardLine{},
+		)
+	}
+
+	var mappingInclusionsDoc prettier.Concat
+
+	for _, typ := range d.Inclusions {
+		mappingInclusionsDoc = append(
+			mappingInclusionsDoc,
+			prettier.Concat{
+				prettier.HardLine{},
+				includeKeywordSpaceDoc,
+				typ.Doc(),
+			},
 		)
 	}
 
@@ -265,6 +282,13 @@ func (d *EntitlementMappingDeclaration) Doc() prettier.Doc {
 		prettier.Text(d.Identifier.Identifier),
 		prettier.Space,
 		mappingStartDoc,
+		prettier.Indent{
+			Doc: prettier.Join(
+				prettier.HardLine{},
+				mappingInclusionsDoc...,
+			),
+		},
+		prettier.HardLine{},
 		prettier.Indent{
 			Doc: prettier.Join(
 				prettier.HardLine{},

--- a/runtime/ast/entitlement_declaration_test.go
+++ b/runtime/ast/entitlement_declaration_test.go
@@ -136,8 +136,14 @@ func TestEntitlementMappingDeclaration_MarshalJSON(t *testing.T) {
 			StartPos: Position{Offset: 7, Line: 8, Column: 9},
 			EndPos:   Position{Offset: 10, Line: 11, Column: 12},
 		},
-		Associations: []*EntitlementMapElement{
-			{
+		Elements: []EntitlementMapElement{
+			&NominalType{
+				Identifier: Identifier{
+					Identifier: "X",
+					Pos:        Position{Offset: 1, Line: 2, Column: 3},
+				},
+			},
+			&EntitlementMapRelation{
 				Input: &NominalType{
 					Identifier: Identifier{
 						Identifier: "X",
@@ -149,14 +155,6 @@ func TestEntitlementMappingDeclaration_MarshalJSON(t *testing.T) {
 						Identifier: "Y",
 						Pos:        Position{Offset: 1, Line: 2, Column: 3},
 					},
-				},
-			},
-		},
-		Inclusions: []*NominalType{
-			{
-				Identifier: Identifier{
-					Identifier: "X",
-					Pos:        Position{Offset: 1, Line: 2, Column: 3},
 				},
 			},
 		},
@@ -176,7 +174,17 @@ func TestEntitlementMappingDeclaration_MarshalJSON(t *testing.T) {
 				"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
 				"EndPos": {"Offset": 2, "Line": 2, "Column": 4}
             },
-			"Associations": [
+			"Elements": [
+				{
+					"Type": "NominalType",
+						"Identifier": { 
+							"Identifier": "X",
+							"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+							"EndPos": {"Offset": 1, "Line": 2, "Column": 3}
+						},
+					"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+					"EndPos": {"Offset": 1, "Line": 2, "Column": 3}
+				},
 				{
 					"Input": {
 						"Type": "NominalType",
@@ -198,18 +206,6 @@ func TestEntitlementMappingDeclaration_MarshalJSON(t *testing.T) {
 						"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
 						"EndPos": {"Offset": 1, "Line": 2, "Column": 3}
 					}
-				}
-			],
-			"Inclusions": [
-				{
-					"Type": "NominalType",
-						"Identifier": { 
-							"Identifier": "X",
-							"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
-							"EndPos": {"Offset": 1, "Line": 2, "Column": 3}
-						},
-					"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
-					"EndPos": {"Offset": 1, "Line": 2, "Column": 3}
 				}
 			],
             "DocString": "test",
@@ -236,8 +232,13 @@ func TestEntitlementMappingDeclaration_Doc(t *testing.T) {
 			StartPos: Position{Offset: 7, Line: 8, Column: 9},
 			EndPos:   Position{Offset: 10, Line: 11, Column: 12},
 		},
-		Associations: []*EntitlementMapElement{
-			{
+		Elements: []EntitlementMapElement{
+			&NominalType{
+				Identifier: Identifier{Identifier: "X",
+					Pos: Position{Offset: 1, Line: 2, Column: 3},
+				},
+			},
+			&EntitlementMapRelation{
 				Input: &NominalType{
 					Identifier: Identifier{
 						Identifier: "X",
@@ -249,13 +250,6 @@ func TestEntitlementMappingDeclaration_Doc(t *testing.T) {
 						Identifier: "Y",
 						Pos:        Position{Offset: 1, Line: 2, Column: 3},
 					},
-				},
-			},
-		},
-		Inclusions: []*NominalType{
-			{
-				Identifier: Identifier{Identifier: "X",
-					Pos: Position{Offset: 1, Line: 2, Column: 3},
 				},
 			},
 		},
@@ -271,21 +265,20 @@ func TestEntitlementMappingDeclaration_Doc(t *testing.T) {
 			prettier.Text("AB"),
 			prettier.Space,
 			prettier.Text("{"),
-			prettier.Indent{
-				Doc: prettier.Concat{
-					prettier.HardLine{},
-					prettier.Text("include "),
-					prettier.Text("X"),
-				},
-			},
 			prettier.HardLine{},
 			prettier.Indent{
 				Doc: prettier.Concat{
+					prettier.Concat{
+						prettier.Text("include "),
+						prettier.Text("X"),
+					},
 					prettier.HardLine{},
 					prettier.Concat{
-						prettier.Text("X"),
-						prettier.Text(" -> "),
-						prettier.Text("Y"),
+						prettier.Concat{
+							prettier.Text("X"),
+							prettier.Text(" -> "),
+							prettier.Text("Y"),
+						},
 					},
 				},
 			},
@@ -312,8 +305,13 @@ func TestEntitlementMappingDeclaration_String(t *testing.T) {
 			StartPos: Position{Offset: 7, Line: 8, Column: 9},
 			EndPos:   Position{Offset: 10, Line: 11, Column: 12},
 		},
-		Associations: []*EntitlementMapElement{
-			{
+		Elements: []EntitlementMapElement{
+			&NominalType{
+				Identifier: Identifier{Identifier: "X",
+					Pos: Position{Offset: 1, Line: 2, Column: 3},
+				},
+			},
+			&EntitlementMapRelation{
 				Input: &NominalType{
 					Identifier: Identifier{
 						Identifier: "X",
@@ -328,21 +326,13 @@ func TestEntitlementMappingDeclaration_String(t *testing.T) {
 				},
 			},
 		},
-		Inclusions: []*NominalType{
-			{
-				Identifier: Identifier{Identifier: "X",
-					Pos: Position{Offset: 1, Line: 2, Column: 3},
-				},
-			},
-		},
 	}
 
 	require.Equal(
 		t,
 		`access(all)
 entitlement mapping AB {
-    include X
-
+include X
     X -> Y
 }`,
 		decl.String(),

--- a/runtime/ast/entitlement_declaration_test.go
+++ b/runtime/ast/entitlement_declaration_test.go
@@ -152,6 +152,14 @@ func TestEntitlementMappingDeclaration_MarshalJSON(t *testing.T) {
 				},
 			},
 		},
+		Inclusions: []*NominalType{
+			{
+				Identifier: Identifier{
+					Identifier: "X",
+					Pos:        Position{Offset: 1, Line: 2, Column: 3},
+				},
+			},
+		},
 	}
 
 	actual, err := json.Marshal(decl)
@@ -190,6 +198,18 @@ func TestEntitlementMappingDeclaration_MarshalJSON(t *testing.T) {
 						"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
 						"EndPos": {"Offset": 1, "Line": 2, "Column": 3}
 					}
+				}
+			],
+			"Inclusions": [
+				{
+					"Type": "NominalType",
+						"Identifier": { 
+							"Identifier": "X",
+							"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+							"EndPos": {"Offset": 1, "Line": 2, "Column": 3}
+						},
+					"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
+					"EndPos": {"Offset": 1, "Line": 2, "Column": 3}
 				}
 			],
             "DocString": "test",
@@ -232,6 +252,13 @@ func TestEntitlementMappingDeclaration_Doc(t *testing.T) {
 				},
 			},
 		},
+		Inclusions: []*NominalType{
+			{
+				Identifier: Identifier{Identifier: "X",
+					Pos: Position{Offset: 1, Line: 2, Column: 3},
+				},
+			},
+		},
 	}
 
 	require.Equal(
@@ -244,6 +271,14 @@ func TestEntitlementMappingDeclaration_Doc(t *testing.T) {
 			prettier.Text("AB"),
 			prettier.Space,
 			prettier.Text("{"),
+			prettier.Indent{
+				Doc: prettier.Concat{
+					prettier.HardLine{},
+					prettier.Text("include "),
+					prettier.Text("X"),
+				},
+			},
+			prettier.HardLine{},
 			prettier.Indent{
 				Doc: prettier.Concat{
 					prettier.HardLine{},
@@ -293,12 +328,21 @@ func TestEntitlementMappingDeclaration_String(t *testing.T) {
 				},
 			},
 		},
+		Inclusions: []*NominalType{
+			{
+				Identifier: Identifier{Identifier: "X",
+					Pos: Position{Offset: 1, Line: 2, Column: 3},
+				},
+			},
+		},
 	}
 
 	require.Equal(
 		t,
 		`access(all)
 entitlement mapping AB {
+    include X
+
     X -> Y
 }`,
 		decl.String(),

--- a/runtime/ast/type.go
+++ b/runtime/ast/type.go
@@ -182,6 +182,8 @@ func (t *NominalType) CheckEqual(other Type, checker TypeEqualityChecker) error 
 	return checker.CheckNominalTypeEquality(t, other)
 }
 
+func (*NominalType) isEntitlementMapElement() {}
+
 // OptionalType represents am optional variant of another type
 
 type OptionalType struct {

--- a/runtime/entitlements_test.go
+++ b/runtime/entitlements_test.go
@@ -934,16 +934,16 @@ func TestRuntimeCapabilityEntitlements(t *testing.T) {
 
 		test(t, `
           access(all)
-	      entitlement X
+          entitlement X
 
           access(all)
-	      entitlement Y
+          entitlement Y
 
           access(all)
-	      resource R {}
+          resource R {}
 
           access(all)
-	      fun main() {
+          fun main() {
                let account = getAuthAccount(0x1)
 
                let r <- create R()
@@ -952,13 +952,13 @@ func TestRuntimeCapabilityEntitlements(t *testing.T) {
                let issuedCap = account.capabilities.storage.issue<auth(X, Y) &R>(/storage/foo)
                account.capabilities.publish(issuedCap, at: /public/foo)
 
-	           let ref = account.capabilities.borrow<auth(X, Y) &R>(/public/foo)
+               let ref = account.capabilities.borrow<auth(X, Y) &R>(/public/foo)
                assert(ref != nil, message: "failed borrow")
 
                let ref2 = ref! as? auth(X, Y) &R
                assert(ref2 != nil, message: "failed cast")
-	      }
-	    `)
+          }
+        `)
 	})
 
 	t.Run("upcast runtime entitlements", func(t *testing.T) {
@@ -966,31 +966,31 @@ func TestRuntimeCapabilityEntitlements(t *testing.T) {
 
 		test(t, `
           access(all)
-	      entitlement X
+          entitlement X
 
           access(all)
-	      struct S {}
+          struct S {}
 
           access(all)
-	      fun main() {
+          fun main() {
               let account = getAuthAccount(0x1)
 
-	          let s = S()
-	          account.save(s, to: /storage/foo)
+              let s = S()
+              account.save(s, to: /storage/foo)
 
-	          let issuedCap = account.capabilities.storage.issue<auth(X) &S>(/storage/foo)
+              let issuedCap = account.capabilities.storage.issue<auth(X) &S>(/storage/foo)
               account.capabilities.publish(issuedCap, at: /public/foo)
 
-	          let cap: Capability<auth(X) &S> = account.capabilities.get<auth(X) &S>(/public/foo)!
+              let cap: Capability<auth(X) &S> = account.capabilities.get<auth(X) &S>(/public/foo)!
 
-	          let runtimeType = cap.getType()
+              let runtimeType = cap.getType()
 
-	          let upcastCap = cap as Capability<&S>
-	          let upcastRuntimeType = upcastCap.getType()
+              let upcastCap = cap as Capability<&S>
+              let upcastRuntimeType = upcastCap.getType()
 
-	          assert(runtimeType != upcastRuntimeType)
-	      }
-	    `)
+              assert(runtimeType != upcastRuntimeType)
+          }
+        `)
 	})
 
 	t.Run("upcast runtime type", func(t *testing.T) {
@@ -998,26 +998,26 @@ func TestRuntimeCapabilityEntitlements(t *testing.T) {
 
 		test(t, `
           access(all)
-	      struct S {}
+          struct S {}
 
           access(all)
-	      fun main() {
+          fun main() {
               let account = getAuthAccount(0x1)
 
-	          let s = S()
-	          account.save(s, to: /storage/foo)
+              let s = S()
+              account.save(s, to: /storage/foo)
 
-	          let issuedCap = account.capabilities.storage.issue<&S>(/storage/foo)
+              let issuedCap = account.capabilities.storage.issue<&S>(/storage/foo)
               account.capabilities.publish(issuedCap, at: /public/foo)
 
-	          let cap: Capability<&S> = account.capabilities.get<&S>(/public/foo)!
+              let cap: Capability<&S> = account.capabilities.get<&S>(/public/foo)!
 
-	          let runtimeType = cap.getType()
-	          let upcastCap = cap as Capability<&AnyStruct>
-	          let upcastRuntimeType = upcastCap.getType()
-	          assert(runtimeType == upcastRuntimeType)
-	       }
-	    `)
+              let runtimeType = cap.getType()
+              let upcastCap = cap as Capability<&AnyStruct>
+              let upcastRuntimeType = upcastCap.getType()
+              assert(runtimeType == upcastRuntimeType)
+           }
+        `)
 	})
 
 	t.Run("can check with supertype", func(t *testing.T) {
@@ -1025,28 +1025,28 @@ func TestRuntimeCapabilityEntitlements(t *testing.T) {
 
 		test(t, `
           access(all)
-	      entitlement X
+          entitlement X
 
           access(all)
-	      entitlement Y
+          entitlement Y
 
           access(all)
-	      resource R {}
+          resource R {}
 
           access(all)
-	      fun main() {
+          fun main() {
               let account = getAuthAccount(0x1)
 
-	          let r <- create R()
-	          account.save(<-r, to: /storage/foo)
+              let r <- create R()
+              account.save(<-r, to: /storage/foo)
 
-	          let issuedCap = account.capabilities.storage.issue<auth(X, Y) &R>(/storage/foo)
+              let issuedCap = account.capabilities.storage.issue<auth(X, Y) &R>(/storage/foo)
               account.capabilities.publish(issuedCap, at: /public/foo)
 
-	          let cap = account.capabilities.get<auth(X | Y) &R>(/public/foo)!
-	          assert(cap.check())
-	      }
-	    `)
+              let cap = account.capabilities.get<auth(X | Y) &R>(/public/foo)!
+              assert(cap.check())
+          }
+        `)
 	})
 
 	t.Run("cannot borrow with subtype", func(t *testing.T) {
@@ -1054,28 +1054,28 @@ func TestRuntimeCapabilityEntitlements(t *testing.T) {
 
 		test(t, `
           access(all)
-	      entitlement X
+          entitlement X
 
           access(all)
-	      entitlement Y
+          entitlement Y
 
           access(all)
-	      resource R {}
+          resource R {}
 
           access(all)
-	      fun main() {
+          fun main() {
               let account = getAuthAccount(0x1)
 
-	          let r <- create R()
-	          account.save(<-r, to: /storage/foo)
+              let r <- create R()
+              account.save(<-r, to: /storage/foo)
 
-	          let issuedCap = account.capabilities.storage.issue<auth(X) &R>(/storage/foo)
+              let issuedCap = account.capabilities.storage.issue<auth(X) &R>(/storage/foo)
               account.capabilities.publish(issuedCap, at: /public/foo)
 
-	          let ref = account.capabilities.borrow<auth(X, Y) &R>(/public/foo)
-	          assert(ref == nil)
-	      }
-	    `)
+              let ref = account.capabilities.borrow<auth(X, Y) &R>(/public/foo)
+              assert(ref == nil)
+          }
+        `)
 	})
 
 	t.Run("cannot get with subtype", func(t *testing.T) {
@@ -1083,28 +1083,28 @@ func TestRuntimeCapabilityEntitlements(t *testing.T) {
 
 		test(t, `
           access(all)
-	      entitlement X
+          entitlement X
 
           access(all)
-	      entitlement Y
+          entitlement Y
 
           access(all)
-	      resource R {}
+          resource R {}
 
           access(all)
-	      fun main() {
+          fun main() {
               let account = getAuthAccount(0x1)
 
-	          let r <- create R()
-	          account.save(<-r, to: /storage/foo)
+              let r <- create R()
+              account.save(<-r, to: /storage/foo)
 
-	          let issuedCap = account.capabilities.storage.issue<auth(X) &R>(/storage/foo)
+              let issuedCap = account.capabilities.storage.issue<auth(X) &R>(/storage/foo)
               account.capabilities.publish(issuedCap, at: /public/foo)
 
-	          let cap = account.capabilities.get<auth(X, Y) &R>(/public/foo)
-	          assert(cap == nil)
-	      }
-	    `)
+              let cap = account.capabilities.get<auth(X, Y) &R>(/public/foo)
+              assert(cap == nil)
+          }
+        `)
 	})
 }
 
@@ -1118,90 +1118,90 @@ func TestRuntimeImportedEntitlementMapInclude(t *testing.T) {
 	furtherUpstreamDeployTx := DeploymentTransaction("FurtherUpstream", []byte(`
         access(all) contract FurtherUpstream {
             access(all) entitlement X
-			access(all) entitlement Y
-			access(all) entitlement Z
+            access(all) entitlement Y
+            access(all) entitlement Z
 
-			access(all) entitlement mapping M {
-				X -> Y 
-				Y -> Z
-			}
+            access(all) entitlement mapping M {
+                X -> Y 
+                Y -> Z
+            }
         }
     `))
 
 	upstreamDeployTx := DeploymentTransaction("Upstream", []byte(`
-	    import FurtherUpstream from 0x1
+        import FurtherUpstream from 0x1
         access(all) contract Upstream {
             access(all) entitlement A
-			access(all) entitlement B
-			access(all) entitlement C
+            access(all) entitlement B
+            access(all) entitlement C
 
             access(all) entitlement mapping M {
-				include FurtherUpstream.M
+                include FurtherUpstream.M
 
-				A -> FurtherUpstream.Y 
-				FurtherUpstream.X -> B
-			}
+                A -> FurtherUpstream.Y 
+                FurtherUpstream.X -> B
+            }
         }
     `))
 
 	testDeployTx := DeploymentTransaction("Test", []byte(`
-		import FurtherUpstream from 0x1
-		import Upstream from 0x1
+        import FurtherUpstream from 0x1
+        import Upstream from 0x1
         access(all) contract Test {
-			access(all) entitlement E
-			access(all) entitlement F
-			access(all) entitlement G
+            access(all) entitlement E
+            access(all) entitlement F
+            access(all) entitlement G
 
-			access(all) entitlement mapping M {
-				include Upstream.M
+            access(all) entitlement mapping M {
+                include Upstream.M
 
-				E -> FurtherUpstream.Z
-				E -> G
-				F -> Upstream.C
-				Upstream.C -> FurtherUpstream.X
-			}
+                E -> FurtherUpstream.Z
+                E -> G
+                F -> Upstream.C
+                Upstream.C -> FurtherUpstream.X
+            }
 
-			access(all) struct S {
-				access(M) fun performMap(): auth(M) &Int {
-					return &1
-				}
-			} 
+            access(all) struct S {
+                access(M) fun performMap(): auth(M) &Int {
+                    return &1
+                }
+            } 
         }
     `))
 
 	script := []byte(`
         import Test from 0x1
         import Upstream from 0x1
-		import FurtherUpstream from 0x1
+        import FurtherUpstream from 0x1
 
         access(all) fun main() {
             let ref1 = &Test.S() as auth(FurtherUpstream.X, Upstream.C, Test.E) &Test.S
 
-			assert([ref1.performMap()].getType() == 
-			Type<[auth(
-				// from map of FurtherUpstream.X 
-				FurtherUpstream.Y, 
-				Upstream.B, 
-				// from map of Upstream.C
-				FurtherUpstream.X, 
-				// from map of Test.E 
-				FurtherUpstream.Z,
-				Test.G
-			) &Int]>(), message: "test 1 failed")
+            assert([ref1.performMap()].getType() == 
+            Type<[auth(
+                // from map of FurtherUpstream.X 
+                FurtherUpstream.Y, 
+                Upstream.B, 
+                // from map of Upstream.C
+                FurtherUpstream.X, 
+                // from map of Test.E 
+                FurtherUpstream.Z,
+                Test.G
+            ) &Int]>(), message: "test 1 failed")
 
-			let ref2 = &Test.S() as auth(FurtherUpstream.Y, Upstream.A, Test.F) &Test.S
-			assert([ref2.performMap()].getType() == 
-				Type<[auth(
-					// from map of FurtherUpstream.Y 
-					FurtherUpstream.Z, 
-					// from map of Upstream.A
-					FurtherUpstream.Y,
-					// from map of Test.F 
-					Upstream.C
-				) &Int]>(), message: "test 2 failed")
+            let ref2 = &Test.S() as auth(FurtherUpstream.Y, Upstream.A, Test.F) &Test.S
+            assert([ref2.performMap()].getType() == 
+                Type<[auth(
+                    // from map of FurtherUpstream.Y 
+                    FurtherUpstream.Z, 
+                    // from map of Upstream.A
+                    FurtherUpstream.Y,
+                    // from map of Test.F 
+                    Upstream.C
+                ) &Int]>(), message: "test 2 failed")
 
-			let ref3 = &Test.S() as auth(FurtherUpstream.Z, Upstream.B, Test.G) &Test.S
-          	assert([ref3.performMap()].getType() == Type<[&Int]>(), message: "test 3 failed")
+            let ref3 = &Test.S() as auth(FurtherUpstream.Z, Upstream.B, Test.G) &Test.S
+              assert([ref3.performMap()].getType() == Type<[&Int]>(), message: "test 3 failed")
         }
      `)
 

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -9289,6 +9289,115 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 		)
 	})
 
+	t.Run("mappings with includes", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := testParseDeclarations(` access(all) entitlement mapping M { 
+			include Y
+			A -> B
+			C -> D
+			include X
+		} `)
+		require.Empty(t, errs)
+
+		utils.AssertEqualWithDiff(t,
+			[]ast.Declaration{
+				&ast.EntitlementMappingDeclaration{
+					Access:    ast.AccessAll,
+					DocString: "",
+					Identifier: ast.Identifier{
+						Identifier: "M",
+						Pos: ast.Position{
+							Offset: 33,
+							Line:   1,
+							Column: 33,
+						},
+					},
+					Inclusions: []*ast.NominalType{
+						{
+							Identifier: ast.Identifier{
+								Identifier: "Y",
+								Pos: ast.Position{
+									Offset: 49,
+									Line:   2,
+									Column: 11,
+								},
+							},
+						},
+						{
+							Identifier: ast.Identifier{Identifier: "X",
+								Pos: ast.Position{
+									Offset: 82,
+									Line:   5,
+									Column: 11,
+								},
+							},
+						},
+					},
+					Associations: []*ast.EntitlementMapElement{
+						{
+							Input: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "A",
+									Pos: ast.Position{
+										Offset: 54,
+										Line:   3,
+										Column: 3,
+									},
+								},
+							},
+							Output: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "B",
+									Pos: ast.Position{
+										Offset: 59,
+										Line:   3,
+										Column: 8,
+									},
+								},
+							},
+						}, {
+							Input: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "C",
+									Pos: ast.Position{
+										Offset: 64,
+										Line:   4,
+										Column: 3,
+									},
+								},
+							},
+							Output: &ast.NominalType{
+								Identifier: ast.Identifier{
+									Identifier: "D",
+									Pos: ast.Position{
+										Offset: 69,
+										Line:   4,
+										Column: 8,
+									},
+								},
+							},
+						},
+					},
+					Range: ast.Range{
+						StartPos: ast.Position{
+							Offset: 1,
+							Line:   1,
+							Column: 1,
+						},
+						EndPos: ast.Position{
+							Offset: 86,
+							Line:   6,
+							Column: 2,
+						},
+					},
+				},
+			},
+			result,
+		)
+	})
+
 	t.Run("same line mappings", func(t *testing.T) {
 
 		t.Parallel()
@@ -9540,6 +9649,44 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 				&SyntaxError{
 					Message: "expected token '->'",
 					Pos:     ast.Position{Offset: 43, Line: 2, Column: 5},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("non-nominal include", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations(` access(all) entitlement mapping M { 
+			include &A
+		} `)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "expected nominal type, got &A",
+					Pos:     ast.Position{Offset: 51, Line: 2, Column: 13},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("include with arrow", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations(` access(all) entitlement mapping M { 
+			include -> B
+		} `)
+
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected token in type: '->'",
+					Pos:     ast.Position{Offset: 51, Line: 2, Column: 13},
 				},
 			},
 			errs,

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -9226,8 +9226,8 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 							Column: 33,
 						},
 					},
-					Associations: []*ast.EntitlementMapElement{
-						{
+					Elements: []ast.EntitlementMapElement{
+						&ast.EntitlementMapRelation{
 							Input: &ast.NominalType{
 								Identifier: ast.Identifier{
 									Identifier: "A",
@@ -9248,7 +9248,8 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 									},
 								},
 							},
-						}, {
+						},
+						&ast.EntitlementMapRelation{
 							Input: &ast.NominalType{
 								Identifier: ast.Identifier{
 									Identifier: "C",
@@ -9314,8 +9315,8 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 							Column: 33,
 						},
 					},
-					Inclusions: []*ast.NominalType{
-						{
+					Elements: []ast.EntitlementMapElement{
+						&ast.NominalType{
 							Identifier: ast.Identifier{
 								Identifier: "Y",
 								Pos: ast.Position{
@@ -9325,18 +9326,7 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 								},
 							},
 						},
-						{
-							Identifier: ast.Identifier{Identifier: "X",
-								Pos: ast.Position{
-									Offset: 82,
-									Line:   5,
-									Column: 11,
-								},
-							},
-						},
-					},
-					Associations: []*ast.EntitlementMapElement{
-						{
+						&ast.EntitlementMapRelation{
 							Input: &ast.NominalType{
 								Identifier: ast.Identifier{
 									Identifier: "A",
@@ -9357,7 +9347,8 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 									},
 								},
 							},
-						}, {
+						},
+						&ast.EntitlementMapRelation{
 							Input: &ast.NominalType{
 								Identifier: ast.Identifier{
 									Identifier: "C",
@@ -9376,6 +9367,15 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 										Line:   4,
 										Column: 8,
 									},
+								},
+							},
+						},
+						&ast.NominalType{
+							Identifier: ast.Identifier{Identifier: "X",
+								Pos: ast.Position{
+									Offset: 82,
+									Line:   5,
+									Column: 11,
 								},
 							},
 						},
@@ -9419,8 +9419,8 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 							Column: 33,
 						},
 					},
-					Associations: []*ast.EntitlementMapElement{
-						{
+					Elements: []ast.EntitlementMapElement{
+						&ast.EntitlementMapRelation{
 							Input: &ast.NominalType{
 								Identifier: ast.Identifier{
 									Identifier: "A",
@@ -9442,7 +9442,7 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 								},
 							},
 						},
-						{
+						&ast.EntitlementMapRelation{
 							Input: &ast.NominalType{
 								Identifier: ast.Identifier{
 									Identifier: "C",

--- a/runtime/parser/keyword.go
+++ b/runtime/parser/keyword.go
@@ -75,6 +75,7 @@ const (
 	KeywordNative      = "native"
 	KeywordPub         = "pub"
 	KeywordPriv        = "priv"
+	KeywordInclude     = "include"
 	// NOTE: ensure to update allKeywords when adding a new keyword
 )
 
@@ -128,6 +129,7 @@ var allKeywords = []string{
 	keywordAttachment,
 	keywordTo,
 	keywordRemove,
+	KeywordInclude,
 }
 
 // Keywords that can be used in identifier position without ambiguity.

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -330,6 +330,9 @@ func (e EntitlementMapAccess) entitlementImage(entitlement *EntitlementType) (ou
 			output.Set(relation.Output, struct{}{})
 		}
 	}
+	if e.Type.IncludesIdentity {
+		output.Set(entitlement, struct{}{})
+	}
 
 	e.images[entitlement] = output
 	return
@@ -349,9 +352,6 @@ func (e EntitlementMapAccess) Image(inputs Access, astRange func() ast.Range) (A
 		var err error = nil
 		inputs.Entitlements.Foreach(func(entitlement *EntitlementType, _ struct{}) {
 			entitlementImage := e.entitlementImage(entitlement)
-			if e.Type.IncludesIdentity {
-				entitlementImage.Set(entitlement, struct{}{})
-			}
 			// the image of a single element is always a conjunctive set; consider a mapping
 			// M defined as X -> Y, X -> Z, A -> B, A -> C. M(X) = Y & Z and M(A) = B & C.
 			// Thus M(X | A) would be ((Y & Z) | (B & C)), which is a disjunction of two conjunctions,

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -346,12 +346,12 @@ func (e EntitlementMapAccess) Image(inputs Access, astRange func() ast.Range) (A
 		return inputs, nil
 	case EntitlementSetAccess:
 		output := orderedmap.New[EntitlementOrderedSet](inputs.Entitlements.Len())
-		if e.Type.IncludesIdentity {
-			output.SetAll(inputs.Entitlements)
-		}
 		var err error = nil
 		inputs.Entitlements.Foreach(func(entitlement *EntitlementType, _ struct{}) {
 			entitlementImage := e.entitlementImage(entitlement)
+			if e.Type.IncludesIdentity {
+				entitlementImage.Set(entitlement, struct{}{})
+			}
 			// the image of a single element is always a conjunctive set; consider a mapping
 			// M defined as X -> Y, X -> Z, A -> B, A -> C. M(X) = Y & Z and M(A) = B & C.
 			// Thus M(X | A) would be ((Y & Z) | (B & C)), which is a disjunction of two conjunctions,

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -340,7 +340,7 @@ func (e EntitlementMapAccess) entitlementImage(entitlement *EntitlementType) (ou
 // arguments.
 func (e EntitlementMapAccess) Image(inputs Access, astRange func() ast.Range) (Access, error) {
 
-	if e.Type == IdentityMappingType {
+	if e.Type.IncludesIdentity {
 		return inputs, nil
 	}
 

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -340,16 +340,15 @@ func (e EntitlementMapAccess) entitlementImage(entitlement *EntitlementType) (ou
 // arguments.
 func (e EntitlementMapAccess) Image(inputs Access, astRange func() ast.Range) (Access, error) {
 
-	if e.Type.IncludesIdentity {
-		return inputs, nil
-	}
-
 	switch inputs := inputs.(type) {
 	// primitive access always passes trivially through the map
 	case PrimitiveAccess:
 		return inputs, nil
 	case EntitlementSetAccess:
 		output := orderedmap.New[EntitlementOrderedSet](inputs.Entitlements.Len())
+		if e.Type.IncludesIdentity {
+			output.SetAll(inputs.Entitlements)
+		}
 		var err error = nil
 		inputs.Entitlements.Foreach(func(entitlement *EntitlementType, _ struct{}) {
 			entitlementImage := e.entitlementImage(entitlement)

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -569,6 +569,7 @@ func (checker *Checker) resolveEntitlementMappingInclusions(
 ) {
 	mapType.resolveInclusions.Do(func() {
 		visitedMaps[mapType] = struct{}{}
+		defer delete(visitedMaps, mapType)
 
 		// track locally included maps to report duplicates, which are unrelated to cycles
 		// we do not enforce that no maps are duplicated across the entire chain; only the specific map definition
@@ -606,15 +607,16 @@ func (checker *Checker) resolveEntitlementMappingInclusions(
 			}
 
 			// recursively resolve the included map type's includes, skipping any that have already been resolved
-			includedDecl := checker.Elaboration.EntitlementMapTypeDeclaration(includedMapType)
-			checker.resolveEntitlementMappingInclusions(includedMapType, includedDecl, visitedMaps)
+			checker.resolveEntitlementMappingInclusions(
+				includedMapType,
+				checker.Elaboration.EntitlementMapTypeDeclaration(includedMapType),
+				visitedMaps,
+			)
 			mapType.Relations = append(mapType.Relations, includedMapType.Relations...)
 			mapType.IncludesIdentity = mapType.IncludesIdentity || includedMapType.IncludesIdentity
 
 			includedMaps[includedMapType] = struct{}{}
 		}
-
-		delete(visitedMaps, mapType)
 	})
 }
 

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -557,7 +557,7 @@ func (checker *Checker) declareEntitlementMappingType(declaration *ast.Entitleme
 	return entitlementMapType
 }
 
-// Recursively resolve the include statements of an entitlement mapping declaration, walking the "heirarchy" defined in this file
+// Recursively resolve the include statements of an entitlement mapping declaration, walking the "hierarchy" defined in this file
 // Uses the sync primitive stored in `resolveInclusions` to ensure each map type's includes are computed only once.
 // This assumes that any includes coming from imported files are necessarily already completely resolved, since that imported file
 // must necessarily already have been fully checked. Additionally, because import cycles are not allowed in Cadence, we only

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -519,9 +519,11 @@ func (checker *Checker) declareEntitlementMappingType(declaration *ast.Entitleme
 		)
 	}
 
-	entitlementRelations := make([]EntitlementRelation, 0, len(declaration.Associations))
+	relations := declaration.Relations()
 
-	for _, association := range declaration.Associations {
+	entitlementRelations := make([]EntitlementRelation, 0, len(relations))
+
+	for _, association := range relations {
 		input := checker.convertNominalType(association.Input)
 		inputEntitlement, isEntitlement := input.(*EntitlementType)
 

--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -571,6 +571,9 @@ func (checker *Checker) resolveEntitlementMappingInclusions(
 		visitedMaps[mapType] = struct{}{}
 
 		// track locally included maps to report duplicates, which are unrelated to cycles
+		// we do not enforce that no maps are duplicated across the entire chain; only the specific map definition
+		// currently being considered. This is to avoid reporting annoying errors when trying to include two
+		// maps defined elsewhere that may have small overlap.
 		includedMaps := map[*EntitlementMapType]struct{}{}
 
 		for _, inclusion := range declaration.Inclusions {
@@ -610,6 +613,8 @@ func (checker *Checker) resolveEntitlementMappingInclusions(
 
 			includedMaps[includedMapType] = struct{}{}
 		}
+
+		delete(visitedMaps, mapType)
 	})
 }
 

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -4353,6 +4353,36 @@ func (e *DuplicateEntitlementMappingInclusionError) EndPosition(common.MemoryGau
 	return e.EndPos
 }
 
+// CyclicEntitlementMappingError
+type CyclicEntitlementMappingError struct {
+	Map          *EntitlementMapType
+	IncludedType *EntitlementMapType
+	ast.Range
+}
+
+var _ SemanticError = &CyclicEntitlementMappingError{}
+var _ errors.UserError = &CyclicEntitlementMappingError{}
+
+func (*CyclicEntitlementMappingError) isSemanticError() {}
+
+func (*CyclicEntitlementMappingError) IsUserError() {}
+
+func (e *CyclicEntitlementMappingError) Error() string {
+	return fmt.Sprintf(
+		"including `%s` in the definition of `%s` creates a cyclical entitlement mapping",
+		e.IncludedType.QualifiedIdentifier(),
+		e.Map.QualifiedIdentifier(),
+	)
+}
+
+func (e *CyclicEntitlementMappingError) StartPosition() ast.Position {
+	return e.StartPos
+}
+
+func (e *CyclicEntitlementMappingError) EndPosition(common.MemoryGauge) ast.Position {
+	return e.EndPos
+}
+
 type DuplicateEntitlementRequirementError struct {
 	Entitlement *EntitlementType
 	ast.Range

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -4323,6 +4323,36 @@ func (e *InvalidEntitlementMappingInclusionError) EndPosition(common.MemoryGauge
 	return e.EndPos
 }
 
+// DuplicateEntitlementMappingInclusionError
+type DuplicateEntitlementMappingInclusionError struct {
+	Map          *EntitlementMapType
+	IncludedType *EntitlementMapType
+	ast.Range
+}
+
+var _ SemanticError = &DuplicateEntitlementMappingInclusionError{}
+var _ errors.UserError = &DuplicateEntitlementMappingInclusionError{}
+
+func (*DuplicateEntitlementMappingInclusionError) isSemanticError() {}
+
+func (*DuplicateEntitlementMappingInclusionError) IsUserError() {}
+
+func (e *DuplicateEntitlementMappingInclusionError) Error() string {
+	return fmt.Sprintf(
+		"`%s` is already included in the definition of `%s`",
+		e.IncludedType.QualifiedIdentifier(),
+		e.Map.QualifiedIdentifier(),
+	)
+}
+
+func (e *DuplicateEntitlementMappingInclusionError) StartPosition() ast.Position {
+	return e.StartPos
+}
+
+func (e *DuplicateEntitlementMappingInclusionError) EndPosition(common.MemoryGauge) ast.Position {
+	return e.EndPos
+}
+
 type DuplicateEntitlementRequirementError struct {
 	Entitlement *EntitlementType
 	ast.Range

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -4382,13 +4382,6 @@ func (e *InvalidEntitlementMappingInclusionError) Error() string {
 	)
 }
 
-func (e *InvalidEntitlementMappingInclusionError) StartPosition() ast.Position {
-	return e.StartPos
-}
-
-func (e *InvalidEntitlementMappingInclusionError) EndPosition(common.MemoryGauge) ast.Position {
-	return e.EndPos
-}
 
 // DuplicateEntitlementMappingInclusionError
 type DuplicateEntitlementMappingInclusionError struct {
@@ -4412,13 +4405,6 @@ func (e *DuplicateEntitlementMappingInclusionError) Error() string {
 	)
 }
 
-func (e *DuplicateEntitlementMappingInclusionError) StartPosition() ast.Position {
-	return e.StartPos
-}
-
-func (e *DuplicateEntitlementMappingInclusionError) EndPosition(common.MemoryGauge) ast.Position {
-	return e.EndPos
-}
 
 // CyclicEntitlementMappingError
 type CyclicEntitlementMappingError struct {
@@ -4440,14 +4426,6 @@ func (e *CyclicEntitlementMappingError) Error() string {
 		e.IncludedType.QualifiedIdentifier(),
 		e.Map.QualifiedIdentifier(),
 	)
-}
-
-func (e *CyclicEntitlementMappingError) StartPosition() ast.Position {
-	return e.StartPos
-}
-
-func (e *CyclicEntitlementMappingError) EndPosition(common.MemoryGauge) ast.Position {
-	return e.EndPos
 }
 
 type DuplicateEntitlementRequirementError struct {

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -4382,7 +4382,6 @@ func (e *InvalidEntitlementMappingInclusionError) Error() string {
 	)
 }
 
-
 // DuplicateEntitlementMappingInclusionError
 type DuplicateEntitlementMappingInclusionError struct {
 	Map          *EntitlementMapType
@@ -4404,7 +4403,6 @@ func (e *DuplicateEntitlementMappingInclusionError) Error() string {
 		e.Map.QualifiedIdentifier(),
 	)
 }
-
 
 // CyclicEntitlementMappingError
 type CyclicEntitlementMappingError struct {

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -4293,6 +4293,36 @@ func (e *InvalidMappedAuthorizationOutsideOfFieldError) EndPosition(common.Memor
 	return e.EndPos
 }
 
+// InvalidEntitlementMappingInclusionError
+type InvalidEntitlementMappingInclusionError struct {
+	Map          *EntitlementMapType
+	IncludedType Type
+	ast.Range
+}
+
+var _ SemanticError = &InvalidEntitlementMappingInclusionError{}
+var _ errors.UserError = &InvalidEntitlementMappingInclusionError{}
+
+func (*InvalidEntitlementMappingInclusionError) isSemanticError() {}
+
+func (*InvalidEntitlementMappingInclusionError) IsUserError() {}
+
+func (e *InvalidEntitlementMappingInclusionError) Error() string {
+	return fmt.Sprintf(
+		"cannot include `%s` in the definition of `%s`, as it is not an entitlement map",
+		e.IncludedType.QualifiedString(),
+		e.Map.QualifiedIdentifier(),
+	)
+}
+
+func (e *InvalidEntitlementMappingInclusionError) StartPosition() ast.Position {
+	return e.StartPos
+}
+
+func (e *InvalidEntitlementMappingInclusionError) EndPosition(common.MemoryGauge) ast.Position {
+	return e.EndPos
+}
+
 type DuplicateEntitlementRequirementError struct {
 	Entitlement *EntitlementType
 	ast.Range

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -4436,7 +4436,7 @@ func (*CyclicEntitlementMappingError) IsUserError() {}
 
 func (e *CyclicEntitlementMappingError) Error() string {
 	return fmt.Sprintf(
-		"including `%s` in the definition of `%s` creates a cyclical entitlement mapping",
+		"cannot include `%s` in the definition of `%s`, as it would create a cyclical mapping",
 		e.IncludedType.QualifiedIdentifier(),
 		e.Map.QualifiedIdentifier(),
 	)

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -7805,7 +7805,7 @@ func (t *EntitlementMapType) resolveEntitlementMappingInclusions(
 		// maps defined elsewhere that may have small overlap.
 		includedMaps := map[*EntitlementMapType]struct{}{}
 
-		for _, inclusion := range declaration.Inclusions {
+		for _, inclusion := range declaration.Inclusions() {
 
 			includedType := checker.convertNominalType(inclusion)
 			includedMapType, isEntitlementMapping := includedType.(*EntitlementMapType)

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3601,7 +3601,12 @@ func addToBaseActivation(ty Type) {
 	)
 }
 
-var IdentityMappingType = NewEntitlementMapType(nil, nil, "Identity")
+// The `Identity` mapping is an empty map that includes the Identity map
+var IdentityMappingType = func() *EntitlementMapType {
+	m := NewEntitlementMapType(nil, nil, "Identity")
+	m.IncludesIdentity = true
+	return m
+}()
 
 func baseTypeVariable(name string, ty Type) *Variable {
 	return &Variable{
@@ -7647,10 +7652,11 @@ type EntitlementRelation struct {
 }
 
 type EntitlementMapType struct {
-	Location      common.Location
-	containerType Type
-	Identifier    string
-	Relations     []EntitlementRelation
+	Location         common.Location
+	containerType    Type
+	Identifier       string
+	Relations        []EntitlementRelation
+	IncludesIdentity bool
 }
 
 var _ Type = &EntitlementMapType{}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3601,9 +3601,11 @@ func addToBaseActivation(ty Type) {
 	)
 }
 
-// The `Identity` mapping is an empty map that includes the Identity map
 const IdentityMappingIdentifier string = "Identity"
 
+// The `Identity` mapping is an empty map that includes the Identity map,
+// and is considered already "resolved" with regards to its (vacuously empty) inclusions.
+// defining it this way eliminates the need to do any special casing for its behavior
 var IdentityMappingType = func() *EntitlementMapType {
 	m := NewEntitlementMapType(nil, nil, IdentityMappingIdentifier)
 	m.IncludesIdentity = true

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3607,6 +3607,7 @@ const IdentityMappingIdentifier string = "Identity"
 var IdentityMappingType = func() *EntitlementMapType {
 	m := NewEntitlementMapType(nil, nil, IdentityMappingIdentifier)
 	m.IncludesIdentity = true
+	m.resolveInclusions.Do(func() {})
 	return m
 }()
 
@@ -7654,11 +7655,12 @@ type EntitlementRelation struct {
 }
 
 type EntitlementMapType struct {
-	Location         common.Location
-	containerType    Type
-	Identifier       string
-	Relations        []EntitlementRelation
-	IncludesIdentity bool
+	Location          common.Location
+	containerType     Type
+	Identifier        string
+	Relations         []EntitlementRelation
+	IncludesIdentity  bool
+	resolveInclusions sync.Once
 }
 
 var _ Type = &EntitlementMapType{}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3602,8 +3602,10 @@ func addToBaseActivation(ty Type) {
 }
 
 // The `Identity` mapping is an empty map that includes the Identity map
+const IdentityMappingIdentifier string = "Identity"
+
 var IdentityMappingType = func() *EntitlementMapType {
-	m := NewEntitlementMapType(nil, nil, "Identity")
+	m := NewEntitlementMapType(nil, nil, IdentityMappingIdentifier)
 	m.IncludesIdentity = true
 	return m
 }()

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -5859,7 +5859,7 @@ func TestCheckMappingDefinitionWithInclude(t *testing.T) {
 		require.ErrorAs(t, errors[0], &duplicateIncludeError)
 	})
 
-	t.Run("non duplicate across heirarchy", func(t *testing.T) {
+	t.Run("non duplicate across hierarchy", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := ParseAndCheck(t, `

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -5742,6 +5742,8 @@ func TestCheckMappingDefinitionWithInclude(t *testing.T) {
 			"struct interface X {}",
 			"resource X {}",
 			"resource interface X {}",
+			"contract X {}",
+			"contract interface X {}",
 			"enum X: Int {}",
 			"event X()",
 			"entitlement X",
@@ -6154,6 +6156,48 @@ func TestCheckGeneralIncludedMaps(t *testing.T) {
 			entitlement mapping A {
 				E -> F
 				F -> X
+			}
+
+			struct S {
+				access(M) fun foo(): auth(M) &Int {
+					return &3
+				}
+			}
+
+			fun foo(s: auth(E, X, F) &S): auth(F, Y, X) &Int {
+				return s.foo()
+			}
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("diamond include", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            entitlement E
+			entitlement F
+			entitlement X
+			entitlement Y
+
+			entitlement mapping M {
+				include B
+				include C
+			}
+
+			entitlement mapping C {
+				include A
+				X -> Y
+			}
+
+			entitlement mapping B {
+				F -> X
+				include A
+			}
+
+			entitlement mapping A {
+				E -> F
 			}
 
 			struct S {


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2643

This implements the proposed `include` syntax for entitlement mappings, allowing them to "inherit" relations from other maps for less code duplication. In general, `include A` for some entitlement map `A` is equivalent to just copy-pasting all of `A`s relations into the new map. 

Inclusions are all "resolved" when the map's definition is type checked, so that when they are "used" by a field or function access, all inherited relations are already present in the map, i.e. the hierarchy is flattened. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
