### PR TITLE
Replace `simpleTypeIDByType` with a bimap

### DIFF
--- a/encoding/ccf/simpletype.go
+++ b/encoding/ccf/simpletype.go
@@ -20,7 +20,10 @@ package ccf
 
 //go:generate go run golang.org/x/tools/cmd/stringer -type=SimpleType
 
-import "github.com/onflow/cadence"
+import (
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/common/bimap"
+)
 
 // Simple type ID is a compact representation of a type
 // which doesn't need additional information.
@@ -145,377 +148,137 @@ const ( // Cadence simple type IDs
 // because this function is used by both inline-type and type-value.
 // cadence.FunctionType needs to be handled differently when this
 // function is used by inline-type and type-value.
+func initSimpleTypeIDBiMap() (m *bimap.BiMap[cadence.PrimitiveType, SimpleType]) {
+	m = bimap.NewBiMap[cadence.PrimitiveType, SimpleType]()
+
+	m.Insert(cadence.AnyType, SimpleTypeAny)
+	m.Insert(cadence.AnyStructType, SimpleTypeAnyStruct)
+	m.Insert(cadence.AnyResourceType, SimpleTypeAnyResource)
+	m.Insert(cadence.AddressType, SimpleTypeAddress)
+	m.Insert(cadence.MetaType, SimpleTypeMetaType)
+	m.Insert(cadence.VoidType, SimpleTypeVoid)
+	m.Insert(cadence.NeverType, SimpleTypeNever)
+	m.Insert(cadence.BoolType, SimpleTypeBool)
+	m.Insert(cadence.StringType, SimpleTypeString)
+	m.Insert(cadence.CharacterType, SimpleTypeCharacter)
+
+	m.Insert(cadence.NumberType, SimpleTypeNumber)
+	m.Insert(cadence.SignedNumberType, SimpleTypeSignedNumber)
+	m.Insert(cadence.IntegerType, SimpleTypeInteger)
+	m.Insert(cadence.SignedIntegerType, SimpleTypeSignedInteger)
+	m.Insert(cadence.FixedPointType, SimpleTypeFixedPoint)
+	m.Insert(cadence.SignedFixedPointType, SimpleTypeSignedFixedPoint)
+
+	m.Insert(cadence.IntType, SimpleTypeInt)
+	m.Insert(cadence.Int8Type, SimpleTypeInt8)
+	m.Insert(cadence.Int16Type, SimpleTypeInt16)
+	m.Insert(cadence.Int32Type, SimpleTypeInt32)
+	m.Insert(cadence.Int64Type, SimpleTypeInt64)
+	m.Insert(cadence.Int128Type, SimpleTypeInt128)
+	m.Insert(cadence.Int256Type, SimpleTypeInt256)
+
+	m.Insert(cadence.UIntType, SimpleTypeUInt)
+	m.Insert(cadence.UInt8Type, SimpleTypeUInt8)
+	m.Insert(cadence.UInt16Type, SimpleTypeUInt16)
+	m.Insert(cadence.UInt32Type, SimpleTypeUInt32)
+	m.Insert(cadence.UInt64Type, SimpleTypeUInt64)
+	m.Insert(cadence.UInt128Type, SimpleTypeUInt128)
+	m.Insert(cadence.UInt256Type, SimpleTypeUInt256)
+
+	m.Insert(cadence.Word8Type, SimpleTypeWord8)
+	m.Insert(cadence.Word16Type, SimpleTypeWord16)
+	m.Insert(cadence.Word32Type, SimpleTypeWord32)
+	m.Insert(cadence.Word64Type, SimpleTypeWord64)
+	m.Insert(cadence.Word128Type, SimpleTypeWord128)
+	m.Insert(cadence.Word256Type, SimpleTypeWord256)
+	m.Insert(cadence.Fix64Type, SimpleTypeFix64)
+	m.Insert(cadence.UFix64Type, SimpleTypeUFix64)
+
+	m.Insert(cadence.BlockType, SimpleTypeBlock)
+	m.Insert(cadence.PathType, SimpleTypePath)
+	m.Insert(cadence.CapabilityPathType, SimpleTypeCapabilityPath)
+	m.Insert(cadence.StoragePathType, SimpleTypeStoragePath)
+	m.Insert(cadence.PublicPathType, SimpleTypePublicPath)
+	m.Insert(cadence.PrivatePathType, SimpleTypePrivatePath)
+	m.Insert(cadence.DeployedContractType, SimpleTypeDeployedContract)
+	m.Insert(cadence.AnyStructAttachmentType, SimpleTypeAnyStructAttachmentType)
+	m.Insert(cadence.AnyResourceAttachmentType, SimpleTypeAnyResourceAttachmentType)
+
+	m.Insert(cadence.BlockType, SimpleTypeBlock)
+	m.Insert(cadence.PathType, SimpleTypePath)
+	m.Insert(cadence.CapabilityPathType, SimpleTypeCapabilityPath)
+	m.Insert(cadence.StoragePathType, SimpleTypeStoragePath)
+	m.Insert(cadence.PublicPathType, SimpleTypePublicPath)
+	m.Insert(cadence.PrivatePathType, SimpleTypePrivatePath)
+	m.Insert(cadence.DeployedContractType, SimpleTypeDeployedContract)
+	m.Insert(cadence.AnyStructAttachmentType, SimpleTypeAnyStructAttachmentType)
+	m.Insert(cadence.AnyResourceAttachmentType, SimpleTypeAnyResourceAttachmentType)
+
+	m.Insert(cadence.StorageCapabilityControllerType, SimpleTypeStorageCapabilityController)
+	m.Insert(cadence.AccountCapabilityControllerType, SimpleTypeAccountCapabilityController)
+	m.Insert(cadence.AccountType, SimpleTypeAccount)
+	m.Insert(cadence.Account_ContractsType, SimpleTypeAccount_Contracts)
+	m.Insert(cadence.Account_KeysType, SimpleTypeAccount_Keys)
+	m.Insert(cadence.Account_InboxType, SimpleTypeAccount_Inbox)
+	m.Insert(cadence.Account_StorageCapabilitiesType, SimpleTypeAccount_StorageCapabilities)
+	m.Insert(cadence.Account_AccountCapabilitiesType, SimpleTypeAccount_AccountCapabilities)
+	m.Insert(cadence.Account_CapabilitiesType, SimpleTypeAccount_Capabilities)
+	m.Insert(cadence.Account_StorageType, SimpleTypeAccount_Storage)
+
+	m.Insert(cadence.MutateType, SimpleTypeMutate)
+	m.Insert(cadence.InsertType, SimpleTypeInsert)
+	m.Insert(cadence.RemoveType, SimpleTypeRemove)
+	m.Insert(cadence.IdentityType, SimpleTypeIdentity)
+	m.Insert(cadence.StorageType, SimpleTypeStorage)
+	m.Insert(cadence.SaveValueType, SimpleTypeSaveValue)
+	m.Insert(cadence.LoadValueType, SimpleTypeLoadValue)
+	m.Insert(cadence.CopyValueType, SimpleTypeCopyValue)
+	m.Insert(cadence.BorrowValueType, SimpleTypeBorrowValue)
+	m.Insert(cadence.ContractsType, SimpleTypeContracts)
+	m.Insert(cadence.AddContractType, SimpleTypeAddContract)
+	m.Insert(cadence.UpdateContractType, SimpleTypeUpdateContract)
+	m.Insert(cadence.RemoveContractType, SimpleTypeRemoveContract)
+	m.Insert(cadence.KeysType, SimpleTypeKeys)
+	m.Insert(cadence.AddKeyType, SimpleTypeAddKey)
+	m.Insert(cadence.RevokeKeyType, SimpleTypeRevokeKey)
+	m.Insert(cadence.InboxType, SimpleTypeInbox)
+	m.Insert(cadence.PublishInboxCapabilityType, SimpleTypePublishInboxCapability)
+	m.Insert(cadence.UnpublishInboxCapabilityType, SimpleTypeUnpublishInboxCapability)
+	m.Insert(cadence.ClaimInboxCapabilityType, SimpleTypeClaimInboxCapability)
+	m.Insert(cadence.CapabilitiesType, SimpleTypeCapabilities)
+	m.Insert(cadence.StorageCapabilitiesType, SimpleTypeStorageCapabilities)
+	m.Insert(cadence.AccountCapabilitiesType, SimpleTypeAccountCapabilities)
+	m.Insert(cadence.PublishCapabilityType, SimpleTypePublishCapability)
+	m.Insert(cadence.UnpublishCapabilityType, SimpleTypeUnpublishCapability)
+	m.Insert(cadence.GetStorageCapabilityControllerType, SimpleTypeGetStorageCapabilityController)
+	m.Insert(cadence.IssueStorageCapabilityControllerType, SimpleTypeIssueStorageCapabilityController)
+	m.Insert(cadence.GetAccountCapabilityControllerType, SimpleTypeGetAccountCapabilityController)
+	m.Insert(cadence.IssueAccountCapabilityControllerType, SimpleTypeIssueAccountCapabilityController)
+	m.Insert(cadence.CapabilitiesMappingType, SimpleTypeCapabilitiesMapping)
+	m.Insert(cadence.AccountMappingType, SimpleTypeAccountMapping)
+
+	return
+}
+
+var simpleTypeIDBiMap *bimap.BiMap[cadence.PrimitiveType, SimpleType] = initSimpleTypeIDBiMap()
+
 func simpleTypeIDByType(typ cadence.Type) (SimpleType, bool) {
-
-	switch typ {
-	case cadence.AnyType:
-		return SimpleTypeAny, true
-	case cadence.AnyStructType:
-		return SimpleTypeAnyStruct, true
-	case cadence.AnyResourceType:
-		return SimpleTypeAnyResource, true
-	case cadence.AddressType:
-		return SimpleTypeAddress, true
-	case cadence.MetaType:
-		return SimpleTypeMetaType, true
-	case cadence.VoidType:
-		return SimpleTypeVoid, true
-	case cadence.NeverType:
-		return SimpleTypeNever, true
-	case cadence.BoolType:
-		return SimpleTypeBool, true
-	case cadence.StringType:
-		return SimpleTypeString, true
-	case cadence.CharacterType:
-		return SimpleTypeCharacter, true
-	case cadence.NumberType:
-		return SimpleTypeNumber, true
-	case cadence.SignedNumberType:
-		return SimpleTypeSignedNumber, true
-	case cadence.IntegerType:
-		return SimpleTypeInteger, true
-	case cadence.SignedIntegerType:
-		return SimpleTypeSignedInteger, true
-	case cadence.FixedPointType:
-		return SimpleTypeFixedPoint, true
-	case cadence.SignedFixedPointType:
-		return SimpleTypeSignedFixedPoint, true
-	case cadence.IntType:
-		return SimpleTypeInt, true
-	case cadence.Int8Type:
-		return SimpleTypeInt8, true
-	case cadence.Int16Type:
-		return SimpleTypeInt16, true
-	case cadence.Int32Type:
-		return SimpleTypeInt32, true
-	case cadence.Int64Type:
-		return SimpleTypeInt64, true
-	case cadence.Int128Type:
-		return SimpleTypeInt128, true
-	case cadence.Int256Type:
-		return SimpleTypeInt256, true
-	case cadence.UIntType:
-		return SimpleTypeUInt, true
-	case cadence.UInt8Type:
-		return SimpleTypeUInt8, true
-	case cadence.UInt16Type:
-		return SimpleTypeUInt16, true
-	case cadence.UInt32Type:
-		return SimpleTypeUInt32, true
-	case cadence.UInt64Type:
-		return SimpleTypeUInt64, true
-	case cadence.UInt128Type:
-		return SimpleTypeUInt128, true
-	case cadence.UInt256Type:
-		return SimpleTypeUInt256, true
-	case cadence.Word8Type:
-		return SimpleTypeWord8, true
-	case cadence.Word16Type:
-		return SimpleTypeWord16, true
-	case cadence.Word32Type:
-		return SimpleTypeWord32, true
-	case cadence.Word64Type:
-		return SimpleTypeWord64, true
-	case cadence.Word128Type:
-		return SimpleTypeWord128, true
-	case cadence.Word256Type:
-		return SimpleTypeWord256, true
-	case cadence.Fix64Type:
-		return SimpleTypeFix64, true
-	case cadence.UFix64Type:
-		return SimpleTypeUFix64, true
-	case cadence.BlockType:
-		return SimpleTypeBlock, true
-	case cadence.PathType:
-		return SimpleTypePath, true
-	case cadence.CapabilityPathType:
-		return SimpleTypeCapabilityPath, true
-	case cadence.StoragePathType:
-		return SimpleTypeStoragePath, true
-	case cadence.PublicPathType:
-		return SimpleTypePublicPath, true
-	case cadence.PrivatePathType:
-		return SimpleTypePrivatePath, true
-	case cadence.DeployedContractType:
-		return SimpleTypeDeployedContract, true
-	case cadence.AnyStructAttachmentType:
-		return SimpleTypeAnyStructAttachmentType, true
-	case cadence.AnyResourceAttachmentType:
-		return SimpleTypeAnyResourceAttachmentType, true
-	case cadence.StorageCapabilityControllerType:
-		return SimpleTypeStorageCapabilityController, true
-	case cadence.AccountCapabilityControllerType:
-		return SimpleTypeAccountCapabilityController, true
-	case cadence.AccountType:
-		return SimpleTypeAccount, true
-	case cadence.Account_ContractsType:
-		return SimpleTypeAccount_Contracts, true
-	case cadence.Account_KeysType:
-		return SimpleTypeAccount_Keys, true
-	case cadence.Account_InboxType:
-		return SimpleTypeAccount_Inbox, true
-	case cadence.Account_StorageCapabilitiesType:
-		return SimpleTypeAccount_StorageCapabilities, true
-	case cadence.Account_AccountCapabilitiesType:
-		return SimpleTypeAccount_AccountCapabilities, true
-	case cadence.Account_CapabilitiesType:
-		return SimpleTypeAccount_Capabilities, true
-	case cadence.Account_StorageType:
-		return SimpleTypeAccount_Storage, true
-	case cadence.MutateType:
-		return SimpleTypeMutate, true
-	case cadence.InsertType:
-		return SimpleTypeInsert, true
-	case cadence.RemoveType:
-		return SimpleTypeRemove, true
-	case cadence.IdentityType:
-		return SimpleTypeIdentity, true
-	case cadence.StorageType:
-		return SimpleTypeStorage, true
-	case cadence.SaveValueType:
-		return SimpleTypeSaveValue, true
-	case cadence.LoadValueType:
-		return SimpleTypeLoadValue, true
-	case cadence.CopyValueType:
-		return SimpleTypeCopyValue, true
-	case cadence.BorrowValueType:
-		return SimpleTypeBorrowValue, true
-	case cadence.ContractsType:
-		return SimpleTypeContracts, true
-	case cadence.AddContractType:
-		return SimpleTypeAddContract, true
-	case cadence.UpdateContractType:
-		return SimpleTypeUpdateContract, true
-	case cadence.RemoveContractType:
-		return SimpleTypeRemoveContract, true
-	case cadence.KeysType:
-		return SimpleTypeKeys, true
-	case cadence.AddKeyType:
-		return SimpleTypeAddKey, true
-	case cadence.RevokeKeyType:
-		return SimpleTypeRevokeKey, true
-	case cadence.InboxType:
-		return SimpleTypeInbox, true
-	case cadence.PublishInboxCapabilityType:
-		return SimpleTypePublishInboxCapability, true
-	case cadence.UnpublishInboxCapabilityType:
-		return SimpleTypeUnpublishInboxCapability, true
-	case cadence.ClaimInboxCapabilityType:
-		return SimpleTypeClaimInboxCapability, true
-	case cadence.CapabilitiesType:
-		return SimpleTypeCapabilities, true
-	case cadence.StorageCapabilitiesType:
-		return SimpleTypeStorageCapabilities, true
-	case cadence.AccountCapabilitiesType:
-		return SimpleTypeAccountCapabilities, true
-	case cadence.PublishCapabilityType:
-		return SimpleTypePublishCapability, true
-	case cadence.UnpublishCapabilityType:
-		return SimpleTypeUnpublishCapability, true
-	case cadence.GetStorageCapabilityControllerType:
-		return SimpleTypeGetStorageCapabilityController, true
-	case cadence.IssueStorageCapabilityControllerType:
-		return SimpleTypeIssueStorageCapabilityController, true
-	case cadence.GetAccountCapabilityControllerType:
-		return SimpleTypeGetAccountCapabilityController, true
-	case cadence.IssueAccountCapabilityControllerType:
-		return SimpleTypeIssueAccountCapabilityController, true
-	case cadence.CapabilitiesMappingType:
-		return SimpleTypeCapabilitiesMapping, true
-	case cadence.AccountMappingType:
-		return SimpleTypeAccountMapping, true
-
-	}
-
-	switch typ.(type) {
+	switch typ := typ.(type) {
 	case cadence.BytesType:
 		return SimpleTypeBytes, true
+	case cadence.PrimitiveType:
+		return simpleTypeIDBiMap.Get(typ)
 	}
 
 	return 0, false
 }
 
 func typeBySimpleTypeID(simpleTypeID SimpleType) cadence.Type {
-	switch simpleTypeID {
-	case SimpleTypeBool:
-		return cadence.BoolType
-	case SimpleTypeString:
-		return cadence.StringType
-	case SimpleTypeCharacter:
-		return cadence.CharacterType
-	case SimpleTypeAddress:
-		return cadence.AddressType
-	case SimpleTypeInt:
-		return cadence.IntType
-	case SimpleTypeInt8:
-		return cadence.Int8Type
-	case SimpleTypeInt16:
-		return cadence.Int16Type
-	case SimpleTypeInt32:
-		return cadence.Int32Type
-	case SimpleTypeInt64:
-		return cadence.Int64Type
-	case SimpleTypeInt128:
-		return cadence.Int128Type
-	case SimpleTypeInt256:
-		return cadence.Int256Type
-	case SimpleTypeUInt:
-		return cadence.UIntType
-	case SimpleTypeUInt8:
-		return cadence.UInt8Type
-	case SimpleTypeUInt16:
-		return cadence.UInt16Type
-	case SimpleTypeUInt32:
-		return cadence.UInt32Type
-	case SimpleTypeUInt64:
-		return cadence.UInt64Type
-	case SimpleTypeUInt128:
-		return cadence.UInt128Type
-	case SimpleTypeUInt256:
-		return cadence.UInt256Type
-	case SimpleTypeWord8:
-		return cadence.Word8Type
-	case SimpleTypeWord16:
-		return cadence.Word16Type
-	case SimpleTypeWord32:
-		return cadence.Word32Type
-	case SimpleTypeWord64:
-		return cadence.Word64Type
-	case SimpleTypeWord128:
-		return cadence.Word128Type
-	case SimpleTypeWord256:
-		return cadence.Word256Type
-	case SimpleTypeFix64:
-		return cadence.Fix64Type
-	case SimpleTypeUFix64:
-		return cadence.UFix64Type
-	case SimpleTypePath:
-		return cadence.PathType
-	case SimpleTypeCapabilityPath:
-		return cadence.CapabilityPathType
-	case SimpleTypeStoragePath:
-		return cadence.StoragePathType
-	case SimpleTypePublicPath:
-		return cadence.PublicPathType
-	case SimpleTypePrivatePath:
-		return cadence.PrivatePathType
-	case SimpleTypeDeployedContract:
-		return cadence.DeployedContractType
-	case SimpleTypeBlock:
-		return cadence.BlockType
-	case SimpleTypeAny:
-		return cadence.AnyType
-	case SimpleTypeAnyStruct:
-		return cadence.AnyStructType
-	case SimpleTypeAnyResource:
-		return cadence.AnyResourceType
-	case SimpleTypeMetaType:
-		return cadence.MetaType
-	case SimpleTypeNever:
-		return cadence.NeverType
-	case SimpleTypeNumber:
-		return cadence.NumberType
-	case SimpleTypeSignedNumber:
-		return cadence.SignedNumberType
-	case SimpleTypeInteger:
-		return cadence.IntegerType
-	case SimpleTypeSignedInteger:
-		return cadence.SignedIntegerType
-	case SimpleTypeFixedPoint:
-		return cadence.FixedPointType
-	case SimpleTypeSignedFixedPoint:
-		return cadence.SignedFixedPointType
-	case SimpleTypeBytes:
+	if simpleTypeID == SimpleTypeBytes {
 		return cadence.TheBytesType
-	case SimpleTypeVoid:
-		return cadence.VoidType
-	case SimpleTypeAnyStructAttachmentType:
-		return cadence.AnyStructAttachmentType
-	case SimpleTypeAnyResourceAttachmentType:
-		return cadence.AnyResourceAttachmentType
-	case SimpleTypeStorageCapabilityController:
-		return cadence.StorageCapabilityControllerType
-	case SimpleTypeAccountCapabilityController:
-		return cadence.AccountCapabilityControllerType
-	case SimpleTypeAccount:
-		return cadence.AccountType
-	case SimpleTypeAccount_Contracts:
-		return cadence.Account_ContractsType
-	case SimpleTypeAccount_Keys:
-		return cadence.Account_KeysType
-	case SimpleTypeAccount_Inbox:
-		return cadence.Account_InboxType
-	case SimpleTypeAccount_StorageCapabilities:
-		return cadence.Account_StorageCapabilitiesType
-	case SimpleTypeAccount_AccountCapabilities:
-		return cadence.Account_AccountCapabilitiesType
-	case SimpleTypeAccount_Capabilities:
-		return cadence.Account_CapabilitiesType
-	case SimpleTypeAccount_Storage:
-		return cadence.Account_StorageType
-	case SimpleTypeMutate:
-		return cadence.MutateType
-	case SimpleTypeInsert:
-		return cadence.InsertType
-	case SimpleTypeRemove:
-		return cadence.RemoveType
-	case SimpleTypeIdentity:
-		return cadence.IdentityType
-	case SimpleTypeStorage:
-		return cadence.StorageType
-	case SimpleTypeSaveValue:
-		return cadence.SaveValueType
-	case SimpleTypeLoadValue:
-		return cadence.LoadValueType
-	case SimpleTypeCopyValue:
-		return cadence.CopyValueType
-	case SimpleTypeBorrowValue:
-		return cadence.BorrowValueType
-	case SimpleTypeContracts:
-		return cadence.ContractsType
-	case SimpleTypeAddContract:
-		return cadence.AddContractType
-	case SimpleTypeUpdateContract:
-		return cadence.UpdateContractType
-	case SimpleTypeRemoveContract:
-		return cadence.RemoveContractType
-	case SimpleTypeKeys:
-		return cadence.KeysType
-	case SimpleTypeAddKey:
-		return cadence.AddKeyType
-	case SimpleTypeRevokeKey:
-		return cadence.RevokeKeyType
-	case SimpleTypeInbox:
-		return cadence.InboxType
-	case SimpleTypePublishInboxCapability:
-		return cadence.PublishInboxCapabilityType
-	case SimpleTypeUnpublishInboxCapability:
-		return cadence.UnpublishInboxCapabilityType
-	case SimpleTypeClaimInboxCapability:
-		return cadence.ClaimInboxCapabilityType
-	case SimpleTypeCapabilities:
-		return cadence.CapabilitiesType
-	case SimpleTypeStorageCapabilities:
-		return cadence.StorageCapabilitiesType
-	case SimpleTypeAccountCapabilities:
-		return cadence.AccountCapabilitiesType
-	case SimpleTypePublishCapability:
-		return cadence.PublishCapabilityType
-	case SimpleTypeUnpublishCapability:
-		return cadence.UnpublishCapabilityType
-	case SimpleTypeGetStorageCapabilityController:
-		return cadence.GetStorageCapabilityControllerType
-	case SimpleTypeIssueStorageCapabilityController:
-		return cadence.IssueStorageCapabilityControllerType
-	case SimpleTypeGetAccountCapabilityController:
-		return cadence.GetAccountCapabilityControllerType
-	case SimpleTypeIssueAccountCapabilityController:
-		return cadence.IssueAccountCapabilityControllerType
-	case SimpleTypeCapabilitiesMapping:
-		return cadence.CapabilitiesMappingType
-	case SimpleTypeAccountMapping:
-		return cadence.AccountMappingType
 	}
-
+	if typ, present := simpleTypeIDBiMap.GetInverse(simpleTypeID); present {
+		return typ
+	}
 	return nil
 }

--- a/runtime/common/bimap/bimap.go
+++ b/runtime/common/bimap/bimap.go
@@ -31,15 +31,6 @@ func NewBiMap[K comparable, V comparable]() *BiMap[K, V] {
 	return &BiMap[K, V]{forward: make(map[K]V), backward: make(map[V]K)}
 }
 
-// NewBiMapFrom returns a new BiMap from a map[K, V]
-func NewBiMapFromMap[K comparable, V comparable](forwardMap map[K]V) *BiMap[K, V] {
-	biMap := NewBiMap[K, V]()
-	for k, v := range forwardMap {
-		biMap.Insert(k, v)
-	}
-	return biMap
-}
-
 // Insert puts a key and value into the BiMap, and creates the reverse mapping from value to key.
 func (b *BiMap[K, V]) Insert(k K, v V) {
 	if _, ok := b.forward[k]; ok {

--- a/runtime/common/bimap/bimap.go
+++ b/runtime/common/bimap/bimap.go
@@ -78,7 +78,7 @@ func (b *BiMap[K, V]) Delete(k K) {
 	delete(b.backward, val)
 }
 
-// DeleteInverse emoves a key-value pair from the BiMap for a given value. Returns if the value doesn't exist
+// DeleteInverse removes a key-value pair from the BiMap for a given value. Returns if the value doesn't exist
 func (b *BiMap[K, V]) DeleteInverse(v V) {
 	if !b.ExistsInverse(v) {
 		return

--- a/runtime/common/bimap/bimap.go
+++ b/runtime/common/bimap/bimap.go
@@ -1,0 +1,105 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Based on https://github.com/vishalkuo/bimap, Copyright Vishal Kuo
+ *
+ */
+
+package bimap
+
+type BiMap[K comparable, V comparable] struct {
+	forward  map[K]V
+	backward map[V]K
+}
+
+// NewBiMap returns a an empty, mutable, biMap
+func NewBiMap[K comparable, V comparable]() *BiMap[K, V] {
+	return &BiMap[K, V]{forward: make(map[K]V), backward: make(map[V]K)}
+}
+
+// NewBiMapFrom returns a new BiMap from a map[K, V]
+func NewBiMapFromMap[K comparable, V comparable](forwardMap map[K]V) *BiMap[K, V] {
+	biMap := NewBiMap[K, V]()
+	for k, v := range forwardMap {
+		biMap.Insert(k, v)
+	}
+	return biMap
+}
+
+// Insert puts a key and value into the BiMap, and creates the reverse mapping from value to key.
+func (b *BiMap[K, V]) Insert(k K, v V) {
+	if _, ok := b.forward[k]; ok {
+		delete(b.backward, b.forward[k])
+	}
+	b.forward[k] = v
+	b.backward[v] = k
+}
+
+// Exists checks whether or not a key exists in the BiMap
+func (b *BiMap[K, V]) Exists(k K) bool {
+	_, ok := b.forward[k]
+	return ok
+}
+
+// ExistsInverse checks whether or not a value exists in the BiMap
+func (b *BiMap[K, V]) ExistsInverse(k V) bool {
+	_, ok := b.backward[k]
+	return ok
+}
+
+// Get returns the value for a given key in the BiMap and whether or not the element was present.
+func (b *BiMap[K, V]) Get(k K) (V, bool) {
+	if !b.Exists(k) {
+		return *new(V), false
+	}
+	return b.forward[k], true
+}
+
+// GetInverse returns the key for a given value in the BiMap and whether or not the element was present.
+func (b *BiMap[K, V]) GetInverse(v V) (K, bool) {
+	if !b.ExistsInverse(v) {
+		return *new(K), false
+	}
+	return b.backward[v], true
+}
+
+// Delete removes a key-value pair from the BiMap for a given key. Returns if the key doesn't exist
+func (b *BiMap[K, V]) Delete(k K) {
+	if !b.Exists(k) {
+		return
+	}
+	val, _ := b.Get(k)
+	delete(b.forward, k)
+	delete(b.backward, val)
+}
+
+// DeleteInverse emoves a key-value pair from the BiMap for a given value. Returns if the value doesn't exist
+func (b *BiMap[K, V]) DeleteInverse(v V) {
+	if !b.ExistsInverse(v) {
+		return
+	}
+
+	key, _ := b.GetInverse(v)
+	delete(b.backward, v)
+	delete(b.forward, key)
+
+}
+
+// Size returns the number of elements in the bimap
+func (b *BiMap[K, V]) Size() int {
+	return len(b.forward)
+}

--- a/runtime/common/bimap/bimap_test.go
+++ b/runtime/common/bimap/bimap_test.go
@@ -1,0 +1,206 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package bimap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const key = "key"
+const value = "value"
+
+func TestNewBiMap(t *testing.T) {
+	actual := NewBiMap[string, string]()
+	expected := &BiMap[string, string]{forward: make(map[string]string), backward: make(map[string]string)}
+	assert.Equal(t, expected, actual, "They should be equal")
+}
+
+func TestNewBiMapFrom(t *testing.T) {
+	actual := NewBiMapFromMap(map[string]string{
+		key: value,
+	})
+	actual.Insert(key, value)
+
+	fwdExpected := make(map[string]string)
+	invExpected := make(map[string]string)
+	fwdExpected[key] = value
+	invExpected[value] = key
+	expected := &BiMap[string, string]{forward: fwdExpected, backward: invExpected}
+
+	assert.Equal(t, expected, actual, "They should be equal")
+}
+
+func TestBiMap_Insert(t *testing.T) {
+	actual := NewBiMap[string, string]()
+	actual.Insert(key, value)
+
+	fwdExpected := make(map[string]string)
+	invExpected := make(map[string]string)
+	fwdExpected[key] = value
+	invExpected[value] = key
+	expected := &BiMap[string, string]{forward: fwdExpected, backward: invExpected}
+
+	assert.Equal(t, expected, actual, "They should be equal")
+}
+
+func TestBiMap_InsertTwice(t *testing.T) {
+	additionalValue := value + value
+
+	actual := NewBiMap[string, string]()
+	actual.Insert(key, value)
+	actual.Insert(key, additionalValue)
+
+	fwdExpected := make(map[string]string)
+	invExpected := make(map[string]string)
+	fwdExpected[key] = additionalValue
+
+	invExpected[additionalValue] = key
+	expected := &BiMap[string, string]{forward: fwdExpected, backward: invExpected}
+
+	assert.Equal(t, expected, actual, "They should be equal")
+}
+
+func TestBiMap_Exists(t *testing.T) {
+	actual := NewBiMap[string, string]()
+
+	actual.Insert(key, value)
+	assert.False(t, actual.Exists("ARBITARY_KEY"), "Key should not exist")
+	assert.True(t, actual.Exists(key), "Inserted key should exist")
+}
+
+func TestBiMap_InverseExists(t *testing.T) {
+	actual := NewBiMap[string, string]()
+
+	actual.Insert(key, value)
+	assert.False(t, actual.ExistsInverse("ARBITARY_VALUE"), "Value should not exist")
+	assert.True(t, actual.ExistsInverse(value), "Inserted value should exist")
+}
+
+func TestBiMap_Get(t *testing.T) {
+	actual := NewBiMap[string, string]()
+
+	actual.Insert(key, value)
+
+	actualVal, ok := actual.Get(key)
+
+	assert.True(t, ok, "It should return true")
+	assert.Equal(t, value, actualVal, "Value and returned val should be equal")
+
+	actualVal, ok = actual.Get(value)
+
+	assert.False(t, ok, "It should return false")
+	assert.Empty(t, actualVal, "Actual val should be empty")
+}
+
+func TestBiMap_GetInverse(t *testing.T) {
+	actual := NewBiMap[string, string]()
+
+	actual.Insert(key, value)
+
+	actualKey, ok := actual.GetInverse(value)
+
+	assert.True(t, ok, "It should return true")
+	assert.Equal(t, key, actualKey, "Key and returned key should be equal")
+
+	actualKey, ok = actual.Get(value)
+
+	assert.False(t, ok, "It should return false")
+	assert.Empty(t, actualKey, "Actual key should be empty")
+}
+
+func TestBiMap_Size(t *testing.T) {
+	actual := NewBiMap[string, string]()
+
+	assert.Equal(t, 0, actual.Size(), "Length of empty bimap should be zero")
+
+	actual.Insert(key, value)
+
+	assert.Equal(t, 1, actual.Size(), "Length of bimap should be one")
+}
+
+func TestBiMap_Delete(t *testing.T) {
+	actual := NewBiMap[string, string]()
+	dummyKey := "DummyKey"
+	dummyVal := "DummyVal"
+	actual.Insert(key, value)
+	actual.Insert(dummyKey, dummyVal)
+
+	assert.Equal(t, 2, actual.Size(), "Size of bimap should be two")
+
+	actual.Delete(dummyKey)
+
+	fwdExpected := make(map[string]string)
+	invExpected := make(map[string]string)
+	fwdExpected[key] = value
+	invExpected[value] = key
+
+	expected := &BiMap[string, string]{forward: fwdExpected, backward: invExpected}
+
+	assert.Equal(t, 1, actual.Size(), "Size of bimap should be two")
+	assert.Equal(t, expected, actual, "They should be the same")
+
+	actual.Delete(dummyKey)
+
+	assert.Equal(t, 1, actual.Size(), "Size of bimap should be two")
+	assert.Equal(t, expected, actual, "They should be the same")
+}
+
+func TestBiMap_InverseDelete(t *testing.T) {
+	actual := NewBiMap[string, string]()
+	dummyKey := "DummyKey"
+	dummyVal := "DummyVal"
+	actual.Insert(key, value)
+	actual.Insert(dummyKey, dummyVal)
+
+	assert.Equal(t, 2, actual.Size(), "Size of bimap should be two")
+
+	actual.DeleteInverse(dummyVal)
+
+	fwdExpected := make(map[string]string)
+	invExpected := make(map[string]string)
+	fwdExpected[key] = value
+	invExpected[value] = key
+
+	expected := &BiMap[string, string]{forward: fwdExpected, backward: invExpected}
+
+	assert.Equal(t, 1, actual.Size(), "Size of bimap should be two")
+	assert.Equal(t, expected, actual, "They should be the same")
+
+	actual.DeleteInverse(dummyVal)
+
+	assert.Equal(t, 1, actual.Size(), "Size of bimap should be two")
+	assert.Equal(t, expected, actual, "They should be the same")
+}
+
+func TestBiMap_WithVaryingType(t *testing.T) {
+	actual := NewBiMap[string, int]()
+	dummyKey := "Dummy key"
+	dummyVal := 3
+
+	actual.Insert(dummyKey, dummyVal)
+
+	res, _ := actual.Get(dummyKey)
+	resVal, _ := actual.GetInverse(dummyVal)
+	assert.Equal(t, dummyVal, res, "Get by string key should return integer val")
+	assert.Equal(t, dummyKey, resVal, "Get by integer val should return string key")
+
+}

--- a/runtime/common/bimap/bimap_test.go
+++ b/runtime/common/bimap/bimap_test.go
@@ -34,21 +34,6 @@ func TestNewBiMap(t *testing.T) {
 	assert.Equal(t, expected, actual, "They should be equal")
 }
 
-func TestNewBiMapFrom(t *testing.T) {
-	actual := NewBiMapFromMap(map[string]string{
-		key: value,
-	})
-	actual.Insert(key, value)
-
-	fwdExpected := make(map[string]string)
-	invExpected := make(map[string]string)
-	fwdExpected[key] = value
-	invExpected[value] = key
-	expected := &BiMap[string, string]{forward: fwdExpected, backward: invExpected}
-
-	assert.Equal(t, expected, actual, "They should be equal")
-}
-
 func TestBiMap_Insert(t *testing.T) {
 	actual := NewBiMap[string, string]()
 	actual.Insert(key, value)
@@ -83,7 +68,7 @@ func TestBiMap_Exists(t *testing.T) {
 	actual := NewBiMap[string, string]()
 
 	actual.Insert(key, value)
-	assert.False(t, actual.Exists("ARBITARY_KEY"), "Key should not exist")
+	assert.False(t, actual.Exists("ARBITRARY_KEY"), "Key should not exist")
 	assert.True(t, actual.Exists(key), "Inserted key should exist")
 }
 
@@ -91,7 +76,7 @@ func TestBiMap_InverseExists(t *testing.T) {
 	actual := NewBiMap[string, string]()
 
 	actual.Insert(key, value)
-	assert.False(t, actual.ExistsInverse("ARBITARY_VALUE"), "Value should not exist")
+	assert.False(t, actual.ExistsInverse("ARBITRARY_VALUE"), "Value should not exist")
 	assert.True(t, actual.ExistsInverse(value), "Inserted value should exist")
 }
 


### PR DESCRIPTION
Part of https://github.com/onflow/cadence/issues/2642

## Description

This implements a lock free (thread unsafe) version of https://github.com/vishalkuo/bimap, and then uses it to implement the behavior of `simpleTypeIDByType` and `typeBySimpleTypeID` in the CCF. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
