### PR TITLE
Allow use of type code generator in any package, refactor RLP and BLS contracts

### DIFF
--- a/runtime/sema/account.gen.go
+++ b/runtime/sema/account.gen.go
@@ -445,8 +445,8 @@ var Account_StorageType = func() *CompositeType {
 	var t = &CompositeType{
 		Identifier:         Account_StorageTypeName,
 		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
 	}
 
 	return t
@@ -731,8 +731,8 @@ var Account_ContractsType = func() *CompositeType {
 	var t = &CompositeType{
 		Identifier:         Account_ContractsTypeName,
 		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
 	}
 
 	return t
@@ -918,8 +918,8 @@ var Account_KeysType = func() *CompositeType {
 	var t = &CompositeType{
 		Identifier:         Account_KeysTypeName,
 		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
 	}
 
 	return t
@@ -1096,8 +1096,8 @@ var Account_InboxType = func() *CompositeType {
 	var t = &CompositeType{
 		Identifier:         Account_InboxTypeName,
 		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
 	}
 
 	return t
@@ -1291,8 +1291,8 @@ var Account_CapabilitiesType = func() *CompositeType {
 	var t = &CompositeType{
 		Identifier:         Account_CapabilitiesTypeName,
 		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
 	}
 
 	return t
@@ -1497,8 +1497,8 @@ var Account_StorageCapabilitiesType = func() *CompositeType {
 	var t = &CompositeType{
 		Identifier:         Account_StorageCapabilitiesTypeName,
 		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
 	}
 
 	return t
@@ -1669,8 +1669,8 @@ var Account_AccountCapabilitiesType = func() *CompositeType {
 	var t = &CompositeType{
 		Identifier:         Account_AccountCapabilitiesTypeName,
 		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
 	}
 
 	return t
@@ -1730,8 +1730,8 @@ var AccountType = func() *CompositeType {
 	var t = &CompositeType{
 		Identifier:         AccountTypeName,
 		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
 	}
 
 	t.SetNestedType(Account_StorageTypeName, Account_StorageType)

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -278,10 +278,10 @@ func newNativeEnumType(
 	membersConstructor func(enumType *CompositeType) []*Member,
 ) *CompositeType {
 	ty := &CompositeType{
-		Identifier:  identifier,
-		EnumRawType: rawType,
-		Kind:        common.CompositeKindEnum,
-		importable:  true,
+		Identifier:        identifier,
+		EnumRawType:       rawType,
+		Kind:              common.CompositeKindEnum,
+		ImportableBuiltin: true,
 	}
 
 	// Members of the enum type are *not* the enum cases!

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -783,6 +783,23 @@ func typeExpr(t ast.Type, typeParams map[string]string) dst.Expr {
 			},
 		}
 
+	case *ast.DictionaryType:
+		keyType := typeExpr(t.KeyType, typeParams)
+		valueType := typeExpr(t.ValueType, typeParams)
+		return &dst.UnaryExpr{
+			Op: token.AND,
+			X: &dst.CompositeLit{
+				Type: &dst.Ident{
+					Name: "DictionaryType",
+					Path: semaPath,
+				},
+				Elts: []dst.Expr{
+					goKeyValue("KeyType", keyType),
+					goKeyValue("ValueType", valueType),
+				},
+			},
+		}
+
 	case *ast.FunctionType:
 		return functionTypeExpr(t, nil, nil, typeParams)
 

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -41,6 +41,7 @@ import (
 )
 
 const semaPath = "github.com/onflow/cadence/runtime/sema"
+const astPath = "github.com/onflow/cadence/runtime/ast"
 
 var packagePathFlag = flag.String("p", semaPath, "package path")
 
@@ -734,7 +735,13 @@ func typeExpr(t ast.Type, typeParams map[string]string) dst.Expr {
 				Elts: []dst.Expr{
 					goKeyValue("Type", borrowType),
 					// TODO: add support for parsing entitlements
-					goKeyValue("Authorization", dst.NewIdent("UnauthorizedAccess")),
+					goKeyValue(
+						"Authorization",
+						&dst.Ident{
+							Name: "UnauthorizedAccess",
+							Path: semaPath,
+						},
+					),
 				},
 			},
 		}
@@ -861,7 +868,10 @@ func functionTypeExpr(
 
 	var purityExpr dst.Expr
 	if t.PurityAnnotation == ast.FunctionPurityView {
-		purityExpr = dst.NewIdent("FunctionPurityView")
+		purityExpr = &dst.Ident{
+			Name: "FunctionPurityView",
+			Path: semaPath,
+		}
 	}
 
 	// Type parameters
@@ -1521,11 +1531,14 @@ func accessExpr(access ast.Access) dst.Expr {
 	switch access := access.(type) {
 	case ast.PrimitiveAccess:
 		return &dst.CallExpr{
-			Fun: dst.NewIdent("PrimitiveAccess"),
+			Fun: &dst.Ident{
+				Name: "PrimitiveAccess",
+				Path: semaPath,
+			},
 			Args: []dst.Expr{
 				&dst.Ident{
 					Name: access.String(),
-					Path: "github.com/onflow/cadence/runtime/ast",
+					Path: astPath,
 				},
 			},
 		}
@@ -1544,9 +1557,15 @@ func accessExpr(access ast.Access) dst.Expr {
 
 		switch access.EntitlementSet.Separator() {
 		case ast.Conjunction:
-			setKind = dst.NewIdent("Conjunction")
+			setKind = &dst.Ident{
+				Name: "Conjunction",
+				Path: semaPath,
+			}
 		case ast.Disjunction:
-			setKind = dst.NewIdent("Disjunction")
+			setKind = &dst.Ident{
+				Name: "Disjunction",
+				Path: semaPath,
+			}
 		default:
 			panic(errors.NewUnreachableError())
 		}
@@ -1554,7 +1573,10 @@ func accessExpr(access ast.Access) dst.Expr {
 		args := []dst.Expr{
 			&dst.CompositeLit{
 				Type: &dst.ArrayType{
-					Elt: dst.NewIdent("Type"),
+					Elt: &dst.Ident{
+						Name: "Type",
+						Path: semaPath,
+					},
 				},
 				Elts: entitlementExprs,
 			},
@@ -1567,7 +1589,10 @@ func accessExpr(access ast.Access) dst.Expr {
 		}
 
 		return &dst.CallExpr{
-			Fun:  dst.NewIdent("newEntitlementAccess"),
+			Fun: &dst.Ident{
+				Name: "newEntitlementAccess",
+				Path: semaPath,
+			},
 			Args: args,
 		}
 
@@ -1579,7 +1604,7 @@ func accessExpr(access ast.Access) dst.Expr {
 func variableKindIdent(variableKind ast.VariableKind) *dst.Ident {
 	return &dst.Ident{
 		Name: variableKind.String(),
-		Path: "github.com/onflow/cadence/runtime/ast",
+		Path: astPath,
 	}
 }
 
@@ -1810,7 +1835,10 @@ func entitlementTypeLiteral(name string) dst.Expr {
 	return &dst.UnaryExpr{
 		Op: token.AND,
 		X: &dst.CompositeLit{
-			Type: dst.NewIdent("EntitlementType"),
+			Type: &dst.Ident{
+				Name: "EntitlementType",
+				Path: semaPath,
+			},
 			Elts: []dst.Expr{
 				goKeyValue("Identifier", goStringLit(name)),
 			},
@@ -1839,7 +1867,10 @@ func entitlementMapTypeLiteral(name string, elements []ast.EntitlementMapElement
 		}
 
 		relationExpr := &dst.CompositeLit{
-			Type: dst.NewIdent("EntitlementRelation"),
+			Type: &dst.Ident{
+				Name: "EntitlementRelation",
+				Path: semaPath,
+			},
 			Elts: []dst.Expr{
 				goKeyValue("Input", typeExpr(relation.Input, nil)),
 				goKeyValue("Output", typeExpr(relation.Output, nil)),
@@ -1854,7 +1885,10 @@ func entitlementMapTypeLiteral(name string, elements []ast.EntitlementMapElement
 
 	relationsExpr := &dst.CompositeLit{
 		Type: &dst.ArrayType{
-			Elt: dst.NewIdent("EntitlementRelation"),
+			Elt: &dst.Ident{
+				Name: "EntitlementRelation",
+				Path: semaPath,
+			},
 		},
 		Elts: relationExprs,
 	}
@@ -1862,7 +1896,10 @@ func entitlementMapTypeLiteral(name string, elements []ast.EntitlementMapElement
 	return &dst.UnaryExpr{
 		Op: token.AND,
 		X: &dst.CompositeLit{
-			Type: dst.NewIdent("EntitlementMapType"),
+			Type: &dst.Ident{
+				Name: "EntitlementMapType",
+				Path: semaPath,
+			},
 			Elts: []dst.Expr{
 				goKeyValue("Identifier", goStringLit(name)),
 				goKeyValue("Relations", relationsExpr),

--- a/runtime/sema/gen/main_test.go
+++ b/runtime/sema/gen/main_test.go
@@ -50,7 +50,7 @@ func TestFiles(t *testing.T) {
 			require.NoError(t, err)
 			defer outFile.Close()
 
-			gen(inputPath, outFile)
+			gen(inputPath, outFile, "github.com/onflow/cadence/runtime/sema")
 
 			goldenPath := filepath.Join(testDataDirectory, testname+".golden.go")
 			want, err := os.ReadFile(goldenPath)

--- a/runtime/sema/gen/testdata/fields.cdc
+++ b/runtime/sema/gen/testdata/fields.cdc
@@ -14,6 +14,9 @@ access(all) struct Test {
     /// This is a test constant-sized integer array.
     access(all) let testConstInts: [UInt64; 2]
 
+    /// This is a test integer dictionary.
+    access(all) let testIntDict: {UInt64: Bool}
+
     /// This is a test parameterized-type field.
     access(all) let testParam: Foo<Bar>
 

--- a/runtime/sema/gen/testdata/fields.golden.go
+++ b/runtime/sema/gen/testdata/fields.golden.go
@@ -71,6 +71,17 @@ const TestTypeTestConstIntsFieldDocString = `
 This is a test constant-sized integer array.
 `
 
+const TestTypeTestIntDictFieldName = "testIntDict"
+
+var TestTypeTestIntDictFieldType = &DictionaryType{
+	KeyType:   UInt64Type,
+	ValueType: BoolType,
+}
+
+const TestTypeTestIntDictFieldDocString = `
+This is a test integer dictionary.
+`
+
 const TestTypeTestParamFieldName = "testParam"
 
 var TestTypeTestParamFieldType = MustInstantiate(
@@ -185,6 +196,14 @@ func init() {
 				TestTypeTestConstIntsFieldName,
 				TestTypeTestConstIntsFieldType,
 				TestTypeTestConstIntsFieldDocString,
+			),
+			NewUnmeteredFieldMember(
+				t,
+				PrimitiveAccess(ast.AccessAll),
+				ast.VariableKindConstant,
+				TestTypeTestIntDictFieldName,
+				TestTypeTestIntDictFieldType,
+				TestTypeTestIntDictFieldDocString,
 			),
 			NewUnmeteredFieldMember(
 				t,

--- a/runtime/sema/gen/testdata/nested.golden.go
+++ b/runtime/sema/gen/testdata/nested.golden.go
@@ -62,8 +62,8 @@ var Foo_BarType = func() *CompositeType {
 	var t = &CompositeType{
 		Identifier:         Foo_BarTypeName,
 		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
 	}
 
 	return t
@@ -90,8 +90,8 @@ var FooType = func() *CompositeType {
 	var t = &CompositeType{
 		Identifier:         FooTypeName,
 		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
 	}
 
 	t.SetNestedType(Foo_BarTypeName, Foo_BarType)

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4277,9 +4277,9 @@ type CompositeType struct {
 	effectiveInterfaceConformancesOnce   sync.Once
 	memberResolversOnce                  sync.Once
 	ConstructorPurity                    FunctionPurity
-	hasComputedMembers                   bool
+	HasComputedMembers                   bool
 	// Only applicable for native composite types
-	importable            bool
+	ImportableBuiltin     bool
 	supportedEntitlements *EntitlementOrderedSet
 }
 
@@ -4488,7 +4488,7 @@ func (*CompositeType) IsInvalidType() bool {
 }
 
 func (t *CompositeType) IsStorable(results map[*Member]bool) bool {
-	if t.hasComputedMembers {
+	if t.HasComputedMembers {
 		return false
 	}
 
@@ -4524,7 +4524,7 @@ func (t *CompositeType) IsStorable(results map[*Member]bool) bool {
 func (t *CompositeType) IsImportable(results map[*Member]bool) bool {
 	// Use the pre-determined flag for native types
 	if t.Location == nil {
-		return t.importable
+		return t.ImportableBuiltin
 	}
 
 	// Only structures and enums can be imported
@@ -7440,9 +7440,9 @@ const AccountKeyIsRevokedFieldName = "isRevoked"
 var AccountKeyType = func() *CompositeType {
 
 	accountKeyType := &CompositeType{
-		Identifier: AccountKeyTypeName,
-		Kind:       common.CompositeKindStructure,
-		importable: false,
+		Identifier:        AccountKeyTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
 	}
 
 	const accountKeyKeyIndexFieldDocString = `The index of the account key`
@@ -7523,8 +7523,8 @@ var PublicKeyType = func() *CompositeType {
 	publicKeyType := &CompositeType{
 		Identifier:         PublicKeyTypeName,
 		Kind:               common.CompositeKindStructure,
-		hasComputedMembers: true,
-		importable:         true,
+		HasComputedMembers: true,
+		ImportableBuiltin:  true,
 	}
 
 	var members = []*Member{

--- a/runtime/stdlib/bls.cdc
+++ b/runtime/stdlib/bls.cdc
@@ -1,0 +1,22 @@
+access(all)
+contract BLS {
+    /// Aggregates multiple BLS signatures into one,
+    /// considering the proof of possession as a defense against rogue attacks.
+    ///
+    /// Signatures could be generated from the same or distinct messages,
+    /// they could also be the aggregation of other signatures.
+    /// The order of the signatures in the slice does not matter since the aggregation is commutative.
+    /// No subgroup membership check is performed on the input signatures.
+    /// The function returns nil if the array is empty or if decoding one of the signature fails.
+    access(all)
+    fun aggregateSignatures(_ signatures: [[UInt8]]): [UInt8]?
+
+
+    /// Aggregates multiple BLS public keys into one.
+    ///
+    /// The order of the public keys in the slice does not matter since the aggregation is commutative.
+    /// No subgroup membership check is performed on the input keys.
+    /// The function returns nil if the array is empty or any of the input keys is not a BLS key.
+    access(all)
+    fun aggregatePublicKeys(_ keys: [PublicKey]): PublicKey?
+}

--- a/runtime/stdlib/bls.cdc
+++ b/runtime/stdlib/bls.cdc
@@ -9,7 +9,7 @@ contract BLS {
     /// No subgroup membership check is performed on the input signatures.
     /// The function returns nil if the array is empty or if decoding one of the signature fails.
     access(all)
-    fun aggregateSignatures(_ signatures: [[UInt8]]): [UInt8]?
+    view fun aggregateSignatures(_ signatures: [[UInt8]]): [UInt8]?
 
 
     /// Aggregates multiple BLS public keys into one.
@@ -18,5 +18,5 @@ contract BLS {
     /// No subgroup membership check is performed on the input keys.
     /// The function returns nil if the array is empty or any of the input keys is not a BLS key.
     access(all)
-    fun aggregatePublicKeys(_ keys: [PublicKey]): PublicKey?
+    view fun aggregatePublicKeys(_ keys: [PublicKey]): PublicKey?
 }

--- a/runtime/stdlib/bls.gen.go
+++ b/runtime/stdlib/bls.gen.go
@@ -28,6 +28,7 @@ import (
 const BLSTypeAggregateSignaturesFunctionName = "aggregateSignatures"
 
 var BLSTypeAggregateSignaturesFunctionType = &sema.FunctionType{
+	Purity: FunctionPurityView,
 	Parameters: []sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
@@ -62,6 +63,7 @@ The function returns nil if the array is empty or if decoding one of the signatu
 const BLSTypeAggregatePublicKeysFunctionName = "aggregatePublicKeys"
 
 var BLSTypeAggregatePublicKeysFunctionType = &sema.FunctionType{
+	Purity: FunctionPurityView,
 	Parameters: []sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,

--- a/runtime/stdlib/bls.gen.go
+++ b/runtime/stdlib/bls.gen.go
@@ -103,14 +103,14 @@ func init() {
 	var members = []*sema.Member{
 		sema.NewUnmeteredFunctionMember(
 			BLSType,
-			ast.AccessPublic,
+			PrimitiveAccess(ast.AccessAll),
 			BLSTypeAggregateSignaturesFunctionName,
 			BLSTypeAggregateSignaturesFunctionType,
 			BLSTypeAggregateSignaturesFunctionDocString,
 		),
 		sema.NewUnmeteredFunctionMember(
 			BLSType,
-			ast.AccessPublic,
+			PrimitiveAccess(ast.AccessAll),
 			BLSTypeAggregatePublicKeysFunctionName,
 			BLSTypeAggregatePublicKeysFunctionType,
 			BLSTypeAggregatePublicKeysFunctionDocString,

--- a/runtime/stdlib/bls.gen.go
+++ b/runtime/stdlib/bls.gen.go
@@ -1,0 +1,122 @@
+// Code generated from bls.cdc. DO NOT EDIT.
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stdlib
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+const BLSTypeAggregateSignaturesFunctionName = "aggregateSignatures"
+
+var BLSTypeAggregateSignaturesFunctionType = &sema.FunctionType{
+	Parameters: []sema.Parameter{
+		{
+			Label:      sema.ArgumentLabelNotRequired,
+			Identifier: "signatures",
+			TypeAnnotation: sema.NewTypeAnnotation(&sema.VariableSizedType{
+				Type: &sema.VariableSizedType{
+					Type: UInt8Type,
+				},
+			}),
+		},
+	},
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		&sema.OptionalType{
+			Type: &sema.VariableSizedType{
+				Type: UInt8Type,
+			},
+		},
+	),
+}
+
+const BLSTypeAggregateSignaturesFunctionDocString = `
+Aggregates multiple BLS signatures into one,
+considering the proof of possession as a defense against rogue attacks.
+
+Signatures could be generated from the same or distinct messages,
+they could also be the aggregation of other signatures.
+The order of the signatures in the slice does not matter since the aggregation is commutative.
+No subgroup membership check is performed on the input signatures.
+The function returns nil if the array is empty or if decoding one of the signature fails.
+`
+
+const BLSTypeAggregatePublicKeysFunctionName = "aggregatePublicKeys"
+
+var BLSTypeAggregatePublicKeysFunctionType = &sema.FunctionType{
+	Parameters: []sema.Parameter{
+		{
+			Label:      sema.ArgumentLabelNotRequired,
+			Identifier: "keys",
+			TypeAnnotation: sema.NewTypeAnnotation(&sema.VariableSizedType{
+				Type: PublicKeyType,
+			}),
+		},
+	},
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		&sema.OptionalType{
+			Type: PublicKeyType,
+		},
+	),
+}
+
+const BLSTypeAggregatePublicKeysFunctionDocString = `
+Aggregates multiple BLS public keys into one.
+
+The order of the public keys in the slice does not matter since the aggregation is commutative.
+No subgroup membership check is performed on the input keys.
+The function returns nil if the array is empty or any of the input keys is not a BLS key.
+`
+
+const BLSTypeName = "BLS"
+
+var BLSType = func() *sema.CompositeType {
+	var t = &sema.CompositeType{
+		Identifier:         BLSTypeName,
+		Kind:               common.CompositeKindContract,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
+	}
+
+	return t
+}()
+
+func init() {
+	var members = []*sema.Member{
+		sema.NewUnmeteredFunctionMember(
+			BLSType,
+			ast.AccessPublic,
+			BLSTypeAggregateSignaturesFunctionName,
+			BLSTypeAggregateSignaturesFunctionType,
+			BLSTypeAggregateSignaturesFunctionDocString,
+		),
+		sema.NewUnmeteredFunctionMember(
+			BLSType,
+			ast.AccessPublic,
+			BLSTypeAggregatePublicKeysFunctionName,
+			BLSTypeAggregatePublicKeysFunctionType,
+			BLSTypeAggregatePublicKeysFunctionDocString,
+		),
+	}
+
+	BLSType.Members = sema.MembersAsMap(members)
+	BLSType.Fields = sema.MembersFieldNames(members)
+}

--- a/runtime/stdlib/bls.gen.go
+++ b/runtime/stdlib/bls.gen.go
@@ -28,7 +28,7 @@ import (
 const BLSTypeAggregateSignaturesFunctionName = "aggregateSignatures"
 
 var BLSTypeAggregateSignaturesFunctionType = &sema.FunctionType{
-	Purity: FunctionPurityView,
+	Purity: sema.FunctionPurityView,
 	Parameters: []sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
@@ -63,7 +63,7 @@ The function returns nil if the array is empty or if decoding one of the signatu
 const BLSTypeAggregatePublicKeysFunctionName = "aggregatePublicKeys"
 
 var BLSTypeAggregatePublicKeysFunctionType = &sema.FunctionType{
-	Purity: FunctionPurityView,
+	Purity: sema.FunctionPurityView,
 	Parameters: []sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
@@ -105,14 +105,14 @@ func init() {
 	var members = []*sema.Member{
 		sema.NewUnmeteredFunctionMember(
 			BLSType,
-			PrimitiveAccess(ast.AccessAll),
+			sema.PrimitiveAccess(ast.AccessAll),
 			BLSTypeAggregateSignaturesFunctionName,
 			BLSTypeAggregateSignaturesFunctionType,
 			BLSTypeAggregateSignaturesFunctionDocString,
 		),
 		sema.NewUnmeteredFunctionMember(
 			BLSType,
-			PrimitiveAccess(ast.AccessAll),
+			sema.PrimitiveAccess(ast.AccessAll),
 			BLSTypeAggregatePublicKeysFunctionName,
 			BLSTypeAggregatePublicKeysFunctionType,
 			BLSTypeAggregatePublicKeysFunctionDocString,

--- a/runtime/stdlib/bls.go
+++ b/runtime/stdlib/bls.go
@@ -187,7 +187,7 @@ func NewBLSContract(
 	}
 
 	blsContractValue := interpreter.NewSimpleCompositeValue(
-		nil,
+		gauge,
 		BLSType.ID(),
 		BLSTypeStaticType,
 		nil,
@@ -198,7 +198,7 @@ func NewBLSContract(
 	)
 
 	return StandardLibraryValue{
-		Name:  "BLS",
+		Name:  BLSTypeName,
 		Type:  BLSType,
 		Value: blsContractValue,
 		Kind:  common.DeclarationKindContract,

--- a/runtime/stdlib/bls.go
+++ b/runtime/stdlib/bls.go
@@ -18,94 +18,13 @@
 
 package stdlib
 
+//go:generate go run ../sema/gen -p stdlib bls.cdc bls.gen.go
+
 import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
-)
-
-var blsContractType = func() *sema.CompositeType {
-	ty := &sema.CompositeType{
-		Identifier: "BLS",
-		Kind:       common.CompositeKindContract,
-	}
-
-	ty.Members = sema.MembersAsMap([]*sema.Member{
-		sema.NewUnmeteredPublicFunctionMember(
-			ty,
-			blsAggregatePublicKeysFunctionName,
-			blsAggregatePublicKeysFunctionType,
-			blsAggregatePublicKeysFunctionDocString,
-		),
-		sema.NewUnmeteredPublicFunctionMember(
-			ty,
-			blsAggregateSignaturesFunctionName,
-			blsAggregateSignaturesFunctionType,
-			blsAggregateSignaturesFunctionDocString,
-		),
-	})
-	return ty
-}()
-
-var blsContractStaticType interpreter.StaticType = interpreter.ConvertSemaCompositeTypeToStaticCompositeType(
-	nil,
-	blsContractType,
-)
-
-const blsAggregateSignaturesFunctionDocString = `
-Aggregates multiple BLS signatures into one,
-considering the proof of possession as a defense against rogue attacks.
-
-Signatures could be generated from the same or distinct messages,
-they could also be the aggregation of other signatures.
-The order of the signatures in the slice does not matter since the aggregation is commutative.
-No subgroup membership check is performed on the input signatures.
-The function returns nil if the array is empty or if decoding one of the signature fails.
-`
-
-const blsAggregateSignaturesFunctionName = "aggregateSignatures"
-
-var blsAggregateSignaturesFunctionType = sema.NewSimpleFunctionType(
-	sema.FunctionPurityView,
-	[]sema.Parameter{
-		{
-			Label:          sema.ArgumentLabelNotRequired,
-			Identifier:     "signatures",
-			TypeAnnotation: sema.ByteArrayArrayTypeAnnotation,
-		},
-	},
-	sema.NewTypeAnnotation(
-		&sema.OptionalType{
-			Type: sema.ByteArrayType,
-		},
-	),
-)
-
-const blsAggregatePublicKeysFunctionDocString = `
-Aggregates multiple BLS public keys into one.
-
-The order of the public keys in the slice does not matter since the aggregation is commutative.
-No subgroup membership check is performed on the input keys.
-The function returns nil if the array is empty or any of the input keys is not a BLS key.
-`
-
-const blsAggregatePublicKeysFunctionName = "aggregatePublicKeys"
-
-var blsAggregatePublicKeysFunctionType = sema.NewSimpleFunctionType(
-	sema.FunctionPurityView,
-	[]sema.Parameter{
-		{
-			Label:          sema.ArgumentLabelNotRequired,
-			Identifier:     "keys",
-			TypeAnnotation: sema.PublicKeyArrayTypeAnnotation,
-		},
-	},
-	sema.NewTypeAnnotation(
-		&sema.OptionalType{
-			Type: sema.PublicKeyType,
-		},
-	),
 )
 
 type BLSPublicKeyAggregator interface {
@@ -121,7 +40,7 @@ func newBLSAggregatePublicKeysFunction(
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
 		gauge,
-		blsAggregatePublicKeysFunctionType,
+		BLSTypeAggregatePublicKeysFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			publicKeysValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 			if !ok {
@@ -193,7 +112,7 @@ func newBLSAggregateSignaturesFunction(
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
 		gauge,
-		blsAggregateSignaturesFunctionType,
+		BLSTypeAggregateSignaturesFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			signaturesValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 			if !ok {
@@ -256,19 +175,21 @@ type BLSContractHandler interface {
 	BLSSignatureAggregator
 }
 
+var BLSTypeStaticType = interpreter.ConvertSemaToStaticType(nil, BLSType)
+
 func NewBLSContract(
 	gauge common.MemoryGauge,
 	handler BLSContractHandler,
 ) StandardLibraryValue {
-	var blsContractFields = map[string]interpreter.Value{
-		blsAggregatePublicKeysFunctionName: newBLSAggregatePublicKeysFunction(gauge, handler),
-		blsAggregateSignaturesFunctionName: newBLSAggregateSignaturesFunction(gauge, handler),
+	blsContractFields := map[string]interpreter.Value{
+		BLSTypeAggregatePublicKeysFunctionName: newBLSAggregatePublicKeysFunction(gauge, handler),
+		BLSTypeAggregateSignaturesFunctionName: newBLSAggregateSignaturesFunction(gauge, handler),
 	}
 
-	var blsContractValue = interpreter.NewSimpleCompositeValue(
+	blsContractValue := interpreter.NewSimpleCompositeValue(
 		nil,
-		blsContractType.ID(),
-		blsContractStaticType,
+		BLSType.ID(),
+		BLSTypeStaticType,
 		nil,
 		blsContractFields,
 		nil,
@@ -278,7 +199,7 @@ func NewBLSContract(
 
 	return StandardLibraryValue{
 		Name:  "BLS",
-		Type:  blsContractType,
+		Type:  BLSType,
 		Value: blsContractValue,
 		Kind:  common.DeclarationKindContract,
 	}

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -18,6 +18,10 @@
 
 package stdlib
 
+import "github.com/onflow/cadence/runtime/sema"
+
+var UInt8Type = sema.UInt8Type
+
 type StandardLibraryHandler interface {
 	Logger
 	UnsafeRandomGenerator

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -193,7 +193,7 @@ var AccountEventCodeHashParameter = sema.Parameter{
 var AccountEventPublicKeyParameterAsCompositeType = sema.Parameter{
 	Identifier: "publicKey",
 	TypeAnnotation: sema.NewTypeAnnotation(
-		sema.PublicKeyType,
+		PublicKeyType,
 	),
 }
 

--- a/runtime/stdlib/publickey.go
+++ b/runtime/stdlib/publickey.go
@@ -25,6 +25,8 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 )
 
+var PublicKeyType = sema.PublicKeyType
+
 const publicKeyConstructorFunctionDocString = `
 Constructs a new public key
 `
@@ -258,7 +260,7 @@ func newPublicKeyVerifySignatureFunction(
 
 			inter.ExpectType(
 				publicKeyValue,
-				sema.PublicKeyType,
+				PublicKeyType,
 				locationRange,
 			)
 
@@ -328,7 +330,7 @@ func newPublicKeyVerifyPoPFunction(
 
 			inter.ExpectType(
 				publicKeyValue,
-				sema.PublicKeyType,
+				PublicKeyType,
 				locationRange,
 			)
 

--- a/runtime/stdlib/rlp.cdc
+++ b/runtime/stdlib/rlp.cdc
@@ -1,0 +1,18 @@
+access(all)
+contract RLP {
+    /// Decodes an RLP-encoded byte array (called string in the context of RLP).
+    /// The byte array should only contain of a single encoded value for a string;
+    /// if the encoded value type does not match, or it has trailing unnecessary bytes, the program aborts.
+    /// If any error is encountered while decoding, the program aborts.
+    access(all)
+    fun decodeString(_ input: [UInt8]): [UInt8]
+
+
+    /// Decodes an RLP-encoded list into an array of RLP-encoded items.
+    /// Note that this function does not recursively decode, so each element of the resulting array is RLP-encoded data.
+    /// The byte array should only contain of a single encoded value for a list;
+    /// if the encoded value type does not match, or it has trailing unnecessary bytes, the program aborts.
+    /// If any error is encountered while decoding, the program aborts.
+    access(all)
+    fun decodeList(_ input: [UInt8]): [[UInt8]]
+}

--- a/runtime/stdlib/rlp.cdc
+++ b/runtime/stdlib/rlp.cdc
@@ -5,7 +5,7 @@ contract RLP {
     /// if the encoded value type does not match, or it has trailing unnecessary bytes, the program aborts.
     /// If any error is encountered while decoding, the program aborts.
     access(all)
-    fun decodeString(_ input: [UInt8]): [UInt8]
+    view fun decodeString(_ input: [UInt8]): [UInt8]
 
 
     /// Decodes an RLP-encoded list into an array of RLP-encoded items.
@@ -14,5 +14,5 @@ contract RLP {
     /// if the encoded value type does not match, or it has trailing unnecessary bytes, the program aborts.
     /// If any error is encountered while decoding, the program aborts.
     access(all)
-    fun decodeList(_ input: [UInt8]): [[UInt8]]
+    view fun decodeList(_ input: [UInt8]): [[UInt8]]
 }

--- a/runtime/stdlib/rlp.gen.go
+++ b/runtime/stdlib/rlp.gen.go
@@ -28,7 +28,7 @@ import (
 const RLPTypeDecodeStringFunctionName = "decodeString"
 
 var RLPTypeDecodeStringFunctionType = &sema.FunctionType{
-	Purity: FunctionPurityView,
+	Purity: sema.FunctionPurityView,
 	Parameters: []sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
@@ -55,7 +55,7 @@ If any error is encountered while decoding, the program aborts.
 const RLPTypeDecodeListFunctionName = "decodeList"
 
 var RLPTypeDecodeListFunctionType = &sema.FunctionType{
-	Purity: FunctionPurityView,
+	Purity: sema.FunctionPurityView,
 	Parameters: []sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
@@ -99,14 +99,14 @@ func init() {
 	var members = []*sema.Member{
 		sema.NewUnmeteredFunctionMember(
 			RLPType,
-			PrimitiveAccess(ast.AccessAll),
+			sema.PrimitiveAccess(ast.AccessAll),
 			RLPTypeDecodeStringFunctionName,
 			RLPTypeDecodeStringFunctionType,
 			RLPTypeDecodeStringFunctionDocString,
 		),
 		sema.NewUnmeteredFunctionMember(
 			RLPType,
-			PrimitiveAccess(ast.AccessAll),
+			sema.PrimitiveAccess(ast.AccessAll),
 			RLPTypeDecodeListFunctionName,
 			RLPTypeDecodeListFunctionType,
 			RLPTypeDecodeListFunctionDocString,

--- a/runtime/stdlib/rlp.gen.go
+++ b/runtime/stdlib/rlp.gen.go
@@ -1,0 +1,116 @@
+// Code generated from rlp.cdc. DO NOT EDIT.
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stdlib
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+const RLPTypeDecodeStringFunctionName = "decodeString"
+
+var RLPTypeDecodeStringFunctionType = &sema.FunctionType{
+	Parameters: []sema.Parameter{
+		{
+			Label:      sema.ArgumentLabelNotRequired,
+			Identifier: "input",
+			TypeAnnotation: sema.NewTypeAnnotation(&sema.VariableSizedType{
+				Type: UInt8Type,
+			}),
+		},
+	},
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		&sema.VariableSizedType{
+			Type: UInt8Type,
+		},
+	),
+}
+
+const RLPTypeDecodeStringFunctionDocString = `
+Decodes an RLP-encoded byte array (called string in the context of RLP).
+The byte array should only contain of a single encoded value for a string;
+if the encoded value type does not match, or it has trailing unnecessary bytes, the program aborts.
+If any error is encountered while decoding, the program aborts.
+`
+
+const RLPTypeDecodeListFunctionName = "decodeList"
+
+var RLPTypeDecodeListFunctionType = &sema.FunctionType{
+	Parameters: []sema.Parameter{
+		{
+			Label:      sema.ArgumentLabelNotRequired,
+			Identifier: "input",
+			TypeAnnotation: sema.NewTypeAnnotation(&sema.VariableSizedType{
+				Type: UInt8Type,
+			}),
+		},
+	},
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		&sema.VariableSizedType{
+			Type: &sema.VariableSizedType{
+				Type: UInt8Type,
+			},
+		},
+	),
+}
+
+const RLPTypeDecodeListFunctionDocString = `
+Decodes an RLP-encoded list into an array of RLP-encoded items.
+Note that this function does not recursively decode, so each element of the resulting array is RLP-encoded data.
+The byte array should only contain of a single encoded value for a list;
+if the encoded value type does not match, or it has trailing unnecessary bytes, the program aborts.
+If any error is encountered while decoding, the program aborts.
+`
+
+const RLPTypeName = "RLP"
+
+var RLPType = func() *sema.CompositeType {
+	var t = &sema.CompositeType{
+		Identifier:         RLPTypeName,
+		Kind:               common.CompositeKindContract,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
+	}
+
+	return t
+}()
+
+func init() {
+	var members = []*sema.Member{
+		sema.NewUnmeteredFunctionMember(
+			RLPType,
+			ast.AccessPublic,
+			RLPTypeDecodeStringFunctionName,
+			RLPTypeDecodeStringFunctionType,
+			RLPTypeDecodeStringFunctionDocString,
+		),
+		sema.NewUnmeteredFunctionMember(
+			RLPType,
+			ast.AccessPublic,
+			RLPTypeDecodeListFunctionName,
+			RLPTypeDecodeListFunctionType,
+			RLPTypeDecodeListFunctionDocString,
+		),
+	}
+
+	RLPType.Members = sema.MembersAsMap(members)
+	RLPType.Fields = sema.MembersFieldNames(members)
+}

--- a/runtime/stdlib/rlp.gen.go
+++ b/runtime/stdlib/rlp.gen.go
@@ -97,14 +97,14 @@ func init() {
 	var members = []*sema.Member{
 		sema.NewUnmeteredFunctionMember(
 			RLPType,
-			ast.AccessPublic,
+			PrimitiveAccess(ast.AccessAll),
 			RLPTypeDecodeStringFunctionName,
 			RLPTypeDecodeStringFunctionType,
 			RLPTypeDecodeStringFunctionDocString,
 		),
 		sema.NewUnmeteredFunctionMember(
 			RLPType,
-			ast.AccessPublic,
+			PrimitiveAccess(ast.AccessAll),
 			RLPTypeDecodeListFunctionName,
 			RLPTypeDecodeListFunctionType,
 			RLPTypeDecodeListFunctionDocString,

--- a/runtime/stdlib/rlp.gen.go
+++ b/runtime/stdlib/rlp.gen.go
@@ -28,6 +28,7 @@ import (
 const RLPTypeDecodeStringFunctionName = "decodeString"
 
 var RLPTypeDecodeStringFunctionType = &sema.FunctionType{
+	Purity: FunctionPurityView,
 	Parameters: []sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
@@ -54,6 +55,7 @@ If any error is encountered while decoding, the program aborts.
 const RLPTypeDecodeListFunctionName = "decodeList"
 
 var RLPTypeDecodeListFunctionType = &sema.FunctionType{
+	Purity: FunctionPurityView,
 	Parameters: []sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,

--- a/runtime/stdlib/rlp.go
+++ b/runtime/stdlib/rlp.go
@@ -166,7 +166,7 @@ var rlpContractValue = interpreter.NewSimpleCompositeValue(
 )
 
 var RLPContract = StandardLibraryValue{
-	Name:  "RLP",
+	Name:  RLPTypeName,
 	Type:  RLPType,
 	Value: rlpContractValue,
 	Kind:  common.DeclarationKindContract,

--- a/runtime/stdlib/rlp.go
+++ b/runtime/stdlib/rlp.go
@@ -18,65 +18,15 @@
 
 package stdlib
 
+//go:generate go run ../sema/gen -p stdlib rlp.cdc rlp.gen.go
+
 import (
 	"fmt"
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
-	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib/rlp"
-)
-
-var rlpContractType = func() *sema.CompositeType {
-	ty := &sema.CompositeType{
-		Identifier: "RLP",
-		Kind:       common.CompositeKindContract,
-	}
-
-	ty.Members = sema.MembersAsMap([]*sema.Member{
-		sema.NewUnmeteredPublicFunctionMember(
-			ty,
-			rlpDecodeListFunctionName,
-			rlpDecodeListFunctionType,
-			rlpDecodeListFunctionDocString,
-		),
-		sema.NewUnmeteredPublicFunctionMember(
-			ty,
-			rlpDecodeStringFunctionName,
-			rlpDecodeStringFunctionType,
-			rlpDecodeStringFunctionDocString,
-		),
-	})
-	return ty
-}()
-
-var rlpContractStaticType interpreter.StaticType = interpreter.ConvertSemaCompositeTypeToStaticCompositeType(
-	nil,
-	rlpContractType,
-)
-
-const rlpErrMsgInputContainsExtraBytes = "input data is expected to be RLP-encoded of a single string or a single list but it seems it contains extra trailing bytes."
-
-const rlpDecodeStringFunctionDocString = `
-Decodes an RLP-encoded byte array (called string in the context of RLP). 
-The byte array should only contain of a single encoded value for a string;
-if the encoded value type does not match, or it has trailing unnecessary bytes, the program aborts.
-If any error is encountered while decoding, the program aborts.
-`
-
-const rlpDecodeStringFunctionName = "decodeString"
-
-var rlpDecodeStringFunctionType = sema.NewSimpleFunctionType(
-	sema.FunctionPurityView,
-	[]sema.Parameter{
-		{
-			Label:          sema.ArgumentLabelNotRequired,
-			Identifier:     "input",
-			TypeAnnotation: sema.ByteArrayTypeAnnotation,
-		},
-	},
-	sema.ByteArrayTypeAnnotation,
 )
 
 type RLPDecodeStringError struct {
@@ -92,8 +42,10 @@ func (e RLPDecodeStringError) Error() string {
 	return fmt.Sprintf("failed to RLP-decode string: %s", e.Msg)
 }
 
+const rlpErrMsgInputContainsExtraBytes = "input data is expected to be RLP-encoded of a single string or a single list but it seems it contains extra trailing bytes."
+
 var rlpDecodeStringFunction = interpreter.NewUnmeteredHostFunctionValue(
-	rlpDecodeStringFunctionType,
+	RLPTypeDecodeStringFunctionType,
 	func(invocation interpreter.Invocation) interpreter.Value {
 		input, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 		if !ok {
@@ -128,28 +80,6 @@ var rlpDecodeStringFunction = interpreter.NewUnmeteredHostFunctionValue(
 	},
 )
 
-const rlpDecodeListFunctionDocString = `
-Decodes an RLP-encoded list into an array of RLP-encoded items.
-Note that this function does not recursively decode, so each element of the resulting array is RLP-encoded data. 
-The byte array should only contain of a single encoded value for a list;
-if the encoded value type does not match, or it has trailing unnecessary bytes, the program aborts.
-If any error is encountered while decoding, the program aborts.
-`
-
-const rlpDecodeListFunctionName = "decodeList"
-
-var rlpDecodeListFunctionType = sema.NewSimpleFunctionType(
-	sema.FunctionPurityView,
-	[]sema.Parameter{
-		{
-			Label:          sema.ArgumentLabelNotRequired,
-			Identifier:     "input",
-			TypeAnnotation: sema.ByteArrayTypeAnnotation,
-		},
-	},
-	sema.ByteArrayArrayTypeAnnotation,
-)
-
 type RLPDecodeListError struct {
 	interpreter.LocationRange
 	Msg string
@@ -164,7 +94,7 @@ func (e RLPDecodeListError) Error() string {
 }
 
 var rlpDecodeListFunction = interpreter.NewUnmeteredHostFunctionValue(
-	rlpDecodeListFunctionType,
+	RLPTypeDecodeListFunctionType,
 	func(invocation interpreter.Invocation) interpreter.Value {
 		input, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 		if !ok {
@@ -218,14 +148,16 @@ var rlpDecodeListFunction = interpreter.NewUnmeteredHostFunctionValue(
 )
 
 var rlpContractFields = map[string]interpreter.Value{
-	rlpDecodeListFunctionName:   rlpDecodeListFunction,
-	rlpDecodeStringFunctionName: rlpDecodeStringFunction,
+	RLPTypeDecodeListFunctionName:   rlpDecodeListFunction,
+	RLPTypeDecodeStringFunctionName: rlpDecodeStringFunction,
 }
+
+var RLPTypeStaticType = interpreter.ConvertSemaToStaticType(nil, RLPType)
 
 var rlpContractValue = interpreter.NewSimpleCompositeValue(
 	nil,
-	rlpContractType.ID(),
-	rlpContractStaticType,
+	RLPType.ID(),
+	RLPTypeStaticType,
 	nil,
 	rlpContractFields,
 	nil,
@@ -235,7 +167,7 @@ var rlpContractValue = interpreter.NewSimpleCompositeValue(
 
 var RLPContract = StandardLibraryValue{
 	Name:  "RLP",
-	Type:  rlpContractType,
+	Type:  RLPType,
 	Value: rlpContractValue,
 	Kind:  common.DeclarationKindContract,
 }


### PR DESCRIPTION

## Description

- Improve type code generator: Add support for generating contracts, and add support for generating code in any package (previously only `sema` was supported / hard-coded)
- Refactor the stdlib RLP and BLS contracts to CDC files and using the type code generator

These changes will make it easier and faster to add new types to the standard library.

Also, add support for generating code for dictionary types.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
