### PR TITLE
Sync Stable Cadence

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -16,6 +16,9 @@ changelog:
     - title: 🐞 Bug Fixes
       labels:
         - Bugfix
+    - title: 🧪 Testing
+      labels:
+        - Testing
     - title: 📖 Documentation
       labels:
         - Documentation

--- a/meetings/2023-09-12.md
+++ b/meetings/2023-09-12.md
@@ -1,0 +1,185 @@
+
+## Sep 12th, 2023
+
+### Ways to contribute
+
+* Participate in [FLIP (Flow Improvement Proposal) discussions](https://github.com/onflow/flips)
+
+* Contribute to Cadence implementation: ➡️[GitHub issues](https://github.com/onflow/cadence/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Good+First+Issue%22)
+
+* Contribute Cadence tools: ➡️[GitHub issues](https://github.com/onflow/cadence-tools/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Good+First+Issue%22)
+
+### Website
+
+[https://cadence-lang.org/](https://cadence-lang.org/) 👀
+
+### Progress on Cadence 1.0
+
+[https://forum.onflow.org/t/update-on-cadence-1-0/5197](https://forum.onflow.org/t/update-on-cadence-1-0/5197) 🎉
+
+### FLIPs
+
+#### Relax interface conformance restrictions
+
+* FLIP: [https://github.com/onflow/flips/pull/134](https://github.com/onflow/flips/pull/134)
+
+* Overview:
+
+    * Follow up on interface conformance improvements ([https://github.com/onflow/flips/pull/83](https://github.com/onflow/flips/pull/83)).
+
+    * Proposes to allow empty function declaration defined in one interface to coexist with a default function implementation defined in another interface.
+
+    * Currently the same is allowed if the empty declaration has a pre/post condition.
+
+    * When interface default functions were introduced, interface inheritance did not exist yet
+
+    * Current behavior was intentional, tried to avoid interface author breaking implementations by adding function implementation (default function)
+
+* Status:
+
+    * FLIP is waiting for a final decision
+
+    * Reference implementation is complete: [https://github.com/onflow/cadence/pull/2725](https://github.com/onflow/cadence/pull/2725)
+
+* Next steps:
+
+    * Would like to get more feedback
+
+    * Provide means / explanation to try out
+
+#### Random function
+
+* FLIP: [https://github.com/onflow/flips/pull/120](https://github.com/onflow/flips/pull/120)
+
+* Overview:
+
+    * Rename unsafeRandom to random, underlying implementation has been secured using Flow protocol native random beacon
+
+    * Update the interface to a safer and more convenient one (generalized types and a modulo parameter)
+
+    * Rollout: add random, deprecate unsafeRandom, finally remove in SC release
+
+* Status:
+
+    * Positive sentiment for random
+
+    * Renamed to revertibleRandom
+
+* Open problems:
+
+    * Behavior in scripts
+
+        * Should not panic
+
+        * Several options
+
+    * Naming:
+
+        * Potential for misuse by developers. Unsafe → safe renaming might be confusing
+
+        * Maybe addressed by commit-reveal scheme FLIP: [https://github.com/onflow/flips/pull/123](https://github.com/onflow/flips/pull/123)
+
+* Next steps:
+
+    * Voted, approved 🎉
+
+#### Commit-reveal scheme for non-reverted randomness
+
+* FLIP: [https://github.com/onflow/flips/pull/123](https://github.com/onflow/flips/pull/123)
+
+* Overview:
+
+    * Provide a safe pattern to address transaction abortion after a random is revealed
+
+    * Commit to block
+
+    * In the future, query history of past randoms
+
+    * Use past, committed seed for new random
+
+* Status:
+
+    * Positive sentiment
+
+    * Waiting for feedback
+
+* Open problems:
+
+    * Storage/sharing of state, see below
+
+* Next steps:
+
+    * Gather more feedback
+
+    * Maybe have breakout session to discuss concerns
+
+* Feedback:
+
+    * Why stored on-chain?
+
+        * What is the concern?
+
+            * Should be stored in protocol state
+
+            * Details on how data is shared/stored
+
+            * If just implementation detail, make it explicit
+
+        * Where else?
+
+#### Remove custom destructors
+
+* FLIP:  [https://github.com/onflow/flips/pull/131](https://github.com/onflow/flips/pull/131)
+
+* Overview:
+
+    * Proposal to address inability for users to destroy resources they own
+
+    * One of the discussed options (others: try/catch, etc.)
+
+    * Originated from attachments feature (attachment might prevent destruction of whole resource)
+
+    * Remove destroy
+
+    * Allows users to always destroy resources
+
+* Status:
+
+    * Breakout session: Came up open problem
+
+    * Synced with execution team, discussed tombstoning (marking data as deleted, "garbage collection")
+
+    * Updated FLIP with default events
+
+    * FLIP ready for another round of discussion
+
+* Open problems:
+
+    * Philosophical question (sending to "burner account")
+
+    * Existing code / applications
+
+    * "Migration" path for use-cases like FT total supply
+
+    * Tombstoning implementation
+
+* Next steps:
+
+    * Need to discuss implementation approach more
+
+    * Implementation is not blocking Stable Cadence release, but can vote on change itself, removal of custom destructors
+
+        * Do not need a solution for "large resource deletion" problem
+
+    * Breakout session next week, after giving time to read through updated proposal
+
+* Feedback:
+
+### Related FLIPs / forum discussions
+
+* [https://forum.onflow.org/t/idea-wasm-execution-engine-in-cadence/5164](https://forum.onflow.org/t/idea-wasm-execution-engine-in-cadence/5164)
+
+* [https://forum.onflow.org/t/storage-fees-improvements-and-few-random-ideas-on-the-way/5104](https://forum.onflow.org/t/storage-fees-improvements-and-few-random-ideas-on-the-way/5104)
+
+* [https://forum.onflow.org/t/seeking-feedback-on-cadence-cookbook-modernization/5200/2](https://forum.onflow.org/t/seeking-feedback-on-cadence-cookbook-modernization/5200/2)
+

--- a/npm-packages/cadence-parser/package.json
+++ b/npm-packages/cadence-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-parser",
-  "version": "0.40.0",
+  "version": "0.41.1",
   "description": "The Cadence parser",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -1390,8 +1390,6 @@ func (e *FunctionExpression) String() string {
 
 var functionFunKeywordSpaceDoc prettier.Doc = prettier.Text("fun ")
 
-var functionExpressionEmptyBlockDoc prettier.Doc = prettier.Text(" {}")
-
 func FunctionDocument(
 	access Access,
 	purity FunctionPurity,
@@ -1494,17 +1492,17 @@ func FunctionDocument(
 		)
 	}
 
-	if block.IsEmpty() {
-		return append(doc, functionExpressionEmptyBlockDoc)
-	} else {
+	if block != nil {
 		blockDoc := block.Doc()
 
-		return append(
+		doc = append(
 			doc,
 			prettier.Space,
 			blockDoc,
 		)
 	}
+
+	return doc
 }
 
 func (e *FunctionExpression) Doc() prettier.Doc {

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -4480,7 +4480,8 @@ func TestFunctionExpression_Doc(t *testing.T) {
 					prettier.Text("()"),
 				},
 			},
-			prettier.Text(" {}"),
+			prettier.Text(" "),
+			prettier.Text("{}"),
 		}
 
 		assert.Equal(t, expected, expr.Doc())
@@ -4762,7 +4763,8 @@ func TestFunctionExpression_Doc(t *testing.T) {
 					prettier.Text("()"),
 				},
 			},
-			prettier.Text(" {}"),
+			prettier.Text(" "),
+			prettier.Text("{}"),
 		}
 
 		assert.Equal(t, expected, expr.Doc())

--- a/runtime/ast/function_declaration_test.go
+++ b/runtime/ast/function_declaration_test.go
@@ -368,7 +368,8 @@ func TestFunctionDeclaration_Doc(t *testing.T) {
 					},
 				},
 			},
-			prettier.Text(" {}"),
+			prettier.Text(" "),
+			prettier.Text("{}"),
 		},
 		decl.Doc(),
 	)
@@ -835,7 +836,8 @@ func TestSpecialFunctionDeclaration_Doc(t *testing.T) {
 					},
 				},
 			},
-			prettier.Text(" {}"),
+			prettier.Text(" "),
+			prettier.Text("{}"),
 		},
 		decl.Doc(),
 	)

--- a/runtime/ast/transaction_declaration_test.go
+++ b/runtime/ast/transaction_declaration_test.go
@@ -138,6 +138,11 @@ func TestTransactionDeclaration_Doc(t *testing.T) {
 						},
 					},
 				},
+				FunctionBlock: &FunctionBlock{
+					Block: &Block{
+						Statements: []Statement{},
+					},
+				},
 			},
 		},
 		PreConditions: &Conditions{
@@ -253,7 +258,8 @@ func TestTransactionDeclaration_Doc(t *testing.T) {
 									},
 								},
 							},
-							prettier.Text(" {}"),
+							prettier.Text(" "),
+							prettier.Text("{}"),
 						},
 					},
 					prettier.HardLine{},
@@ -402,6 +408,11 @@ func TestTransactionDeclaration_String(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+				FunctionBlock: &FunctionBlock{
+					Block: &Block{
+						Statements: []Statement{},
 					},
 				},
 			},

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -5074,8 +5074,10 @@ func (interpreter *Interpreter) invalidateReferencedResources(value Value, destr
 
 	switch value := value.(type) {
 	case *CompositeValue:
-		value.ForEachLoadedField(interpreter, func(_ string, fieldValue Value) {
+		value.ForEachLoadedField(interpreter, func(_ string, fieldValue Value) (resume bool) {
 			interpreter.invalidateReferencedResources(fieldValue, destroyed)
+			// continue iteration
+			return true
 		})
 		storageID = value.StorageID()
 	case *DictionaryValue:

--- a/runtime/program_params_validation_test.go
+++ b/runtime/program_params_validation_test.go
@@ -1134,4 +1134,140 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 		var entryPointErr *InvalidEntryPointArgumentError
 		require.ErrorAs(t, err, &entryPointErr)
 	})
+
+	t.Run("Invalid private cap in struct", func(t *testing.T) {
+		t.Parallel()
+
+		contracts := map[common.AddressLocation][]byte{
+			{
+				Address: common.MustBytesToAddress([]byte{0x1}),
+				Name:    "C",
+			}: []byte(`
+               access(all)
+               contract C {
+
+                    access(all)
+                    struct S {
+
+                        access(all)
+                        let cap: Capability
+
+                        init(cap: Capability) {
+                            self.cap = cap
+                        }
+                    }
+               }
+            `),
+		}
+
+		script := `
+          import C from 0x1
+
+          transaction(arg: C.S) {}
+        `
+
+		address := common.MustBytesToAddress([]byte{0x1})
+
+		capability := cadence.NewCapability(
+			1,
+			cadence.Address(address),
+			cadence.NewReferenceType(cadence.UnauthorizedAccess, cadence.AccountType),
+		)
+
+		arg := cadence.Struct{
+			StructType: &cadence.StructType{
+				Location: common.AddressLocation{
+					Address: address,
+					Name:    "C",
+				},
+				QualifiedIdentifier: "C.S",
+				Fields: []cadence.Field{
+					{
+						Identifier: "cap",
+						Type:       &cadence.CapabilityType{},
+					},
+				},
+			},
+			Fields: []cadence.Value{
+				capability,
+			},
+		}
+
+		err := executeTransaction(t, script, contracts, arg)
+		expectRuntimeError(t, err, &ArgumentNotImportableError{})
+	})
+
+	t.Run("Invalid private cap in array", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+          transaction(arg: [AnyStruct]) {}
+        `
+
+		address := common.MustBytesToAddress([]byte{0x1})
+
+		capability := cadence.NewCapability(
+			1,
+			cadence.Address(address),
+			cadence.NewReferenceType(cadence.UnauthorizedAccess, cadence.AccountType),
+		)
+
+		arg := cadence.Array{
+			ArrayType: cadence.NewVariableSizedArrayType(cadence.AnyStructType),
+			Values: []cadence.Value{
+				capability,
+			},
+		}
+
+		err := executeTransaction(t, script, nil, arg)
+		expectRuntimeError(t, err, &ArgumentNotImportableError{})
+	})
+
+	t.Run("Invalid private cap in optional", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+          transaction(arg: AnyStruct?) {}
+        `
+
+		address := common.MustBytesToAddress([]byte{0x1})
+
+		capability := cadence.NewCapability(
+			1,
+			cadence.Address(address),
+			cadence.NewReferenceType(cadence.UnauthorizedAccess, cadence.AccountType),
+		)
+
+		arg := cadence.NewOptional(capability)
+
+		err := executeTransaction(t, script, nil, arg)
+		expectRuntimeError(t, err, &ArgumentNotImportableError{})
+	})
+
+	t.Run("Invalid private cap in dictionary value", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+          transaction(arg: {String: AnyStruct}) {}
+        `
+
+		address := common.MustBytesToAddress([]byte{0x1})
+
+		capability := cadence.NewCapability(
+			1,
+			cadence.Address(address),
+			cadence.NewReferenceType(cadence.UnauthorizedAccess, cadence.AccountType),
+		)
+
+		arg := cadence.NewDictionary([]cadence.KeyValuePair{
+			{
+				Key:   cadence.String("cap"),
+				Value: capability,
+			},
+		})
+
+		err := executeTransaction(t, script, nil, arg)
+		expectRuntimeError(t, err, &ArgumentNotImportableError{})
+	})
+
 }

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -37,6 +37,11 @@ const StringTypeFromCharactersFunctionDocString = `
 Returns a string from the given array of characters
 `
 
+const StringTypeJoinFunctionName = "join"
+const StringTypeJoinFunctionDocString = `
+Returns a string after joining the array of strings with the provided separator.
+`
+
 // StringType represents the string type
 var StringType = &SimpleType{
 	Name:          "String",
@@ -252,6 +257,13 @@ var StringFunctionType = func() *FunctionType {
 		StringTypeFromCharactersFunctionDocString,
 	))
 
+	addMember(NewUnmeteredPublicFunctionMember(
+		functionType,
+		StringTypeJoinFunctionName,
+		StringTypeJoinFunctionType,
+		StringTypeJoinFunctionDocString,
+	))
+
 	BaseValueActivation.Set(
 		typeName,
 		baseFunctionVariable(
@@ -301,6 +313,24 @@ var StringTypeFromCharactersFunctionType = NewSimpleFunctionType(
 			TypeAnnotation: NewTypeAnnotation(&VariableSizedType{
 				Type: CharacterType,
 			}),
+		},
+	},
+	StringTypeAnnotation,
+)
+
+var StringTypeJoinFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]Parameter{
+		{
+			Label:      ArgumentLabelNotRequired,
+			Identifier: "strings",
+			TypeAnnotation: NewTypeAnnotation(&VariableSizedType{
+				Type: StringType,
+			}),
+		},
+		{
+			Identifier:     "separator",
+			TypeAnnotation: NewTypeAnnotation(StringType),
 		},
 	},
 	StringTypeAnnotation,

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -354,3 +354,57 @@ func TestCheckStringToLower(t *testing.T) {
 		RequireGlobalValue(t, checker.Elaboration, "x"),
 	)
 }
+
+func TestCheckStringJoin(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+		let s = String.join(["👪", "❤️", "Abc"], separator: "/")
+	`)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		sema.StringType,
+		RequireGlobalValue(t, checker.Elaboration, "s"),
+	)
+}
+
+func TestCheckStringJoinTypeMismatchStrs(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		let s = String.join([1], separator: "/")
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+}
+
+func TestCheckStringJoinTypeMismatchSeparator(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		let s = String.join(["Abc", "1"], separator: 1234)
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+}
+
+func TestCheckStringJoinTypeMissingArgumentLabelSeparator(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+	let s = String.join(["👪", "❤️", "Abc"], "/")
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[0])
+}

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -462,3 +462,40 @@ func TestInterpretCompareCharacters(t *testing.T) {
 		inter.Globals.Get("z").GetValue(),
 	)
 }
+
+func TestInterpretStringJoin(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+		fun test(): String {
+			return String.join(["👪", "❤️"], separator: "//")
+		}
+
+		fun testEmptyArray(): String {
+			return String.join([], separator: "//")
+		}
+
+		fun testSingletonArray(): String {
+			return String.join(["pqrS"], separator: "//")
+		}
+	`)
+
+	testCase := func(t *testing.T, funcName string, expected *interpreter.StringValue) {
+		t.Run(funcName, func(t *testing.T) {
+			result, err := inter.Invoke(funcName)
+			require.NoError(t, err)
+
+			RequireValuesEqual(
+				t,
+				inter,
+				expected,
+				result,
+			)
+		})
+	}
+
+	testCase(t, "test", interpreter.NewUnmeteredStringValue("👪//❤️"))
+	testCase(t, "testEmptyArray", interpreter.NewUnmeteredStringValue(""))
+	testCase(t, "testSingletonArray", interpreter.NewUnmeteredStringValue("pqrS"))
+}

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -928,11 +928,14 @@ func TestInterpretRandomCompositeValueOperations(t *testing.T) {
 
 	t.Run("iterate", func(t *testing.T) {
 		fieldCount := 0
-		testComposite.ForEachField(inter, func(name string, value interpreter.Value) {
+		testComposite.ForEachField(inter, func(name string, value interpreter.Value) (resume bool) {
 			orgValue, ok := orgFields[name]
 			require.True(t, ok)
 			utils.AssertValuesEqual(t, inter, orgValue, value)
 			fieldCount++
+
+			// continue iteration
+			return true
 		})
 
 		assert.Equal(t, len(orgFields), fieldCount)

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v0.40.0"
+const Version = "v0.41.1"


### PR DESCRIPTION
## Description

Resolving conflicts mainly involved:
- Adjusting `TestRuntimeInvalidWrappedPrivateCapability` to Cap Cons
- Adjusting field iteration of composite values

Also, added the `view` modifier to the new `String.join` function. (re: #2466)

<details>
<summary>Conflict resolution</summary>

```diff
commit 8859243f1a8646ed0415a69569331e19e6f8f6ca
Merge: 238db584c 833562efb
Author: Bastian Müller <bastian@turbolent.com>
Date:   Tue Sep 19 13:15:38 2023 -0700

    Merge branch 'master' into bastian/sync-stable-cadence-7

diff --git a/runtime/ast/expression_test.go b/runtime/ast/expression_test.go
index c490586b3..0d4263e0d 100644
--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -4763,6 +4763,7 @@ func TestFunctionExpression_Doc(t *testing.T) {
 					prettier.Text("()"),
 				},
 			},
+			prettier.Text(" "),
 			prettier.Text("{}"),
 		}
 
diff --git a/runtime/interpreter/interpreter.go b/runtime/interpreter/interpreter.go
index 55be367a3..e297a8d80 100644
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -5074,8 +5074,10 @@ func (interpreter *Interpreter) invalidateReferencedResources(value Value, destr
 
 	switch value := value.(type) {
 	case *CompositeValue:
-		value.ForEachLoadedField(interpreter, func(_ string, fieldValue Value) {
+		value.ForEachLoadedField(interpreter, func(_ string, fieldValue Value) (resume bool) {
 			interpreter.invalidateReferencedResources(fieldValue, destroyed)
+			// continue iteration
+			return true
 		})
 		storageID = value.StorageID()
 	case *DictionaryValue:
diff --git a/runtime/interpreter/value.go b/runtime/interpreter/value.go
remerge CONFLICT (content): Merge conflict in runtime/interpreter/value.go
index b8b3df93e..b80d96da8 100644
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -17438,31 +17438,29 @@ func (v *CompositeValue) GetOwner() common.Address {
 
 // ForEachField iterates over all field-name field-value pairs of the composite value.
 // It does NOT iterate over computed fields and functions!
-<<<<<<< 238db584c (Merge pull request #2778 from onflow/bastian/capability-exists)
-func (v *CompositeValue) ForEachField(gauge common.MemoryGauge, f func(fieldName string, fieldValue Value)) {
+func (v *CompositeValue) ForEachField(
+	gauge common.MemoryGauge,
+	f func(fieldName string, fieldValue Value) (resume bool),
+) {
 	v.forEachField(gauge, v.dictionary.Iterate, f)
 }
 
-func (v *CompositeValue) ForEachLoadedField(gauge common.MemoryGauge, f func(fieldName string, fieldValue Value)) {
+// ForEachLoadedField iterates over all LOADED field-name field-value pairs of the composite value.
+// It does NOT iterate over computed fields and functions!
+func (v *CompositeValue) ForEachLoadedField(
+	gauge common.MemoryGauge,
+	f func(fieldName string, fieldValue Value) (resume bool),
+) {
 	v.forEachField(gauge, v.dictionary.IterateLoadedValues, f)
 }
 
 func (v *CompositeValue) forEachField(
 	gauge common.MemoryGauge,
 	atreeIterate func(fn atree.MapEntryIterationFunc) error,
-	f func(fieldName string, fieldValue Value),
-) {
-	err := atreeIterate(func(key atree.Value, value atree.Value) (resume bool, err error) {
-		f(
-=======
-func (v *CompositeValue) ForEachField(
-	gauge common.MemoryGauge,
 	f func(fieldName string, fieldValue Value) (resume bool),
 ) {
-
-	err := v.dictionary.Iterate(func(key atree.Value, value atree.Value) (resume bool, err error) {
+	err := atreeIterate(func(key atree.Value, value atree.Value) (resume bool, err error) {
 		resume = f(
->>>>>>> 833562efb (Merge pull request #2795 from onflow/release/v0.41.1)
 			string(key.(StringAtreeValue)),
 			MustConvertStoredValue(gauge, value),
 		)
diff --git a/runtime/program_params_validation_test.go b/runtime/program_params_validation_test.go
index 49fd41b0f..988b2a210 100644
--- a/runtime/program_params_validation_test.go
+++ b/runtime/program_params_validation_test.go
@@ -1143,9 +1143,14 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 				Address: common.MustBytesToAddress([]byte{0x1}),
 				Name:    "C",
 			}: []byte(`
-               pub contract C {
-                    pub struct S {
-                        pub let cap: Capability
+               access(all)
+               contract C {
+
+                    access(all)
+                    struct S {
+
+                        access(all)
+                        let cap: Capability
 
                         init(cap: Capability) {
                             self.cap = cap
@@ -1163,13 +1168,10 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 
 		address := common.MustBytesToAddress([]byte{0x1})
 
-		path, err := cadence.NewPath(common.PathDomainPrivate, "foo")
-		require.NoError(t, err)
-
-		capability := cadence.NewPathCapability(
+		capability := cadence.NewCapability(
+			1,
 			cadence.Address(address),
-			path,
-			cadence.NewReferenceType(false, cadence.AuthAccountType{}),
+			cadence.NewReferenceType(cadence.UnauthorizedAccess, cadence.AccountType),
 		)
 
 		arg := cadence.Struct{
@@ -1191,7 +1193,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 			},
 		}
 
-		err = executeTransaction(t, script, contracts, arg)
+		err := executeTransaction(t, script, contracts, arg)
 		expectRuntimeError(t, err, &ArgumentNotImportableError{})
 	})
 
@@ -1204,23 +1206,20 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 
 		address := common.MustBytesToAddress([]byte{0x1})
 
-		path, err := cadence.NewPath(common.PathDomainPrivate, "foo")
-		require.NoError(t, err)
-
-		capability := cadence.NewPathCapability(
+		capability := cadence.NewCapability(
+			1,
 			cadence.Address(address),
-			path,
-			cadence.NewReferenceType(false, cadence.AuthAccountType{}),
+			cadence.NewReferenceType(cadence.UnauthorizedAccess, cadence.AccountType),
 		)
 
 		arg := cadence.Array{
-			ArrayType: cadence.NewVariableSizedArrayType(cadence.AnyStructType{}),
+			ArrayType: cadence.NewVariableSizedArrayType(cadence.AnyStructType),
 			Values: []cadence.Value{
 				capability,
 			},
 		}
 
-		err = executeTransaction(t, script, nil, arg)
+		err := executeTransaction(t, script, nil, arg)
 		expectRuntimeError(t, err, &ArgumentNotImportableError{})
 	})
 
@@ -1233,18 +1232,15 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 
 		address := common.MustBytesToAddress([]byte{0x1})
 
-		path, err := cadence.NewPath(common.PathDomainPrivate, "foo")
-		require.NoError(t, err)
-
-		capability := cadence.NewPathCapability(
+		capability := cadence.NewCapability(
+			1,
 			cadence.Address(address),
-			path,
-			cadence.NewReferenceType(false, cadence.AuthAccountType{}),
+			cadence.NewReferenceType(cadence.UnauthorizedAccess, cadence.AccountType),
 		)
 
 		arg := cadence.NewOptional(capability)
 
-		err = executeTransaction(t, script, nil, arg)
+		err := executeTransaction(t, script, nil, arg)
 		expectRuntimeError(t, err, &ArgumentNotImportableError{})
 	})
 
@@ -1257,13 +1253,10 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 
 		address := common.MustBytesToAddress([]byte{0x1})
 
-		path, err := cadence.NewPath(common.PathDomainPrivate, "foo")
-		require.NoError(t, err)
-
-		capability := cadence.NewPathCapability(
+		capability := cadence.NewCapability(
+			1,
 			cadence.Address(address),
-			path,
-			cadence.NewReferenceType(false, cadence.AuthAccountType{}),
+			cadence.NewReferenceType(cadence.UnauthorizedAccess, cadence.AccountType),
 		)
 
 		arg := cadence.NewDictionary([]cadence.KeyValuePair{
@@ -1273,7 +1266,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 			},
 		})
 
-		err = executeTransaction(t, script, nil, arg)
+		err := executeTransaction(t, script, nil, arg)
 		expectRuntimeError(t, err, &ArgumentNotImportableError{})
 	})
 
diff --git a/runtime/runtime_test.go b/runtime/runtime_test.go
remerge CONFLICT (content): Merge conflict in runtime/runtime_test.go
index ee56f61e6..766add29b 100644
--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -9316,7 +9316,6 @@ func TestRuntimeWrappedErrorHandling(t *testing.T) {
 	assertRuntimeErrorIsUserError(t, err)
 }
 
-<<<<<<< 238db584c (Merge pull request #2778 from onflow/bastian/capability-exists)
 func BenchmarkRuntimeResourceTracking(b *testing.B) {
 
 	runtime := newTestInterpreterRuntime()
@@ -9614,31 +9613,26 @@ func TestRuntimeEventEmission(t *testing.T) {
 		)
 
 	})
-=======
+}
+
 func TestRuntimeInvalidWrappedPrivateCapability(t *testing.T) {
 
 	t.Parallel()
 
 	runtime := newTestInterpreterRuntime()
 	runtime.defaultConfig.AtreeValidationEnabled = false
-	runtime.defaultConfig.AccountLinkingEnabled = true
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
-	linkTx := []byte(`
-      #allowAccountLinking
+	helperContract := []byte(`
+      access(all)
+      contract Foo {
 
-      transaction {
-          prepare(acct: AuthAccount) {
-              acct.linkAccount(/private/foo)
-          }
-      }
-    `)
+          access(all)
+          struct Thing {
 
-	helperContract := []byte(`
-      pub contract Foo {
-          pub struct Thing {
-              pub let cap: Capability
+              access(all)
+              let cap: Capability
 
               init(cap: Capability) {
                   self.cap = cap
@@ -9650,10 +9644,11 @@ func TestRuntimeInvalidWrappedPrivateCapability(t *testing.T) {
 	getCapScript := []byte(`
       import Foo from 0x1
 
-      pub fun main(addr: Address): AnyStruct {
-          let acct = getAuthAccount(addr)
-          let authCap = acct.getCapability<&AuthAccount>(/private/foo)
-          return Foo.Thing(cap: authCap)
+      access(all)
+      fun main(addr: Address): AnyStruct {
+          let acct = getAuthAccount<auth(Capabilities) &Account>(addr)
+          let cap = acct.capabilities.account.issue<auth(Storage) &Account>()
+          return Foo.Thing(cap: cap)
       }
 	`)
 
@@ -9661,8 +9656,9 @@ func TestRuntimeInvalidWrappedPrivateCapability(t *testing.T) {
       import Foo from 0x1
 
       transaction(thing: Foo.Thing) {
-          prepare(_: AuthAccount) {
-		      thing.cap.borrow<&AuthAccount>()!.save("Hello, World", to: /storage/attack)
+          prepare(_: &Account) {
+ 		      thing.cap.borrow<auth(Storage) &Account>()!
+                  .storage.save("Hello, World", to: /storage/attack)
           }
       }
     `)
@@ -9700,22 +9696,9 @@ func TestRuntimeInvalidWrappedPrivateCapability(t *testing.T) {
 	nextTransactionLocation := newTransactionLocationGenerator()
 	nextScriptLocation := newScriptLocationGenerator()
 
-	// Deploy
-
-	err := runtime.ExecuteTransaction(
-		Script{
-			Source: linkTx,
-		},
-		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-		},
-	)
-	require.NoError(t, err)
-
 	// Deploy helper contract
 
-	err = runtime.ExecuteTransaction(
+	err := runtime.ExecuteTransaction(
 		Script{
 			Source: deploy,
 		},
@@ -9760,5 +9743,4 @@ func TestRuntimeInvalidWrappedPrivateCapability(t *testing.T) {
 
 	var argumentNotImportableErr *ArgumentNotImportableError
 	require.ErrorAs(t, err, &argumentNotImportableErr)
->>>>>>> 833562efb (Merge pull request #2795 from onflow/release/v0.41.1)
 }
diff --git a/runtime/sema/string_type.go b/runtime/sema/string_type.go
remerge CONFLICT (content): Merge conflict in runtime/sema/string_type.go
index 37cb87b25..b4fa76259 100644
--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -315,20 +315,15 @@ var StringTypeFromCharactersFunctionType = NewSimpleFunctionType(
 			}),
 		},
 	},
-<<<<<<< 238db584c (Merge pull request #2778 from onflow/bastian/capability-exists)
 	StringTypeAnnotation,
 )
-=======
-	ReturnTypeAnnotation: NewTypeAnnotation(
-		StringType,
-	),
-}
 
-var StringTypeJoinFunctionType = &FunctionType{
-	Parameters: []Parameter{
+var StringTypeJoinFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]Parameter{
 		{
 			Label:      ArgumentLabelNotRequired,
-			Identifier: "strs",
+			Identifier: "strings",
 			TypeAnnotation: NewTypeAnnotation(&VariableSizedType{
 				Type: StringType,
 			}),
@@ -338,6 +333,5 @@ var StringTypeJoinFunctionType = &FunctionType{
 			TypeAnnotation: NewTypeAnnotation(StringType),
 		},
 	},
-	ReturnTypeAnnotation: NewTypeAnnotation(StringType),
-}
->>>>>>> 833562efb (Merge pull request #2795 from onflow/release/v0.41.1)
+	StringTypeAnnotation,
+)
```

</details>

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
