### PR TITLE
Eagerly normalize String and Character values at construction time

### DIFF
--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -362,7 +362,9 @@ func (d StorableDecoder) decodeCharacter() (CharacterValue, error) {
 		)
 	}
 
-	// NOTE: already metered by decodeCharacter
+	// NOTE: character value memory usage already metered by decodeCharacter,
+	// but NewUnmeteredCharacterValue normalizes (= allocates)
+	common.UseMemory(d.memoryGauge, common.NewRawStringMemoryUsage(len(v)))
 	return NewUnmeteredCharacterValue(v), nil
 }
 
@@ -378,7 +380,9 @@ func (d StorableDecoder) decodeStringValue() (*StringValue, error) {
 		return nil, err
 	}
 
-	// NOTE: already metered by decodeString
+	// NOTE: character value memory usage already metered by decodeString,
+	// but NewUnmeteredStringValue normalizes (= allocates)
+	common.UseMemory(d.memoryGauge, common.NewRawStringMemoryUsage(len(str)))
 	return NewUnmeteredStringValue(str), nil
 }
 

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -644,7 +644,7 @@ func TestInterpretCompositeMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindStringValue))
-		assert.Equal(t, uint64(66), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(72), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindCompositeValueBase))
 		assert.Equal(t, uint64(5), meter.getMemory(common.MemoryKindAtreeMapDataSlab))
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindAtreeMapMetaDataSlab))
@@ -767,7 +767,7 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(18), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindCompositeValueBase))
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindAtreeMapElementOverhead))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindAtreeMapDataSlab))
@@ -798,7 +798,7 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(34), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(40), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindAtreeMapDataSlab))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindAtreeMapElementOverhead))
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindAtreeMapMetaDataSlab))


### PR DESCRIPTION
Work towards #2752
Alternative to #2777

## Description

Instead of lazily normalizing, if needed, always eagerly normalize at construction time.


______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
