### PR TITLE
Make CodesAndPrograms public

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -29,24 +29,24 @@ type Context struct {
 	CoverageReport *CoverageReport
 }
 
-// codesAndPrograms collects the source code and AST for each location.
+// CodesAndPrograms collects the source code and AST for each location.
 // It is purely used for debugging: Both the codes and the programs
 // are provided in runtime errors.
-type codesAndPrograms struct {
+type CodesAndPrograms struct {
 	codes    map[Location][]byte
 	programs map[Location]*ast.Program
 }
 
-func (c codesAndPrograms) setCode(location Location, code []byte) {
+func (c CodesAndPrograms) setCode(location Location, code []byte) {
 	c.codes[location] = code
 }
 
-func (c codesAndPrograms) setProgram(location Location, program *ast.Program) {
+func (c CodesAndPrograms) setProgram(location Location, program *ast.Program) {
 	c.programs[location] = program
 }
 
-func newCodesAndPrograms() codesAndPrograms {
-	return codesAndPrograms{
+func NewCodesAndPrograms() CodesAndPrograms {
+	return CodesAndPrograms{
 		codes:    map[Location][]byte{},
 		programs: map[Location]*ast.Program{},
 	}

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -34,7 +34,7 @@ type interpreterContractFunctionExecutor struct {
 	result           cadence.Value
 	executeErr       error
 	preprocessErr    error
-	codesAndPrograms codesAndPrograms
+	codesAndPrograms CodesAndPrograms
 	runtime          *interpreterRuntime
 	storage          *Storage
 	contractLocation common.AddressLocation
@@ -90,7 +90,7 @@ func (executor *interpreterContractFunctionExecutor) preprocess() (err error) {
 	context := executor.context
 	location := context.Location
 
-	codesAndPrograms := newCodesAndPrograms()
+	codesAndPrograms := NewCodesAndPrograms()
 	executor.codesAndPrograms = codesAndPrograms
 
 	interpreterRuntime := executor.runtime

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -41,7 +41,7 @@ type Environment interface {
 	Declare(valueDeclaration stdlib.StandardLibraryValue)
 	Configure(
 		runtimeInterface Interface,
-		codesAndPrograms codesAndPrograms,
+		codesAndPrograms CodesAndPrograms,
 		storage *Storage,
 		coverageReport *CoverageReport,
 	)
@@ -73,7 +73,7 @@ type interpreterEnvironmentReconfigured struct {
 	runtimeInterface Interface
 	storage          *Storage
 	coverageReport   *CoverageReport
-	codesAndPrograms codesAndPrograms
+	codesAndPrograms CodesAndPrograms
 }
 
 type interpreterEnvironment struct {
@@ -186,7 +186,7 @@ func NewScriptInterpreterEnvironment(config Config) Environment {
 
 func (e *interpreterEnvironment) Configure(
 	runtimeInterface Interface,
-	codesAndPrograms codesAndPrograms,
+	codesAndPrograms CodesAndPrograms,
 	storage *Storage,
 	coverageReport *CoverageReport,
 ) {

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -37,7 +37,7 @@ type Error struct {
 	Programs map[Location]*ast.Program
 }
 
-func newError(err error, location Location, codesAndPrograms codesAndPrograms) Error {
+func newError(err error, location Location, codesAndPrograms CodesAndPrograms) Error {
 	return Error{
 		Err:      err,
 		Location: location,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -224,7 +224,7 @@ func (r *interpreterRuntime) Config() Config {
 	return r.defaultConfig
 }
 
-func (r *interpreterRuntime) Recover(onError func(Error), location Location, codesAndPrograms codesAndPrograms) {
+func (r *interpreterRuntime) Recover(onError func(Error), location Location, codesAndPrograms CodesAndPrograms) {
 	recovered := recover()
 	if recovered == nil {
 		return
@@ -234,7 +234,7 @@ func (r *interpreterRuntime) Recover(onError func(Error), location Location, cod
 	onError(err)
 }
 
-func getWrappedError(recovered any, location Location, codesAndPrograms codesAndPrograms) Error {
+func getWrappedError(recovered any, location Location, codesAndPrograms CodesAndPrograms) Error {
 	switch recovered := recovered.(type) {
 
 	// If the error is already a `runtime.Error`, then avoid redundant wrapping.
@@ -513,7 +513,7 @@ func (r *interpreterRuntime) ParseAndCheckProgram(
 ) {
 	location := context.Location
 
-	codesAndPrograms := newCodesAndPrograms()
+	codesAndPrograms := NewCodesAndPrograms()
 
 	defer r.Recover(
 		func(internalErr Error) {
@@ -552,7 +552,7 @@ func (r *interpreterRuntime) Storage(context Context) (*Storage, *interpreter.In
 
 	location := context.Location
 
-	codesAndPrograms := newCodesAndPrograms()
+	codesAndPrograms := NewCodesAndPrograms()
 
 	storage := NewStorage(context.Interface, context.Interface)
 
@@ -589,7 +589,7 @@ func (r *interpreterRuntime) ReadStored(
 ) {
 	location := context.Location
 
-	var codesAndPrograms codesAndPrograms
+	var codesAndPrograms CodesAndPrograms
 
 	defer r.Recover(
 		func(internalErr Error) {
@@ -635,7 +635,7 @@ func (r *interpreterRuntime) ReadLinked(
 ) {
 	location := context.Location
 
-	var codesAndPrograms codesAndPrograms
+	var codesAndPrograms CodesAndPrograms
 
 	defer r.Recover(
 		func(internalErr Error) {

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -29,7 +29,7 @@ import (
 type interpreterScriptExecutorPreparation struct {
 	environment            Environment
 	preprocessErr          error
-	codesAndPrograms       codesAndPrograms
+	codesAndPrograms       CodesAndPrograms
 	functionEntryPointType *sema.FunctionType
 	program                *interpreter.Program
 	storage                *Storage
@@ -92,7 +92,7 @@ func (executor *interpreterScriptExecutor) preprocess() (err error) {
 	location := context.Location
 	script := executor.script
 
-	codesAndPrograms := newCodesAndPrograms()
+	codesAndPrograms := NewCodesAndPrograms()
 	executor.codesAndPrograms = codesAndPrograms
 
 	interpreterRuntime := executor.runtime

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -28,7 +28,7 @@ import (
 )
 
 type interpreterTransactionExecutorPreparation struct {
-	codesAndPrograms codesAndPrograms
+	codesAndPrograms CodesAndPrograms
 	environment      Environment
 	preprocessErr    error
 	transactionType  *sema.TransactionType
@@ -92,7 +92,7 @@ func (executor *interpreterTransactionExecutor) preprocess() (err error) {
 	location := context.Location
 	script := executor.script
 
-	codesAndPrograms := newCodesAndPrograms()
+	codesAndPrograms := NewCodesAndPrograms()
 	executor.codesAndPrograms = codesAndPrograms
 
 	interpreterRuntime := executor.runtime


### PR DESCRIPTION

## Description

The reasoning behind this is so that interpreter environment `Configure` can be called publicly. Which I need int the migration: https://github.com/onflow/flow-go/pull/4633

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
