### PR TITLE
Add functions on testing framework's blockchain to create/load snapshots

### DIFF
--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -138,8 +138,9 @@ pub contract Test {
         /// Creates a snapshot of the blockchain, at the
         /// current ledger state, with the given name.
         ///
-        pub fun createSnapshot(_ name: String) {
-            let err = self.backend.createSnapshot(name)
+        access(all)
+        fun createSnapshot(name: String) {
+            let err = self.backend.createSnapshot(name: name)
             if err != nil {
                 panic(err!.message)
             }
@@ -149,8 +150,9 @@ pub contract Test {
         /// given name, and updates the current ledger
         /// state.
         ///
-        pub fun loadSnapshot(_ name: String) {
-            let err = self.backend.loadSnapshot(name)
+        access(all)
+        fun loadSnapshot(name: String) {
+            let err = self.backend.loadSnapshot(name: name)
             if err != nil {
                 panic(err!.message)
             }
@@ -349,13 +351,15 @@ pub contract Test {
         /// Creates a snapshot of the blockchain, at the
         /// current ledger state, with the given name.
         ///
-        pub fun createSnapshot(_ name: String): Error?
+        access(all)
+        fun createSnapshot(name: String): Error?
 
         /// Loads a snapshot of the blockchain, with the
         /// given name, and updates the current ledger
         /// state.
         ///
-        pub fun loadSnapshot(_ name: String): Error?
+        access(all)
+        fun loadSnapshot(name: String): Error?
     }
 
     /// Returns a new matcher that negates the test of the given matcher.

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -134,6 +134,27 @@ pub contract Test {
         pub fun moveTime(by delta: Fix64) {
             self.backend.moveTime(by: delta)
         }
+
+        /// Creates a snapshot of the blockchain, at the
+        /// current ledger state, with the given name.
+        ///
+        pub fun createSnapshot(_ name: String) {
+            let err = self.backend.createSnapshot(name)
+            if err != nil {
+                panic(err!.message)
+            }
+        }
+
+        /// Loads a snapshot of the blockchain, with the
+        /// given name, and updates the current ledger
+        /// state.
+        ///
+        pub fun loadSnapshot(_ name: String) {
+            let err = self.backend.loadSnapshot(name)
+            if err != nil {
+                panic(err!.message)
+            }
+        }
     }
 
     pub struct Matcher {
@@ -324,6 +345,17 @@ pub contract Test {
         /// which should be passed in the form of seconds.
         ///
         pub fun moveTime(by delta: Fix64)
+
+        /// Creates a snapshot of the blockchain, at the
+        /// current ledger state, with the given name.
+        ///
+        pub fun createSnapshot(_ name: String): Error?
+
+        /// Loads a snapshot of the blockchain, with the
+        /// given name, and updates the current ledger
+        /// state.
+        ///
+        pub fun loadSnapshot(_ name: String): Error?
     }
 
     /// Returns a new matcher that negates the test of the given matcher.

--- a/runtime/stdlib/test-framework.go
+++ b/runtime/stdlib/test-framework.go
@@ -79,6 +79,10 @@ type Blockchain interface {
 	Reset(uint64)
 
 	MoveTime(int64)
+
+	CreateSnapshot(string) error
+
+	LoadSnapshot(string) error
 }
 
 type ScriptResult struct {

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -20,6 +20,7 @@ package stdlib
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -2339,6 +2340,162 @@ func TestBlockchain(t *testing.T) {
 		assert.True(t, newEmulatorBackendInvoked)
 	})
 
+	t.Run("createSnapshot", func(t *testing.T) {
+		t.Parallel()
+
+		const script = `
+            import Test
+
+            pub fun test() {
+                let blockchain = Test.newEmulatorBlockchain()
+                blockchain.createSnapshot("adminCreated")
+            }
+		`
+
+		createSnapshotInvoked := false
+
+		testFramework := &mockedTestFramework{
+			newEmulatorBackend: func() Blockchain {
+				return &mockedBlockchain{
+					createSnapshot: func(name string) error {
+						createSnapshotInvoked = true
+						assert.Equal(t, "adminCreated", name)
+
+						return nil
+					},
+				}
+			},
+		}
+
+		inter, err := newTestContractInterpreterWithTestFramework(t, script, testFramework)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.NoError(t, err)
+
+		assert.True(t, createSnapshotInvoked)
+	})
+
+	t.Run("createSnapshot failure", func(t *testing.T) {
+		t.Parallel()
+
+		const script = `
+            import Test
+
+            pub fun test() {
+                let blockchain = Test.newEmulatorBlockchain()
+                blockchain.createSnapshot("adminCreated")
+            }
+		`
+
+		createSnapshotInvoked := false
+
+		testFramework := &mockedTestFramework{
+			newEmulatorBackend: func() Blockchain {
+				return &mockedBlockchain{
+					createSnapshot: func(name string) error {
+						createSnapshotInvoked = true
+						assert.Equal(t, "adminCreated", name)
+
+						return fmt.Errorf("failed to create snapshot: %s", name)
+					},
+				}
+			},
+		}
+
+		inter, err := newTestContractInterpreterWithTestFramework(t, script, testFramework)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.ErrorContains(t, err, "panic: failed to create snapshot: adminCreated")
+
+		assert.True(t, createSnapshotInvoked)
+	})
+
+	t.Run("loadSnapshot", func(t *testing.T) {
+		t.Parallel()
+
+		const script = `
+            import Test
+
+            pub fun test() {
+                let blockchain = Test.newEmulatorBlockchain()
+                blockchain.createSnapshot("adminCreated")
+				blockchain.loadSnapshot("adminCreated")
+            }
+		`
+
+		loadSnapshotInvoked := false
+
+		testFramework := &mockedTestFramework{
+			newEmulatorBackend: func() Blockchain {
+				return &mockedBlockchain{
+					createSnapshot: func(name string) error {
+						assert.Equal(t, "adminCreated", name)
+
+						return nil
+					},
+					loadSnapshot: func(name string) error {
+						loadSnapshotInvoked = true
+						assert.Equal(t, "adminCreated", name)
+
+						return nil
+					},
+				}
+			},
+		}
+
+		inter, err := newTestContractInterpreterWithTestFramework(t, script, testFramework)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.NoError(t, err)
+
+		assert.True(t, loadSnapshotInvoked)
+	})
+
+	t.Run("loadSnapshot failure", func(t *testing.T) {
+		t.Parallel()
+
+		const script = `
+            import Test
+
+            pub fun test() {
+                let blockchain = Test.newEmulatorBlockchain()
+                blockchain.createSnapshot("adminCreated")
+				blockchain.loadSnapshot("contractDeployed")
+            }
+		`
+
+		loadSnapshotInvoked := false
+
+		testFramework := &mockedTestFramework{
+			newEmulatorBackend: func() Blockchain {
+				return &mockedBlockchain{
+					createSnapshot: func(name string) error {
+						assert.Equal(t, "adminCreated", name)
+
+						return nil
+					},
+					loadSnapshot: func(name string) error {
+						loadSnapshotInvoked = true
+						assert.Equal(t, "contractDeployed", name)
+
+						return fmt.Errorf("failed to create snapshot: %s", name)
+					},
+				}
+			},
+		}
+
+		inter, err := newTestContractInterpreterWithTestFramework(t, script, testFramework)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.ErrorContains(t, err, "panic: failed to create snapshot: contractDeployed")
+
+		assert.True(t, loadSnapshotInvoked)
+	})
+
 	// TODO: Add more tests for the remaining functions.
 }
 
@@ -2379,6 +2536,8 @@ type mockedBlockchain struct {
 	events             func(inter *interpreter.Interpreter, eventType interpreter.StaticType) interpreter.Value
 	reset              func(uint64)
 	moveTime           func(int64)
+	createSnapshot     func(string) error
+	loadSnapshot       func(string) error
 }
 
 var _ Blockchain = &mockedBlockchain{}
@@ -2504,4 +2663,20 @@ func (m mockedBlockchain) MoveTime(timeDelta int64) {
 	}
 
 	m.moveTime(timeDelta)
+}
+
+func (m mockedBlockchain) CreateSnapshot(name string) error {
+	if m.createSnapshot == nil {
+		panic("'CreateSnapshot' is not implemented")
+	}
+
+	return m.createSnapshot(name)
+}
+
+func (m mockedBlockchain) LoadSnapshot(name string) error {
+	if m.loadSnapshot == nil {
+		panic("'LoadSnapshot' is not implemented")
+	}
+
+	return m.loadSnapshot(name)
 }

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -2348,7 +2348,7 @@ func TestBlockchain(t *testing.T) {
 
             pub fun test() {
                 let blockchain = Test.newEmulatorBlockchain()
-                blockchain.createSnapshot("adminCreated")
+                blockchain.createSnapshot(name: "adminCreated")
             }
 		`
 
@@ -2384,7 +2384,7 @@ func TestBlockchain(t *testing.T) {
 
             pub fun test() {
                 let blockchain = Test.newEmulatorBlockchain()
-                blockchain.createSnapshot("adminCreated")
+                blockchain.createSnapshot(name: "adminCreated")
             }
 		`
 
@@ -2420,8 +2420,8 @@ func TestBlockchain(t *testing.T) {
 
             pub fun test() {
                 let blockchain = Test.newEmulatorBlockchain()
-                blockchain.createSnapshot("adminCreated")
-				blockchain.loadSnapshot("adminCreated")
+                blockchain.createSnapshot(name: "adminCreated")
+                blockchain.loadSnapshot(name: "adminCreated")
             }
 		`
 
@@ -2462,8 +2462,8 @@ func TestBlockchain(t *testing.T) {
 
             pub fun test() {
                 let blockchain = Test.newEmulatorBlockchain()
-                blockchain.createSnapshot("adminCreated")
-				blockchain.loadSnapshot("contractDeployed")
+                blockchain.createSnapshot(name: "adminCreated")
+                blockchain.loadSnapshot(name: "contractDeployed")
             }
 		`
 


### PR DESCRIPTION
## Description

Allow developers to create snapshots of the blockchain's current ledge state, and load them on demand at any time. For example:

```cadence
import Test
import BlockchainHelpers

pub let blockchain = Test.newEmulatorBlockchain()
pub let helpers = BlockchainHelpers(blockchain: blockchain)

pub fun test() {
    let admin = blockchain.createAccount()
    blockchain.createSnapshot("adminCreated")

    helpers.mintFlow(to: admin, amount: 1000.0)
    blockchain.createSnapshot("adminFunded")

    var balance = helpers.getFlowBalance(for: admin)
    Test.assertEqual(1000.0, balance)

    blockchain.loadSnapshot("adminCreated")
            
    balance = helpers.getFlowBalance(for: admin)
    Test.assertEqual(0.0, balance)

    blockchain.loadSnapshot("adminFunded")
            
    balance = helpers.getFlowBalance(for: admin)
    Test.assertEqual(1000.0, balance)
}
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
