### PR TITLE
Cache normalized string

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -88,11 +88,12 @@ func exportValueWithInterpreter(
 	case interpreter.BoolValue:
 		return cadence.NewMeteredBool(inter, bool(v)), nil
 	case *interpreter.StringValue:
+		str := v.Str(inter)
 		return cadence.NewMeteredString(
 			inter,
-			common.NewCadenceStringMemoryUsage(len(v.Str)),
+			common.NewCadenceStringMemoryUsage(len(str)),
 			func() string {
-				return v.Str
+				return str
 			},
 		)
 	case interpreter.CharacterValue:

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -275,7 +275,8 @@ func (v *StringValue) Encode(e *atree.Encoder) error {
 	if err != nil {
 		return err
 	}
-	return e.CBOR.EncodeString(v.Str)
+	// TODO: write normalized? no memory gauge available
+	return e.CBOR.EncodeString(v._str)
 }
 
 // Encode encodes the value as a CBOR string

--- a/runtime/runtime_memory_metering_test.go
+++ b/runtime/runtime_memory_metering_test.go
@@ -97,7 +97,7 @@ func TestRuntimeInterpreterAddressLocationMetering(t *testing.T) {
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindAddressLocation))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindElaboration))
-		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(21), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindCadenceVoidValue))
 	})
 }
@@ -783,10 +783,8 @@ func TestRuntimeLogFunctionStringConversionMetering(t *testing.T) {
 			getSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			storage: newTestLedger(nil, nil),
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
+			storage:     newTestLedger(nil, nil),
+			meterMemory: meter.MeterMemory,
 			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCode, nil
 			},
@@ -818,7 +816,7 @@ func TestRuntimeLogFunctionStringConversionMetering(t *testing.T) {
 	diffOfActualLen := nonEmptyStrActualLen - emptyStrActualLen
 	diffOfMeteredAmount := nonEmptyStrMeteredAmount - emptyStrMeteredAmount
 
-	assert.Equal(t, diffOfActualLen, diffOfMeteredAmount)
+	assert.Equal(t, diffOfActualLen*2, diffOfMeteredAmount)
 }
 
 func TestRuntimeStorageCommitsMetering(t *testing.T) {

--- a/runtime/stdlib/assert.go
+++ b/runtime/stdlib/assert.go
@@ -58,6 +58,8 @@ var AssertFunction = NewStandardLibraryFunction(
 	assertFunctionType,
 	assertFunctionDocString,
 	func(invocation interpreter.Invocation) interpreter.Value {
+		inter := invocation.Interpreter
+
 		result, ok := invocation.Arguments[0].(interpreter.BoolValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
@@ -70,7 +72,7 @@ var AssertFunction = NewStandardLibraryFunction(
 				if !ok {
 					panic(errors.NewUnreachableError())
 				}
-				message = messageValue.Str
+				message = messageValue.Str(inter)
 			}
 			panic(AssertionError{
 				Message:       message,

--- a/runtime/stdlib/hashalgorithm.go
+++ b/runtime/stdlib/hashalgorithm.go
@@ -144,7 +144,7 @@ func hash(
 
 	var tag string
 	if tagValue != nil {
-		tag = tagValue.Str
+		tag = tagValue.Str(inter)
 	}
 
 	hashAlgorithm := NewHashAlgorithmFromValue(inter, locationRange, hashAlgorithmValue)

--- a/runtime/stdlib/panic.go
+++ b/runtime/stdlib/panic.go
@@ -60,15 +60,18 @@ var PanicFunction = NewStandardLibraryFunction(
 	panicFunctionType,
 	panicFunctionDocString,
 	func(invocation interpreter.Invocation) interpreter.Value {
+		inter := invocation.Interpreter
+		locationRange := invocation.LocationRange
+
 		messageValue, ok := invocation.Arguments[0].(*interpreter.StringValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
-		message := messageValue.Str
+		message := messageValue.Str(inter)
 
 		panic(PanicError{
 			Message:       message,
-			LocationRange: invocation.LocationRange,
+			LocationRange: locationRange,
 		})
 	},
 )

--- a/runtime/stdlib/publickey.go
+++ b/runtime/stdlib/publickey.go
@@ -274,7 +274,7 @@ func newPublicKeyVerifySignatureFunction(
 				panic(errors.NewUnexpectedError("failed to get signed data. %w", err))
 			}
 
-			domainSeparationTag := domainSeparationTagValue.Str
+			domainSeparationTag := domainSeparationTagValue.Str(inter)
 
 			hashAlgorithm := NewHashAlgorithmFromValue(inter, locationRange, hashAlgorithmValue)
 

--- a/runtime/stdlib/test_emulatorbackend.go
+++ b/runtime/stdlib/test_emulatorbackend.go
@@ -269,7 +269,11 @@ func (t *testEmulatorBackendType) newExecuteScriptFunction(
 				panic(errors.NewUnexpectedErrorFromCause(err))
 			}
 
-			result := blockchain.RunScript(inter, script.Str, args)
+			result := blockchain.RunScript(
+				inter,
+				script.Str(inter),
+				args,
+			)
 
 			return newScriptResult(inter, result.Value, result)
 		},
@@ -421,7 +425,7 @@ func (t *testEmulatorBackendType) newAddTransactionFunction(
 
 			err = blockchain.AddTransaction(
 				inter,
-				code.Str,
+				code.Str(inter),
 				authorizers,
 				signerAccounts,
 				args,
@@ -531,8 +535,8 @@ func (t *testEmulatorBackendType) newDeployContractFunction(
 
 			err = blockchain.DeployContract(
 				inter,
-				name.Str,
-				code.Str,
+				name.Str(inter),
+				code.Str(inter),
 				account,
 				args,
 			)
@@ -587,7 +591,9 @@ func (t *testEmulatorBackendType) newUseConfigFunction(
 					panic(errors.NewUnreachableError())
 				}
 
-				mapping[location.Str] = common.Address(address)
+				locationStr := location.Str(inter)
+
+				mapping[locationStr] = common.Address(address)
 
 				return true
 			})
@@ -780,12 +786,14 @@ func (t *testEmulatorBackendType) newCreateSnapshotFunction(
 	return interpreter.NewUnmeteredHostFunctionValue(
 		t.createSnapshotFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+
 			name, ok := invocation.Arguments[0].(*interpreter.StringValue)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}
 
-			err := blockchain.CreateSnapshot(name.Str)
+			err := blockchain.CreateSnapshot(name.Str(inter))
 			return newErrorValue(invocation.Interpreter, err)
 		},
 	)
@@ -806,12 +814,14 @@ func (t *testEmulatorBackendType) newLoadSnapshotFunction(
 	return interpreter.NewUnmeteredHostFunctionValue(
 		t.loadSnapshotFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+
 			name, ok := invocation.Arguments[0].(*interpreter.StringValue)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}
 
-			err := blockchain.LoadSnapshot(name.Str)
+			err := blockchain.LoadSnapshot(name.Str(inter))
 			return newErrorValue(invocation.Interpreter, err)
 		},
 	)

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -539,7 +539,11 @@ func TestInterpretDictionaryMutation(t *testing.T) {
 			interpreter.NewUnmeteredStringValue("foo"),
 		)
 		assert.True(t, present)
-		assert.Equal(t, interpreter.NewUnmeteredStringValue("baz"), val)
+		AssertValuesEqual(t,
+			inter,
+			interpreter.NewUnmeteredStringValue("baz"),
+			val,
+		)
 	})
 
 	t.Run("simple dictionary invalid", func(t *testing.T) {
@@ -618,7 +622,11 @@ func TestInterpretDictionaryMutation(t *testing.T) {
 			interpreter.NewUnmeteredStringValue("foo"),
 		)
 		assert.True(t, present)
-		assert.Equal(t, interpreter.NewUnmeteredStringValue("baz"), val)
+		AssertValuesEqual(t,
+			inter,
+			interpreter.NewUnmeteredStringValue("baz"),
+			val,
+		)
 	})
 
 	t.Run("dictionary insert invalid", func(t *testing.T) {
@@ -1058,7 +1066,11 @@ func TestInterpretInnerContainerMutationWhileIteratingOuter(t *testing.T) {
 			interpreter.NewUnmeteredStringValue("name"),
 		)
 		assert.True(t, present)
-		assert.Equal(t, interpreter.NewUnmeteredStringValue("hello"), val)
+		AssertValuesEqual(t,
+			inter,
+			interpreter.NewUnmeteredStringValue("hello"),
+			val,
+		)
 	})
 
 	t.Run("dictionary", func(t *testing.T) {
@@ -1093,6 +1105,10 @@ func TestInterpretInnerContainerMutationWhileIteratingOuter(t *testing.T) {
 			interpreter.NewUnmeteredStringValue("name"),
 		)
 		assert.True(t, present)
-		assert.Equal(t, interpreter.NewUnmeteredStringValue("foo"), val)
+		AssertValuesEqual(t,
+			inter,
+			interpreter.NewUnmeteredStringValue("foo"),
+			val,
+		)
 	})
 }

--- a/runtime/tests/interpreter/interface_test.go
+++ b/runtime/tests/interpreter/interface_test.go
@@ -578,7 +578,8 @@ func TestInterpretInterfaceFunctionConditionsInheritance(t *testing.T) {
 			logFunctionType,
 			"",
 			func(invocation interpreter.Invocation) interpreter.Value {
-				msg := invocation.Arguments[0].(*interpreter.StringValue).Str
+				inter := invocation.Interpreter
+				msg := invocation.Arguments[0].(*interpreter.StringValue).Str(inter)
 				logs = append(logs, msg)
 				return interpreter.Void
 			},
@@ -686,7 +687,8 @@ func TestInterpretInterfaceFunctionConditionsInheritance(t *testing.T) {
 			logFunctionType,
 			"",
 			func(invocation interpreter.Invocation) interpreter.Value {
-				msg := invocation.Arguments[0].(*interpreter.StringValue).Str
+				inter := invocation.Interpreter
+				msg := invocation.Arguments[0].(*interpreter.StringValue).Str(inter)
 				logs = append(logs, msg)
 				return interpreter.Void
 			},
@@ -794,7 +796,8 @@ func TestInterpretInterfaceFunctionConditionsInheritance(t *testing.T) {
 			logFunctionType,
 			"",
 			func(invocation interpreter.Invocation) interpreter.Value {
-				msg := invocation.Arguments[0].(*interpreter.StringValue).Str
+				inter := invocation.Interpreter
+				msg := invocation.Arguments[0].(*interpreter.StringValue).Str(inter)
 				logs = append(logs, msg)
 				return interpreter.Void
 			},

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -4491,39 +4491,45 @@ func TestInterpretDictionaryIndexingType(t *testing.T) {
       let f = x[Type<@TestResource>()]
     `)
 
-	assert.Equal(t,
+	AssertValuesEqual(t,
+		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("a"),
 		),
 		inter.Globals.Get("a").GetValue(),
 	)
 
-	assert.Equal(t,
+	AssertValuesEqual(t,
+		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("b"),
 		),
 		inter.Globals.Get("b").GetValue(),
 	)
 
-	assert.Equal(t,
+	AssertValuesEqual(t,
+		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("c"),
 		),
 		inter.Globals.Get("c").GetValue(),
 	)
 
-	assert.Equal(t,
+	AssertValuesEqual(t,
+		inter,
 		interpreter.Nil,
 		inter.Globals.Get("d").GetValue(),
 	)
 
 	// types need to match exactly, subtypes won't cut it
-	assert.Equal(t,
+	AssertValuesEqual(t,
+		inter,
 		interpreter.Nil,
 		inter.Globals.Get("e").GetValue(),
 	)
 
-	assert.Equal(t,
+	AssertValuesEqual(t,
+		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("f"),
 		),

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -644,7 +644,7 @@ func TestInterpretCompositeMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindStringValue))
-		assert.Equal(t, uint64(66), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(76), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindCompositeValueBase))
 		assert.Equal(t, uint64(5), meter.getMemory(common.MemoryKindAtreeMapDataSlab))
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindAtreeMapMetaDataSlab))
@@ -767,7 +767,7 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(20), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindCompositeValueBase))
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindAtreeMapElementOverhead))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindAtreeMapDataSlab))
@@ -798,7 +798,7 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(34), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(44), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindAtreeMapDataSlab))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindAtreeMapElementOverhead))
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindAtreeMapMetaDataSlab))
@@ -7826,7 +7826,7 @@ func TestInterpreterStringLocationMetering(t *testing.T) {
 		testLocationStringCount := meter.getMemory(common.MemoryKindRawString)
 
 		// raw string location is "test" + locationIDs
-		assert.Equal(t, uint64(5), testLocationStringCount-emptyLocationStringCount)
+		assert.Equal(t, uint64(13), testLocationStringCount-emptyLocationStringCount)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindCompositeStaticType))
 


### PR DESCRIPTION
Work towards #2752 

## Description

String functions, like checking for equality, already operate on the normalized form of the string.
However, the results are currently discarded. 

As strings are immutable, we can cache the normalized form and re-use it.

As the hash value is changed, this will need a migration. Given that we can perform breaking changes in the Stable Cadence release, we should use this opportunity. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
