### PR TITLE
Improve and fix static types and their ID and string functions

### DIFF
--- a/encoding/ccf/ccf_test.go
+++ b/encoding/ccf/ccf_test.go
@@ -6125,8 +6125,8 @@ func TestEncodeEvent(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(
 				t,
-				cadence.ValueWithCachedTypeID(tc.val),
-				cadence.ValueWithCachedTypeID(decodedVal),
+				tc.val,
+				decodedVal,
 			)
 		})
 	}
@@ -8295,8 +8295,8 @@ func TestEncodeType(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(
 			t,
-			cadence.ValueWithCachedTypeID(val),
-			cadence.ValueWithCachedTypeID(decodedVal),
+			val,
+			decodedVal,
 		)
 	})
 
@@ -11571,8 +11571,8 @@ func testDecode(t *testing.T, actualCBOR []byte, expectedVal cadence.Value) {
 	require.NoError(t, err)
 	assert.Equal(
 		t,
-		cadence.ValueWithCachedTypeID(expectedVal),
-		cadence.ValueWithCachedTypeID(decodedVal),
+		expectedVal,
+		decodedVal,
 	)
 }
 
@@ -12853,8 +12853,8 @@ func TestDeployedEvents(t *testing.T) {
 			// Since event encoding doesn't sort fields, make sure that input event is identical to decoded event.
 			require.Equal(
 				t,
-				cadence.ValueWithCachedTypeID(tc.event),
-				cadence.ValueWithCachedTypeID(decodedEvent),
+				tc.event,
+				decodedEvent,
 			)
 		})
 	}
@@ -14616,8 +14616,8 @@ func TestSortOptions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(
 			t,
-			cadence.ValueWithCachedTypeID(expectedVal),
-			cadence.ValueWithCachedTypeID(decodedVal),
+			expectedVal,
+			decodedVal,
 		)
 
 		// Decode value enforcing sorting of composite fields should return error.
@@ -14805,8 +14805,8 @@ func TestSortOptions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(
 			t,
-			cadence.ValueWithCachedTypeID(expectedVal),
-			cadence.ValueWithCachedTypeID(decodedVal),
+			expectedVal,
+			decodedVal,
 		)
 
 		// Decode value without enforcing sorting should return no error.
@@ -14994,8 +14994,8 @@ func TestSortOptions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(
 			t,
-			cadence.ValueWithCachedTypeID(expectedVal),
-			cadence.ValueWithCachedTypeID(decodedVal),
+			expectedVal,
+			decodedVal,
 		)
 
 		// Decode value without enforcing sorting should return no error.
@@ -15183,8 +15183,8 @@ func TestSortOptions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(
 			t,
-			cadence.ValueWithCachedTypeID(expectedVal),
-			cadence.ValueWithCachedTypeID(decodedVal),
+			expectedVal,
+			decodedVal,
 		)
 
 		// Decode value without enforcing sorting should return no error.

--- a/encoding/ccf/decode_typedef.go
+++ b/encoding/ccf/decode_typedef.go
@@ -193,7 +193,7 @@ func (d *Decoder) decodeTypeDef(
 ) {
 	tagNum, err := d.dec.DecodeTagNumber()
 	if err != nil {
-		return ccfTypeID(0), cadenceTypeID(""), nil, err
+		return ccfTypeID(0), "", nil, err
 	}
 
 	switch tagNum {
@@ -296,7 +296,7 @@ func (d *Decoder) decodeTypeDef(
 
 	default:
 		return ccfTypeID(0),
-			cadenceTypeID(""),
+			"",
 			nil,
 			fmt.Errorf("unsupported type definition with CBOR tag number %d", tagNum)
 	}
@@ -329,32 +329,32 @@ func (d *Decoder) decodeCompositeType(
 	// Decode array head of length 3.
 	err := decodeCBORArrayWithKnownSize(d.dec, 3)
 	if err != nil {
-		return ccfTypeID(0), cadenceTypeID(""), nil, err
+		return ccfTypeID(0), "", nil, err
 	}
 
 	// element 0: id
 	ccfID, err := d.decodeCCFTypeID()
 	if err != nil {
-		return ccfTypeID(0), cadenceTypeID(""), nil, err
+		return ccfTypeID(0), "", nil, err
 	}
 
 	// "Valid CCF Encoding Requirements" in CCF specs:
 	//
 	//   "composite-type.id MUST be unique in ccf-typedef-message or ccf-typedef-and-value-message."
 	if types.has(ccfID) {
-		return ccfTypeID(0), cadenceTypeID(""), nil, fmt.Errorf("found duplicate CCF type ID %d in composite-type", ccfID)
+		return ccfTypeID(0), "", nil, fmt.Errorf("found duplicate CCF type ID %d in composite-type", ccfID)
 	}
 
 	// element 1: cadence-type-id
 	cadenceID, location, identifier, err := d.decodeCadenceTypeID()
 	if err != nil {
-		return ccfTypeID(0), cadenceTypeID(""), nil, err
+		return ccfTypeID(0), "", nil, err
 	}
 
 	// element 2: fields
 	rawField, err := d.dec.DecodeRawBytes()
 	if err != nil {
-		return ccfTypeID(0), cadenceTypeID(""), nil, err
+		return ccfTypeID(0), "", nil, err
 	}
 
 	// The return value can be ignored, because its non-existence was already checked above
@@ -476,26 +476,26 @@ func (d *Decoder) decodeInterfaceType(
 	// Decode array head of length 2.
 	err := decodeCBORArrayWithKnownSize(d.dec, 2)
 	if err != nil {
-		return ccfTypeID(0), cadenceTypeID(""), nil, err
+		return ccfTypeID(0), "", nil, err
 	}
 
 	// element 0: id
 	ccfID, err := d.decodeCCFTypeID()
 	if err != nil {
-		return ccfTypeID(0), cadenceTypeID(""), nil, err
+		return ccfTypeID(0), "", nil, err
 	}
 
 	// "Valid CCF Encoding Requirements" in CCF specs:
 	//
 	//   "composite-type.id MUST be unique in ccf-typedef-message or ccf-typedef-and-value-message."
 	if types.has(ccfID) {
-		return ccfTypeID(0), cadenceTypeID(""), nil, fmt.Errorf("found duplicate CCF type ID %d in interface-type", ccfID)
+		return ccfTypeID(0), "", nil, fmt.Errorf("found duplicate CCF type ID %d in interface-type", ccfID)
 	}
 
 	// element 1: cadence-type-id
 	cadenceID, location, identifier, err := d.decodeCadenceTypeID()
 	if err != nil {
-		return ccfTypeID(0), cadenceTypeID(""), nil, err
+		return ccfTypeID(0), "", nil, err
 	}
 
 	// The return value can be ignored, because its non-existence was already checked above

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -3288,8 +3288,8 @@ func testDecode(t *testing.T, actualJSON string, expectedVal cadence.Value, opti
 
 	assert.Equal(
 		t,
-		cadence.ValueWithCachedTypeID(expectedVal),
-		cadence.ValueWithCachedTypeID(decodedVal),
+		expectedVal,
+		decodedVal,
 	)
 }
 

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -881,13 +881,7 @@ var SignAlgoType = ExportedBuiltinType(sema.SignatureAlgorithmType).(*cadence.En
 var HashAlgoType = ExportedBuiltinType(sema.HashAlgorithmType).(*cadence.EnumType)
 
 func ExportedBuiltinType(internalType sema.Type) cadence.Type {
-	typ := ExportType(internalType, map[sema.TypeID]cadence.Type{})
-
-	// These types are re-used across tests.
-	// Hence, cache the ID always to avoid any non-determinism.
-	typ = cadence.TypeWithCachedTypeID(typ)
-
-	return typ
+	return ExportType(internalType, map[sema.TypeID]cadence.Type{})
 }
 
 func newBytesValue(bytes []byte) cadence.Array {
@@ -921,7 +915,7 @@ func accountKeyExportedValue(
 		panic(err)
 	}
 
-	value := cadence.Struct{
+	return cadence.Struct{
 		StructType: AccountKeyType,
 		Fields: []cadence.Value{
 			// Key index
@@ -951,8 +945,6 @@ func accountKeyExportedValue(
 			cadence.NewBool(isRevoked),
 		},
 	}
-
-	return cadence.ValueWithCachedTypeID(value)
 }
 
 func getAccountKeyTestRuntimeInterface(storage *testAccountKeyStorage) *testRuntimeInterface {
@@ -1115,10 +1107,6 @@ func (test accountKeyTestCase) executeScript(
 		},
 	)
 
-	if err == nil {
-		value = cadence.ValueWithCachedTypeID(value)
-	}
-
 	return value, err
 }
 
@@ -1154,10 +1142,6 @@ func TestRuntimePublicKey(t *testing.T) {
 				Location:  common.ScriptLocation{},
 			},
 		)
-
-		if err == nil {
-			value = cadence.ValueWithCachedTypeID(value)
-		}
 
 		return value, err
 	}
@@ -1197,7 +1181,6 @@ func TestRuntimePublicKey(t *testing.T) {
 			},
 		}
 
-		expected = cadence.ValueWithCachedTypeID(expected)
 		assert.Equal(t, expected, value)
 	})
 
@@ -1463,8 +1446,6 @@ func TestRuntimePublicKey(t *testing.T) {
 			},
 		}
 
-		expected = cadence.ValueWithCachedTypeID(expected)
-
 		assert.Equal(t, expected, value)
 	})
 
@@ -1505,7 +1486,6 @@ func TestRuntimePublicKey(t *testing.T) {
 			},
 		}
 
-		expected = cadence.ValueWithCachedTypeID(expected)
 		assert.Equal(t, expected, value)
 	})
 

--- a/runtime/common/metering.go
+++ b/runtime/common/metering.go
@@ -257,10 +257,12 @@ var (
 
 	// Static types string representations
 
-	VariableSizedStaticTypeStringMemoryUsage = NewRawStringMemoryUsage(2)  // []
-	DictionaryStaticTypeStringMemoryUsage    = NewRawStringMemoryUsage(4)  // {: }
-	OptionalStaticTypeStringMemoryUsage      = NewRawStringMemoryUsage(1)  // ?
-	CapabilityStaticTypeStringMemoryUsage    = NewRawStringMemoryUsage(12) // Capability<>
+	VariableSizedStaticTypeStringMemoryUsage         = NewRawStringMemoryUsage(2)  // []
+	DictionaryStaticTypeStringMemoryUsage            = NewRawStringMemoryUsage(4)  // {: }
+	OptionalStaticTypeStringMemoryUsage              = NewRawStringMemoryUsage(1)  // ?
+	CapabilityStaticTypeStringMemoryUsage            = NewRawStringMemoryUsage(12) // Capability<>
+	IntersectionStaticTypeStringMemoryUsage          = NewRawStringMemoryUsage(2)  // {}
+	IntersectionStaticTypeSeparatorStringMemoryUsage = NewRawStringMemoryUsage(2)  // ,
 )
 
 func UseMemory(gauge MemoryGauge, usage MemoryUsage) {

--- a/runtime/common/orderedmap/orderedmap.go
+++ b/runtime/common/orderedmap/orderedmap.go
@@ -22,10 +22,6 @@
 package orderedmap
 
 import (
-	"sort"
-
-	"golang.org/x/exp/maps"
-
 	"github.com/onflow/cadence/runtime/common/list"
 )
 
@@ -231,36 +227,6 @@ func (om *OrderedMap[K, V]) ForAllKeys(predicate func(key K) bool) bool {
 		}
 	}
 	return true
-}
-
-// MapKeys returns a new ordered map whose keys are mapped according to
-// the provided mapping function between
-func MapKeys[T OrderedMap[K, V], K comparable, V any, H comparable](om *OrderedMap[K, V], f func(K) H) *OrderedMap[H, V] {
-	mapped := New[OrderedMap[H, V]](om.Len())
-
-	om.Foreach(func(key K, value V) {
-		mapped.Set(f(key), value)
-	})
-
-	return mapped
-}
-
-// SortByKeys returns a new ordered map whose insertion order is sorted according to
-// the provided comparison function between keys
-func (om *OrderedMap[K, V]) SortByKey(compare func(K, K) bool) *OrderedMap[K, V] {
-	sorted := New[OrderedMap[K, V]](om.Len())
-	// non-deterministic order is okay here because the result is immediately sorted
-	keys := maps.Keys(om.pairs) //nolint:forbidigo
-	sort.Slice(keys, func(i, j int) bool {
-		return compare(keys[i], keys[j])
-	})
-
-	for _, key := range keys {
-		value, _ := om.Get(key)
-		sorted.Set(key, value)
-	}
-
-	return sorted
 }
 
 // ForAnyKey iterates over the keys of the map, and returns whether the provided

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -564,7 +564,7 @@ func exportAuthorization(
 		})
 		return cadence.EntitlementSetAuthorization{
 			Entitlements: entitlements,
-			Kind:         cadence.EntitlementSetKind(access.SetKind),
+			Kind:         access.SetKind,
 		}
 	}
 	panic(fmt.Sprintf("cannot export authorization with access %T", access))
@@ -646,7 +646,7 @@ func importAuthorization(memoryGauge common.MemoryGauge, auth cadence.Authorizat
 			memoryGauge,
 			func() []common.TypeID { return auth.Entitlements },
 			len(auth.Entitlements),
-			sema.EntitlementSetKind(auth.Kind),
+			auth.Kind,
 		)
 	}
 	panic(fmt.Sprintf("cannot import authorization of type %T", auth))

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -619,7 +619,7 @@ func exportCapabilityType(
 	)
 }
 
-func importInterfaceType(memoryGauge common.MemoryGauge, t cadence.InterfaceType) interpreter.InterfaceStaticType {
+func importInterfaceType(memoryGauge common.MemoryGauge, t cadence.InterfaceType) *interpreter.InterfaceStaticType {
 	return interpreter.NewInterfaceStaticTypeComputeTypeID(
 		memoryGauge,
 		t.InterfaceTypeLocation(),
@@ -712,7 +712,7 @@ func ImportType(memoryGauge common.MemoryGauge, t cadence.Type) interpreter.Stat
 		)
 
 	case *cadence.IntersectionType:
-		types := make([]interpreter.InterfaceStaticType, 0, len(t.Types))
+		types := make([]*interpreter.InterfaceStaticType, 0, len(t.Types))
 		for _, typ := range t.Types {
 			intf, ok := typ.(cadence.InterfaceType)
 			if !ok {

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -627,7 +627,7 @@ func importInterfaceType(memoryGauge common.MemoryGauge, t cadence.InterfaceType
 	)
 }
 
-func importCompositeType(memoryGauge common.MemoryGauge, t cadence.CompositeType) interpreter.CompositeStaticType {
+func importCompositeType(memoryGauge common.MemoryGauge, t cadence.CompositeType) *interpreter.CompositeStaticType {
 	return interpreter.NewCompositeStaticTypeComputeTypeID(
 		memoryGauge,
 		t.CompositeTypeLocation(),

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -1245,7 +1245,7 @@ func (i valueImporter) importDictionaryValue(
 		keysAndValues[pairIndex*2+1] = value
 	}
 
-	var dictionaryStaticType interpreter.DictionaryStaticType
+	var dictionaryStaticType *interpreter.DictionaryStaticType
 	if dictionaryType != nil {
 		dictionaryStaticType = interpreter.ConvertSemaDictionaryTypeToStaticDictionaryType(inter, dictionaryType)
 	} else {

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -188,7 +188,7 @@ func TestRuntimeExportValue(t *testing.T) {
 				return interpreter.NewArrayValue(
 					inter,
 					interpreter.EmptyLocationRange,
-					interpreter.VariableSizedStaticType{
+					&interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
 					common.ZeroAddress,
@@ -205,7 +205,7 @@ func TestRuntimeExportValue(t *testing.T) {
 				return interpreter.NewArrayValue(
 					inter,
 					interpreter.EmptyLocationRange,
-					interpreter.VariableSizedStaticType{
+					&interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
 					common.ZeroAddress,
@@ -639,7 +639,7 @@ func TestRuntimeImportValue(t *testing.T) {
 			expected: interpreter.NewArrayValue(
 				newTestInterpreter(t),
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
 				common.ZeroAddress,
@@ -657,7 +657,7 @@ func TestRuntimeImportValue(t *testing.T) {
 			expected: interpreter.NewArrayValue(
 				newTestInterpreter(t),
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
 				common.ZeroAddress,
@@ -1197,7 +1197,7 @@ func TestRuntimeImportRuntimeType(t *testing.T) {
 			actual: &cadence.VariableSizedArrayType{
 				ElementType: cadence.IntType,
 			},
-			expected: interpreter.VariableSizedStaticType{
+			expected: &interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
@@ -3339,7 +3339,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 		value := interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			common.ZeroAddress,
@@ -3385,7 +3385,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeUInt8,
 				},
 				common.ZeroAddress,
@@ -3403,7 +3403,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 		value := interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			common.ZeroAddress,
@@ -3458,7 +3458,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
 				common.ZeroAddress,
@@ -3501,8 +3501,8 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
-					Type: interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
+					Type: &interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeInt8,
 					},
 				},
@@ -3510,7 +3510,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 				interpreter.NewArrayValue(
 					inter,
 					interpreter.EmptyLocationRange,
-					interpreter.VariableSizedStaticType{
+					&interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeInt8,
 					},
 					common.ZeroAddress,
@@ -3520,7 +3520,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 				interpreter.NewArrayValue(
 					inter,
 					interpreter.EmptyLocationRange,
-					interpreter.VariableSizedStaticType{
+					&interpreter.VariableSizedStaticType{
 						Type: interpreter.PrimitiveStaticTypeInt8,
 					},
 					common.ZeroAddress,
@@ -4807,7 +4807,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		Type: sema.AnyStructType,
 	}
 
-	staticArrayType := interpreter.VariableSizedStaticType{
+	staticArrayType := &interpreter.VariableSizedStaticType{
 		Type: interpreter.PrimitiveStaticTypeAnyStruct,
 	}
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1292,7 +1292,7 @@ func TestRuntimeImportRuntimeType(t *testing.T) {
 			actual: &cadence.CapabilityType{
 				BorrowType: cadence.IntType,
 			},
-			expected: interpreter.CapabilityStaticType{
+			expected: &interpreter.CapabilityStaticType{
 				BorrowType: interpreter.PrimitiveStaticTypeInt,
 			},
 		},

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1371,7 +1371,7 @@ func TestRuntimeImportRuntimeType(t *testing.T) {
 				},
 			},
 			expected: &interpreter.IntersectionStaticType{
-				Types: []interpreter.InterfaceStaticType{
+				Types: []*interpreter.InterfaceStaticType{
 					interpreter.NewInterfaceStaticTypeComputeTypeID(nil, TestLocation, "T"),
 				},
 			},
@@ -2148,7 +2148,7 @@ func TestRuntimeExportTypeValue(t *testing.T) {
 
 		ty := interpreter.TypeValue{
 			Type: &interpreter.IntersectionStaticType{
-				Types: []interpreter.InterfaceStaticType{
+				Types: []*interpreter.InterfaceStaticType{
 					interpreter.NewInterfaceStaticTypeComputeTypeID(nil, TestLocation, "SI"),
 				},
 			},

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1229,7 +1229,7 @@ func TestRuntimeImportRuntimeType(t *testing.T) {
 				Authorization: cadence.UnauthorizedAccess,
 				Type:          cadence.IntType,
 			},
-			expected: interpreter.ReferenceStaticType{
+			expected: &interpreter.ReferenceStaticType{
 				Authorization:  interpreter.UnauthorizedAccess,
 				ReferencedType: interpreter.PrimitiveStaticTypeInt,
 			},
@@ -1243,7 +1243,7 @@ func TestRuntimeImportRuntimeType(t *testing.T) {
 				},
 				Type: cadence.IntType,
 			},
-			expected: interpreter.ReferenceStaticType{
+			expected: &interpreter.ReferenceStaticType{
 				Authorization: interpreter.NewEntitlementSetAuthorization(
 					nil,
 					func() []common.TypeID { return []common.TypeID{"E", "F"} },
@@ -1263,7 +1263,7 @@ func TestRuntimeImportRuntimeType(t *testing.T) {
 				},
 				Type: cadence.IntType,
 			},
-			expected: interpreter.ReferenceStaticType{
+			expected: &interpreter.ReferenceStaticType{
 				Authorization: interpreter.NewEntitlementSetAuthorization(
 					nil,
 					func() []common.TypeID { return []common.TypeID{"E", "F"} },
@@ -1280,7 +1280,7 @@ func TestRuntimeImportRuntimeType(t *testing.T) {
 				},
 				Type: cadence.IntType,
 			},
-			expected: interpreter.ReferenceStaticType{
+			expected: &interpreter.ReferenceStaticType{
 				Authorization: interpreter.EntitlementMapAuthorization{
 					TypeID: "M",
 				},

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1207,7 +1207,7 @@ func TestRuntimeImportRuntimeType(t *testing.T) {
 				ElementType: cadence.IntType,
 				Size:        3,
 			},
-			expected: interpreter.ConstantSizedStaticType{
+			expected: &interpreter.ConstantSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 				Size: 3,
 			},

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1493,11 +1493,9 @@ func TestRuntimeExportStructValue(t *testing.T) {
 	}
 
 	actual := exportValueFromScript(t, script)
-	expected := cadence.ValueWithCachedTypeID(
-		cadence.NewStruct([]cadence.Value{
-			cadence.NewInt(42),
-		}).WithType(fooStructType),
-	)
+	expected := cadence.NewStruct([]cadence.Value{
+		cadence.NewInt(42),
+	}).WithType(fooStructType)
 
 	assert.Equal(t, expected, actual)
 }
@@ -1521,12 +1519,10 @@ func TestRuntimeExportResourceValue(t *testing.T) {
     `
 
 	actual := exportValueFromScript(t, script)
-	expected := cadence.ValueWithCachedTypeID(
-		cadence.NewResource([]cadence.Value{
-			cadence.NewUInt64(1),
-			cadence.NewInt(42),
-		}).WithType(newFooResourceType()),
-	)
+	expected := cadence.NewResource([]cadence.Value{
+		cadence.NewUInt64(1),
+		cadence.NewInt(42),
+	}).WithType(newFooResourceType())
 
 	assert.Equal(t, expected, actual)
 }
@@ -1551,37 +1547,33 @@ func TestRuntimeExportResourceArrayValue(t *testing.T) {
 
 	fooResourceType := newFooResourceType()
 
-	actual := cadence.ValueWithCachedTypeID(
-		exportValueFromScript(t, script),
-	)
+	actual := exportValueFromScript(t, script)
 
-	expected := cadence.ValueWithCachedTypeID(
-		cadence.NewArray([]cadence.Value{
-			cadence.NewResource([]cadence.Value{
-				cadence.NewUInt64(1),
-				cadence.NewInt(3),
-			}).WithType(fooResourceType),
-			cadence.NewResource([]cadence.Value{
-				cadence.NewUInt64(2),
-				cadence.NewInt(4),
-			}).WithType(fooResourceType),
-		}).WithType(&cadence.VariableSizedArrayType{
-			ElementType: &cadence.ResourceType{
-				Location:            common.ScriptLocation{},
-				QualifiedIdentifier: "Foo",
-				Fields: []cadence.Field{
-					{
-						Identifier: "uuid",
-						Type:       cadence.UInt64Type,
-					},
-					{
-						Identifier: "bar",
-						Type:       cadence.IntType,
-					},
+	expected := cadence.NewArray([]cadence.Value{
+		cadence.NewResource([]cadence.Value{
+			cadence.NewUInt64(1),
+			cadence.NewInt(3),
+		}).WithType(fooResourceType),
+		cadence.NewResource([]cadence.Value{
+			cadence.NewUInt64(2),
+			cadence.NewInt(4),
+		}).WithType(fooResourceType),
+	}).WithType(&cadence.VariableSizedArrayType{
+		ElementType: &cadence.ResourceType{
+			Location:            common.ScriptLocation{},
+			QualifiedIdentifier: "Foo",
+			Fields: []cadence.Field{
+				{
+					Identifier: "uuid",
+					Type:       cadence.UInt64Type,
+				},
+				{
+					Identifier: "bar",
+					Type:       cadence.IntType,
 				},
 			},
-		}),
-	)
+		},
+	})
 
 	assert.Equal(t, expected, actual)
 }
@@ -1609,44 +1601,40 @@ func TestRuntimeExportResourceDictionaryValue(t *testing.T) {
 
 	fooResourceType := newFooResourceType()
 
-	actual := cadence.ValueWithCachedTypeID(
-		exportValueFromScript(t, script),
-	)
+	actual := exportValueFromScript(t, script)
 
-	expected := cadence.ValueWithCachedTypeID(
-		cadence.NewDictionary([]cadence.KeyValuePair{
-			{
-				Key: cadence.String("b"),
-				Value: cadence.NewResource([]cadence.Value{
-					cadence.NewUInt64(2),
-					cadence.NewInt(4),
-				}).WithType(fooResourceType),
-			},
-			{
-				Key: cadence.String("a"),
-				Value: cadence.NewResource([]cadence.Value{
-					cadence.NewUInt64(1),
-					cadence.NewInt(3),
-				}).WithType(fooResourceType),
-			},
-		}).WithType(&cadence.DictionaryType{
-			KeyType: cadence.StringType,
-			ElementType: &cadence.ResourceType{
-				Location:            common.ScriptLocation{},
-				QualifiedIdentifier: "Foo",
-				Fields: []cadence.Field{
-					{
-						Identifier: "uuid",
-						Type:       cadence.UInt64Type,
-					},
-					{
-						Identifier: "bar",
-						Type:       cadence.IntType,
-					},
+	expected := cadence.NewDictionary([]cadence.KeyValuePair{
+		{
+			Key: cadence.String("b"),
+			Value: cadence.NewResource([]cadence.Value{
+				cadence.NewUInt64(2),
+				cadence.NewInt(4),
+			}).WithType(fooResourceType),
+		},
+		{
+			Key: cadence.String("a"),
+			Value: cadence.NewResource([]cadence.Value{
+				cadence.NewUInt64(1),
+				cadence.NewInt(3),
+			}).WithType(fooResourceType),
+		},
+	}).WithType(&cadence.DictionaryType{
+		KeyType: cadence.StringType,
+		ElementType: &cadence.ResourceType{
+			Location:            common.ScriptLocation{},
+			QualifiedIdentifier: "Foo",
+			Fields: []cadence.Field{
+				{
+					Identifier: "uuid",
+					Type:       cadence.UInt64Type,
+				},
+				{
+					Identifier: "bar",
+					Type:       cadence.IntType,
 				},
 			},
-		}),
-	)
+		},
+	})
 
 	assert.Equal(t, expected, actual)
 }
@@ -1711,18 +1699,14 @@ func TestRuntimeExportNestedResourceValueFromScript(t *testing.T) {
         }
     `
 
-	actual := cadence.ValueWithCachedTypeID(
-		exportValueFromScript(t, script),
-	)
-	expected := cadence.ValueWithCachedTypeID(
+	actual := exportValueFromScript(t, script)
+	expected := cadence.NewResource([]cadence.Value{
+		cadence.NewUInt64(2),
 		cadence.NewResource([]cadence.Value{
-			cadence.NewUInt64(2),
-			cadence.NewResource([]cadence.Value{
-				cadence.NewUInt64(1),
-				cadence.NewInt(42),
-			}).WithType(barResourceType),
-		}).WithType(fooResourceType),
-	)
+			cadence.NewUInt64(1),
+			cadence.NewInt(42),
+		}).WithType(barResourceType),
+	}).WithType(fooResourceType)
 
 	assert.Equal(t, expected, actual)
 }
@@ -2294,20 +2278,16 @@ func TestRuntimeExportCompositeValueWithFunctionValueField(t *testing.T) {
 		},
 	}
 
-	actual := cadence.ValueWithCachedTypeID(
-		exportValueFromScript(t, script),
-	)
+	actual := exportValueFromScript(t, script)
 
-	expected := cadence.ValueWithCachedTypeID(
-		cadence.NewStruct([]cadence.Value{
-			cadence.NewInt(42),
-			cadence.Function{
-				FunctionType: &cadence.FunctionType{
-					ReturnType: cadence.VoidType,
-				},
+	expected := cadence.NewStruct([]cadence.Value{
+		cadence.NewInt(42),
+		cadence.Function{
+			FunctionType: &cadence.FunctionType{
+				ReturnType: cadence.VoidType,
 			},
-		}).WithType(fooStructType),
-	)
+		},
+	}).WithType(fooStructType)
 
 	assert.Equal(t, expected, actual)
 }
@@ -2432,10 +2412,7 @@ func TestRuntimeEnumValue(t *testing.T) {
 		expected := newEnumValue()
 		actual := exportValueFromScript(t, script)
 
-		assert.Equal(t,
-			cadence.ValueWithCachedTypeID(expected),
-			cadence.ValueWithCachedTypeID(actual),
-		)
+		assert.Equal(t, expected, actual)
 	})
 
 	t.Run("test import", func(t *testing.T) {
@@ -2496,10 +2473,6 @@ func executeTestScript(t *testing.T, script string, arg cadence.Value) (cadence.
 			Location:  common.ScriptLocation{},
 		},
 	)
-
-	if err == nil {
-		value = cadence.ValueWithCachedTypeID(value)
-	}
 
 	return value, err
 }
@@ -2748,7 +2721,7 @@ func TestRuntimeArgumentPassing(t *testing.T) {
 			require.NoError(t, err)
 
 			if !test.skipExport {
-				expected := cadence.ValueWithCachedTypeID(test.exportedValue)
+				expected := test.exportedValue
 				assert.Equal(t, expected, actual)
 			}
 		})
@@ -2909,7 +2882,7 @@ func TestRuntimeComplexStructArgumentPassing(t *testing.T) {
 	actual, err := executeTestScript(t, script, complexStructValue)
 	require.NoError(t, err)
 
-	expected := cadence.ValueWithCachedTypeID(complexStructValue)
+	expected := complexStructValue
 	assert.Equal(t, expected, actual)
 
 }
@@ -3021,7 +2994,7 @@ func TestRuntimeComplexStructWithAnyStructFields(t *testing.T) {
 	actual, err := executeTestScript(t, script, complexStructValue)
 	require.NoError(t, err)
 
-	expected := cadence.ValueWithCachedTypeID(complexStructValue)
+	expected := complexStructValue
 	assert.Equal(t, expected, actual)
 }
 
@@ -4709,6 +4682,7 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 			},
 		)
 
+		RequireError(t, err)
 		assert.Contains(t, err.Error(),
 			"invalid argument at index 0: cannot import value of type 'PublicKey'. missing field 'publicKey'")
 		assert.False(t, publicKeyValidated)
@@ -4782,6 +4756,7 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 			},
 		)
 
+		RequireError(t, err)
 		assert.Contains(t, err.Error(),
 			"invalid argument at index 0: cannot import value of type 'PublicKey'. missing field 'signatureAlgorithm'")
 		assert.False(t, publicKeyValidated)

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1188,7 +1188,7 @@ func TestRuntimeImportRuntimeType(t *testing.T) {
 			actual: &cadence.OptionalType{
 				Type: cadence.IntType,
 			},
-			expected: interpreter.OptionalStaticType{
+			expected: &interpreter.OptionalStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 		},

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -226,7 +226,7 @@ func TestRuntimeExportValue(t *testing.T) {
 				return interpreter.NewDictionaryValue(
 					inter,
 					interpreter.EmptyLocationRange,
-					interpreter.DictionaryStaticType{
+					&interpreter.DictionaryStaticType{
 						KeyType:   interpreter.PrimitiveStaticTypeString,
 						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
@@ -244,7 +244,7 @@ func TestRuntimeExportValue(t *testing.T) {
 				return interpreter.NewDictionaryValue(
 					inter,
 					interpreter.EmptyLocationRange,
-					interpreter.DictionaryStaticType{
+					&interpreter.DictionaryStaticType{
 						KeyType:   interpreter.PrimitiveStaticTypeString,
 						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
@@ -673,7 +673,7 @@ func TestRuntimeImportValue(t *testing.T) {
 			expected: interpreter.NewDictionaryValue(
 				newTestInterpreter(t),
 				interpreter.EmptyLocationRange,
-				interpreter.DictionaryStaticType{
+				&interpreter.DictionaryStaticType{
 					KeyType:   interpreter.PrimitiveStaticTypeString,
 					ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
@@ -689,7 +689,7 @@ func TestRuntimeImportValue(t *testing.T) {
 			expected: interpreter.NewDictionaryValue(
 				newTestInterpreter(t),
 				interpreter.EmptyLocationRange,
-				interpreter.DictionaryStaticType{
+				&interpreter.DictionaryStaticType{
 					KeyType:   interpreter.PrimitiveStaticTypeString,
 					ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
@@ -1218,7 +1218,7 @@ func TestRuntimeImportRuntimeType(t *testing.T) {
 				ElementType: cadence.IntType,
 				KeyType:     cadence.StringType,
 			},
-			expected: interpreter.DictionaryStaticType{
+			expected: &interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeString,
 				ValueType: interpreter.PrimitiveStaticTypeInt,
 			},
@@ -3544,7 +3544,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 		value := interpreter.NewDictionaryValue(
 			newTestInterpreter(t),
 			interpreter.EmptyLocationRange,
-			interpreter.DictionaryStaticType{
+			&interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeString,
 				ValueType: interpreter.PrimitiveStaticTypeInt,
 			},
@@ -3594,7 +3594,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 			interpreter.NewDictionaryValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.DictionaryStaticType{
+				&interpreter.DictionaryStaticType{
 					KeyType:   interpreter.PrimitiveStaticTypeString,
 					ValueType: interpreter.PrimitiveStaticTypeUInt8,
 				},
@@ -3612,7 +3612,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 		value := interpreter.NewDictionaryValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.DictionaryStaticType{
+			&interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeString,
 				ValueType: interpreter.PrimitiveStaticTypeInt,
 			},
@@ -3681,7 +3681,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 			interpreter.NewDictionaryValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.DictionaryStaticType{
+				&interpreter.DictionaryStaticType{
 					KeyType:   interpreter.PrimitiveStaticTypeString,
 					ValueType: interpreter.PrimitiveStaticTypeInt,
 				},
@@ -3742,9 +3742,9 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 			interpreter.NewDictionaryValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.DictionaryStaticType{
+				&interpreter.DictionaryStaticType{
 					KeyType: interpreter.PrimitiveStaticTypeString,
-					ValueType: interpreter.DictionaryStaticType{
+					ValueType: &interpreter.DictionaryStaticType{
 						KeyType:   interpreter.PrimitiveStaticTypeSignedInteger,
 						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
@@ -3754,7 +3754,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 				interpreter.NewDictionaryValue(
 					inter,
 					interpreter.EmptyLocationRange,
-					interpreter.DictionaryStaticType{
+					&interpreter.DictionaryStaticType{
 						KeyType:   interpreter.PrimitiveStaticTypeInt8,
 						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
@@ -3766,7 +3766,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 				interpreter.NewDictionaryValue(
 					inter,
 					interpreter.EmptyLocationRange,
-					interpreter.DictionaryStaticType{
+					&interpreter.DictionaryStaticType{
 						KeyType:   interpreter.PrimitiveStaticTypeSignedInteger,
 						ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
@@ -4838,7 +4838,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		ValueType: semaArrayType,
 	}
 
-	staticDictionaryType := interpreter.DictionaryStaticType{
+	staticDictionaryType := &interpreter.DictionaryStaticType{
 		KeyType:   interpreter.PrimitiveStaticTypeString,
 		ValueType: staticArrayType,
 	}

--- a/runtime/interpreter/conversion_test.go
+++ b/runtime/interpreter/conversion_test.go
@@ -186,7 +186,7 @@ func TestByteSliceToArrayValue(t *testing.T) {
 
 		inter := newTestInterpreter(t)
 
-		expectedType := ConstantSizedStaticType{
+		expectedType := &ConstantSizedStaticType{
 			Size: int64(len(b)),
 			Type: PrimitiveStaticTypeUInt8,
 		}

--- a/runtime/interpreter/conversion_test.go
+++ b/runtime/interpreter/conversion_test.go
@@ -45,7 +45,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 			NewArrayValue(
 				inter,
 				EmptyLocationRange,
-				VariableSizedStaticType{
+				&VariableSizedStaticType{
 					Type: PrimitiveStaticTypeUInt64,
 				},
 				common.ZeroAddress,
@@ -54,7 +54,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 			NewArrayValue(
 				inter,
 				EmptyLocationRange,
-				VariableSizedStaticType{
+				&VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInt256,
 				},
 				common.ZeroAddress,
@@ -79,7 +79,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 			NewArrayValue(
 				inter,
 				EmptyLocationRange,
-				VariableSizedStaticType{
+				&VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInteger,
 				},
 				common.ZeroAddress,
@@ -87,7 +87,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 			NewArrayValue(
 				inter,
 				EmptyLocationRange,
-				VariableSizedStaticType{
+				&VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInteger,
 				},
 				common.ZeroAddress,
@@ -97,7 +97,7 @@ func TestByteArrayValueToByteSlice(t *testing.T) {
 			NewArrayValue(
 				inter,
 				EmptyLocationRange,
-				VariableSizedStaticType{
+				&VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInteger,
 				},
 				common.ZeroAddress,
@@ -162,7 +162,7 @@ func TestByteSliceToArrayValue(t *testing.T) {
 
 		inter := newTestInterpreter(t)
 
-		expectedType := VariableSizedStaticType{
+		expectedType := &VariableSizedStaticType{
 			Type: PrimitiveStaticTypeUInt8,
 		}
 

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1020,7 +1020,7 @@ func (d StorableDecoder) decodeStorageCapabilityController() (*StorageCapability
 	if err != nil {
 		return nil, errors.NewUnexpectedError("invalid storage capability controller borrow type encoding: %w", err)
 	}
-	borrowReferenceStaticType, ok := borrowStaticType.(ReferenceStaticType)
+	borrowReferenceStaticType, ok := borrowStaticType.(*ReferenceStaticType)
 	if !ok {
 		return nil, errors.NewUnexpectedError(
 			"invalid storage capability controller borrow type encoding: expected reference static type, got %T",
@@ -1092,7 +1092,7 @@ func (d StorableDecoder) decodeAccountCapabilityController() (*AccountCapability
 	if err != nil {
 		return nil, errors.NewUnexpectedError("invalid account capability controller borrow type encoding: %w", err)
 	}
-	borrowReferenceStaticType, ok := borrowStaticType.(ReferenceStaticType)
+	borrowReferenceStaticType, ok := borrowStaticType.(*ReferenceStaticType)
 	if !ok {
 		return nil, errors.NewUnexpectedError(
 			"invalid account capability controller borrow type encoding: expected reference static type, got %T",

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1354,36 +1354,34 @@ func (d TypeDecoder) decodeCompositeStaticType() (StaticType, error) {
 	return NewCompositeStaticTypeComputeTypeID(d.memoryGauge, location, qualifiedIdentifier), nil
 }
 
-func (d TypeDecoder) decodeInterfaceStaticType() (InterfaceStaticType, error) {
+func (d TypeDecoder) decodeInterfaceStaticType() (*InterfaceStaticType, error) {
 	const expectedLength = encodedInterfaceStaticTypeLength
 
 	size, err := d.decoder.DecodeArrayHead()
 
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
-			return InterfaceStaticType{},
-				errors.NewUnexpectedError(
-					"invalid interface static type encoding: expected [%d]any, got %s",
-					expectedLength,
-					e.ActualType.String(),
-				)
+			return nil, errors.NewUnexpectedError(
+				"invalid interface static type encoding: expected [%d]any, got %s",
+				expectedLength,
+				e.ActualType.String(),
+			)
 		}
-		return InterfaceStaticType{}, err
+		return nil, err
 	}
 
 	if size != expectedLength {
-		return InterfaceStaticType{},
-			errors.NewUnexpectedError(
-				"invalid interface static type encoding: expected [%d]any, got [%d]any",
-				expectedLength,
-				size,
-			)
+		return nil, errors.NewUnexpectedError(
+			"invalid interface static type encoding: expected [%d]any, got [%d]any",
+			expectedLength,
+			size,
+		)
 	}
 
 	// Decode location at array index encodedInterfaceStaticTypeLocationFieldKey
 	location, err := d.DecodeLocation()
 	if err != nil {
-		return InterfaceStaticType{}, errors.NewUnexpectedError(
+		return nil, errors.NewUnexpectedError(
 			"invalid interface static type location encoding: %w",
 			err,
 		)
@@ -1393,13 +1391,12 @@ func (d TypeDecoder) decodeInterfaceStaticType() (InterfaceStaticType, error) {
 	qualifiedIdentifier, err := decodeString(d.decoder, d.memoryGauge, common.MemoryKindRawString)
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
-			return InterfaceStaticType{},
-				errors.NewUnexpectedError(
-					"invalid interface static type qualified identifier encoding: %s",
-					e.ActualType.String(),
-				)
+			return nil, errors.NewUnexpectedError(
+				"invalid interface static type qualified identifier encoding: %s",
+				e.ActualType.String(),
+			)
 		}
-		return InterfaceStaticType{}, err
+		return nil, err
 	}
 
 	return NewInterfaceStaticTypeComputeTypeID(d.memoryGauge, location, qualifiedIdentifier), nil
@@ -1752,9 +1749,9 @@ func (d TypeDecoder) decodeIntersectionStaticType() (StaticType, error) {
 		return nil, err
 	}
 
-	var intersections []InterfaceStaticType
+	var intersections []*InterfaceStaticType
 	if intersectionSize > 0 {
-		intersections = make([]InterfaceStaticType, intersectionSize)
+		intersections = make([]*InterfaceStaticType, intersectionSize)
 		for i := 0; i < int(intersectionSize); i++ {
 
 			number, err := d.decoder.DecodeTagNumber()

--- a/runtime/interpreter/deepcopyremove_test.go
+++ b/runtime/interpreter/deepcopyremove_test.go
@@ -67,7 +67,7 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 	arrayValue := NewArrayValue(
 		inter,
 		EmptyLocationRange,
-		VariableSizedStaticType{
+		&VariableSizedStaticType{
 			Type: dictionaryStaticType,
 		},
 		common.ZeroAddress,

--- a/runtime/interpreter/deepcopyremove_test.go
+++ b/runtime/interpreter/deepcopyremove_test.go
@@ -47,7 +47,7 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	dictionaryStaticType := DictionaryStaticType{
+	dictionaryStaticType := &DictionaryStaticType{
 		KeyType:   PrimitiveStaticTypeString,
 		ValueType: PrimitiveStaticTypeInt256,
 	}

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1512,7 +1512,7 @@ func (t *IntersectionStaticType) Encode(e *cbor.StreamEncoder) error {
 //			Number:  CBORTagCapabilityStaticType,
 //			Content: StaticType(v.BorrowType),
 //	}
-func (t CapabilityStaticType) Encode(e *cbor.StreamEncoder) error {
+func (t *CapabilityStaticType) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, CBORTagCapabilityStaticType,

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1383,7 +1383,7 @@ const (
 //					encodedReferenceStaticTypeTypeFieldKey:          StaticType(v.Type),
 //			},
 //		}
-func (t ReferenceStaticType) Encode(e *cbor.StreamEncoder) error {
+func (t *ReferenceStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
 		// tag number

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1313,7 +1313,7 @@ func (t Unauthorized) Encode(e *cbor.StreamEncoder) error {
 	return e.EncodeNil()
 }
 
-func (t EntitlementMapAuthorization) Encode(e *cbor.StreamEncoder) error {
+func (a EntitlementMapAuthorization) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, CBORTagEntitlementMapStaticAuthorization,
@@ -1321,7 +1321,7 @@ func (t EntitlementMapAuthorization) Encode(e *cbor.StreamEncoder) error {
 	if err != nil {
 		return err
 	}
-	return e.EncodeString(string(t.TypeID))
+	return e.EncodeString(string(a.TypeID))
 }
 
 // NOTE: NEVER change, only add/increment; ensure uint64
@@ -1336,7 +1336,7 @@ const (
 	encodedSetAuthorizationStaticTypeLength = 2
 )
 
-func (t EntitlementSetAuthorization) Encode(e *cbor.StreamEncoder) error {
+func (a EntitlementSetAuthorization) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, CBORTagEntitlementSetStaticAuthorization,
@@ -1347,16 +1347,16 @@ func (t EntitlementSetAuthorization) Encode(e *cbor.StreamEncoder) error {
 		return err
 	}
 
-	err = e.EncodeUint8(uint8(t.SetKind))
+	err = e.EncodeUint8(uint8(a.SetKind))
 	if err != nil {
 		return err
 	}
 
-	err = e.EncodeArrayHead(uint64(t.Entitlements.Len()))
+	err = e.EncodeArrayHead(uint64(a.Entitlements.Len()))
 	if err != nil {
 		return err
 	}
-	return t.Entitlements.ForeachWithError(func(entitlement common.TypeID, value struct{}) error {
+	return a.Entitlements.ForeachWithError(func(entitlement common.TypeID, value struct{}) error {
 		// Encode entitlement as array entitlements element
 		return e.EncodeString(string(entitlement))
 	})

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1179,7 +1179,7 @@ const (
 //					encodedCompositeStaticTypeQualifiedIdentifierFieldKey: string(v.QualifiedIdentifier),
 //			},
 //	}
-func (t CompositeStaticType) Encode(e *cbor.StreamEncoder) error {
+func (t *CompositeStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
 		// tag number

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1146,7 +1146,7 @@ func (t PrimitiveStaticType) Encode(e *cbor.StreamEncoder) error {
 //			Number:  CBORTagOptionalStaticType,
 //			Content: StaticType(v.Type),
 //	}
-func (t OptionalStaticType) Encode(e *cbor.StreamEncoder) error {
+func (t *OptionalStaticType) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, CBORTagOptionalStaticType,

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1282,7 +1282,7 @@ const (
 //					encodedConstantSizedStaticTypeTypeFieldKey: StaticType(v.Type),
 //			},
 //	}
-func (t ConstantSizedStaticType) Encode(e *cbor.StreamEncoder) error {
+func (t *ConstantSizedStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
 		// tag number

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1424,7 +1424,7 @@ const (
 //					encodedDictionaryStaticTypeValueTypeFieldKey: StaticType(v.ValueType),
 //			},
 //	}
-func (t DictionaryStaticType) Encode(e *cbor.StreamEncoder) error {
+func (t *DictionaryStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
 		// tag number

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1250,7 +1250,7 @@ func (t *InterfaceStaticType) Encode(e *cbor.StreamEncoder) error {
 //			Number:  CBORTagVariableSizedStaticType,
 //			Content: StaticType(v.Type),
 //	}
-func (t VariableSizedStaticType) Encode(e *cbor.StreamEncoder) error {
+func (t *VariableSizedStaticType) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, CBORTagVariableSizedStaticType,

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -1222,7 +1222,7 @@ const (
 //					encodedInterfaceStaticTypeQualifiedIdentifierFieldKey: string(v.QualifiedIdentifier),
 //			},
 //	}
-func (t InterfaceStaticType) Encode(e *cbor.StreamEncoder) error {
+func (t *InterfaceStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
 		// tag number

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -432,7 +432,7 @@ func TestEncodeDecodeArray(t *testing.T) {
 		expected := NewArrayValue(
 			inter,
 			EmptyLocationRange,
-			VariableSizedStaticType{
+			&VariableSizedStaticType{
 				Type: PrimitiveStaticTypeAnyStruct,
 			},
 			common.ZeroAddress,
@@ -3759,7 +3759,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 		value := &StorageCapabilityControllerValue{
 			TargetPath: publicPathValue,
 			BorrowType: ReferenceStaticType{
-				ReferencedType: VariableSizedStaticType{
+				ReferencedType: &VariableSizedStaticType{
 					Type: PrimitiveStaticTypeBool,
 				},
 				Authorization: UnauthorizedAccess,

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -400,7 +400,7 @@ func TestEncodeDecodeArray(t *testing.T) {
 		expected := NewArrayValue(
 			inter,
 			EmptyLocationRange,
-			ConstantSizedStaticType{
+			&ConstantSizedStaticType{
 				Type: PrimitiveStaticTypeAnyStruct,
 				Size: 0,
 			},
@@ -3799,7 +3799,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 		value := &StorageCapabilityControllerValue{
 			TargetPath: publicPathValue,
 			BorrowType: ReferenceStaticType{
-				ReferencedType: ConstantSizedStaticType{
+				ReferencedType: &ConstantSizedStaticType{
 					Type: PrimitiveStaticTypeBool,
 					Size: 42,
 				},

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -3584,7 +3584,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		value := &StorageCapabilityControllerValue{
 			TargetPath: publicPathValue,
-			BorrowType: ReferenceStaticType{
+			BorrowType: &ReferenceStaticType{
 				ReferencedType: PrimitiveStaticTypeBool,
 				Authorization:  UnauthorizedAccess,
 			},
@@ -3620,7 +3620,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		value := &StorageCapabilityControllerValue{
 			TargetPath: publicPathValue,
-			BorrowType: ReferenceStaticType{
+			BorrowType: &ReferenceStaticType{
 				ReferencedType: &OptionalStaticType{
 					Type: PrimitiveStaticTypeBool,
 				},
@@ -3660,7 +3660,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		value := &StorageCapabilityControllerValue{
 			TargetPath: publicPathValue,
-			BorrowType: ReferenceStaticType{
+			BorrowType: &ReferenceStaticType{
 				ReferencedType: NewCompositeStaticTypeComputeTypeID(
 					nil,
 					utils.TestLocation,
@@ -3711,7 +3711,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		value := &StorageCapabilityControllerValue{
 			TargetPath: publicPathValue,
-			BorrowType: ReferenceStaticType{
+			BorrowType: &ReferenceStaticType{
 				ReferencedType: NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "SimpleInterface"),
 				Authorization:  UnauthorizedAccess,
 			},
@@ -3758,7 +3758,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		value := &StorageCapabilityControllerValue{
 			TargetPath: publicPathValue,
-			BorrowType: ReferenceStaticType{
+			BorrowType: &ReferenceStaticType{
 				ReferencedType: &VariableSizedStaticType{
 					Type: PrimitiveStaticTypeBool,
 				},
@@ -3798,7 +3798,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		value := &StorageCapabilityControllerValue{
 			TargetPath: publicPathValue,
-			BorrowType: ReferenceStaticType{
+			BorrowType: &ReferenceStaticType{
 				ReferencedType: &ConstantSizedStaticType{
 					Type: PrimitiveStaticTypeBool,
 					Size: 42,
@@ -3843,7 +3843,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		value := &StorageCapabilityControllerValue{
 			TargetPath: publicPathValue,
-			BorrowType: ReferenceStaticType{
+			BorrowType: &ReferenceStaticType{
 				ReferencedType: &DictionaryStaticType{
 					KeyType:   PrimitiveStaticTypeBool,
 					ValueType: PrimitiveStaticTypeString,
@@ -3889,7 +3889,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		value := &StorageCapabilityControllerValue{
 			TargetPath: publicPathValue,
-			BorrowType: ReferenceStaticType{
+			BorrowType: &ReferenceStaticType{
 				ReferencedType: &IntersectionStaticType{
 					Types: []*InterfaceStaticType{
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "I1"),
@@ -3971,7 +3971,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		expected := &StorageCapabilityControllerValue{
 			TargetPath: path,
-			BorrowType: ReferenceStaticType{
+			BorrowType: &ReferenceStaticType{
 				ReferencedType: PrimitiveStaticTypeNever,
 				Authorization:  UnauthorizedAccess,
 			},
@@ -4039,7 +4039,7 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 		t.Parallel()
 
 		value := &AccountCapabilityControllerValue{
-			BorrowType: ReferenceStaticType{
+			BorrowType: &ReferenceStaticType{
 				Authorization:  UnauthorizedAccess,
 				ReferencedType: PrimitiveStaticTypeAuthAccount,
 			},
@@ -4074,7 +4074,7 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 		t.Parallel()
 
 		value := &AccountCapabilityControllerValue{
-			BorrowType: ReferenceStaticType{
+			BorrowType: &ReferenceStaticType{
 				Authorization:  UnauthorizedAccess,
 				ReferencedType: PrimitiveStaticTypeAccount,
 			},
@@ -4109,7 +4109,7 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 		t.Parallel()
 
 		value := &AccountCapabilityControllerValue{
-			BorrowType: ReferenceStaticType{
+			BorrowType: &ReferenceStaticType{
 				ReferencedType: &IntersectionStaticType{
 					Types: []*InterfaceStaticType{
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "SimpleInterface"),
@@ -4177,7 +4177,7 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 		}
 
 		expected := &AccountCapabilityControllerValue{
-			BorrowType: ReferenceStaticType{
+			BorrowType: &ReferenceStaticType{
 				ReferencedType: borrowType,
 				Authorization:  UnauthorizedAccess,
 			},

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -3891,7 +3891,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 			TargetPath: publicPathValue,
 			BorrowType: ReferenceStaticType{
 				ReferencedType: &IntersectionStaticType{
-					Types: []InterfaceStaticType{
+					Types: []*InterfaceStaticType{
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "I1"),
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "I2"),
 					},
@@ -4111,7 +4111,7 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 		value := &AccountCapabilityControllerValue{
 			BorrowType: ReferenceStaticType{
 				ReferencedType: &IntersectionStaticType{
-					Types: []InterfaceStaticType{
+					Types: []*InterfaceStaticType{
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "SimpleInterface"),
 					},
 				},

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -3337,7 +3337,7 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 		var borrowType StaticType = PrimitiveStaticTypeNever
 
 		for i := uint64(0); i < maxInlineElementSize; i++ {
-			borrowType = OptionalStaticType{
+			borrowType = &OptionalStaticType{
 				Type: borrowType,
 			}
 		}
@@ -3621,7 +3621,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 		value := &StorageCapabilityControllerValue{
 			TargetPath: publicPathValue,
 			BorrowType: ReferenceStaticType{
-				ReferencedType: OptionalStaticType{
+				ReferencedType: &OptionalStaticType{
 					Type: PrimitiveStaticTypeBool,
 				},
 				Authorization: UnauthorizedAccess,
@@ -4171,7 +4171,7 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 		var borrowType StaticType = PrimitiveStaticTypeNever
 
 		for i := uint64(0); i < maxInlineElementSize; i++ {
-			borrowType = OptionalStaticType{
+			borrowType = &OptionalStaticType{
 				Type: borrowType,
 			}
 		}

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -3844,7 +3844,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 		value := &StorageCapabilityControllerValue{
 			TargetPath: publicPathValue,
 			BorrowType: ReferenceStaticType{
-				ReferencedType: DictionaryStaticType{
+				ReferencedType: &DictionaryStaticType{
 					KeyType:   PrimitiveStaticTypeBool,
 					ValueType: PrimitiveStaticTypeString,
 				},

--- a/runtime/interpreter/inspect_test.go
+++ b/runtime/interpreter/inspect_test.go
@@ -52,7 +52,7 @@ func TestInspectValue(t *testing.T) {
 		arrayValue := NewArrayValue(
 			inter,
 			EmptyLocationRange,
-			VariableSizedStaticType{
+			&VariableSizedStaticType{
 				Type: dictionaryStaticType,
 			},
 			common.ZeroAddress,

--- a/runtime/interpreter/inspect_test.go
+++ b/runtime/interpreter/inspect_test.go
@@ -36,7 +36,7 @@ func TestInspectValue(t *testing.T) {
 
 	var compositeValue *CompositeValue
 	{
-		dictionaryStaticType := DictionaryStaticType{
+		dictionaryStaticType := &DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeInt256,
 		}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1832,7 +1832,7 @@ func (interpreter *Interpreter) convertStaticType(
 				),
 			)
 		}
-	case ConstantSizedStaticType:
+	case *ConstantSizedStaticType:
 		if targetArrayType, isArrayType := targetSemaType.(*sema.ConstantSizedType); isArrayType {
 			return NewConstantSizedStaticType(
 				interpreter,
@@ -4917,7 +4917,7 @@ func (interpreter *Interpreter) maybeValidateAtreeValue(v atree.Value) {
 func (interpreter *Interpreter) ValidateAtreeValue(value atree.Value) {
 	tic := func(info atree.TypeInfo, other atree.TypeInfo) bool {
 		switch info := info.(type) {
-		case ConstantSizedStaticType:
+		case *ConstantSizedStaticType:
 			return info.Equal(other.(StaticType))
 		case VariableSizedStaticType:
 			return info.Equal(other.(StaticType))

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1844,7 +1844,7 @@ func (interpreter *Interpreter) convertStaticType(
 			)
 		}
 
-	case CapabilityStaticType:
+	case *CapabilityStaticType:
 		if targetCapabilityType, isCapabilityType := targetSemaType.(*sema.CapabilityType); isCapabilityType {
 			return NewCapabilityStaticType(
 				interpreter,
@@ -4090,7 +4090,7 @@ func (interpreter *Interpreter) checkValue(
 		// So take the borrow type from the value itself
 
 		// Capability values always have a `CapabilityStaticType` static type.
-		borrowType := staticType.(CapabilityStaticType).BorrowType
+		borrowType := staticType.(*CapabilityStaticType).BorrowType
 
 		var borrowSemaType sema.Type
 		borrowSemaType, valueError = interpreter.ConvertStaticToSemaType(borrowType)

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1808,7 +1808,7 @@ func (interpreter *Interpreter) convertStaticType(
 				),
 			)
 		}
-	case DictionaryStaticType:
+	case *DictionaryStaticType:
 		if targetDictionaryType, isDictionaryType := targetSemaType.(*sema.DictionaryType); isDictionaryType {
 			return NewDictionaryStaticType(
 				interpreter,
@@ -2046,7 +2046,7 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 		if dictValue, isDict := value.(*DictionaryValue); isDict && !valueType.Equal(unwrappedTargetType) {
 
 			oldDictStaticType := dictValue.StaticType(interpreter)
-			dictStaticType := interpreter.convertStaticType(oldDictStaticType, unwrappedTargetType).(DictionaryStaticType)
+			dictStaticType := interpreter.convertStaticType(oldDictStaticType, unwrappedTargetType).(*DictionaryStaticType)
 
 			if oldDictStaticType.Equal(dictStaticType) {
 				return value
@@ -4921,7 +4921,7 @@ func (interpreter *Interpreter) ValidateAtreeValue(value atree.Value) {
 			return info.Equal(other.(StaticType))
 		case VariableSizedStaticType:
 			return info.Equal(other.(StaticType))
-		case DictionaryStaticType:
+		case *DictionaryStaticType:
 			return info.Equal(other.(StaticType))
 		case compositeTypeInfo:
 			return info.Equal(other)

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1798,7 +1798,8 @@ func (interpreter *Interpreter) convertStaticType(
 				valueStaticType.ReferencedType,
 			)
 		}
-	case OptionalStaticType:
+
+	case *OptionalStaticType:
 		if targetOptionalType, isOptionalType := targetSemaType.(*sema.OptionalType); isOptionalType {
 			return NewOptionalStaticType(
 				interpreter,
@@ -1808,6 +1809,7 @@ func (interpreter *Interpreter) convertStaticType(
 				),
 			)
 		}
+
 	case *DictionaryStaticType:
 		if targetDictionaryType, isDictionaryType := targetSemaType.(*sema.DictionaryType); isDictionaryType {
 			return NewDictionaryStaticType(
@@ -1822,6 +1824,7 @@ func (interpreter *Interpreter) convertStaticType(
 				),
 			)
 		}
+
 	case *VariableSizedStaticType:
 		if targetArrayType, isArrayType := targetSemaType.(*sema.VariableSizedType); isArrayType {
 			return NewVariableSizedStaticType(
@@ -1832,6 +1835,7 @@ func (interpreter *Interpreter) convertStaticType(
 				),
 			)
 		}
+
 	case *ConstantSizedStaticType:
 		if targetArrayType, isArrayType := targetSemaType.(*sema.ConstantSizedType); isArrayType {
 			return NewConstantSizedStaticType(
@@ -1870,6 +1874,7 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 		switch value := value.(type) {
 		case NilValue:
 			return value
+
 		case *SomeValue:
 			if !optionalValueType.Type.Equal(unwrappedTargetType) {
 				innerValue := interpreter.convert(value.value, optionalValueType.Type, unwrappedTargetType, locationRange)
@@ -3860,7 +3865,7 @@ func (interpreter *Interpreter) IsSubTypeOfSemaType(subType StaticType, superTyp
 	}
 
 	switch subType := subType.(type) {
-	case OptionalStaticType:
+	case *OptionalStaticType:
 		if superType, ok := superType.(*sema.OptionalType); ok {
 			return interpreter.IsSubTypeOfSemaType(subType.Type, superType.Type)
 		}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1712,13 +1712,10 @@ func (interpreter *Interpreter) substituteMappedEntitlements(ty sema.Type) sema.
 		switch refType := t.(type) {
 		case *sema.ReferenceType:
 			if _, isMappedAuth := refType.Authorization.(*sema.EntitlementMapAccess); isMappedAuth {
-				return sema.NewReferenceType(
-					interpreter,
-					refType.Type,
-					interpreter.MustConvertStaticAuthorizationToSemaAccess(
-						interpreter.SharedState.currentEntitlementMappedValue,
-					),
+				authorization := interpreter.MustConvertStaticAuthorizationToSemaAccess(
+					interpreter.SharedState.currentEntitlementMappedValue,
 				)
+				return sema.NewReferenceType(interpreter, authorization, refType.Type)
 			}
 		}
 		return t

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3555,12 +3555,12 @@ func intersectionTypeFunction(invocation Invocation) Value {
 		panic(errors.NewUnreachableError())
 	}
 
-	var staticIntersections []InterfaceStaticType
+	var staticIntersections []*InterfaceStaticType
 	var semaIntersections []*sema.InterfaceType
 
 	count := intersectionIDs.Count()
 	if count > 0 {
-		staticIntersections = make([]InterfaceStaticType, 0, count)
+		staticIntersections = make([]*InterfaceStaticType, 0, count)
 		semaIntersections = make([]*sema.InterfaceType, 0, count)
 
 		var invalidIntersectionID bool
@@ -3578,7 +3578,7 @@ func intersectionTypeFunction(invocation Invocation) Value {
 
 			staticIntersections = append(
 				staticIntersections,
-				ConvertSemaToStaticType(invocation.Interpreter, intersectedInterface).(InterfaceStaticType),
+				ConvertSemaToStaticType(invocation.Interpreter, intersectedInterface).(*InterfaceStaticType),
 			)
 			semaIntersections = append(semaIntersections, intersectedInterface)
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1822,7 +1822,7 @@ func (interpreter *Interpreter) convertStaticType(
 				),
 			)
 		}
-	case VariableSizedStaticType:
+	case *VariableSizedStaticType:
 		if targetArrayType, isArrayType := targetSemaType.(*sema.VariableSizedType); isArrayType {
 			return NewVariableSizedStaticType(
 				interpreter,
@@ -4919,7 +4919,7 @@ func (interpreter *Interpreter) ValidateAtreeValue(value atree.Value) {
 		switch info := info.(type) {
 		case *ConstantSizedStaticType:
 			return info.Equal(other.(StaticType))
-		case VariableSizedStaticType:
+		case *VariableSizedStaticType:
 			return info.Equal(other.(StaticType))
 		case *DictionaryStaticType:
 			return info.Equal(other.(StaticType))

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1790,7 +1790,7 @@ func (interpreter *Interpreter) convertStaticType(
 	targetSemaType sema.Type,
 ) StaticType {
 	switch valueStaticType := valueStaticType.(type) {
-	case ReferenceStaticType:
+	case *ReferenceStaticType:
 		if targetReferenceType, isReferenceType := targetSemaType.(*sema.ReferenceType); isReferenceType {
 			return NewReferenceStaticType(
 				interpreter,
@@ -2104,7 +2104,7 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 
 			switch capability := value.(type) {
 			case *CapabilityValue:
-				valueBorrowType := capability.BorrowType.(ReferenceStaticType)
+				valueBorrowType := capability.BorrowType.(*ReferenceStaticType)
 				borrowType := interpreter.convertStaticType(valueBorrowType, targetBorrowType)
 				return NewCapabilityValue(
 					interpreter,
@@ -3784,7 +3784,7 @@ var runtimeTypeConstructors = []runtimeTypeConstructor{
 
 				ty := typeValue.Type
 				// Capabilities must hold references
-				_, ok = ty.(ReferenceStaticType)
+				_, ok = ty.(*ReferenceStaticType)
 				if !ok {
 					return Nil
 				}
@@ -3875,7 +3875,7 @@ func (interpreter *Interpreter) IsSubTypeOfSemaType(subType StaticType, superTyp
 			return interpreter.IsSubTypeOfSemaType(subType.Type, superType)
 		}
 
-	case ReferenceStaticType:
+	case *ReferenceStaticType:
 		if superType, ok := superType.(*sema.ReferenceType); ok {
 
 			// First, check that the static type of the referenced value

--- a/runtime/interpreter/interpreter_test.go
+++ b/runtime/interpreter/interpreter_test.go
@@ -169,7 +169,7 @@ func BenchmarkValueIsSubtypeOfSemaType(b *testing.B) {
 
 	inter := newTestInterpreter(b)
 	owner := common.Address{'A'}
-	typ := ConstantSizedStaticType{
+	typ := &ConstantSizedStaticType{
 		Type: PrimitiveStaticTypeString,
 		Size: size,
 	}

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -96,7 +96,7 @@ func TestInterpreterTracing(t *testing.T) {
 		dict := interpreter.NewDictionaryValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.DictionaryStaticType{
+			&interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeString,
 				ValueType: interpreter.PrimitiveStaticTypeInt,
 			},

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -67,7 +67,7 @@ func TestInterpreterTracing(t *testing.T) {
 		array := interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			owner,
@@ -155,7 +155,7 @@ func TestInterpreterTracing(t *testing.T) {
 		array := interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			common.ZeroAddress,

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -108,12 +108,12 @@ func (*CompositeStaticType) elementSize() uint {
 }
 
 func (t *CompositeStaticType) String() string {
-	return string(t.TypeID)
+	return t.MeteredString(nil)
 }
 
 func (t *CompositeStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
 	common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(len(t.TypeID)))
-	return t.String()
+	return string(t.TypeID)
 }
 
 func (t *CompositeStaticType) Equal(other StaticType) bool {
@@ -184,12 +184,12 @@ func (*InterfaceStaticType) elementSize() uint {
 }
 
 func (t *InterfaceStaticType) String() string {
-	return string(t.TypeID)
+	return t.MeteredString(nil)
 }
 
 func (t *InterfaceStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
 	common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(len(t.TypeID)))
-	return t.String()
+	return string(t.TypeID)
 }
 
 func (t *InterfaceStaticType) Equal(other StaticType) bool {
@@ -246,7 +246,7 @@ func (t *VariableSizedStaticType) ElementType() StaticType {
 }
 
 func (t *VariableSizedStaticType) String() string {
-	return fmt.Sprintf("[%s]", t.Type)
+	return t.MeteredString(nil)
 }
 
 func (t *VariableSizedStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
@@ -305,7 +305,7 @@ func (t *ConstantSizedStaticType) ElementType() StaticType {
 }
 
 func (t *ConstantSizedStaticType) String() string {
-	return fmt.Sprintf("[%s; %d]", t.Type, t.Size)
+	return t.MeteredString(nil)
 }
 
 func (t *ConstantSizedStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
@@ -365,7 +365,7 @@ func (*DictionaryStaticType) elementSize() uint {
 }
 
 func (t *DictionaryStaticType) String() string {
-	return fmt.Sprintf("{%s: %s}", t.KeyType, t.ValueType)
+	return t.MeteredString(nil)
 }
 
 func (t *DictionaryStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
@@ -418,7 +418,7 @@ func (*OptionalStaticType) elementSize() uint {
 }
 
 func (t *OptionalStaticType) String() string {
-	return fmt.Sprintf("%s?", t.Type)
+	return t.MeteredString(nil)
 }
 
 func (t *OptionalStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
@@ -477,18 +477,7 @@ func (*IntersectionStaticType) elementSize() uint {
 }
 
 func (t *IntersectionStaticType) String() string {
-	var types []string
-
-	count := len(t.Types)
-	if count > 0 {
-		types = make([]string, count)
-
-		for i, typ := range t.Types {
-			types[i] = typ.String()
-		}
-	}
-
-	return fmt.Sprintf("{%s}", strings.Join(types, ", "))
+	return t.MeteredString(nil)
 }
 
 func (t *IntersectionStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
@@ -736,8 +725,7 @@ func (*ReferenceStaticType) elementSize() uint {
 }
 
 func (t *ReferenceStaticType) String() string {
-	auth := t.Authorization.String()
-	return fmt.Sprintf("%s&%s", auth, t.ReferencedType)
+	return t.MeteredString(nil)
 }
 
 func (t *ReferenceStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
@@ -788,10 +776,7 @@ func (*CapabilityStaticType) elementSize() uint {
 }
 
 func (t *CapabilityStaticType) String() string {
-	if t.BorrowType != nil {
-		return fmt.Sprintf("Capability<%s>", t.BorrowType)
-	}
-	return "Capability"
+	return t.MeteredString(nil)
 }
 
 func (t *CapabilityStaticType) MeteredString(memoryGauge common.MemoryGauge) string {

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -219,45 +219,45 @@ type VariableSizedStaticType struct {
 	Type StaticType
 }
 
-var _ ArrayStaticType = VariableSizedStaticType{}
-var _ atree.TypeInfo = VariableSizedStaticType{}
+var _ ArrayStaticType = &VariableSizedStaticType{}
+var _ atree.TypeInfo = &VariableSizedStaticType{}
 
 func NewVariableSizedStaticType(
 	memoryGauge common.MemoryGauge,
 	elementType StaticType,
-) VariableSizedStaticType {
+) *VariableSizedStaticType {
 	common.UseMemory(memoryGauge, common.VariableSizedStaticTypeMemoryUsage)
 
-	return VariableSizedStaticType{
+	return &VariableSizedStaticType{
 		Type: elementType,
 	}
 }
 
-func (VariableSizedStaticType) isStaticType() {}
+func (*VariableSizedStaticType) isStaticType() {}
 
-func (VariableSizedStaticType) elementSize() uint {
+func (*VariableSizedStaticType) elementSize() uint {
 	return UnknownElementSize
 }
 
-func (VariableSizedStaticType) isArrayStaticType() {}
+func (*VariableSizedStaticType) isArrayStaticType() {}
 
-func (t VariableSizedStaticType) ElementType() StaticType {
+func (t *VariableSizedStaticType) ElementType() StaticType {
 	return t.Type
 }
 
-func (t VariableSizedStaticType) String() string {
+func (t *VariableSizedStaticType) String() string {
 	return fmt.Sprintf("[%s]", t.Type)
 }
 
-func (t VariableSizedStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
+func (t *VariableSizedStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
 	common.UseMemory(memoryGauge, common.VariableSizedStaticTypeStringMemoryUsage)
 
 	typeStr := t.Type.MeteredString(memoryGauge)
 	return fmt.Sprintf("[%s]", typeStr)
 }
 
-func (t VariableSizedStaticType) Equal(other StaticType) bool {
-	otherVariableSizedType, ok := other.(VariableSizedStaticType)
+func (t *VariableSizedStaticType) Equal(other StaticType) bool {
+	otherVariableSizedType, ok := other.(*VariableSizedStaticType)
 	if !ok {
 		return false
 	}
@@ -265,7 +265,7 @@ func (t VariableSizedStaticType) Equal(other StaticType) bool {
 	return t.Type.Equal(otherVariableSizedType.Type)
 }
 
-func (t VariableSizedStaticType) ID() TypeID {
+func (t *VariableSizedStaticType) ID() TypeID {
 	return sema.VariableSizedTypeID(t.Type.ID())
 }
 
@@ -899,7 +899,7 @@ func ConvertSemaArrayTypeToStaticArrayType(
 ) ArrayStaticType {
 	switch t := t.(type) {
 	case *sema.VariableSizedType:
-		return VariableSizedStaticType{
+		return &VariableSizedStaticType{
 			Type: ConvertSemaToStaticType(memoryGauge, t.Type),
 		}
 
@@ -1046,7 +1046,7 @@ func ConvertStaticToSemaType(
 	case *InterfaceStaticType:
 		return getInterface(t.Location, t.QualifiedIdentifier, t.TypeID)
 
-	case VariableSizedStaticType:
+	case *VariableSizedStaticType:
 		ty, err := ConvertStaticToSemaType(
 			memoryGauge,
 			t.Type,

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -448,7 +448,6 @@ var NilStaticType = &OptionalStaticType{
 type IntersectionStaticType struct {
 	Types      []*InterfaceStaticType
 	LegacyType StaticType
-	typeID     TypeID
 }
 
 var _ StaticType = &IntersectionStaticType{}
@@ -521,18 +520,15 @@ outer:
 }
 
 func (t *IntersectionStaticType) ID() TypeID {
-	if t.typeID == "" {
-		var intersectionStrings []string
-		typeCount := len(t.Types)
-		if typeCount > 0 {
-			intersectionStrings = make([]string, 0, typeCount)
-			for _, ty := range t.Types {
-				intersectionStrings = append(intersectionStrings, string(ty.ID()))
-			}
+	var intersectionStrings []string
+	typeCount := len(t.Types)
+	if typeCount > 0 {
+		intersectionStrings = make([]string, 0, typeCount)
+		for _, ty := range t.Types {
+			intersectionStrings = append(intersectionStrings, string(ty.ID()))
 		}
-		t.typeID = TypeID(sema.FormatIntersectionTypeID(intersectionStrings))
 	}
-	return t.typeID
+	return TypeID(sema.FormatIntersectionTypeID(intersectionStrings))
 }
 
 // Authorization
@@ -749,8 +745,10 @@ func (t *ReferenceStaticType) Equal(other StaticType) bool {
 }
 
 func (t *ReferenceStaticType) ID() TypeID {
-	// TODO: cache
-	return TypeID(sema.FormatReferenceTypeID(t.Authorization.ID(), string(t.ReferencedType.ID())))
+	return TypeID(sema.FormatReferenceTypeID(
+		t.Authorization.ID(),
+		string(t.ReferencedType.ID()),
+	))
 }
 
 // CapabilityStaticType

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -1208,38 +1208,6 @@ func NewFunctionStaticType(
 	}
 }
 
-func (t FunctionStaticType) TypeParameters(interpreter *Interpreter) []*TypeParameter {
-	var typeParameters []*TypeParameter
-
-	count := len(t.Type.TypeParameters)
-	if count > 0 {
-		typeParameters = make([]*TypeParameter, count)
-		for i, typeParameter := range t.Type.TypeParameters {
-			typeParameters[i] = &TypeParameter{
-				Name:      typeParameter.Name,
-				TypeBound: ConvertSemaToStaticType(interpreter, typeParameter.TypeBound),
-				Optional:  typeParameter.Optional,
-			}
-		}
-	}
-
-	return typeParameters
-}
-
-func (t FunctionStaticType) ParameterTypes(interpreter *Interpreter) []StaticType {
-	var parameterTypes []StaticType
-
-	count := len(t.Type.Parameters)
-	if count > 0 {
-		parameterTypes = make([]StaticType, count)
-		for i, parameter := range t.Type.Parameters {
-			parameterTypes[i] = ConvertSemaToStaticType(interpreter, parameter.TypeAnnotation.Type)
-		}
-	}
-
-	return parameterTypes
-}
-
 func (t FunctionStaticType) ReturnType(interpreter *Interpreter) StaticType {
 	var returnType StaticType
 	if t.Type.ReturnTypeAnnotation.Type != nil {

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -276,39 +276,39 @@ type ConstantSizedStaticType struct {
 	Size int64
 }
 
-var _ ArrayStaticType = ConstantSizedStaticType{}
-var _ atree.TypeInfo = ConstantSizedStaticType{}
+var _ ArrayStaticType = &ConstantSizedStaticType{}
+var _ atree.TypeInfo = &ConstantSizedStaticType{}
 
 func NewConstantSizedStaticType(
 	memoryGauge common.MemoryGauge,
 	elementType StaticType,
 	size int64,
-) ConstantSizedStaticType {
+) *ConstantSizedStaticType {
 	common.UseMemory(memoryGauge, common.ConstantSizedStaticTypeMemoryUsage)
 
-	return ConstantSizedStaticType{
+	return &ConstantSizedStaticType{
 		Type: elementType,
 		Size: size,
 	}
 }
 
-func (ConstantSizedStaticType) isStaticType() {}
+func (*ConstantSizedStaticType) isStaticType() {}
 
-func (ConstantSizedStaticType) elementSize() uint {
+func (*ConstantSizedStaticType) elementSize() uint {
 	return UnknownElementSize
 }
 
-func (ConstantSizedStaticType) isArrayStaticType() {}
+func (*ConstantSizedStaticType) isArrayStaticType() {}
 
-func (t ConstantSizedStaticType) ElementType() StaticType {
+func (t *ConstantSizedStaticType) ElementType() StaticType {
 	return t.Type
 }
 
-func (t ConstantSizedStaticType) String() string {
+func (t *ConstantSizedStaticType) String() string {
 	return fmt.Sprintf("[%s; %d]", t.Type, t.Size)
 }
 
-func (t ConstantSizedStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
+func (t *ConstantSizedStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
 	// n - for size
 	// 2 - for open and close bracket.
 	// 1 - for space
@@ -322,8 +322,8 @@ func (t ConstantSizedStaticType) MeteredString(memoryGauge common.MemoryGauge) s
 	return fmt.Sprintf("[%s; %d]", typeStr, t.Size)
 }
 
-func (t ConstantSizedStaticType) Equal(other StaticType) bool {
-	otherConstantSizedType, ok := other.(ConstantSizedStaticType)
+func (t *ConstantSizedStaticType) Equal(other StaticType) bool {
+	otherConstantSizedType, ok := other.(*ConstantSizedStaticType)
 	if !ok {
 		return false
 	}
@@ -332,7 +332,7 @@ func (t ConstantSizedStaticType) Equal(other StaticType) bool {
 		t.Type.Equal(otherConstantSizedType.Type)
 }
 
-func (t ConstantSizedStaticType) ID() TypeID {
+func (t *ConstantSizedStaticType) ID() TypeID {
 	return sema.ConstantSizedTypeID(t.Type.ID(), t.Size)
 }
 
@@ -904,7 +904,7 @@ func ConvertSemaArrayTypeToStaticArrayType(
 		}
 
 	case *sema.ConstantSizedType:
-		return ConstantSizedStaticType{
+		return &ConstantSizedStaticType{
 			Type: ConvertSemaToStaticType(memoryGauge, t.Type),
 			Size: t.Size,
 		}
@@ -1060,7 +1060,7 @@ func ConvertStaticToSemaType(
 		}
 		return sema.NewVariableSizedType(memoryGauge, ty), nil
 
-	case ConstantSizedStaticType:
+	case *ConstantSizedStaticType:
 		ty, err := ConvertStaticToSemaType(
 			memoryGauge,
 			t.Type,

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -61,21 +61,21 @@ type CompositeStaticType struct {
 	TypeID              TypeID
 }
 
-var _ StaticType = CompositeStaticType{}
+var _ StaticType = &CompositeStaticType{}
 
 func NewCompositeStaticType(
 	memoryGauge common.MemoryGauge,
 	location common.Location,
 	qualifiedIdentifier string,
 	typeID TypeID,
-) CompositeStaticType {
+) *CompositeStaticType {
 	common.UseMemory(memoryGauge, common.CompositeStaticTypeMemoryUsage)
 
 	if typeID == "" {
 		panic(errors.NewUnreachableError())
 	}
 
-	return CompositeStaticType{
+	return &CompositeStaticType{
 		Location:            location,
 		QualifiedIdentifier: qualifiedIdentifier,
 		TypeID:              typeID,
@@ -86,7 +86,7 @@ func NewCompositeStaticTypeComputeTypeID(
 	memoryGauge common.MemoryGauge,
 	location common.Location,
 	qualifiedIdentifier string,
-) CompositeStaticType {
+) *CompositeStaticType {
 	typeID := common.NewTypeIDFromQualifiedName(
 		memoryGauge,
 		location,
@@ -101,33 +101,23 @@ func NewCompositeStaticTypeComputeTypeID(
 	)
 }
 
-func (CompositeStaticType) isStaticType() {}
+func (*CompositeStaticType) isStaticType() {}
 
-func (CompositeStaticType) elementSize() uint {
+func (*CompositeStaticType) elementSize() uint {
 	return UnknownElementSize
 }
 
-func (t CompositeStaticType) String() string {
-	if t.Location == nil {
-		return t.QualifiedIdentifier
-	}
+func (t *CompositeStaticType) String() string {
 	return string(t.TypeID)
 }
 
-func (t CompositeStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
-	var amount int
-	if t.Location == nil {
-		amount = len(t.QualifiedIdentifier)
-	} else {
-		amount = len(t.TypeID)
-	}
-
-	common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(amount))
+func (t *CompositeStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
+	common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(len(t.TypeID)))
 	return t.String()
 }
 
-func (t CompositeStaticType) Equal(other StaticType) bool {
-	otherCompositeType, ok := other.(CompositeStaticType)
+func (t *CompositeStaticType) Equal(other StaticType) bool {
+	otherCompositeType, ok := other.(*CompositeStaticType)
 	if !ok {
 		return false
 	}
@@ -135,7 +125,7 @@ func (t CompositeStaticType) Equal(other StaticType) bool {
 	return otherCompositeType.TypeID == t.TypeID
 }
 
-func (t CompositeStaticType) ID() TypeID {
+func (t *CompositeStaticType) ID() TypeID {
 	return t.TypeID
 }
 
@@ -995,7 +985,7 @@ func ConvertSemaReferenceTypeToStaticReferenceType(
 func ConvertSemaCompositeTypeToStaticCompositeType(
 	memoryGauge common.MemoryGauge,
 	t *sema.CompositeType,
-) CompositeStaticType {
+) *CompositeStaticType {
 	return NewCompositeStaticType(
 		memoryGauge,
 		t.Location,
@@ -1060,7 +1050,7 @@ func ConvertStaticToSemaType(
 	getEntitlementMapType func(typeID TypeID) (*sema.EntitlementMapType, error),
 ) (_ sema.Type, err error) {
 	switch t := typ.(type) {
-	case CompositeStaticType:
+	case *CompositeStaticType:
 		return getComposite(t.Location, t.QualifiedIdentifier, t.TypeID)
 
 	case InterfaceStaticType:

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -266,7 +266,7 @@ func (t *VariableSizedStaticType) Equal(other StaticType) bool {
 }
 
 func (t *VariableSizedStaticType) ID() TypeID {
-	return sema.VariableSizedTypeID(t.Type.ID())
+	return sema.FormatVariableSizedTypeID(t.Type.ID())
 }
 
 // ConstantSizedStaticType
@@ -332,7 +332,7 @@ func (t *ConstantSizedStaticType) Equal(other StaticType) bool {
 }
 
 func (t *ConstantSizedStaticType) ID() TypeID {
-	return sema.ConstantSizedTypeID(t.Type.ID(), t.Size)
+	return sema.FormatConstantSizedTypeID(t.Type.ID(), t.Size)
 }
 
 // DictionaryStaticType
@@ -386,7 +386,7 @@ func (t *DictionaryStaticType) Equal(other StaticType) bool {
 }
 
 func (t *DictionaryStaticType) ID() TypeID {
-	return sema.DictionaryTypeID(
+	return sema.FormatDictionaryTypeID(
 		t.KeyType.ID(),
 		t.ValueType.ID(),
 	)
@@ -436,7 +436,7 @@ func (t *OptionalStaticType) Equal(other StaticType) bool {
 }
 
 func (t *OptionalStaticType) ID() TypeID {
-	return sema.OptionalTypeID(t.Type.ID())
+	return sema.FormatOptionalTypeID(t.Type.ID())
 }
 
 var NilStaticType = &OptionalStaticType{
@@ -520,16 +520,16 @@ outer:
 }
 
 func (t *IntersectionStaticType) ID() TypeID {
-	var intersectionStrings []string
+	var interfaceTypeIDs []TypeID
 	typeCount := len(t.Types)
 	if typeCount > 0 {
-		intersectionStrings = make([]string, 0, typeCount)
+		interfaceTypeIDs = make([]TypeID, 0, typeCount)
 		for _, ty := range t.Types {
-			intersectionStrings = append(intersectionStrings, string(ty.ID()))
+			interfaceTypeIDs = append(interfaceTypeIDs, ty.ID())
 		}
 	}
 	// FormatIntersectionTypeID sorts
-	return TypeID(sema.FormatIntersectionTypeID(intersectionStrings))
+	return sema.FormatIntersectionTypeID(interfaceTypeIDs)
 }
 
 // Authorization
@@ -603,11 +603,11 @@ func NewEntitlementSetAuthorization(
 func (EntitlementSetAuthorization) isAuthorization() {}
 
 func (a EntitlementSetAuthorization) ID() TypeID {
-	entitlementTypeIDs := make([]string, 0, a.Entitlements.Len())
+	entitlementTypeIDs := make([]TypeID, 0, a.Entitlements.Len())
 	a.Entitlements.Foreach(func(typeID TypeID, _ struct{}) {
 		entitlementTypeIDs = append(
 			entitlementTypeIDs,
-			string(typeID),
+			typeID,
 		)
 	})
 
@@ -755,14 +755,14 @@ func (t *ReferenceStaticType) Equal(other StaticType) bool {
 }
 
 func (t *ReferenceStaticType) ID() TypeID {
-	var authorizationString string
+	var authorization TypeID
 	if t.Authorization != UnauthorizedAccess {
-		authorizationString = string(t.Authorization.ID())
+		authorization = t.Authorization.ID()
 	}
-	return TypeID(sema.FormatReferenceTypeID(
-		authorizationString,
-		string(t.ReferencedType.ID()),
-	))
+	return sema.FormatReferenceTypeID(
+		authorization,
+		t.ReferencedType.ID(),
+	)
 }
 
 // CapabilityStaticType
@@ -822,12 +822,12 @@ func (t *CapabilityStaticType) Equal(other StaticType) bool {
 }
 
 func (t *CapabilityStaticType) ID() TypeID {
-	var borrowTypeString string
+	var borrowTypeID TypeID
 	borrowType := t.BorrowType
 	if borrowType != nil {
-		borrowTypeString = string(borrowType.ID())
+		borrowTypeID = borrowType.ID()
 	}
-	return TypeID(sema.FormatCapabilityTypeID(borrowTypeString))
+	return sema.FormatCapabilityTypeID(borrowTypeID)
 }
 
 // Conversion

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -768,33 +768,33 @@ type CapabilityStaticType struct {
 	BorrowType StaticType
 }
 
-var _ StaticType = CapabilityStaticType{}
+var _ StaticType = &CapabilityStaticType{}
 
 func NewCapabilityStaticType(
 	memoryGauge common.MemoryGauge,
 	borrowType StaticType,
-) CapabilityStaticType {
+) *CapabilityStaticType {
 	common.UseMemory(memoryGauge, common.CapabilityStaticTypeMemoryUsage)
 
-	return CapabilityStaticType{
+	return &CapabilityStaticType{
 		BorrowType: borrowType,
 	}
 }
 
-func (CapabilityStaticType) isStaticType() {}
+func (*CapabilityStaticType) isStaticType() {}
 
-func (CapabilityStaticType) elementSize() uint {
+func (*CapabilityStaticType) elementSize() uint {
 	return UnknownElementSize
 }
 
-func (t CapabilityStaticType) String() string {
+func (t *CapabilityStaticType) String() string {
 	if t.BorrowType != nil {
 		return fmt.Sprintf("Capability<%s>", t.BorrowType)
 	}
 	return "Capability"
 }
 
-func (t CapabilityStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
+func (t *CapabilityStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
 	common.UseMemory(memoryGauge, common.CapabilityStaticTypeStringMemoryUsage)
 
 	if t.BorrowType != nil {
@@ -805,8 +805,8 @@ func (t CapabilityStaticType) MeteredString(memoryGauge common.MemoryGauge) stri
 	return "Capability"
 }
 
-func (t CapabilityStaticType) Equal(other StaticType) bool {
-	otherCapabilityType, ok := other.(CapabilityStaticType)
+func (t *CapabilityStaticType) Equal(other StaticType) bool {
+	otherCapabilityType, ok := other.(*CapabilityStaticType)
 	if !ok {
 		return false
 	}
@@ -821,7 +821,7 @@ func (t CapabilityStaticType) Equal(other StaticType) bool {
 	return t.BorrowType.Equal(otherCapabilityType.BorrowType)
 }
 
-func (t CapabilityStaticType) ID() TypeID {
+func (t *CapabilityStaticType) ID() TypeID {
 	var borrowTypeString string
 	borrowType := t.BorrowType
 	if borrowType != nil {
@@ -1174,7 +1174,7 @@ func ConvertStaticToSemaType(
 			access,
 		), nil
 
-	case CapabilityStaticType:
+	case *CapabilityStaticType:
 		var borrowType sema.Type
 		if t.BorrowType != nil {
 			borrowType, err = ConvertStaticToSemaType(

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -343,32 +343,32 @@ type DictionaryStaticType struct {
 	ValueType StaticType
 }
 
-var _ StaticType = DictionaryStaticType{}
-var _ atree.TypeInfo = DictionaryStaticType{}
+var _ StaticType = &DictionaryStaticType{}
+var _ atree.TypeInfo = &DictionaryStaticType{}
 
 func NewDictionaryStaticType(
 	memoryGauge common.MemoryGauge,
 	keyType, valueType StaticType,
-) DictionaryStaticType {
+) *DictionaryStaticType {
 	common.UseMemory(memoryGauge, common.DictionaryStaticTypeMemoryUsage)
 
-	return DictionaryStaticType{
+	return &DictionaryStaticType{
 		KeyType:   keyType,
 		ValueType: valueType,
 	}
 }
 
-func (DictionaryStaticType) isStaticType() {}
+func (*DictionaryStaticType) isStaticType() {}
 
-func (DictionaryStaticType) elementSize() uint {
+func (*DictionaryStaticType) elementSize() uint {
 	return UnknownElementSize
 }
 
-func (t DictionaryStaticType) String() string {
+func (t *DictionaryStaticType) String() string {
 	return fmt.Sprintf("{%s: %s}", t.KeyType, t.ValueType)
 }
 
-func (t DictionaryStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
+func (t *DictionaryStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
 	common.UseMemory(memoryGauge, common.DictionaryStaticTypeStringMemoryUsage)
 
 	keyStr := t.KeyType.MeteredString(memoryGauge)
@@ -377,8 +377,8 @@ func (t DictionaryStaticType) MeteredString(memoryGauge common.MemoryGauge) stri
 	return fmt.Sprintf("{%s: %s}", keyStr, valueStr)
 }
 
-func (t DictionaryStaticType) Equal(other StaticType) bool {
-	otherDictionaryType, ok := other.(DictionaryStaticType)
+func (t *DictionaryStaticType) Equal(other StaticType) bool {
+	otherDictionaryType, ok := other.(*DictionaryStaticType)
 	if !ok {
 		return false
 	}
@@ -387,7 +387,7 @@ func (t DictionaryStaticType) Equal(other StaticType) bool {
 		t.ValueType.Equal(otherDictionaryType.ValueType)
 }
 
-func (t DictionaryStaticType) ID() TypeID {
+func (t *DictionaryStaticType) ID() TypeID {
 	return sema.DictionaryTypeID(
 		t.KeyType.ID(),
 		t.ValueType.ID(),
@@ -917,7 +917,7 @@ func ConvertSemaArrayTypeToStaticArrayType(
 func ConvertSemaDictionaryTypeToStaticDictionaryType(
 	memoryGauge common.MemoryGauge,
 	t *sema.DictionaryType,
-) DictionaryStaticType {
+) *DictionaryStaticType {
 	return NewDictionaryStaticType(
 		memoryGauge,
 		ConvertSemaToStaticType(memoryGauge, t.KeyType),
@@ -1079,7 +1079,7 @@ func ConvertStaticToSemaType(
 			t.Size,
 		), nil
 
-	case DictionaryStaticType:
+	case *DictionaryStaticType:
 		keyType, err := ConvertStaticToSemaType(
 			memoryGauge,
 			t.KeyType,

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -400,36 +400,36 @@ type OptionalStaticType struct {
 	Type StaticType
 }
 
-var _ StaticType = OptionalStaticType{}
+var _ StaticType = &OptionalStaticType{}
 
 func NewOptionalStaticType(
 	memoryGauge common.MemoryGauge,
 	typ StaticType,
-) OptionalStaticType {
+) *OptionalStaticType {
 	common.UseMemory(memoryGauge, common.OptionalStaticTypeMemoryUsage)
 
-	return OptionalStaticType{Type: typ}
+	return &OptionalStaticType{Type: typ}
 }
 
-func (OptionalStaticType) isStaticType() {}
+func (*OptionalStaticType) isStaticType() {}
 
-func (OptionalStaticType) elementSize() uint {
+func (*OptionalStaticType) elementSize() uint {
 	return UnknownElementSize
 }
 
-func (t OptionalStaticType) String() string {
+func (t *OptionalStaticType) String() string {
 	return fmt.Sprintf("%s?", t.Type)
 }
 
-func (t OptionalStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
+func (t *OptionalStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
 	common.UseMemory(memoryGauge, common.OptionalStaticTypeStringMemoryUsage)
 
 	typeStr := t.Type.MeteredString(memoryGauge)
 	return fmt.Sprintf("%s?", typeStr)
 }
 
-func (t OptionalStaticType) Equal(other StaticType) bool {
-	otherOptionalType, ok := other.(OptionalStaticType)
+func (t *OptionalStaticType) Equal(other StaticType) bool {
+	otherOptionalType, ok := other.(*OptionalStaticType)
 	if !ok {
 		return false
 	}
@@ -437,11 +437,11 @@ func (t OptionalStaticType) Equal(other StaticType) bool {
 	return t.Type.Equal(otherOptionalType.Type)
 }
 
-func (t OptionalStaticType) ID() TypeID {
+func (t *OptionalStaticType) ID() TypeID {
 	return sema.OptionalTypeID(t.Type.ID())
 }
 
-var NilStaticType = OptionalStaticType{
+var NilStaticType = &OptionalStaticType{
 	Type: PrimitiveStaticTypeNever,
 }
 
@@ -1110,7 +1110,7 @@ func ConvertStaticToSemaType(
 			valueType,
 		), nil
 
-	case OptionalStaticType:
+	case *OptionalStaticType:
 		ty, err := ConvertStaticToSemaType(
 			memoryGauge,
 			t.Type,

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -714,41 +714,41 @@ type ReferenceStaticType struct {
 	Authorization  Authorization
 }
 
-var _ StaticType = ReferenceStaticType{}
+var _ StaticType = &ReferenceStaticType{}
 
 func NewReferenceStaticType(
 	memoryGauge common.MemoryGauge,
 	authorization Authorization,
 	referencedType StaticType,
-) ReferenceStaticType {
+) *ReferenceStaticType {
 	common.UseMemory(memoryGauge, common.ReferenceStaticTypeMemoryUsage)
 
-	return ReferenceStaticType{
+	return &ReferenceStaticType{
 		Authorization:  authorization,
 		ReferencedType: referencedType,
 	}
 }
 
-func (ReferenceStaticType) isStaticType() {}
+func (*ReferenceStaticType) isStaticType() {}
 
-func (ReferenceStaticType) elementSize() uint {
+func (*ReferenceStaticType) elementSize() uint {
 	return UnknownElementSize
 }
 
-func (t ReferenceStaticType) String() string {
+func (t *ReferenceStaticType) String() string {
 	auth := t.Authorization.String()
 	return fmt.Sprintf("%s&%s", auth, t.ReferencedType)
 }
 
-func (t ReferenceStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
+func (t *ReferenceStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
 	typeStr := t.ReferencedType.MeteredString(memoryGauge)
 	authString := t.Authorization.MeteredString(memoryGauge)
 	common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(len(typeStr)+len(authString)))
 	return fmt.Sprintf("%s&%s", authString, typeStr)
 }
 
-func (t ReferenceStaticType) Equal(other StaticType) bool {
-	otherReferenceType, ok := other.(ReferenceStaticType)
+func (t *ReferenceStaticType) Equal(other StaticType) bool {
+	otherReferenceType, ok := other.(*ReferenceStaticType)
 	if !ok {
 		return false
 	}
@@ -757,7 +757,7 @@ func (t ReferenceStaticType) Equal(other StaticType) bool {
 		t.ReferencedType.Equal(otherReferenceType.ReferencedType)
 }
 
-func (t ReferenceStaticType) ID() TypeID {
+func (t *ReferenceStaticType) ID() TypeID {
 	// TODO: cache
 	return TypeID(sema.FormatReferenceTypeID(t.Authorization.ID(), string(t.ReferencedType.ID())))
 }
@@ -964,7 +964,7 @@ func ConvertSemaAccessToStaticAuthorization(
 func ConvertSemaReferenceTypeToStaticReferenceType(
 	memoryGauge common.MemoryGauge,
 	t *sema.ReferenceType,
-) ReferenceStaticType {
+) *ReferenceStaticType {
 	return NewReferenceStaticType(
 		memoryGauge,
 		ConvertSemaAccessToStaticAuthorization(memoryGauge, t.Authorization),
@@ -1144,7 +1144,7 @@ func ConvertStaticToSemaType(
 			intersectedTypes,
 		), nil
 
-	case ReferenceStaticType:
+	case *ReferenceStaticType:
 		ty, err := ConvertStaticToSemaType(
 			memoryGauge,
 			t.ReferencedType,

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -38,10 +38,10 @@ func TestCapabilityStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.True(t,
-			CapabilityStaticType{
+			(&CapabilityStaticType{
 				BorrowType: PrimitiveStaticTypeString,
-			}.Equal(
-				CapabilityStaticType{
+			}).Equal(
+				&CapabilityStaticType{
 					BorrowType: PrimitiveStaticTypeString,
 				},
 			),
@@ -52,8 +52,8 @@ func TestCapabilityStaticType_Equal(t *testing.T) {
 
 		t.Parallel()
 
-		a := CapabilityStaticType{}
-		b := CapabilityStaticType{}
+		a := &CapabilityStaticType{}
+		b := &CapabilityStaticType{}
 		require.True(t, a.Equal(b))
 	})
 
@@ -62,8 +62,8 @@ func TestCapabilityStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			CapabilityStaticType{}.Equal(
-				CapabilityStaticType{
+			(&CapabilityStaticType{}).Equal(
+				&CapabilityStaticType{
 					BorrowType: PrimitiveStaticTypeString,
 				},
 			),
@@ -75,10 +75,10 @@ func TestCapabilityStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			CapabilityStaticType{
+			(&CapabilityStaticType{
 				BorrowType: PrimitiveStaticTypeString,
-			}.Equal(
-				CapabilityStaticType{},
+			}).Equal(
+				&CapabilityStaticType{},
 			),
 		)
 	})
@@ -88,9 +88,9 @@ func TestCapabilityStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			CapabilityStaticType{
+			(&CapabilityStaticType{
 				BorrowType: PrimitiveStaticTypeString,
-			}.Equal(
+			}).Equal(
 				ReferenceStaticType{
 					ReferencedType: PrimitiveStaticTypeString,
 				},
@@ -162,9 +162,9 @@ func TestReferenceStaticType_Equal(t *testing.T) {
 			ReferenceStaticType{
 				ReferencedType: PrimitiveStaticTypeString,
 			}.Equal(
-				CapabilityStaticType{
+				(&CapabilityStaticType{
 					BorrowType: PrimitiveStaticTypeString,
-				},
+				}),
 			),
 		)
 	})
@@ -560,7 +560,7 @@ func TestPrimitiveStaticType_Equal(t *testing.T) {
 
 		require.False(t,
 			PrimitiveStaticTypeInt.
-				Equal(CapabilityStaticType{}),
+				Equal(&CapabilityStaticType{}),
 		)
 	})
 }
@@ -1419,7 +1419,7 @@ func TestStaticTypeConversion(t *testing.T) {
 			semaType: &sema.CapabilityType{
 				BorrowType: sema.IntType,
 			},
-			staticType: CapabilityStaticType{
+			staticType: &CapabilityStaticType{
 				BorrowType: PrimitiveStaticTypeInt,
 			},
 		},

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -624,11 +624,11 @@ func TestDictionaryStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.True(t,
-			DictionaryStaticType{
+			(&DictionaryStaticType{
 				KeyType:   PrimitiveStaticTypeInt,
 				ValueType: PrimitiveStaticTypeString,
-			}.Equal(
-				DictionaryStaticType{
+			}).Equal(
+				&DictionaryStaticType{
 					KeyType:   PrimitiveStaticTypeInt,
 					ValueType: PrimitiveStaticTypeString,
 				},
@@ -641,11 +641,11 @@ func TestDictionaryStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			DictionaryStaticType{
+			(&DictionaryStaticType{
 				KeyType:   PrimitiveStaticTypeInt,
 				ValueType: PrimitiveStaticTypeString,
-			}.Equal(
-				DictionaryStaticType{
+			}).Equal(
+				&DictionaryStaticType{
 					KeyType:   PrimitiveStaticTypeVoid,
 					ValueType: PrimitiveStaticTypeString,
 				},
@@ -658,11 +658,11 @@ func TestDictionaryStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			DictionaryStaticType{
+			(&DictionaryStaticType{
 				KeyType:   PrimitiveStaticTypeInt,
 				ValueType: PrimitiveStaticTypeVoid,
-			}.Equal(
-				DictionaryStaticType{
+			}).Equal(
+				&DictionaryStaticType{
 					KeyType:   PrimitiveStaticTypeInt,
 					ValueType: PrimitiveStaticTypeString,
 				},
@@ -675,10 +675,10 @@ func TestDictionaryStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			DictionaryStaticType{
+			(&DictionaryStaticType{
 				KeyType:   PrimitiveStaticTypeInt,
 				ValueType: PrimitiveStaticTypeVoid,
-			}.Equal(
+			}).Equal(
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInt,
 				},
@@ -1470,7 +1470,7 @@ func TestStaticTypeConversion(t *testing.T) {
 				KeyType:   sema.IntType,
 				ValueType: sema.StringType,
 			},
-			staticType: DictionaryStaticType{
+			staticType: &DictionaryStaticType{
 				KeyType:   PrimitiveStaticTypeInt,
 				ValueType: PrimitiveStaticTypeString,
 			},

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -472,7 +472,7 @@ func TestConstantSizedStaticType_Equal(t *testing.T) {
 				Type: PrimitiveStaticTypeInt,
 				Size: 10,
 			}).Equal(
-				VariableSizedStaticType{
+				&VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInt,
 				},
 			),
@@ -489,10 +489,10 @@ func TestVariableSizedStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.True(t,
-			VariableSizedStaticType{
+			(&VariableSizedStaticType{
 				Type: PrimitiveStaticTypeString,
-			}.Equal(
-				VariableSizedStaticType{
+			}).Equal(
+				&VariableSizedStaticType{
 					Type: PrimitiveStaticTypeString,
 				},
 			),
@@ -504,9 +504,9 @@ func TestVariableSizedStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			VariableSizedStaticType{
+			(&VariableSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
-			}.Equal(
+			}).Equal(
 				&ConstantSizedStaticType{
 					Type: PrimitiveStaticTypeInt,
 					Size: 10,
@@ -520,10 +520,10 @@ func TestVariableSizedStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			VariableSizedStaticType{
+			(&VariableSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
-			}.Equal(
-				VariableSizedStaticType{
+			}).Equal(
+				&VariableSizedStaticType{
 					Type: PrimitiveStaticTypeString,
 				},
 			),
@@ -607,7 +607,7 @@ func TestOptionalStaticType_Equal(t *testing.T) {
 			OptionalStaticType{
 				Type: PrimitiveStaticTypeInt,
 			}.Equal(
-				VariableSizedStaticType{
+				&VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInt,
 				},
 			),
@@ -679,7 +679,7 @@ func TestDictionaryStaticType_Equal(t *testing.T) {
 				KeyType:   PrimitiveStaticTypeInt,
 				ValueType: PrimitiveStaticTypeVoid,
 			}).Equal(
-				VariableSizedStaticType{
+				&VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInt,
 				},
 			),
@@ -1429,7 +1429,7 @@ func TestStaticTypeConversion(t *testing.T) {
 			semaType: &sema.VariableSizedType{
 				Type: sema.IntType,
 			},
-			staticType: VariableSizedStaticType{
+			staticType: &VariableSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
 			},
 		},

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -417,11 +417,11 @@ func TestConstantSizedStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.True(t,
-			ConstantSizedStaticType{
+			(&ConstantSizedStaticType{
 				Type: PrimitiveStaticTypeString,
 				Size: 10,
-			}.Equal(
-				ConstantSizedStaticType{
+			}).Equal(
+				&ConstantSizedStaticType{
 					Type: PrimitiveStaticTypeString,
 					Size: 10,
 				},
@@ -434,11 +434,11 @@ func TestConstantSizedStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			ConstantSizedStaticType{
+			(&ConstantSizedStaticType{
 				Type: PrimitiveStaticTypeString,
 				Size: 20,
-			}.Equal(
-				ConstantSizedStaticType{
+			}).Equal(
+				&ConstantSizedStaticType{
 					Type: PrimitiveStaticTypeString,
 					Size: 10,
 				},
@@ -451,11 +451,11 @@ func TestConstantSizedStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			ConstantSizedStaticType{
+			(&ConstantSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
 				Size: 10,
-			}.Equal(
-				ConstantSizedStaticType{
+			}).Equal(
+				&ConstantSizedStaticType{
 					Type: PrimitiveStaticTypeString,
 					Size: 10,
 				},
@@ -468,10 +468,10 @@ func TestConstantSizedStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			ConstantSizedStaticType{
+			(&ConstantSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
 				Size: 10,
-			}.Equal(
+			}).Equal(
 				VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInt,
 				},
@@ -507,7 +507,7 @@ func TestVariableSizedStaticType_Equal(t *testing.T) {
 			VariableSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
 			}.Equal(
-				ConstantSizedStaticType{
+				&ConstantSizedStaticType{
 					Type: PrimitiveStaticTypeInt,
 					Size: 10,
 				},
@@ -1439,7 +1439,7 @@ func TestStaticTypeConversion(t *testing.T) {
 				Type: sema.IntType,
 				Size: 42,
 			},
-			staticType: ConstantSizedStaticType{
+			staticType: &ConstantSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
 				Size: 42,
 			},

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -574,10 +574,10 @@ func TestOptionalStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.True(t,
-			OptionalStaticType{
+			(&OptionalStaticType{
 				Type: PrimitiveStaticTypeString,
-			}.Equal(
-				OptionalStaticType{
+			}).Equal(
+				&OptionalStaticType{
 					Type: PrimitiveStaticTypeString,
 				},
 			),
@@ -589,10 +589,10 @@ func TestOptionalStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			OptionalStaticType{
+			(&OptionalStaticType{
 				Type: PrimitiveStaticTypeInt,
-			}.Equal(
-				OptionalStaticType{
+			}).Equal(
+				&OptionalStaticType{
 					Type: PrimitiveStaticTypeString,
 				},
 			),
@@ -604,9 +604,9 @@ func TestOptionalStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			OptionalStaticType{
+			(&OptionalStaticType{
 				Type: PrimitiveStaticTypeInt,
-			}.Equal(
+			}).Equal(
 				&VariableSizedStaticType{
 					Type: PrimitiveStaticTypeInt,
 				},
@@ -1449,7 +1449,7 @@ func TestStaticTypeConversion(t *testing.T) {
 			semaType: &sema.OptionalType{
 				Type: sema.IntType,
 			},
-			staticType: OptionalStaticType{
+			staticType: &OptionalStaticType{
 				Type: PrimitiveStaticTypeInt,
 			},
 		},

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -697,13 +697,13 @@ func TestIntersectionStaticType_Equal(t *testing.T) {
 
 		require.True(t,
 			(&IntersectionStaticType{
-				Types: []InterfaceStaticType{
+				Types: []*InterfaceStaticType{
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 				},
 			}).Equal(
 				&IntersectionStaticType{
-					Types: []InterfaceStaticType{
+					Types: []*InterfaceStaticType{
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 					},
@@ -718,10 +718,10 @@ func TestIntersectionStaticType_Equal(t *testing.T) {
 
 		require.True(t,
 			(&IntersectionStaticType{
-				Types: []InterfaceStaticType{},
+				Types: []*InterfaceStaticType{},
 			}).Equal(
 				&IntersectionStaticType{
-					Types: []InterfaceStaticType{},
+					Types: []*InterfaceStaticType{},
 				},
 			),
 		)
@@ -733,13 +733,13 @@ func TestIntersectionStaticType_Equal(t *testing.T) {
 
 		require.False(t,
 			(&IntersectionStaticType{
-				Types: []InterfaceStaticType{
+				Types: []*InterfaceStaticType{
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 				},
 			}).Equal(
 				&IntersectionStaticType{
-					Types: []InterfaceStaticType{
+					Types: []*InterfaceStaticType{
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 					},
 				},
@@ -753,13 +753,13 @@ func TestIntersectionStaticType_Equal(t *testing.T) {
 
 		require.True(t,
 			(&IntersectionStaticType{
-				Types: []InterfaceStaticType{
+				Types: []*InterfaceStaticType{
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 				},
 			}).Equal(
 				&IntersectionStaticType{
-					Types: []InterfaceStaticType{
+					Types: []*InterfaceStaticType{
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 					},
@@ -774,13 +774,13 @@ func TestIntersectionStaticType_Equal(t *testing.T) {
 
 		require.True(t,
 			(&IntersectionStaticType{
-				Types: []InterfaceStaticType{
+				Types: []*InterfaceStaticType{
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 				},
 			}).Equal(
 				&IntersectionStaticType{
-					Types: []InterfaceStaticType{
+					Types: []*InterfaceStaticType{
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 					},
@@ -795,13 +795,13 @@ func TestIntersectionStaticType_Equal(t *testing.T) {
 
 		require.False(t,
 			(&IntersectionStaticType{
-				Types: []InterfaceStaticType{
+				Types: []*InterfaceStaticType{
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 				},
 			}).Equal(
 				&IntersectionStaticType{
-					Types: []InterfaceStaticType{
+					Types: []*InterfaceStaticType{
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Z"),
 					},
@@ -816,12 +816,12 @@ func TestIntersectionStaticType_Equal(t *testing.T) {
 
 		require.False(t,
 			(&IntersectionStaticType{
-				Types: []InterfaceStaticType{
+				Types: []*InterfaceStaticType{
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 				},
 			}).Equal(
 				&IntersectionStaticType{
-					Types: []InterfaceStaticType{
+					Types: []*InterfaceStaticType{
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 					},
@@ -836,13 +836,13 @@ func TestIntersectionStaticType_Equal(t *testing.T) {
 
 		require.False(t,
 			(&IntersectionStaticType{
-				Types: []InterfaceStaticType{
+				Types: []*InterfaceStaticType{
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 				},
 			}).Equal(
 				&IntersectionStaticType{
-					Types: []InterfaceStaticType{
+					Types: []*InterfaceStaticType{
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 						NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Z"),
 					},
@@ -857,7 +857,7 @@ func TestIntersectionStaticType_Equal(t *testing.T) {
 
 		require.False(t,
 			(&IntersectionStaticType{
-				Types: []InterfaceStaticType{
+				Types: []*InterfaceStaticType{
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "X"),
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 				},
@@ -1483,7 +1483,7 @@ func TestStaticTypeConversion(t *testing.T) {
 				},
 			},
 			staticType: &IntersectionStaticType{
-				Types: []InterfaceStaticType{
+				Types: []*InterfaceStaticType{
 					testInterfaceStaticType,
 				},
 			},

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -91,7 +91,7 @@ func TestCapabilityStaticType_Equal(t *testing.T) {
 			(&CapabilityStaticType{
 				BorrowType: PrimitiveStaticTypeString,
 			}).Equal(
-				ReferenceStaticType{
+				&ReferenceStaticType{
 					ReferencedType: PrimitiveStaticTypeString,
 				},
 			),
@@ -108,11 +108,11 @@ func TestReferenceStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.True(t,
-			ReferenceStaticType{
+			(&ReferenceStaticType{
 				Authorization:  UnauthorizedAccess,
 				ReferencedType: PrimitiveStaticTypeString,
-			}.Equal(
-				ReferenceStaticType{
+			}).Equal(
+				&ReferenceStaticType{
 					Authorization:  UnauthorizedAccess,
 					ReferencedType: PrimitiveStaticTypeString,
 				},
@@ -125,11 +125,11 @@ func TestReferenceStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			ReferenceStaticType{
+			(&ReferenceStaticType{
 				Authorization:  UnauthorizedAccess,
 				ReferencedType: PrimitiveStaticTypeInt,
-			}.Equal(
-				ReferenceStaticType{
+			}).Equal(
+				&ReferenceStaticType{
 					Authorization:  UnauthorizedAccess,
 					ReferencedType: PrimitiveStaticTypeString,
 				},
@@ -142,11 +142,11 @@ func TestReferenceStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			ReferenceStaticType{
+			(&ReferenceStaticType{
 				Authorization:  UnauthorizedAccess,
 				ReferencedType: PrimitiveStaticTypeInt,
-			}.Equal(
-				ReferenceStaticType{
+			}).Equal(
+				&ReferenceStaticType{
 					Authorization:  EntitlementMapAuthorization{TypeID: "Foo"},
 					ReferencedType: PrimitiveStaticTypeInt,
 				},
@@ -159,9 +159,9 @@ func TestReferenceStaticType_Equal(t *testing.T) {
 		t.Parallel()
 
 		require.False(t,
-			ReferenceStaticType{
+			(&ReferenceStaticType{
 				ReferencedType: PrimitiveStaticTypeString,
-			}.Equal(
+			}).Equal(
 				(&CapabilityStaticType{
 					BorrowType: PrimitiveStaticTypeString,
 				}),
@@ -862,7 +862,7 @@ func TestIntersectionStaticType_Equal(t *testing.T) {
 					NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "Y"),
 				},
 			}).Equal(
-				ReferenceStaticType{
+				&ReferenceStaticType{
 					ReferencedType: PrimitiveStaticTypeInt,
 				},
 			),
@@ -1459,7 +1459,7 @@ func TestStaticTypeConversion(t *testing.T) {
 				Type:          sema.IntType,
 				Authorization: sema.UnauthorizedAccess,
 			},
-			staticType: ReferenceStaticType{
+			staticType: &ReferenceStaticType{
 				ReferencedType: PrimitiveStaticTypeInt,
 				Authorization:  UnauthorizedAccess,
 			},

--- a/runtime/interpreter/storage.go
+++ b/runtime/interpreter/storage.go
@@ -69,7 +69,7 @@ func ConvertStoredValue(gauge common.MemoryGauge, value atree.Value) (Value, err
 	case *atree.OrderedMap:
 		typeInfo := value.Type()
 		switch typeInfo := typeInfo.(type) {
-		case DictionaryStaticType:
+		case *DictionaryStaticType:
 			return newDictionaryValueFromConstructor(gauge, typeInfo, value.Count(), func() *atree.OrderedMap { return value }), nil
 		case compositeTypeInfo:
 			return newCompositeValueFromConstructor(gauge, value.Count(), typeInfo, func() *atree.OrderedMap { return value }), nil

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -247,7 +247,7 @@ func TestDictionaryStorage(t *testing.T) {
 		value := NewDictionaryValue(
 			inter,
 			EmptyLocationRange,
-			DictionaryStaticType{
+			&DictionaryStaticType{
 				KeyType:   PrimitiveStaticTypeString,
 				ValueType: PrimitiveStaticTypeAnyStruct,
 			},
@@ -304,7 +304,7 @@ func TestDictionaryStorage(t *testing.T) {
 		value := NewDictionaryValue(
 			inter,
 			EmptyLocationRange,
-			DictionaryStaticType{
+			&DictionaryStaticType{
 				KeyType:   PrimitiveStaticTypeString,
 				ValueType: PrimitiveStaticTypeAnyStruct,
 			},
@@ -354,7 +354,7 @@ func TestDictionaryStorage(t *testing.T) {
 		value := NewDictionaryValue(
 			inter,
 			EmptyLocationRange,
-			DictionaryStaticType{
+			&DictionaryStaticType{
 				KeyType:   PrimitiveStaticTypeString,
 				ValueType: PrimitiveStaticTypeAnyStruct,
 			},
@@ -403,7 +403,7 @@ func TestDictionaryStorage(t *testing.T) {
 		value := NewDictionaryValue(
 			inter,
 			EmptyLocationRange,
-			DictionaryStaticType{
+			&DictionaryStaticType{
 				KeyType:   PrimitiveStaticTypeString,
 				ValueType: PrimitiveStaticTypeAnyStruct,
 			},

--- a/runtime/interpreter/storage_test.go
+++ b/runtime/interpreter/storage_test.go
@@ -122,7 +122,7 @@ func TestArrayStorage(t *testing.T) {
 		value := NewArrayValue(
 			inter,
 			EmptyLocationRange,
-			VariableSizedStaticType{
+			&VariableSizedStaticType{
 				Type: element.StaticType(inter),
 			},
 			common.ZeroAddress,
@@ -188,7 +188,7 @@ func TestArrayStorage(t *testing.T) {
 		value := NewArrayValue(
 			inter,
 			EmptyLocationRange,
-			VariableSizedStaticType{
+			&VariableSizedStaticType{
 				Type: element.StaticType(inter),
 			},
 			common.ZeroAddress,
@@ -454,7 +454,7 @@ func TestInterpretStorageOverwriteAndRemove(t *testing.T) {
 	array1 := NewArrayValue(
 		inter,
 		EmptyLocationRange,
-		VariableSizedStaticType{
+		&VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
 		address,
@@ -471,7 +471,7 @@ func TestInterpretStorageOverwriteAndRemove(t *testing.T) {
 	array2 := NewArrayValue(
 		inter,
 		EmptyLocationRange,
-		VariableSizedStaticType{
+		&VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
 		address,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -18265,7 +18265,7 @@ func (v *DictionaryValue) SetKey(
 
 	interpreter.checkContainerMutation(v.Type.KeyType, keyValue, locationRange)
 	interpreter.checkContainerMutation(
-		OptionalStaticType{ // intentionally unmetered
+		&OptionalStaticType{ // intentionally unmetered
 			Type: v.Type.ValueType,
 		},
 		value,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2556,7 +2556,7 @@ func (v *ArrayValue) ConformsToStaticType(
 
 	var elementType StaticType
 	switch staticType := v.StaticType(interpreter).(type) {
-	case ConstantSizedStaticType:
+	case *ConstantSizedStaticType:
 		elementType = staticType.ElementType()
 		if v.Count() != int(staticType.Size) {
 			return false
@@ -3099,7 +3099,7 @@ func (v *ArrayValue) Map(
 			interpreter,
 			returnType,
 		)
-	case ConstantSizedStaticType:
+	case *ConstantSizedStaticType:
 		returnArrayStaticType = NewConstantSizedStaticType(
 			interpreter,
 			returnType,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -17003,7 +17003,7 @@ func (v *CompositeValue) ConformsToStaticType(
 		}()
 	}
 
-	staticType := v.StaticType(interpreter).(CompositeStaticType)
+	staticType := v.StaticType(interpreter).(*CompositeStaticType)
 
 	semaType := interpreter.MustConvertStaticToSemaType(staticType)
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -17598,7 +17598,7 @@ func (v *CompositeValue) forEachAttachmentFunction(interpreter *Interpreter, loc
 					nil,
 					nil,
 					[]Value{attachmentReference},
-					[]sema.Type{sema.NewReferenceType(interpreter, attachmentType, sema.UnauthorizedAccess)},
+					[]sema.Type{sema.NewReferenceType(interpreter, sema.UnauthorizedAccess, attachmentType)},
 					nil,
 					locationRange,
 				)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -17762,7 +17762,7 @@ func (v *CompositeValue) RemoveTypeKey(
 // DictionaryValue
 
 type DictionaryValue struct {
-	Type             DictionaryStaticType
+	Type             *DictionaryStaticType
 	semaType         *sema.DictionaryType
 	isResourceKinded *bool
 	dictionary       *atree.OrderedMap
@@ -17773,7 +17773,7 @@ type DictionaryValue struct {
 func NewDictionaryValue(
 	interpreter *Interpreter,
 	locationRange LocationRange,
-	dictionaryType DictionaryStaticType,
+	dictionaryType *DictionaryStaticType,
 	keysAndValues ...Value,
 ) *DictionaryValue {
 	return NewDictionaryValueWithAddress(
@@ -17788,7 +17788,7 @@ func NewDictionaryValue(
 func NewDictionaryValueWithAddress(
 	interpreter *Interpreter,
 	locationRange LocationRange,
-	dictionaryType DictionaryStaticType,
+	dictionaryType *DictionaryStaticType,
 	address common.Address,
 	keysAndValues ...Value,
 ) *DictionaryValue {
@@ -17870,7 +17870,7 @@ func NewDictionaryValueWithAddress(
 
 func newDictionaryValueFromOrderedMap(
 	dict *atree.OrderedMap,
-	staticType DictionaryStaticType,
+	staticType *DictionaryStaticType,
 ) *DictionaryValue {
 	return &DictionaryValue{
 		Type:       staticType,
@@ -17881,7 +17881,7 @@ func newDictionaryValueFromOrderedMap(
 func newDictionaryValueWithIterator(
 	interpreter *Interpreter,
 	locationRange LocationRange,
-	staticType DictionaryStaticType,
+	staticType *DictionaryStaticType,
 	count uint64,
 	seed uint64,
 	address common.Address,
@@ -17942,7 +17942,7 @@ func newDictionaryValueWithIterator(
 
 func newDictionaryValueFromConstructor(
 	gauge common.MemoryGauge,
-	staticType DictionaryStaticType,
+	staticType *DictionaryStaticType,
 	count uint64,
 	constructor func() *atree.OrderedMap,
 ) (dict *DictionaryValue) {
@@ -18713,7 +18713,7 @@ func (v *DictionaryValue) ConformsToStaticType(
 		}()
 	}
 
-	staticType, ok := v.StaticType(interpreter).(DictionaryStaticType)
+	staticType, ok := v.StaticType(interpreter).(*DictionaryStaticType)
 	if !ok {
 		return false
 	}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2561,7 +2561,7 @@ func (v *ArrayValue) ConformsToStaticType(
 		if v.Count() != int(staticType.Size) {
 			return false
 		}
-	case VariableSizedStaticType:
+	case *VariableSizedStaticType:
 		elementType = staticType.ElementType()
 	default:
 		return false
@@ -3094,7 +3094,7 @@ func (v *ArrayValue) Map(
 
 	var returnArrayStaticType ArrayStaticType
 	switch v.Type.(type) {
-	case VariableSizedStaticType:
+	case *VariableSizedStaticType:
 		returnArrayStaticType = NewVariableSizedStaticType(
 			interpreter,
 			returnType,

--- a/runtime/interpreter/value_accountcapabilitycontroller.go
+++ b/runtime/interpreter/value_accountcapabilitycontroller.go
@@ -30,7 +30,7 @@ import (
 // AccountCapabilityControllerValue
 
 type AccountCapabilityControllerValue struct {
-	BorrowType   ReferenceStaticType
+	BorrowType   *ReferenceStaticType
 	CapabilityID UInt64Value
 
 	// tag is locally cached result of GetTag, and not stored.
@@ -49,7 +49,7 @@ type AccountCapabilityControllerValue struct {
 }
 
 func NewUnmeteredAccountCapabilityControllerValue(
-	borrowType ReferenceStaticType,
+	borrowType *ReferenceStaticType,
 	capabilityID UInt64Value,
 ) *AccountCapabilityControllerValue {
 	return &AccountCapabilityControllerValue{
@@ -60,7 +60,7 @@ func NewUnmeteredAccountCapabilityControllerValue(
 
 func NewAccountCapabilityControllerValue(
 	memoryGauge common.MemoryGauge,
-	borrowType ReferenceStaticType,
+	borrowType *ReferenceStaticType,
 	capabilityID UInt64Value,
 ) *AccountCapabilityControllerValue {
 	// Constant because its constituents are already metered.
@@ -81,7 +81,7 @@ func (*AccountCapabilityControllerValue) isValue() {}
 
 func (*AccountCapabilityControllerValue) isCapabilityControllerValue() {}
 
-func (v *AccountCapabilityControllerValue) CapabilityControllerBorrowType() ReferenceStaticType {
+func (v *AccountCapabilityControllerValue) CapabilityControllerBorrowType() *ReferenceStaticType {
 	return v.BorrowType
 }
 

--- a/runtime/interpreter/value_storagecapabilitycontroller.go
+++ b/runtime/interpreter/value_storagecapabilitycontroller.go
@@ -30,7 +30,7 @@ import (
 type CapabilityControllerValue interface {
 	Value
 	isCapabilityControllerValue()
-	CapabilityControllerBorrowType() ReferenceStaticType
+	CapabilityControllerBorrowType() *ReferenceStaticType
 	ReferenceValue(
 		interpreter *Interpreter,
 		capabilityAddress common.Address,
@@ -42,7 +42,7 @@ type CapabilityControllerValue interface {
 // StorageCapabilityControllerValue
 
 type StorageCapabilityControllerValue struct {
-	BorrowType   ReferenceStaticType
+	BorrowType   *ReferenceStaticType
 	CapabilityID UInt64Value
 	TargetPath   PathValue
 
@@ -64,7 +64,7 @@ type StorageCapabilityControllerValue struct {
 }
 
 func NewUnmeteredStorageCapabilityControllerValue(
-	borrowType ReferenceStaticType,
+	borrowType *ReferenceStaticType,
 	capabilityID UInt64Value,
 	targetPath PathValue,
 ) *StorageCapabilityControllerValue {
@@ -77,7 +77,7 @@ func NewUnmeteredStorageCapabilityControllerValue(
 
 func NewStorageCapabilityControllerValue(
 	memoryGauge common.MemoryGauge,
-	borrowType ReferenceStaticType,
+	borrowType *ReferenceStaticType,
 	capabilityID UInt64Value,
 	targetPath PathValue,
 ) *StorageCapabilityControllerValue {
@@ -100,7 +100,7 @@ func (*StorageCapabilityControllerValue) isValue() {}
 
 func (*StorageCapabilityControllerValue) isCapabilityControllerValue() {}
 
-func (v *StorageCapabilityControllerValue) CapabilityControllerBorrowType() ReferenceStaticType {
+func (v *StorageCapabilityControllerValue) CapabilityControllerBorrowType() *ReferenceStaticType {
 	return v.BorrowType
 }
 

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -3916,7 +3916,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 				return NewUnmeteredCapabilityValue(
 					NewUnmeteredUInt64Value(4),
 					NewUnmeteredAddressValueFromBytes(testAddress.Bytes()),
-					ReferenceStaticType{
+					&ReferenceStaticType{
 						Authorization:  UnauthorizedAccess,
 						ReferencedType: PrimitiveStaticTypeBool,
 					},

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -108,7 +108,7 @@ func TestOwnerNewArray(t *testing.T) {
 	array := NewArrayValue(
 		inter,
 		EmptyLocationRange,
-		VariableSizedStaticType{
+		&VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
 		common.ZeroAddress,
@@ -162,7 +162,7 @@ func TestOwnerArrayDeepCopy(t *testing.T) {
 	array := NewArrayValue(
 		inter,
 		EmptyLocationRange,
-		VariableSizedStaticType{
+		&VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
 		common.ZeroAddress,
@@ -218,7 +218,7 @@ func TestOwnerArrayElement(t *testing.T) {
 	array := NewArrayValue(
 		inter,
 		EmptyLocationRange,
-		VariableSizedStaticType{
+		&VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
 		newOwner,
@@ -261,7 +261,7 @@ func TestOwnerArraySetIndex(t *testing.T) {
 	array := NewArrayValue(
 		inter,
 		EmptyLocationRange,
-		VariableSizedStaticType{
+		&VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
 		newOwner,
@@ -312,7 +312,7 @@ func TestOwnerArrayAppend(t *testing.T) {
 	array := NewArrayValue(
 		inter,
 		EmptyLocationRange,
-		VariableSizedStaticType{
+		&VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
 		newOwner,
@@ -358,7 +358,7 @@ func TestOwnerArrayInsert(t *testing.T) {
 	array := NewArrayValue(
 		inter,
 		EmptyLocationRange,
-		VariableSizedStaticType{
+		&VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
 		newOwner,
@@ -403,7 +403,7 @@ func TestOwnerArrayRemove(t *testing.T) {
 	array := NewArrayValue(
 		inter,
 		EmptyLocationRange,
-		VariableSizedStaticType{
+		&VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
 		owner,
@@ -1008,7 +1008,7 @@ func TestStringer(t *testing.T) {
 			value: NewArrayValue(
 				newTestInterpreter(t),
 				EmptyLocationRange,
-				VariableSizedStaticType{
+				&VariableSizedStaticType{
 					Type: PrimitiveStaticTypeAnyStruct,
 				},
 				common.ZeroAddress,
@@ -1112,7 +1112,7 @@ func TestStringer(t *testing.T) {
 				array := NewArrayValue(
 					inter,
 					EmptyLocationRange,
-					VariableSizedStaticType{
+					&VariableSizedStaticType{
 						Type: PrimitiveStaticTypeAnyStruct,
 					},
 					common.ZeroAddress,
@@ -1173,7 +1173,7 @@ func TestVisitor(t *testing.T) {
 	value = NewArrayValue(
 		inter,
 		EmptyLocationRange,
-		VariableSizedStaticType{
+		&VariableSizedStaticType{
 			Type: PrimitiveStaticTypeAnyStruct,
 		},
 		common.ZeroAddress,
@@ -2258,7 +2258,7 @@ func TestArrayValue_Equal(t *testing.T) {
 
 	t.Parallel()
 
-	uint8ArrayStaticType := VariableSizedStaticType{
+	uint8ArrayStaticType := &VariableSizedStaticType{
 		Type: PrimitiveStaticTypeUInt8,
 	}
 
@@ -2382,7 +2382,7 @@ func TestArrayValue_Equal(t *testing.T) {
 
 		inter := newTestInterpreter(t)
 
-		uint16ArrayStaticType := VariableSizedStaticType{
+		uint16ArrayStaticType := &VariableSizedStaticType{
 			Type: PrimitiveStaticTypeUInt16,
 		}
 
@@ -3184,7 +3184,7 @@ func TestPublicKeyValue(t *testing.T) {
 		publicKey := NewArrayValue(
 			inter,
 			EmptyLocationRange,
-			VariableSizedStaticType{
+			&VariableSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
 			},
 			common.ZeroAddress,
@@ -3237,7 +3237,7 @@ func TestPublicKeyValue(t *testing.T) {
 		publicKey := NewArrayValue(
 			inter,
 			EmptyLocationRange,
-			VariableSizedStaticType{
+			&VariableSizedStaticType{
 				Type: PrimitiveStaticTypeInt,
 			},
 			common.ZeroAddress,
@@ -3935,7 +3935,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 				return NewArrayValue(
 					inter,
 					EmptyLocationRange,
-					VariableSizedStaticType{
+					&VariableSizedStaticType{
 						Type: PrimitiveStaticTypeNumber,
 					},
 					testAddress,
@@ -3951,7 +3951,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 				return NewArrayValue(
 					inter,
 					EmptyLocationRange,
-					VariableSizedStaticType{
+					&VariableSizedStaticType{
 						Type: PrimitiveStaticTypeAnyStruct,
 					},
 					testAddress,
@@ -3967,7 +3967,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 				return NewArrayValue(
 					inter,
 					EmptyLocationRange,
-					VariableSizedStaticType{
+					&VariableSizedStaticType{
 						Type: PrimitiveStaticTypeInteger,
 					},
 					testAddress,
@@ -3983,7 +3983,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 				return NewArrayValue(
 					inter,
 					EmptyLocationRange,
-					VariableSizedStaticType{
+					&VariableSizedStaticType{
 						Type: PrimitiveStaticTypeAnyStruct,
 					},
 					testAddress,

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -450,7 +450,7 @@ func TestOwnerNewDictionary(t *testing.T) {
 	dictionary := NewDictionaryValue(
 		inter,
 		EmptyLocationRange,
-		DictionaryStaticType{
+		&DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
 		},
@@ -496,7 +496,7 @@ func TestOwnerDictionary(t *testing.T) {
 	dictionary := NewDictionaryValueWithAddress(
 		inter,
 		EmptyLocationRange,
-		DictionaryStaticType{
+		&DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
 		},
@@ -555,7 +555,7 @@ func TestOwnerDictionaryCopy(t *testing.T) {
 	dictionary := NewDictionaryValueWithAddress(
 		inter,
 		EmptyLocationRange,
-		DictionaryStaticType{
+		&DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
 		},
@@ -615,7 +615,7 @@ func TestOwnerDictionarySetSome(t *testing.T) {
 	dictionary := NewDictionaryValueWithAddress(
 		inter,
 		EmptyLocationRange,
-		DictionaryStaticType{
+		&DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
 		},
@@ -669,7 +669,7 @@ func TestOwnerDictionaryInsertNonExisting(t *testing.T) {
 	dictionary := NewDictionaryValueWithAddress(
 		inter,
 		EmptyLocationRange,
-		DictionaryStaticType{
+		&DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
 		},
@@ -725,7 +725,7 @@ func TestOwnerDictionaryRemove(t *testing.T) {
 	dictionary := NewDictionaryValueWithAddress(
 		inter,
 		EmptyLocationRange,
-		DictionaryStaticType{
+		&DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
 		},
@@ -785,7 +785,7 @@ func TestOwnerDictionaryInsertExisting(t *testing.T) {
 	dictionary := NewDictionaryValueWithAddress(
 		inter,
 		EmptyLocationRange,
-		DictionaryStaticType{
+		&DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAnyStruct,
 		},
@@ -1021,7 +1021,7 @@ func TestStringer(t *testing.T) {
 			value: NewDictionaryValue(
 				newTestInterpreter(t),
 				EmptyLocationRange,
-				DictionaryStaticType{
+				&DictionaryStaticType{
 					KeyType:   PrimitiveStaticTypeString,
 					ValueType: PrimitiveStaticTypeUInt8,
 				},
@@ -1183,7 +1183,7 @@ func TestVisitor(t *testing.T) {
 	value = NewDictionaryValue(
 		inter,
 		EmptyLocationRange,
-		DictionaryStaticType{
+		&DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeAny,
 		},
@@ -2506,7 +2506,7 @@ func TestDictionaryValue_Equal(t *testing.T) {
 
 	t.Parallel()
 
-	byteStringDictionaryType := DictionaryStaticType{
+	byteStringDictionaryType := &DictionaryStaticType{
 		KeyType:   PrimitiveStaticTypeUInt8,
 		ValueType: PrimitiveStaticTypeString,
 	}
@@ -2668,7 +2668,7 @@ func TestDictionaryValue_Equal(t *testing.T) {
 
 		inter := newTestInterpreter(t)
 
-		stringByteDictionaryStaticType := DictionaryStaticType{
+		stringByteDictionaryStaticType := &DictionaryStaticType{
 			KeyType:   PrimitiveStaticTypeString,
 			ValueType: PrimitiveStaticTypeUInt8,
 		}
@@ -4003,7 +4003,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 				return NewDictionaryValueWithAddress(
 					inter,
 					EmptyLocationRange,
-					DictionaryStaticType{
+					&DictionaryStaticType{
 						KeyType:   PrimitiveStaticTypeString,
 						ValueType: PrimitiveStaticTypeNumber,
 					},
@@ -4022,7 +4022,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 				return NewDictionaryValueWithAddress(
 					inter,
 					EmptyLocationRange,
-					DictionaryStaticType{
+					&DictionaryStaticType{
 						KeyType:   PrimitiveStaticTypeString,
 						ValueType: PrimitiveStaticTypeAnyStruct,
 					},
@@ -4041,7 +4041,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 				return NewDictionaryValueWithAddress(
 					inter,
 					EmptyLocationRange,
-					DictionaryStaticType{
+					&DictionaryStaticType{
 						KeyType:   PrimitiveStaticTypeAnyStruct,
 						ValueType: PrimitiveStaticTypeNumber,
 					},
@@ -4060,7 +4060,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		//test(
 		//	NewDictionaryValueWithAddress(
 		//		inter,
-		//		DictionaryStaticType{
+		//		&DictionaryStaticTypeX{
 		//			KeyType:   PrimitiveStaticTypeInt,
 		//			ValueType: PrimitiveStaticTypeNumber,
 		//		},
@@ -4076,7 +4076,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 		//test(
 		//	NewDictionaryValueWithAddress(
 		//		inter,
-		//		DictionaryStaticType{
+		//		&DictionaryStaticTypeX{
 		//			KeyType:   PrimitiveStaticTypeAnyStruct,
 		//			ValueType: PrimitiveStaticTypeInteger,
 		//		},
@@ -4094,7 +4094,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 				return NewDictionaryValueWithAddress(
 					inter,
 					EmptyLocationRange,
-					DictionaryStaticType{
+					&DictionaryStaticType{
 						KeyType:   PrimitiveStaticTypeAnyStruct,
 						ValueType: PrimitiveStaticTypeAnyStruct,
 					},

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2774,11 +2774,9 @@ func TestRuntimeScriptReturnSpecial(t *testing.T) {
                   }
                 `,
 				expected: cadence.Function{
-					FunctionType: cadence.TypeWithCachedTypeID(
-						&cadence.FunctionType{
-							ReturnType: cadence.IntType,
-						},
-					).(*cadence.FunctionType),
+					FunctionType: &cadence.FunctionType{
+						ReturnType: cadence.IntType,
+					},
 				},
 			},
 		)
@@ -2796,19 +2794,17 @@ func TestRuntimeScriptReturnSpecial(t *testing.T) {
                   }
                 `,
 				expected: cadence.Function{
-					FunctionType: cadence.TypeWithCachedTypeID(
-						&cadence.FunctionType{
-							Purity: sema.FunctionPurityView,
-							Parameters: []cadence.Parameter{
-								{
-									Label:      sema.ArgumentLabelNotRequired,
-									Identifier: "message",
-									Type:       cadence.StringType,
-								},
+					FunctionType: &cadence.FunctionType{
+						Purity: sema.FunctionPurityView,
+						Parameters: []cadence.Parameter{
+							{
+								Label:      sema.ArgumentLabelNotRequired,
+								Identifier: "message",
+								Type:       cadence.StringType,
 							},
-							ReturnType: cadence.NeverType,
 						},
-					).(*cadence.FunctionType),
+						ReturnType: cadence.NeverType,
+					},
 				},
 			},
 		)
@@ -2831,11 +2827,9 @@ func TestRuntimeScriptReturnSpecial(t *testing.T) {
                   }
                 `,
 				expected: cadence.Function{
-					FunctionType: cadence.TypeWithCachedTypeID(
-						&cadence.FunctionType{
-							ReturnType: cadence.VoidType,
-						},
-					).(*cadence.FunctionType),
+					FunctionType: &cadence.FunctionType{
+						ReturnType: cadence.VoidType,
+					},
 				},
 			},
 		)

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -19,9 +19,10 @@
 package sema
 
 import (
-	"sort"
 	"strings"
 	"sync"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -74,18 +75,19 @@ func NewEntitlementSetAccess(
 func (EntitlementSetAccess) isAccess() {}
 
 func (e EntitlementSetAccess) ID() TypeID {
-	entitlementTypeIDs := make([]string, 0, e.Entitlements.Len())
+	entitlementTypeIDs := make([]TypeID, 0, e.Entitlements.Len())
 	e.Entitlements.Foreach(func(entitlement *EntitlementType, _ struct{}) {
 		entitlementTypeIDs = append(
 			entitlementTypeIDs,
-			string(entitlement.ID()),
+			entitlement.ID(),
 		)
 	})
 
+	// FormatEntitlementSetTypeID sorts
 	return FormatEntitlementSetTypeID(entitlementTypeIDs, e.SetKind)
 }
 
-func FormatEntitlementSetTypeID(entitlementTypeIDs []string, kind EntitlementSetKind) TypeID {
+func FormatEntitlementSetTypeID[T ~string](entitlementTypeIDs []T, kind EntitlementSetKind) T {
 	var builder strings.Builder
 	var separator string
 
@@ -100,16 +102,16 @@ func FormatEntitlementSetTypeID(entitlementTypeIDs []string, kind EntitlementSet
 
 	// Join entitlements' type IDs in increasing order (sorted)
 
-	sort.Strings(entitlementTypeIDs)
+	slices.Sort(entitlementTypeIDs)
 
 	for i, entitlementTypeID := range entitlementTypeIDs {
 		if i > 0 {
 			builder.WriteString(separator)
 		}
-		builder.WriteString(entitlementTypeID)
+		builder.WriteString(string(entitlementTypeID))
 	}
 
-	return TypeID(builder.String())
+	return T(builder.String())
 }
 
 func (e EntitlementSetAccess) string(typeFormatter func(Type) string) string {

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -74,10 +74,22 @@ func NewEntitlementSetAccess(
 func (EntitlementSetAccess) isAccess() {}
 
 func (e EntitlementSetAccess) ID() TypeID {
+	entitlementTypeIDs := make([]string, 0, e.Entitlements.Len())
+	e.Entitlements.Foreach(func(entitlement *EntitlementType, _ struct{}) {
+		entitlementTypeIDs = append(
+			entitlementTypeIDs,
+			string(entitlement.ID()),
+		)
+	})
+
+	return FormatEntitlementSetTypeID(entitlementTypeIDs, e.SetKind)
+}
+
+func FormatEntitlementSetTypeID(entitlementTypeIDs []string, kind EntitlementSetKind) TypeID {
 	var builder strings.Builder
 	var separator string
 
-	switch e.SetKind {
+	switch kind {
 	case Conjunction:
 		separator = ","
 	case Disjunction:
@@ -87,14 +99,6 @@ func (e EntitlementSetAccess) ID() TypeID {
 	}
 
 	// Join entitlements' type IDs in increasing order (sorted)
-
-	entitlementTypeIDs := make([]string, 0, e.Entitlements.Len())
-	e.Entitlements.Foreach(func(entitlement *EntitlementType, _ struct{}) {
-		entitlementTypeIDs = append(
-			entitlementTypeIDs,
-			string(entitlement.ID()),
-		)
-	})
 
 	sort.Strings(entitlementTypeIDs)
 

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -2219,7 +2219,7 @@ func (checker *Checker) declareSelfValue(selfType Type, selfDocString string) {
 		if typedSelfType.AttachmentEntitlementAccess != nil {
 			selfAccess = typedSelfType.AttachmentEntitlementAccess.Codomain()
 		}
-		selfType = NewReferenceType(checker.memoryGauge, typedSelfType, selfAccess)
+		selfType = NewReferenceType(checker.memoryGauge, selfAccess, typedSelfType)
 	}
 	checker.declareLowerScopedValue(selfType, selfDocString, SelfIdentifier, common.DeclarationKindSelf)
 }
@@ -2247,7 +2247,7 @@ func (checker *Checker) declareBaseValue(baseType Type, attachmentType *Composit
 			SetKind:      Conjunction,
 		}
 	}
-	base := NewReferenceType(checker.memoryGauge, baseType, baseAccess)
+	base := NewReferenceType(checker.memoryGauge, baseAccess, baseType)
 	checker.declareLowerScopedValue(base, superDocString, BaseIdentifier, common.DeclarationKindBase)
 }
 

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -108,7 +108,7 @@ func (checker *Checker) getReferenceType(typ Type, substituteAuthorization bool,
 		auth = authorization
 	}
 
-	return NewReferenceType(checker.memoryGauge, typ, auth)
+	return NewReferenceType(checker.memoryGauge, auth, typ)
 }
 
 func shouldReturnReference(parentType, memberType Type) bool {
@@ -311,12 +311,12 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (accessedT
 	substituteConcreteAuthorization := func(resultingType Type) Type {
 		switch ty := resultingType.(type) {
 		case *ReferenceType:
-			return NewReferenceType(checker.memoryGauge, ty.Type, resultingAuthorization)
+			return NewReferenceType(checker.memoryGauge, resultingAuthorization, ty.Type)
 		case *OptionalType:
 			switch innerTy := ty.Type.(type) {
 			case *ReferenceType:
 				return NewOptionalType(checker.memoryGauge,
-					NewReferenceType(checker.memoryGauge, innerTy.Type, resultingAuthorization))
+					NewReferenceType(checker.memoryGauge, resultingAuthorization, innerTy.Type))
 			}
 		}
 		return resultingType

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -790,7 +790,7 @@ func (e *InvalidAccessModifierError) Error() string {
 		return fmt.Sprintf(
 			"invalid access modifier for %s: `%s`%s",
 			e.DeclarationKind.Name(),
-			e.Access.AccessKeyword(),
+			e.Access.String(),
 			explanation,
 		)
 	}
@@ -805,7 +805,7 @@ func (e *InvalidAccessModifierError) EndPosition(memoryGauge common.MemoryGauge)
 		return e.Pos
 	}
 
-	length := len(e.Access.AccessKeyword())
+	length := len(e.Access.String())
 	return e.Pos.Shifted(memoryGauge, length-1)
 }
 
@@ -3014,7 +3014,7 @@ func (e *InvalidAccessError) Error() string {
 		} else {
 			possessedDescription = fmt.Sprintf(
 				", but reference only has `%s` authorization",
-				e.PossessedAccess.Description(),
+				e.PossessedAccess.String(),
 			)
 		}
 	}
@@ -3023,7 +3023,7 @@ func (e *InvalidAccessError) Error() string {
 		"cannot access `%s`: %s requires `%s` authorization%s",
 		e.Name,
 		e.DeclarationKind.Name(),
-		e.RestrictingAccess.Description(),
+		e.RestrictingAccess.String(),
 		possessedDescription,
 	)
 }
@@ -3116,7 +3116,7 @@ func (e *InvalidAssignmentAccessError) Error() string {
 		"cannot assign to `%s`: %s has `%s` access",
 		e.Name,
 		e.DeclarationKind.Name(),
-		e.RestrictingAccess.Description(),
+		e.RestrictingAccess.String(),
 	)
 }
 
@@ -3148,13 +3148,13 @@ func (e *UnauthorizedReferenceAssignmentError) Error() string {
 	if e.FoundAccess == UnauthorizedAccess {
 		foundAccess = "non-auth"
 	} else {
-		foundAccess = fmt.Sprintf("(%s)", e.FoundAccess.Description())
+		foundAccess = fmt.Sprintf("(%s)", e.FoundAccess.String())
 	}
 
 	return fmt.Sprintf(
 		"invalid assignment: can only assign to a reference with (%s) or (%s) access, but found a %s reference",
-		e.RequiredAccess[0].Description(),
-		e.RequiredAccess[1].Description(),
+		e.RequiredAccess[0].String(),
+		e.RequiredAccess[1].String(),
 		foundAccess,
 	)
 }
@@ -3162,8 +3162,8 @@ func (e *UnauthorizedReferenceAssignmentError) Error() string {
 func (e *UnauthorizedReferenceAssignmentError) SecondaryError() string {
 	return fmt.Sprintf(
 		"consider taking a reference with `%s` or `%s` access",
-		e.RequiredAccess[0].Description(),
-		e.RequiredAccess[1].Description(),
+		e.RequiredAccess[0].String(),
+		e.RequiredAccess[1].String(),
 	)
 }
 
@@ -4312,7 +4312,7 @@ func (*UnrepresentableEntitlementMapOutputError) IsUserError() {}
 func (e *UnrepresentableEntitlementMapOutputError) Error() string {
 	return fmt.Sprintf(
 		"cannot map `%s` through `%s` because the output is unrepresentable",
-		e.Input.AccessKeyword(),
+		e.Input.String(),
 		e.Map.QualifiedString(),
 	)
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -5852,7 +5852,11 @@ var _ TypeIndexableType = &ReferenceType{}
 
 var UnauthorizedAccess Access = PrimitiveAccess(ast.AccessAll)
 
-func NewReferenceType(memoryGauge common.MemoryGauge, typ Type, authorization Access) *ReferenceType {
+func NewReferenceType(
+	memoryGauge common.MemoryGauge,
+	authorization Access,
+	typ Type,
+) *ReferenceType {
 	common.UseMemory(memoryGauge, common.ReferenceSemaTypeMemoryUsage)
 	return &ReferenceType{
 		Type:          typ,
@@ -5989,11 +5993,7 @@ func (t *ReferenceType) RewriteWithIntersectionTypes() (Type, bool) {
 
 func (t *ReferenceType) Map(gauge common.MemoryGauge, typeParamMap map[*TypeParameter]*TypeParameter, f func(Type) Type) Type {
 	mappedType := t.Type.Map(gauge, typeParamMap, f)
-	return f(NewReferenceType(
-		gauge,
-		mappedType,
-		t.Authorization,
-	))
+	return f(NewReferenceType(gauge, t.Authorization, mappedType))
 }
 
 func (t *ReferenceType) GetMembers() map[string]MemberResolver {

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -1936,8 +1936,8 @@ func TestMapType(t *testing.T) {
 	t.Run("map reference type", func(t *testing.T) {
 		t.Parallel()
 		mapType := NewEntitlementMapAccess(&EntitlementMapType{Identifier: "X"})
-		original := NewReferenceType(nil, StringType, mapType)
-		mapped := NewReferenceType(nil, BoolType, mapType)
+		original := NewReferenceType(nil, mapType, StringType)
+		mapped := NewReferenceType(nil, mapType, BoolType)
 
 		require.Equal(t, mapped, original.Map(nil, make(map[*TypeParameter]*TypeParameter), mapFn))
 	})
@@ -2060,7 +2060,7 @@ func TestReferenceType_ID(t *testing.T) {
 	t.Run("top-level, unauthorized", func(t *testing.T) {
 		t.Parallel()
 
-		referenceType := NewReferenceType(nil, IntType, UnauthorizedAccess)
+		referenceType := NewReferenceType(nil, UnauthorizedAccess, IntType)
 		assert.Equal(t,
 			TypeID("&Int"),
 			referenceType.ID(),
@@ -2072,7 +2072,7 @@ func TestReferenceType_ID(t *testing.T) {
 
 		access := NewEntitlementMapAccess(NewEntitlementMapType(nil, testLocation, "M"))
 
-		referenceType := NewReferenceType(nil, IntType, access)
+		referenceType := NewReferenceType(nil, access, IntType)
 		assert.Equal(t,
 			TypeID("auth(S.test.M)&Int"),
 			referenceType.ID(),
@@ -2091,7 +2091,7 @@ func TestReferenceType_ID(t *testing.T) {
 			Conjunction,
 		)
 
-		referenceType := NewReferenceType(nil, IntType, access)
+		referenceType := NewReferenceType(nil, access, IntType)
 
 		// NOTE: sorted
 		assert.Equal(t,
@@ -2108,7 +2108,7 @@ func TestReferenceType_ID(t *testing.T) {
 
 		access := NewEntitlementMapAccess(mapType)
 
-		referenceType := NewReferenceType(nil, IntType, access)
+		referenceType := NewReferenceType(nil, access, IntType)
 		assert.Equal(t,
 			TypeID("auth(S.test.C.M)&Int"),
 			referenceType.ID(),
@@ -2133,7 +2133,7 @@ func TestReferenceType_ID(t *testing.T) {
 			Conjunction,
 		)
 
-		referenceType := NewReferenceType(nil, IntType, access)
+		referenceType := NewReferenceType(nil, access, IntType)
 
 		// NOTE: sorted
 		assert.Equal(t,
@@ -2151,7 +2151,7 @@ func TestReferenceType_String(t *testing.T) {
 	t.Run("unauthorized", func(t *testing.T) {
 		t.Parallel()
 
-		referenceType := NewReferenceType(nil, IntType, UnauthorizedAccess)
+		referenceType := NewReferenceType(nil, UnauthorizedAccess, IntType)
 		assert.Equal(t, "&Int", referenceType.String())
 	})
 
@@ -2160,7 +2160,7 @@ func TestReferenceType_String(t *testing.T) {
 
 		access := NewEntitlementMapAccess(NewEntitlementMapType(nil, testLocation, "M"))
 
-		referenceType := NewReferenceType(nil, IntType, access)
+		referenceType := NewReferenceType(nil, access, IntType)
 		assert.Equal(t,
 			"auth(M) &Int",
 			referenceType.String(),
@@ -2179,7 +2179,7 @@ func TestReferenceType_String(t *testing.T) {
 			Conjunction,
 		)
 
-		referenceType := NewReferenceType(nil, IntType, access)
+		referenceType := NewReferenceType(nil, access, IntType)
 
 		// NOTE: order
 		assert.Equal(t,
@@ -2202,7 +2202,7 @@ func TestReferenceType_QualifiedString(t *testing.T) {
 	t.Run("top-level, unauthorized", func(t *testing.T) {
 		t.Parallel()
 
-		referenceType := NewReferenceType(nil, IntType, UnauthorizedAccess)
+		referenceType := NewReferenceType(nil, UnauthorizedAccess, IntType)
 		assert.Equal(t,
 			"&Int",
 			referenceType.QualifiedString(),
@@ -2214,7 +2214,7 @@ func TestReferenceType_QualifiedString(t *testing.T) {
 
 		access := NewEntitlementMapAccess(NewEntitlementMapType(nil, testLocation, "M"))
 
-		referenceType := NewReferenceType(nil, IntType, access)
+		referenceType := NewReferenceType(nil, access, IntType)
 		assert.Equal(t,
 			"auth(M) &Int",
 			referenceType.QualifiedString(),
@@ -2233,7 +2233,7 @@ func TestReferenceType_QualifiedString(t *testing.T) {
 			Conjunction,
 		)
 
-		referenceType := NewReferenceType(nil, IntType, access)
+		referenceType := NewReferenceType(nil, access, IntType)
 
 		// NOTE: order
 		assert.Equal(t,
@@ -2250,7 +2250,7 @@ func TestReferenceType_QualifiedString(t *testing.T) {
 
 		access := NewEntitlementMapAccess(mapType)
 
-		referenceType := NewReferenceType(nil, IntType, access)
+		referenceType := NewReferenceType(nil, access, IntType)
 		assert.Equal(t,
 			"auth(C.M) &Int",
 			referenceType.QualifiedString(),
@@ -2275,7 +2275,7 @@ func TestReferenceType_QualifiedString(t *testing.T) {
 			Conjunction,
 		)
 
-		referenceType := NewReferenceType(nil, IntType, access)
+		referenceType := NewReferenceType(nil, access, IntType)
 		assert.Equal(t,
 			"auth(C.E2, C.E1) &Int",
 			referenceType.QualifiedString(),

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -2046,3 +2046,453 @@ func TestMapType(t *testing.T) {
 		require.True(t, outputFunction.Parameters[0].TypeAnnotation.Type.(*GenericType).TypeParameter == outputFunction.TypeParameters[0])
 	})
 }
+
+func TestReferenceType_ID(t *testing.T) {
+	t.Parallel()
+
+	testLocation := common.StringLocation("test")
+
+	containerType := &CompositeType{
+		Location:   testLocation,
+		Identifier: "C",
+	}
+
+	t.Run("top-level, unauthorized", func(t *testing.T) {
+		t.Parallel()
+
+		referenceType := NewReferenceType(nil, IntType, UnauthorizedAccess)
+		assert.Equal(t,
+			TypeID("&Int"),
+			referenceType.ID(),
+		)
+	})
+
+	t.Run("top-level, authorized, map", func(t *testing.T) {
+		t.Parallel()
+
+		access := NewEntitlementMapAccess(NewEntitlementMapType(nil, testLocation, "M"))
+
+		referenceType := NewReferenceType(nil, IntType, access)
+		assert.Equal(t,
+			TypeID("auth(S.test.M)&Int"),
+			referenceType.ID(),
+		)
+	})
+
+	t.Run("top-level, authorized, set", func(t *testing.T) {
+		t.Parallel()
+
+		access := NewEntitlementSetAccess(
+			[]*EntitlementType{
+				// NOTE: order
+				NewEntitlementType(nil, testLocation, "E2"),
+				NewEntitlementType(nil, testLocation, "E1"),
+			},
+			Conjunction,
+		)
+
+		referenceType := NewReferenceType(nil, IntType, access)
+
+		// NOTE: sorted
+		assert.Equal(t,
+			TypeID("auth(S.test.E1,S.test.E2)&Int"),
+			referenceType.ID(),
+		)
+	})
+
+	t.Run("nested, authorized, map", func(t *testing.T) {
+		t.Parallel()
+
+		mapType := NewEntitlementMapType(nil, testLocation, "M")
+		mapType.SetContainerType(containerType)
+
+		access := NewEntitlementMapAccess(mapType)
+
+		referenceType := NewReferenceType(nil, IntType, access)
+		assert.Equal(t,
+			TypeID("auth(S.test.C.M)&Int"),
+			referenceType.ID(),
+		)
+	})
+
+	t.Run("nested, authorized, set", func(t *testing.T) {
+		t.Parallel()
+
+		entitlementType1 := NewEntitlementType(nil, testLocation, "E1")
+		entitlementType1.SetContainerType(containerType)
+
+		entitlementType2 := NewEntitlementType(nil, testLocation, "E2")
+		entitlementType2.SetContainerType(containerType)
+
+		access := NewEntitlementSetAccess(
+			[]*EntitlementType{
+				// NOTE: order
+				entitlementType2,
+				entitlementType1,
+			},
+			Conjunction,
+		)
+
+		referenceType := NewReferenceType(nil, IntType, access)
+
+		// NOTE: sorted
+		assert.Equal(t,
+			TypeID("auth(S.test.C.E1,S.test.C.E2)&Int"),
+			referenceType.ID(),
+		)
+	})
+}
+
+func TestReferenceType_String(t *testing.T) {
+	t.Parallel()
+
+	testLocation := common.StringLocation("test")
+
+	t.Run("unauthorized", func(t *testing.T) {
+		t.Parallel()
+
+		referenceType := NewReferenceType(nil, IntType, UnauthorizedAccess)
+		assert.Equal(t, "&Int", referenceType.String())
+	})
+
+	t.Run("top-level, authorized, map", func(t *testing.T) {
+		t.Parallel()
+
+		access := NewEntitlementMapAccess(NewEntitlementMapType(nil, testLocation, "M"))
+
+		referenceType := NewReferenceType(nil, IntType, access)
+		assert.Equal(t,
+			"auth(M) &Int",
+			referenceType.String(),
+		)
+	})
+
+	t.Run("top-level, authorized, set", func(t *testing.T) {
+		t.Parallel()
+
+		access := NewEntitlementSetAccess(
+			[]*EntitlementType{
+				// NOTE: order
+				NewEntitlementType(nil, testLocation, "E2"),
+				NewEntitlementType(nil, testLocation, "E1"),
+			},
+			Conjunction,
+		)
+
+		referenceType := NewReferenceType(nil, IntType, access)
+
+		// NOTE: order
+		assert.Equal(t,
+			"auth(E2, E1) &Int",
+			referenceType.String(),
+		)
+	})
+}
+
+func TestReferenceType_QualifiedString(t *testing.T) {
+	t.Parallel()
+
+	testLocation := common.StringLocation("test")
+
+	containerType := &CompositeType{
+		Location:   testLocation,
+		Identifier: "C",
+	}
+
+	t.Run("top-level, unauthorized", func(t *testing.T) {
+		t.Parallel()
+
+		referenceType := NewReferenceType(nil, IntType, UnauthorizedAccess)
+		assert.Equal(t,
+			"&Int",
+			referenceType.QualifiedString(),
+		)
+	})
+
+	t.Run("top-level, authorized, map", func(t *testing.T) {
+		t.Parallel()
+
+		access := NewEntitlementMapAccess(NewEntitlementMapType(nil, testLocation, "M"))
+
+		referenceType := NewReferenceType(nil, IntType, access)
+		assert.Equal(t,
+			"auth(M) &Int",
+			referenceType.QualifiedString(),
+		)
+	})
+
+	t.Run("top-level, authorized, set", func(t *testing.T) {
+		t.Parallel()
+
+		access := NewEntitlementSetAccess(
+			[]*EntitlementType{
+				// NOTE: order
+				NewEntitlementType(nil, testLocation, "E2"),
+				NewEntitlementType(nil, testLocation, "E1"),
+			},
+			Conjunction,
+		)
+
+		referenceType := NewReferenceType(nil, IntType, access)
+
+		// NOTE: order
+		assert.Equal(t,
+			"auth(E2, E1) &Int",
+			referenceType.QualifiedString(),
+		)
+	})
+
+	t.Run("nested, authorized, map", func(t *testing.T) {
+		t.Parallel()
+
+		mapType := NewEntitlementMapType(nil, testLocation, "M")
+		mapType.SetContainerType(containerType)
+
+		access := NewEntitlementMapAccess(mapType)
+
+		referenceType := NewReferenceType(nil, IntType, access)
+		assert.Equal(t,
+			"auth(C.M) &Int",
+			referenceType.QualifiedString(),
+		)
+	})
+
+	t.Run("nested, authorized, set", func(t *testing.T) {
+		t.Parallel()
+
+		entitlementType1 := NewEntitlementType(nil, testLocation, "E1")
+		entitlementType1.SetContainerType(containerType)
+
+		entitlementType2 := NewEntitlementType(nil, testLocation, "E2")
+		entitlementType2.SetContainerType(containerType)
+
+		access := NewEntitlementSetAccess(
+			[]*EntitlementType{
+				// NOTE: order
+				entitlementType2,
+				entitlementType1,
+			},
+			Conjunction,
+		)
+
+		referenceType := NewReferenceType(nil, IntType, access)
+		assert.Equal(t,
+			"auth(C.E2, C.E1) &Int",
+			referenceType.QualifiedString(),
+		)
+	})
+}
+
+func TestIntersectionType_ID(t *testing.T) {
+	t.Parallel()
+
+	testLocation := common.StringLocation("test")
+
+	containerType := &CompositeType{
+		Location:   testLocation,
+		Identifier: "C",
+	}
+
+	t.Run("top-level, single", func(t *testing.T) {
+		t.Parallel()
+
+		intersectionType := NewIntersectionType(
+			nil,
+			[]*InterfaceType{
+				{
+					Location:   testLocation,
+					Identifier: "I",
+				},
+			},
+		)
+		assert.Equal(t,
+			TypeID("{S.test.I}"),
+			intersectionType.ID(),
+		)
+	})
+
+	t.Run("top-level, two", func(t *testing.T) {
+		t.Parallel()
+
+		intersectionType := NewIntersectionType(
+			nil,
+			[]*InterfaceType{
+				// NOTE: order
+				{
+					Location:   testLocation,
+					Identifier: "I2",
+				},
+				{
+					Location:   testLocation,
+					Identifier: "I1",
+				},
+			},
+		)
+		// NOTE: sorted
+		assert.Equal(t,
+			TypeID("{S.test.I1,S.test.I2}"),
+			intersectionType.ID(),
+		)
+	})
+
+	t.Run("nested, two", func(t *testing.T) {
+		t.Parallel()
+
+		interfaceType1 := &InterfaceType{
+			Location:   testLocation,
+			Identifier: "I1",
+		}
+		interfaceType1.SetContainerType(containerType)
+
+		interfaceType2 := &InterfaceType{
+			Location:   testLocation,
+			Identifier: "I2",
+		}
+		interfaceType2.SetContainerType(containerType)
+
+		intersectionType := NewIntersectionType(
+			nil,
+			[]*InterfaceType{
+				// NOTE: order
+				interfaceType2,
+				interfaceType1,
+			},
+		)
+		// NOTE: sorted
+		assert.Equal(t,
+			TypeID("{S.test.C.I1,S.test.C.I2}"),
+			intersectionType.ID(),
+		)
+	})
+}
+
+func TestIntersectionType_String(t *testing.T) {
+	t.Parallel()
+
+	testLocation := common.StringLocation("test")
+
+	t.Run("top-level, single", func(t *testing.T) {
+		t.Parallel()
+
+		intersectionType := NewIntersectionType(
+			nil,
+			[]*InterfaceType{
+				{
+					Location:   testLocation,
+					Identifier: "I",
+				},
+			},
+		)
+		assert.Equal(t,
+			"{I}",
+			intersectionType.String(),
+		)
+	})
+
+	t.Run("top-level, two", func(t *testing.T) {
+		t.Parallel()
+
+		intersectionType := NewIntersectionType(
+			nil,
+			[]*InterfaceType{
+				// NOTE: order
+				{
+					Location:   testLocation,
+					Identifier: "I2",
+				},
+				{
+					Location:   testLocation,
+					Identifier: "I1",
+				},
+			},
+		)
+		// NOTE: order
+		assert.Equal(t,
+			"{I2, I1}",
+			intersectionType.String(),
+		)
+	})
+}
+
+func TestIntersectionType_QualifiedString(t *testing.T) {
+	t.Parallel()
+
+	testLocation := common.StringLocation("test")
+
+	containerType := &CompositeType{
+		Location:   testLocation,
+		Identifier: "C",
+	}
+
+	t.Run("top-level, single", func(t *testing.T) {
+		t.Parallel()
+
+		intersectionType := NewIntersectionType(
+			nil,
+			[]*InterfaceType{
+				{
+					Location:   testLocation,
+					Identifier: "I",
+				},
+			},
+		)
+		assert.Equal(t,
+			"{I}",
+			intersectionType.QualifiedString(),
+		)
+	})
+
+	t.Run("top-level, two", func(t *testing.T) {
+		t.Parallel()
+
+		intersectionType := NewIntersectionType(
+			nil,
+			[]*InterfaceType{
+				// NOTE: order
+				{
+					Location:   testLocation,
+					Identifier: "I2",
+				},
+				{
+					Location:   testLocation,
+					Identifier: "I1",
+				},
+			},
+		)
+		// NOTE: order
+		assert.Equal(t,
+			"{I2, I1}",
+			intersectionType.QualifiedString(),
+		)
+	})
+
+	t.Run("nested, two", func(t *testing.T) {
+		t.Parallel()
+
+		interfaceType1 := &InterfaceType{
+			Location:   testLocation,
+			Identifier: "I1",
+		}
+		interfaceType1.SetContainerType(containerType)
+
+		interfaceType2 := &InterfaceType{
+			Location:   testLocation,
+			Identifier: "I2",
+		}
+		interfaceType2.SetContainerType(containerType)
+
+		intersectionType := NewIntersectionType(
+			nil,
+			[]*InterfaceType{
+				// NOTE: order
+				interfaceType2,
+				interfaceType1,
+			},
+		)
+		// NOTE: sorted
+		assert.Equal(t,
+			"{C.I2, C.I1}",
+			intersectionType.QualifiedString(),
+		)
+	})
+}

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -2158,7 +2158,7 @@ func newAccountStorageCapabilitiesGetControllerFunction(
 	)
 }
 
-var storageCapabilityControllerReferencesArrayStaticType = interpreter.VariableSizedStaticType{
+var storageCapabilityControllerReferencesArrayStaticType = &interpreter.VariableSizedStaticType{
 	Type: interpreter.ReferenceStaticType{
 		ReferencedType: interpreter.PrimitiveStaticTypeStorageCapabilityController,
 		Authorization:  interpreter.UnauthorizedAccess,
@@ -3472,7 +3472,7 @@ func newAccountAccountCapabilitiesGetControllerFunction(
 	)
 }
 
-var accountCapabilityControllerReferencesArrayStaticType = interpreter.VariableSizedStaticType{
+var accountCapabilityControllerReferencesArrayStaticType = &interpreter.VariableSizedStaticType{
 	Type: interpreter.ReferenceStaticType{
 		ReferencedType: interpreter.PrimitiveStaticTypeAccountCapabilityController,
 		Authorization:  interpreter.UnauthorizedAccess,

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -2159,7 +2159,7 @@ func newAccountStorageCapabilitiesGetControllerFunction(
 }
 
 var storageCapabilityControllerReferencesArrayStaticType = &interpreter.VariableSizedStaticType{
-	Type: interpreter.ReferenceStaticType{
+	Type: &interpreter.ReferenceStaticType{
 		ReferencedType: interpreter.PrimitiveStaticTypeStorageCapabilityController,
 		Authorization:  interpreter.UnauthorizedAccess,
 	},
@@ -2391,7 +2391,7 @@ func issueStorageCapabilityController(
 	targetPathValue interpreter.PathValue,
 ) (
 	interpreter.UInt64Value,
-	interpreter.ReferenceStaticType,
+	*interpreter.ReferenceStaticType,
 ) {
 	// Create and write StorageCapabilityController
 
@@ -2473,7 +2473,7 @@ func issueAccountCapabilityController(
 	borrowType *sema.ReferenceType,
 ) (
 	interpreter.UInt64Value,
-	interpreter.ReferenceStaticType,
+	*interpreter.ReferenceStaticType,
 ) {
 	// Create and write AccountCapabilityController
 
@@ -3473,7 +3473,7 @@ func newAccountAccountCapabilitiesGetControllerFunction(
 }
 
 var accountCapabilityControllerReferencesArrayStaticType = &interpreter.VariableSizedStaticType{
-	Type: interpreter.ReferenceStaticType{
+	Type: &interpreter.ReferenceStaticType{
 		ReferencedType: interpreter.PrimitiveStaticTypeAccountCapabilityController,
 		Authorization:  interpreter.UnauthorizedAccess,
 	},

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -2735,7 +2735,7 @@ func newStorageCapabilityControllerDeleteFunction(
 	)
 }
 
-var capabilityIDSetStaticType = interpreter.DictionaryStaticType{
+var capabilityIDSetStaticType = &interpreter.DictionaryStaticType{
 	KeyType:   interpreter.PrimitiveStaticTypeUInt64,
 	ValueType: interpreter.NilStaticType,
 }

--- a/runtime/stdlib/block.go
+++ b/runtime/stdlib/block.go
@@ -102,7 +102,7 @@ func NewGetBlockFunction(provider BlockAtHeightProvider) StandardLibraryValue {
 	)
 }
 
-var BlockIDStaticType = interpreter.ConstantSizedStaticType{
+var BlockIDStaticType = &interpreter.ConstantSizedStaticType{
 	Type: interpreter.PrimitiveStaticTypeUInt8, // unmetered
 	Size: 32,
 }

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -2144,8 +2144,8 @@ func TestBlockchain(t *testing.T) {
 						eventsInvoked = true
 						assert.NotNil(t, eventType)
 
-						require.IsType(t, interpreter.CompositeStaticType{}, eventType)
-						compositeType := eventType.(interpreter.CompositeStaticType)
+						require.IsType(t, &interpreter.CompositeStaticType{}, eventType)
+						compositeType := eventType.(*interpreter.CompositeStaticType)
 						assert.Equal(t, "Foo", compositeType.QualifiedIdentifier)
 
 						return interpreter.NewArrayValue(

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -1210,8 +1210,7 @@ func TestRuntimeStorageSaveCapability(t *testing.T) {
 		ty,
 	)
 
-	actual := cadence.ValueWithCachedTypeID(value)
-	require.Equal(t, expected, actual)
+	require.Equal(t, expected, value)
 }
 
 func TestRuntimeStorageReferenceCast(t *testing.T) {

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -720,7 +720,10 @@ func TestCheckAccountStorageBorrow(t *testing.T) {
 
 	testExplicitTypeArgumentReference := func(domain common.PathDomain, auth sema.Access) {
 
-		authKeyword := auth.AuthKeyword()
+		var authKeyword string
+		if auth != sema.UnauthorizedAccess {
+			authKeyword = fmt.Sprintf("auth(%s)", auth.QualifiedString())
+		}
 
 		testName := fmt.Sprintf(
 			"explicit type argument, %s reference, %s",

--- a/runtime/tests/checker/capability_test.go
+++ b/runtime/tests/checker/capability_test.go
@@ -97,7 +97,10 @@ func TestCheckCapability_borrow(t *testing.T) {
 		}}, sema.Conjunction),
 	} {
 
-		authKeyword := auth.AuthKeyword()
+		var authKeyword string
+		if auth != sema.UnauthorizedAccess {
+			authKeyword = fmt.Sprintf("auth(%s)", auth.QualifiedString())
+		}
 
 		testName := fmt.Sprintf(
 			"explicit type argument, %s reference",
@@ -320,7 +323,10 @@ func TestCheckCapability_check(t *testing.T) {
 			Identifier: "X",
 		}}, sema.Conjunction),
 	} {
-		authKeyword := auth.AuthKeyword()
+		var authKeyword string
+		if auth != sema.UnauthorizedAccess {
+			authKeyword = fmt.Sprintf("auth(%s)", auth.QualifiedString())
+		}
 
 		testName := fmt.Sprintf(
 			"explicit type argument, %s reference",

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -1033,7 +1033,10 @@ func TestCheckReferenceExpressionReferenceType(t *testing.T) {
 
 	test := func(t *testing.T, auth sema.Access, kind common.CompositeKind) {
 
-		authKeyword := auth.AuthKeyword()
+		var authKeyword string
+		if auth != sema.UnauthorizedAccess {
+			authKeyword = fmt.Sprintf("auth(%s)", auth.QualifiedString())
+		}
 
 		testName := fmt.Sprintf("%s, auth: %v", kind.Name(), auth)
 

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -133,7 +133,7 @@ func TestInterpretToBytes(t *testing.T) {
 			interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeUInt8,
 				},
 				common.ZeroAddress,

--- a/runtime/tests/interpreter/character_test.go
+++ b/runtime/tests/interpreter/character_test.go
@@ -50,7 +50,7 @@ func TestInterpretCharacterUtf8Field(t *testing.T) {
 			interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeUInt8,
 				},
 				common.ZeroAddress,

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -61,7 +61,7 @@ func TestInterpetArrayMutation(t *testing.T) {
 			interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
 				common.ZeroAddress,
@@ -135,7 +135,7 @@ func TestInterpetArrayMutation(t *testing.T) {
 			interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
 				common.ZeroAddress,
@@ -210,7 +210,7 @@ func TestInterpetArrayMutation(t *testing.T) {
 			interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
 				common.ZeroAddress,
@@ -271,7 +271,7 @@ func TestInterpetArrayMutation(t *testing.T) {
 			interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
 				common.ZeroAddress,
@@ -985,7 +985,7 @@ func TestInterpretInnerContainerMutationWhileIteratingOuter(t *testing.T) {
 			interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
 				common.ZeroAddress,
@@ -1019,7 +1019,7 @@ func TestInterpretInnerContainerMutationWhileIteratingOuter(t *testing.T) {
 			interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
 				common.ZeroAddress,

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -1365,7 +1365,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 						expectedDictionary := interpreter.NewDictionaryValue(
 							inter,
 							interpreter.EmptyLocationRange,
-							interpreter.DictionaryStaticType{
+							&interpreter.DictionaryStaticType{
 								KeyType:   interpreter.PrimitiveStaticTypeString,
 								ValueType: interpreter.PrimitiveStaticTypeInt,
 							},

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -136,7 +136,7 @@ func TestInterpretEnumCaseEquality(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
 			common.ZeroAddress,
@@ -172,7 +172,7 @@ func TestInterpretEnumConstructor(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
 			common.ZeroAddress,
@@ -207,7 +207,7 @@ func TestInterpretEnumInstance(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
 			common.ZeroAddress,

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -245,7 +245,7 @@ func TestInterpretForString(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeCharacter,
 			},
 			common.ZeroAddress,

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7561,7 +7561,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 				value: interpreter.NewArrayValue(
 					inter,
 					interpreter.EmptyLocationRange,
-					interpreter.ConstantSizedStaticType{
+					&interpreter.ConstantSizedStaticType{
 						Type: interpreter.ConvertSemaToStaticType(nil, testCase.ty),
 						Size: 1,
 					},

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4317,7 +4317,7 @@ func TestInterpretDictionary(t *testing.T) {
 	expectedDict := interpreter.NewDictionaryValue(
 		inter,
 		interpreter.EmptyLocationRange,
-		interpreter.DictionaryStaticType{
+		&interpreter.DictionaryStaticType{
 			KeyType:   interpreter.PrimitiveStaticTypeString,
 			ValueType: interpreter.PrimitiveStaticTypeInt,
 		},
@@ -4346,7 +4346,7 @@ func TestInterpretDictionaryInsertionOrder(t *testing.T) {
 	expectedDict := interpreter.NewDictionaryValue(
 		inter,
 		interpreter.EmptyLocationRange,
-		interpreter.DictionaryStaticType{
+		&interpreter.DictionaryStaticType{
 			KeyType:   interpreter.PrimitiveStaticTypeString,
 			ValueType: interpreter.PrimitiveStaticTypeInt,
 		},
@@ -4603,7 +4603,7 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 	expectedDict := interpreter.NewDictionaryValue(
 		inter,
 		interpreter.EmptyLocationRange,
-		interpreter.DictionaryStaticType{
+		&interpreter.DictionaryStaticType{
 			KeyType:   interpreter.PrimitiveStaticTypeString,
 			ValueType: interpreter.PrimitiveStaticTypeInt,
 		},
@@ -4670,7 +4670,7 @@ func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 	expectedDict := interpreter.NewDictionaryValue(
 		inter,
 		interpreter.EmptyLocationRange,
-		interpreter.DictionaryStaticType{
+		&interpreter.DictionaryStaticType{
 			KeyType:   interpreter.PrimitiveStaticTypeString,
 			ValueType: interpreter.PrimitiveStaticTypeInt,
 		},
@@ -7576,7 +7576,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 			value := interpreter.NewDictionaryValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.DictionaryStaticType{
+				&interpreter.DictionaryStaticType{
 					KeyType:   interpreter.ConvertSemaToStaticType(nil, testCase.ty),
 					ValueType: interpreter.ConvertSemaToStaticType(nil, testCase.ty),
 				},
@@ -9641,7 +9641,7 @@ func TestInterpretInternalAssignment(t *testing.T) {
 	value, err := inter.Invoke("test")
 	require.NoError(t, err)
 
-	stringIntDictionaryStaticType := interpreter.DictionaryStaticType{
+	stringIntDictionaryStaticType := &interpreter.DictionaryStaticType{
 		KeyType:   interpreter.PrimitiveStaticTypeString,
 		ValueType: interpreter.PrimitiveStaticTypeInt,
 	}
@@ -9769,7 +9769,7 @@ func TestInterpretCopyOnReturn(t *testing.T) {
 		interpreter.NewDictionaryValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.DictionaryStaticType{
+			&interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeString,
 				ValueType: interpreter.PrimitiveStaticTypeString,
 			},

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -317,7 +317,7 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.ZeroAddress,
@@ -786,7 +786,7 @@ func TestInterpretArrayIndexingAssignment(t *testing.T) {
 	expectedArray := interpreter.NewArrayValue(
 		inter,
 		interpreter.EmptyLocationRange,
-		interpreter.VariableSizedStaticType{
+		&interpreter.VariableSizedStaticType{
 			Type: interpreter.PrimitiveStaticTypeInt,
 		},
 		common.ZeroAddress,
@@ -2626,7 +2626,7 @@ func TestInterpretStructCopyOnDeclaration(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
 			common.ZeroAddress,
@@ -2671,7 +2671,7 @@ func TestInterpretStructCopyOnDeclarationModifiedWithStructFunction(t *testing.T
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
 			common.ZeroAddress,
@@ -2713,7 +2713,7 @@ func TestInterpretStructCopyOnIdentifierAssignment(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
 			common.ZeroAddress,
@@ -2755,7 +2755,7 @@ func TestInterpretStructCopyOnIndexingAssignment(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
 			common.ZeroAddress,
@@ -2804,7 +2804,7 @@ func TestInterpretStructCopyOnMemberAssignment(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeBool,
 			},
 			common.ZeroAddress,
@@ -2880,7 +2880,7 @@ func TestInterpretArrayCopy(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.ZeroAddress,
@@ -2921,7 +2921,7 @@ func TestInterpretStructCopyInArray(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.ZeroAddress,
@@ -6739,7 +6739,7 @@ func TestInterpretSwapVariables(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.ZeroAddress,
@@ -6780,7 +6780,7 @@ func TestInterpretSwapArrayAndField(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.ZeroAddress,
@@ -7547,7 +7547,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 				value: interpreter.NewArrayValue(
 					inter,
 					interpreter.EmptyLocationRange,
-					interpreter.VariableSizedStaticType{
+					&interpreter.VariableSizedStaticType{
 						Type: interpreter.ConvertSemaToStaticType(nil, testCase.ty),
 					},
 					common.ZeroAddress,
@@ -7858,7 +7858,7 @@ func TestInterpretReferenceUse(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.ZeroAddress,
@@ -7910,7 +7910,7 @@ func TestInterpretReferenceUseAccess(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 			common.ZeroAddress,
@@ -9018,7 +9018,7 @@ func TestInterpretReferenceUseAfterCopy(t *testing.T) {
 			interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
 				common.ZeroAddress,
@@ -9652,7 +9652,7 @@ func TestInterpretInternalAssignment(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: stringIntDictionaryStaticType,
 			},
 			common.ZeroAddress,
@@ -9974,7 +9974,7 @@ func TestInterpretArrayTypeInference(t *testing.T) {
 			t,
 			inter,
 			interpreter.TypeValue{
-				Type: interpreter.VariableSizedStaticType{
+				Type: &interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
 				},
 			},
@@ -9999,7 +9999,7 @@ func TestInterpretArrayTypeInference(t *testing.T) {
 			t,
 			inter,
 			interpreter.TypeValue{
-				Type: interpreter.VariableSizedStaticType{
+				Type: &interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeInt,
 				},
 			},

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -659,7 +659,7 @@ func TestInterpretGetType(t *testing.T) {
               }
             `,
 			result: interpreter.TypeValue{
-				Type: interpreter.OptionalStaticType{
+				Type: &interpreter.OptionalStaticType{
 					Type: interpreter.ReferenceStaticType{
 						Authorization: interpreter.NewEntitlementSetAuthorization(
 							nil,
@@ -687,7 +687,7 @@ func TestInterpretGetType(t *testing.T) {
               }
             `,
 			result: interpreter.TypeValue{
-				Type: interpreter.OptionalStaticType{
+				Type: &interpreter.OptionalStaticType{
 					Type: interpreter.ReferenceStaticType{
 						// Reference was converted
 						Authorization:  interpreter.UnauthorizedAccess,
@@ -712,7 +712,7 @@ func TestInterpretGetType(t *testing.T) {
               }
             `,
 			result: interpreter.TypeValue{
-				Type: interpreter.OptionalStaticType{
+				Type: &interpreter.OptionalStaticType{
 					Type: interpreter.ReferenceStaticType{
 						Authorization: interpreter.NewEntitlementSetAuthorization(
 							nil,
@@ -743,7 +743,7 @@ func TestInterpretGetType(t *testing.T) {
               }
             `,
 			result: interpreter.TypeValue{
-				Type: interpreter.OptionalStaticType{
+				Type: &interpreter.OptionalStaticType{
 					Type: interpreter.ReferenceStaticType{
 						// Reference was converted
 						Authorization:  interpreter.UnauthorizedAccess,
@@ -772,7 +772,7 @@ func TestInterpretGetType(t *testing.T) {
               }
             `,
 			result: interpreter.TypeValue{
-				Type: interpreter.OptionalStaticType{
+				Type: &interpreter.OptionalStaticType{
 					Type: interpreter.ReferenceStaticType{
 						Authorization: interpreter.NewEntitlementSetAuthorization(
 							nil,

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -660,7 +660,7 @@ func TestInterpretGetType(t *testing.T) {
             `,
 			result: interpreter.TypeValue{
 				Type: &interpreter.OptionalStaticType{
-					Type: interpreter.ReferenceStaticType{
+					Type: &interpreter.ReferenceStaticType{
 						Authorization: interpreter.NewEntitlementSetAuthorization(
 							nil,
 							func() []common.TypeID { return []common.TypeID{"S.test.X"} },
@@ -688,7 +688,7 @@ func TestInterpretGetType(t *testing.T) {
             `,
 			result: interpreter.TypeValue{
 				Type: &interpreter.OptionalStaticType{
-					Type: interpreter.ReferenceStaticType{
+					Type: &interpreter.ReferenceStaticType{
 						// Reference was converted
 						Authorization:  interpreter.UnauthorizedAccess,
 						ReferencedType: interpreter.PrimitiveStaticTypeInt,
@@ -713,7 +713,7 @@ func TestInterpretGetType(t *testing.T) {
             `,
 			result: interpreter.TypeValue{
 				Type: &interpreter.OptionalStaticType{
-					Type: interpreter.ReferenceStaticType{
+					Type: &interpreter.ReferenceStaticType{
 						Authorization: interpreter.NewEntitlementSetAuthorization(
 							nil,
 							func() []common.TypeID { return []common.TypeID{"S.test.X"} },
@@ -744,7 +744,7 @@ func TestInterpretGetType(t *testing.T) {
             `,
 			result: interpreter.TypeValue{
 				Type: &interpreter.OptionalStaticType{
-					Type: interpreter.ReferenceStaticType{
+					Type: &interpreter.ReferenceStaticType{
 						// Reference was converted
 						Authorization:  interpreter.UnauthorizedAccess,
 						ReferencedType: interpreter.PrimitiveStaticTypeInt,
@@ -773,7 +773,7 @@ func TestInterpretGetType(t *testing.T) {
             `,
 			result: interpreter.TypeValue{
 				Type: &interpreter.OptionalStaticType{
-					Type: interpreter.ReferenceStaticType{
+					Type: &interpreter.ReferenceStaticType{
 						Authorization: interpreter.NewEntitlementSetAuthorization(
 							nil,
 							func() []common.TypeID { return []common.TypeID{"S.test.X"} },

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -792,7 +792,7 @@ func TestInterpretGetType(t *testing.T) {
               }
             `,
 			result: interpreter.TypeValue{
-				Type: interpreter.VariableSizedStaticType{
+				Type: &interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeInt,
 				},
 			},

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -641,7 +641,7 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 		array := interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.ConvertSemaToStaticType(nil, rType),
 			},
 			address,
@@ -746,7 +746,7 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 		array1 := interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.ConvertSemaToStaticType(nil, rType),
 			},
 			common.Address{0x1},
@@ -770,7 +770,7 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 		array2 := interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.ConvertSemaToStaticType(nil, rType),
 			},
 			common.Address{0x2},
@@ -841,7 +841,7 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 		array := interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.ConvertSemaToStaticType(nil, rType),
 			},
 			address,
@@ -965,7 +965,7 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 		array := interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.ConvertSemaToStaticType(nil, rType),
 			},
 			address,

--- a/runtime/tests/interpreter/runtimetype_test.go
+++ b/runtime/tests/interpreter/runtimetype_test.go
@@ -229,7 +229,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.DictionaryStaticType{
+			Type: &interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeString,
 				ValueType: interpreter.PrimitiveStaticTypeInt,
 			},
@@ -239,7 +239,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.DictionaryStaticType{
+			Type: &interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeInt,
 				ValueType: interpreter.PrimitiveStaticTypeString,
 			},
@@ -249,7 +249,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.DictionaryStaticType{
+			Type: &interpreter.DictionaryStaticType{
 				ValueType: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 				KeyType:   interpreter.PrimitiveStaticTypeInt,
 			},
@@ -259,8 +259,8 @@ func TestInterpretDictionaryType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.DictionaryStaticType{
-				ValueType: interpreter.DictionaryStaticType{
+			Type: &interpreter.DictionaryStaticType{
+				ValueType: &interpreter.DictionaryStaticType{
 					KeyType:   interpreter.PrimitiveStaticTypeString,
 					ValueType: interpreter.PrimitiveStaticTypeInt,
 				},

--- a/runtime/tests/interpreter/runtimetype_test.go
+++ b/runtime/tests/interpreter/runtimetype_test.go
@@ -626,7 +626,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.CapabilityStaticType{
+			Type: &interpreter.CapabilityStaticType{
 				BorrowType: interpreter.ReferenceStaticType{
 					ReferencedType: interpreter.PrimitiveStaticTypeString,
 					Authorization:  interpreter.UnauthorizedAccess,
@@ -638,7 +638,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.CapabilityStaticType{
+			Type: &interpreter.CapabilityStaticType{
 				BorrowType: interpreter.ReferenceStaticType{
 					ReferencedType: interpreter.PrimitiveStaticTypeInt,
 					Authorization:  interpreter.UnauthorizedAccess,
@@ -650,7 +650,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.CapabilityStaticType{
+			Type: &interpreter.CapabilityStaticType{
 				BorrowType: interpreter.ReferenceStaticType{
 					ReferencedType: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 					Authorization:  interpreter.UnauthorizedAccess,

--- a/runtime/tests/interpreter/runtimetype_test.go
+++ b/runtime/tests/interpreter/runtimetype_test.go
@@ -552,7 +552,7 @@ func TestInterpretIntersectionType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: &interpreter.IntersectionStaticType{
-				Types: []interpreter.InterfaceStaticType{
+				Types: []*interpreter.InterfaceStaticType{
 					interpreter.NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 				},
 			},
@@ -568,7 +568,7 @@ func TestInterpretIntersectionType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: &interpreter.IntersectionStaticType{
-				Types: []interpreter.InterfaceStaticType{
+				Types: []*interpreter.InterfaceStaticType{
 					interpreter.NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "S"),
 				},
 			},
@@ -584,7 +584,7 @@ func TestInterpretIntersectionType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: &interpreter.IntersectionStaticType{
-				Types: []interpreter.InterfaceStaticType{
+				Types: []*interpreter.InterfaceStaticType{
 					interpreter.NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "S"),
 					interpreter.NewInterfaceStaticTypeComputeTypeID(nil, utils.TestLocation, "S2"),
 				},

--- a/runtime/tests/interpreter/runtimetype_test.go
+++ b/runtime/tests/interpreter/runtimetype_test.go
@@ -46,7 +46,7 @@ func TestInterpretOptionalType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.OptionalStaticType{
+			Type: &interpreter.OptionalStaticType{
 				Type: interpreter.PrimitiveStaticTypeString,
 			},
 		},
@@ -55,7 +55,7 @@ func TestInterpretOptionalType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.OptionalStaticType{
+			Type: &interpreter.OptionalStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
@@ -64,7 +64,7 @@ func TestInterpretOptionalType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.OptionalStaticType{
+			Type: &interpreter.OptionalStaticType{
 				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 			},
 		},
@@ -73,8 +73,8 @@ func TestInterpretOptionalType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.OptionalStaticType{
-				Type: interpreter.OptionalStaticType{
+			Type: &interpreter.OptionalStaticType{
+				Type: &interpreter.OptionalStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
 			},

--- a/runtime/tests/interpreter/runtimetype_test.go
+++ b/runtime/tests/interpreter/runtimetype_test.go
@@ -163,7 +163,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.ConstantSizedStaticType{
+			Type: &interpreter.ConstantSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeString,
 				Size: int64(10),
 			},
@@ -173,7 +173,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.ConstantSizedStaticType{
+			Type: &interpreter.ConstantSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 				Size: int64(5),
 			},
@@ -183,7 +183,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.ConstantSizedStaticType{
+			Type: &interpreter.ConstantSizedStaticType{
 				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 				Size: int64(400),
 			},
@@ -193,8 +193,8 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.ConstantSizedStaticType{
-				Type: interpreter.ConstantSizedStaticType{
+			Type: &interpreter.ConstantSizedStaticType{
+				Type: &interpreter.ConstantSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 					Size: int64(10),
 				},

--- a/runtime/tests/interpreter/runtimetype_test.go
+++ b/runtime/tests/interpreter/runtimetype_test.go
@@ -105,7 +105,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.VariableSizedStaticType{
+			Type: &interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeString,
 			},
 		},
@@ -114,7 +114,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.VariableSizedStaticType{
+			Type: &interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
@@ -123,7 +123,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.VariableSizedStaticType{
+			Type: &interpreter.VariableSizedStaticType{
 				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 			},
 		},
@@ -132,8 +132,8 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.VariableSizedStaticType{
-				Type: interpreter.VariableSizedStaticType{
+			Type: &interpreter.VariableSizedStaticType{
+				Type: &interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeString,
 				},
 			},

--- a/runtime/tests/interpreter/runtimetype_test.go
+++ b/runtime/tests/interpreter/runtimetype_test.go
@@ -472,7 +472,7 @@ func TestInterpretReferenceType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.ReferenceStaticType{
+			Type: &interpreter.ReferenceStaticType{
 				ReferencedType: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 				Authorization: interpreter.NewEntitlementSetAuthorization(
 					nil,
@@ -487,7 +487,7 @@ func TestInterpretReferenceType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.ReferenceStaticType{
+			Type: &interpreter.ReferenceStaticType{
 				ReferencedType: interpreter.PrimitiveStaticTypeString,
 				Authorization:  interpreter.UnauthorizedAccess,
 			},
@@ -497,7 +497,7 @@ func TestInterpretReferenceType(t *testing.T) {
 
 	assert.Equal(t,
 		interpreter.TypeValue{
-			Type: interpreter.ReferenceStaticType{
+			Type: &interpreter.ReferenceStaticType{
 				ReferencedType: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "S"),
 				Authorization: interpreter.NewEntitlementSetAuthorization(
 					nil,
@@ -627,7 +627,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: &interpreter.CapabilityStaticType{
-				BorrowType: interpreter.ReferenceStaticType{
+				BorrowType: &interpreter.ReferenceStaticType{
 					ReferencedType: interpreter.PrimitiveStaticTypeString,
 					Authorization:  interpreter.UnauthorizedAccess,
 				},
@@ -639,7 +639,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: &interpreter.CapabilityStaticType{
-				BorrowType: interpreter.ReferenceStaticType{
+				BorrowType: &interpreter.ReferenceStaticType{
 					ReferencedType: interpreter.PrimitiveStaticTypeInt,
 					Authorization:  interpreter.UnauthorizedAccess,
 				},
@@ -651,7 +651,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: &interpreter.CapabilityStaticType{
-				BorrowType: interpreter.ReferenceStaticType{
+				BorrowType: &interpreter.ReferenceStaticType{
 					ReferencedType: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 					Authorization:  interpreter.UnauthorizedAccess,
 				},

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -103,7 +103,7 @@ func TestInterpretStringDecodeHex(t *testing.T) {
 			interpreter.NewArrayValue(
 				inter,
 				interpreter.EmptyLocationRange,
-				interpreter.VariableSizedStaticType{
+				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeUInt8,
 				},
 				common.ZeroAddress,
@@ -269,7 +269,7 @@ func TestInterpretStringUtf8Field(t *testing.T) {
 		interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeUInt8,
 			},
 			common.ZeroAddress,

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -559,7 +559,7 @@ func TestInterpretRandomArrayOperations(t *testing.T) {
 		testArray = interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			orgOwner,
@@ -645,7 +645,7 @@ func TestInterpretRandomArrayOperations(t *testing.T) {
 		testArray = interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			orgOwner,
@@ -680,7 +680,7 @@ func TestInterpretRandomArrayOperations(t *testing.T) {
 		testArray = interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			orgOwner,
@@ -718,7 +718,7 @@ func TestInterpretRandomArrayOperations(t *testing.T) {
 		testArray = interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			orgOwner,
@@ -769,7 +769,7 @@ func TestInterpretRandomArrayOperations(t *testing.T) {
 		testArray = interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			orgOwner,
@@ -840,7 +840,7 @@ func TestInterpretRandomArrayOperations(t *testing.T) {
 		array := interpreter.NewArrayValue(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.VariableSizedStaticType{
+			&interpreter.VariableSizedStaticType{
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			orgOwner,
@@ -1396,7 +1396,7 @@ func (r randomValueGenerator) randomArrayValue(inter *interpreter.Interpreter, c
 	return interpreter.NewArrayValue(
 		inter,
 		interpreter.EmptyLocationRange,
-		interpreter.VariableSizedStaticType{
+		&interpreter.VariableSizedStaticType{
 			Type: interpreter.PrimitiveStaticTypeAnyStruct,
 		},
 		common.ZeroAddress,

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -101,7 +101,7 @@ func TestInterpretRandomMapOperations(t *testing.T) {
 		testMap = interpreter.NewDictionaryValueWithAddress(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.DictionaryStaticType{
+			&interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 				ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -202,7 +202,7 @@ func TestInterpretRandomMapOperations(t *testing.T) {
 		dictionary := interpreter.NewDictionaryValueWithAddress(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.DictionaryStaticType{
+			&interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 				ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -251,7 +251,7 @@ func TestInterpretRandomMapOperations(t *testing.T) {
 		dictionary := interpreter.NewDictionaryValueWithAddress(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.DictionaryStaticType{
+			&interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 				ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -299,7 +299,7 @@ func TestInterpretRandomMapOperations(t *testing.T) {
 		dictionary := interpreter.NewDictionaryValueWithAddress(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.DictionaryStaticType{
+			&interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 				ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -382,7 +382,7 @@ func TestInterpretRandomMapOperations(t *testing.T) {
 		dictionary := interpreter.NewDictionaryValueWithAddress(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.DictionaryStaticType{
+			&interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 				ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -472,7 +472,7 @@ func TestInterpretRandomMapOperations(t *testing.T) {
 		dictionary := interpreter.NewDictionaryValueWithAddress(
 			inter,
 			interpreter.EmptyLocationRange,
-			interpreter.DictionaryStaticType{
+			&interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 				ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
@@ -1371,7 +1371,7 @@ func (r randomValueGenerator) randomDictionaryValue(
 	return interpreter.NewDictionaryValueWithAddress(
 		inter,
 		interpreter.EmptyLocationRange,
-		interpreter.DictionaryStaticType{
+		&interpreter.DictionaryStaticType{
 			KeyType:   interpreter.PrimitiveStaticTypeAnyStruct,
 			ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 		},

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -1168,7 +1168,7 @@ func (r randomValueGenerator) randomStorableValue(inter *interpreter.Interpreter
 		return interpreter.NewUnmeteredCapabilityValue(
 			interpreter.UInt64Value(r.randomInt(math.MaxInt-1)),
 			r.randomAddressValue(),
-			interpreter.ReferenceStaticType{
+			&interpreter.ReferenceStaticType{
 				Authorization:  interpreter.UnauthorizedAccess,
 				ReferencedType: interpreter.PrimitiveStaticTypeAnyStruct,
 			},

--- a/types.go
+++ b/types.go
@@ -21,7 +21,6 @@ package cadence
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"sync"
 
 	"github.com/onflow/cadence/runtime/common"
@@ -40,7 +39,7 @@ type Type interface {
 // This type should not be used when encoding values,
 // and should only be used for decoding values that were encoded
 // using an older format of the JSON encoding (<v0.3.0)
-type TypeID string
+type TypeID common.TypeID
 
 func (TypeID) isType() {}
 
@@ -55,8 +54,7 @@ func (t TypeID) Equal(other Type) bool {
 // OptionalType
 
 type OptionalType struct {
-	Type   Type
-	typeID string
+	Type Type
 }
 
 var _ Type = &OptionalType{}
@@ -73,10 +71,7 @@ func NewMeteredOptionalType(gauge common.MemoryGauge, typ Type) *OptionalType {
 func (*OptionalType) isType() {}
 
 func (t *OptionalType) ID() string {
-	if len(t.typeID) == 0 {
-		t.typeID = fmt.Sprintf("%s?", t.Type.ID())
-	}
-	return t.typeID
+	return sema.FormatOptionalTypeID(t.Type.ID())
 }
 
 func (t *OptionalType) Equal(other Type) bool {
@@ -113,7 +108,7 @@ var _ Type = PrimitiveType(interpreter.PrimitiveStaticTypeUnknown)
 func (p PrimitiveType) isType() {}
 
 func (p PrimitiveType) ID() string {
-	return string(interpreter.PrimitiveStaticType(p).SemaType().ID())
+	return string(interpreter.PrimitiveStaticType(p).ID())
 }
 
 func (p PrimitiveType) Equal(other Type) bool {
@@ -233,7 +228,6 @@ type ArrayType interface {
 
 type VariableSizedArrayType struct {
 	ElementType Type
-	typeID      string
 }
 
 var _ Type = &VariableSizedArrayType{}
@@ -255,10 +249,7 @@ func NewMeteredVariableSizedArrayType(
 func (*VariableSizedArrayType) isType() {}
 
 func (t *VariableSizedArrayType) ID() string {
-	if len(t.typeID) == 0 {
-		t.typeID = fmt.Sprintf("[%s]", t.ElementType.ID())
-	}
-	return t.typeID
+	return sema.FormatVariableSizedTypeID(t.ElementType.ID())
 }
 
 func (t *VariableSizedArrayType) Element() Type {
@@ -306,10 +297,7 @@ func NewMeteredConstantSizedArrayType(
 func (*ConstantSizedArrayType) isType() {}
 
 func (t *ConstantSizedArrayType) ID() string {
-	if len(t.typeID) == 0 {
-		t.typeID = fmt.Sprintf("[%s;%d]", t.ElementType.ID(), t.Size)
-	}
-	return t.typeID
+	return sema.FormatConstantSizedTypeID(t.ElementType.ID(), int64(t.Size))
 }
 
 func (t *ConstantSizedArrayType) Element() Type {
@@ -331,7 +319,6 @@ func (t *ConstantSizedArrayType) Equal(other Type) bool {
 type DictionaryType struct {
 	KeyType     Type
 	ElementType Type
-	typeID      string
 }
 
 var _ Type = &DictionaryType{}
@@ -358,14 +345,10 @@ func NewMeteredDictionaryType(
 func (*DictionaryType) isType() {}
 
 func (t *DictionaryType) ID() string {
-	if len(t.typeID) == 0 {
-		t.typeID = fmt.Sprintf(
-			"{%s:%s}",
-			t.KeyType.ID(),
-			t.ElementType.ID(),
-		)
-	}
-	return t.typeID
+	return sema.FormatDictionaryTypeID(
+		t.KeyType.ID(),
+		t.ElementType.ID(),
+	)
 }
 
 func (t *DictionaryType) Equal(other Type) bool {
@@ -675,7 +658,6 @@ type StructType struct {
 	QualifiedIdentifier string
 	Fields              []Field
 	Initializers        [][]Parameter
-	typeID              string
 }
 
 func NewStructType(
@@ -706,10 +688,7 @@ func NewMeteredStructType(
 func (*StructType) isType() {}
 
 func (t *StructType) ID() string {
-	if len(t.typeID) == 0 {
-		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
-	}
-	return t.typeID
+	return string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 }
 
 func (*StructType) isCompositeType() {}
@@ -751,7 +730,6 @@ type ResourceType struct {
 	QualifiedIdentifier string
 	Fields              []Field
 	Initializers        [][]Parameter
-	typeID              string
 }
 
 func NewResourceType(
@@ -782,10 +760,7 @@ func NewMeteredResourceType(
 func (*ResourceType) isType() {}
 
 func (t *ResourceType) ID() string {
-	if len(t.typeID) == 0 {
-		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
-	}
-	return t.typeID
+	return string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 }
 
 func (*ResourceType) isCompositeType() {}
@@ -821,13 +796,13 @@ func (t *ResourceType) Equal(other Type) bool {
 }
 
 // AttachmentType
+
 type AttachmentType struct {
 	Location            common.Location
 	BaseType            Type
 	QualifiedIdentifier string
 	Fields              []Field
 	Initializers        [][]Parameter
-	typeID              string
 }
 
 func NewAttachmentType(
@@ -867,10 +842,7 @@ func NewMeteredAttachmentType(
 func (*AttachmentType) isType() {}
 
 func (t *AttachmentType) ID() string {
-	if len(t.typeID) == 0 {
-		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
-	}
-	return t.typeID
+	return string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 }
 
 func (*AttachmentType) isCompositeType() {}
@@ -916,7 +888,6 @@ type EventType struct {
 	QualifiedIdentifier string
 	Fields              []Field
 	Initializer         []Parameter
-	typeID              string
 }
 
 func NewEventType(
@@ -947,10 +918,7 @@ func NewMeteredEventType(
 func (*EventType) isType() {}
 
 func (t *EventType) ID() string {
-	if len(t.typeID) == 0 {
-		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
-	}
-	return t.typeID
+	return string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 }
 
 func (*EventType) isCompositeType() {}
@@ -992,7 +960,6 @@ type ContractType struct {
 	QualifiedIdentifier string
 	Fields              []Field
 	Initializers        [][]Parameter
-	typeID              string
 }
 
 func NewContractType(
@@ -1023,10 +990,7 @@ func NewMeteredContractType(
 func (*ContractType) isType() {}
 
 func (t *ContractType) ID() string {
-	if len(t.typeID) == 0 {
-		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
-	}
-	return t.typeID
+	return string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 }
 
 func (*ContractType) isCompositeType() {}
@@ -1080,7 +1044,6 @@ type StructInterfaceType struct {
 	QualifiedIdentifier string
 	Fields              []Field
 	Initializers        [][]Parameter
-	typeID              string
 }
 
 func NewStructInterfaceType(
@@ -1111,10 +1074,7 @@ func NewMeteredStructInterfaceType(
 func (*StructInterfaceType) isType() {}
 
 func (t *StructInterfaceType) ID() string {
-	if len(t.typeID) == 0 {
-		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
-	}
-	return t.typeID
+	return string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 }
 
 func (*StructInterfaceType) isInterfaceType() {}
@@ -1156,7 +1116,6 @@ type ResourceInterfaceType struct {
 	QualifiedIdentifier string
 	Fields              []Field
 	Initializers        [][]Parameter
-	typeID              string
 }
 
 func NewResourceInterfaceType(
@@ -1187,10 +1146,7 @@ func NewMeteredResourceInterfaceType(
 func (*ResourceInterfaceType) isType() {}
 
 func (t *ResourceInterfaceType) ID() string {
-	if len(t.typeID) == 0 {
-		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
-	}
-	return t.typeID
+	return string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 }
 
 func (*ResourceInterfaceType) isInterfaceType() {}
@@ -1232,7 +1188,6 @@ type ContractInterfaceType struct {
 	QualifiedIdentifier string
 	Fields              []Field
 	Initializers        [][]Parameter
-	typeID              string
 }
 
 func NewContractInterfaceType(
@@ -1263,10 +1218,7 @@ func NewMeteredContractInterfaceType(
 func (*ContractInterfaceType) isType() {}
 
 func (t *ContractInterfaceType) ID() string {
-	if len(t.typeID) == 0 {
-		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
-	}
-	return t.typeID
+	return string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 }
 
 func (*ContractInterfaceType) isInterfaceType() {}
@@ -1315,7 +1267,6 @@ type FunctionType struct {
 	Parameters     []Parameter
 	ReturnType     Type
 	Purity         FunctionPurity
-	typeID         string
 }
 
 func NewFunctionType(
@@ -1346,41 +1297,38 @@ func NewMeteredFunctionType(
 func (*FunctionType) isType() {}
 
 func (t *FunctionType) ID() string {
-	if t.typeID == "" {
 
-		var purity string
-		if t.Purity == FunctionPurityView {
-			purity = "view"
-		}
-
-		typeParameterCount := len(t.TypeParameters)
-		var typeParameters []string
-		if typeParameterCount > 0 {
-			typeParameters = make([]string, typeParameterCount)
-			for i, typeParameter := range t.TypeParameters {
-				typeParameters[i] = typeParameter.Name
-			}
-		}
-
-		parameterCount := len(t.Parameters)
-		var parameters []string
-		if parameterCount > 0 {
-			parameters = make([]string, parameterCount)
-			for i, parameter := range t.Parameters {
-				parameters[i] = parameter.Type.ID()
-			}
-		}
-
-		returnType := t.ReturnType.ID()
-
-		t.typeID = sema.FormatFunctionTypeID(
-			purity,
-			typeParameters,
-			parameters,
-			returnType,
-		)
+	var purity string
+	if t.Purity == FunctionPurityView {
+		purity = "view"
 	}
-	return t.typeID
+
+	typeParameterCount := len(t.TypeParameters)
+	var typeParameters []string
+	if typeParameterCount > 0 {
+		typeParameters = make([]string, typeParameterCount)
+		for i, typeParameter := range t.TypeParameters {
+			typeParameters[i] = typeParameter.Name
+		}
+	}
+
+	parameterCount := len(t.Parameters)
+	var parameters []string
+	if parameterCount > 0 {
+		parameters = make([]string, parameterCount)
+		for i, parameter := range t.Parameters {
+			parameters[i] = parameter.Type.ID()
+		}
+	}
+
+	returnType := t.ReturnType.ID()
+
+	return sema.FormatFunctionTypeID(
+		purity,
+		typeParameters,
+		parameters,
+		returnType,
+	)
 }
 
 func (t *FunctionType) Equal(other Type) bool {
@@ -1440,7 +1388,7 @@ var UnauthorizedAccess Authorization = Unauthorized{}
 func (Unauthorized) isAuthorization() {}
 
 func (Unauthorized) ID() string {
-	return ""
+	panic(errors.NewUnreachableError())
 }
 
 func (Unauthorized) Equal(other Authorization) bool {
@@ -1448,12 +1396,10 @@ func (Unauthorized) Equal(other Authorization) bool {
 	return ok
 }
 
-type EntitlementSetKind uint8
+type EntitlementSetKind = sema.EntitlementSetKind
 
-const (
-	Conjunction EntitlementSetKind = iota
-	Disjunction
-)
+const Conjunction = sema.Conjunction
+const Disjunction = sema.Disjunction
 
 type EntitlementSetAuthorization struct {
 	Entitlements []common.TypeID
@@ -1480,27 +1426,16 @@ func NewEntitlementSetAuthorization(
 func (EntitlementSetAuthorization) isAuthorization() {}
 
 func (e EntitlementSetAuthorization) ID() string {
-	var builder strings.Builder
-	builder.WriteString("auth(")
-	var separator string
-
-	switch e.Kind {
-	case Conjunction:
-		separator = ", "
-	case Disjunction:
-		separator = " | "
-	default:
-		panic(errors.NewUnreachableError())
+	entitlementTypeIDs := make([]string, 0, len(e.Entitlements))
+	for _, typeID := range e.Entitlements {
+		entitlementTypeIDs = append(
+			entitlementTypeIDs,
+			string(typeID),
+		)
 	}
 
-	for i, entitlement := range e.Entitlements {
-		builder.WriteString(string(entitlement))
-		if i < len(e.Entitlements) {
-			builder.WriteString(separator)
-		}
-	}
-	builder.WriteString(")")
-	return builder.String()
+	// FormatEntitlementSetTypeID sorts
+	return sema.FormatEntitlementSetTypeID(entitlementTypeIDs, e.Kind)
 }
 
 func (e EntitlementSetAuthorization) Equal(auth Authorization) bool {
@@ -1536,7 +1471,7 @@ func NewEntitlementMapAuthorization(gauge common.MemoryGauge, id common.TypeID) 
 func (EntitlementMapAuthorization) isAuthorization() {}
 
 func (e EntitlementMapAuthorization) ID() string {
-	return fmt.Sprintf("auth(%s)", e.TypeID)
+	return string(e.TypeID)
 }
 
 func (e EntitlementMapAuthorization) Equal(other Authorization) bool {
@@ -1552,7 +1487,6 @@ func (e EntitlementMapAuthorization) Equal(other Authorization) bool {
 type ReferenceType struct {
 	Type          Type
 	Authorization Authorization
-	typeID        string
 }
 
 var _ Type = &ReferenceType{}
@@ -1579,10 +1513,14 @@ func NewMeteredReferenceType(
 func (*ReferenceType) isType() {}
 
 func (t *ReferenceType) ID() string {
-	if t.typeID == "" {
-		t.typeID = fmt.Sprintf("%s&%s", t.Authorization.ID(), t.Type.ID())
+	var authorization string
+	if t.Authorization != UnauthorizedAccess {
+		authorization = t.Authorization.ID()
 	}
-	return t.typeID
+	return sema.FormatReferenceTypeID(
+		authorization,
+		t.Type.ID(),
+	)
 }
 
 func (t *ReferenceType) Equal(other Type) bool {
@@ -1600,7 +1538,6 @@ func (t *ReferenceType) Equal(other Type) bool {
 type IntersectionSet = map[Type]struct{}
 
 type IntersectionType struct {
-	typeID              string
 	Types               []Type
 	intersectionSet     IntersectionSet
 	intersectionSetOnce sync.Once
@@ -1625,18 +1562,16 @@ func NewMeteredIntersectionType(
 func (*IntersectionType) isType() {}
 
 func (t *IntersectionType) ID() string {
-	if t.typeID == "" {
-		var typeStrings []string
-		typeCount := len(t.Types)
-		if typeCount > 0 {
-			typeStrings = make([]string, 0, typeCount)
-			for _, typ := range t.Types {
-				typeStrings = append(typeStrings, typ.ID())
-			}
+	var interfaceTypeIDs []string
+	typeCount := len(t.Types)
+	if typeCount > 0 {
+		interfaceTypeIDs = make([]string, 0, typeCount)
+		for _, typ := range t.Types {
+			interfaceTypeIDs = append(interfaceTypeIDs, typ.ID())
 		}
-		t.typeID = sema.FormatIntersectionTypeID(typeStrings)
 	}
-	return t.typeID
+	// FormatIntersectionTypeID sorts
+	return sema.FormatIntersectionTypeID(interfaceTypeIDs)
 }
 
 func (t *IntersectionType) Equal(other Type) bool {
@@ -1680,7 +1615,6 @@ func (t *IntersectionType) IntersectionSet() IntersectionSet {
 
 type CapabilityType struct {
 	BorrowType Type
-	typeID     string
 }
 
 var _ Type = &CapabilityType{}
@@ -1700,15 +1634,12 @@ func NewMeteredCapabilityType(
 func (*CapabilityType) isType() {}
 
 func (t *CapabilityType) ID() string {
-	if t.typeID == "" {
-		var borrowTypeString string
-		borrowType := t.BorrowType
-		if borrowType != nil {
-			borrowTypeString = borrowType.ID()
-		}
-		t.typeID = sema.FormatCapabilityTypeID(borrowTypeString)
+	var borrowTypeID string
+	borrowType := t.BorrowType
+	if borrowType != nil {
+		borrowTypeID = borrowType.ID()
 	}
-	return t.typeID
+	return sema.FormatCapabilityTypeID(borrowTypeID)
 }
 
 func (t *CapabilityType) Equal(other Type) bool {
@@ -1725,13 +1656,13 @@ func (t *CapabilityType) Equal(other Type) bool {
 }
 
 // EnumType
+
 type EnumType struct {
 	Location            common.Location
 	QualifiedIdentifier string
 	RawType             Type
 	Fields              []Field
 	Initializers        [][]Parameter
-	typeID              string
 }
 
 func NewEnumType(
@@ -1765,10 +1696,7 @@ func NewMeteredEnumType(
 func (*EnumType) isType() {}
 
 func (t *EnumType) ID() string {
-	if len(t.typeID) == 0 {
-		t.typeID = string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
-	}
-	return t.typeID
+	return string(common.NewTypeIDFromQualifiedName(nil, t.Location, t.QualifiedIdentifier))
 }
 
 func (*EnumType) isCompositeType() {}
@@ -1801,39 +1729,4 @@ func (t *EnumType) Equal(other Type) bool {
 
 	return t.Location == otherType.Location &&
 		t.QualifiedIdentifier == otherType.QualifiedIdentifier
-}
-
-// TypeWithCachedTypeID recursively caches type ID of type t.
-// This is needed because each type ID is lazily cached on
-// its first use in ID() to avoid performance penalty.
-func TypeWithCachedTypeID(t Type) Type {
-	if t == nil {
-		return t
-	}
-
-	// Cache type ID by calling ID()
-	t.ID()
-
-	switch t := t.(type) {
-
-	case CompositeType:
-		fields := t.CompositeFields()
-		for _, f := range fields {
-			TypeWithCachedTypeID(f.Type)
-		}
-
-		initializers := t.CompositeInitializers()
-		for _, params := range initializers {
-			for _, p := range params {
-				TypeWithCachedTypeID(p.Type)
-			}
-		}
-
-	case *IntersectionType:
-		for _, typ := range t.Types {
-			TypeWithCachedTypeID(typ)
-		}
-	}
-
-	return t
 }

--- a/types.go
+++ b/types.go
@@ -270,7 +270,6 @@ func (t *VariableSizedArrayType) Equal(other Type) bool {
 type ConstantSizedArrayType struct {
 	ElementType Type
 	Size        uint
-	typeID      string
 }
 
 var _ Type = &ConstantSizedArrayType{}

--- a/values.go
+++ b/values.go
@@ -1720,7 +1720,11 @@ func (v Struct) ToGoValue() any {
 }
 
 func (v Struct) String() string {
-	return formatComposite(v.StructType.ID(), v.StructType.Fields, v.Fields)
+	return formatComposite(
+		v.StructType.ID(),
+		v.StructType.Fields,
+		v.Fields,
+	)
 }
 
 func (v Struct) GetFields() []Field {
@@ -1815,7 +1819,11 @@ func (v Resource) ToGoValue() any {
 }
 
 func (v Resource) String() string {
-	return formatComposite(v.ResourceType.ID(), v.ResourceType.Fields, v.Fields)
+	return formatComposite(
+		v.ResourceType.ID(),
+		v.ResourceType.Fields,
+		v.Fields,
+	)
 }
 
 func (v Resource) GetFields() []Field {
@@ -1889,7 +1897,11 @@ func (v Attachment) ToGoValue() any {
 }
 
 func (v Attachment) String() string {
-	return formatComposite(v.AttachmentType.ID(), v.AttachmentType.Fields, v.Fields)
+	return formatComposite(
+		v.AttachmentType.ID(),
+		v.AttachmentType.Fields,
+		v.Fields,
+	)
 }
 
 func (v Attachment) GetFields() []Field {
@@ -1962,7 +1974,11 @@ func (v Event) ToGoValue() any {
 	return ret
 }
 func (v Event) String() string {
-	return formatComposite(v.EventType.ID(), v.EventType.Fields, v.Fields)
+	return formatComposite(
+		v.EventType.ID(),
+		v.EventType.Fields,
+		v.Fields,
+	)
 }
 
 func (v Event) GetFields() []Field {
@@ -2036,7 +2052,11 @@ func (v Contract) ToGoValue() any {
 }
 
 func (v Contract) String() string {
-	return formatComposite(v.ContractType.ID(), v.ContractType.Fields, v.Fields)
+	return formatComposite(
+		v.ContractType.ID(),
+		v.ContractType.Fields,
+		v.Fields,
+	)
 }
 
 func (v Contract) GetFields() []Field {
@@ -2267,7 +2287,11 @@ func (v Enum) ToGoValue() any {
 }
 
 func (v Enum) String() string {
-	return formatComposite(v.EnumType.ID(), v.EnumType.Fields, v.Fields)
+	return formatComposite(
+		v.EnumType.ID(),
+		v.EnumType.Fields,
+		v.Fields,
+	)
 }
 
 func (v Enum) GetFields() []Field {
@@ -2322,64 +2346,4 @@ func (Function) ToGoValue() any {
 func (v Function) String() string {
 	// TODO: include function type
 	return "fun ..."
-}
-
-// ValueWithCachedTypeID recursively caches type ID of value v's type.
-// This is needed because each type ID is lazily cached on
-// its first use in ID() to avoid performance penalty.
-func ValueWithCachedTypeID[T Value](value T) T {
-	var v Value = value
-
-	if v == nil {
-		return value
-	}
-
-	TypeWithCachedTypeID(value.Type())
-
-	switch v := v.(type) {
-
-	case TypeValue:
-		TypeWithCachedTypeID(v.StaticType)
-
-	case Optional:
-		ValueWithCachedTypeID(v.Value)
-
-	case Array:
-		for _, v := range v.Values {
-			ValueWithCachedTypeID(v)
-		}
-
-	case Dictionary:
-		for _, p := range v.Pairs {
-			ValueWithCachedTypeID(p.Key)
-			ValueWithCachedTypeID(p.Value)
-		}
-
-	case Struct:
-		for _, f := range v.Fields {
-			ValueWithCachedTypeID(f)
-		}
-
-	case Resource:
-		for _, f := range v.Fields {
-			ValueWithCachedTypeID(f)
-		}
-
-	case Event:
-		for _, f := range v.Fields {
-			ValueWithCachedTypeID(f)
-		}
-
-	case Contract:
-		for _, f := range v.Fields {
-			ValueWithCachedTypeID(f)
-		}
-
-	case Enum:
-		for _, f := range v.Fields {
-			ValueWithCachedTypeID(f)
-		}
-	}
-
-	return value
 }


### PR DESCRIPTION
Depends on #2648 

## Description

So far, both `sema.Type` and `cadence.Type` had `ID` functions, which returned the type ID. With #2750, also `interpreter.StaticType` got an `ID` function. 

Most of these functions re-implemented the ID generation, which is hard to maintain and error prone (inconsistencies). In some cases the ID generation was mixed with the string (human-readable) representation, and the string formatting was re-implemented as both metered and unmetered variants.  

Reduce the potential for inconsistencies by implementing the ID generation in a central place, as `sema.Format*TypeID` functions, and use them in the `ID` functions of all three Go types representing types.

#2754 had previously already started to sort entitlement sets. 
We also need to sort type IDs in intersection type IDs.

Avoid code duplication in string formatting functions, by delegating unmetered functions (`String`) to metered ones (`MeteredString`). Also fix memory metering along the way (in some cases memory was allocated before it was metered).

Ensure that the type ID generation for entitlement sets in entitlement set authorizations and for intersection types sorts the type IDs. Keep the user-defined order in string formatting functions (e.g. `String` and `QualifiedString`). Avoid allocating multiple ordered maps when generating the sorted type IDs.

Add tests for the ID and string functions of authorizations, reference types, and intersection types, on all three levels (`sema`, `interpreter`, and `cadence`).

Also:
- Refactor `interpreter.StaticType`s to be pointer types, as they might get nested and could potentially lead to lots of data being copied. This wasn't really necessary, but noticed a bit late, but maybe still a good improvement.
- Remove any type ID caching, as it might result in lots of memory being allocated
- Improve the tests for entitlements, e.g. use `assert` where it makes sense, fix argument order (expected, actual), avoid repeated casts, etc. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
