### PR TITLE
Clean up intersection types

### DIFF
--- a/encoding/ccf/decode.go
+++ b/encoding/ccf/decode.go
@@ -1468,7 +1468,7 @@ func (d *Decoder) decodeTypeValue(visited *cadenceTypeByCCFTypeID) (cadence.Type
 		return d.decodeReferenceType(visited, d.decodeTypeValue)
 
 	case CBORTagIntersectionTypeValue:
-		return d.decodeIntersectionType(visited, d.decodeNullableTypeValue, d.decodeTypeValue)
+		return d.decodeIntersectionType(visited, d.decodeTypeValue)
 
 	case CBORTagFunctionTypeValue:
 		return d.decodeFunctionTypeValue(visited)

--- a/encoding/ccf/decode_type.go
+++ b/encoding/ccf/decode_type.go
@@ -75,7 +75,7 @@ func (d *Decoder) decodeInlineType(types *cadenceTypeByCCFTypeID) (cadence.Type,
 		return d.decodeReferenceType(types, d.decodeInlineType)
 
 	case CBORTagIntersectionType:
-		return d.decodeIntersectionType(types, d.decodeNullableInlineType, d.decodeInlineType)
+		return d.decodeIntersectionType(types, d.decodeInlineType)
 
 	case CBORTagCapabilityType:
 		return d.decodeCapabilityType(types, d.decodeNullableInlineType)
@@ -550,7 +550,6 @@ func (d *Decoder) decodeReferenceType(
 // NOTE: decodeTypeFn is responsible for decoding inline-type or type-value.
 func (d *Decoder) decodeIntersectionType(
 	types *cadenceTypeByCCFTypeID,
-	decodeTypeFn decodeTypeFn,
 	decodeIntersectionTypeFn decodeTypeFn,
 ) (cadence.Type, error) {
 	// types

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -973,33 +973,7 @@ func CheckIntersectionType(
 		panic(errors.NewUnreachableError())
 	}
 
-	var compositeType *CompositeType
-
-	// If the intersection type is a composite type,
-	// check that the intersections are conformances
-
-	if compositeType != nil {
-
-		// Prepare a set of all the conformances
-
-		conformances := compositeType.EffectiveInterfaceConformanceSet()
-
-		for _, intersectedType := range types {
-			// The intersected type must be an explicit or implicit conformance
-			// of the composite (intersection type)
-
-			if !conformances.Contains(intersectedType) {
-				report(func(t *ast.IntersectionType) error {
-					return &InvalidNonConformanceIntersectionError{
-						Type:  intersectedType,
-						Range: intersectionRanges[intersectedType](t),
-					}
-				})
-			}
-		}
-	}
-
-	return &IntersectionType{Types: types}
+	return NewIntersectionType(memoryGauge, types)
 }
 
 func (checker *Checker) convertIntersectionType(t *ast.IntersectionType) Type {

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -8589,7 +8589,7 @@ func TestInterpretStaticTypeConversionMetering(t *testing.T) {
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindVariableSizedSemaType))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindConstantSizedSemaType))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindOptionalSemaType))
-		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindIntersectionSemaType))
+		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindIntersectionSemaType))
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindReferenceSemaType))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindCapabilitySemaType))
 	})


### PR DESCRIPTION
## Description

- In `decodeIntersectionType`, the `decodeTypeFn` parameter is unused. 
  The parameter was used back when the function was used for decoding restricted types. 
  Remove the parameter
- In `CheckIntersectionType`, a local `compositeType` variable is declared, i.e. is `nil`, and immediately after there's an `if compositeType != nil`, which is basically dead code.
  The variable was previous set when the function was checking a restricted type, and the LHS was a composite (e.g. `T{}`, vs e.g. `AnyStruct{}`).
  Remove the variable and the following if statement.
- Meter the allocation of the intersection type

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
