### PR TITLE
PoC: WebAssembly API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 
 require (
 	github.com/SaveTheRbtz/mph v0.1.2
-	github.com/bytecodealliance/wasmtime-go/v7 v7.0.0
+	github.com/bytecodealliance/wasmtime-go/v12 v12.0.0
 	github.com/k0kubun/pp v3.0.1+incompatible
 	github.com/k0kubun/pp/v3 v3.2.0
 	github.com/logrusorgru/aurora/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/SaveTheRbtz/mph v0.1.2 h1:5l3W496Up+7BNOVJQnJhzcGBh+wWfxWdmPUAkx3WmaM
 github.com/SaveTheRbtz/mph v0.1.2/go.mod h1:V4+WtKQPe2+dEA5os1WnGsEB0NR9qgqqgIiSt73+sT4=
 github.com/bits-and-blooms/bitset v1.2.2 h1:J5gbX05GpMdBjCvQ9MteIg2KKDExr7DrgK+Yc15FvIk=
 github.com/bits-and-blooms/bitset v1.2.2/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
-github.com/bytecodealliance/wasmtime-go/v7 v7.0.0 h1:/rBNjgFju2HCZnkPb1eL+W4GBwP8DMbaQu7i+GR9DH4=
-github.com/bytecodealliance/wasmtime-go/v7 v7.0.0/go.mod h1:bu6fic7trDt20w+LMooX7j3fsOwv4/ln6j8gAdP6vmA=
+github.com/bytecodealliance/wasmtime-go/v12 v12.0.0 h1:Wga02UaZXYF3p0LIeL5xFp09/RI7UhjfT2uB0mLrwlw=
+github.com/bytecodealliance/wasmtime-go/v12 v12.0.0/go.mod h1:a3PRoftJxxUzkQvgjC6sv7pKyJJK0ZsFVmH+eeEKQC4=
 github.com/c-bata/go-prompt v0.2.5 h1:3zg6PecEywxNn0xiqcXHD96fkbxghD+gdB2tbsYfl+Y=
 github.com/c-bata/go-prompt v0.2.5/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
 github.com/dave/dst v0.27.2 h1:4Y5VFTkhGLC1oddtNwuxxe36pnyLxMFXT51FOzH8Ekc=

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -496,7 +496,7 @@ func TestRuntimeAuthAccountKeysAdd(t *testing.T) {
 	err := rt.ExecuteTransaction(
 		Script{
 			Source:    []byte(code),
-			Arguments: encodeArgs([]cadence.Value{pubKey}),
+			Arguments: encodeArgs(pubKey),
 		},
 		Context{
 			Location:  nextTransactionLocation(),
@@ -1059,7 +1059,7 @@ func addPublicKeyValidation(runtimeInterface *testRuntimeInterface, returnError 
 	}
 }
 
-func encodeArgs(argValues []cadence.Value) [][]byte {
+func encodeArgs(argValues ...cadence.Value) [][]byte {
 	args := make([][]byte, len(argValues))
 	for i, arg := range argValues {
 		var err error
@@ -1082,7 +1082,7 @@ func (test accountKeyTestCase) executeTransaction(
 	runtimeInterface *testRuntimeInterface,
 	location Location,
 ) error {
-	args := encodeArgs(test.args)
+	args := encodeArgs(test.args...)
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -1102,7 +1102,7 @@ func (test accountKeyTestCase) executeScript(
 	runtimeInterface *testRuntimeInterface,
 ) (cadence.Value, error) {
 
-	args := encodeArgs(test.args)
+	args := encodeArgs(test.args...)
 
 	value, err := runtime.ExecuteScript(
 		Script{

--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -402,6 +402,10 @@ func (*StandardLibraryHandler) BLSAggregateSignatures(_ [][]byte) ([]byte, error
 	return nil, goerrors.New("crypto functionality is not available in this environment")
 }
 
+func (*StandardLibraryHandler) CompileWebAssembly(_ []byte) (stdlib.WebAssemblyModule, error) {
+	return nil, goerrors.New("WebAssembly functionality is not available in this environment")
+}
+
 func (h *StandardLibraryHandler) NewOnEventEmittedHandler() interpreter.OnEventEmittedFunc {
 	return func(
 		inter *interpreter.Interpreter,

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -351,7 +351,7 @@ func TestRuntimeSignatureAlgorithmImport(t *testing.T) {
 		value, err := runtime.ExecuteScript(
 			Script{
 				Source: []byte(script),
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					cadence.NewEnum([]cadence.Value{
 						cadence.UInt8(algo.RawValue()),
 					}).WithType(&cadence.EnumType{
@@ -364,7 +364,7 @@ func TestRuntimeSignatureAlgorithmImport(t *testing.T) {
 							},
 						},
 					}),
-				}),
+				),
 			},
 			Context{
 				Interface: runtimeInterface,
@@ -433,7 +433,7 @@ func TestRuntimeHashAlgorithmImport(t *testing.T) {
 		value, err := runtime.ExecuteScript(
 			Script{
 				Source: []byte(script),
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					cadence.NewEnum([]cadence.Value{
 						cadence.UInt8(algo.RawValue()),
 					}).WithType(&cadence.EnumType{
@@ -446,7 +446,7 @@ func TestRuntimeHashAlgorithmImport(t *testing.T) {
 							},
 						},
 					}),
-				}),
+				),
 			},
 			Context{
 				Interface: runtimeInterface,
@@ -810,7 +810,7 @@ func TestRuntimeTraversingMerkleProof(t *testing.T) {
 	_, err := runtime.ExecuteScript(
 		Script{
 			Source:    script,
-			Arguments: encodeArgs([]cadence.Value{rootHash, address, accountProof}),
+			Arguments: encodeArgs(rootHash, address, accountProof),
 		},
 		Context{
 			Interface: runtimeInterface,

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -681,6 +681,10 @@ func (e *interpreterEnvironment) Hash(data []byte, tag string, algorithm sema.Ha
 	return e.runtimeInterface.Hash(data, tag, algorithm)
 }
 
+func (e *interpreterEnvironment) CompileWebAssembly(bytes []byte) (stdlib.WebAssemblyModule, error) {
+	return e.runtimeInterface.CompileWebAssembly(bytes)
+}
+
 func (e *interpreterEnvironment) DecodeArgument(argument []byte, argumentType cadence.Type) (cadence.Value, error) {
 	return e.runtimeInterface.DecodeArgument(argument, argumentType)
 }

--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -617,10 +617,10 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 	err = runtime.ExecuteTransaction(
 		Script{
 			Source: []byte(realMintFlowTokenTransaction),
-			Arguments: encodeArgs([]cadence.Value{
+			Arguments: encodeArgs(
 				cadence.Address(senderAddress),
 				mintAmount,
-			}),
+			),
 		},
 		Context{
 			Interface:   runtimeInterface,
@@ -645,10 +645,10 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 		err = runtime.ExecuteTransaction(
 			Script{
 				Source: []byte(realFlowTokenTransferTransaction),
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					sendAmount,
 					cadence.Address(receiverAddress),
-				}),
+				),
 			},
 			Context{
 				Interface:   runtimeInterface,
@@ -675,9 +675,9 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 		result, err := runtime.ExecuteScript(
 			Script{
 				Source: []byte(realFlowTokenBalanceScript),
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					cadence.Address(address),
-				}),
+				),
 			},
 			Context{
 				Interface:   runtimeInterface,

--- a/runtime/imported_values_memory_metering_test.go
+++ b/runtime/imported_values_memory_metering_test.go
@@ -56,7 +56,7 @@ func TestRuntimeImportedValueMemoryMetering(t *testing.T) {
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source:    script,
-				Arguments: encodeArgs(args),
+				Arguments: encodeArgs(args...),
 			},
 			Context{
 				Interface: runtimeInterface,
@@ -508,9 +508,9 @@ func TestRuntimeImportedValueMemoryMeteringForSimpleTypes(t *testing.T) {
 			_, err := runtime.ExecuteScript(
 				Script{
 					Source: script,
-					Arguments: encodeArgs([]cadence.Value{
+					Arguments: encodeArgs(
 						test.TypeInstance,
-					}),
+					),
 				},
 				Context{
 					Interface: runtimeInterface,
@@ -583,7 +583,7 @@ func TestRuntimeScriptDecodedLocationMetering(t *testing.T) {
 			_, err := runtime.ExecuteScript(
 				Script{
 					Source:    script,
-					Arguments: encodeArgs([]cadence.Value{value}),
+					Arguments: encodeArgs(value),
 				},
 				Context{
 					Interface: runtimeInterface,

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/stdlib"
 )
 
 type Interface interface {
@@ -143,6 +144,7 @@ type Interface interface {
 	)
 	// GenerateAccountID generates a new, *non-zero*, unique ID for the given account.
 	GenerateAccountID(address common.Address) (uint64, error)
+	CompileWebAssembly(bytes []byte) (stdlib.WebAssemblyModule, error)
 }
 
 type MeterInterface interface {

--- a/runtime/rlp_test.go
+++ b/runtime/rlp_test.go
@@ -136,14 +136,14 @@ func TestRuntimeRLPDecodeString(t *testing.T) {
 			result, err := runtime.ExecuteScript(
 				Script{
 					Source: script,
-					Arguments: encodeArgs([]cadence.Value{
+					Arguments: encodeArgs(
 						cadence.Array{
 							ArrayType: &cadence.VariableSizedArrayType{
 								ElementType: cadence.UInt8Type,
 							},
 							Values: test.input,
 						},
-					}),
+					),
 				},
 				Context{
 					Interface: runtimeInterface,
@@ -295,14 +295,14 @@ func TestRuntimeRLPDecodeList(t *testing.T) {
 			result, err := runtime.ExecuteScript(
 				Script{
 					Source: script,
-					Arguments: encodeArgs([]cadence.Value{
+					Arguments: encodeArgs(
 						cadence.Array{
 							ArrayType: &cadence.VariableSizedArrayType{
 								ElementType: cadence.UInt8Type,
 							},
 							Values: test.input,
 						},
-					}),
+					),
 				},
 				Context{
 					Interface: runtimeInterface,

--- a/runtime/runtime_memory_metering_test.go
+++ b/runtime/runtime_memory_metering_test.go
@@ -228,9 +228,9 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: []byte(script),
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					cadence.NewInt(12),
-				}),
+				),
 			},
 			Context{
 				Interface: runtimeInterface,
@@ -271,9 +271,9 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: []byte(script),
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					largeInt,
-				}),
+				),
 			},
 			Context{
 				Interface: runtimeInterface,
@@ -307,9 +307,9 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: []byte(script),
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					cadence.NewInt8(12),
-				}),
+				),
 			},
 			Context{
 				Interface: runtimeInterface,
@@ -343,9 +343,9 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: []byte(script),
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					cadence.NewInt16(12),
-				}),
+				),
 			},
 			Context{
 				Interface: runtimeInterface,
@@ -379,9 +379,9 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: []byte(script),
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					cadence.NewInt32(12),
-				}),
+				),
 			},
 			Context{
 				Interface: runtimeInterface,
@@ -415,9 +415,9 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: []byte(script),
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					cadence.NewInt64(12),
-				}),
+				),
 			},
 			Context{
 				Interface: runtimeInterface,
@@ -451,9 +451,9 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: []byte(script),
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					cadence.NewInt128(12),
-				}),
+				),
 			},
 			Context{
 				Interface: runtimeInterface,
@@ -487,9 +487,9 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: []byte(script),
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					cadence.NewInt256(12),
-				}),
+				),
 			},
 			Context{
 				Interface: runtimeInterface,
@@ -989,7 +989,7 @@ func TestRuntimeMemoryMeteringErrors(t *testing.T) {
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source:    script,
-				Arguments: encodeArgs(args),
+				Arguments: encodeArgs(args...),
 			},
 			Context{
 				Interface: runtimeInterface(meter),

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -227,6 +227,7 @@ type testRuntimeInterface struct {
 	interactionUsed            func() (uint64, error)
 	updatedContractCode        bool
 	generateAccountID          func(address common.Address) (uint64, error)
+	compileWebAssembly         func(bytes []byte) (stdlib.WebAssemblyModule, error)
 
 	uuid       uint64
 	accountIDs map[common.Address]uint64
@@ -616,6 +617,14 @@ func (i *testRuntimeInterface) BLSAggregatePublicKeys(keys []*stdlib.PublicKey) 
 	}
 
 	return i.blsAggregatePublicKeys(keys)
+}
+
+func (i *testRuntimeInterface) CompileWebAssembly(bytes []byte) (stdlib.WebAssemblyModule, error) {
+	if i.compileWebAssembly == nil {
+		return nil, nil
+	}
+
+	return i.compileWebAssembly(bytes)
 }
 
 func (i *testRuntimeInterface) GetAccountContractNames(address Address) ([]string, error) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -8075,9 +8075,9 @@ func TestRuntimeAccountTypeEquality(t *testing.T) {
 	result, err := rt.ExecuteScript(
 		Script{
 			Source: script,
-			Arguments: encodeArgs([]cadence.Value{
+			Arguments: encodeArgs(
 				cadence.Address(common.MustBytesToAddress([]byte{0x1})),
-			}),
+			),
 		},
 		Context{
 			Interface: runtimeInterface,

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -783,6 +783,23 @@ func typeExpr(t ast.Type, typeParams map[string]string) dst.Expr {
 			},
 		}
 
+	case *ast.DictionaryType:
+		keyType := typeExpr(t.KeyType, typeParams)
+		valueType := typeExpr(t.ValueType, typeParams)
+		return &dst.UnaryExpr{
+			Op: token.AND,
+			X: &dst.CompositeLit{
+				Type: &dst.Ident{
+					Name: "DictionaryType",
+					Path: semaPath,
+				},
+				Elts: []dst.Expr{
+					goKeyValue("KeyType", keyType),
+					goKeyValue("ValueType", valueType),
+				},
+			},
+		}
+
 	case *ast.FunctionType:
 		return functionTypeExpr(t, nil, nil, typeParams)
 

--- a/runtime/sema/gen/testdata/fields.cdc
+++ b/runtime/sema/gen/testdata/fields.cdc
@@ -14,6 +14,9 @@ access(all) struct Test {
     /// This is a test constant-sized integer array.
     access(all) let testConstInts: [UInt64; 2]
 
+    /// This is a test integer dictionary.
+    access(all) let testIntDict: {UInt64: Bool}
+
     /// This is a test parameterized-type field.
     access(all) let testParam: Foo<Bar>
 

--- a/runtime/sema/gen/testdata/fields.golden.go
+++ b/runtime/sema/gen/testdata/fields.golden.go
@@ -71,6 +71,17 @@ const TestTypeTestConstIntsFieldDocString = `
 This is a test constant-sized integer array.
 `
 
+const TestTypeTestIntDictFieldName = "testIntDict"
+
+var TestTypeTestIntDictFieldType = &DictionaryType{
+	KeyType:   UInt64Type,
+	ValueType: BoolType,
+}
+
+const TestTypeTestIntDictFieldDocString = `
+This is a test integer dictionary.
+`
+
 const TestTypeTestParamFieldName = "testParam"
 
 var TestTypeTestParamFieldType = MustInstantiate(
@@ -185,6 +196,14 @@ func init() {
 				TestTypeTestConstIntsFieldName,
 				TestTypeTestConstIntsFieldType,
 				TestTypeTestConstIntsFieldDocString,
+			),
+			NewUnmeteredFieldMember(
+				t,
+				PrimitiveAccess(ast.AccessAll),
+				ast.VariableKindConstant,
+				TestTypeTestIntDictFieldName,
+				TestTypeTestIntDictFieldType,
+				TestTypeTestIntDictFieldDocString,
 			),
 			NewUnmeteredFieldMember(
 				t,

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -34,6 +34,7 @@ type StandardLibraryHandler interface {
 	BLSPublicKeyAggregator
 	BLSSignatureAggregator
 	Hasher
+	WebAssemblyContractHandler
 }
 
 func DefaultStandardLibraryValues(handler StandardLibraryHandler) []StandardLibraryValue {
@@ -51,6 +52,7 @@ func DefaultStandardLibraryValues(handler StandardLibraryHandler) []StandardLibr
 		NewPublicKeyConstructor(handler, handler, handler),
 		NewBLSContract(nil, handler),
 		NewHashAlgorithmConstructor(handler),
+		NewWebAssemblyContract(nil, handler),
 	}
 }
 

--- a/runtime/stdlib/webassembly.cdc
+++ b/runtime/stdlib/webassembly.cdc
@@ -1,0 +1,23 @@
+access(all)
+contract WebAssembly {
+
+    /// Compile WebAssembly binary code into a Module
+    /// and instantiate it with the given imports.
+    access(all)
+    view fun compileAndInstantiate(bytes: [UInt8]): &WebAssembly.InstantiatedSource
+
+    access(all)
+    struct InstantiatedSource {
+
+        /// The instance.
+        access(all)
+        let instance: &WebAssembly.Instance
+    }
+
+    struct Instance {
+
+        /// Get the exported value.
+        access(all)
+        view fun getExport<T: AnyStruct>(name: String): T
+    }
+}

--- a/runtime/stdlib/webassembly.gen.go
+++ b/runtime/stdlib/webassembly.gen.go
@@ -1,0 +1,178 @@
+// Code generated from webassembly.cdc. DO NOT EDIT.
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stdlib
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+const WebAssemblyTypeCompileAndInstantiateFunctionName = "compileAndInstantiate"
+
+var WebAssemblyTypeCompileAndInstantiateFunctionType = &sema.FunctionType{
+	Purity: sema.FunctionPurityView,
+	Parameters: []sema.Parameter{
+		{
+			Identifier: "bytes",
+			TypeAnnotation: sema.NewTypeAnnotation(&sema.VariableSizedType{
+				Type: UInt8Type,
+			}),
+		},
+	},
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		&sema.ReferenceType{
+			Type:          WebAssembly_InstantiatedSourceType,
+			Authorization: sema.UnauthorizedAccess,
+		},
+	),
+}
+
+const WebAssemblyTypeCompileAndInstantiateFunctionDocString = `
+Compile WebAssembly binary code into a Module
+and instantiate it with the given imports.
+`
+
+const WebAssembly_InstantiatedSourceTypeInstanceFieldName = "instance"
+
+var WebAssembly_InstantiatedSourceTypeInstanceFieldType = &sema.ReferenceType{
+	Type:          WebAssembly_InstanceType,
+	Authorization: sema.UnauthorizedAccess,
+}
+
+const WebAssembly_InstantiatedSourceTypeInstanceFieldDocString = `
+The instance.
+`
+
+const WebAssembly_InstantiatedSourceTypeName = "InstantiatedSource"
+
+var WebAssembly_InstantiatedSourceType = func() *sema.CompositeType {
+	var t = &sema.CompositeType{
+		Identifier:         WebAssembly_InstantiatedSourceTypeName,
+		Kind:               common.CompositeKindStructure,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
+	}
+
+	return t
+}()
+
+func init() {
+	var members = []*sema.Member{
+		sema.NewUnmeteredFieldMember(
+			WebAssembly_InstantiatedSourceType,
+			sema.PrimitiveAccess(ast.AccessAll),
+			ast.VariableKindConstant,
+			WebAssembly_InstantiatedSourceTypeInstanceFieldName,
+			WebAssembly_InstantiatedSourceTypeInstanceFieldType,
+			WebAssembly_InstantiatedSourceTypeInstanceFieldDocString,
+		),
+	}
+
+	WebAssembly_InstantiatedSourceType.Members = sema.MembersAsMap(members)
+	WebAssembly_InstantiatedSourceType.Fields = sema.MembersFieldNames(members)
+}
+
+const WebAssembly_InstanceTypeGetExportFunctionName = "getExport"
+
+var WebAssembly_InstanceTypeGetExportFunctionTypeParameterT = &sema.TypeParameter{
+	Name:      "T",
+	TypeBound: AnyStructType,
+}
+
+var WebAssembly_InstanceTypeGetExportFunctionType = &sema.FunctionType{
+	Purity: sema.FunctionPurityView,
+	TypeParameters: []*sema.TypeParameter{
+		WebAssembly_InstanceTypeGetExportFunctionTypeParameterT,
+	},
+	Parameters: []sema.Parameter{
+		{
+			Identifier:     "name",
+			TypeAnnotation: sema.NewTypeAnnotation(StringType),
+		},
+	},
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		&sema.GenericType{
+			TypeParameter: WebAssembly_InstanceTypeGetExportFunctionTypeParameterT,
+		},
+	),
+}
+
+const WebAssembly_InstanceTypeGetExportFunctionDocString = `
+Get the exported value.
+`
+
+const WebAssembly_InstanceTypeName = "Instance"
+
+var WebAssembly_InstanceType = func() *sema.CompositeType {
+	var t = &sema.CompositeType{
+		Identifier:         WebAssembly_InstanceTypeName,
+		Kind:               common.CompositeKindStructure,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
+	}
+
+	return t
+}()
+
+func init() {
+	var members = []*sema.Member{
+		sema.NewUnmeteredFunctionMember(
+			WebAssembly_InstanceType,
+			sema.PrimitiveAccess(ast.AccessAll),
+			WebAssembly_InstanceTypeGetExportFunctionName,
+			WebAssembly_InstanceTypeGetExportFunctionType,
+			WebAssembly_InstanceTypeGetExportFunctionDocString,
+		),
+	}
+
+	WebAssembly_InstanceType.Members = sema.MembersAsMap(members)
+	WebAssembly_InstanceType.Fields = sema.MembersFieldNames(members)
+}
+
+const WebAssemblyTypeName = "WebAssembly"
+
+var WebAssemblyType = func() *sema.CompositeType {
+	var t = &sema.CompositeType{
+		Identifier:         WebAssemblyTypeName,
+		Kind:               common.CompositeKindContract,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
+	}
+
+	t.SetNestedType(WebAssembly_InstantiatedSourceTypeName, WebAssembly_InstantiatedSourceType)
+	t.SetNestedType(WebAssembly_InstanceTypeName, WebAssembly_InstanceType)
+	return t
+}()
+
+func init() {
+	var members = []*sema.Member{
+		sema.NewUnmeteredFunctionMember(
+			WebAssemblyType,
+			sema.PrimitiveAccess(ast.AccessAll),
+			WebAssemblyTypeCompileAndInstantiateFunctionName,
+			WebAssemblyTypeCompileAndInstantiateFunctionType,
+			WebAssemblyTypeCompileAndInstantiateFunctionDocString,
+		),
+	}
+
+	WebAssemblyType.Members = sema.MembersAsMap(members)
+	WebAssemblyType.Fields = sema.MembersFieldNames(members)
+}

--- a/runtime/stdlib/webassembly.go
+++ b/runtime/stdlib/webassembly.go
@@ -1,0 +1,219 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stdlib
+
+import (
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+//go:generate go run ../sema/gen -p stdlib webassembly.cdc webassembly.gen.go
+
+var AnyStructType = sema.AnyStructType
+var StringType = sema.StringType
+
+func newWebAssemblyCompileAndInstantiateFunction(
+	gauge common.MemoryGauge,
+	handler WebAssemblyContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewHostFunctionValue(
+		gauge,
+		WebAssemblyTypeCompileAndInstantiateFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			bytesValue := invocation.Arguments[0]
+			bytes, err := interpreter.ByteArrayValueToByteSlice(inter, bytesValue, locationRange)
+			if err != nil {
+				panic(err)
+			}
+
+			module, err := handler.CompileWebAssembly(bytes)
+			if err != nil {
+				panic(err)
+			}
+
+			instance, err := module.InstantiateWebAssemblyModule(gauge)
+			if err != nil {
+				panic(err)
+			}
+
+			instanceValue := NewWebAssemblyInstanceValue(gauge, instance)
+			instanceReferenceValue := interpreter.NewEphemeralReferenceValue(
+				gauge,
+				interpreter.UnauthorizedAccess,
+				instanceValue,
+				WebAssembly_InstanceType,
+			)
+
+			instantiatedSourceValue := NewWebAssemblyInstantiatedSourceValue(gauge, instanceReferenceValue)
+			return interpreter.NewEphemeralReferenceValue(
+				gauge,
+				interpreter.UnauthorizedAccess,
+				instantiatedSourceValue,
+				WebAssembly_InstantiatedSourceType,
+			)
+		},
+	)
+}
+
+func newWebAssemblyInstanceGetExportFunction(
+	gauge common.MemoryGauge,
+	instance WebAssemblyInstance,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewHostFunctionValue(
+		gauge,
+		WebAssembly_InstanceTypeGetExportFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			// Name
+			nameValue, ok := invocation.Arguments[0].(*interpreter.StringValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+			name := nameValue.Str
+
+			// Type
+			typeParameterPair := invocation.TypeParameterTypes.Oldest()
+			if typeParameterPair == nil {
+				panic(errors.NewUnreachableError())
+			}
+			ty := typeParameterPair.Value
+
+			// Get and check export
+			export, err := instance.GetExport(inter, name)
+			if err != nil {
+				panic(err)
+			}
+			if export == nil {
+				panic(errors.NewDefaultUserError(
+					"WebAssembly module does not have an export with name '%s'",
+					name,
+				))
+			}
+
+			if !sema.IsSubType(export.Type, ty) {
+				panic(interpreter.TypeMismatchError{
+					ExpectedType:  ty,
+					ActualType:    export.Type,
+					LocationRange: locationRange,
+				})
+			}
+
+			return export.Value
+		},
+	)
+}
+
+var webAssembly_InstanceStaticType = interpreter.ConvertSemaCompositeTypeToStaticCompositeType(
+	nil,
+	WebAssembly_InstanceType,
+)
+
+func NewWebAssemblyInstanceValue(
+	gauge common.MemoryGauge,
+	instance WebAssemblyInstance,
+) *interpreter.SimpleCompositeValue {
+	return interpreter.NewSimpleCompositeValue(
+		gauge,
+		WebAssembly_InstanceType.ID(),
+		webAssembly_InstanceStaticType,
+		WebAssembly_InstanceType.Fields,
+		map[string]interpreter.Value{
+			WebAssembly_InstanceTypeGetExportFunctionName: newWebAssemblyInstanceGetExportFunction(gauge, instance),
+		},
+		nil,
+		nil,
+		nil,
+	)
+}
+
+var webAssembly_InstantiatedSourceStaticType = interpreter.ConvertSemaCompositeTypeToStaticCompositeType(
+	nil,
+	WebAssembly_InstantiatedSourceType,
+)
+
+func NewWebAssemblyInstantiatedSourceValue(
+	gauge common.MemoryGauge,
+	instanceValue interpreter.Value,
+) *interpreter.SimpleCompositeValue {
+	return interpreter.NewSimpleCompositeValue(
+		gauge,
+		WebAssembly_InstantiatedSourceType.ID(),
+		webAssembly_InstantiatedSourceStaticType,
+		WebAssembly_InstantiatedSourceType.Fields,
+		map[string]interpreter.Value{
+			WebAssembly_InstantiatedSourceTypeInstanceFieldName: instanceValue,
+		},
+		nil,
+		nil,
+		nil,
+	)
+}
+
+type WebAssemblyModule interface {
+	InstantiateWebAssemblyModule(gauge common.MemoryGauge) (WebAssemblyInstance, error)
+}
+
+type WebAssemblyInstance interface {
+	GetExport(gauge common.MemoryGauge, name string) (*WebAssemblyExport, error)
+}
+
+type WebAssemblyExport struct {
+	Type  sema.Type
+	Value interpreter.Value
+}
+
+type WebAssemblyContractHandler interface {
+	CompileWebAssembly(bytes []byte) (WebAssemblyModule, error)
+}
+
+var WebAssemblyTypeStaticType = interpreter.ConvertSemaToStaticType(nil, WebAssemblyType)
+
+func NewWebAssemblyContract(
+	gauge common.MemoryGauge,
+	handler WebAssemblyContractHandler,
+) StandardLibraryValue {
+	webAssemblyContractFields := map[string]interpreter.Value{
+		WebAssemblyTypeCompileAndInstantiateFunctionName: newWebAssemblyCompileAndInstantiateFunction(gauge, handler),
+	}
+
+	webAssemblyContractValue := interpreter.NewSimpleCompositeValue(
+		gauge,
+		WebAssemblyType.ID(),
+		WebAssemblyTypeStaticType,
+		nil,
+		webAssemblyContractFields,
+		nil,
+		nil,
+		nil,
+	)
+
+	return StandardLibraryValue{
+		Name:  WebAssemblyTypeName,
+		Type:  WebAssemblyType,
+		Value: webAssemblyContractValue,
+		Kind:  common.DeclarationKindContract,
+	}
+}

--- a/runtime/validation_test.go
+++ b/runtime/validation_test.go
@@ -66,7 +66,7 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 		err := runtime.ExecuteTransaction(
 			Script{
 				Source: script,
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					cadence.Struct{}.
 						WithType(&cadence.StructType{
 							Location: common.AddressLocation{
@@ -75,7 +75,7 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 							},
 							QualifiedIdentifier: "Foo.Bar",
 						}),
-				}),
+				),
 			},
 			Context{
 				Interface: runtimeInterface,
@@ -116,7 +116,7 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: script,
-				Arguments: encodeArgs([]cadence.Value{
+				Arguments: encodeArgs(
 					cadence.Struct{}.
 						WithType(&cadence.StructType{
 							Location: common.AddressLocation{
@@ -125,7 +125,7 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 							},
 							QualifiedIdentifier: "Foo.Bar",
 						}),
-				}),
+				),
 			},
 			Context{
 				Interface: runtimeInterface,

--- a/runtime/webassembly_test.go
+++ b/runtime/webassembly_test.go
@@ -1,0 +1,257 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bytecodealliance/wasmtime-go/v12"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/json"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/stdlib"
+)
+
+type WasmtimeModule struct {
+	Module *wasmtime.Module
+	Store  *wasmtime.Store
+}
+
+var _ stdlib.WebAssemblyModule = WasmtimeModule{}
+
+func (m WasmtimeModule) InstantiateWebAssemblyModule(_ common.MemoryGauge) (stdlib.WebAssemblyInstance, error) {
+	instance, err := wasmtime.NewInstance(m.Store, m.Module, nil)
+	if err != nil {
+		return nil, err
+	}
+	return WasmtimeInstance{
+		Instance: instance,
+		Store:    m.Store,
+	}, nil
+}
+
+type WasmtimeInstance struct {
+	Instance *wasmtime.Instance
+	Store    *wasmtime.Store
+}
+
+var _ stdlib.WebAssemblyInstance = WasmtimeInstance{}
+
+func wasmtimeValKindToSemaType(valKind wasmtime.ValKind) sema.Type {
+	switch valKind {
+	case wasmtime.KindI32:
+		return sema.Int32Type
+
+	case wasmtime.KindI64:
+		return sema.Int64Type
+
+	default:
+		return nil
+	}
+}
+
+func (i WasmtimeInstance) GetExport(gauge common.MemoryGauge, name string) (*stdlib.WebAssemblyExport, error) {
+	extern := i.Instance.GetExport(i.Store, name)
+	if extern == nil {
+		return nil, nil
+	}
+
+	if function := extern.Func(); function != nil {
+		return newWasmtimeFunctionWebAssemblyExport(gauge, function, i.Store)
+	}
+
+	return nil, fmt.Errorf("unsupported export")
+}
+
+func newWasmtimeFunctionWebAssemblyExport(
+	gauge common.MemoryGauge,
+	function *wasmtime.Func,
+	store *wasmtime.Store,
+) (
+	*stdlib.WebAssemblyExport,
+	error,
+) {
+	funcType := function.Type(store)
+
+	functionType := &sema.FunctionType{}
+
+	// Parameters
+
+	for _, paramType := range funcType.Params() {
+		paramKind := paramType.Kind()
+		parameterType := wasmtimeValKindToSemaType(paramKind)
+		if parameterType == nil {
+			return nil, fmt.Errorf(
+				"unsupported export: function with unsupported parameter type '%s'",
+				paramKind,
+			)
+		}
+		functionType.Parameters = append(
+			functionType.Parameters,
+			sema.Parameter{
+				TypeAnnotation: sema.NewTypeAnnotation(parameterType),
+			},
+		)
+	}
+
+	// Result
+
+	results := funcType.Results()
+	switch len(results) {
+	case 0:
+		break
+
+	case 1:
+		result := results[0]
+		resultKind := result.Kind()
+		returnType := wasmtimeValKindToSemaType(resultKind)
+		if returnType == nil {
+			return nil, fmt.Errorf(
+				"unsupported export: function with unsupported result type '%s'",
+				resultKind,
+			)
+		}
+		functionType.ReturnTypeAnnotation = sema.NewTypeAnnotation(returnType)
+
+	default:
+		return nil, fmt.Errorf("unsupported export: function has more than one result")
+	}
+
+	hostFunctionValue := interpreter.NewHostFunctionValue(
+		gauge,
+		functionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			arguments := invocation.Arguments
+
+			convertedArguments := make([]any, 0, len(arguments))
+
+			for i, argument := range arguments {
+				ty := functionType.Parameters[i].TypeAnnotation.Type
+
+				var convertedArgument any
+
+				switch ty {
+				case sema.Int32Type:
+					convertedArgument = int32(argument.(interpreter.Int32Value))
+
+				case sema.Int64Type:
+					convertedArgument = argument.(interpreter.Int64Value)
+
+				default:
+					panic(errors.NewUnreachableError())
+				}
+
+				convertedArguments = append(convertedArguments, convertedArgument)
+			}
+
+			result, err := function.Call(store, convertedArguments...)
+			if err != nil {
+				panic(err)
+			}
+
+			switch result := result.(type) {
+			case int32:
+				return interpreter.Int32Value(result)
+
+			case int64:
+				return interpreter.Int64Value(result)
+
+			default:
+				panic(errors.NewUnreachableError())
+
+			}
+		},
+	)
+
+	return &stdlib.WebAssemblyExport{
+		Type:  functionType,
+		Value: hostFunctionValue,
+	}, nil
+}
+
+func TestRuntimeWebAssembly(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := newTestInterpreterRuntime()
+
+	addProgram := []byte{
+		0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01, 0x60,
+		0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x07, 0x01,
+		0x03, 0x61, 0x64, 0x64, 0x00, 0x00, 0x0a, 0x09, 0x01, 0x07, 0x00, 0x20,
+		0x00, 0x20, 0x01, 0x6a, 0x0b,
+	}
+
+	// language=cadence
+	script := []byte(`
+      access(all)
+      fun main(program: [UInt8], a: Int32, b: Int32): Int32 {
+          let instance = WebAssembly.compileAndInstantiate(bytes: program).instance
+          let add = instance.getExport<fun(Int32, Int32): Int32>(name: "add")
+          return add(a, b)
+      }
+    `)
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: newTestLedger(nil, nil),
+		compileWebAssembly: func(bytes []byte) (stdlib.WebAssemblyModule, error) {
+			store := wasmtime.NewStore(wasmtime.NewEngine())
+			module, err := wasmtime.NewModule(store.Engine, bytes)
+			if err != nil {
+				return nil, err
+			}
+
+			return WasmtimeModule{
+				Store:  store,
+				Module: module,
+			}, nil
+		},
+		decodeArgument: func(b []byte, _ cadence.Type) (cadence.Value, error) {
+			return json.Decode(nil, b)
+		},
+	}
+
+	result, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+			Arguments: encodeArgs(
+				newBytesValue(addProgram),
+				cadence.Int32(1),
+				cadence.Int32(2),
+			),
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  common.ScriptLocation{},
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t,
+		cadence.Int32(3),
+		result,
+	)
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -27,7 +27,7 @@ import (
 
 	"C"
 
-	"github.com/bytecodealliance/wasmtime-go/v7"
+	"github.com/bytecodealliance/wasmtime-go/v12"
 
 	"github.com/onflow/cadence/runtime/interpreter"
 )


### PR DESCRIPTION
## Description

This PoC explores the [idea of adding a WebAssembly API to Cadence](https://forum.onflow.org/t/idea-wasm-execution-engine-in-cadence/5164), i.e. exposing a WebAssembly VM to Cadence programs.

The PRs adds:
- A `WebAssembly` contract with an API inspired by the [WebAssembly JavaScript Interface](https://www.w3.org/TR/wasm-js-api-1/). The beginnings of the API support module instantiation, without imports, and access to function exports with `i32` and `i64` types.
- An implementation of the WebAssembly API based on [wasmtime](https://wasmtime.dev/). The VM is not yet configured for metering and limits have not been set.
- A test case which demonstrates loading a simple `add` `(i32, i32) -> i32` function, calling it with Cadence `UInt32` values, and getting back the result as a Cadence `UInt32`.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
