### PR TITLE
Introduce `String.join` function

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -402,10 +402,7 @@ func (v TypeValue) GetMember(interpreter *Interpreter, _ LocationRange, name str
 		if staticType != nil {
 			typeID = string(staticType.ID())
 		}
-		memoryUsage := common.MemoryUsage{
-			Kind:   common.MemoryKindStringValue,
-			Amount: uint64(len(typeID)),
-		}
+		memoryUsage := common.NewStringMemoryUsage(len(typeID))
 		return NewStringValue(interpreter, memoryUsage, func() string {
 			return typeID
 		})

--- a/runtime/interpreter/value_string.go
+++ b/runtime/interpreter/value_string.go
@@ -84,22 +84,14 @@ func stringFunctionFromCharacters(invocation Invocation) Value {
 
 	inter := invocation.Interpreter
 
-	common.UseMemory(inter,
-		common.MemoryUsage{
-			Kind:   common.MemoryKindStringValue,
-			Amount: 1,
-		},
-	)
+	// NewStringMemoryUsage already accounts for empty string.
+	common.UseMemory(inter, common.NewStringMemoryUsage(0))
 	var builder strings.Builder
 
 	argument.Iterate(inter, func(element Value) (resume bool) {
 		character := element.(CharacterValue)
-		common.UseMemory(inter,
-			common.MemoryUsage{
-				Kind:   common.MemoryKindStringValue,
-				Amount: uint64(len(character)),
-			},
-		)
+		// -1 to offset the double counting for empty string.
+		common.UseMemory(inter, common.NewStringMemoryUsage(len(character)-1))
 		builder.WriteString(string(character))
 
 		return true
@@ -135,24 +127,16 @@ func stringFunctionJoin(invocation Invocation) Value {
 		separator = StringTypeJoinDefaultSeparator
 	}
 
-	common.UseMemory(inter,
-		common.MemoryUsage{
-			Kind:   common.MemoryKindStringValue,
-			Amount: 1,
-		},
-	)
+	// NewStringMemoryUsage already accounts for empty string.
+	common.UseMemory(inter, common.NewStringMemoryUsage(0))
 	var builder strings.Builder
 	first := true
 
 	argument.Iterate(inter, func(element Value) (resume bool) {
 		// Add separator
 		if !first {
-			common.UseMemory(inter,
-				common.MemoryUsage{
-					Kind:   common.MemoryKindStringValue,
-					Amount: uint64(len(separator.Str)),
-				},
-			)
+			// -1 to offset the double counting for empty string.
+			common.UseMemory(inter, common.NewStringMemoryUsage(len(separator.Str)))
 			builder.WriteString(separator.Str)
 		}
 		first = false
@@ -162,12 +146,8 @@ func stringFunctionJoin(invocation Invocation) Value {
 			panic(errors.NewUnreachableError())
 		}
 
-		common.UseMemory(inter,
-			common.MemoryUsage{
-				Kind:   common.MemoryKindStringValue,
-				Amount: uint64(len(str.Str)),
-			},
-		)
+		// -1 to offset the double counting for empty string.
+		common.UseMemory(inter, common.NewStringMemoryUsage(len(str.Str)))
 		builder.WriteString(str.Str)
 
 		return true

--- a/runtime/interpreter/value_string.go
+++ b/runtime/interpreter/value_string.go
@@ -108,6 +108,8 @@ func stringFunctionFromCharacters(invocation Invocation) Value {
 	return NewUnmeteredStringValue(builder.String())
 }
 
+var StringTypeJoinDefaultSeparator = NewUnmeteredStringValue(",")
+
 func stringFunctionJoin(invocation Invocation) Value {
 	argument, ok := invocation.Arguments[0].(*ArrayValue)
 	if !ok {
@@ -116,6 +118,13 @@ func stringFunctionJoin(invocation Invocation) Value {
 
 	inter := invocation.Interpreter
 
+	switch argument.Count() {
+	case 0:
+		return EmptyString
+	case 1:
+		return argument.Get(inter, invocation.LocationRange, 0)
+	}
+
 	var separator *StringValue
 	if len(invocation.Arguments) > 1 {
 		separator, ok = invocation.Arguments[1].(*StringValue)
@@ -123,15 +132,7 @@ func stringFunctionJoin(invocation Invocation) Value {
 			panic(errors.NewUnreachableError())
 		}
 	} else {
-		separator = NewStringValue(
-			inter,
-			common.MemoryUsage{
-				Kind:   common.MemoryKindStringValue,
-				Amount: 1,
-			},
-			func() string {
-				return ","
-			})
+		separator = StringTypeJoinDefaultSeparator
 	}
 
 	common.UseMemory(inter,

--- a/runtime/interpreter/value_string.go
+++ b/runtime/interpreter/value_string.go
@@ -106,8 +106,6 @@ func stringFunctionFromCharacters(invocation Invocation) Value {
 	return NewUnmeteredStringValue(builder.String())
 }
 
-var StringTypeJoinDefaultSeparator = NewUnmeteredStringValue(",")
-
 func stringFunctionJoin(invocation Invocation) Value {
 	stringArray, ok := invocation.Arguments[0].(*ArrayValue)
 	if !ok {
@@ -123,14 +121,9 @@ func stringFunctionJoin(invocation Invocation) Value {
 		return stringArray.Get(inter, invocation.LocationRange, 0)
 	}
 
-	var separator *StringValue
-	if len(invocation.Arguments) > 1 {
-		separator, ok = invocation.Arguments[1].(*StringValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-	} else {
-		separator = StringTypeJoinDefaultSeparator
+	separator, ok := invocation.Arguments[1].(*StringValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
 	}
 
 	// NewStringMemoryUsage already accounts for empty string.

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -39,7 +39,8 @@ Returns a string from the given array of characters
 
 const StringTypeJoinFunctionName = "join"
 const StringTypeJoinFunctionDocString = `
-Returns a string after joining the array of strings with the given separator.
+Returns a string after joining the array of strings with the optional separator if provided.
+Uses ',' as the default separator when not provided.
 `
 
 // StringType represents the string type
@@ -321,7 +322,6 @@ var StringTypeJoinFunctionType = &FunctionType{
 			}),
 		},
 		{
-			Label:          ArgumentLabelNotRequired,
 			Identifier:     "separator",
 			TypeAnnotation: NewTypeAnnotation(StringType),
 		},

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -37,6 +37,11 @@ const StringTypeFromCharactersFunctionDocString = `
 Returns a string from the given array of characters
 `
 
+const StringTypeJoinFunctionName = "join"
+const StringTypeJoinFunctionDocString = `
+Returns a string after joining the array of strings with the given separator.
+`
+
 // StringType represents the string type
 var StringType = &SimpleType{
 	Name:          "String",
@@ -242,6 +247,13 @@ var StringFunctionType = func() *FunctionType {
 		StringTypeFromCharactersFunctionDocString,
 	))
 
+	addMember(NewUnmeteredPublicFunctionMember(
+		functionType,
+		StringTypeJoinFunctionName,
+		StringTypeJoinFunctionType,
+		StringTypeJoinFunctionDocString,
+	))
+
 	BaseValueActivation.Set(
 		typeName,
 		baseFunctionVariable(
@@ -297,4 +309,24 @@ var StringTypeFromCharactersFunctionType = &FunctionType{
 	ReturnTypeAnnotation: NewTypeAnnotation(
 		StringType,
 	),
+}
+
+var StringTypeJoinFunctionType = &FunctionType{
+	Parameters: []Parameter{
+		{
+			Label:      ArgumentLabelNotRequired,
+			Identifier: "strs",
+			TypeAnnotation: NewTypeAnnotation(&VariableSizedType{
+				Type: StringType,
+			}),
+		},
+		{
+			Label:          ArgumentLabelNotRequired,
+			Identifier:     "separator",
+			TypeAnnotation: NewTypeAnnotation(StringType),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(StringType),
+	// separator is optional
+	Arity: &Arity{Min: 1, Max: 2},
 }

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -39,8 +39,7 @@ Returns a string from the given array of characters
 
 const StringTypeJoinFunctionName = "join"
 const StringTypeJoinFunctionDocString = `
-Returns a string after joining the array of strings with the optional separator if provided.
-Uses ',' as the default separator when not provided.
+Returns a string after joining the array of strings with the provided separator.
 `
 
 // StringType represents the string type
@@ -327,6 +326,5 @@ var StringTypeJoinFunctionType = &FunctionType{
 		},
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(StringType),
-	// separator is optional
-	Arity: &Arity{Min: 1, Max: 2},
+	Arity:                &Arity{Min: 2, Max: 2},
 }

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -326,5 +326,4 @@ var StringTypeJoinFunctionType = &FunctionType{
 		},
 	},
 	ReturnTypeAnnotation: NewTypeAnnotation(StringType),
-	Arity:                &Arity{Min: 2, Max: 2},
 }

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -361,7 +361,7 @@ func TestCheckStringJoin(t *testing.T) {
 
 	checker, err := ParseAndCheck(t, `
 		let s_default_sep = String.join(["👪", "❤️", "Abc"])
-		let s = String.join(["👪", "❤️", "Abc"], "/")
+		let s = String.join(["👪", "❤️", "Abc"], separator: "/")
 	`)
 	require.NoError(t, err)
 
@@ -381,7 +381,7 @@ func TestCheckStringJoinTypeMismatchStrs(t *testing.T) {
 	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
-		let s = String.join([1], "/")
+		let s = String.join([1], separator: "/")
 	`)
 
 	errs := RequireCheckerErrors(t, err, 1)
@@ -394,10 +394,23 @@ func TestCheckStringJoinTypeMismatchSeparator(t *testing.T) {
 	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
-		let s = String.join(["Abc", "1"], 1234)
+		let s = String.join(["Abc", "1"], separator: 1234)
 	`)
 
 	errs := RequireCheckerErrors(t, err, 1)
 
 	assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+}
+
+func TestCheckStringJoinTypeMissingArgumentLabelSeparator(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+	let s = String.join(["👪", "❤️", "Abc"], "/")
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[0])
 }

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -360,15 +360,9 @@ func TestCheckStringJoin(t *testing.T) {
 	t.Parallel()
 
 	checker, err := ParseAndCheck(t, `
-		let s_default_sep = String.join(["👪", "❤️", "Abc"])
 		let s = String.join(["👪", "❤️", "Abc"], separator: "/")
 	`)
 	require.NoError(t, err)
-
-	assert.Equal(t,
-		sema.StringType,
-		RequireGlobalValue(t, checker.Elaboration, "s_default_sep"),
-	)
 
 	assert.Equal(t,
 		sema.StringType,

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -354,3 +354,50 @@ func TestCheckStringToLower(t *testing.T) {
 		RequireGlobalValue(t, checker.Elaboration, "x"),
 	)
 }
+
+func TestCheckStringJoin(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+		let s_default_sep = String.join(["👪", "❤️", "Abc"])
+		let s = String.join(["👪", "❤️", "Abc"], "/")
+	`)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		sema.StringType,
+		RequireGlobalValue(t, checker.Elaboration, "s_default_sep"),
+	)
+
+	assert.Equal(t,
+		sema.StringType,
+		RequireGlobalValue(t, checker.Elaboration, "s"),
+	)
+}
+
+func TestCheckStringJoinTypeMismatchStrs(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		let s = String.join([1], "/")
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+}
+
+func TestCheckStringJoinTypeMismatchSeparator(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		let s = String.join(["Abc", "1"], 1234)
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+}

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -473,15 +473,15 @@ func TestInterpretStringJoin(t *testing.T) {
 		}
 
 		fun test(): String {
-			return String.join(["👪", "❤️"], "//")
+			return String.join(["👪", "❤️"], separator: "//")
 		}
 
 		fun testEmptyArray(): String {
-			return String.join([], "//")
+			return String.join([], separator: "//")
 		}
 
 		fun testSingletonArray(): String {
-			return String.join(["pqrS"], "//")
+			return String.join(["pqrS"], separator: "//")
 		}
 	`)
 

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -462,3 +462,45 @@ func TestInterpretCompareCharacters(t *testing.T) {
 		inter.Globals.Get("z").GetValue(),
 	)
 }
+
+func TestInterpretStringJoin(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+		fun testDefaultSeparator(): String {
+			return String.join(["👪", "❤️"])
+		}
+
+		fun test(): String {
+			return String.join(["👪", "❤️"], "//")
+		}
+
+		fun testEmptyArray(): String {
+			return String.join([], "//")
+		}
+
+		fun testSingletonArray(): String {
+			return String.join(["pqrS"], "//")
+		}
+	`)
+
+	testCase := func(t *testing.T, funcName string, expected *interpreter.StringValue) {
+		t.Run(funcName, func(t *testing.T) {
+			result, err := inter.Invoke(funcName)
+			require.NoError(t, err)
+
+			RequireValuesEqual(
+				t,
+				inter,
+				expected,
+				result,
+			)
+		})
+	}
+
+	testCase(t, "testDefaultSeparator", interpreter.NewUnmeteredStringValue("👪,❤️"))
+	testCase(t, "test", interpreter.NewUnmeteredStringValue("👪//❤️"))
+	testCase(t, "testEmptyArray", interpreter.NewUnmeteredStringValue(""))
+	testCase(t, "testSingletonArray", interpreter.NewUnmeteredStringValue("pqrS"))
+}

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -468,10 +468,6 @@ func TestInterpretStringJoin(t *testing.T) {
 	t.Parallel()
 
 	inter := parseCheckAndInterpret(t, `
-		fun testDefaultSeparator(): String {
-			return String.join(["👪", "❤️"])
-		}
-
 		fun test(): String {
 			return String.join(["👪", "❤️"], separator: "//")
 		}
@@ -499,7 +495,6 @@ func TestInterpretStringJoin(t *testing.T) {
 		})
 	}
 
-	testCase(t, "testDefaultSeparator", interpreter.NewUnmeteredStringValue("👪,❤️"))
 	testCase(t, "test", interpreter.NewUnmeteredStringValue("👪//❤️"))
 	testCase(t, "testEmptyArray", interpreter.NewUnmeteredStringValue(""))
 	testCase(t, "testSingletonArray", interpreter.NewUnmeteredStringValue("pqrS"))


### PR DESCRIPTION
Work towards #2752

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Adds `join(_ strs: [String], _ separator: String): String` function to Cadence. The function returns a string value after concatenating elements of the provided array of string with the given separator.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
