### PR TITLE
Fix doc (pretty printing) for function declaration without function block

### DIFF
--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -1387,8 +1387,6 @@ func (e *FunctionExpression) String() string {
 
 var functionFunKeywordSpaceDoc prettier.Doc = prettier.Text("fun ")
 
-var functionExpressionEmptyBlockDoc prettier.Doc = prettier.Text(" {}")
-
 func FunctionDocument(
 	access Access,
 	isStatic bool,
@@ -1482,17 +1480,17 @@ func FunctionDocument(
 		)
 	}
 
-	if block.IsEmpty() {
-		return append(doc, functionExpressionEmptyBlockDoc)
-	} else {
+	if block != nil {
 		blockDoc := block.Doc()
 
-		return append(
+		doc = append(
 			doc,
 			prettier.Space,
 			blockDoc,
 		)
 	}
+
+	return doc
 }
 
 func (e *FunctionExpression) Doc() prettier.Doc {

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -4591,7 +4591,8 @@ func TestFunctionExpression_Doc(t *testing.T) {
 					prettier.Text("()"),
 				},
 			},
-			prettier.Text(" {}"),
+			prettier.Text(" "),
+			prettier.Text("{}"),
 		}
 
 		assert.Equal(t, expected, expr.Doc())

--- a/runtime/ast/function_declaration_test.go
+++ b/runtime/ast/function_declaration_test.go
@@ -364,7 +364,8 @@ func TestFunctionDeclaration_Doc(t *testing.T) {
 					},
 				},
 			},
-			prettier.Text(" {}"),
+			prettier.Text(" "),
+			prettier.Text("{}"),
 		},
 		decl.Doc(),
 	)
@@ -828,7 +829,8 @@ func TestSpecialFunctionDeclaration_Doc(t *testing.T) {
 					},
 				},
 			},
-			prettier.Text(" {}"),
+			prettier.Text(" "),
+			prettier.Text("{}"),
 		},
 		decl.Doc(),
 	)

--- a/runtime/ast/transaction_declaration_test.go
+++ b/runtime/ast/transaction_declaration_test.go
@@ -137,6 +137,11 @@ func TestTransactionDeclaration_Doc(t *testing.T) {
 						},
 					},
 				},
+				FunctionBlock: &FunctionBlock{
+					Block: &Block{
+						Statements: []Statement{},
+					},
+				},
 			},
 		},
 		PreConditions: &Conditions{
@@ -251,7 +256,8 @@ func TestTransactionDeclaration_Doc(t *testing.T) {
 									},
 								},
 							},
-							prettier.Text(" {}"),
+							prettier.Text(" "),
+							prettier.Text("{}"),
 						},
 					},
 					prettier.HardLine{},
@@ -397,6 +403,11 @@ func TestTransactionDeclaration_String(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+				FunctionBlock: &FunctionBlock{
+					Block: &Block{
+						Statements: []Statement{},
 					},
 				},
 			},


### PR DESCRIPTION
Closes #2773

## Description

Do not produces empty braces when 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
