### PR TITLE
Avoid unnecessary static to sema type conversions for `Type` 

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -612,7 +612,7 @@ func (e UUIDUnavailableError) Error() string {
 
 // TypeLoadingError
 type TypeLoadingError struct {
-	TypeID common.TypeID
+	TypeID TypeID
 }
 
 var _ errors.UserError = TypeLoadingError{}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -180,7 +180,7 @@ type PublicAccountHandlerFunc func(
 type UUIDHandlerFunc func() (uint64, error)
 
 // CompositeTypeHandlerFunc is a function that loads composite types.
-type CompositeTypeHandlerFunc func(location common.Location, typeID common.TypeID) *sema.CompositeType
+type CompositeTypeHandlerFunc func(location common.Location, typeID TypeID) *sema.CompositeType
 
 // CompositeTypeCode contains the "prepared" / "callable" "code"
 // for the functions and the destructor of a composite
@@ -3061,7 +3061,7 @@ func lookupComposite(interpreter *Interpreter, typeID string) (*sema.CompositeTy
 		return nil, err
 	}
 
-	typ, err := interpreter.GetCompositeType(location, qualifiedIdentifier, common.TypeID(typeID))
+	typ, err := interpreter.GetCompositeType(location, qualifiedIdentifier, TypeID(typeID))
 	if err != nil {
 		return nil, err
 	}
@@ -4730,7 +4730,7 @@ func (interpreter *Interpreter) ConvertStaticToSemaType(staticType StaticType) (
 		func(location common.Location, qualifiedIdentifier string) (*sema.InterfaceType, error) {
 			return interpreter.getInterfaceType(location, qualifiedIdentifier)
 		},
-		func(location common.Location, qualifiedIdentifier string, typeID common.TypeID) (*sema.CompositeType, error) {
+		func(location common.Location, qualifiedIdentifier string, typeID TypeID) (*sema.CompositeType, error) {
 			return interpreter.GetCompositeType(location, qualifiedIdentifier, typeID)
 		},
 	)
@@ -4788,7 +4788,7 @@ func (interpreter *Interpreter) GetContractComposite(contractLocation common.Add
 func (interpreter *Interpreter) GetCompositeType(
 	location common.Location,
 	qualifiedIdentifier string,
-	typeID common.TypeID,
+	typeID TypeID,
 ) (*sema.CompositeType, error) {
 	var compositeType *sema.CompositeType
 	if location == nil {
@@ -4817,7 +4817,7 @@ func (interpreter *Interpreter) GetCompositeType(
 	}
 }
 
-func (interpreter *Interpreter) getUserCompositeType(location common.Location, typeID common.TypeID) *sema.CompositeType {
+func (interpreter *Interpreter) getUserCompositeType(location common.Location, typeID TypeID) *sema.CompositeType {
 	elaboration := interpreter.getElaboration(location)
 	if elaboration == nil {
 		return nil

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3108,7 +3108,7 @@ func init() {
 	// We assign this here because it depends on the interpreter, so this breaks the initialization cycle
 	defineBaseValue(
 		BaseActivation,
-		"DictionaryType",
+		sema.DictionaryTypeFunctionName,
 		NewUnmeteredHostFunctionValue(
 			sema.DictionaryTypeFunctionType,
 			func(invocation Invocation) Value {
@@ -3147,7 +3147,7 @@ func init() {
 
 	defineBaseValue(
 		BaseActivation,
-		"CompositeType",
+		sema.CompositeTypeFunctionName,
 		NewUnmeteredHostFunctionValue(
 			sema.CompositeTypeFunctionType,
 			func(invocation Invocation) Value {
@@ -3175,7 +3175,7 @@ func init() {
 
 	defineBaseValue(
 		BaseActivation,
-		"InterfaceType",
+		sema.InterfaceTypeFunctionName,
 		NewUnmeteredHostFunctionValue(
 			sema.InterfaceTypeFunctionType,
 			func(invocation Invocation) Value {
@@ -3203,7 +3203,7 @@ func init() {
 
 	defineBaseValue(
 		BaseActivation,
-		"FunctionType",
+		sema.FunctionTypeFunctionName,
 		NewUnmeteredHostFunctionValue(
 			sema.FunctionTypeFunctionType,
 			func(invocation Invocation) Value {
@@ -3250,7 +3250,7 @@ func init() {
 
 	defineBaseValue(
 		BaseActivation,
-		"RestrictedType",
+		sema.RestrictedTypeFunctionName,
 		NewUnmeteredHostFunctionValue(
 			sema.RestrictedTypeFunctionType,
 			RestrictedTypeFunction,
@@ -3428,7 +3428,7 @@ type runtimeTypeConstructor struct {
 // Constructor functions are stateless functions. Hence they can be re-used across interpreters.
 var runtimeTypeConstructors = []runtimeTypeConstructor{
 	{
-		name: "OptionalType",
+		name: sema.OptionalTypeFunctionName,
 		converter: NewUnmeteredHostFunctionValue(
 			sema.OptionalTypeFunctionType,
 			func(invocation Invocation) Value {
@@ -3448,7 +3448,7 @@ var runtimeTypeConstructors = []runtimeTypeConstructor{
 		),
 	},
 	{
-		name: "VariableSizedArrayType",
+		name: sema.VariableSizedArrayTypeFunctionName,
 		converter: NewUnmeteredHostFunctionValue(
 			sema.VariableSizedArrayTypeFunctionType,
 			func(invocation Invocation) Value {
@@ -3469,7 +3469,7 @@ var runtimeTypeConstructors = []runtimeTypeConstructor{
 		),
 	},
 	{
-		name: "ConstantSizedArrayType",
+		name: sema.ConstantSizedArrayTypeFunctionName,
 		converter: NewUnmeteredHostFunctionValue(
 			sema.ConstantSizedArrayTypeFunctionType,
 			func(invocation Invocation) Value {
@@ -3495,7 +3495,7 @@ var runtimeTypeConstructors = []runtimeTypeConstructor{
 		),
 	},
 	{
-		name: "ReferenceType",
+		name: sema.ReferenceTypeFunctionName,
 		converter: NewUnmeteredHostFunctionValue(
 			sema.ReferenceTypeFunctionType,
 			func(invocation Invocation) Value {
@@ -3522,7 +3522,7 @@ var runtimeTypeConstructors = []runtimeTypeConstructor{
 		),
 	},
 	{
-		name: "CapabilityType",
+		name: sema.CapabilityTypeFunctionName,
 		converter: NewUnmeteredHostFunctionValue(
 			sema.CapabilityTypeFunctionType,
 			func(invocation Invocation) Value {

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -35,31 +35,11 @@ var PrimitiveStaticTypes = _PrimitiveStaticType_map
 
 type PrimitiveStaticType uint
 
-func (t PrimitiveStaticType) Equal(other StaticType) bool {
-	otherPrimitiveType, ok := other.(PrimitiveStaticType)
-	if !ok {
-		return false
-	}
-
-	return t == otherPrimitiveType
-}
+var _ StaticType = PrimitiveStaticType(0)
 
 const primitiveStaticTypePrefix = "PrimitiveStaticType"
 
 var primitiveStaticTypeConstantLength = len(primitiveStaticTypePrefix) + 2 // + 2 for parentheses
-
-func (t PrimitiveStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
-	if str, ok := PrimitiveStaticTypes[t]; ok {
-		common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(len(str)))
-		return str
-	}
-
-	memoryAmount := primitiveStaticTypeConstantLength + OverEstimateIntStringLength(int(t))
-	common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(memoryAmount))
-
-	rawValueStr := strconv.FormatInt(int64(t), 10)
-	return fmt.Sprintf("%s(%s)", primitiveStaticTypePrefix, rawValueStr)
-}
 
 func NewPrimitiveStaticType(
 	memoryGauge common.MemoryGauge,
@@ -300,8 +280,34 @@ func (t PrimitiveStaticType) elementSize() uint {
 	return UnknownElementSize
 }
 
-func (i PrimitiveStaticType) SemaType() sema.Type {
-	switch i {
+func (t PrimitiveStaticType) Equal(other StaticType) bool {
+	otherPrimitiveType, ok := other.(PrimitiveStaticType)
+	if !ok {
+		return false
+	}
+
+	return t == otherPrimitiveType
+}
+
+func (t PrimitiveStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
+	if str, ok := PrimitiveStaticTypes[t]; ok {
+		common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(len(str)))
+		return str
+	}
+
+	memoryAmount := primitiveStaticTypeConstantLength + OverEstimateIntStringLength(int(t))
+	common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(memoryAmount))
+
+	rawValueStr := strconv.FormatInt(int64(t), 10)
+	return fmt.Sprintf("%s(%s)", primitiveStaticTypePrefix, rawValueStr)
+}
+
+func (t PrimitiveStaticType) ID() TypeID {
+	return t.SemaType().ID()
+}
+
+func (t PrimitiveStaticType) SemaType() sema.Type {
+	switch t {
 	case PrimitiveStaticTypeVoid:
 		return sema.VoidType
 
@@ -454,7 +460,7 @@ func (i PrimitiveStaticType) SemaType() sema.Type {
 	case PrimitiveStaticTypePublicAccountCapabilities:
 		return sema.PublicAccountCapabilitiesType
 	default:
-		panic(errors.NewUnexpectedError("missing case for %s", i))
+		panic(errors.NewUnexpectedError("missing case for %s", t))
 	}
 }
 

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -1021,7 +1021,7 @@ func TestStaticTypeConversion(t *testing.T) {
 		getComposite func(
 			location common.Location,
 			qualifiedIdentifier string,
-			typeID common.TypeID,
+			typeID TypeID,
 		) (
 			*sema.CompositeType,
 			error,
@@ -1409,7 +1409,7 @@ func TestStaticTypeConversion(t *testing.T) {
 			name:       "Composite",
 			semaType:   testCompositeSemaType,
 			staticType: testCompositeStaticType,
-			getComposite: func(location common.Location, qualifiedIdentifier string, typeID common.TypeID) (*sema.CompositeType, error) {
+			getComposite: func(location common.Location, qualifiedIdentifier string, typeID TypeID) (*sema.CompositeType, error) {
 				require.Equal(t, testLocation, location)
 				require.Equal(t, testCompositeQualifiedIdentifier, qualifiedIdentifier)
 				return testCompositeSemaType, nil
@@ -1447,7 +1447,7 @@ func TestStaticTypeConversion(t *testing.T) {
 
 			getComposite := test.getComposite
 			if getComposite == nil {
-				getComposite = func(_ common.Location, _ string, _ common.TypeID) (*sema.CompositeType, error) {
+				getComposite = func(_ common.Location, _ string, _ TypeID) (*sema.CompositeType, error) {
 					require.FailNow(t, "getComposite should not be called")
 					return nil, nil
 				}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -16243,7 +16243,7 @@ type CompositeValue struct {
 	NestedVariables map[string]*Variable
 	Functions       map[string]FunctionValue
 	dictionary      *atree.OrderedMap
-	typeID          common.TypeID
+	typeID          TypeID
 
 	// attachments also have a reference to their base value. This field is set in three cases:
 	// 1) when an attachment `A` is accessed off `v` using `v[A]`, this is set to `&v`
@@ -16993,12 +16993,12 @@ func (v *CompositeValue) HashInput(interpreter *Interpreter, locationRange Locat
 	panic(errors.NewUnreachableError())
 }
 
-func (v *CompositeValue) TypeID() common.TypeID {
+func (v *CompositeValue) TypeID() TypeID {
 	if v.typeID == "" {
 		location := v.Location
 		qualifiedIdentifier := v.QualifiedIdentifier
 		if location == nil {
-			return common.TypeID(qualifiedIdentifier)
+			return TypeID(qualifiedIdentifier)
 		}
 		v.typeID = location.TypeID(nil, qualifiedIdentifier)
 	}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -518,7 +518,7 @@ func (TypeValue) ChildStorables() []atree.Storable {
 // - HashInputTypeType (1 byte)
 // - type id (n bytes)
 func (v TypeValue) HashInput(interpreter *Interpreter, _ LocationRange, scratch []byte) []byte {
-	typeID := interpreter.MustConvertStaticToSemaType(v.Type).ID()
+	typeID := v.Type.ID()
 
 	length := 1 + len(typeID)
 	var buf []byte

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -400,7 +400,7 @@ func (v TypeValue) GetMember(interpreter *Interpreter, _ LocationRange, name str
 		var typeID string
 		staticType := v.Type
 		if staticType != nil {
-			typeID = string(interpreter.MustConvertStaticToSemaType(staticType).ID())
+			typeID = string(staticType.ID())
 		}
 		memoryUsage := common.MemoryUsage{
 			Kind:   common.MemoryKindStringValue,

--- a/runtime/sema/runtime_type_constructors.go
+++ b/runtime/sema/runtime_type_constructors.go
@@ -24,6 +24,8 @@ type RuntimeTypeConstructor struct {
 	DocString string
 }
 
+const OptionalTypeFunctionName = "OptionalType"
+
 var OptionalTypeFunctionType = &FunctionType{
 	Parameters: []Parameter{
 		{
@@ -35,6 +37,8 @@ var OptionalTypeFunctionType = &FunctionType{
 	ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
 }
 
+const VariableSizedArrayTypeFunctionName = "VariableSizedArrayType"
+
 var VariableSizedArrayTypeFunctionType = &FunctionType{
 	Parameters: []Parameter{
 		{
@@ -45,6 +49,8 @@ var VariableSizedArrayTypeFunctionType = &FunctionType{
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
 }
+
+const ConstantSizedArrayTypeFunctionName = "ConstantSizedArrayType"
 
 var ConstantSizedArrayTypeFunctionType = &FunctionType{
 	Parameters: []Parameter{
@@ -59,6 +65,8 @@ var ConstantSizedArrayTypeFunctionType = &FunctionType{
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
 }
+
+const DictionaryTypeFunctionName = "DictionaryType"
 
 var DictionaryTypeFunctionType = &FunctionType{
 	Parameters: []Parameter{
@@ -78,6 +86,8 @@ var DictionaryTypeFunctionType = &FunctionType{
 	),
 }
 
+const CompositeTypeFunctionName = "CompositeType"
+
 var CompositeTypeFunctionType = &FunctionType{
 	Parameters: []Parameter{
 		{
@@ -93,6 +103,8 @@ var CompositeTypeFunctionType = &FunctionType{
 	),
 }
 
+const InterfaceTypeFunctionName = "InterfaceType"
+
 var InterfaceTypeFunctionType = &FunctionType{
 	Parameters: []Parameter{
 		{
@@ -107,6 +119,8 @@ var InterfaceTypeFunctionType = &FunctionType{
 		},
 	),
 }
+
+const FunctionTypeFunctionName = "FunctionType"
 
 var FunctionTypeFunctionType = &FunctionType{
 	Parameters: []Parameter{
@@ -125,6 +139,8 @@ var FunctionTypeFunctionType = &FunctionType{
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
 }
+
+const RestrictedTypeFunctionName = "RestrictedType"
 
 var RestrictedTypeFunctionType = &FunctionType{
 	Parameters: []Parameter{
@@ -152,6 +168,8 @@ var RestrictedTypeFunctionType = &FunctionType{
 	),
 }
 
+const ReferenceTypeFunctionName = "ReferenceType"
+
 var ReferenceTypeFunctionType = &FunctionType{
 	Parameters: []Parameter{
 		{
@@ -165,6 +183,8 @@ var ReferenceTypeFunctionType = &FunctionType{
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(MetaType),
 }
+
+const CapabilityTypeFunctionName = "CapabilityType"
 
 var CapabilityTypeFunctionType = &FunctionType{
 	Parameters: []Parameter{
@@ -183,65 +203,65 @@ var CapabilityTypeFunctionType = &FunctionType{
 
 var runtimeTypeConstructors = []*RuntimeTypeConstructor{
 	{
-		Name:      "OptionalType",
+		Name:      OptionalTypeFunctionName,
 		Value:     OptionalTypeFunctionType,
 		DocString: "Creates a run-time type representing an optional version of the given run-time type.",
 	},
 
 	{
-		Name:      "VariableSizedArrayType",
+		Name:      VariableSizedArrayTypeFunctionName,
 		Value:     VariableSizedArrayTypeFunctionType,
 		DocString: "Creates a run-time type representing a variable-sized array type of the given run-time type.",
 	},
 
 	{
-		Name:      "ConstantSizedArrayType",
+		Name:      ConstantSizedArrayTypeFunctionName,
 		Value:     ConstantSizedArrayTypeFunctionType,
-		DocString: "Creates a run-time type representing a constant-sized array type of the given run-time type with the specifized size.",
+		DocString: "Creates a run-time type representing a constant-sized array type of the given run-time type with the specified size.",
 	},
 
 	{
-		Name:  "DictionaryType",
+		Name:  DictionaryTypeFunctionName,
 		Value: DictionaryTypeFunctionType,
 		DocString: `Creates a run-time type representing a dictionary type of the given run-time key and value types. 
 		Returns nil if the key type is not a valid dictionary key.`,
 	},
 
 	{
-		Name:  "CompositeType",
+		Name:  CompositeTypeFunctionName,
 		Value: CompositeTypeFunctionType,
 		DocString: `Creates a run-time type representing the composite type associated with the given type identifier. 
 		Returns nil if the identifier does not correspond to any composite type.`,
 	},
 
 	{
-		Name:  "InterfaceType",
+		Name:  InterfaceTypeFunctionName,
 		Value: InterfaceTypeFunctionType,
 		DocString: `Creates a run-time type representing the interface type associated with the given type identifier. 
 		Returns nil if the identifier does not correspond to any interface type.`,
 	},
 
 	{
-		Name:      "FunctionType",
+		Name:      FunctionTypeFunctionName,
 		Value:     FunctionTypeFunctionType,
 		DocString: "Creates a run-time type representing a function type associated with the given parameters and return type.",
 	},
 
 	{
-		Name:      "ReferenceType",
+		Name:      ReferenceTypeFunctionName,
 		Value:     ReferenceTypeFunctionType,
 		DocString: "Creates a run-time type representing a reference type of the given type, with authorization provided by the first argument.",
 	},
 
 	{
-		Name:  "RestrictedType",
+		Name:  RestrictedTypeFunctionName,
 		Value: RestrictedTypeFunctionType,
 		DocString: `Creates a run-time type representing a restricted type of the first argument, restricted by the interface identifiers in the second argument. 
 		Returns nil if the restriction is not valid.`,
 	},
 
 	{
-		Name:      "CapabilityType",
+		Name:      CapabilityTypeFunctionName,
 		Value:     CapabilityTypeFunctionType,
 		DocString: "Creates a run-time type representing a capability type of the given reference type. Returns nil if the type is not a reference.",
 	},

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -574,12 +574,12 @@ func (t *OptionalType) QualifiedString() string {
 	return fmt.Sprintf("%s?", t.Type.QualifiedString())
 }
 
+func OptionalTypeID(elementTypeID TypeID) TypeID {
+	return TypeID(fmt.Sprintf("%s?", elementTypeID))
+}
+
 func (t *OptionalType) ID() TypeID {
-	var id string
-	if t.Type != nil {
-		id = string(t.Type.ID())
-	}
-	return TypeID(fmt.Sprintf("%s?", id))
+	return OptionalTypeID(t.Type.ID())
 }
 
 func (t *OptionalType) Equal(other Type) bool {
@@ -2404,8 +2404,12 @@ func (t *VariableSizedType) QualifiedString() string {
 	return fmt.Sprintf("[%s]", t.Type.QualifiedString())
 }
 
+func VariableSizedTypeID(elementTypeID TypeID) TypeID {
+	return TypeID(fmt.Sprintf("[%s]", elementTypeID))
+}
+
 func (t *VariableSizedType) ID() TypeID {
-	return TypeID(fmt.Sprintf("[%s]", t.Type.ID()))
+	return VariableSizedTypeID(t.Type.ID())
 }
 
 func (t *VariableSizedType) Equal(other Type) bool {
@@ -2549,8 +2553,12 @@ func (t *ConstantSizedType) QualifiedString() string {
 	return fmt.Sprintf("[%s; %d]", t.Type.QualifiedString(), t.Size)
 }
 
+func ConstantSizedTypeID(elementTypeID TypeID, size int64) TypeID {
+	return TypeID(fmt.Sprintf("[%s;%d]", elementTypeID, size))
+}
+
 func (t *ConstantSizedType) ID() TypeID {
-	return TypeID(fmt.Sprintf("[%s;%d]", t.Type.ID(), t.Size))
+	return ConstantSizedTypeID(t.Type.ID(), t.Size)
 }
 
 func (t *ConstantSizedType) Equal(other Type) bool {
@@ -4839,12 +4847,16 @@ func (t *DictionaryType) QualifiedString() string {
 	)
 }
 
-func (t *DictionaryType) ID() TypeID {
+func DictionaryTypeID(keyTypeID TypeID, valueTypeID TypeID) TypeID {
 	return TypeID(fmt.Sprintf(
 		"{%s:%s}",
-		t.KeyType.ID(),
-		t.ValueType.ID(),
+		keyTypeID,
+		valueTypeID,
 	))
+}
+
+func (t *DictionaryType) ID() TypeID {
+	return DictionaryTypeID(t.KeyType.ID(), t.ValueType.ID())
 }
 
 func (t *DictionaryType) Equal(other Type) bool {

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -303,6 +303,33 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			inter.Globals.Get("identifier").GetValue(),
 		)
 	})
+
+	t.Run("no loading of program", func(t *testing.T) {
+
+		t.Parallel()
+
+		// TypeValue.GetMember for `identifier` should not load the program
+
+		inter := parseCheckAndInterpret(t, `
+           fun test(_ type: Type): String {
+               return type.identifier
+           }
+        `)
+
+		location := common.NewAddressLocation(nil, common.MustBytesToAddress([]byte{0x1}), "Foo")
+		staticType := interpreter.NewCompositeStaticTypeComputeTypeID(nil, location, "Foo.Bar")
+		typeValue := interpreter.NewUnmeteredTypeValue(staticType)
+
+		result, err := inter.Invoke("test", typeValue)
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredStringValue("A.0000000000000001.Foo.Bar"),
+			result,
+		)
+	})
 }
 
 func TestInterpretIsInstance(t *testing.T) {

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -458,7 +458,7 @@ func TestInterpretIsInstance(t *testing.T) {
 	}
 }
 
-func TestInterpretIsSubtype(t *testing.T) {
+func TestInterpretMetaTypeIsSubtype(t *testing.T) {
 
 	t.Parallel()
 
@@ -823,4 +823,25 @@ func TestInterpretGetType(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestInterpretMetaTypeHashInput(t *testing.T) {
+
+	t.Parallel()
+
+	// TypeValue.HashInput should not load the program
+
+	inter := parseCheckAndInterpret(t, `
+           fun test(_ type: Type) {
+               {type: 1}
+           }
+        `)
+
+	location := common.NewAddressLocation(nil, common.MustBytesToAddress([]byte{0x1}), "Foo")
+	staticType := interpreter.NewCompositeStaticTypeComputeTypeID(nil, location, "Foo.Bar")
+	typeValue := interpreter.NewUnmeteredTypeValue(staticType)
+
+	_, err := inter.Invoke("test", typeValue)
+	require.NoError(t, err)
+
 }


### PR DESCRIPTION
Closes #2748 

## Description

`interpreter.StaticType` currently does not expose a mechanism to get the type's ID.

`interpreter.TypeValue` needs to get a type ID in two places:
- For the `identifier` field
- For the `HashInput` function, e.g. used when the type value is used as a dictionary key

`interpreter.TypeValue` calculated the type ID by converting the static type to a sema type. This causes the whole program to be loaded, which is inefficient or even unavailable (e.g. during a state migration).

Introduce `func StaticType.ID() TypeID` to allow getting the type ID for a static type without overhead, and remove the unnecessary conversions from static to sema type.

cc @janezpodhostnik 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
