### PR TITLE
Add `tryUpdate` method to `Account.Contracts`

### DIFF
--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -26,8 +26,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/cadence/runtime/tests/checker"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 
 	"github.com/onflow/cadence"
@@ -1013,4 +1016,290 @@ func TestRuntimeContractInterfaceConditionEventEmission(t *testing.T) {
 	require.Equal(t, intfEvent.Fields[0], cadence.NewInt(3))
 	require.Equal(t, concreteEvent.Fields[0], cadence.String(""))
 	require.Equal(t, concreteEvent.Fields[1], cadence.NewInt(2))
+}
+
+func TestRuntimeContractTryUpdate(t *testing.T) {
+	t.Parallel()
+
+	newTestRuntimeInterface := func(onUpdate func()) *testRuntimeInterface {
+		var actualEvents []cadence.Event
+		storage := newTestLedger(nil, nil)
+		accountCodes := map[Location][]byte{}
+
+		return &testRuntimeInterface{
+			storage: storage,
+			log:     func(message string) {},
+			emitEvent: func(event cadence.Event) error {
+				actualEvents = append(actualEvents, event)
+				return nil
+			},
+			resolveLocation: singleIdentifierLocationResolver(t),
+			getSigningAccounts: func() ([]Address, error) {
+				return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
+			},
+			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+				onUpdate()
+				accountCodes[location] = code
+				return nil
+			},
+			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+				code = accountCodes[location]
+				return code, nil
+			},
+		}
+	}
+
+	t.Run("tryUpdate simple", func(t *testing.T) {
+
+		t.Parallel()
+
+		rt := newTestInterpreterRuntime()
+
+		deployTx := DeploymentTransaction("Foo", []byte(`access(all) contract Foo {}`))
+
+		updateTx := []byte(`
+			transaction {
+				prepare(signer: auth(UpdateContract) &Account) {
+					signer.contracts.tryUpdate(
+						name: "Foo",
+						code: "access(all) contract Foo { access(all) fun sayHello(): String {return \"hello\"} }".utf8,
+					)
+				}
+			}
+		`)
+
+		invokeTx := []byte(`
+			import Foo from 0x1
+
+			transaction {
+				prepare(signer: &Account) {
+					assert(Foo.sayHello() == "hello")
+				}
+			}
+		`)
+
+		runtimeInterface := newTestRuntimeInterface(func() {})
+		nextTransactionLocation := newTransactionLocationGenerator()
+
+		// Deploy 'Foo'
+		err := rt.ExecuteTransaction(
+			Script{
+				Source: deployTx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+
+		// Update 'Foo'
+		err = rt.ExecuteTransaction(
+			Script{
+				Source: updateTx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+
+		// Test the updated 'Foo'
+		err = rt.ExecuteTransaction(
+			Script{
+				Source: invokeTx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("tryUpdate non existing", func(t *testing.T) {
+
+		t.Parallel()
+
+		rt := newTestInterpreterRuntime()
+
+		updateTx := []byte(`
+			transaction {
+				prepare(signer: auth(UpdateContract) &Account) {
+					let deploymentResult = signer.contracts.tryUpdate(
+						name: "Foo",
+						code: "access(all) contract Foo { access(all) fun sayHello(): String {return \"hello\"} }".utf8,
+					)
+
+					assert(deploymentResult.deployedContract == nil)
+				}
+			}
+		`)
+
+		invokeTx := []byte(`
+			import Foo from 0x1
+
+			transaction {
+				prepare(signer: &Account) {
+					assert(Foo.sayHello() == "hello")
+				}
+			}
+		`)
+
+		runtimeInterface := newTestRuntimeInterface(func() {})
+		nextTransactionLocation := newTransactionLocationGenerator()
+
+		// Update non-existing 'Foo'. Should not panic.
+		err := rt.ExecuteTransaction(
+			Script{
+				Source: updateTx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+
+		// Test the updated 'Foo'.
+		// Foo must not be available.
+
+		err = rt.ExecuteTransaction(
+			Script{
+				Source: invokeTx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		RequireError(t, err)
+
+		errs := checker.RequireCheckerErrors(t, err, 1)
+		var notExportedError *sema.NotExportedError
+		require.ErrorAs(t, errs[0], &notExportedError)
+	})
+
+	t.Run("tryUpdate with checking error", func(t *testing.T) {
+
+		t.Parallel()
+
+		rt := newTestInterpreterRuntime()
+
+		deployTx := DeploymentTransaction("Foo", []byte(`access(all) contract Foo {}`))
+
+		updateTx := []byte(`
+			transaction {
+				prepare(signer: auth(UpdateContract) &Account) {
+					let deploymentResult = signer.contracts.tryUpdate(
+						name: "Foo",
+
+						// Has a semantic error!
+						code: "access(all) contract Foo { access(all) fun sayHello(): Int { return \"hello\" } }".utf8,
+					)
+
+					assert(deploymentResult.deployedContract == nil)
+				}
+			}
+		`)
+
+		runtimeInterface := newTestRuntimeInterface(func() {})
+
+		nextTransactionLocation := newTransactionLocationGenerator()
+
+		// Deploy 'Foo'
+		err := rt.ExecuteTransaction(
+			Script{
+				Source: deployTx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+
+		// Update 'Foo'.
+		// User errors (parsing, checking and interpreting) should be handled gracefully.
+
+		err = rt.ExecuteTransaction(
+			Script{
+				Source: updateTx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("tryUpdate panic with internal error", func(t *testing.T) {
+
+		t.Parallel()
+
+		rt := newTestInterpreterRuntime()
+
+		deployTx := DeploymentTransaction("Foo", []byte(`access(all) contract Foo {}`))
+
+		updateTx := []byte(`
+			transaction {
+				prepare(signer: auth(UpdateContract) &Account) {
+					let deploymentResult = signer.contracts.tryUpdate(
+						name: "Foo",
+						code: "access(all) contract Foo { access(all) fun sayHello(): String {return \"hello\"} }".utf8,
+					)
+
+					assert(deploymentResult.deployedContract == nil)
+				}
+			}
+		`)
+
+		shouldPanic := false
+		didPanic := false
+
+		runtimeInterface := newTestRuntimeInterface(func() {
+			if shouldPanic {
+				didPanic = true
+				panic("panic during update")
+			}
+		})
+
+		nextTransactionLocation := newTransactionLocationGenerator()
+
+		// Deploy 'Foo'
+		err := rt.ExecuteTransaction(
+			Script{
+				Source: deployTx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+		assert.False(t, didPanic)
+
+		// Update 'Foo'.
+		// Internal errors should NOT be handled gracefully.
+
+		shouldPanic = true
+		err = rt.ExecuteTransaction(
+			Script{
+				Source: updateTx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+
+		RequireError(t, err)
+		var unexpectedError errors.UnexpectedError
+		require.ErrorAs(t, err, &unexpectedError)
+
+		assert.True(t, didPanic)
+	})
 }

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -1060,10 +1060,17 @@ func TestRuntimeContractTryUpdate(t *testing.T) {
 		updateTx := []byte(`
 			transaction {
 				prepare(signer: auth(UpdateContract) &Account) {
-					signer.contracts.tryUpdate(
+					let code = "access(all) contract Foo { access(all) fun sayHello(): String {return \"hello\"} }".utf8
+
+					let deploymentResult = signer.contracts.tryUpdate(
 						name: "Foo",
-						code: "access(all) contract Foo { access(all) fun sayHello(): String {return \"hello\"} }".utf8,
+						code: code,
 					)
+
+					let deployedContract = deploymentResult.deployedContract!
+					assert(deployedContract.name == "Foo")
+					assert(deployedContract.address == 0x1)
+					assert(deployedContract.code == code)
 				}
 			}
 		`)

--- a/runtime/interpreter/value_account_contracts.go
+++ b/runtime/interpreter/value_account_contracts.go
@@ -38,6 +38,7 @@ func NewAccountContractsValue(
 	address AddressValue,
 	addFunction FunctionValue,
 	updateFunction FunctionValue,
+	tryUpdateFunction FunctionValue,
 	getFunction FunctionValue,
 	borrowFunction FunctionValue,
 	removeFunction FunctionValue,
@@ -45,11 +46,12 @@ func NewAccountContractsValue(
 ) Value {
 
 	fields := map[string]Value{
-		sema.Account_ContractsTypeAddFunctionName:    addFunction,
-		sema.Account_ContractsTypeGetFunctionName:    getFunction,
-		sema.Account_ContractsTypeBorrowFunctionName: borrowFunction,
-		sema.Account_ContractsTypeRemoveFunctionName: removeFunction,
-		sema.Account_ContractsTypeUpdateFunctionName: updateFunction,
+		sema.Account_ContractsTypeAddFunctionName:       addFunction,
+		sema.Account_ContractsTypeGetFunctionName:       getFunction,
+		sema.Account_ContractsTypeBorrowFunctionName:    borrowFunction,
+		sema.Account_ContractsTypeRemoveFunctionName:    removeFunction,
+		sema.Account_ContractsTypeUpdateFunctionName:    updateFunction,
+		sema.Account_ContractsTypeTryUpdateFunctionName: tryUpdateFunction,
 	}
 
 	computeField := func(

--- a/runtime/interpreter/value_deployment_result.go
+++ b/runtime/interpreter/value_deployment_result.go
@@ -31,7 +31,7 @@ var deploymentResultFieldNames []string = nil
 
 func NewDeploymentResultValue(
 	gauge common.MemoryGauge,
-	deployedContract Value,
+	deployedContract OptionalValue,
 ) Value {
 
 	return NewSimpleCompositeValue(

--- a/runtime/interpreter/value_deployment_result.go
+++ b/runtime/interpreter/value_deployment_result.go
@@ -1,0 +1,49 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+// DeploymentResult
+
+var deploymentResultTypeID = sema.DeploymentResultType.ID()
+var deploymentResultStaticType = ConvertSemaToStaticType(nil, sema.DeploymentResultType) // unmetered
+var deploymentResultFieldNames []string = nil
+
+func NewDeploymentResultValue(
+	gauge common.MemoryGauge,
+	deployedContract Value,
+) Value {
+
+	return NewSimpleCompositeValue(
+		gauge,
+		deploymentResultTypeID,
+		deploymentResultStaticType,
+		deploymentResultFieldNames,
+		map[string]Value{
+			sema.DeploymentResultTypeDeployedContractFieldName: deployedContract,
+		},
+		nil,
+		nil,
+		nil,
+	)
+}

--- a/runtime/sema/account.cdc
+++ b/runtime/sema/account.cdc
@@ -205,6 +205,26 @@ struct Account {
         access(Contracts | UpdateContract)
         fun update(name: String, code: [UInt8]): DeployedContract
 
+        /// Updates the code for the contract/contract interface in the account,
+        /// and handle any deployment errors gracefully.
+        ///
+        /// The `code` parameter is the UTF-8 encoded representation of the source code.
+        /// The code must contain exactly one contract or contract interface,
+        /// which must have the same name as the `name` parameter.
+        ///
+        /// Does **not** run the initializer of the contract/contract interface again.
+        /// The contract instance in the world state stays as is.
+        ///
+        /// Fails if no contract/contract interface with the given name exists in the account,
+        /// if the given code does not declare exactly one contract or contract interface,
+        /// or if the given name does not match the name of the contract/contract interface declaration in the code.
+        ///
+        /// Returns the deployment result.
+        /// Result would contain the deployed contract for the updated contract, if the update was successfull.
+        /// Otherwise, the deployed contract would be nil.
+        access(Contracts | UpdateContract)
+        fun tryUpdate(name: String, code: [UInt8]): DeploymentResult
+
         /// Returns the deployed contract for the contract/contract interface with the given name in the account, if any.
         ///
         /// Returns nil if no contract/contract interface with the given name exists in the account.

--- a/runtime/sema/account.gen.go
+++ b/runtime/sema/account.gen.go
@@ -641,6 +641,46 @@ or if the given name does not match the name of the contract/contract interface 
 Returns the deployed contract for the updated contract.
 `
 
+const Account_ContractsTypeTryUpdateFunctionName = "tryUpdate"
+
+var Account_ContractsTypeTryUpdateFunctionType = &FunctionType{
+	Parameters: []Parameter{
+		{
+			Identifier:     "name",
+			TypeAnnotation: NewTypeAnnotation(StringType),
+		},
+		{
+			Identifier: "code",
+			TypeAnnotation: NewTypeAnnotation(&VariableSizedType{
+				Type: UInt8Type,
+			}),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		DeploymentResultType,
+	),
+}
+
+const Account_ContractsTypeTryUpdateFunctionDocString = `
+Updates the code for the contract/contract interface in the account,
+and handle any deployment errors gracefully.
+
+The ` + "`code`" + ` parameter is the UTF-8 encoded representation of the source code.
+The code must contain exactly one contract or contract interface,
+which must have the same name as the ` + "`name`" + ` parameter.
+
+Does **not** run the initializer of the contract/contract interface again.
+The contract instance in the world state stays as is.
+
+Fails if no contract/contract interface with the given name exists in the account,
+if the given code does not declare exactly one contract or contract interface,
+or if the given name does not match the name of the contract/contract interface declaration in the code.
+
+Returns the deployment result.
+Result would contain the deployed contract for the updated contract, if the update was successfull.
+Otherwise, the deployed contract would be nil.
+`
+
 const Account_ContractsTypeGetFunctionName = "get"
 
 var Account_ContractsTypeGetFunctionType = &FunctionType{
@@ -767,6 +807,16 @@ func init() {
 			Account_ContractsTypeUpdateFunctionName,
 			Account_ContractsTypeUpdateFunctionType,
 			Account_ContractsTypeUpdateFunctionDocString,
+		),
+		NewUnmeteredFunctionMember(
+			Account_ContractsType,
+			newEntitlementAccess(
+				[]Type{ContractsType, UpdateContractType},
+				Disjunction,
+			),
+			Account_ContractsTypeTryUpdateFunctionName,
+			Account_ContractsTypeTryUpdateFunctionType,
+			Account_ContractsTypeTryUpdateFunctionDocString,
 		),
 		NewUnmeteredFunctionMember(
 			Account_ContractsType,

--- a/runtime/sema/deployment_result.cdc
+++ b/runtime/sema/deployment_result.cdc
@@ -1,0 +1,11 @@
+#compositeType
+access(all)
+struct DeploymentResult {
+
+    /// The deployed contract.
+    ///
+    /// If the the deployment was unsuccessfull, this will be nil.
+    ///
+    access(all)
+    let deployedContract: DeployedContract?
+}

--- a/runtime/sema/deployment_result.gen.go
+++ b/runtime/sema/deployment_result.gen.go
@@ -1,0 +1,66 @@
+// Code generated from deployment_result.cdc. DO NOT EDIT.
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+)
+
+const DeploymentResultTypeDeployedContractFieldName = "deployedContract"
+
+var DeploymentResultTypeDeployedContractFieldType = &OptionalType{
+	Type: DeployedContractType,
+}
+
+const DeploymentResultTypeDeployedContractFieldDocString = `
+The deployed contract.
+
+If the the deployment was unsuccessfull, this will be nil.
+`
+
+const DeploymentResultTypeName = "DeploymentResult"
+
+var DeploymentResultType = func() *CompositeType {
+	var t = &CompositeType{
+		Identifier:         DeploymentResultTypeName,
+		Kind:               common.CompositeKindStructure,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
+	}
+
+	return t
+}()
+
+func init() {
+	var members = []*Member{
+		NewUnmeteredFieldMember(
+			DeploymentResultType,
+			PrimitiveAccess(ast.AccessAll),
+			ast.VariableKindConstant,
+			DeploymentResultTypeDeployedContractFieldName,
+			DeploymentResultTypeDeployedContractFieldType,
+			DeploymentResultTypeDeployedContractFieldDocString,
+		),
+	}
+
+	DeploymentResultType.Members = MembersAsMap(members)
+	DeploymentResultType.Fields = MembersFieldNames(members)
+}

--- a/runtime/sema/deployment_result.go
+++ b/runtime/sema/deployment_result.go
@@ -1,0 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+//go:generate go run ./gen deployment_result.cdc deployment_result.gen.go

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -368,10 +368,12 @@ func (g *generator) VisitCompositeDeclaration(decl *ast.CompositeDeclaration) (_
 
 	var generateSimpleType bool
 
-	// Check if the declaration is explicit marked to generate a composite type.
+	// Check if the declaration is explicitly marked to be generated as a composite type.
 	if _, ok := g.leadingPragma["compositeType"]; ok {
 		generateSimpleType = false
 	} else {
+		// If not, decide what to generate depending on the type.
+
 		// We can generate a SimpleType declaration,
 		// if this is a top-level type,
 		// and this declaration has no nested type declarations.

--- a/runtime/sema/gen/testdata/composite-type-pragma.cdc
+++ b/runtime/sema/gen/testdata/composite-type-pragma.cdc
@@ -1,0 +1,2 @@
+#compositeType
+access(all) struct Test {}

--- a/runtime/sema/gen/testdata/composite-type-pragma.golden.go
+++ b/runtime/sema/gen/testdata/composite-type-pragma.golden.go
@@ -1,0 +1,35 @@
+// Code generated from testdata/composite-type-pragma.cdc. DO NOT EDIT.
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import "github.com/onflow/cadence/runtime/common"
+
+const TestTypeName = "Test"
+
+var TestType = func() *CompositeType {
+	var t = &CompositeType{
+		Identifier:         TestTypeName,
+		Kind:               common.CompositeKindStructure,
+		ImportableBuiltin:  false,
+		HasComputedMembers: true,
+	}
+
+	return t
+}()

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -3722,6 +3722,7 @@ func init() {
 			HashAlgorithmType,
 			StorageCapabilityControllerType,
 			AccountCapabilityControllerType,
+			DeploymentResultType,
 		},
 	)
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -8009,6 +8009,7 @@ func init() {
 		HashAlgorithmType,
 		SignatureAlgorithmType,
 		AccountType,
+		DeploymentResultType,
 	}
 
 	for len(compositeTypes) > 0 {

--- a/runtime/sema/type_tags.go
+++ b/runtime/sema/type_tags.go
@@ -220,7 +220,7 @@ const (
 	anyStructAttachmentMask
 	storageCapabilityControllerTypeMask
 	accountCapabilityControllerTypeMask
-
+	deploymentResultMask
 	interfaceTypeMask
 	functionTypeMask
 
@@ -344,6 +344,7 @@ var (
 	AnyStructAttachmentTypeTag         = newTypeTagFromUpperMask(anyStructAttachmentMask)
 	StorageCapabilityControllerTypeTag = newTypeTagFromUpperMask(storageCapabilityControllerTypeMask)
 	AccountCapabilityControllerTypeTag = newTypeTagFromUpperMask(accountCapabilityControllerTypeMask)
+	DeploymentResultTypeTag            = newTypeTagFromUpperMask(deploymentResultMask)
 
 	// AnyStructTypeTag only includes the types that are pre-known
 	// to belong to AnyStruct type. This is more of an optimization.

--- a/runtime/sema/type_tags.go
+++ b/runtime/sema/type_tags.go
@@ -220,7 +220,7 @@ const (
 	anyStructAttachmentMask
 	storageCapabilityControllerTypeMask
 	accountCapabilityControllerTypeMask
-	deploymentResultMask
+
 	interfaceTypeMask
 	functionTypeMask
 
@@ -344,7 +344,6 @@ var (
 	AnyStructAttachmentTypeTag         = newTypeTagFromUpperMask(anyStructAttachmentMask)
 	StorageCapabilityControllerTypeTag = newTypeTagFromUpperMask(storageCapabilityControllerTypeMask)
 	AccountCapabilityControllerTypeTag = newTypeTagFromUpperMask(accountCapabilityControllerTypeMask)
-	DeploymentResultTypeTag            = newTypeTagFromUpperMask(deploymentResultMask)
 
 	// AnyStructTypeTag only includes the types that are pre-known
 	// to belong to AnyStruct type. This is more of an optimization.

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -1664,11 +1664,14 @@ func newAccountContractsTryUpdateFunction(
 					}
 				}
 
+				var optionalDeployedContract interpreter.OptionalValue
 				if deployedContract == nil {
-					deployedContract = interpreter.Nil
+					optionalDeployedContract = interpreter.NilOptionalValue
+				} else {
+					optionalDeployedContract = interpreter.NewSomeValueNonCopying(invocation.Interpreter, deployedContract)
 				}
 
-				deploymentResult = interpreter.NewDeploymentResultValue(gauge, deployedContract)
+				deploymentResult = interpreter.NewDeploymentResultValue(gauge, optionalDeployedContract)
 			}()
 
 			deployedContract = changeAccountContracts(invocation, handler, addressValue, true)

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"golang.org/x/crypto/sha3"
+	"golang.org/x/xerrors"
 
 	"github.com/onflow/atree"
 
@@ -326,6 +327,12 @@ func newAccountContractsValue(
 			handler,
 			addressValue,
 			true,
+		),
+		newAccountContractsTryUpdateFunction(
+			sema.Account_ContractsTypeUpdateFunctionType,
+			gauge,
+			handler,
+			addressValue,
 		),
 		newAccountContractsGetFunction(
 			sema.Account_ContractsTypeGetFunctionType,
@@ -1369,250 +1376,303 @@ func newAccountContractsChangeFunction(
 		gauge,
 		functionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
+			return changeAccountContracts(invocation, handler, addressValue, isUpdate)
+		},
+	)
+}
 
-			locationRange := invocation.LocationRange
+func changeAccountContracts(
+	invocation interpreter.Invocation,
+	handler AccountContractAdditionHandler,
+	addressValue interpreter.AddressValue,
+	isUpdate bool,
+) interpreter.Value {
 
-			const requiredArgumentCount = 2
+	locationRange := invocation.LocationRange
 
-			nameValue, ok := invocation.Arguments[0].(*interpreter.StringValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
+	const requiredArgumentCount = 2
+
+	nameValue, ok := invocation.Arguments[0].(*interpreter.StringValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+
+	newCodeValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+
+	constructorArguments := invocation.Arguments[requiredArgumentCount:]
+	constructorArgumentTypes := invocation.ArgumentTypes[requiredArgumentCount:]
+
+	code, err := interpreter.ByteArrayValueToByteSlice(invocation.Interpreter, newCodeValue, locationRange)
+	if err != nil {
+		panic(errors.NewDefaultUserError("add requires the second argument to be an array"))
+	}
+
+	// Get the existing code
+
+	contractName := nameValue.Str
+
+	if contractName == "" {
+		panic(errors.NewDefaultUserError(
+			"contract name argument cannot be empty." +
+				"it must match the name of the deployed contract declaration or contract interface declaration",
+		))
+	}
+
+	address := addressValue.ToAddress()
+	location := common.NewAddressLocation(invocation.Interpreter, address, contractName)
+
+	existingCode, err := handler.GetAccountContractCode(location)
+	if err != nil {
+		panic(err)
+	}
+
+	if isUpdate {
+		// We are updating an existing contract.
+		// Ensure that there's a contract/contract-interface with the given name exists already
+
+		if len(existingCode) == 0 {
+			panic(errors.NewDefaultUserError(
+				"cannot update non-existing contract with name %q in account %s",
+				contractName,
+				address.ShortHexWithPrefix(),
+			))
+		}
+
+	} else {
+		// We are adding a new contract.
+		// Ensure that no contract/contract interface with the given name exists already
+
+		if len(existingCode) > 0 {
+			panic(errors.NewDefaultUserError(
+				"cannot overwrite existing contract with name %q in account %s",
+				contractName,
+				address.ShortHexWithPrefix(),
+			))
+		}
+	}
+
+	// Check the code
+	handleContractUpdateError := func(err error) {
+		if err == nil {
+			return
+		}
+
+		// Update the code for the error pretty printing
+		// NOTE: only do this when an error occurs
+
+		handler.TemporarilyRecordCode(location, code)
+
+		panic(&InvalidContractDeploymentError{
+			Err:           err,
+			LocationRange: locationRange,
+		})
+	}
+
+	// NOTE: do NOT use the program obtained from the host environment, as the current program.
+	// Always re-parse and re-check the new program.
+
+	// NOTE: *DO NOT* store the program – the new or updated program
+	// should not be effective during the execution
+
+	const getAndSetProgram = false
+
+	program, err := handler.ParseAndCheckProgram(
+		code,
+		location,
+		getAndSetProgram,
+	)
+	handleContractUpdateError(err)
+
+	// The code may declare exactly one contract or one contract interface.
+
+	var contractTypes []*sema.CompositeType
+	var contractInterfaceTypes []*sema.InterfaceType
+
+	program.Elaboration.ForEachGlobalType(func(_ string, variable *sema.Variable) {
+		switch ty := variable.Type.(type) {
+		case *sema.CompositeType:
+			if ty.Kind == common.CompositeKindContract {
+				contractTypes = append(contractTypes, ty)
 			}
 
-			newCodeValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
+		case *sema.InterfaceType:
+			if ty.CompositeKind == common.CompositeKindContract {
+				contractInterfaceTypes = append(contractInterfaceTypes, ty)
 			}
+		}
+	})
 
-			constructorArguments := invocation.Arguments[requiredArgumentCount:]
-			constructorArgumentTypes := invocation.ArgumentTypes[requiredArgumentCount:]
+	var deployedType sema.Type
+	var contractType *sema.CompositeType
+	var contractInterfaceType *sema.InterfaceType
+	var declaredName string
+	var declarationKind common.DeclarationKind
 
-			code, err := interpreter.ByteArrayValueToByteSlice(invocation.Interpreter, newCodeValue, locationRange)
-			if err != nil {
-				panic(errors.NewDefaultUserError("add requires the second argument to be an array"))
-			}
+	switch {
+	case len(contractTypes) == 1 && len(contractInterfaceTypes) == 0:
+		contractType = contractTypes[0]
+		declaredName = contractType.Identifier
+		deployedType = contractType
+		declarationKind = common.DeclarationKindContract
+	case len(contractInterfaceTypes) == 1 && len(contractTypes) == 0:
+		contractInterfaceType = contractInterfaceTypes[0]
+		declaredName = contractInterfaceType.Identifier
+		deployedType = contractInterfaceType
+		declarationKind = common.DeclarationKindContractInterface
+	}
 
-			// Get the existing code
+	if deployedType == nil {
+		// Update the code for the error pretty printing
+		// NOTE: only do this when an error occurs
 
-			contractName := nameValue.Str
+		handler.TemporarilyRecordCode(location, code)
 
-			if contractName == "" {
-				panic(errors.NewDefaultUserError(
-					"contract name argument cannot be empty." +
-						"it must match the name of the deployed contract declaration or contract interface declaration",
-				))
-			}
+		panic(errors.NewDefaultUserError(
+			"invalid %s: the code must declare exactly one contract or contract interface",
+			declarationKind.Name(),
+		))
+	}
 
-			address := addressValue.ToAddress()
-			location := common.NewAddressLocation(invocation.Interpreter, address, contractName)
+	// The declared contract or contract interface must have the name
+	// passed to the constructor as the first argument
 
-			existingCode, err := handler.GetAccountContractCode(location)
-			if err != nil {
-				panic(err)
-			}
+	if declaredName != contractName {
+		// Update the code for the error pretty printing
+		// NOTE: only do this when an error occurs
 
-			if isUpdate {
-				// We are updating an existing contract.
-				// Ensure that there's a contract/contract-interface with the given name exists already
+		handler.TemporarilyRecordCode(location, code)
 
-				if len(existingCode) == 0 {
-					panic(errors.NewDefaultUserError(
-						"cannot update non-existing contract with name %q in account %s",
-						contractName,
-						address.ShortHexWithPrefix(),
-					))
-				}
+		panic(errors.NewDefaultUserError(
+			"invalid %s: the name argument must match the name of the declaration: got %q, expected %q",
+			declarationKind.Name(),
+			contractName,
+			declaredName,
+		))
+	}
 
-			} else {
-				// We are adding a new contract.
-				// Ensure that no contract/contract interface with the given name exists already
+	// Validate the contract update
 
-				if len(existingCode) > 0 {
-					panic(errors.NewDefaultUserError(
-						"cannot overwrite existing contract with name %q in account %s",
-						contractName,
-						address.ShortHexWithPrefix(),
-					))
-				}
-			}
+	if isUpdate {
+		oldCode, err := handler.GetAccountContractCode(location)
+		handleContractUpdateError(err)
 
-			// Check the code
-			handleContractUpdateError := func(err error) {
-				if err == nil {
-					return
-				}
+		oldProgram, err := parser.ParseProgram(
+			invocation.Interpreter.SharedState.Config.MemoryGauge,
+			oldCode,
+			parser.Config{
+				IgnoreLeadingIdentifierEnabled: true,
+			},
+		)
 
-				// Update the code for the error pretty printing
-				// NOTE: only do this when an error occurs
-
-				handler.TemporarilyRecordCode(location, code)
-
-				panic(&InvalidContractDeploymentError{
-					Err:           err,
-					LocationRange: locationRange,
-				})
-			}
-
-			// NOTE: do NOT use the program obtained from the host environment, as the current program.
-			// Always re-parse and re-check the new program.
-
-			// NOTE: *DO NOT* store the program – the new or updated program
-			// should not be effective during the execution
-
-			const getAndSetProgram = false
-
-			program, err := handler.ParseAndCheckProgram(
-				code,
-				location,
-				getAndSetProgram,
-			)
+		if !ignoreUpdatedProgramParserError(err) {
 			handleContractUpdateError(err)
+		}
 
-			// The code may declare exactly one contract or one contract interface.
+		validator := NewContractUpdateValidator(
+			location,
+			contractName,
+			oldProgram,
+			program.Program,
+		)
+		err = validator.Validate()
+		handleContractUpdateError(err)
+	}
 
-			var contractTypes []*sema.CompositeType
-			var contractInterfaceTypes []*sema.InterfaceType
+	inter := invocation.Interpreter
 
-			program.Elaboration.ForEachGlobalType(func(_ string, variable *sema.Variable) {
-				switch ty := variable.Type.(type) {
-				case *sema.CompositeType:
-					if ty.Kind == common.CompositeKindContract {
-						contractTypes = append(contractTypes, ty)
-					}
+	err = updateAccountContractCode(
+		handler,
+		location,
+		program,
+		code,
+		contractType,
+		constructorArguments,
+		constructorArgumentTypes,
+		updateAccountContractCodeOptions{
+			createContract: !isUpdate,
+		},
+	)
+	if err != nil {
+		// Update the code for the error pretty printing
+		// NOTE: only do this when an error occurs
 
-				case *sema.InterfaceType:
-					if ty.CompositeKind == common.CompositeKindContract {
-						contractInterfaceTypes = append(contractInterfaceTypes, ty)
+		handler.TemporarilyRecordCode(location, code)
+
+		panic(err)
+	}
+
+	var eventType *sema.CompositeType
+
+	if isUpdate {
+		eventType = AccountContractUpdatedEventType
+	} else {
+		eventType = AccountContractAddedEventType
+	}
+
+	codeHashValue := CodeToHashValue(inter, code)
+
+	handler.EmitEvent(
+		inter,
+		eventType,
+		[]interpreter.Value{
+			addressValue,
+			codeHashValue,
+			nameValue,
+		},
+		locationRange,
+	)
+
+	return interpreter.NewDeployedContractValue(
+		inter,
+		addressValue,
+		nameValue,
+		newCodeValue,
+	)
+}
+
+func newAccountContractsTryUpdateFunction(
+	functionType *sema.FunctionType,
+	gauge common.MemoryGauge,
+	handler AccountContractAdditionHandler,
+	addressValue interpreter.AddressValue,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewHostFunctionValue(
+		gauge,
+		functionType,
+		func(invocation interpreter.Invocation) (deploymentResult interpreter.Value) {
+			var deployedContract interpreter.Value
+
+			defer func() {
+				if r := recover(); r != nil {
+					rootError := r
+					for {
+						switch err := r.(type) {
+						case errors.UserError, errors.ExternalError:
+							// Error is ignored for now.
+							// Simply return with a `nil` deployed-contract
+						case xerrors.Wrapper:
+							r = err.Unwrap()
+							continue
+						default:
+							panic(rootError)
+						}
+
+						break
 					}
 				}
-			})
 
-			var deployedType sema.Type
-			var contractType *sema.CompositeType
-			var contractInterfaceType *sema.InterfaceType
-			var declaredName string
-			var declarationKind common.DeclarationKind
-
-			switch {
-			case len(contractTypes) == 1 && len(contractInterfaceTypes) == 0:
-				contractType = contractTypes[0]
-				declaredName = contractType.Identifier
-				deployedType = contractType
-				declarationKind = common.DeclarationKindContract
-			case len(contractInterfaceTypes) == 1 && len(contractTypes) == 0:
-				contractInterfaceType = contractInterfaceTypes[0]
-				declaredName = contractInterfaceType.Identifier
-				deployedType = contractInterfaceType
-				declarationKind = common.DeclarationKindContractInterface
-			}
-
-			if deployedType == nil {
-				// Update the code for the error pretty printing
-				// NOTE: only do this when an error occurs
-
-				handler.TemporarilyRecordCode(location, code)
-
-				panic(errors.NewDefaultUserError(
-					"invalid %s: the code must declare exactly one contract or contract interface",
-					declarationKind.Name(),
-				))
-			}
-
-			// The declared contract or contract interface must have the name
-			// passed to the constructor as the first argument
-
-			if declaredName != contractName {
-				// Update the code for the error pretty printing
-				// NOTE: only do this when an error occurs
-
-				handler.TemporarilyRecordCode(location, code)
-
-				panic(errors.NewDefaultUserError(
-					"invalid %s: the name argument must match the name of the declaration: got %q, expected %q",
-					declarationKind.Name(),
-					contractName,
-					declaredName,
-				))
-			}
-
-			// Validate the contract update
-
-			if isUpdate {
-				oldCode, err := handler.GetAccountContractCode(location)
-				handleContractUpdateError(err)
-
-				oldProgram, err := parser.ParseProgram(
-					gauge,
-					oldCode,
-					parser.Config{
-						IgnoreLeadingIdentifierEnabled: true,
-					},
-				)
-
-				if !ignoreUpdatedProgramParserError(err) {
-					handleContractUpdateError(err)
+				if deployedContract == nil {
+					deployedContract = interpreter.Nil
 				}
 
-				validator := NewContractUpdateValidator(
-					location,
-					contractName,
-					oldProgram,
-					program.Program,
-				)
-				err = validator.Validate()
-				handleContractUpdateError(err)
-			}
+				deploymentResult = interpreter.NewDeploymentResultValue(gauge, deployedContract)
+			}()
 
-			inter := invocation.Interpreter
-
-			err = updateAccountContractCode(
-				handler,
-				location,
-				program,
-				code,
-				contractType,
-				constructorArguments,
-				constructorArgumentTypes,
-				updateAccountContractCodeOptions{
-					createContract: !isUpdate,
-				},
-			)
-			if err != nil {
-				// Update the code for the error pretty printing
-				// NOTE: only do this when an error occurs
-
-				handler.TemporarilyRecordCode(location, code)
-
-				panic(err)
-			}
-
-			var eventType *sema.CompositeType
-
-			if isUpdate {
-				eventType = AccountContractUpdatedEventType
-			} else {
-				eventType = AccountContractAddedEventType
-			}
-
-			codeHashValue := CodeToHashValue(inter, code)
-
-			handler.EmitEvent(
-				inter,
-				eventType,
-				[]interpreter.Value{
-					addressValue,
-					codeHashValue,
-					nameValue,
-				},
-				locationRange,
-			)
-
-			return interpreter.NewDeployedContractValue(
-				inter,
-				addressValue,
-				nameValue,
-				newCodeValue,
-			)
+			deployedContract = changeAccountContracts(invocation, handler, addressValue, true)
+			return
 		},
 	)
 }

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -1083,6 +1083,33 @@ func TestCheckAccountContractsUpdate(t *testing.T) {
         `)
 		require.NoError(t, err)
 	})
+
+	t.Run("try update, unauthorized", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            fun test(contracts: &Account.Contracts): DeploymentResult {
+                return contracts.tryUpdate(name: "foo", code: "012".decodeHex())
+            }
+        `)
+
+		errors := RequireCheckerErrors(t, err, 1)
+
+		var invalidAccessErr *sema.InvalidAccessError
+		require.ErrorAs(t, errors[0], &invalidAccessErr)
+		assert.Equal(t, "tryUpdate", invalidAccessErr.Name)
+	})
+
+	t.Run("try update, authorized", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            fun test(contracts: auth(Contracts) &Account.Contracts): DeploymentResult {
+                return contracts.tryUpdate(name: "foo", code: "012".decodeHex())
+            }
+        `)
+		require.NoError(t, err)
+	})
 }
 
 func TestCheckAccountContractsRemove(t *testing.T) {

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -1110,6 +1110,21 @@ func TestCheckAccountContractsUpdate(t *testing.T) {
         `)
 		require.NoError(t, err)
 	})
+
+	t.Run("deployment result fields", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            fun test(contracts: auth(Contracts) &Account.Contracts) {
+                let deploymentResult: DeploymentResult = contracts.tryUpdate(name: "foo", code: "012".decodeHex())
+                let deployedContract: DeployedContract = deploymentResult.deployedContract!
+                let name: String = deployedContract.name
+                let address: Address = deployedContract.address
+                let code: [UInt8] = deployedContract.code
+            }
+        `)
+		require.NoError(t, err)
+	})
 }
 
 func TestCheckAccountContractsRemove(t *testing.T) {

--- a/runtime/tests/checker/type_inference_test.go
+++ b/runtime/tests/checker/type_inference_test.go
@@ -1258,3 +1258,31 @@ func TestCheckCompositeSupertypeInference(t *testing.T) {
 		assert.Equal(t, expectedType.ID(), intersectionType.ID())
 	})
 }
+
+func TestCheckDeploymentResultInference(t *testing.T) {
+
+	t.Parallel()
+
+	code := `
+        let x: DeploymentResult = getDeploymentResult()
+        let y: DeploymentResult = getDeploymentResult()
+
+        // Function is just to get a 'DeploymentResult' return type.
+        fun getDeploymentResult(): DeploymentResult {
+            let v: DeploymentResult? = nil
+            return v!
+        }
+
+        let z = [x, y]
+    `
+
+	checker, err := ParseAndCheck(t, code)
+	require.NoError(t, err)
+
+	zType := RequireGlobalValue(t, checker.Elaboration, "z")
+
+	require.IsType(t, &sema.VariableSizedType{}, zType)
+	variableSizedType := zType.(*sema.VariableSizedType)
+
+	assert.Equal(t, sema.DeploymentResultType, variableSizedType.Type)
+}


### PR DESCRIPTION
Closes #2700

## Description

Adds a `tryUpdate` method that gracefully handles deployment errors.

```cadence
struct Account {
    ...
    struct Contracts {
        ...
        access(Contracts | UpdateContract)
        fun tryUpdate(name: String, code: [UInt8]): DeploymentResult
    }
}

access(all) struct DeploymentResult {
    access(all) let deployedContract: DeployedContract?
}
```

If the update was unsuccessful, `DeploymentResult.deployedContract` will be `nil`.

This `tryUpdate` method handles any user error (syntax errors, semantic errors, etc.) gracefully. Any internal error would still cause the script/transaction to terminate.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
