### PR TITLE
Add tests for invalidation of references created with index/field-access

### DIFF
--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -2578,6 +2578,116 @@ func TestCheckInvalidatedReferenceUse(t *testing.T) {
 				Column: 24,
 			})
 	})
+
+	t.Run("create ref by field access", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t,
+			`
+            access(all) fun test() {
+                let foo <- create Foo()
+                var fooRef = &foo as &Foo
+
+                let barRef = fooRef.bar
+                destroy foo
+                barRef.id
+            }
+
+            resource Foo {
+                let bar: @Bar
+                init() {
+                    self.bar <-create Bar()
+                }
+                destroy() {
+                    destroy self.bar
+                }
+            }
+
+            resource Bar {
+                let id: UInt8
+                init() {
+                    self.id = 1
+                }
+            }
+            `,
+		)
+
+		errors := RequireCheckerErrors(t, err, 1)
+
+		invalidatedRefError := &sema.InvalidatedResourceReferenceError{}
+		assert.ErrorAs(t, errors[0], &invalidatedRefError)
+	})
+
+	t.Run("create ref by index access", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t,
+			`
+            access(all) fun test() {
+                let array <- [<- create Foo()]
+                var arrayRef = &array as &[Foo]
+
+                let fooRef = arrayRef[0]
+                destroy array
+                fooRef.id
+            }
+
+            resource Foo {
+                let id: UInt8
+                init() {
+                    self.id = 1
+                }
+            }
+            `,
+		)
+
+		errors := RequireCheckerErrors(t, err, 1)
+
+		invalidatedRefError := &sema.InvalidatedResourceReferenceError{}
+		assert.ErrorAs(t, errors[0], &invalidatedRefError)
+	})
+
+	t.Run("create ref by field and index access", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t,
+			`
+            access(all) fun test() {
+                let array <- [<- create Foo()]
+                var arrayRef = &array as &[Foo]
+
+                let barRef = arrayRef[0].bar
+                destroy array
+                barRef.id
+            }
+
+            resource Foo {
+                let bar: @Bar
+                init() {
+                    self.bar <-create Bar()
+                }
+                destroy() {
+                    destroy self.bar
+                }
+            }
+
+            resource Bar {
+                let id: UInt8
+                init() {
+                    self.id = 1
+                }
+            }
+            `,
+		)
+
+		errors := RequireCheckerErrors(t, err, 1)
+
+		invalidatedRefError := &sema.InvalidatedResourceReferenceError{}
+		assert.ErrorAs(t, errors[0], &invalidatedRefError)
+	})
 }
 
 func TestCheckReferenceUseAfterCopy(t *testing.T) {

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -1368,6 +1368,178 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 		RequireError(t, err)
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
 	})
+
+	t.Run("reference created by field access", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            resource Foo {
+                let bar: @Bar
+                init() {
+                    self.bar <-create Bar()
+                }
+                destroy() {
+                    destroy self.bar
+                }
+            }
+
+            resource Bar {
+                let id: UInt8
+                init() {
+                    self.id = 1
+                }
+            }
+
+            fun main() {
+                var foo <- create Foo()
+                var fooRef = &foo as &Foo
+
+                // Get a reference to the inner resource.
+                // Function call is just to trick the checker.
+                var barRef = getRef(fooRef.bar)
+
+                // Move the outer resource
+                var foo2 <- foo
+
+                // Access the moved resource
+                barRef.id
+
+                destroy foo2
+            }
+
+            fun getRef(_ ref: &Bar): &Bar {
+                return ref
+            }
+        `,
+		)
+
+		_, err := inter.Invoke("main")
+		RequireError(t, err)
+		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	})
+
+	t.Run("reference created by index access", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            resource Foo {
+                let id: UInt8
+                init() {
+                    self.id = 1
+                }
+            }
+
+            fun main() {
+                let array <- [<- create Foo()]
+                var arrayRef = &array as &[Foo]
+
+                // Get a reference to the inner resource.
+                // Function call is just to trick the checker.
+                var fooRef = getRef(arrayRef[0])
+
+                // Move the outer resource
+                var array2 <- array
+
+                // Access the moved resource
+                fooRef.id
+
+                destroy array2
+            }
+
+            fun getRef(_ ref: &Foo): &Foo {
+                return ref
+            }
+        `,
+		)
+
+		_, err := inter.Invoke("main")
+		RequireError(t, err)
+		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	})
+
+	t.Run("reference created by field and index access", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+             resource Foo {
+                let bar: @Bar
+                init() {
+                    self.bar <-create Bar()
+                }
+                destroy() {
+                    destroy self.bar
+                }
+            }
+
+            resource Bar {
+                let id: UInt8
+                init() {
+                    self.id = 1
+                }
+            }
+
+            fun main() {
+                let array <- [<- create Foo()]
+                var arrayRef = &array as &[Foo]
+
+                // Get a reference to the inner resource.
+                // Function call is just to trick the checker.
+                var barRef = getRef(arrayRef[0].bar)
+
+                // Move the outer resource
+                var array2 <- array
+
+                // Access the moved resource
+                barRef.id
+
+                destroy array2
+            }
+
+            fun getRef(_ ref: &Bar): &Bar {
+                return ref
+            }
+        `,
+		)
+
+		_, err := inter.Invoke("main")
+		RequireError(t, err)
+		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	})
+
+	t.Run("downcasted reference", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+             resource Foo {
+                let id: UInt8
+                init() {
+                    self.id = 1
+                }
+            }
+
+            fun main() {
+                var foo <- create Foo()
+                var fooRef = &foo as &Foo
+
+                var anyStruct: AnyStruct = fooRef
+
+                var downCastedRef = anyStruct as! &Foo
+
+                // Move the outer resource
+                var foo2 <- foo
+
+                // Access the moved resource
+                downCastedRef.id
+
+                destroy foo2
+            }
+        `,
+		)
+
+		_, err := inter.Invoke("main")
+		RequireError(t, err)
+		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	})
 }
 
 func TestInterpretResourceReferenceInvalidationOnDestroy(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-internal/issues/139

## Description

Add more tests for reference invalidation, for references created by field and index access (after the mutability change)

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
