### PR TITLE
Add view annotations to newly added array functions

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2492,6 +2492,7 @@ func ArrayFilterFunctionType(memoryGauge common.MemoryGauge, elementType Type) *
 			},
 		},
 		ReturnTypeAnnotation: NewTypeAnnotation(BoolType),
+		Purity:               FunctionPurityView,
 	}
 
 	return &FunctionType{
@@ -2503,6 +2504,7 @@ func ArrayFilterFunctionType(memoryGauge common.MemoryGauge, elementType Type) *
 			},
 		},
 		ReturnTypeAnnotation: NewTypeAnnotation(NewVariableSizedType(memoryGauge, elementType)),
+		Purity:               FunctionPurityView,
 	}
 }
 

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2478,6 +2478,7 @@ func ArrayReverseFunctionType(arrayType ArrayType) *FunctionType {
 	return &FunctionType{
 		Parameters:           []Parameter{},
 		ReturnTypeAnnotation: NewTypeAnnotation(arrayType),
+		Purity:               FunctionPurityView,
 	}
 }
 

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -1136,7 +1136,7 @@ func TestCheckArrayFilter(t *testing.T) {
 		fun test() {
 			let x = [1, 2, 3]
 			let onlyEven =
-				fun (_ x: Int): Bool {
+				view fun (_ x: Int): Bool {
 					return x % 2 == 0
 				}
 
@@ -1146,7 +1146,7 @@ func TestCheckArrayFilter(t *testing.T) {
 		fun testFixedSize() {
 			let x : [Int; 5] = [1, 2, 3, 21, 30]
 			let onlyEvenInt =
-				fun (_ x: Int): Bool {
+				view fun (_ x: Int): Bool {
 					return x % 2 == 0
 				}
 
@@ -1186,7 +1186,7 @@ func TestCheckArrayFilterInvalidArgs(t *testing.T) {
 		fun test() {
 			let x = [1, 2, 3]
 			let onlyEvenInt16 =
-				fun (_ x: Int16): Bool {
+				view fun (_ x: Int16): Bool {
 					return x % 2 == 0
 				}
 
@@ -1220,9 +1220,10 @@ func TestCheckResourceArrayFilterInvalid(t *testing.T) {
 		}
     `)
 
-	errs := RequireCheckerErrors(t, err, 1)
+	errs := RequireCheckerErrors(t, err, 2)
 
 	assert.IsType(t, &sema.InvalidResourceArrayMemberError{}, errs[0])
+	assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
 }
 
 func TestCheckArrayMap(t *testing.T) {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -10330,7 +10330,7 @@ func TestInterpretArrayFilter(t *testing.T) {
 			let emptyVals: [Int] = []
 
 			let onlyEven =
-				fun (_ x: Int): Bool {
+				view fun (_ x: Int): Bool {
 					return x % 2 == 0
 				}
 
@@ -10368,7 +10368,7 @@ func TestInterpretArrayFilter(t *testing.T) {
 			let xs = [1, 2, 3, 100, 201]
 
 			let onlyEven =
-				fun (_ x: Int): Bool {
+				view fun (_ x: Int): Bool {
 					return x % 2 == 0
 				}
 
@@ -10425,7 +10425,7 @@ func TestInterpretArrayFilter(t *testing.T) {
 			}
 
 			let onlyOddStruct =
-				fun (_ x: TestStruct): Bool {
+				view fun (_ x: TestStruct): Bool {
 					return x.test % 2 == 1
 				}
 
@@ -10485,7 +10485,7 @@ func TestInterpretArrayFilter(t *testing.T) {
 			let emptyVals_fixed: [Int; 0] = []
 
 			let onlyEven =
-				fun (_ x: Int): Bool {
+				view fun (_ x: Int): Bool {
 					return x % 2 == 0
 				}
 
@@ -10529,7 +10529,7 @@ func TestInterpretArrayFilter(t *testing.T) {
 			let xs_fixed: [Int; 5] = [1, 2, 3, 100, 201]
 
 			let onlyEven =
-				fun (_ x: Int): Bool {
+				view fun (_ x: Int): Bool {
 					return x % 2 == 0
 				}
 
@@ -10587,7 +10587,7 @@ func TestInterpretArrayFilter(t *testing.T) {
 			}
 
 			let onlyOddStruct =
-				fun (_ x: TestStruct): Bool {
+				view fun (_ x: TestStruct): Bool {
 					return x.test % 2 == 1
 				}
 


### PR DESCRIPTION
Continue https://github.com/onflow/cadence/issues/2466

These functions can be marked as `view`. 

Note that this marks `filter` as `view` as well by restricting it's inputs to `view` functions. This makes sense to me personally considering these are intended to be boolean predicates, which should not have side effects. 
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
