### PR TITLE
Better error messages for use of old restricted types

### DIFF
--- a/runtime/parser/type.go
+++ b/runtime/parser/type.go
@@ -481,7 +481,7 @@ func defineIntersectionOrDictionaryType() {
 
 	// While restricted types have been removed from Cadence, during the first few months of the
 	// migration period, leave a special error in place to help developers
-
+	// TODO: remove this after Stable Cadence migration period is finished
 	setTypeMetaLeftDenotation(
 		lexer.TokenBraceOpen,
 		func(p *parser, rightBindingPower int, left ast.Type) (result ast.Type, err error, done bool) {

--- a/runtime/parser/type.go
+++ b/runtime/parser/type.go
@@ -503,8 +503,7 @@ func defineIntersectionOrDictionaryType() {
 				return left, nil, true
 			}
 
-			// It was determined that a restricted type is parsed, so error
-			return nil, p.syntaxError("restricted types have been removed; replace with an intersection type"), true
+			return nil, p.syntaxError("restricted types have been removed; replace with the concrete type or an equivalent intersection type"), true
 		},
 	)
 }

--- a/runtime/parser/type.go
+++ b/runtime/parser/type.go
@@ -80,6 +80,17 @@ func setTypeLeftDenotation(tokenType lexer.TokenType, leftDenotation typeLeftDen
 	typeLeftDenotations[tokenType] = leftDenotation
 }
 
+func setTypeMetaLeftDenotation(tokenType lexer.TokenType, metaLeftDenotation typeMetaLeftDenotationFunc) {
+	current := typeMetaLeftDenotations[tokenType]
+	if current != nil {
+		panic(errors.NewUnexpectedError(
+			"type meta left denotation for token %s already exists",
+			tokenType,
+		))
+	}
+	typeMetaLeftDenotations[tokenType] = metaLeftDenotation
+}
+
 type prefixTypeFunc func(parser *parser, right ast.Type, tokenRange ast.Range) ast.Type
 type postfixTypeFunc func(parser *parser, left ast.Type, tokenRange ast.Range) ast.Type
 
@@ -465,6 +476,35 @@ func defineIntersectionOrDictionaryType() {
 				}
 				return intersectionType, nil
 			}
+		},
+	)
+
+	// While restricted types have been removed from Cadence, during the first few months of the
+	// migration period, leave a special error in place to help developers
+
+	setTypeMetaLeftDenotation(
+		lexer.TokenBraceOpen,
+		func(p *parser, rightBindingPower int, left ast.Type) (result ast.Type, err error, done bool) {
+
+			// Perform a lookahead
+
+			current := p.current
+			cursor := p.tokens.Cursor()
+
+			// Skip the `{` token.
+			p.next()
+
+			// In case there is a space, the type is *not* considered a restricted type.
+			// The buffered tokens are replayed to allow them to be re-parsed.
+			if p.current.Is(lexer.TokenSpace) {
+				p.current = current
+				p.tokens.Revert(cursor)
+
+				return left, nil, true
+			}
+
+			// It was determined that a restricted type is parsed, so error
+			return nil, p.syntaxError("restricted types have been removed; replace with an intersection type"), true
 		},
 	)
 }

--- a/runtime/parser/type_test.go
+++ b/runtime/parser/type_test.go
@@ -516,7 +516,7 @@ func TestParseIntersectionType(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "restricted types have been removed; replace with an intersection type",
+					Message: "restricted types have been removed; replace with the concrete type or an equivalent intersection type",
 					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
 				},
 			},
@@ -532,7 +532,7 @@ func TestParseIntersectionType(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "restricted types have been removed; replace with an intersection type",
+					Message: "restricted types have been removed; replace with the concrete type or an equivalent intersection type",
 					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
 				},
 			},
@@ -548,7 +548,7 @@ func TestParseIntersectionType(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "restricted types have been removed; replace with an intersection type",
+					Message: "restricted types have been removed; replace with the concrete type or an equivalent intersection type",
 					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
 				},
 			},

--- a/runtime/parser/type_test.go
+++ b/runtime/parser/type_test.go
@@ -516,8 +516,8 @@ func TestParseIntersectionType(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "unexpected token: '{'",
-					Pos:     ast.Position{Offset: 1, Line: 1, Column: 1},
+					Message: "restricted types have been removed; replace with an intersection type",
+					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
 				},
 			},
 			errs,
@@ -532,8 +532,8 @@ func TestParseIntersectionType(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "unexpected token: '{'",
-					Pos:     ast.Position{Offset: 1, Line: 1, Column: 1},
+					Message: "restricted types have been removed; replace with an intersection type",
+					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
 				},
 			},
 			errs,
@@ -548,8 +548,8 @@ func TestParseIntersectionType(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "unexpected token: '{'",
-					Pos:     ast.Position{Offset: 1, Line: 1, Column: 1},
+					Message: "restricted types have been removed; replace with an intersection type",
+					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
 				},
 			},
 			errs,


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2759

Restricted types have been removed, but parsing old code that uses them results in a confusing error. Add special handling for this case for now. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
