### PR TITLE
Properly check removed expression for resource loss

### DIFF
--- a/runtime/sema/check_remove_statement.go
+++ b/runtime/sema/check_remove_statement.go
@@ -33,6 +33,7 @@ func (checker *Checker) VisitRemoveStatement(statement *ast.RemoveStatement) (_ 
 
 	nominalType := checker.convertNominalType(statement.Attachment)
 	base := checker.VisitExpression(statement.Value, nil)
+	checker.checkUnusedExpressionResourceLoss(base, statement.Value)
 
 	if nominalType == InvalidType {
 		return

--- a/runtime/tests/checker/attachments_test.go
+++ b/runtime/tests/checker/attachments_test.go
@@ -4372,3 +4372,44 @@ func TestCheckAttachmentsNotEnabled(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestCheckAttachmentRemoveLossTracking(t *testing.T) {
+
+	t.Run("remove immediately added attachment", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			resource R {}
+			attachment A for R {}
+			fun loseResource(r: @R) {
+				remove A from <- attach A() to <- r
+			}
+			fun test() {
+				loseResource(r: <- create R())
+			}
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+	})
+
+	t.Run("remove from function call result", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			resource R {}
+			attachment A for R {}
+			fun createRwithA(): @R {
+				return <- attach A() to <- create R()
+			}
+			fun loseResource() {
+				remove A from <- createRwithA()
+			}
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.ResourceLossError{}, errs[0])
+	})
+}


### PR DESCRIPTION
Fixes an issue where a `remove` expression could result in the loss of a resource if the value from which the attachment was being removed was "owned" by that expression. 

Thanks @oebeling for the report

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
