### PR TITLE
Fix capability controller deletion

### DIFF
--- a/runtime/interpreter/value_accountcapabilitycontroller.go
+++ b/runtime/interpreter/value_accountcapabilitycontroller.go
@@ -33,18 +33,21 @@ type AccountCapabilityControllerValue struct {
 	BorrowType   ReferenceStaticType
 	CapabilityID UInt64Value
 
-	// tag is locally cached result of GetTag, and not stored.
-	// It is populated when the field `tag` is read.
-	tag *StringValue
+	// deleted indicates if the controller got deleted. Not stored
+	deleted bool
 
-	// Injected functions
+	// Lazily initialized function values.
+	// Host functions based on injected functions (see below).
+	deleteFunction FunctionValue
+
+	// Injected functions.
 	// Tags are not stored directly inside the controller
 	// to avoid unnecessary storage reads
 	// when the controller is loaded for borrowing/checking
-	GetCapability  func() *IDCapabilityValue
-	GetTag         func() *StringValue
-	SetTag         func(*StringValue)
-	DeleteFunction FunctionValue
+	GetCapability func(inter *Interpreter) *IDCapabilityValue
+	GetTag        func(inter *Interpreter) *StringValue
+	SetTag        func(inter *Interpreter, tag *StringValue)
+	Delete        func(inter *Interpreter, locationRange LocationRange)
 }
 
 func NewUnmeteredAccountCapabilityControllerValue(
@@ -208,16 +211,12 @@ func (v *AccountCapabilityControllerValue) ChildStorables() []atree.Storable {
 }
 
 func (v *AccountCapabilityControllerValue) GetMember(inter *Interpreter, _ LocationRange, name string) Value {
+	// NOTE: check if controller is already deleted
+	v.checkDeleted()
 
 	switch name {
 	case sema.AccountCapabilityControllerTypeTagFieldName:
-		if v.tag == nil {
-			v.tag = v.GetTag()
-			if v.tag == nil {
-				v.tag = EmptyString
-			}
-		}
-		return v.tag
+		return v.GetTag(inter)
 
 	case sema.AccountCapabilityControllerTypeCapabilityIDFieldName:
 		return v.CapabilityID
@@ -225,11 +224,16 @@ func (v *AccountCapabilityControllerValue) GetMember(inter *Interpreter, _ Locat
 	case sema.AccountCapabilityControllerTypeBorrowTypeFieldName:
 		return NewTypeValue(inter, v.BorrowType)
 
-	case sema.AccountCapabilityControllerTypeDeleteFunctionName:
-		return v.DeleteFunction
-
 	case sema.AccountCapabilityControllerTypeCapabilityFieldName:
-		return v.GetCapability()
+		return v.GetCapability(inter)
+
+	case sema.AccountCapabilityControllerTypeDeleteFunctionName:
+		if v.deleteFunction == nil {
+			v.deleteFunction = v.newDeleteFunction(inter)
+		}
+		return v.deleteFunction
+
+		// NOTE: when adding new functions, ensure checkDeleted is called!
 	}
 
 	return nil
@@ -241,19 +245,21 @@ func (*AccountCapabilityControllerValue) RemoveMember(_ *Interpreter, _ Location
 }
 
 func (v *AccountCapabilityControllerValue) SetMember(
-	_ *Interpreter,
+	inter *Interpreter,
 	_ LocationRange,
 	identifier string,
 	value Value,
 ) bool {
+	// NOTE: check if controller is already deleted
+	v.checkDeleted()
+
 	switch identifier {
 	case sema.AccountCapabilityControllerTypeTagFieldName:
 		stringValue, ok := value.(*StringValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
-		v.tag = stringValue
-		v.SetTag(stringValue)
+		v.SetTag(inter, stringValue)
 		return true
 	}
 
@@ -278,29 +284,32 @@ func (v *AccountCapabilityControllerValue) ReferenceValue(
 	)
 }
 
-// SetDeleted sets the controller as deleted, i.e. functions panic from now on
-func (v *AccountCapabilityControllerValue) SetDeleted(gauge common.MemoryGauge) {
-
-	raiseError := func() {
+// checkDeleted checks if the controller is deleted,
+// and panics if it is.
+func (v *AccountCapabilityControllerValue) checkDeleted() {
+	if v.deleted {
 		panic(errors.NewDefaultUserError("controller is deleted"))
 	}
+}
 
-	v.SetTag = func(s *StringValue) {
-		raiseError()
-	}
-	v.GetTag = func() *StringValue {
-		raiseError()
-		return nil
-	}
-
-	panicHostFunction := func(Invocation) Value {
-		raiseError()
-		return nil
-	}
-
-	v.DeleteFunction = NewHostFunctionValue(
-		gauge,
+func (v *AccountCapabilityControllerValue) newDeleteFunction(
+	inter *Interpreter,
+) *HostFunctionValue {
+	return NewHostFunctionValue(
+		inter,
 		sema.AccountCapabilityControllerTypeDeleteFunctionType,
-		panicHostFunction,
+		func(invocation Invocation) Value {
+			// NOTE: check if controller is already deleted
+			v.checkDeleted()
+
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			v.Delete(inter, locationRange)
+
+			v.deleted = true
+
+			return Void
+		},
 	)
 }

--- a/runtime/interpreter/value_storagecapabilitycontroller.go
+++ b/runtime/interpreter/value_storagecapabilitycontroller.go
@@ -46,20 +46,24 @@ type StorageCapabilityControllerValue struct {
 	CapabilityID UInt64Value
 	TargetPath   PathValue
 
-	// tag is locally cached result of GetTag, and not stored.
-	// It is populated when the field `tag` is read.
-	tag *StringValue
+	// deleted indicates if the controller got deleted. Not stored
+	deleted bool
+
+	// Lazily initialized function values.
+	// Host functions based on injected functions (see below).
+	deleteFunction   FunctionValue
+	targetFunction   FunctionValue
+	retargetFunction FunctionValue
 
 	// Injected functions.
 	// Tags are not stored directly inside the controller
 	// to avoid unnecessary storage reads
 	// when the controller is loaded for borrowing/checking
-	GetCapability    func() *IDCapabilityValue
-	GetTag           func() *StringValue
-	SetTag           func(*StringValue)
-	TargetFunction   FunctionValue
-	RetargetFunction FunctionValue
-	DeleteFunction   FunctionValue
+	GetCapability func(inter *Interpreter) *IDCapabilityValue
+	GetTag        func(inter *Interpreter) *StringValue
+	SetTag        func(inter *Interpreter, tag *StringValue)
+	Delete        func(inter *Interpreter, locationRange LocationRange)
+	SetTarget     func(inter *Interpreter, locationRange LocationRange, target PathValue)
 }
 
 func NewUnmeteredStorageCapabilityControllerValue(
@@ -233,16 +237,12 @@ func (v *StorageCapabilityControllerValue) ChildStorables() []atree.Storable {
 }
 
 func (v *StorageCapabilityControllerValue) GetMember(inter *Interpreter, _ LocationRange, name string) Value {
+	// NOTE: check if controller is already deleted
+	v.checkDeleted()
 
 	switch name {
 	case sema.StorageCapabilityControllerTypeTagFieldName:
-		if v.tag == nil {
-			v.tag = v.GetTag()
-			if v.tag == nil {
-				v.tag = EmptyString
-			}
-		}
-		return v.tag
+		return v.GetTag(inter)
 
 	case sema.StorageCapabilityControllerTypeCapabilityIDFieldName:
 		return v.CapabilityID
@@ -250,17 +250,28 @@ func (v *StorageCapabilityControllerValue) GetMember(inter *Interpreter, _ Locat
 	case sema.StorageCapabilityControllerTypeBorrowTypeFieldName:
 		return NewTypeValue(inter, v.BorrowType)
 
-	case sema.StorageCapabilityControllerTypeTargetFunctionName:
-		return v.TargetFunction
-
-	case sema.StorageCapabilityControllerTypeRetargetFunctionName:
-		return v.RetargetFunction
+	case sema.StorageCapabilityControllerTypeCapabilityFieldName:
+		return v.GetCapability(inter)
 
 	case sema.StorageCapabilityControllerTypeDeleteFunctionName:
-		return v.DeleteFunction
+		if v.deleteFunction == nil {
+			v.deleteFunction = v.newDeleteFunction(inter)
+		}
+		return v.deleteFunction
 
-	case sema.StorageCapabilityControllerTypeCapabilityFieldName:
-		return v.GetCapability()
+	case sema.StorageCapabilityControllerTypeTargetFunctionName:
+		if v.targetFunction == nil {
+			v.targetFunction = v.newTargetFunction(inter)
+		}
+		return v.targetFunction
+
+	case sema.StorageCapabilityControllerTypeRetargetFunctionName:
+		if v.retargetFunction == nil {
+			v.retargetFunction = v.newRetargetFunction(inter)
+		}
+		return v.retargetFunction
+
+		// NOTE: when adding new functions, ensure checkDeleted is called!
 	}
 
 	return nil
@@ -272,19 +283,21 @@ func (*StorageCapabilityControllerValue) RemoveMember(_ *Interpreter, _ Location
 }
 
 func (v *StorageCapabilityControllerValue) SetMember(
-	_ *Interpreter,
+	inter *Interpreter,
 	_ LocationRange,
 	identifier string,
 	value Value,
 ) bool {
+	// NOTE: check if controller is already deleted
+	v.checkDeleted()
+
 	switch identifier {
 	case sema.StorageCapabilityControllerTypeTagFieldName:
 		stringValue, ok := value.(*StringValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
-		v.tag = stringValue
-		v.SetTag(stringValue)
+		v.SetTag(inter, stringValue)
 		return true
 	}
 
@@ -309,39 +322,75 @@ func (v *StorageCapabilityControllerValue) ReferenceValue(
 	)
 }
 
-// SetDeleted sets the controller as deleted, i.e. functions panic from now on
-func (v *StorageCapabilityControllerValue) SetDeleted(gauge common.MemoryGauge) {
-
-	raiseError := func() {
+// checkDeleted checks if the controller is deleted,
+// and panics if it is.
+func (v *StorageCapabilityControllerValue) checkDeleted() {
+	if v.deleted {
 		panic(errors.NewDefaultUserError("controller is deleted"))
 	}
+}
 
-	v.SetTag = func(s *StringValue) {
-		raiseError()
-	}
-	v.GetTag = func() *StringValue {
-		raiseError()
-		return nil
-	}
-
-	panicHostFunction := func(Invocation) Value {
-		raiseError()
-		return nil
-	}
-
-	v.TargetFunction = NewHostFunctionValue(
-		gauge,
-		sema.StorageCapabilityControllerTypeTargetFunctionType,
-		panicHostFunction,
-	)
-	v.RetargetFunction = NewHostFunctionValue(
-		gauge,
-		sema.StorageCapabilityControllerTypeRetargetFunctionType,
-		panicHostFunction,
-	)
-	v.DeleteFunction = NewHostFunctionValue(
-		gauge,
+func (v *StorageCapabilityControllerValue) newDeleteFunction(
+	inter *Interpreter,
+) *HostFunctionValue {
+	return NewHostFunctionValue(
+		inter,
 		sema.StorageCapabilityControllerTypeDeleteFunctionType,
-		panicHostFunction,
+		func(invocation Invocation) Value {
+			// NOTE: check if controller is already deleted
+			v.checkDeleted()
+
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			v.Delete(inter, locationRange)
+
+			v.deleted = true
+
+			return Void
+		},
+	)
+}
+
+func (v *StorageCapabilityControllerValue) newTargetFunction(
+	inter *Interpreter,
+) *HostFunctionValue {
+	return NewHostFunctionValue(
+		inter,
+		sema.StorageCapabilityControllerTypeTargetFunctionType,
+		func(invocation Invocation) Value {
+			// NOTE: check if controller is already deleted
+			v.checkDeleted()
+
+			return v.TargetPath
+		},
+	)
+}
+
+func (v *StorageCapabilityControllerValue) newRetargetFunction(
+	inter *Interpreter,
+) *HostFunctionValue {
+	return NewHostFunctionValue(
+		inter,
+		sema.StorageCapabilityControllerTypeRetargetFunctionType,
+		func(invocation Invocation) Value {
+			// NOTE: check if controller is already deleted
+			v.checkDeleted()
+
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			// Get path argument
+
+			newTargetPathValue, ok := invocation.Arguments[0].(PathValue)
+			if !ok || newTargetPathValue.Domain != common.PathDomainStorage {
+				panic(errors.NewUnreachableError())
+			}
+
+			v.SetTarget(inter, locationRange, newTargetPathValue)
+			v.TargetPath = newTargetPathValue
+
+			return Void
+		},
 	)
 }


### PR DESCRIPTION
## Description

Properly handle deletion of capability controllers.

After deletion, the previous implementation replaced functions replaced the functions implementing the controller operations (e.g. delete, retarget, etc.) by replacing the function values.

However, those function values might have been bound.

Properly handle deletion, by keeping a `deleted` flag, keeping function values, and checking the deletion flag in member callbacks (`GetMember` and `SetMember`) and inside of the function values. 

In addition, some of the host function function types were incorrect.

Reported by @oebeling 🙏 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
