### PR TITLE
update account type mappings to include identity

### DIFF
--- a/runtime/sema/account.cdc
+++ b/runtime/sema/account.cdc
@@ -445,38 +445,7 @@ entitlement IssueAccountCapabilityController
 /* Entitlement mappings */
 
 entitlement mapping AccountMapping {
-    // TODO: include Identity
-
-    Storage -> Storage
-    Contracts -> Contracts
-    Keys -> Keys
-    Inbox -> Inbox
-    Capabilities -> Capabilities
-
-    SaveValue -> SaveValue
-    LoadValue -> LoadValue
-    BorrowValue -> BorrowValue
-
-    AddContract -> AddContract
-    UpdateContract -> UpdateContract
-    RemoveContract -> RemoveContract
-
-    AddKey -> AddKey
-    RevokeKey -> RevokeKey
-
-    PublishInboxCapability -> PublishInboxCapability
-    UnpublishInboxCapability -> UnpublishInboxCapability
-
-    StorageCapabilities -> StorageCapabilities
-    AccountCapabilities -> AccountCapabilities
-
-    GetStorageCapabilityController -> GetStorageCapabilityController
-    IssueStorageCapabilityController -> IssueStorageCapabilityController
-
-    GetAccountCapabilityController -> GetAccountCapabilityController
-    IssueAccountCapabilityController -> IssueAccountCapabilityController
-
-    // ---
+    include Identity
 
     Storage -> SaveValue
     Storage -> LoadValue
@@ -498,18 +467,7 @@ entitlement mapping AccountMapping {
 }
 
 entitlement mapping CapabilitiesMapping {
-    // TODO: include Identity
-
-    Capabilities -> Capabilities
-
-    StorageCapabilities -> StorageCapabilities
-    AccountCapabilities -> AccountCapabilities
-
-    GetStorageCapabilityController -> GetStorageCapabilityController
-    IssueStorageCapabilityController -> IssueStorageCapabilityController
-
-    GetAccountCapabilityController -> GetAccountCapabilityController
-    IssueAccountCapabilityController -> IssueAccountCapabilityController
+    include Identity
 
     // ---
 

--- a/runtime/sema/account.cdc
+++ b/runtime/sema/account.cdc
@@ -469,8 +469,6 @@ entitlement mapping AccountMapping {
 entitlement mapping CapabilitiesMapping {
     include Identity
 
-    // ---
-
     StorageCapabilities -> GetStorageCapabilityController
     StorageCapabilities -> IssueStorageCapabilityController
 

--- a/runtime/sema/account.gen.go
+++ b/runtime/sema/account.gen.go
@@ -1928,92 +1928,9 @@ var IssueAccountCapabilityControllerType = &EntitlementType{
 }
 
 var AccountMappingType = &EntitlementMapType{
-	Identifier: "AccountMapping",
+	Identifier:       "AccountMapping",
+	IncludesIdentity: true,
 	Relations: []EntitlementRelation{
-		EntitlementRelation{
-			Input:  StorageType,
-			Output: StorageType,
-		},
-		EntitlementRelation{
-			Input:  ContractsType,
-			Output: ContractsType,
-		},
-		EntitlementRelation{
-			Input:  KeysType,
-			Output: KeysType,
-		},
-		EntitlementRelation{
-			Input:  InboxType,
-			Output: InboxType,
-		},
-		EntitlementRelation{
-			Input:  CapabilitiesType,
-			Output: CapabilitiesType,
-		},
-		EntitlementRelation{
-			Input:  SaveValueType,
-			Output: SaveValueType,
-		},
-		EntitlementRelation{
-			Input:  LoadValueType,
-			Output: LoadValueType,
-		},
-		EntitlementRelation{
-			Input:  BorrowValueType,
-			Output: BorrowValueType,
-		},
-		EntitlementRelation{
-			Input:  AddContractType,
-			Output: AddContractType,
-		},
-		EntitlementRelation{
-			Input:  UpdateContractType,
-			Output: UpdateContractType,
-		},
-		EntitlementRelation{
-			Input:  RemoveContractType,
-			Output: RemoveContractType,
-		},
-		EntitlementRelation{
-			Input:  AddKeyType,
-			Output: AddKeyType,
-		},
-		EntitlementRelation{
-			Input:  RevokeKeyType,
-			Output: RevokeKeyType,
-		},
-		EntitlementRelation{
-			Input:  PublishInboxCapabilityType,
-			Output: PublishInboxCapabilityType,
-		},
-		EntitlementRelation{
-			Input:  UnpublishInboxCapabilityType,
-			Output: UnpublishInboxCapabilityType,
-		},
-		EntitlementRelation{
-			Input:  StorageCapabilitiesType,
-			Output: StorageCapabilitiesType,
-		},
-		EntitlementRelation{
-			Input:  AccountCapabilitiesType,
-			Output: AccountCapabilitiesType,
-		},
-		EntitlementRelation{
-			Input:  GetStorageCapabilityControllerType,
-			Output: GetStorageCapabilityControllerType,
-		},
-		EntitlementRelation{
-			Input:  IssueStorageCapabilityControllerType,
-			Output: IssueStorageCapabilityControllerType,
-		},
-		EntitlementRelation{
-			Input:  GetAccountCapabilityControllerType,
-			Output: GetAccountCapabilityControllerType,
-		},
-		EntitlementRelation{
-			Input:  IssueAccountCapabilityControllerType,
-			Output: IssueAccountCapabilityControllerType,
-		},
 		EntitlementRelation{
 			Input:  StorageType,
 			Output: SaveValueType,
@@ -2070,36 +1987,9 @@ var AccountMappingType = &EntitlementMapType{
 }
 
 var CapabilitiesMappingType = &EntitlementMapType{
-	Identifier: "CapabilitiesMapping",
+	Identifier:       "CapabilitiesMapping",
+	IncludesIdentity: true,
 	Relations: []EntitlementRelation{
-		EntitlementRelation{
-			Input:  CapabilitiesType,
-			Output: CapabilitiesType,
-		},
-		EntitlementRelation{
-			Input:  StorageCapabilitiesType,
-			Output: StorageCapabilitiesType,
-		},
-		EntitlementRelation{
-			Input:  AccountCapabilitiesType,
-			Output: AccountCapabilitiesType,
-		},
-		EntitlementRelation{
-			Input:  GetStorageCapabilityControllerType,
-			Output: GetStorageCapabilityControllerType,
-		},
-		EntitlementRelation{
-			Input:  IssueStorageCapabilityControllerType,
-			Output: IssueStorageCapabilityControllerType,
-		},
-		EntitlementRelation{
-			Input:  GetAccountCapabilityControllerType,
-			Output: GetAccountCapabilityControllerType,
-		},
-		EntitlementRelation{
-			Input:  IssueAccountCapabilityControllerType,
-			Output: IssueAccountCapabilityControllerType,
-		},
 		EntitlementRelation{
 			Input:  StorageCapabilitiesType,
 			Output: GetStorageCapabilityControllerType,

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -1740,7 +1740,7 @@ func entitlementMapTypeLiteral(name string, elements []ast.EntitlementMapElement
 		relation, isRelation := element.(*ast.EntitlementMapRelation)
 		include, isInclude := element.(*ast.NominalType)
 		if !isRelation && !isInclude {
-			panic(fmt.Errorf("non-relation map element is not supported: %s", element))
+			panic(fmt.Errorf("invalid map element: expected relations or include, got '%s'", element))
 		}
 		if isInclude && include.Identifier.Identifier == "Identity" {
 			includesIdentity = true

--- a/runtime/sema/gen/testdata/entitlement.cdc
+++ b/runtime/sema/gen/testdata/entitlement.cdc
@@ -5,3 +5,8 @@ entitlement Bar
 entitlement mapping Baz {
     Foo -> Bar
 }
+
+entitlement mapping Qux {
+    include Identity
+    Foo -> Bar
+}

--- a/runtime/sema/gen/testdata/entitlement.golden.go
+++ b/runtime/sema/gen/testdata/entitlement.golden.go
@@ -28,7 +28,19 @@ var BarType = &EntitlementType{
 }
 
 var BazType = &EntitlementMapType{
-	Identifier: "Baz",
+	Identifier:       "Baz",
+	IncludesIdentity: false,
+	Relations: []EntitlementRelation{
+		EntitlementRelation{
+			Input:  FooType,
+			Output: BarType,
+		},
+	},
+}
+
+var QuxType = &EntitlementMapType{
+	Identifier:       "Qux",
+	IncludesIdentity: true,
 	Relations: []EntitlementRelation{
 		EntitlementRelation{
 			Input:  FooType,
@@ -40,6 +52,8 @@ var BazType = &EntitlementMapType{
 func init() {
 	BuiltinEntitlementMappings[BazType.Identifier] = BazType
 	addToBaseActivation(BazType)
+	BuiltinEntitlementMappings[QuxType.Identifier] = QuxType
+	addToBaseActivation(QuxType)
 	BuiltinEntitlements[FooType.Identifier] = FooType
 	addToBaseActivation(FooType)
 	BuiltinEntitlements[BarType.Identifier] = BarType


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2643

With the features introduced in https://github.com/onflow/cadence/pull/2743 we can now update these definitions to `include Identity` instead of manually specifying X -> X relations

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
