### PR TITLE
Add an exists function, allows checking if capability exists/is published

### DIFF
--- a/runtime/capabilities_test.go
+++ b/runtime/capabilities_test.go
@@ -124,13 +124,16 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
                   let rAsSCap = self.account.capabilities.storage.issue<&S>(/storage/r)
                   self.account.capabilities.publish(rAsSCap, at: /public/rAsS)
 
-                  let noCap = self.account.capabilities.storage.issue<&R>(/storage/nonExistent)
-                  self.account.capabilities.publish(noCap, at: /public/nonExistent)
+                  let noCap = self.account.capabilities.storage.issue<&R>(/storage/nonExistentTarget)
+                  self.account.capabilities.publish(noCap, at: /public/nonExistentTarget)
               }
 
               access(all)
               fun testR() {
-                  let cap = self.account.capabilities.get<&R>(/public/r)!
+                  let path = /public/r
+                  let cap = self.account.capabilities.get<&R>(path)!
+
+                  assert(self.account.capabilities.exists(path))
 
                   assert(
                       cap.check(),
@@ -156,7 +159,10 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
               access(all)
               fun testRAsR2() {
-                  let cap = self.account.capabilities.get<&R2>(/public/rAsR2)!
+                  let path = /public/rAsR2
+                  let cap = self.account.capabilities.get<&R2>(path)!
+
+                  assert(self.account.capabilities.exists(path))
 
                   assert(
                       !cap.check(),
@@ -176,7 +182,33 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
               access(all)
               fun testRAsS() {
-                  let cap = self.account.capabilities.get<&S>(/public/rAsS)!
+                  let path = /public/rAsS
+                  let cap = self.account.capabilities.get<&S>(path)!
+
+                  assert(self.account.capabilities.exists(path))
+
+                  assert(
+                      !cap.check(),
+                      message: "invalid check"
+                  )
+
+                  assert(
+                      cap.address == 0x1,
+                      message: "invalid address"
+                  )
+
+                  assert(
+                      cap.borrow() == nil,
+                      message: "invalid borrow"
+                  )
+              }
+
+              access(all)
+              fun testNonExistentTarget() {
+                  let path = /public/nonExistentTarget
+                  let cap = self.account.capabilities.get<&R>(path)!
+
+                  assert(self.account.capabilities.exists(path))
 
                   assert(
                       !cap.check(),
@@ -196,22 +228,9 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
               access(all)
               fun testNonExistent() {
-                  let cap = self.account.capabilities.get<&R>(/public/nonExistent)!
-
-                  assert(
-                      !cap.check(),
-                      message: "invalid check"
-                  )
-
-                  assert(
-                      cap.address == 0x1,
-                      message: "invalid address"
-                  )
-
-                  assert(
-                      cap.borrow() == nil,
-                      message: "invalid borrow"
-                  )
+                  let path = /public/nonExistent
+                  assert(self.account.capabilities.get<&AnyResource>(path) == nil)
+                  assert(!self.account.capabilities.exists(path))
               }
 
               access(all)
@@ -271,6 +290,11 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
 		t.Run("testRAsS", func(t *testing.T) {
 			_, err := invoke("testRAsS")
+			require.NoError(t, err)
+		})
+
+		t.Run("testNonExistentTarget", func(t *testing.T) {
+			_, err := invoke("testNonExistentTarget")
 			require.NoError(t, err)
 		})
 
@@ -352,13 +376,16 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
                   let sAsRCap = self.account.capabilities.storage.issue<&R>(/storage/s)
                   self.account.capabilities.publish(sAsRCap, at: /public/sAsR)
 
-                  let noCap = self.account.capabilities.storage.issue<&S>(/storage/nonExistent)
-                  self.account.capabilities.publish(noCap, at: /public/nonExistent)
+                  let noCap = self.account.capabilities.storage.issue<&S>(/storage/nonExistentTarget)
+                  self.account.capabilities.publish(noCap, at: /public/nonExistentTarget)
               }
 
               access(all)
               fun testS() {
-                  let cap = self.account.capabilities.get<&S>(/public/s)!
+                  let path = /public/s
+                  let cap = self.account.capabilities.get<&S>(path)!
+
+                  assert(self.account.capabilities.exists(path))
 
                   assert(
                        cap.check(),
@@ -384,7 +411,10 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
               access(all)
               fun testSAsS2() {
-                  let cap = self.account.capabilities.get<&S2>(/public/sAsS2)!
+                  let path = /public/sAsS2
+                  let cap = self.account.capabilities.get<&S2>(path)!
+
+                  assert(self.account.capabilities.exists(path))
 
                   assert(
                       !cap.check(),
@@ -404,7 +434,33 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
               access(all)
               fun testSAsR() {
-                  let cap = self.account.capabilities.get<&R>(/public/sAsR)!
+                  let path = /public/sAsR
+                  let cap = self.account.capabilities.get<&R>(path)!
+
+                  assert(self.account.capabilities.exists(path))
+
+                  assert(
+                      !cap.check(),
+                      message: "invalid check"
+                  )
+
+                  assert(
+                      cap.address == 0x1,
+                      message: "invalid address"
+                  )
+
+                  assert(
+                      cap.borrow() == nil,
+                      message: "invalid borrow"
+                  )
+              }
+
+              access(all)
+              fun testNonExistentTarget() {
+                  let path = /public/nonExistentTarget
+                  let cap = self.account.capabilities.get<&S>(path)!
+
+                  assert(self.account.capabilities.exists(path))
 
                   assert(
                       !cap.check(),
@@ -424,22 +480,9 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
               access(all)
               fun testNonExistent() {
-                  let cap = self.account.capabilities.get<&S>(/public/nonExistent)!
-
-                  assert(
-                      !cap.check(),
-                      message: "invalid check"
-                  )
-
-                  assert(
-                      cap.address == 0x1,
-                      message: "invalid address"
-                  )
-
-                  assert(
-                      cap.borrow() == nil,
-                      message: "invalid borrow"
-                  )
+                  let path = /public/nonExistent
+                  assert(self.account.capabilities.get<&AnyStruct>(path) == nil)
+                  assert(!self.account.capabilities.exists(path))
               }
 
               access(all)
@@ -498,6 +541,11 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
 		t.Run("testSAsR", func(t *testing.T) {
 			_, err := invoke("testSAsR")
+			require.NoError(t, err)
+		})
+
+		t.Run("testNonExistentTarget", func(t *testing.T) {
+			_, err := invoke("testNonExistentTarget")
 			require.NoError(t, err)
 		})
 

--- a/runtime/capabilitycontrollers_test.go
+++ b/runtime/capabilitycontrollers_test.go
@@ -203,11 +203,14 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						`
                             transaction {
                                 prepare(signer: auth(Capabilities) &Account) {
+                                    let path = /public/x
+
                                     // Act
                                     let gotCap: Capability<&AnyStruct>? =
-                                        %s.capabilities.get<&AnyStruct>(/public/x)
+                                        %[1]s.capabilities.get<&AnyStruct>(path)
 
                                     // Assert
+                                    assert(!%[1]s.capabilities.exists(path))
                                     assert(gotCap == nil)
                                 }
                             }
@@ -244,9 +247,10 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
                                       // Act
                                       let gotCap: Capability<&Test.R> =
-                                          %s.capabilities.get<&Test.R>(publicPath)!
+                                          %[1]s.capabilities.get<&Test.R>(publicPath)!
 
                                       // Assert
+                                      assert(%[1]s.capabilities.exists(publicPath))
                                       assert(issuedCap.id == expectedCapID)
                                       assert(gotCap.check())
                                       assert(gotCap.id == expectedCapID)
@@ -276,9 +280,10 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
                                       // Act
                                       let gotCap: Capability<&Account> =
-                                          %s.capabilities.get<&Account>(publicPath)!
+                                          %[1]s.capabilities.get<&Account>(publicPath)!
 
                                       // Assert
+                                      assert(%[1]s.capabilities.exists(publicPath))
                                       assert(issuedCap.id == expectedCapID)
                                       assert(gotCap.check())
                                       assert(gotCap.id == expectedCapID)
@@ -319,10 +324,11 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
                                       // Act
                                       let gotCap: Capability<&Test.R> =
-                                          %s.capabilities.get<&Test.R>(publicPath)!
+                                          %[1]s.capabilities.get<&Test.R>(publicPath)!
                                       let ref: &Test.R = gotCap.borrow()!
 
                                       // Assert
+                                      assert(%[1]s.capabilities.exists(publicPath))
                                       assert(issuedCap.id == expectedCapID)
                                       assert(gotCap.check())
                                       assert(gotCap.id == expectedCapID)
@@ -354,10 +360,11 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
                                       // Act
                                       let gotCap: Capability<&Account> =
-                                          %s.capabilities.get<&Account>(publicPath)!
+                                          %[1]s.capabilities.get<&Account>(publicPath)!
                                       let ref: &Account = gotCap.borrow()!
 
                                       // Assert
+                                      assert(%[1]s.capabilities.exists(publicPath))
                                       assert(issuedCap.id == expectedCapID)
                                       assert(gotCap.check())
                                       assert(gotCap.id == expectedCapID)
@@ -399,9 +406,10 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
                                       // Act
                                       let gotCap: Capability<auth(Test.X) &Test.R>? =
-                                          %s.capabilities.get<auth(Test.X) &Test.R>(publicPath)
+                                          %[1]s.capabilities.get<auth(Test.X) &Test.R>(publicPath)
 
                                       // Assert
+                                      assert(%[1]s.capabilities.exists(publicPath))
                                       assert(issuedCap.id == expectedCapID)
                                       assert(gotCap == nil)
                                   }
@@ -433,9 +441,10 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
                                       // Act
                                       let gotCap: Capability<&Test.R>? =
-                                          %s.capabilities.get<&Test.R>(publicPath)
+                                          %[1]s.capabilities.get<&Test.R>(publicPath)
 
                                       // Assert
+                                      assert(%[1]s.capabilities.exists(publicPath))
                                       assert(issuedCap.id == expectedCapID)
                                       assert(gotCap == nil)
                                   }
@@ -475,9 +484,10 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
                                       // Act
                                       let gotCap: Capability<&Test.S>? =
-                                          %s.capabilities.get<&Test.S>(publicPath)
+                                          %[1]s.capabilities.get<&Test.S>(publicPath)
 
                                       // Assert
+                                      assert(%[1]s.capabilities.exists(publicPath))
                                       assert(issuedCap.id == expectedCapID)
                                       assert(gotCap == nil)
                                   }
@@ -507,9 +517,10 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
                                       // Act
                                       let gotCap: Capability<&AnyResource>? =
-                                          %s.capabilities.get<&AnyResource>(publicPath)
+                                          %[1]s.capabilities.get<&AnyResource>(publicPath)
 
                                       // Assert
+                                      assert(%[1]s.capabilities.exists(publicPath))
                                       assert(issuedCap.id == expectedCapID)
                                       assert(gotCap == nil)
                                   }
@@ -549,9 +560,10 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
                                       // Act
                                       let gotCap: Capability<&Test.R>? =
-                                          %s.capabilities.get<&Test.R>(publicPath)
+                                          %[1]s.capabilities.get<&Test.R>(publicPath)
 
                                       // Assert
+                                      assert(!%[1]s.capabilities.exists(publicPath))
                                       assert(issuedCap.id == expectedCapID)
                                       assert(unpublishedcap!.id == expectedCapID)
                                       assert(gotCap == nil)
@@ -582,9 +594,10 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
                                       // Act
                                       let gotCap: Capability<&Account>? =
-                                          %s.capabilities.get<&Account>(publicPath)
+                                          %[1]s.capabilities.get<&Account>(publicPath)
 
                                       // Assert
+                                      assert(!%[1]s.capabilities.exists(publicPath))
                                       assert(issuedCap.id == expectedCapID)
                                       assert(unpublishedcap!.id == expectedCapID)
                                       assert(gotCap == nil)

--- a/runtime/interpreter/value_account_capabilities.go
+++ b/runtime/interpreter/value_account_capabilities.go
@@ -35,6 +35,7 @@ func NewAccountCapabilitiesValue(
 	address AddressValue,
 	getFunction FunctionValue,
 	borrowFunction FunctionValue,
+	existsFunction FunctionValue,
 	publishFunction FunctionValue,
 	unpublishFunction FunctionValue,
 	storageCapabilitiesConstructor func() Value,
@@ -44,6 +45,7 @@ func NewAccountCapabilitiesValue(
 	fields := map[string]Value{
 		sema.Account_CapabilitiesTypeGetFunctionName:       getFunction,
 		sema.Account_CapabilitiesTypeBorrowFunctionName:    borrowFunction,
+		sema.Account_CapabilitiesTypeExistsFunctionName:    existsFunction,
 		sema.Account_CapabilitiesTypePublishFunctionName:   publishFunction,
 		sema.Account_CapabilitiesTypeUnpublishFunctionName: unpublishFunction,
 	}

--- a/runtime/sema/account.cdc
+++ b/runtime/sema/account.cdc
@@ -335,6 +335,10 @@ struct Account {
         access(all)
         view fun borrow<T: &Any>(_ path: PublicPath): T?
 
+        /// Returns true if a capability exists at the given public path.
+        access(all)
+        view fun exists(_ path: PublicPath): Bool
+
         /// Publish the capability at the given public path.
         ///
         /// If there is already a capability published under the given path, the program aborts.

--- a/runtime/sema/account.gen.go
+++ b/runtime/sema/account.gen.go
@@ -1287,6 +1287,26 @@ Returns nil if the capability does not exist, or cannot be borrowed using the gi
 The function is equivalent to ` + "`get(path)?.borrow()`" + `.
 `
 
+const Account_CapabilitiesTypeExistsFunctionName = "exists"
+
+var Account_CapabilitiesTypeExistsFunctionType = &FunctionType{
+	Purity: FunctionPurityView,
+	Parameters: []Parameter{
+		{
+			Label:          ArgumentLabelNotRequired,
+			Identifier:     "path",
+			TypeAnnotation: NewTypeAnnotation(PublicPathType),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		BoolType,
+	),
+}
+
+const Account_CapabilitiesTypeExistsFunctionDocString = `
+Returns true if a capability exists at the given public path.
+`
+
 const Account_CapabilitiesTypePublishFunctionName = "publish"
 
 var Account_CapabilitiesTypePublishFunctionType = &FunctionType{
@@ -1388,6 +1408,13 @@ func init() {
 			Account_CapabilitiesTypeBorrowFunctionName,
 			Account_CapabilitiesTypeBorrowFunctionType,
 			Account_CapabilitiesTypeBorrowFunctionDocString,
+		),
+		NewUnmeteredFunctionMember(
+			Account_CapabilitiesType,
+			PrimitiveAccess(ast.AccessAll),
+			Account_CapabilitiesTypeExistsFunctionName,
+			Account_CapabilitiesTypeExistsFunctionType,
+			Account_CapabilitiesTypeExistsFunctionDocString,
 		),
 		NewUnmeteredFunctionMember(
 			Account_CapabilitiesType,


### PR DESCRIPTION
## Description

While updating the design patterns in the documentation, I realized that there is currently no means to check if a capability has already been published under a public path.

Add a new `exists` function to `Account.Capabilities`.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
