### PR TITLE
sort entitlement sets alphabetically when generating strings

### DIFF
--- a/runtime/common/orderedmap/orderedmap.go
+++ b/runtime/common/orderedmap/orderedmap.go
@@ -22,7 +22,10 @@
 package orderedmap
 
 import (
+	"sort"
+
 	"github.com/onflow/cadence/runtime/common/list"
+	"golang.org/x/exp/maps"
 )
 
 // OrderedMap
@@ -227,6 +230,35 @@ func (om *OrderedMap[K, V]) ForAllKeys(predicate func(key K) bool) bool {
 		}
 	}
 	return true
+}
+
+// MapKeys returns a new ordered map whose keys are mapped according to
+// the provided mapping function between
+func MapKeys[T OrderedMap[K, V], K comparable, V any, H comparable](om *OrderedMap[K, V], f func(K) H) *OrderedMap[H, V] {
+	mapped := New[OrderedMap[H, V]](om.Len())
+
+	om.Foreach(func(key K, value V) {
+		mapped.Set(f(key), value)
+	})
+
+	return mapped
+}
+
+// SortByKeys returns a new ordered map whose insertion order is sorted according to
+// the provided comparison function between keys
+func (om *OrderedMap[K, V]) SortByKey(compare func(K, K) bool) *OrderedMap[K, V] {
+	sorted := New[OrderedMap[K, V]](om.Len())
+	keys := maps.Keys(om.pairs)
+	sort.Slice(keys, func(i, j int) bool {
+		return compare(keys[i], keys[j])
+	})
+
+	for _, key := range keys {
+		value, _ := om.Get(key)
+		sorted.Set(key, value)
+	}
+
+	return sorted
 }
 
 // ForAnyKey iterates over the keys of the map, and returns whether the provided

--- a/runtime/common/orderedmap/orderedmap.go
+++ b/runtime/common/orderedmap/orderedmap.go
@@ -24,8 +24,9 @@ package orderedmap
 import (
 	"sort"
 
-	"github.com/onflow/cadence/runtime/common/list"
 	"golang.org/x/exp/maps"
+
+	"github.com/onflow/cadence/runtime/common/list"
 )
 
 // OrderedMap
@@ -248,7 +249,8 @@ func MapKeys[T OrderedMap[K, V], K comparable, V any, H comparable](om *OrderedM
 // the provided comparison function between keys
 func (om *OrderedMap[K, V]) SortByKey(compare func(K, K) bool) *OrderedMap[K, V] {
 	sorted := New[OrderedMap[K, V]](om.Len())
-	keys := maps.Keys(om.pairs)
+	// non-deterministic order is okay here because the result is immediately sorted
+	keys := maps.Keys(om.pairs) //nolint:forbidigo
 	sort.Slice(keys, func(i, j int) bool {
 		return compare(keys[i], keys[j])
 	})

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -95,8 +95,11 @@ func (e EntitlementSetAccess) string(typeFormatter func(ty Type) string) string 
 		separator = " | "
 	}
 
-	e.Entitlements.ForeachWithIndex(func(i int, entitlement *EntitlementType, _ struct{}) {
-		builder.WriteString(typeFormatter(entitlement))
+	compareFn := func(i string, j string) bool { return i < j }
+	mappedToIDs := orderedmap.MapKeys(e.Entitlements, func(et *EntitlementType) string { return typeFormatter(et) })
+
+	mappedToIDs.SortByKey(compareFn).ForeachWithIndex(func(i int, id string, _ struct{}) {
+		builder.WriteString(id)
 		if i < e.Entitlements.Len()-1 {
 			builder.WriteString(separator)
 		}

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -3601,8 +3601,8 @@ func TestCheckEntitlementMapAccess(t *testing.T) {
 		errs := RequireCheckerErrors(t, err, 1)
 
 		require.IsType(t, &sema.TypeMismatchError{}, errs[0])
-		require.Equal(t, errs[0].(*sema.TypeMismatchError).ExpectedType.QualifiedString(), "auth(Y, F) &Int")
-		require.Equal(t, errs[0].(*sema.TypeMismatchError).ActualType.QualifiedString(), "auth(Y | F) &Int")
+		require.Equal(t, errs[0].(*sema.TypeMismatchError).ExpectedType.QualifiedString(), "auth(F, Y) &Int")
+		require.Equal(t, errs[0].(*sema.TypeMismatchError).ActualType.QualifiedString(), "auth(F | Y) &Int")
 	})
 
 	t.Run("optional", func(t *testing.T) {
@@ -4264,8 +4264,8 @@ func TestCheckAttachmentEntitlements(t *testing.T) {
 		errs := RequireCheckerErrors(t, err, 1)
 
 		require.IsType(t, &sema.TypeMismatchError{}, errs[0])
-		require.Equal(t, errs[0].(*sema.TypeMismatchError).ExpectedType.QualifiedString(), "auth(F, Y, E) &A")
-		require.Equal(t, errs[0].(*sema.TypeMismatchError).ActualType.QualifiedString(), "auth(Y, F) &A")
+		require.Equal(t, errs[0].(*sema.TypeMismatchError).ExpectedType.QualifiedString(), "auth(E, F, Y) &A")
+		require.Equal(t, errs[0].(*sema.TypeMismatchError).ActualType.QualifiedString(), "auth(F, Y) &A")
 	})
 
 	t.Run("missing in codomain", func(t *testing.T) {

--- a/runtime/tests/interpreter/entitlements_test.go
+++ b/runtime/tests/interpreter/entitlements_test.go
@@ -232,6 +232,32 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 		)
 	})
 
+	t.Run("equality", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+		entitlement X
+		entitlement Y
+        resource R {}
+
+        fun test(): Bool {
+			return ReferenceType(entitlements: ["S.test.X", "S.test.Y"], type: Type<@R>())! ==
+				   ReferenceType(entitlements: ["S.test.Y", "S.test.X"], type: Type<@R>())!
+        }
+    `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.TrueValue,
+			value,
+		)
+	})
+
 	t.Run("order irrelevant as dictionary key", func(t *testing.T) {
 
 		t.Parallel()

--- a/runtime/tests/interpreter/entitlements_test.go
+++ b/runtime/tests/interpreter/entitlements_test.go
@@ -243,7 +243,8 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
         fun test(): Bool {
 			return ReferenceType(entitlements: ["S.test.X", "S.test.Y"], type: Type<@R>())! ==
-				   ReferenceType(entitlements: ["S.test.Y", "S.test.X"], type: Type<@R>())!
+				   ReferenceType(entitlements: ["S.test.Y", "S.test.X"], type: Type<@R>())! && 
+				   Type<auth(X, Y) &R>() == Type<auth(Y, X) &R>()
         }
     `)
 

--- a/runtime/tests/interpreter/entitlements_test.go
+++ b/runtime/tests/interpreter/entitlements_test.go
@@ -203,6 +203,122 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 		)
 	})
 
+	t.Run("subtype comparison order irrelevant", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+		entitlement X
+		entitlement Y
+        resource R {}
+
+        fun test(): Bool {
+			return ReferenceType(entitlements: ["S.test.X", "S.test.Y"], type: Type<@R>())!.isSubtype(of: 
+				   ReferenceType(entitlements: ["S.test.Y", "S.test.X"], type: Type<@R>())!
+			) && ReferenceType(entitlements: ["S.test.Y", "S.test.X"], type: Type<@R>())!.isSubtype(of: 
+				 ReferenceType(entitlements: ["S.test.X", "S.test.Y"], type: Type<@R>())!
+			)
+        }
+    `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.TrueValue,
+			value,
+		)
+	})
+
+	t.Run("order irrelevant as dictionary key", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+		entitlement X
+		entitlement Y
+        resource R {}
+
+        fun test(): Int {
+			let runtimeType1 = ReferenceType(entitlements: ["S.test.X", "S.test.Y"], type: Type<@R>())!
+			let runtimeType2 = ReferenceType(entitlements: ["S.test.Y", "S.test.X"], type: Type<@R>())!
+
+			let dict = {runtimeType1 : 3}
+			return dict[runtimeType2]!
+        }
+    `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			value,
+		)
+	})
+
+	t.Run("order irrelevant as dictionary key when obtained from Type<>", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+		entitlement X
+		entitlement Y
+        resource R {}
+
+        fun test(): Int {
+			let runtimeType1 = Type<auth(X, Y) &R>()
+			let runtimeType2 = Type<auth(Y, X) &R>()
+
+			let dict = {runtimeType1 : 3}
+			return dict[runtimeType2]!
+        }
+    `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			value,
+		)
+	})
+
+	t.Run("order irrelevant as dictionary key when obtained from .getType()", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+		entitlement X
+		entitlement Y
+        struct S {}
+
+        fun test(): Int {
+			let runtimeType1 = [&S() as auth(X, Y) &S].getType()
+			let runtimeType2 = [&S() as auth(Y, X) &S].getType()
+
+			let dict = {runtimeType1 : 3}
+			return dict[runtimeType2]!
+        }
+    `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			value,
+		)
+	})
+
 	t.Run("created different auth <: auth", func(t *testing.T) {
 
 		t.Parallel()


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2749

Sort entitlement sets when producing strings from them. This guarantees that equal but differently-ordered entitled references will hash to the same value. 
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
