### PR TITLE
Introduce `String.split` function

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1350,7 +1350,12 @@ func (v *StringValue) GetMember(interpreter *Interpreter, locationRange Location
 			interpreter,
 			sema.StringTypeSplitFunctionType,
 			func(invocation Invocation) Value {
-				return v.Split(invocation)
+				separator, ok := invocation.Arguments[0].(*StringValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				return v.Split(invocation.Interpreter, invocation.LocationRange, separator.Str)
 			},
 		)
 	}
@@ -1407,15 +1412,8 @@ func (v *StringValue) ToLower(interpreter *Interpreter) *StringValue {
 	)
 }
 
-func (v *StringValue) Split(invocation Invocation) Value {
-	inter := invocation.Interpreter
-
-	separator, ok := invocation.Arguments[0].(*StringValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-
-	split := strings.Split(v.Str, separator.Str)
+func (v *StringValue) Split(inter *Interpreter, locationRange LocationRange, separator string) Value {
+	split := strings.Split(v.Str, separator)
 
 	var index int
 	count := len(split)
@@ -1443,7 +1441,7 @@ func (v *StringValue) Split(invocation Invocation) Value {
 
 			value := strValue.Transfer(
 				inter,
-				invocation.LocationRange,
+				locationRange,
 				atree.Address{},
 				true,
 				nil,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1444,7 +1444,7 @@ func (v *StringValue) Split(invocation Invocation) Value {
 			value := strValue.Transfer(
 				inter,
 				invocation.LocationRange,
-				atree.Address(common.ZeroAddress),
+				atree.Address{},
 				true,
 				nil,
 				nil,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1429,26 +1429,14 @@ func (v *StringValue) Split(inter *Interpreter, locationRange LocationRange, sep
 			}
 
 			str := split[index]
-			strValue := NewStringValue(
+			index++
+			return NewStringValue(
 				inter,
 				common.NewStringMemoryUsage(len(str)),
 				func() string {
 					return str
 				},
 			)
-
-			index++
-
-			value := strValue.Transfer(
-				inter,
-				locationRange,
-				atree.Address{},
-				true,
-				nil,
-				nil,
-			)
-
-			return value
 		},
 	)
 }

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -42,6 +42,11 @@ const StringTypeJoinFunctionDocString = `
 Returns a string after joining the array of strings with the provided separator.
 `
 
+const StringTypeSplitFunctionName = "split"
+const StringTypeSplitFunctionDocString = `
+Returns a variable-sized array of strings after splitting the string on the delimiter.
+`
+
 // StringType represents the string type
 var StringType = &SimpleType{
 	Name:          "String",
@@ -104,6 +109,12 @@ func init() {
 				StringTypeToLowerFunctionName,
 				StringTypeToLowerFunctionType,
 				stringTypeToLowerFunctionDocString,
+			),
+			NewUnmeteredPublicFunctionMember(
+				t,
+				StringTypeSplitFunctionName,
+				StringTypeSplitFunctionType,
+				StringTypeSplitFunctionDocString,
 			),
 		})
 	}
@@ -334,4 +345,19 @@ var StringTypeJoinFunctionType = NewSimpleFunctionType(
 		},
 	},
 	StringTypeAnnotation,
+)
+
+var StringTypeSplitFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]Parameter{
+		{
+			Identifier:     "separator",
+			TypeAnnotation: StringTypeAnnotation,
+		},
+	},
+	NewTypeAnnotation(
+		&VariableSizedType{
+			Type: StringType,
+		},
+	),
 )

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -408,3 +408,46 @@ func TestCheckStringJoinTypeMissingArgumentLabelSeparator(t *testing.T) {
 
 	assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[0])
 }
+
+func TestCheckStringSplit(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+		let s = "👪.❤️.Abc".split(separator: ".")
+	`)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		&sema.VariableSizedType{
+			Type: sema.StringType,
+		},
+		RequireGlobalValue(t, checker.Elaboration, "s"),
+	)
+}
+
+func TestCheckStringSplitTypeMismatchSeparator(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		let s = "Abc:1".split(separator: 1234)
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+}
+
+func TestCheckStringSplitTypeMissingArgumentLabelSeparator(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+	let s = "👪Abc".split("/")
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[0])
+}


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2752

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Adds `str.split(_ separator: String): [String]` function to Cadence. The function returns a variable sized array of string value after splitting the string with the given separator.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
