### PR TITLE
Improve composite and interface static types

### DIFF
--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -845,7 +845,7 @@ func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 		return jsonNominalType{
 			Kind:         "Struct",
 			Type:         "",
-			TypeID:       typeId(typ.Location, typ.QualifiedIdentifier),
+			TypeID:       string(common.NewTypeIDFromQualifiedName(nil, typ.Location, typ.QualifiedIdentifier)),
 			Fields:       prepareFields(typ.Fields, results),
 			Initializers: prepareInitializers(typ.Initializers, results),
 		}
@@ -853,7 +853,7 @@ func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 		return jsonNominalType{
 			Kind:         "Resource",
 			Type:         "",
-			TypeID:       typeId(typ.Location, typ.QualifiedIdentifier),
+			TypeID:       string(common.NewTypeIDFromQualifiedName(nil, typ.Location, typ.QualifiedIdentifier)),
 			Fields:       prepareFields(typ.Fields, results),
 			Initializers: prepareInitializers(typ.Initializers, results),
 		}
@@ -861,7 +861,7 @@ func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 		return jsonNominalType{
 			Kind:         "Event",
 			Type:         "",
-			TypeID:       typeId(typ.Location, typ.QualifiedIdentifier),
+			TypeID:       string(common.NewTypeIDFromQualifiedName(nil, typ.Location, typ.QualifiedIdentifier)),
 			Fields:       prepareFields(typ.Fields, results),
 			Initializers: [][]jsonParameterType{prepareParameters(typ.Initializer, results)},
 		}
@@ -869,7 +869,7 @@ func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 		return jsonNominalType{
 			Kind:         "Contract",
 			Type:         "",
-			TypeID:       typeId(typ.Location, typ.QualifiedIdentifier),
+			TypeID:       string(common.NewTypeIDFromQualifiedName(nil, typ.Location, typ.QualifiedIdentifier)),
 			Fields:       prepareFields(typ.Fields, results),
 			Initializers: prepareInitializers(typ.Initializers, results),
 		}
@@ -877,7 +877,7 @@ func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 		return jsonNominalType{
 			Kind:         "StructInterface",
 			Type:         "",
-			TypeID:       typeId(typ.Location, typ.QualifiedIdentifier),
+			TypeID:       string(common.NewTypeIDFromQualifiedName(nil, typ.Location, typ.QualifiedIdentifier)),
 			Fields:       prepareFields(typ.Fields, results),
 			Initializers: prepareInitializers(typ.Initializers, results),
 		}
@@ -885,7 +885,7 @@ func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 		return jsonNominalType{
 			Kind:         "ResourceInterface",
 			Type:         "",
-			TypeID:       typeId(typ.Location, typ.QualifiedIdentifier),
+			TypeID:       string(common.NewTypeIDFromQualifiedName(nil, typ.Location, typ.QualifiedIdentifier)),
 			Fields:       prepareFields(typ.Fields, results),
 			Initializers: prepareInitializers(typ.Initializers, results),
 		}
@@ -893,7 +893,7 @@ func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 		return jsonNominalType{
 			Kind:         "ContractInterface",
 			Type:         "",
-			TypeID:       typeId(typ.Location, typ.QualifiedIdentifier),
+			TypeID:       string(common.NewTypeIDFromQualifiedName(nil, typ.Location, typ.QualifiedIdentifier)),
 			Fields:       prepareFields(typ.Fields, results),
 			Initializers: prepareInitializers(typ.Initializers, results),
 		}
@@ -930,7 +930,7 @@ func prepareType(typ cadence.Type, results typePreparationResults) jsonValue {
 	case *cadence.EnumType:
 		return jsonNominalType{
 			Kind:         "Enum",
-			TypeID:       typeId(typ.Location, typ.QualifiedIdentifier),
+			TypeID:       string(common.NewTypeIDFromQualifiedName(nil, typ.Location, typ.QualifiedIdentifier)),
 			Fields:       prepareFields(typ.Fields, results),
 			Initializers: prepareInitializers(typ.Initializers, results),
 			Type:         prepareType(typ.RawType, results),
@@ -1033,12 +1033,4 @@ func encodeUFix64(v uint64) string {
 		integer,
 		fraction,
 	)
-}
-
-func typeId(location common.Location, identifier string) string {
-	if location == nil {
-		return identifier
-	}
-
-	return string(location.TypeID(nil, identifier))
 }

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -518,7 +518,7 @@ func exportCapabilityType(
 }
 
 func importInterfaceType(memoryGauge common.MemoryGauge, t cadence.InterfaceType) interpreter.InterfaceStaticType {
-	return interpreter.NewInterfaceStaticType(
+	return interpreter.NewInterfaceStaticTypeComputeTypeID(
 		memoryGauge,
 		t.InterfaceTypeLocation(),
 		t.InterfaceTypeQualifiedIdentifier(),
@@ -526,11 +526,10 @@ func importInterfaceType(memoryGauge common.MemoryGauge, t cadence.InterfaceType
 }
 
 func importCompositeType(memoryGauge common.MemoryGauge, t cadence.CompositeType) interpreter.CompositeStaticType {
-	return interpreter.NewCompositeStaticType(
+	return interpreter.NewCompositeStaticTypeComputeTypeID(
 		memoryGauge,
 		t.CompositeTypeLocation(),
 		t.CompositeTypeQualifiedIdentifier(),
-		"", // intentionally empty
 	)
 }
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1241,10 +1241,7 @@ func TestImportRuntimeType(t *testing.T) {
 				Location:            TestLocation,
 				QualifiedIdentifier: "S",
 			},
-			expected: interpreter.CompositeStaticType{
-				Location:            TestLocation,
-				QualifiedIdentifier: "S",
-			},
+			expected: interpreter.NewCompositeStaticTypeComputeTypeID(nil, TestLocation, "S"),
 		},
 		{
 			label: "Resource",
@@ -1252,10 +1249,7 @@ func TestImportRuntimeType(t *testing.T) {
 				Location:            TestLocation,
 				QualifiedIdentifier: "S",
 			},
-			expected: interpreter.CompositeStaticType{
-				Location:            TestLocation,
-				QualifiedIdentifier: "S",
-			},
+			expected: interpreter.NewCompositeStaticTypeComputeTypeID(nil, TestLocation, "S"),
 		},
 		{
 			label: "Contract",
@@ -1263,10 +1257,7 @@ func TestImportRuntimeType(t *testing.T) {
 				Location:            TestLocation,
 				QualifiedIdentifier: "S",
 			},
-			expected: interpreter.CompositeStaticType{
-				Location:            TestLocation,
-				QualifiedIdentifier: "S",
-			},
+			expected: interpreter.NewCompositeStaticTypeComputeTypeID(nil, TestLocation, "S"),
 		},
 		{
 			label: "Event",
@@ -1274,10 +1265,7 @@ func TestImportRuntimeType(t *testing.T) {
 				Location:            TestLocation,
 				QualifiedIdentifier: "S",
 			},
-			expected: interpreter.CompositeStaticType{
-				Location:            TestLocation,
-				QualifiedIdentifier: "S",
-			},
+			expected: interpreter.NewCompositeStaticTypeComputeTypeID(nil, TestLocation, "S"),
 		},
 		{
 			label: "Enum",
@@ -1285,10 +1273,7 @@ func TestImportRuntimeType(t *testing.T) {
 				Location:            TestLocation,
 				QualifiedIdentifier: "S",
 			},
-			expected: interpreter.CompositeStaticType{
-				Location:            TestLocation,
-				QualifiedIdentifier: "S",
-			},
+			expected: interpreter.NewCompositeStaticTypeComputeTypeID(nil, TestLocation, "S"),
 		},
 		{
 			label: "StructInterface",
@@ -1296,10 +1281,7 @@ func TestImportRuntimeType(t *testing.T) {
 				Location:            TestLocation,
 				QualifiedIdentifier: "S",
 			},
-			expected: interpreter.InterfaceStaticType{
-				Location:            TestLocation,
-				QualifiedIdentifier: "S",
-			},
+			expected: interpreter.NewInterfaceStaticTypeComputeTypeID(nil, TestLocation, "S"),
 		},
 		{
 			label: "ResourceInterface",
@@ -1307,10 +1289,7 @@ func TestImportRuntimeType(t *testing.T) {
 				Location:            TestLocation,
 				QualifiedIdentifier: "S",
 			},
-			expected: interpreter.InterfaceStaticType{
-				Location:            TestLocation,
-				QualifiedIdentifier: "S",
-			},
+			expected: interpreter.NewInterfaceStaticTypeComputeTypeID(nil, TestLocation, "S"),
 		},
 		{
 			label: "ContractInterface",
@@ -1318,10 +1297,7 @@ func TestImportRuntimeType(t *testing.T) {
 				Location:            TestLocation,
 				QualifiedIdentifier: "S",
 			},
-			expected: interpreter.InterfaceStaticType{
-				Location:            TestLocation,
-				QualifiedIdentifier: "S",
-			},
+			expected: interpreter.NewInterfaceStaticTypeComputeTypeID(nil, TestLocation, "S"),
 		},
 		{
 			label: "RestrictedType",
@@ -1337,15 +1313,9 @@ func TestImportRuntimeType(t *testing.T) {
 					}},
 			},
 			expected: &interpreter.RestrictedStaticType{
-				Type: interpreter.CompositeStaticType{
-					Location:            TestLocation,
-					QualifiedIdentifier: "S",
-				},
+				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, TestLocation, "S"),
 				Restrictions: []interpreter.InterfaceStaticType{
-					{
-						Location:            TestLocation,
-						QualifiedIdentifier: "T",
-					},
+					interpreter.NewInterfaceStaticTypeComputeTypeID(nil, TestLocation, "T"),
 				},
 			},
 		},

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -2050,10 +2050,7 @@ func TestExportTypeValue(t *testing.T) {
 			Type: &interpreter.RestrictedStaticType{
 				Type: interpreter.NewCompositeStaticTypeComputeTypeID(inter, TestLocation, "S"),
 				Restrictions: []interpreter.InterfaceStaticType{
-					{
-						Location:            TestLocation,
-						QualifiedIdentifier: "SI",
-					},
+					interpreter.NewInterfaceStaticTypeComputeTypeID(nil, TestLocation, "SI"),
 				},
 			},
 		}

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1557,7 +1557,7 @@ func (d TypeDecoder) decodeInterfaceStaticType() (InterfaceStaticType, error) {
 		return InterfaceStaticType{}, err
 	}
 
-	return NewInterfaceStaticType(d.memoryGauge, location, qualifiedIdentifier), nil
+	return NewInterfaceStaticTypeComputeTypeID(d.memoryGauge, location, qualifiedIdentifier), nil
 }
 
 func (d TypeDecoder) decodeVariableSizedStaticType() (StaticType, error) {

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -3998,16 +3998,8 @@ func TestEncodeDecodePathLinkValue(t *testing.T) {
 					"S",
 				),
 				Restrictions: []InterfaceStaticType{
-					{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "I1",
-						TypeID:              "S.test.I1",
-					},
-					{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "I2",
-						TypeID:              "S.test.I2",
-					},
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "I1"),
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "I2"),
 				},
 			},
 		}
@@ -4711,16 +4703,8 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 						"S",
 					),
 					Restrictions: []InterfaceStaticType{
-						{
-							Location:            utils.TestLocation,
-							QualifiedIdentifier: "I1",
-							TypeID:              "S.test.I1",
-						},
-						{
-							Location:            utils.TestLocation,
-							QualifiedIdentifier: "I2",
-							TypeID:              "S.test.I2",
-						},
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "I1"),
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "I2"),
 					},
 				},
 			},

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -3801,10 +3801,7 @@ func TestEncodeDecodePathLinkValue(t *testing.T) {
 
 		value := PathLinkValue{
 			TargetPath: publicPathValue,
-			Type: InterfaceStaticType{
-				Location:            utils.TestLocation,
-				QualifiedIdentifier: "SimpleInterface",
-			},
+			Type:       NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "SimpleInterface"),
 		}
 
 		encoded := assemble(
@@ -4004,10 +4001,12 @@ func TestEncodeDecodePathLinkValue(t *testing.T) {
 					{
 						Location:            utils.TestLocation,
 						QualifiedIdentifier: "I1",
+						TypeID:              "S.test.I1",
 					},
 					{
 						Location:            utils.TestLocation,
 						QualifiedIdentifier: "I2",
+						TypeID:              "S.test.I2",
 					},
 				},
 			},
@@ -4543,10 +4542,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 		value := &StorageCapabilityControllerValue{
 			TargetPath: publicPathValue,
 			BorrowType: ReferenceStaticType{
-				BorrowedType: InterfaceStaticType{
-					Location:            utils.TestLocation,
-					QualifiedIdentifier: "SimpleInterface",
-				},
+				BorrowedType: NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "SimpleInterface"),
 			},
 			CapabilityID: capabilityID,
 		}
@@ -4718,10 +4714,12 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 						{
 							Location:            utils.TestLocation,
 							QualifiedIdentifier: "I1",
+							TypeID:              "S.test.I1",
 						},
 						{
 							Location:            utils.TestLocation,
 							QualifiedIdentifier: "I2",
+							TypeID:              "S.test.I2",
 						},
 					},
 				},

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -205,12 +205,12 @@ func (t InterfaceStaticType) MeteredString(memoryGauge common.MemoryGauge) strin
 }
 
 func (t InterfaceStaticType) Equal(other StaticType) bool {
-	otherCompositeType, ok := other.(InterfaceStaticType)
+	otherInterfaceType, ok := other.(InterfaceStaticType)
 	if !ok {
 		return false
 	}
 
-	return otherCompositeType.TypeID == t.TypeID
+	return otherInterfaceType.TypeID == t.TypeID
 }
 
 // ArrayStaticType

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -67,6 +67,10 @@ func NewCompositeStaticType(
 ) CompositeStaticType {
 	common.UseMemory(memoryGauge, common.CompositeStaticTypeMemoryUsage)
 
+	if typeID == "" {
+		panic(errors.NewUnreachableError())
+	}
+
 	return CompositeStaticType{
 		Location:            location,
 		QualifiedIdentifier: qualifiedIdentifier,
@@ -79,9 +83,18 @@ func NewCompositeStaticTypeComputeTypeID(
 	location common.Location,
 	qualifiedIdentifier string,
 ) CompositeStaticType {
-	typeID := common.NewTypeIDFromQualifiedName(memoryGauge, location, qualifiedIdentifier)
+	typeID := common.NewTypeIDFromQualifiedName(
+		memoryGauge,
+		location,
+		qualifiedIdentifier,
+	)
 
-	return NewCompositeStaticType(memoryGauge, location, qualifiedIdentifier, typeID)
+	return NewCompositeStaticType(
+		memoryGauge,
+		location,
+		qualifiedIdentifier,
+		typeID,
+	)
 }
 
 func (CompositeStaticType) isStaticType() {}
@@ -123,6 +136,7 @@ func (t CompositeStaticType) Equal(other StaticType) bool {
 type InterfaceStaticType struct {
 	Location            common.Location
 	QualifiedIdentifier string
+	TypeID              common.TypeID
 }
 
 var _ StaticType = InterfaceStaticType{}
@@ -131,13 +145,38 @@ func NewInterfaceStaticType(
 	memoryGauge common.MemoryGauge,
 	location common.Location,
 	qualifiedIdentifier string,
+	typeID common.TypeID,
 ) InterfaceStaticType {
 	common.UseMemory(memoryGauge, common.InterfaceStaticTypeMemoryUsage)
+
+	if typeID == "" {
+		panic(errors.NewUnreachableError())
+	}
 
 	return InterfaceStaticType{
 		Location:            location,
 		QualifiedIdentifier: qualifiedIdentifier,
+		TypeID:              typeID,
 	}
+}
+
+func NewInterfaceStaticTypeComputeTypeID(
+	memoryGauge common.MemoryGauge,
+	location common.Location,
+	qualifiedIdentifier string,
+) InterfaceStaticType {
+	typeID := common.NewTypeIDFromQualifiedName(
+		memoryGauge,
+		location,
+		qualifiedIdentifier,
+	)
+
+	return NewInterfaceStaticType(
+		memoryGauge,
+		location,
+		qualifiedIdentifier,
+		typeID,
+	)
 }
 
 func (InterfaceStaticType) isStaticType() {}
@@ -150,24 +189,28 @@ func (t InterfaceStaticType) String() string {
 	if t.Location == nil {
 		return t.QualifiedIdentifier
 	}
-	return string(t.Location.TypeID(nil, t.QualifiedIdentifier))
+	return string(t.TypeID)
 }
 
 func (t InterfaceStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
+	var amount int
 	if t.Location == nil {
-		return t.QualifiedIdentifier
+		amount = len(t.QualifiedIdentifier)
+	} else {
+		amount = len(t.TypeID)
 	}
-	return string(t.Location.TypeID(memoryGauge, t.QualifiedIdentifier))
+
+	common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(amount))
+	return t.String()
 }
 
 func (t InterfaceStaticType) Equal(other StaticType) bool {
-	otherInterfaceType, ok := other.(InterfaceStaticType)
+	otherCompositeType, ok := other.(InterfaceStaticType)
 	if !ok {
 		return false
 	}
 
-	return otherInterfaceType.Location == t.Location &&
-		otherInterfaceType.QualifiedIdentifier == t.QualifiedIdentifier
+	return otherCompositeType.TypeID == t.TypeID
 }
 
 // ArrayStaticType
@@ -616,7 +659,7 @@ func ConvertSemaToStaticType(memoryGauge common.MemoryGauge, t sema.Type) Static
 
 	switch t := t.(type) {
 	case *sema.CompositeType:
-		return NewCompositeStaticType(memoryGauge, t.Location, t.QualifiedIdentifier(), t.ID())
+		return ConvertSemaCompositeTypeToStaticCompositeType(memoryGauge, t)
 
 	case *sema.InterfaceType:
 		return ConvertSemaInterfaceTypeToStaticInterfaceType(memoryGauge, t)
@@ -713,11 +756,28 @@ func ConvertSemaReferenceTypeToStaticReferenceType(
 	)
 }
 
+func ConvertSemaCompositeTypeToStaticCompositeType(
+	memoryGauge common.MemoryGauge,
+	t *sema.CompositeType,
+) CompositeStaticType {
+	return NewCompositeStaticType(
+		memoryGauge,
+		t.Location,
+		t.QualifiedIdentifier(),
+		t.ID(),
+	)
+}
+
 func ConvertSemaInterfaceTypeToStaticInterfaceType(
 	memoryGauge common.MemoryGauge,
 	t *sema.InterfaceType,
 ) InterfaceStaticType {
-	return NewInterfaceStaticType(memoryGauge, t.Location, t.QualifiedIdentifier())
+	return NewInterfaceStaticType(
+		memoryGauge,
+		t.Location,
+		t.QualifiedIdentifier(),
+		t.ID(),
+	)
 }
 
 func ConvertStaticToSemaType(

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -699,27 +699,15 @@ func TestRestrictedStaticType_Equal(t *testing.T) {
 			(&RestrictedStaticType{
 				Type: PrimitiveStaticTypeInt,
 				Restrictions: []InterfaceStaticType{
-					{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "X",
-					},
-					{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "Y",
-					},
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 				},
 			}).Equal(
 				&RestrictedStaticType{
 					Type: PrimitiveStaticTypeInt,
 					Restrictions: []InterfaceStaticType{
-						{
-							Location:            utils.TestLocation,
-							QualifiedIdentifier: "Y",
-						},
-						{
-							Location:            utils.TestLocation,
-							QualifiedIdentifier: "X",
-						},
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 					},
 				},
 			),
@@ -751,27 +739,15 @@ func TestRestrictedStaticType_Equal(t *testing.T) {
 			(&RestrictedStaticType{
 				Type: PrimitiveStaticTypeString,
 				Restrictions: []InterfaceStaticType{
-					{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "X",
-					},
-					{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "Y",
-					},
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 				},
 			}).Equal(
 				&RestrictedStaticType{
 					Type: PrimitiveStaticTypeInt,
 					Restrictions: []InterfaceStaticType{
-						{
-							Location:            utils.TestLocation,
-							QualifiedIdentifier: "Y",
-						},
-						{
-							Location:            utils.TestLocation,
-							QualifiedIdentifier: "X",
-						},
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 					},
 				},
 			),
@@ -786,23 +762,14 @@ func TestRestrictedStaticType_Equal(t *testing.T) {
 			(&RestrictedStaticType{
 				Type: PrimitiveStaticTypeInt,
 				Restrictions: []InterfaceStaticType{
-					{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "X",
-					},
-					{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "Y",
-					},
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 				},
 			}).Equal(
 				&RestrictedStaticType{
 					Type: PrimitiveStaticTypeInt,
 					Restrictions: []InterfaceStaticType{
-						{
-							Location:            utils.TestLocation,
-							QualifiedIdentifier: "Y",
-						},
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 					},
 				},
 			),
@@ -817,25 +784,14 @@ func TestRestrictedStaticType_Equal(t *testing.T) {
 			(&RestrictedStaticType{
 				Type: PrimitiveStaticTypeInt,
 				Restrictions: []InterfaceStaticType{
-					{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "X",
-					},
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 				},
 			}).Equal(
 				&RestrictedStaticType{
 					Type: PrimitiveStaticTypeInt,
 					Restrictions: []InterfaceStaticType{
-						{
-							Location:            utils.TestLocation,
-							QualifiedIdentifier: "Y",
-							TypeID:              "S.test.X",
-						},
-						{
-							Location:            utils.TestLocation,
-							QualifiedIdentifier: "X",
-							TypeID:              "S.test.Y",
-						},
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 					},
 				},
 			),
@@ -850,31 +806,15 @@ func TestRestrictedStaticType_Equal(t *testing.T) {
 			(&RestrictedStaticType{
 				Type: PrimitiveStaticTypeInt,
 				Restrictions: []InterfaceStaticType{
-					{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "X",
-						TypeID:              "S.test.X",
-					},
-					{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "Y",
-						TypeID:              "S.test.Y",
-					},
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 				},
 			}).Equal(
 				&RestrictedStaticType{
 					Type: PrimitiveStaticTypeInt,
 					Restrictions: []InterfaceStaticType{
-						{
-							Location:            utils.TestLocation,
-							QualifiedIdentifier: "X",
-							TypeID:              "S.test.X",
-						},
-						{
-							Location:            utils.TestLocation,
-							QualifiedIdentifier: "Z",
-							TypeID:              "S.test.Z",
-						},
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Z"),
 					},
 				},
 			),
@@ -889,16 +829,8 @@ func TestRestrictedStaticType_Equal(t *testing.T) {
 			(&RestrictedStaticType{
 				Type: PrimitiveStaticTypeInt,
 				Restrictions: []InterfaceStaticType{
-					{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "X",
-						TypeID:              "S.test.X",
-					},
-					{
-						Location:            utils.TestLocation,
-						QualifiedIdentifier: "Y",
-						TypeID:              "S.test.Y",
-					},
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 				},
 			}).Equal(
 				ReferenceStaticType{

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -754,6 +754,52 @@ func TestRestrictedStaticType_Equal(t *testing.T) {
 		)
 	})
 
+	t.Run("same, restrictions in different order", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			(&RestrictedStaticType{
+				Type: PrimitiveStaticTypeString,
+				Restrictions: []InterfaceStaticType{
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
+				},
+			}).Equal(
+				&RestrictedStaticType{
+					Type: PrimitiveStaticTypeString,
+					Restrictions: []InterfaceStaticType{
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
+					},
+				},
+			),
+		)
+	})
+
+	t.Run("same, restrictions in same order", func(t *testing.T) {
+
+		t.Parallel()
+
+		require.True(t,
+			(&RestrictedStaticType{
+				Type: PrimitiveStaticTypeString,
+				Restrictions: []InterfaceStaticType{
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
+					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
+				},
+			}).Equal(
+				&RestrictedStaticType{
+					Type: PrimitiveStaticTypeString,
+					Restrictions: []InterfaceStaticType{
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
+						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
+					},
+				},
+			),
+		)
+	})
+
 	t.Run("fewer restrictions", func(t *testing.T) {
 
 		t.Parallel()

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -317,10 +317,7 @@ func TestCompositeStaticType_Equal(t *testing.T) {
 				nil,
 				"X",
 			).Equal(
-				InterfaceStaticType{
-					Location:            nil,
-					QualifiedIdentifier: "X",
-				},
+				NewInterfaceStaticTypeComputeTypeID(nil, nil, "X"),
 			),
 		)
 	})
@@ -335,15 +332,8 @@ func TestInterfaceStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.True(t,
-			InterfaceStaticType{
-				Location:            utils.TestLocation,
-				QualifiedIdentifier: "X",
-			}.Equal(
-				InterfaceStaticType{
-					Location:            utils.TestLocation,
-					QualifiedIdentifier: "X",
-				},
-			),
+			NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X").
+				Equal(NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X")),
 		)
 	})
 
@@ -352,49 +342,28 @@ func TestInterfaceStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			InterfaceStaticType{
-				Location:            utils.TestLocation,
-				QualifiedIdentifier: "X",
-			}.Equal(
-				InterfaceStaticType{
-					Location:            utils.TestLocation,
-					QualifiedIdentifier: "Y",
-				},
-			),
+			NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X").
+				Equal(NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y")),
 		)
 	})
 
-	t.Run("different locations, different identifier", func(t *testing.T) {
+	t.Run("different locations of same kind, same qualified identifier", func(t *testing.T) {
 
 		t.Parallel()
 
 		require.False(t,
-			InterfaceStaticType{
-				Location:            common.IdentifierLocation("A"),
-				QualifiedIdentifier: "X",
-			}.Equal(
-				InterfaceStaticType{
-					Location:            common.IdentifierLocation("B"),
-					QualifiedIdentifier: "X",
-				},
-			),
+			NewInterfaceStaticTypeComputeTypeID(nil, common.IdentifierLocation("A"), "X").
+				Equal(NewInterfaceStaticTypeComputeTypeID(nil, common.IdentifierLocation("B"), "X")),
 		)
 	})
 
-	t.Run("different locations, different identifier", func(t *testing.T) {
+	t.Run("different locations of different kinds, same qualified identifier", func(t *testing.T) {
 
 		t.Parallel()
 
 		require.False(t,
-			InterfaceStaticType{
-				Location:            common.IdentifierLocation("A"),
-				QualifiedIdentifier: "X",
-			}.Equal(
-				InterfaceStaticType{
-					Location:            common.StringLocation("A"),
-					QualifiedIdentifier: "X",
-				},
-			),
+			NewInterfaceStaticTypeComputeTypeID(nil, common.IdentifierLocation("A"), "X").
+				Equal(NewInterfaceStaticTypeComputeTypeID(nil, common.StringLocation("A"), "X")),
 		)
 	})
 
@@ -403,15 +372,8 @@ func TestInterfaceStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.True(t,
-			InterfaceStaticType{
-				Location:            nil,
-				QualifiedIdentifier: "X",
-			}.Equal(
-				InterfaceStaticType{
-					Location:            nil,
-					QualifiedIdentifier: "X",
-				},
-			),
+			NewInterfaceStaticTypeComputeTypeID(nil, nil, "X").
+				Equal(NewInterfaceStaticTypeComputeTypeID(nil, nil, "X")),
 		)
 	})
 
@@ -420,15 +382,8 @@ func TestInterfaceStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			InterfaceStaticType{
-				Location:            nil,
-				QualifiedIdentifier: "X",
-			}.Equal(
-				InterfaceStaticType{
-					Location:            nil,
-					QualifiedIdentifier: "Y",
-				},
-			),
+			NewInterfaceStaticTypeComputeTypeID(nil, nil, "X").
+				Equal(NewInterfaceStaticTypeComputeTypeID(nil, nil, "Y")),
 		)
 	})
 
@@ -437,15 +392,8 @@ func TestInterfaceStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			InterfaceStaticType{
-				Location:            nil,
-				QualifiedIdentifier: "X",
-			}.Equal(
-				InterfaceStaticType{
-					Location:            common.StringLocation("B"),
-					QualifiedIdentifier: "X",
-				},
-			),
+			NewInterfaceStaticTypeComputeTypeID(nil, nil, "X").
+				Equal(NewInterfaceStaticTypeComputeTypeID(nil, common.StringLocation("B"), "X")),
 		)
 	})
 
@@ -454,16 +402,8 @@ func TestInterfaceStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			InterfaceStaticType{
-				Location:            nil,
-				QualifiedIdentifier: "X",
-			}.Equal(
-				NewCompositeStaticTypeComputeTypeID(
-					nil,
-					nil,
-					"X",
-				),
-			),
+			NewInterfaceStaticTypeComputeTypeID(nil, nil, "X").
+				Equal(NewCompositeStaticTypeComputeTypeID(nil, nil, "X")),
 		)
 	})
 }
@@ -889,10 +829,12 @@ func TestRestrictedStaticType_Equal(t *testing.T) {
 						{
 							Location:            utils.TestLocation,
 							QualifiedIdentifier: "Y",
+							TypeID:              "S.test.X",
 						},
 						{
 							Location:            utils.TestLocation,
 							QualifiedIdentifier: "X",
+							TypeID:              "S.test.Y",
 						},
 					},
 				},
@@ -911,10 +853,12 @@ func TestRestrictedStaticType_Equal(t *testing.T) {
 					{
 						Location:            utils.TestLocation,
 						QualifiedIdentifier: "X",
+						TypeID:              "S.test.X",
 					},
 					{
 						Location:            utils.TestLocation,
 						QualifiedIdentifier: "Y",
+						TypeID:              "S.test.Y",
 					},
 				},
 			}).Equal(
@@ -924,10 +868,12 @@ func TestRestrictedStaticType_Equal(t *testing.T) {
 						{
 							Location:            utils.TestLocation,
 							QualifiedIdentifier: "X",
+							TypeID:              "S.test.X",
 						},
 						{
 							Location:            utils.TestLocation,
 							QualifiedIdentifier: "Z",
+							TypeID:              "S.test.Z",
 						},
 					},
 				},
@@ -946,10 +892,12 @@ func TestRestrictedStaticType_Equal(t *testing.T) {
 					{
 						Location:            utils.TestLocation,
 						QualifiedIdentifier: "X",
+						TypeID:              "S.test.X",
 					},
 					{
 						Location:            utils.TestLocation,
 						QualifiedIdentifier: "Y",
+						TypeID:              "S.test.Y",
 					},
 				},
 			}).Equal(
@@ -987,10 +935,11 @@ func TestStaticTypeConversion(t *testing.T) {
 		Identifier: testInterfaceQualifiedIdentifier,
 	}
 
-	testInterfaceStaticType := InterfaceStaticType{
-		Location:            testLocation,
-		QualifiedIdentifier: testInterfaceQualifiedIdentifier,
-	}
+	testInterfaceStaticType := NewInterfaceStaticTypeComputeTypeID(
+		nil,
+		testLocation,
+		testInterfaceQualifiedIdentifier,
+	)
 
 	const testCompositeQualifiedIdentifier = "TestComposite"
 
@@ -999,11 +948,11 @@ func TestStaticTypeConversion(t *testing.T) {
 		Identifier: testCompositeQualifiedIdentifier,
 	}
 
-	testCompositeStaticType := CompositeStaticType{
-		Location:            testLocation,
-		QualifiedIdentifier: testCompositeQualifiedIdentifier,
-		TypeID:              "S.test.TestComposite",
-	}
+	testCompositeStaticType := NewCompositeStaticTypeComputeTypeID(
+		nil,
+		testLocation,
+		testCompositeQualifiedIdentifier,
+	)
 
 	testFunctionType := &sema.FunctionType{}
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -16995,12 +16995,7 @@ func (v *CompositeValue) HashInput(interpreter *Interpreter, locationRange Locat
 
 func (v *CompositeValue) TypeID() common.TypeID {
 	if v.typeID == "" {
-		location := v.Location
-		qualifiedIdentifier := v.QualifiedIdentifier
-		if location == nil {
-			return common.TypeID(qualifiedIdentifier)
-		}
-		v.typeID = location.TypeID(nil, qualifiedIdentifier)
+		v.typeID = common.NewTypeIDFromQualifiedName(nil, v.Location, v.QualifiedIdentifier)
 	}
 	return v.typeID
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4030,12 +4030,7 @@ func (t *CompositeType) initializeIdentifiers() {
 
 	identifier := qualifiedIdentifier(t.Identifier, t.containerType)
 
-	var typeID TypeID
-	if t.Location == nil {
-		typeID = TypeID(identifier)
-	} else {
-		typeID = t.Location.TypeID(nil, identifier)
-	}
+	typeID := common.NewTypeIDFromQualifiedName(nil, t.Location, identifier)
 
 	t.cachedIdentifiers = &struct {
 		TypeID              TypeID
@@ -4645,12 +4640,7 @@ func (t *InterfaceType) initializeIdentifiers() {
 
 	identifier := qualifiedIdentifier(t.Identifier, t.containerType)
 
-	var typeID TypeID
-	if t.Location == nil {
-		typeID = TypeID(identifier)
-	} else {
-		typeID = t.Location.TypeID(nil, identifier)
-	}
+	typeID := common.NewTypeIDFromQualifiedName(nil, t.Location, identifier)
 
 	t.cachedIdentifiers = &struct {
 		TypeID              TypeID

--- a/runtime/stdlib/bls.go
+++ b/runtime/stdlib/bls.go
@@ -48,11 +48,10 @@ var blsContractType = func() *sema.CompositeType {
 	return ty
 }()
 
-var blsContractTypeID = blsContractType.ID()
-var blsContractStaticType interpreter.StaticType = interpreter.CompositeStaticType{
-	QualifiedIdentifier: blsContractType.Identifier,
-	TypeID:              blsContractTypeID,
-}
+var blsContractStaticType interpreter.StaticType = interpreter.ConvertSemaCompositeTypeToStaticCompositeType(
+	nil,
+	blsContractType,
+)
 
 const blsAggregateSignaturesFunctionDocString = `
 Aggregates multiple BLS signatures into one,

--- a/runtime/stdlib/hashalgorithm.go
+++ b/runtime/stdlib/hashalgorithm.go
@@ -25,11 +25,10 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-var hashAlgorithmTypeID = sema.HashAlgorithmType.ID()
-var hashAlgorithmStaticType interpreter.StaticType = interpreter.CompositeStaticType{
-	QualifiedIdentifier: sema.HashAlgorithmType.Identifier,
-	TypeID:              hashAlgorithmTypeID,
-}
+var hashAlgorithmStaticType interpreter.StaticType = interpreter.ConvertSemaCompositeTypeToStaticCompositeType(
+	nil,
+	sema.HashAlgorithmType,
+)
 
 type Hasher interface {
 	// Hash returns the digest of hashing the given data with using the given hash algorithm

--- a/runtime/stdlib/rlp.go
+++ b/runtime/stdlib/rlp.go
@@ -51,11 +51,10 @@ var rlpContractType = func() *sema.CompositeType {
 	return ty
 }()
 
-var rlpContractTypeID = rlpContractType.ID()
-var rlpContractStaticType interpreter.StaticType = interpreter.CompositeStaticType{
-	QualifiedIdentifier: rlpContractType.Identifier,
-	TypeID:              rlpContractTypeID,
-}
+var rlpContractStaticType interpreter.StaticType = interpreter.ConvertSemaCompositeTypeToStaticCompositeType(
+	nil,
+	rlpContractType,
+)
 
 const rlpErrMsgInputContainsExtraBytes = "input data is expected to be RLP-encoded of a single string or a single list but it seems it contains extra trailing bytes."
 

--- a/runtime/stdlib/signaturealgorithm.go
+++ b/runtime/stdlib/signaturealgorithm.go
@@ -24,11 +24,10 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
-var signatureAlgorithmTypeID = sema.SignatureAlgorithmType.ID()
-var signatureAlgorithmStaticType interpreter.StaticType = interpreter.CompositeStaticType{
-	QualifiedIdentifier: sema.SignatureAlgorithmType.Identifier,
-	TypeID:              signatureAlgorithmTypeID,
-}
+var signatureAlgorithmStaticType interpreter.StaticType = interpreter.ConvertSemaCompositeTypeToStaticCompositeType(
+	nil,
+	sema.SignatureAlgorithmType,
+)
 
 func NewSignatureAlgorithmCase(rawValue interpreter.UInt8Value) interpreter.MemberAccessibleValue {
 

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -305,11 +305,7 @@ func TestInterpretAuthAccount_type(t *testing.T) {
 		require.Equal(t,
 			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.TypeValue{
-					Type: interpreter.CompositeStaticType{
-						Location:            TestLocation,
-						QualifiedIdentifier: "R",
-						TypeID:              "S.test.R",
-					},
+					Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, TestLocation, "R"),
 				},
 			),
 			value,
@@ -328,11 +324,7 @@ func TestInterpretAuthAccount_type(t *testing.T) {
 		require.Equal(t,
 			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.TypeValue{
-					Type: interpreter.CompositeStaticType{
-						Location:            TestLocation,
-						QualifiedIdentifier: "S",
-						TypeID:              "S.test.S",
-					},
+					Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, TestLocation, "S"),
 				},
 			),
 			value,

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -11897,11 +11897,7 @@ func TestInterpretCompositeTypeHandler(t *testing.T) {
 
 	t.Parallel()
 
-	testType := interpreter.CompositeStaticType{
-		Location:            stdlib.FlowLocation{},
-		QualifiedIdentifier: "AccountContractAdded",
-		TypeID:              "flow.AccountContractAdded",
-	}
+	testType := interpreter.NewCompositeStaticTypeComputeTypeID(nil, stdlib.FlowLocation{}, "AccountContractAdded")
 
 	inter, err := parseCheckAndInterpretWithOptions(t,
 		`

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -9049,11 +9049,7 @@ func TestInterpretValueStringConversion(t *testing.T) {
 					Domain:     common.PathDomainPublic,
 					Identifier: "somepath",
 				},
-				interpreter.CompositeStaticType{
-					Location:            utils.TestLocation,
-					QualifiedIdentifier: "Bar",
-					TypeID:              "S.test.Bar",
-				},
+				interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "Bar"),
 			))
 	})
 
@@ -9074,11 +9070,7 @@ func TestInterpretValueStringConversion(t *testing.T) {
 			interpreter.NewUnmeteredIDCapabilityValue(
 				4,
 				interpreter.AddressValue{1},
-				interpreter.CompositeStaticType{
-					Location:            utils.TestLocation,
-					QualifiedIdentifier: "Bar",
-					TypeID:              "S.test.Bar",
-				},
+				interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "Bar"),
 			))
 	})
 

--- a/runtime/tests/interpreter/runtimetype_test.go
+++ b/runtime/tests/interpreter/runtimetype_test.go
@@ -64,11 +64,7 @@ func TestInterpretOptionalType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.OptionalStaticType{
-				Type: interpreter.CompositeStaticType{
-					Location:            utils.TestLocation,
-					QualifiedIdentifier: "R",
-					TypeID:              "S.test.R",
-				},
+				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 			},
 		},
 		inter.Globals.Get("c").GetValue(),
@@ -127,11 +123,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.VariableSizedStaticType{
-				Type: interpreter.CompositeStaticType{
-					Location:            utils.TestLocation,
-					QualifiedIdentifier: "R",
-					TypeID:              "S.test.R",
-				},
+				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 			},
 		},
 		inter.Globals.Get("c").GetValue(),
@@ -191,11 +183,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.ConstantSizedStaticType{
-				Type: interpreter.CompositeStaticType{
-					Location:            utils.TestLocation,
-					QualifiedIdentifier: "R",
-					TypeID:              "S.test.R",
-				},
+				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 				Size: int64(400),
 			},
 		},
@@ -261,12 +249,8 @@ func TestInterpretDictionaryType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.DictionaryStaticType{
-				ValueType: interpreter.CompositeStaticType{
-					Location:            utils.TestLocation,
-					QualifiedIdentifier: "R",
-					TypeID:              "S.test.R",
-				},
-				KeyType: interpreter.PrimitiveStaticTypeInt,
+				ValueType: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
+				KeyType:   interpreter.PrimitiveStaticTypeInt,
 			},
 		},
 		inter.Globals.Get("c").GetValue(),
@@ -320,22 +304,14 @@ func TestInterpretCompositeType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.CompositeStaticType{
-				QualifiedIdentifier: "R",
-				Location:            utils.TestLocation,
-				TypeID:              "S.test.R",
-			},
+			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 		},
 		inter.Globals.Get("a").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.CompositeStaticType{
-				QualifiedIdentifier: "S",
-				Location:            utils.TestLocation,
-				TypeID:              "S.test.S",
-			},
+			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "S"),
 		},
 		inter.Globals.Get("b").GetValue(),
 	)
@@ -357,33 +333,21 @@ func TestInterpretCompositeType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.CompositeStaticType{
-				QualifiedIdentifier: "F",
-				Location:            utils.TestLocation,
-				TypeID:              "S.test.F",
-			},
+			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "F"),
 		},
 		inter.Globals.Get("f").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.CompositeStaticType{
-				QualifiedIdentifier: "PublicKey",
-				Location:            nil,
-				TypeID:              "PublicKey",
-			},
+			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, nil, "PublicKey"),
 		},
 		inter.Globals.Get("g").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.CompositeStaticType{
-				QualifiedIdentifier: "HashAlgorithm",
-				Location:            nil,
-				TypeID:              "HashAlgorithm",
-			},
+			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, nil, "HashAlgorithm"),
 		},
 		inter.Globals.Get("h").GetValue(),
 	)
@@ -406,20 +370,14 @@ func TestInterpretInterfaceType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.InterfaceStaticType{
-				QualifiedIdentifier: "R",
-				Location:            utils.TestLocation,
-			},
+			Type: interpreter.NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 		},
 		inter.Globals.Get("a").GetValue(),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.InterfaceStaticType{
-				QualifiedIdentifier: "S",
-				Location:            utils.TestLocation,
-			},
+			Type: interpreter.NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "S"),
 		},
 		inter.Globals.Get("b").GetValue(),
 	)
@@ -512,12 +470,8 @@ func TestInterpretReferenceType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.ReferenceStaticType{
-				BorrowedType: interpreter.CompositeStaticType{
-					QualifiedIdentifier: "R",
-					Location:            utils.TestLocation,
-					TypeID:              "S.test.R",
-				},
-				Authorized: true,
+				BorrowedType: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
+				Authorized:   true,
 			},
 		},
 		inter.Globals.Get("a").GetValue(),
@@ -536,12 +490,8 @@ func TestInterpretReferenceType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.ReferenceStaticType{
-				BorrowedType: interpreter.CompositeStaticType{
-					QualifiedIdentifier: "S",
-					Location:            utils.TestLocation,
-					TypeID:              "S.test.S",
-				},
-				Authorized: true,
+				BorrowedType: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "S"),
+				Authorized:   true,
 			},
 		},
 		inter.Globals.Get("c").GetValue(),
@@ -587,15 +537,12 @@ func TestInterpretRestrictedType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: &interpreter.RestrictedStaticType{
-				Type: interpreter.CompositeStaticType{
-					QualifiedIdentifier: "A",
-					Location:            utils.TestLocation,
-					TypeID:              "S.test.A",
-				},
+				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "A"),
 				Restrictions: []interpreter.InterfaceStaticType{
 					{
 						QualifiedIdentifier: "R",
 						Location:            utils.TestLocation,
+						TypeID:              "S.test.R",
 					},
 				},
 			},
@@ -606,15 +553,12 @@ func TestInterpretRestrictedType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: &interpreter.RestrictedStaticType{
-				Type: interpreter.CompositeStaticType{
-					QualifiedIdentifier: "B",
-					Location:            utils.TestLocation,
-					TypeID:              "S.test.B",
-				},
+				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "B"),
 				Restrictions: []interpreter.InterfaceStaticType{
 					{
 						QualifiedIdentifier: "S",
 						Location:            utils.TestLocation,
+						TypeID:              "S.test.S",
 					},
 				},
 			},
@@ -630,6 +574,7 @@ func TestInterpretRestrictedType(t *testing.T) {
 					{
 						QualifiedIdentifier: "R",
 						Location:            utils.TestLocation,
+						TypeID:              "S.test.R",
 					},
 				},
 			},
@@ -645,6 +590,7 @@ func TestInterpretRestrictedType(t *testing.T) {
 					{
 						QualifiedIdentifier: "S",
 						Location:            utils.TestLocation,
+						TypeID:              "S.test.S",
 					},
 				},
 			},
@@ -731,12 +677,8 @@ func TestInterpretCapabilityType(t *testing.T) {
 		interpreter.TypeValue{
 			Type: interpreter.CapabilityStaticType{
 				BorrowType: interpreter.ReferenceStaticType{
-					BorrowedType: interpreter.CompositeStaticType{
-						QualifiedIdentifier: "R",
-						Location:            utils.TestLocation,
-						TypeID:              "S.test.R",
-					},
-					Authorized: false,
+					BorrowedType: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
+					Authorized:   false,
 				},
 			},
 		},

--- a/runtime/tests/interpreter/runtimetype_test.go
+++ b/runtime/tests/interpreter/runtimetype_test.go
@@ -539,11 +539,7 @@ func TestInterpretRestrictedType(t *testing.T) {
 			Type: &interpreter.RestrictedStaticType{
 				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "A"),
 				Restrictions: []interpreter.InterfaceStaticType{
-					{
-						QualifiedIdentifier: "R",
-						Location:            utils.TestLocation,
-						TypeID:              "S.test.R",
-					},
+					interpreter.NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 				},
 			},
 		},
@@ -555,11 +551,7 @@ func TestInterpretRestrictedType(t *testing.T) {
 			Type: &interpreter.RestrictedStaticType{
 				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "B"),
 				Restrictions: []interpreter.InterfaceStaticType{
-					{
-						QualifiedIdentifier: "S",
-						Location:            utils.TestLocation,
-						TypeID:              "S.test.S",
-					},
+					interpreter.NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "S"),
 				},
 			},
 		},
@@ -571,11 +563,7 @@ func TestInterpretRestrictedType(t *testing.T) {
 			Type: &interpreter.RestrictedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyResource,
 				Restrictions: []interpreter.InterfaceStaticType{
-					{
-						QualifiedIdentifier: "R",
-						Location:            utils.TestLocation,
-						TypeID:              "S.test.R",
-					},
+					interpreter.NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 				},
 			},
 		},
@@ -587,11 +575,7 @@ func TestInterpretRestrictedType(t *testing.T) {
 			Type: &interpreter.RestrictedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				Restrictions: []interpreter.InterfaceStaticType{
-					{
-						QualifiedIdentifier: "S",
-						Location:            utils.TestLocation,
-						TypeID:              "S.test.S",
-					},
+					interpreter.NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "S"),
 				},
 			},
 		},

--- a/types.go
+++ b/types.go
@@ -1388,7 +1388,7 @@ func (*StructType) isType() {}
 
 func (t *StructType) ID() string {
 	if len(t.typeID) == 0 {
-		t.typeID = generateTypeID(t.Location, t.QualifiedIdentifier)
+		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 	}
 	return t.typeID
 }
@@ -1464,7 +1464,7 @@ func (*ResourceType) isType() {}
 
 func (t *ResourceType) ID() string {
 	if len(t.typeID) == 0 {
-		t.typeID = generateTypeID(t.Location, t.QualifiedIdentifier)
+		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 	}
 	return t.typeID
 }
@@ -1508,6 +1508,7 @@ type AttachmentType struct {
 	QualifiedIdentifier string
 	Fields              []Field
 	Initializers        [][]Parameter
+	typeID              string
 }
 
 func NewAttachmentType(
@@ -1530,22 +1531,27 @@ func NewMeteredAttachmentType(
 	gauge common.MemoryGauge,
 	location common.Location,
 	baseType Type,
-	qualifiedIdentifer string,
+	qualifiedIdentifier string,
 	fields []Field,
 	initializers [][]Parameter,
 ) *AttachmentType {
 	common.UseMemory(gauge, common.CadenceStructTypeMemoryUsage)
-	return NewAttachmentType(location, baseType, qualifiedIdentifer, fields, initializers)
+	return NewAttachmentType(
+		location,
+		baseType,
+		qualifiedIdentifier,
+		fields,
+		initializers,
+	)
 }
 
 func (*AttachmentType) isType() {}
 
 func (t *AttachmentType) ID() string {
-	if t.Location == nil {
-		return t.QualifiedIdentifier
+	if len(t.typeID) == 0 {
+		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 	}
-
-	return string(t.Location.TypeID(nil, t.QualifiedIdentifier))
+	return t.typeID
 }
 
 func (*AttachmentType) isCompositeType() {}
@@ -1623,7 +1629,7 @@ func (*EventType) isType() {}
 
 func (t *EventType) ID() string {
 	if len(t.typeID) == 0 {
-		t.typeID = generateTypeID(t.Location, t.QualifiedIdentifier)
+		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 	}
 	return t.typeID
 }
@@ -1699,7 +1705,7 @@ func (*ContractType) isType() {}
 
 func (t *ContractType) ID() string {
 	if len(t.typeID) == 0 {
-		t.typeID = generateTypeID(t.Location, t.QualifiedIdentifier)
+		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 	}
 	return t.typeID
 }
@@ -1787,7 +1793,7 @@ func (*StructInterfaceType) isType() {}
 
 func (t *StructInterfaceType) ID() string {
 	if len(t.typeID) == 0 {
-		t.typeID = generateTypeID(t.Location, t.QualifiedIdentifier)
+		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 	}
 	return t.typeID
 }
@@ -1863,7 +1869,7 @@ func (*ResourceInterfaceType) isType() {}
 
 func (t *ResourceInterfaceType) ID() string {
 	if len(t.typeID) == 0 {
-		t.typeID = generateTypeID(t.Location, t.QualifiedIdentifier)
+		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 	}
 	return t.typeID
 }
@@ -1939,7 +1945,7 @@ func (*ContractInterfaceType) isType() {}
 
 func (t *ContractInterfaceType) ID() string {
 	if len(t.typeID) == 0 {
-		t.typeID = generateTypeID(t.Location, t.QualifiedIdentifier)
+		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 	}
 	return t.typeID
 }
@@ -2440,7 +2446,7 @@ func (*EnumType) isType() {}
 
 func (t *EnumType) ID() string {
 	if len(t.typeID) == 0 {
-		t.typeID = generateTypeID(t.Location, t.QualifiedIdentifier)
+		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 	}
 	return t.typeID
 }
@@ -2627,14 +2633,6 @@ func (AccountKeyType) ID() string {
 
 func (t AccountKeyType) Equal(other Type) bool {
 	return t == other
-}
-
-func generateTypeID(location common.Location, identifier string) string {
-	if location == nil {
-		return identifier
-	}
-
-	return string(location.TypeID(nil, identifier))
 }
 
 // TypeWithCachedTypeID recursively caches type ID of type t.


### PR DESCRIPTION
## Description

In #2648 I refactored composite static types and _removed_ support for a caching the type ID.

Instead, it is better to also add the type ID caching to interface static types.

While at it, clean up the uses of composite and interface static types and use the constructor functions instead of Go composite literals, to ensure the type ID is always available and correct.

Also, use `NewTypeIDFromQualifiedName` everywhere.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
