### PR TITLE
Refactor runtime test helpers into separate, reusable package

### DIFF
--- a/runtime/attachments_test.go
+++ b/runtime/attachments_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"testing"
@@ -25,22 +25,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
-
-func newTestInterpreterRuntimeWithAttachments() testInterpreterRuntime {
-	rt := newTestInterpreterRuntime()
-	rt.interpreterRuntime.defaultConfig.AttachmentsEnabled = true
-	return rt
-}
 
 func TestRuntimeAccountAttachmentSaveAndLoad(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntimeWithAttachments()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntimeWithAttachments()
 
 	var logs []string
 	var events []string
@@ -86,30 +82,30 @@ func TestRuntimeAccountAttachmentSaveAndLoad(t *testing.T) {
 		}
 	 `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -150,8 +146,8 @@ func TestRuntimeAccountAttachmentSaveAndLoad(t *testing.T) {
 func TestRuntimeAccountAttachmentExportFailure(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntimeWithAttachments()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntimeWithAttachments()
 
 	logs := make([]string, 0)
 	events := make([]string, 0)
@@ -187,31 +183,31 @@ func TestRuntimeAccountAttachmentExportFailure(t *testing.T) {
 		}
 	 `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
-	nextScriptLocation := newScriptLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -241,8 +237,8 @@ func TestRuntimeAccountAttachmentExport(t *testing.T) {
 
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntimeWithAttachments()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntimeWithAttachments()
 
 	var logs []string
 	var events []string
@@ -270,31 +266,31 @@ func TestRuntimeAccountAttachmentExport(t *testing.T) {
 		}
 	 `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
-	nextScriptLocation := newScriptLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -326,8 +322,8 @@ func TestRuntimeAccountAttachedExport(t *testing.T) {
 
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntimeWithAttachments()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntimeWithAttachments()
 
 	var logs []string
 	var events []string
@@ -350,31 +346,31 @@ func TestRuntimeAccountAttachedExport(t *testing.T) {
 		}
 	 `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
-	nextScriptLocation := newScriptLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -407,8 +403,8 @@ func TestRuntimeAccountAttachedExport(t *testing.T) {
 func TestRuntimeAccountAttachmentSaveAndBorrow(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntimeWithAttachments()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntimeWithAttachments()
 
 	var logs []string
 	var events []string
@@ -457,30 +453,30 @@ func TestRuntimeAccountAttachmentSaveAndBorrow(t *testing.T) {
 		}
 	 `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -521,8 +517,8 @@ func TestRuntimeAccountAttachmentSaveAndBorrow(t *testing.T) {
 func TestRuntimeAccountAttachmentCapability(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntimeWithAttachments()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntimeWithAttachments()
 
 	var logs []string
 	var events []string
@@ -573,53 +569,53 @@ func TestRuntimeAccountAttachmentCapability(t *testing.T) {
 		}
 	 `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	runtimeInterface2 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface2 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 2}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -662,27 +658,26 @@ func TestRuntimeAttachmentStorage(t *testing.T) {
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
-	newRuntime := func() (testInterpreterRuntime, *testRuntimeInterface) {
-		runtime := newTestInterpreterRuntime()
-		runtime.defaultConfig.AttachmentsEnabled = true
+	newRuntime := func() (TestInterpreterRuntime, *TestRuntimeInterface) {
+		runtime := NewTestInterpreterRuntimeWithAttachments()
 
 		accountCodes := map[common.Location][]byte{}
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{address}, nil
 			},
-			resolveLocation: singleIdentifierLocationResolver(t),
-			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
-			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				code = accountCodes[location]
 				return code, nil
 			},
-			emitEvent: func(event cadence.Event) error {
+			OnEmitEvent: func(event cadence.Event) error {
 				return nil
 			},
 		}

--- a/runtime/capabilities_test.go
+++ b/runtime/capabilities_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"testing"
@@ -24,8 +24,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -35,25 +37,25 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
-	newRuntime := func() (testInterpreterRuntime, *testRuntimeInterface) {
-		runtime := newTestInterpreterRuntime()
+	newRuntime := func() (TestInterpreterRuntime, *TestRuntimeInterface) {
+		runtime := NewTestInterpreterRuntime()
 		accountCodes := map[common.Location][]byte{}
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{address}, nil
 			},
-			resolveLocation: singleIdentifierLocationResolver(t),
-			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
-			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				code = accountCodes[location]
 				return code, nil
 			},
-			emitEvent: func(event cadence.Event) error {
+			OnEmitEvent: func(event cadence.Event) error {
 				return nil
 			},
 		}
@@ -66,7 +68,7 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
 		runtime, runtimeInterface := newRuntime()
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		// Deploy contract
 
@@ -318,7 +320,7 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
 		runtime, runtimeInterface := newRuntime()
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		// Deploy contract
 
@@ -569,7 +571,7 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
 		runtime, runtimeInterface := newRuntime()
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		// Deploy contract
 

--- a/runtime/capabilitycontrollers_test.go
+++ b/runtime/capabilitycontrollers_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"fmt"
@@ -25,10 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -40,7 +42,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 		storage *Storage,
 	) {
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
 		accountCodes := map[Location][]byte{}
 
@@ -122,30 +124,30 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 		signer := common.MustBytesToAddress([]byte{0x1})
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			log: func(message string) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnProgramLog: func(message string) {
 				// NO-OP
 			},
-			emitEvent: func(event cadence.Event) error {
+			OnEmitEvent: func(event cadence.Event) error {
 				// NO-OP
 				return nil
 			},
-			getSigningAccounts: func() ([]Address, error) {
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{signer}, nil
 			},
-			resolveLocation: singleIdentifierLocationResolver(t),
-			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
-			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				code = accountCodes[location]
 				return code, nil
 			},
 		}
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		// Deploy contract
 
@@ -2604,7 +2606,7 @@ func TestRuntimeCapabilityBorrowAsInheritedInterface(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	contract := []byte(`
         access(all) contract Test {
@@ -2643,28 +2645,28 @@ func TestRuntimeCapabilityBorrowAsInheritedInterface(t *testing.T) {
 
 	var accountCode []byte
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{address}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy
 

--- a/runtime/contract_update_test.go
+++ b/runtime/contract_update_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"testing"
@@ -25,15 +25,17 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestRuntimeContractUpdateWithDependencies(t *testing.T) {
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 	accountCodes := map[common.Location][]byte{}
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 	fooLocation := common.AddressLocation{
@@ -49,29 +51,29 @@ func TestRuntimeContractUpdateWithDependencies(t *testing.T) {
 		}
 	}
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAccount}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 			return json.Decode(nil, b)
 		},
-		getAndSetProgram: func(
+		OnGetAndSetProgram: func(
 			location Location,
 			load func() (*interpreter.Program, error),
 		) (
@@ -101,7 +103,7 @@ func TestRuntimeContractUpdateWithDependencies(t *testing.T) {
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	const fooContractV1 = `
         access(all) contract Foo {
@@ -215,7 +217,7 @@ func TestRuntimeContractUpdateWithDependencies(t *testing.T) {
 func TestRuntimeContractUpdateWithPrecedingIdentifiers(t *testing.T) {
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -251,31 +253,31 @@ func TestRuntimeContractUpdateWithPrecedingIdentifiers(t *testing.T) {
 		fooLocation: []byte(fooContractV1),
 	}
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAccount}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 			return json.Decode(nil, b)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Update contract
 

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"encoding/hex"
@@ -27,10 +27,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -80,38 +82,37 @@ func newContractRemovalTransaction(contractName string) string {
 }
 
 func newContractDeploymentTransactor(t *testing.T) func(code string) error {
-	rt := newTestInterpreterRuntime()
-	rt.defaultConfig.AttachmentsEnabled = true
+	rt := NewTestInterpreterRuntimeWithAttachments()
 
 	accountCodes := map[Location][]byte{}
 	var events []cadence.Event
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{common.MustBytesToAddress([]byte{0x42})}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		removeAccountContractCode: func(location common.AddressLocation) error {
+		OnRemoveAccountContractCode: func(location common.AddressLocation) error {
 			delete(accountCodes, location)
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	return func(code string) error {
 		return rt.ExecuteTransaction(
@@ -2251,7 +2252,7 @@ func TestRuntimeContractUpdateConformanceChanges(t *testing.T) {
           }
         `
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
 		contractLocation := common.AddressLocation{
 			Address: address,
@@ -2263,33 +2264,33 @@ func TestRuntimeContractUpdateConformanceChanges(t *testing.T) {
 		}
 
 		var events []cadence.Event
-		runtimeInterface := &testRuntimeInterface{
-			getCode: func(location Location) (bytes []byte, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetCode: func(location Location) (bytes []byte, err error) {
 				return accountCodes[location], nil
 			},
-			storage: newTestLedger(nil, nil),
-			getSigningAccounts: func() ([]Address, error) {
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{address}, nil
 			},
-			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
-			removeAccountContractCode: func(location common.AddressLocation) error {
+			OnRemoveAccountContractCode: func(location common.AddressLocation) error {
 				delete(accountCodes, location)
 				return nil
 			},
-			emitEvent: func(event cadence.Event) error {
+			OnEmitEvent: func(event cadence.Event) error {
 				events = append(events, event)
 				return nil
 			},
 		}
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		err := rt.ExecuteTransaction(
 			Script{
@@ -2324,12 +2325,12 @@ func TestRuntimeContractUpdateProgramCaching(t *testing.T) {
 	type locationAccessCounts map[Location]int
 
 	newTester := func() (
-		runtimeInterface *testRuntimeInterface,
+		runtimeInterface *TestRuntimeInterface,
 		executeTransaction func(code string) error,
 		programGets locationAccessCounts,
 		programSets locationAccessCounts,
 	) {
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
 		accountCodes := map[Location][]byte{}
 		var events []cadence.Event
@@ -2337,20 +2338,20 @@ func TestRuntimeContractUpdateProgramCaching(t *testing.T) {
 		programGets = locationAccessCounts{}
 		programSets = locationAccessCounts{}
 
-		runtimeInterface = &testRuntimeInterface{
-			getAndSetProgram: func(
+		runtimeInterface = &TestRuntimeInterface{
+			OnGetAndSetProgram: func(
 				location Location,
 				load func() (*interpreter.Program, error),
 			) (
 				program *interpreter.Program,
 				err error,
 			) {
-				if runtimeInterface.programs == nil {
-					runtimeInterface.programs = map[Location]*interpreter.Program{}
+				if runtimeInterface.Programs == nil {
+					runtimeInterface.Programs = map[Location]*interpreter.Program{}
 				}
 
 				var ok bool
-				program, ok = runtimeInterface.programs[location]
+				program, ok = runtimeInterface.Programs[location]
 				if program != nil {
 					programGets[location]++
 				}
@@ -2363,38 +2364,38 @@ func TestRuntimeContractUpdateProgramCaching(t *testing.T) {
 				// NOTE: important: still set empty program,
 				// even if error occurred
 
-				runtimeInterface.programs[location] = program
+				runtimeInterface.Programs[location] = program
 
 				programSets[location]++
 
 				return
 			},
-			getCode: func(location Location) (bytes []byte, err error) {
+			OnGetCode: func(location Location) (bytes []byte, err error) {
 				return accountCodes[location], nil
 			},
-			storage: newTestLedger(nil, nil),
-			getSigningAccounts: func() ([]Address, error) {
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{address}, nil
 			},
-			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
-			removeAccountContractCode: func(location common.AddressLocation) error {
+			OnRemoveAccountContractCode: func(location common.AddressLocation) error {
 				delete(accountCodes, location)
 				return nil
 			},
-			emitEvent: func(event cadence.Event) error {
+			OnEmitEvent: func(event cadence.Event) error {
 				events = append(events, event)
 				return nil
 			},
 		}
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		executeTransaction = func(code string) error {
 			return rt.ExecuteTransaction(
@@ -2439,7 +2440,7 @@ func TestRuntimeContractUpdateProgramCaching(t *testing.T) {
 
 		err := executeTransaction1(addTx)
 		require.NoError(t, err)
-		require.Nil(t, runtimeInterface1.programs[contractLocation])
+		require.Nil(t, runtimeInterface1.Programs[contractLocation])
 
 		require.Equal(t, locationAccessCounts{}, programGets1)
 		// NOTE: deployed contract is *correctly* *NOT* set,
@@ -2451,7 +2452,7 @@ func TestRuntimeContractUpdateProgramCaching(t *testing.T) {
 
 		err = executeTransaction2(addTx)
 		require.NoError(t, err)
-		require.Nil(t, runtimeInterface2.programs[contractLocation])
+		require.Nil(t, runtimeInterface2.Programs[contractLocation])
 		require.Equal(t, locationAccessCounts{}, programGets2)
 		// See NOTE above
 		require.Equal(t, locationAccessCounts{txLocation: 1}, programSets2)
@@ -2480,10 +2481,10 @@ func TestRuntimeContractUpdateProgramCaching(t *testing.T) {
 
 		// only ran import TX against second,
 		// so first should not have the program
-		assert.Nil(t, runtimeInterface1.programs[contractLocation])
+		assert.Nil(t, runtimeInterface1.Programs[contractLocation])
 
 		// NOTE: program in cache of second
-		assert.NotNil(t, runtimeInterface2.programs[contractLocation])
+		assert.NotNil(t, runtimeInterface2.Programs[contractLocation])
 
 		assert.Equal(t,
 			locationAccessCounts{

--- a/runtime/convertTypes_test.go
+++ b/runtime/convertTypes_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"testing"
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	_ "embed"
@@ -29,12 +29,14 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -58,17 +60,16 @@ func TestRuntimeExportValue(t *testing.T) {
 
 			t.Parallel()
 
-			inter := newTestInterpreter(t)
+			inter := NewTestInterpreter(t)
 
 			value := tt.value
 			if tt.valueFactory != nil {
 				value = tt.valueFactory(inter)
 			}
-			actual, err := exportValueWithInterpreter(
+			actual, err := ExportValue(
 				value,
 				inter,
 				interpreter.EmptyLocationRange,
-				seenReferences{},
 			)
 
 			if tt.invalid {
@@ -573,7 +574,7 @@ func TestRuntimeImportValue(t *testing.T) {
 
 			t.Parallel()
 
-			inter := newTestInterpreter(t)
+			inter := NewTestInterpreter(t)
 
 			actual, err := ImportValue(
 				inter,
@@ -637,7 +638,7 @@ func TestRuntimeImportValue(t *testing.T) {
 			label: "Array empty",
 			value: cadence.NewArray([]cadence.Value{}),
 			expected: interpreter.NewArrayValue(
-				newTestInterpreter(t),
+				NewTestInterpreter(t),
 				interpreter.EmptyLocationRange,
 				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -655,7 +656,7 @@ func TestRuntimeImportValue(t *testing.T) {
 				cadence.String("foo"),
 			}),
 			expected: interpreter.NewArrayValue(
-				newTestInterpreter(t),
+				NewTestInterpreter(t),
 				interpreter.EmptyLocationRange,
 				&interpreter.VariableSizedStaticType{
 					Type: interpreter.PrimitiveStaticTypeAnyStruct,
@@ -671,7 +672,7 @@ func TestRuntimeImportValue(t *testing.T) {
 		{
 			label: "Dictionary",
 			expected: interpreter.NewDictionaryValue(
-				newTestInterpreter(t),
+				NewTestInterpreter(t),
 				interpreter.EmptyLocationRange,
 				&interpreter.DictionaryStaticType{
 					KeyType:   interpreter.PrimitiveStaticTypeString,
@@ -687,7 +688,7 @@ func TestRuntimeImportValue(t *testing.T) {
 		{
 			label: "Dictionary (non-empty)",
 			expected: interpreter.NewDictionaryValue(
-				newTestInterpreter(t),
+				NewTestInterpreter(t),
 				interpreter.EmptyLocationRange,
 				&interpreter.DictionaryStaticType{
 					KeyType:   interpreter.PrimitiveStaticTypeString,
@@ -1779,12 +1780,12 @@ func TestRuntimeExportEventValue(t *testing.T) {
 }
 
 func exportEventFromScript(t *testing.T, script string) cadence.Event {
-	rt := newTestInterpreterRuntime()
+	rt := NewTestInterpreterRuntime()
 
 	var events []cadence.Event
 
-	inter := &testRuntimeInterface{
-		emitEvent: func(event cadence.Event) error {
+	inter := &TestRuntimeInterface{
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
@@ -1809,14 +1810,14 @@ func exportEventFromScript(t *testing.T, script string) cadence.Event {
 }
 
 func exportValueFromScript(t *testing.T, script string) cadence.Value {
-	rt := newTestInterpreterRuntime()
+	rt := NewTestInterpreterRuntime()
 
 	value, err := rt.ExecuteScript(
 		Script{
 			Source: []byte(script),
 		},
 		Context{
-			Interface: &testRuntimeInterface{},
+			Interface: &TestRuntimeInterface{},
 			Location:  common.ScriptLocation{},
 		},
 	)
@@ -1884,7 +1885,7 @@ func TestRuntimeExportReferenceValue(t *testing.T) {
 
 		// Arrange
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
 		transaction := `
             transaction {
@@ -1900,9 +1901,9 @@ func TestRuntimeExportReferenceValue(t *testing.T) {
 		address, err := common.HexToAddress("0x1")
 		require.NoError(t, err)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{
 					address,
 				}, nil
@@ -1960,10 +1961,10 @@ func TestRuntimeExportReferenceValue(t *testing.T) {
             }
         `
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
 		}
 
 		_, err := rt.ExecuteScript(
@@ -1997,10 +1998,10 @@ func TestRuntimeExportReferenceValue(t *testing.T) {
             }
         `
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
 		}
 
 		_, err := rt.ExecuteScript(
@@ -2086,11 +2087,10 @@ func TestRuntimeExportTypeValue(t *testing.T) {
 		value := interpreter.TypeValue{
 			Type: nil,
 		}
-		actual, err := exportValueWithInterpreter(
+		actual, err := ExportValue(
 			value,
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 			interpreter.EmptyLocationRange,
-			seenReferences{},
 		)
 		require.NoError(t, err)
 
@@ -2127,7 +2127,7 @@ func TestRuntimeExportTypeValue(t *testing.T) {
 		err = checker.Check()
 		require.NoError(t, err)
 
-		inter := newTestInterpreter(t)
+		inter := NewTestInterpreter(t)
 		inter.Program = interpreter.ProgramFromChecker(checker)
 
 		ty := interpreter.TypeValue{
@@ -2171,11 +2171,10 @@ func TestRuntimeExportCapabilityValue(t *testing.T) {
 			interpreter.PrimitiveStaticTypeInt,
 		)
 
-		actual, err := exportValueWithInterpreter(
+		actual, err := ExportValue(
 			capability,
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 			interpreter.EmptyLocationRange,
-			seenReferences{},
 		)
 		require.NoError(t, err)
 
@@ -2210,7 +2209,7 @@ func TestRuntimeExportCapabilityValue(t *testing.T) {
 		err = checker.Check()
 		require.NoError(t, err)
 
-		inter := newTestInterpreter(t)
+		inter := NewTestInterpreter(t)
 		inter.Program = interpreter.ProgramFromChecker(checker)
 
 		capability := interpreter.NewUnmeteredCapabilityValue(
@@ -2219,11 +2218,10 @@ func TestRuntimeExportCapabilityValue(t *testing.T) {
 			interpreter.NewCompositeStaticTypeComputeTypeID(inter, TestLocation, "S"),
 		)
 
-		actual, err := exportValueWithInterpreter(
+		actual, err := ExportValue(
 			capability,
 			inter,
 			interpreter.EmptyLocationRange,
-			seenReferences{},
 		)
 		require.NoError(t, err)
 
@@ -2444,16 +2442,13 @@ func TestRuntimeEnumValue(t *testing.T) {
 }
 
 func executeTestScript(t *testing.T, script string, arg cadence.Value) (cadence.Value, error) {
-	rt := newTestInterpreterRuntime()
+	rt := NewTestInterpreterRuntime()
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: newTestLedger(nil, nil),
-		meterMemory: func(_ common.MemoryUsage) error {
-			return nil
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: NewTestLedger(nil, nil),
+		OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(nil, b)
 		},
-	}
-	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-		return json.Decode(runtimeInterface, b)
 	}
 
 	scriptParam := Script{
@@ -3307,7 +3302,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 
 		t.Parallel()
 
-		inter := newTestInterpreter(t)
+		inter := NewTestInterpreter(t)
 
 		value := interpreter.NewArrayValue(
 			inter,
@@ -3318,11 +3313,10 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			common.ZeroAddress,
 		)
 
-		actual, err := exportValueWithInterpreter(
+		actual, err := ExportValue(
 			value,
 			inter,
 			interpreter.EmptyLocationRange,
-			seenReferences{},
 		)
 		require.NoError(t, err)
 
@@ -3341,7 +3335,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 
 		value := cadence.NewArray([]cadence.Value{})
 
-		inter := newTestInterpreter(t)
+		inter := NewTestInterpreter(t)
 
 		actual, err := ImportValue(
 			inter,
@@ -3371,7 +3365,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 
 		t.Parallel()
 
-		inter := newTestInterpreter(t)
+		inter := NewTestInterpreter(t)
 
 		value := interpreter.NewArrayValue(
 			inter,
@@ -3384,11 +3378,10 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			interpreter.NewUnmeteredStringValue("foo"),
 		)
 
-		actual, err := exportValueWithInterpreter(
+		actual, err := ExportValue(
 			value,
 			inter,
 			interpreter.EmptyLocationRange,
-			seenReferences{},
 		)
 		require.NoError(t, err)
 
@@ -3412,7 +3405,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			cadence.String("foo"),
 		})
 
-		inter := newTestInterpreter(t)
+		inter := NewTestInterpreter(t)
 
 		actual, err := ImportValue(
 			inter,
@@ -3457,7 +3450,7 @@ func TestRuntimeImportExportArrayValue(t *testing.T) {
 			}),
 		})
 
-		inter := newTestInterpreter(t)
+		inter := NewTestInterpreter(t)
 
 		actual, err := ImportValue(
 			inter,
@@ -3515,7 +3508,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 		t.Parallel()
 
 		value := interpreter.NewDictionaryValue(
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 			interpreter.EmptyLocationRange,
 			&interpreter.DictionaryStaticType{
 				KeyType:   interpreter.PrimitiveStaticTypeString,
@@ -3523,11 +3516,10 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 			},
 		)
 
-		actual, err := exportValueWithInterpreter(
+		actual, err := ExportValue(
 			value,
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 			interpreter.EmptyLocationRange,
-			seenReferences{},
 		)
 		require.NoError(t, err)
 
@@ -3547,7 +3539,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 
 		value := cadence.NewDictionary([]cadence.KeyValuePair{})
 
-		inter := newTestInterpreter(t)
+		inter := NewTestInterpreter(t)
 
 		actual, err := ImportValue(
 			inter,
@@ -3580,7 +3572,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 
 		t.Parallel()
 
-		inter := newTestInterpreter(t)
+		inter := NewTestInterpreter(t)
 
 		value := interpreter.NewDictionaryValue(
 			inter,
@@ -3593,11 +3585,10 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 			interpreter.NewUnmeteredStringValue("b"), interpreter.NewUnmeteredIntValueFromInt64(2),
 		)
 
-		actual, err := exportValueWithInterpreter(
+		actual, err := ExportValue(
 			value,
 			inter,
 			interpreter.EmptyLocationRange,
-			seenReferences{},
 		)
 		require.NoError(t, err)
 
@@ -3634,7 +3625,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 			},
 		})
 
-		inter := newTestInterpreter(t)
+		inter := NewTestInterpreter(t)
 
 		actual, err := ImportValue(
 			inter,
@@ -3698,7 +3689,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 			},
 		})
 
-		inter := newTestInterpreter(t)
+		inter := NewTestInterpreter(t)
 
 		actual, err := ImportValue(
 			inter,
@@ -3858,21 +3849,18 @@ func TestRuntimeStringValueImport(t *testing.T) {
 		encodedArg, err := json.Encode(stringValue)
 		require.NoError(t, err)
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
 		var validated bool
 
-		runtimeInterface := &testRuntimeInterface{
-			log: func(s string) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnProgramLog: func(s string) {
 				assert.True(t, utf8.ValidString(s))
 				validated = true
 			},
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -3911,21 +3899,18 @@ func TestRuntimeTypeValueImport(t *testing.T) {
 		encodedArg, err := json.Encode(typeValue)
 		require.NoError(t, err)
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
 		var ok bool
 
-		runtimeInterface := &testRuntimeInterface{
-			log: func(s string) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnProgramLog: func(s string) {
 				assert.Equal(t, "\"Int\"", s)
 				ok = true
 			},
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -3962,15 +3947,12 @@ func TestRuntimeTypeValueImport(t *testing.T) {
 		encodedArg, err := json.Encode(typeValue)
 		require.NoError(t, err)
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+		runtimeInterface := &TestRuntimeInterface{
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -4012,15 +3994,12 @@ func TestRuntimeCapabilityValueImport(t *testing.T) {
 		encodedArg, err := json.Encode(capabilityValue)
 		require.NoError(t, err)
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+		runtimeInterface := &TestRuntimeInterface{
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -4056,15 +4035,12 @@ func TestRuntimeCapabilityValueImport(t *testing.T) {
 		encodedArg, err := json.Encode(capabilityValue)
 		require.NoError(t, err)
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+		runtimeInterface := &TestRuntimeInterface{
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -4107,15 +4083,12 @@ func TestRuntimeCapabilityValueImport(t *testing.T) {
 		encodedArg, err := json.Encode(capabilityValue)
 		require.NoError(t, err)
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+		runtimeInterface := &TestRuntimeInterface{
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err = rt.ExecuteScript(
@@ -4148,7 +4121,7 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 		encodedArg, err := json.Encode(arg)
 		require.NoError(t, err)
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
 		return rt.ExecuteScript(
 			Script{
@@ -4198,20 +4171,17 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 					var publicKeyValidated bool
 
-					storage := newTestLedger(nil, nil)
+					storage := NewTestLedger(nil, nil)
 
-					runtimeInterface := &testRuntimeInterface{
-						storage: storage,
-						validatePublicKey: func(publicKey *stdlib.PublicKey) error {
+					runtimeInterface := &TestRuntimeInterface{
+						Storage: storage,
+						OnValidatePublicKey: func(publicKey *stdlib.PublicKey) error {
 							publicKeyValidated = true
 							return publicKeyActualError
 						},
-						meterMemory: func(_ common.MemoryUsage) error {
-							return nil
+						OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+							return json.Decode(nil, b)
 						},
-					}
-					runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-						return json.Decode(runtimeInterface, b)
 					}
 
 					_, err := executeScript(t, script, publicKey, runtimeInterface)
@@ -4269,11 +4239,11 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 		var verifyInvoked bool
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			verifySignature: func(
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnVerifySignature: func(
 				signature []byte,
 				tag string,
 				signedData []byte,
@@ -4284,12 +4254,9 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 				verifyInvoked = true
 				return true, nil
 			},
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 		addPublicKeyValidation(runtimeInterface, nil)
 
@@ -4319,16 +4286,13 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 			},
 		).WithType(PublicKeyType)
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := executeScript(t, script, publicKey, runtimeInterface)
@@ -4361,16 +4325,13 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 			},
 		).WithType(PublicKeyType)
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := executeScript(t, script, publicKey, runtimeInterface)
@@ -4396,16 +4357,13 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 			},
 		).WithType(PublicKeyType)
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := executeScript(t, script, publicKey, runtimeInterface)
@@ -4435,16 +4393,13 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 			},
 		).WithType(PublicKeyType)
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := executeScript(t, script, publicKey, runtimeInterface)
@@ -4513,18 +4468,15 @@ func TestRuntimePublicKeyImport(t *testing.T) {
             }
         `
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := rt.ExecuteScript(
@@ -4582,18 +4534,15 @@ func TestRuntimePublicKeyImport(t *testing.T) {
             }
         `
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := rt.ExecuteScript(
@@ -4649,24 +4598,21 @@ func TestRuntimePublicKeyImport(t *testing.T) {
             }
         `
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
 		var publicKeyValidated bool
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			validatePublicKey: func(publicKey *stdlib.PublicKey) error {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnValidatePublicKey: func(publicKey *stdlib.PublicKey) error {
 				publicKeyValidated = true
 				return nil
 			},
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		value, err := rt.ExecuteScript(
@@ -4723,24 +4669,21 @@ func TestRuntimePublicKeyImport(t *testing.T) {
             }
         `
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
 		var publicKeyValidated bool
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			validatePublicKey: func(publicKey *stdlib.PublicKey) error {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnValidatePublicKey: func(publicKey *stdlib.PublicKey) error {
 				publicKeyValidated = true
 				return nil
 			},
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		value, err := rt.ExecuteScript(
@@ -4773,7 +4716,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 		Elaboration: sema.NewElaboration(nil),
 	}
 
-	inter := newTestInterpreter(t)
+	inter := NewTestInterpreter(t)
 	inter.Program = &program
 
 	// Array
@@ -4906,11 +4849,10 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 
 		// NOTE: cannot be parallel, due to type's ID being cached (potential data race)
 
-		actual, err := exportValueWithInterpreter(
+		actual, err := ExportValue(
 			internalCompositeValue,
 			inter,
 			interpreter.EmptyLocationRange,
-			seenReferences{},
 		)
 		require.NoError(t, err)
 
@@ -4928,7 +4870,7 @@ func TestRuntimeImportExportComplex(t *testing.T) {
 			Elaboration: sema.NewElaboration(nil),
 		}
 
-		inter := newTestInterpreter(t)
+		inter := NewTestInterpreter(t)
 		inter.Program = &program
 
 		program.Elaboration.SetCompositeType(
@@ -5037,27 +4979,6 @@ func TestRuntimeStaticTypeAvailability(t *testing.T) {
 	})
 }
 
-func newTestInterpreter(tb testing.TB) *interpreter.Interpreter {
-	storage := newUnmeteredInMemoryStorage()
-
-	inter, err := interpreter.NewInterpreter(
-		nil,
-		TestLocation,
-		&interpreter.Config{
-			Storage:                       storage,
-			AtreeValueValidationEnabled:   true,
-			AtreeStorageValidationEnabled: true,
-		},
-	)
-	require.NoError(tb, err)
-
-	return inter
-}
-
-func newUnmeteredInMemoryStorage() interpreter.Storage {
-	return interpreter.NewInMemoryStorage(nil)
-}
-
 func TestRuntimeNestedStructArgPassing(t *testing.T) {
 	t.Parallel()
 
@@ -5102,18 +5023,15 @@ func TestRuntimeNestedStructArgPassing(t *testing.T) {
           }
         `
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		value, err := rt.ExecuteScript(
@@ -5168,19 +5086,17 @@ func TestRuntimeNestedStructArgPassing(t *testing.T) {
           }
         `
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
 		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
-		}
+
 		_, err := rt.ExecuteScript(
 			Script{
 				Source: []byte(script),
@@ -5205,7 +5121,7 @@ func TestRuntimeNestedStructArgPassing(t *testing.T) {
 func TestRuntimeDestroyedResourceReferenceExport(t *testing.T) {
 	t.Parallel()
 
-	rt := newTestInterpreterRuntimeWithAttachments()
+	rt := NewTestInterpreterRuntimeWithAttachments()
 
 	script := []byte(`
         access(all) resource S {}
@@ -5227,9 +5143,9 @@ func TestRuntimeDestroyedResourceReferenceExport(t *testing.T) {
         }
 	 `)
 
-	runtimeInterface := &testRuntimeInterface{}
+	runtimeInterface := &TestRuntimeInterface{}
 
-	nextScriptLocation := newScriptLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 	_, err := rt.ExecuteScript(
 		Script{
 			Source: script,
@@ -5255,8 +5171,8 @@ func TestRuntimeDeploymentResultValueImportExport(t *testing.T) {
             access(all) fun main(v: DeploymentResult) {}
         `
 
-		rt := newTestInterpreterRuntime()
-		runtimeInterface := &testRuntimeInterface{}
+		rt := NewTestInterpreterRuntime()
+		runtimeInterface := &TestRuntimeInterface{}
 
 		_, err := rt.ExecuteScript(
 			Script{
@@ -5284,8 +5200,8 @@ func TestRuntimeDeploymentResultValueImportExport(t *testing.T) {
             }
         `
 
-		rt := newTestInterpreterRuntime()
-		runtimeInterface := &testRuntimeInterface{}
+		rt := NewTestInterpreterRuntime()
+		runtimeInterface := &TestRuntimeInterface{}
 
 		_, err := rt.ExecuteScript(
 			Script{
@@ -5318,7 +5234,7 @@ func TestRuntimeDeploymentResultTypeImportExport(t *testing.T) {
             }
         `
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
 		typeValue := cadence.NewTypeValue(&cadence.StructType{
 			QualifiedIdentifier: "DeploymentResult",
@@ -5333,10 +5249,10 @@ func TestRuntimeDeploymentResultTypeImportExport(t *testing.T) {
 		encodedArg, err := json.Encode(typeValue)
 		require.NoError(t, err)
 
-		runtimeInterface := &testRuntimeInterface{}
-
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
+		runtimeInterface := &TestRuntimeInterface{
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
+			},
 		}
 
 		_, err = rt.ExecuteScript(
@@ -5363,8 +5279,8 @@ func TestRuntimeDeploymentResultTypeImportExport(t *testing.T) {
             }
         `
 
-		rt := newTestInterpreterRuntime()
-		runtimeInterface := &testRuntimeInterface{}
+		rt := NewTestInterpreterRuntime()
+		runtimeInterface := &TestRuntimeInterface{}
 
 		result, err := rt.ExecuteScript(
 			Script{

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"encoding/json"
@@ -27,9 +27,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/stdlib"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 )
 
 func TestRuntimeNewLocationCoverage(t *testing.T) {
@@ -1283,8 +1285,8 @@ func TestRuntimeCoverage(t *testing.T) {
 	`)
 
 	coverageReport := NewCoverageReport()
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("imported"):
 				return importedScript, nil
@@ -1294,8 +1296,9 @@ func TestRuntimeCoverage(t *testing.T) {
 		},
 	}
 
-	runtime := newTestInterpreterRuntime()
-	runtime.defaultConfig.CoverageReport = coverageReport
+	config := DefaultTestInterpreterConfig
+	config.CoverageReport = coverageReport
+	runtime := NewTestInterpreterRuntimeWithConfig(config)
 
 	value, err := runtime.ExecuteScript(
 		Script{
@@ -1440,8 +1443,8 @@ func TestRuntimeCoverageWithExcludedLocation(t *testing.T) {
 	scriptlocation := common.ScriptLocation{}
 	coverageReport.ExcludeLocation(scriptlocation)
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("imported"):
 				return importedScript, nil
@@ -1451,8 +1454,9 @@ func TestRuntimeCoverageWithExcludedLocation(t *testing.T) {
 		},
 	}
 
-	runtime := newTestInterpreterRuntime()
-	runtime.defaultConfig.CoverageReport = coverageReport
+	config := DefaultTestInterpreterConfig
+	config.CoverageReport = coverageReport
+	runtime := NewTestInterpreterRuntimeWithConfig(config)
 
 	value, err := runtime.ExecuteScript(
 		Script{
@@ -1581,8 +1585,8 @@ func TestRuntimeCoverageWithLocationFilter(t *testing.T) {
 	})
 	scriptlocation := common.ScriptLocation{0x1b, 0x2c}
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("imported"):
 				return importedScript, nil
@@ -1672,8 +1676,8 @@ func TestRuntimeCoverageWithNoStatements(t *testing.T) {
 
 	scriptlocation := common.ScriptLocation{0x1b, 0x2c}
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("FooContract"):
 				return importedScript, nil
@@ -1794,8 +1798,8 @@ func TestRuntimeCoverageReportLCOVFormat(t *testing.T) {
 	scriptlocation := common.ScriptLocation{}
 	coverageReport.ExcludeLocation(scriptlocation)
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("IntegerTraits"):
 				return integerTraits, nil
@@ -1805,8 +1809,9 @@ func TestRuntimeCoverageReportLCOVFormat(t *testing.T) {
 		},
 	}
 
-	runtime := newTestInterpreterRuntime()
-	runtime.defaultConfig.CoverageReport = coverageReport
+	config := DefaultTestInterpreterConfig
+	config.CoverageReport = coverageReport
+	runtime := NewTestInterpreterRuntimeWithConfig(config)
 
 	value, err := runtime.ExecuteScript(
 		Script{

--- a/runtime/debugger_test.go
+++ b/runtime/debugger_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"sync"
@@ -24,9 +24,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 )
 
 func TestRuntimeDebugger(t *testing.T) {
@@ -52,23 +54,24 @@ func TestRuntimeDebugger(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		runtime := newTestInterpreterRuntime()
-		runtime.defaultConfig.Debugger = debugger
+		config := DefaultTestInterpreterConfig
+		config.Debugger = debugger
+		runtime := NewTestInterpreterRuntimeWithConfig(config)
 
 		address := common.MustBytesToAddress([]byte{0x1})
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{address}, nil
 			},
-			log: func(message string) {
+			OnProgramLog: func(message string) {
 				logged = true
 				require.Equal(t, `"Hello, World!"`, message)
 			},
 		}
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -122,7 +125,7 @@ func TestRuntimeDebuggerBreakpoints(t *testing.T) {
 
 	t.Parallel()
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 	location := nextTransactionLocation()
 
 	// Prepare the debugger
@@ -144,17 +147,18 @@ func TestRuntimeDebuggerBreakpoints(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		runtime := newTestInterpreterRuntime()
-		runtime.defaultConfig.Debugger = debugger
+		config := DefaultTestInterpreterConfig
+		config.Debugger = debugger
+		runtime := NewTestInterpreterRuntimeWithConfig(config)
 
 		address := common.MustBytesToAddress([]byte{0x1})
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{address}, nil
 			},
-			log: func(message string) {
+			OnProgramLog: func(message string) {
 				logged = true
 				require.Equal(t, `"Hello, World!"`, message)
 			},

--- a/runtime/deployedcontract_test.go
+++ b/runtime/deployedcontract_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"testing"
@@ -24,7 +24,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -63,38 +65,38 @@ func TestRuntimeDeployedContracts(t *testing.T) {
 		}
 		`
 
-	rt := newTestInterpreterRuntime()
+	rt := NewTestInterpreterRuntime()
 	accountCodes := map[Location][]byte{}
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
 			return accountCodes[location], nil
 		},
-		getAccountContractNames: func(_ Address) ([]string, error) {
+		OnGetAccountContractNames: func(_ Address) ([]string, error) {
 			names := make([]string, 0, len(accountCodes))
 			for location := range accountCodes {
 				names = append(names, location.String())
 			}
 			return names, nil
 		},
-		emitEvent: func(_ cadence.Event) error {
+		OnEmitEvent: func(_ cadence.Event) error {
 			return nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		log:     func(msg string) {},
-		storage: newTestLedger(nil, nil),
+		OnProgramLog: func(msg string) {},
+		Storage:      NewTestLedger(nil, nil),
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 	newContext := func() Context {
 		return Context{Interface: runtimeInterface, Location: nextTransactionLocation()}
 	}

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"encoding/hex"
@@ -29,10 +29,12 @@ import (
 	"golang.org/x/crypto/sha3"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -72,7 +74,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 
 		codeHashValue := event.Fields[codeHashParameterIndex]
 
-		inter := newTestInterpreter(t)
+		inter := NewTestInterpreter(t)
 
 		require.Equal(t,
 			ImportType(inter, codeHashValue.Type()),
@@ -160,24 +162,24 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 			argumentCode,
 		))
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		var accountCode []byte
 		var events []cadence.Event
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+			OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 				return accountCode, nil
 			},
-			updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+			OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 				accountCode = code
 				return nil
 			},
-			emitEvent: func(event cadence.Event) error {
+			OnEmitEvent: func(event cadence.Event) error {
 				events = append(events, event)
 				return nil
 			},

--- a/runtime/entitlements_test.go
+++ b/runtime/entitlements_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"testing"
@@ -24,18 +24,20 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/checker"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestRuntimeAccountEntitlementSaveAndLoadSuccess(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -66,27 +68,27 @@ func TestRuntimeAccountEntitlementSaveAndLoadSuccess(t *testing.T) {
         }
      `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log:     func(message string) {},
-		emitEvent: func(event cadence.Event) error {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage:      storage,
+		OnProgramLog: func(message string) {},
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -126,8 +128,8 @@ func TestRuntimeAccountEntitlementSaveAndLoadSuccess(t *testing.T) {
 func TestRuntimeAccountEntitlementSaveAndLoadFail(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -158,27 +160,27 @@ func TestRuntimeAccountEntitlementSaveAndLoadFail(t *testing.T) {
         }
      `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log:     func(message string) {},
-		emitEvent: func(event cadence.Event) error {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage:      storage,
+		OnProgramLog: func(message string) {},
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -218,8 +220,8 @@ func TestRuntimeAccountEntitlementSaveAndLoadFail(t *testing.T) {
 func TestRuntimeAccountEntitlementAttachmentMap(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntimeWithAttachments()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntimeWithAttachments()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -267,27 +269,27 @@ func TestRuntimeAccountEntitlementAttachmentMap(t *testing.T) {
         }
      `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log:     func(message string) {},
-		emitEvent: func(event cadence.Event) error {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage:      storage,
+		OnProgramLog: func(message string) {},
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -327,8 +329,8 @@ func TestRuntimeAccountEntitlementAttachmentMap(t *testing.T) {
 func TestRuntimeAccountExportEntitledRef(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -354,28 +356,28 @@ func TestRuntimeAccountExportEntitledRef(t *testing.T) {
         }
      `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log:     func(message string) {},
-		emitEvent: func(event cadence.Event) error {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage:      storage,
+		OnProgramLog: func(message string) {},
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
-	nextScriptLocation := newScriptLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -404,8 +406,8 @@ func TestRuntimeAccountExportEntitledRef(t *testing.T) {
 func TestRuntimeAccountEntitlementNamingConflict(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -440,28 +442,28 @@ func TestRuntimeAccountEntitlementNamingConflict(t *testing.T) {
         }
      `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log:     func(message string) {},
-		emitEvent: func(event cadence.Event) error {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage:      storage,
+		OnProgramLog: func(message string) {},
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
-	nextScriptLocation := newScriptLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -507,8 +509,8 @@ func TestRuntimeAccountEntitlementNamingConflict(t *testing.T) {
 func TestRuntimeAccountEntitlementCapabilityCasting(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntimeWithAttachments()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntimeWithAttachments()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -547,27 +549,27 @@ func TestRuntimeAccountEntitlementCapabilityCasting(t *testing.T) {
         }
      `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log:     func(message string) {},
-		emitEvent: func(event cadence.Event) error {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage:      storage,
+		OnProgramLog: func(message string) {},
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -607,8 +609,8 @@ func TestRuntimeAccountEntitlementCapabilityCasting(t *testing.T) {
 func TestRuntimeAccountEntitlementCapabilityDictionary(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntimeWithAttachments()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntimeWithAttachments()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -662,27 +664,27 @@ func TestRuntimeAccountEntitlementCapabilityDictionary(t *testing.T) {
         }
      `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log:     func(message string) {},
-		emitEvent: func(event cadence.Event) error {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage:      storage,
+		OnProgramLog: func(message string) {},
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -722,8 +724,8 @@ func TestRuntimeAccountEntitlementCapabilityDictionary(t *testing.T) {
 func TestRuntimeAccountEntitlementGenericCapabilityDictionary(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntimeWithAttachments()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntimeWithAttachments()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -777,27 +779,27 @@ func TestRuntimeAccountEntitlementGenericCapabilityDictionary(t *testing.T) {
         }
      `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log:     func(message string) {},
-		emitEvent: func(event cadence.Event) error {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage:      storage,
+		OnProgramLog: func(message string) {},
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{
@@ -841,25 +843,25 @@ func TestRuntimeCapabilityEntitlements(t *testing.T) {
 	address := common.MustBytesToAddress([]byte{0x1})
 
 	test := func(t *testing.T, script string) {
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		accountCodes := map[common.Location][]byte{}
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{address}, nil
 			},
-			resolveLocation: singleIdentifierLocationResolver(t),
-			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
-			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				code = accountCodes[location]
 				return code, nil
 			},
-			emitEvent: func(event cadence.Event) error {
+			OnEmitEvent: func(event cadence.Event) error {
 				return nil
 			},
 		}
@@ -1119,8 +1121,8 @@ func TestRuntimeCapabilityEntitlements(t *testing.T) {
 func TestRuntimeImportedEntitlementMapInclude(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 	accountCodes := map[Location][]byte{}
 
 	furtherUpstreamDeployTx := DeploymentTransaction("FurtherUpstream", []byte(`
@@ -1213,28 +1215,28 @@ func TestRuntimeImportedEntitlementMapInclude(t *testing.T) {
         }
      `)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log:     func(message string) {},
-		emitEvent: func(event cadence.Event) error {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage:      storage,
+		OnProgramLog: func(message string) {},
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getSigningAccounts: func() ([]Address, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
-	nextScriptLocation := newScriptLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	err := rt.ExecuteTransaction(
 		Script{

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -540,7 +540,7 @@ func (e *interpreterEnvironment) getProgram(
 			// Loading is done by Cadence.
 			// If it panics with a user error, e.g. when parsing fails due to a memory metering error,
 			// then do not treat it as an external error (the load callback is called by the embedder)
-			panicErr := userPanicToError(func() {
+			panicErr := UserPanicToError(func() {
 				program, err = load()
 			})
 			if panicErr != nil {

--- a/runtime/error_test.go
+++ b/runtime/error_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"encoding/hex"
@@ -26,10 +26,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 )
 
 func TestRuntimeError(t *testing.T) {
@@ -40,11 +42,11 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`X`)
 
-		runtimeInterface := &testRuntimeInterface{}
+		runtimeInterface := &TestRuntimeInterface{}
 
 		location := common.ScriptLocation{0x1}
 
@@ -73,11 +75,11 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`fun test() {}`)
 
-		runtimeInterface := &testRuntimeInterface{}
+		runtimeInterface := &TestRuntimeInterface{}
 
 		location := common.ScriptLocation{0x1}
 
@@ -106,7 +108,7 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
             access(all) fun main() {
@@ -117,7 +119,7 @@ func TestRuntimeError(t *testing.T) {
             }
         `)
 
-		runtimeInterface := &testRuntimeInterface{}
+		runtimeInterface := &TestRuntimeInterface{}
 
 		location := common.ScriptLocation{0x1}
 
@@ -146,7 +148,7 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
 			access(all) fun main() {
@@ -155,7 +157,7 @@ func TestRuntimeError(t *testing.T) {
 			}
         `)
 
-		runtimeInterface := &testRuntimeInterface{}
+		runtimeInterface := &TestRuntimeInterface{}
 
 		location := common.ScriptLocation{0x1}
 
@@ -184,7 +186,7 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
 			access(all) resource Resource {
@@ -204,7 +206,7 @@ func TestRuntimeError(t *testing.T) {
 			}
         `)
 
-		runtimeInterface := &testRuntimeInterface{}
+		runtimeInterface := &TestRuntimeInterface{}
 
 		location := common.ScriptLocation{0x1}
 
@@ -244,14 +246,14 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		importedScript := []byte(`X`)
 
 		script := []byte(`import "imported"`)
 
-		runtimeInterface := &testRuntimeInterface{
-			getCode: func(location Location) (bytes []byte, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetCode: func(location Location) (bytes []byte, err error) {
 				switch location {
 				case common.StringLocation("imported"):
 					return importedScript, nil
@@ -287,14 +289,14 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		importedScript := []byte(`fun test() {}`)
 
 		script := []byte(`import "imported"`)
 
-		runtimeInterface := &testRuntimeInterface{
-			getCode: func(location Location) (bytes []byte, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetCode: func(location Location) (bytes []byte, err error) {
 				switch location {
 				case common.StringLocation("imported"):
 					return importedScript, nil
@@ -331,7 +333,7 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		importedScript := []byte(`
             access(all) fun add() {
@@ -350,8 +352,8 @@ func TestRuntimeError(t *testing.T) {
             }
         `)
 
-		runtimeInterface := &testRuntimeInterface{
-			getCode: func(location Location) (bytes []byte, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetCode: func(location Location) (bytes []byte, err error) {
 				switch location {
 				case common.StringLocation("imported"):
 					return importedScript, nil
@@ -435,15 +437,15 @@ func TestRuntimeError(t *testing.T) {
             `,
 		}
 
-		runtimeInterface := &testRuntimeInterface{
-			resolveLocation: multipleIdentifierLocationResolver,
-			getAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnResolveLocation: MultipleIdentifierLocationResolver,
+			OnGetAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
 				code := codes[location]
 				return []byte(code), nil
 			},
 		}
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 		err = rt.ExecuteTransaction(
 			Script{
 				Source: []byte(codes[location]),
@@ -486,7 +488,7 @@ func TestRuntimeError(t *testing.T) {
 func TestRuntimeDefaultFunctionConflictPrintingError(t *testing.T) {
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	makeDeployTransaction := func(name, code string) []byte {
 		return []byte(fmt.Sprintf(
@@ -539,34 +541,34 @@ func TestRuntimeDefaultFunctionConflictPrintingError(t *testing.T) {
 
 	var nextAccount byte = 0x2
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		createAccount: func(payer Address) (address Address, err error) {
+		Storage: NewTestLedger(nil, nil),
+		OnCreateAccount: func(payer Address) (address Address, err error) {
 			result := interpreter.NewUnmeteredAddressValueFromBytes([]byte{nextAccount})
 			nextAccount++
 			return result.ToAddress(), nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{0x1}}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	deployTransaction := makeDeployTransaction("TestInterfaces", contractInterfaceCode)
 	err := runtime.ExecuteTransaction(
@@ -613,7 +615,7 @@ func TestRuntimeDefaultFunctionConflictPrintingError(t *testing.T) {
 func TestRuntimeMultipleInterfaceDefaultImplementationsError(t *testing.T) {
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	makeDeployTransaction := func(name, code string) []byte {
 		return []byte(fmt.Sprintf(
@@ -668,34 +670,34 @@ func TestRuntimeMultipleInterfaceDefaultImplementationsError(t *testing.T) {
 
 	var nextAccount byte = 0x2
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		createAccount: func(payer Address) (address Address, err error) {
+		Storage: NewTestLedger(nil, nil),
+		OnCreateAccount: func(payer Address) (address Address, err error) {
 			result := interpreter.NewUnmeteredAddressValueFromBytes([]byte{nextAccount})
 			nextAccount++
 			return result.ToAddress(), nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{0x1}}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	deployTransaction := makeDeployTransaction("TestInterfaces", contractInterfaceCode)
 	err := runtime.ExecuteTransaction(

--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"encoding/hex"
@@ -27,8 +27,10 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -501,7 +503,7 @@ access(all) fun main(account: Address): UFix64 {
 
 func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	contractsAddress := common.MustBytesToAddress([]byte{0x1})
 	senderAddress := common.MustBytesToAddress([]byte{0x2})
@@ -513,34 +515,34 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 
 	signerAccount := contractsAddress
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAccount}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(b),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(b),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-	}
-	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-		return json.Decode(runtimeInterface, b)
+		OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(nil, b)
+		},
 	}
 
 	environment := NewBaseInterpreterEnvironment(Config{})
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy Fungible Token contract
 
@@ -665,7 +667,7 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 
 	sum := interpreter.NewUnmeteredUFix64ValueWithInteger(0, interpreter.EmptyLocationRange)
 
-	inter := newTestInterpreter(b)
+	inter := NewTestInterpreter(b)
 
 	for _, address := range []common.Address{
 		senderAddress,

--- a/runtime/import_test.go
+++ b/runtime/import_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"fmt"
@@ -27,9 +27,11 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/checker"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -37,7 +39,7 @@ func TestRuntimeCyclicImport(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	imported1 := []byte(`
       import p2
@@ -55,8 +57,8 @@ func TestRuntimeCyclicImport(t *testing.T) {
 
 	var checkCount int
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.IdentifierLocation("p1"):
 				return imported1, nil
@@ -66,7 +68,7 @@ func TestRuntimeCyclicImport(t *testing.T) {
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
 		},
-		programChecked: func(location Location, duration time.Duration) {
+		OnProgramChecked: func(location Location, duration time.Duration) {
 			checkCount += 1
 		},
 	}
@@ -116,7 +118,7 @@ func TestRuntimeCyclicImport(t *testing.T) {
 
 func TestRuntimeCheckCyclicImportsAfterUpdate(t *testing.T) {
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	contractsAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -124,33 +126,33 @@ func TestRuntimeCheckCyclicImportsAfterUpdate(t *testing.T) {
 
 	signerAccount := contractsAddress
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) ([]byte, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) ([]byte, error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAccount}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-	}
-	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (cadence.Value, error) {
-		return json.Decode(runtimeInterface, b)
+		OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(nil, b)
+		},
 	}
 
 	environment := NewBaseInterpreterEnvironment(Config{})
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	deploy := func(name string, contract string, update bool) error {
 		var txSource = DeploymentTransaction
@@ -213,7 +215,7 @@ func TestRuntimeCheckCyclicImportsAfterUpdate(t *testing.T) {
 
 func TestRuntimeCheckCyclicImportAddress(t *testing.T) {
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	contractsAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -221,15 +223,15 @@ func TestRuntimeCheckCyclicImportAddress(t *testing.T) {
 
 	signerAccount := contractsAddress
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) ([]byte, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) ([]byte, error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAccount}, nil
 		},
-		resolveLocation: func(identifiers []Identifier, location Location) ([]ResolvedLocation, error) {
+		OnResolveLocation: func(identifiers []Identifier, location Location) ([]ResolvedLocation, error) {
 			if len(identifiers) == 0 {
 				require.IsType(t, common.AddressLocation{}, location)
 				addressLocation := location.(common.AddressLocation)
@@ -248,26 +250,26 @@ func TestRuntimeCheckCyclicImportAddress(t *testing.T) {
 				)
 			}
 
-			return multipleIdentifierLocationResolver(identifiers, location)
+			return MultipleIdentifierLocationResolver(identifiers, location)
 		},
-		getAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-	}
-	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (cadence.Value, error) {
-		return json.Decode(runtimeInterface, b)
+		OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(nil, b)
+		},
 	}
 
 	environment := NewBaseInterpreterEnvironment(Config{})
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	deploy := func(name string, contract string, update bool) error {
 		var txSource = DeploymentTransaction
@@ -324,7 +326,7 @@ func TestRuntimeCheckCyclicImportAddress(t *testing.T) {
 
 func TestRuntimeCheckCyclicImportToSelfDuringDeploy(t *testing.T) {
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	contractsAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -332,15 +334,15 @@ func TestRuntimeCheckCyclicImportToSelfDuringDeploy(t *testing.T) {
 
 	signerAccount := contractsAddress
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) ([]byte, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) ([]byte, error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAccount}, nil
 		},
-		resolveLocation: func(identifiers []Identifier, location Location) ([]ResolvedLocation, error) {
+		OnResolveLocation: func(identifiers []Identifier, location Location) ([]ResolvedLocation, error) {
 			if len(identifiers) == 0 {
 				require.IsType(t, common.AddressLocation{}, location)
 				addressLocation := location.(common.AddressLocation)
@@ -349,26 +351,26 @@ func TestRuntimeCheckCyclicImportToSelfDuringDeploy(t *testing.T) {
 			}
 
 			// There are no contracts in the account, so the identifiers are empty.
-			return multipleIdentifierLocationResolver(identifiers, location)
+			return MultipleIdentifierLocationResolver(identifiers, location)
 		},
-		getAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-	}
-	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (cadence.Value, error) {
-		return json.Decode(runtimeInterface, b)
+		OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(nil, b)
+		},
 	}
 
 	environment := NewBaseInterpreterEnvironment(Config{})
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	deploy := func(name string, contract string, update bool) error {
 		var txSource = DeploymentTransaction

--- a/runtime/imported_values_memory_metering_test.go
+++ b/runtime/imported_values_memory_metering_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"fmt"
@@ -26,8 +26,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
-	jsoncdc "github.com/onflow/cadence/encoding/json"
+	"github.com/onflow/cadence/encoding/json"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -44,13 +46,13 @@ func TestRuntimeImportedValueMemoryMetering(t *testing.T) {
 
 	executeScript := func(t *testing.T, script []byte, meter map[common.MemoryKind]uint64, args ...cadence.Value) {
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: testUseMemory(meter),
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: testUseMemory(meter),
 		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (cadence.Value, error) {
-			return jsoncdc.Decode(runtimeInterface, b)
+		runtimeInterface.OnDecodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := runtime.ExecuteScript(
@@ -487,14 +489,14 @@ func TestRuntimeImportedValueMemoryMeteringForSimpleTypes(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runtime := newTestInterpreterRuntime()
+			runtime := NewTestInterpreterRuntime()
 
 			meter := make(map[common.MemoryKind]uint64)
-			runtimeInterface := &testRuntimeInterface{
-				meterMemory: testUseMemory(meter),
+			runtimeInterface := &TestRuntimeInterface{
+				OnMeterMemory: testUseMemory(meter),
 			}
-			runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (cadence.Value, error) {
-				return jsoncdc.Decode(runtimeInterface, b)
+			runtimeInterface.OnDecodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(runtimeInterface, b)
 			}
 
 			script := []byte(fmt.Sprintf(
@@ -559,14 +561,14 @@ func TestRuntimeScriptDecodedLocationMetering(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
 
-			runtime := newTestInterpreterRuntime()
+			runtime := NewTestInterpreterRuntime()
 
 			meter := make(map[common.MemoryKind]uint64)
-			runtimeInterface := &testRuntimeInterface{
-				meterMemory: testUseMemory(meter),
+			runtimeInterface := &TestRuntimeInterface{
+				OnMeterMemory: testUseMemory(meter),
 			}
-			runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (cadence.Value, error) {
-				return jsoncdc.Decode(runtimeInterface, b)
+			runtimeInterface.OnDecodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(runtimeInterface, b)
 			}
 
 			value := cadence.NewStruct([]cadence.Value{}).WithType(

--- a/runtime/inbox_test.go
+++ b/runtime/inbox_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"testing"
@@ -25,13 +25,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 )
 
 func TestRuntimeAccountInboxPublishUnpublish(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -55,21 +57,21 @@ func TestRuntimeAccountInboxPublishUnpublish(t *testing.T) {
 		}
 	`)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// publish from 1 to 2
 	err := rt.ExecuteTransaction(
@@ -119,8 +121,8 @@ func TestRuntimeAccountInboxPublishUnpublish(t *testing.T) {
 func TestRuntimeAccountInboxUnpublishWrongType(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -144,21 +146,21 @@ func TestRuntimeAccountInboxUnpublishWrongType(t *testing.T) {
 		}
 	`)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// publish from 1 to 2
 	err := rt.ExecuteTransaction(
@@ -198,8 +200,8 @@ func TestRuntimeAccountInboxUnpublishWrongType(t *testing.T) {
 func TestRuntimeAccountInboxUnpublishAbsent(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -223,21 +225,21 @@ func TestRuntimeAccountInboxUnpublishAbsent(t *testing.T) {
 		}
 	`)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// publish from 1 to 2
 	err := rt.ExecuteTransaction(
@@ -287,8 +289,8 @@ func TestRuntimeAccountInboxUnpublishAbsent(t *testing.T) {
 func TestRuntimeAccountInboxUnpublishRemove(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -314,21 +316,21 @@ func TestRuntimeAccountInboxUnpublishRemove(t *testing.T) {
 		}
 	`)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 	// publish from 1 to 2
 	err := rt.ExecuteTransaction(
 		Script{
@@ -381,8 +383,8 @@ func TestRuntimeAccountInboxUnpublishRemove(t *testing.T) {
 func TestRuntimeAccountInboxUnpublishWrongAccount(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -415,35 +417,35 @@ func TestRuntimeAccountInboxUnpublishWrongAccount(t *testing.T) {
 		}
 	`)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
 	}
 
-	runtimeInterface2 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface2 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 2}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// publish from 1 to 2
 	err := rt.ExecuteTransaction(
@@ -508,8 +510,8 @@ func TestRuntimeAccountInboxUnpublishWrongAccount(t *testing.T) {
 func TestRuntimeAccountInboxPublishClaim(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -533,35 +535,35 @@ func TestRuntimeAccountInboxPublishClaim(t *testing.T) {
 		}
 	`)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
 	}
 
-	runtimeInterface2 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface2 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 2}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// publish from 1 to 2
 	err := rt.ExecuteTransaction(
@@ -612,8 +614,8 @@ func TestRuntimeAccountInboxPublishClaim(t *testing.T) {
 func TestRuntimeAccountInboxPublishClaimWrongType(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -637,35 +639,35 @@ func TestRuntimeAccountInboxPublishClaimWrongType(t *testing.T) {
 		}
 	`)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
 	}
 
-	runtimeInterface2 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface2 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 2}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// publish from 1 to 2
 	err := rt.ExecuteTransaction(
@@ -713,8 +715,8 @@ func TestRuntimeAccountInboxPublishClaimWrongType(t *testing.T) {
 func TestRuntimeAccountInboxPublishClaimWrongName(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -738,35 +740,35 @@ func TestRuntimeAccountInboxPublishClaimWrongName(t *testing.T) {
 		}
 	`)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
 	}
 
-	runtimeInterface2 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface2 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 2}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// publish from 1 to 2
 	err := rt.ExecuteTransaction(
@@ -815,8 +817,8 @@ func TestRuntimeAccountInboxPublishClaimWrongName(t *testing.T) {
 func TestRuntimeAccountInboxPublishClaimRemove(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -849,35 +851,35 @@ func TestRuntimeAccountInboxPublishClaimRemove(t *testing.T) {
 		}
 	`)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
 	}
 
-	runtimeInterface2 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface2 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 2}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// publish from 1 to 2
 	err := rt.ExecuteTransaction(
@@ -942,8 +944,8 @@ func TestRuntimeAccountInboxPublishClaimRemove(t *testing.T) {
 func TestRuntimeAccountInboxPublishClaimWrongAccount(t *testing.T) {
 	t.Parallel()
 
-	storage := newTestLedger(nil, nil)
-	rt := newTestInterpreterRuntime()
+	storage := NewTestLedger(nil, nil)
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -976,49 +978,49 @@ func TestRuntimeAccountInboxPublishClaimWrongAccount(t *testing.T) {
 		}
 	`)
 
-	runtimeInterface1 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface1 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 1}}, nil
 		},
 	}
 
-	runtimeInterface2 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface2 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 2}}, nil
 		},
 	}
 
-	runtimeInterface3 := &testRuntimeInterface{
-		storage: storage,
-		log: func(message string) {
+	runtimeInterface3 := &TestRuntimeInterface{
+		Storage: storage,
+		OnProgramLog: func(message string) {
 			logs = append(logs, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event.String())
 			return nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{[8]byte{0, 0, 0, 0, 0, 0, 0, 3}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// publish from 1 to 2
 	err := rt.ExecuteTransaction(

--- a/runtime/literal_test.go
+++ b/runtime/literal_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"fmt"
@@ -26,8 +26,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -35,7 +37,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 	t.Parallel()
 
 	t.Run("String, valid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`"hello"`, sema.StringType, newTestInterpreter(t))
+		value, err := ParseLiteral(`"hello"`, sema.StringType, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.String("hello"),
@@ -44,14 +46,14 @@ func TestRuntimeParseLiteral(t *testing.T) {
 	})
 
 	t.Run("String, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`true`, sema.StringType, newTestInterpreter(t))
+		value, err := ParseLiteral(`true`, sema.StringType, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
 	})
 
 	t.Run("Bool, valid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`true`, sema.BoolType, newTestInterpreter(t))
+		value, err := ParseLiteral(`true`, sema.BoolType, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.NewBool(true),
@@ -60,7 +62,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 	})
 
 	t.Run("Bool, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`"hello"`, sema.BoolType, newTestInterpreter(t))
+		value, err := ParseLiteral(`"hello"`, sema.BoolType, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
@@ -70,7 +72,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`nil`,
 			&sema.OptionalType{Type: sema.BoolType},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -87,7 +89,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 					Type: sema.BoolType,
 				},
 			},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -102,7 +104,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`true`,
 			&sema.OptionalType{Type: sema.BoolType},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -119,7 +121,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 					Type: sema.BoolType,
 				},
 			},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -136,7 +138,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`"hello"`,
 			&sema.OptionalType{Type: sema.BoolType},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		RequireError(t, err)
 
@@ -147,7 +149,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`[]`,
 			&sema.VariableSizedType{Type: sema.BoolType},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -160,7 +162,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`[true]`,
 			&sema.VariableSizedType{Type: sema.BoolType},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -175,7 +177,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`"hello"`,
 			&sema.VariableSizedType{Type: sema.BoolType},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		RequireError(t, err)
 
@@ -186,7 +188,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`[]`,
 			&sema.ConstantSizedType{Type: sema.BoolType},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -199,7 +201,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`[true]`,
 			&sema.ConstantSizedType{Type: sema.BoolType},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -214,7 +216,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`"hello"`,
 			&sema.ConstantSizedType{Type: sema.BoolType},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		RequireError(t, err)
 
@@ -228,7 +230,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 				KeyType:   sema.StringType,
 				ValueType: sema.BoolType,
 			},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -244,7 +246,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 				KeyType:   sema.StringType,
 				ValueType: sema.BoolType,
 			},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -265,7 +267,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 				KeyType:   sema.StringType,
 				ValueType: sema.BoolType,
 			},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		RequireError(t, err)
 
@@ -276,7 +278,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`/storage/foo`,
 			sema.PathType,
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -292,7 +294,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`/private/foo`,
 			sema.PathType,
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -308,7 +310,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`/public/foo`,
 			sema.PathType,
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -324,7 +326,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`true`,
 			sema.PathType,
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		RequireError(t, err)
 
@@ -335,7 +337,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`/storage/foo`,
 			sema.StoragePathType,
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -351,7 +353,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`/private/foo`,
 			sema.StoragePathType,
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		RequireError(t, err)
 
@@ -362,7 +364,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`/public/foo`,
 			sema.StoragePathType,
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		RequireError(t, err)
 
@@ -373,7 +375,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`true`,
 			sema.StoragePathType,
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		RequireError(t, err)
 
@@ -384,7 +386,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		value, err := ParseLiteral(
 			`/private/foo`,
 			sema.CapabilityPathType,
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -397,7 +399,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 	})
 
 	t.Run("CapabilityPath, invalid literal (public)", func(t *testing.T) {
-		value, err := ParseLiteral(`/public/foo`, sema.CapabilityPathType, newTestInterpreter(t))
+		value, err := ParseLiteral(`/public/foo`, sema.CapabilityPathType, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.Path{
@@ -409,21 +411,21 @@ func TestRuntimeParseLiteral(t *testing.T) {
 	})
 
 	t.Run("CapabilityPath, invalid literal (storage)", func(t *testing.T) {
-		value, err := ParseLiteral(`/storage/foo`, sema.CapabilityPathType, newTestInterpreter(t))
+		value, err := ParseLiteral(`/storage/foo`, sema.CapabilityPathType, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
 	})
 
 	t.Run("CapabilityPath, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`true`, sema.CapabilityPathType, newTestInterpreter(t))
+		value, err := ParseLiteral(`true`, sema.CapabilityPathType, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
 	})
 
 	t.Run("PublicPath, valid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`/public/foo`, sema.PublicPathType, newTestInterpreter(t))
+		value, err := ParseLiteral(`/public/foo`, sema.PublicPathType, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.Path{
@@ -435,28 +437,28 @@ func TestRuntimeParseLiteral(t *testing.T) {
 	})
 
 	t.Run("PublicPath, invalid literal (private)", func(t *testing.T) {
-		value, err := ParseLiteral(`/private/foo`, sema.PublicPathType, newTestInterpreter(t))
+		value, err := ParseLiteral(`/private/foo`, sema.PublicPathType, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
 	})
 
 	t.Run("PublicPath, invalid literal (storage)", func(t *testing.T) {
-		value, err := ParseLiteral(`/storage/foo`, sema.PublicPathType, newTestInterpreter(t))
+		value, err := ParseLiteral(`/storage/foo`, sema.PublicPathType, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
 	})
 
 	t.Run("PublicPath, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`true`, sema.PublicPathType, newTestInterpreter(t))
+		value, err := ParseLiteral(`true`, sema.PublicPathType, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
 	})
 
 	t.Run("PrivatePath, valid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`/private/foo`, sema.PrivatePathType, newTestInterpreter(t))
+		value, err := ParseLiteral(`/private/foo`, sema.PrivatePathType, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.Path{
@@ -468,28 +470,28 @@ func TestRuntimeParseLiteral(t *testing.T) {
 	})
 
 	t.Run("PrivatePath, invalid literal (public)", func(t *testing.T) {
-		value, err := ParseLiteral(`/public/foo`, sema.PrivatePathType, newTestInterpreter(t))
+		value, err := ParseLiteral(`/public/foo`, sema.PrivatePathType, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
 	})
 
 	t.Run("PrivatePath, invalid literal (storage)", func(t *testing.T) {
-		value, err := ParseLiteral(`/storage/foo`, sema.PrivatePathType, newTestInterpreter(t))
+		value, err := ParseLiteral(`/storage/foo`, sema.PrivatePathType, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
 	})
 
 	t.Run("PrivatePath, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`true`, sema.PrivatePathType, newTestInterpreter(t))
+		value, err := ParseLiteral(`true`, sema.PrivatePathType, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
 	})
 
 	t.Run("Address, valid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`0x1`, sema.TheAddressType, newTestInterpreter(t))
+		value, err := ParseLiteral(`0x1`, sema.TheAddressType, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.NewAddress([8]byte{0, 0, 0, 0, 0, 0, 0, 1}),
@@ -498,7 +500,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 	})
 
 	t.Run("Address, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`1`, sema.TheAddressType, newTestInterpreter(t))
+		value, err := ParseLiteral(`1`, sema.TheAddressType, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
@@ -508,7 +510,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		expected, err := cadence.NewFix64FromParts(false, 1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`1.0`, sema.Fix64Type, newTestInterpreter(t))
+		value, err := ParseLiteral(`1.0`, sema.Fix64Type, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
@@ -517,13 +519,13 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		expected, err := cadence.NewFix64FromParts(true, 1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`-1.0`, sema.Fix64Type, newTestInterpreter(t))
+		value, err := ParseLiteral(`-1.0`, sema.Fix64Type, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
 
 	t.Run("Fix64, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`1`, sema.Fix64Type, newTestInterpreter(t))
+		value, err := ParseLiteral(`1`, sema.Fix64Type, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
@@ -533,20 +535,20 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		expected, err := cadence.NewUFix64FromParts(1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`1.0`, sema.UFix64Type, newTestInterpreter(t))
+		value, err := ParseLiteral(`1.0`, sema.UFix64Type, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
 
 	t.Run("UFix64, invalid literal, negative", func(t *testing.T) {
-		value, err := ParseLiteral(`-1.0`, sema.UFix64Type, newTestInterpreter(t))
+		value, err := ParseLiteral(`-1.0`, sema.UFix64Type, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
 	})
 
 	t.Run("UFix64, invalid literal, invalid expression", func(t *testing.T) {
-		value, err := ParseLiteral(`1`, sema.UFix64Type, newTestInterpreter(t))
+		value, err := ParseLiteral(`1`, sema.UFix64Type, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
@@ -556,7 +558,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		expected, err := cadence.NewFix64FromParts(false, 1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`1.0`, sema.FixedPointType, newTestInterpreter(t))
+		value, err := ParseLiteral(`1.0`, sema.FixedPointType, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
@@ -565,13 +567,13 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		expected, err := cadence.NewFix64FromParts(true, 1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`-1.0`, sema.FixedPointType, newTestInterpreter(t))
+		value, err := ParseLiteral(`-1.0`, sema.FixedPointType, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
 
 	t.Run("FixedPoint, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`1`, sema.FixedPointType, newTestInterpreter(t))
+		value, err := ParseLiteral(`1`, sema.FixedPointType, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
@@ -581,7 +583,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		expected, err := cadence.NewFix64FromParts(false, 1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`1.0`, sema.SignedFixedPointType, newTestInterpreter(t))
+		value, err := ParseLiteral(`1.0`, sema.SignedFixedPointType, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
@@ -590,13 +592,13 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		expected, err := cadence.NewFix64FromParts(true, 1, 0)
 		require.NoError(t, err)
 
-		value, err := ParseLiteral(`-1.0`, sema.SignedFixedPointType, newTestInterpreter(t))
+		value, err := ParseLiteral(`-1.0`, sema.SignedFixedPointType, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t, expected, value)
 	})
 
 	t.Run("SignedFixedPoint, invalid literal", func(t *testing.T) {
-		value, err := ParseLiteral(`1`, sema.SignedFixedPointType, newTestInterpreter(t))
+		value, err := ParseLiteral(`1`, sema.SignedFixedPointType, NewTestInterpreter(t))
 		RequireError(t, err)
 
 		require.Nil(t, value)
@@ -610,7 +612,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 				unsignedIntegerType.String(),
 			),
 			func(t *testing.T) {
-				value, err := ParseLiteral(`1`, unsignedIntegerType, newTestInterpreter(t))
+				value, err := ParseLiteral(`1`, unsignedIntegerType, NewTestInterpreter(t))
 				require.NoError(t, err)
 				require.NotNil(t, value)
 			},
@@ -622,7 +624,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 				unsignedIntegerType.String(),
 			),
 			func(t *testing.T) {
-				value, err := ParseLiteral(`-1`, unsignedIntegerType, newTestInterpreter(t))
+				value, err := ParseLiteral(`-1`, unsignedIntegerType, NewTestInterpreter(t))
 				RequireError(t, err)
 
 				require.Nil(t, value)
@@ -635,7 +637,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 				unsignedIntegerType.String(),
 			),
 			func(t *testing.T) {
-				value, err := ParseLiteral(`true`, unsignedIntegerType, newTestInterpreter(t))
+				value, err := ParseLiteral(`true`, unsignedIntegerType, NewTestInterpreter(t))
 				RequireError(t, err)
 
 				require.Nil(t, value)
@@ -657,7 +659,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 				signedIntegerType.String(),
 			),
 			func(t *testing.T) {
-				value, err := ParseLiteral(`1`, signedIntegerType, newTestInterpreter(t))
+				value, err := ParseLiteral(`1`, signedIntegerType, NewTestInterpreter(t))
 				require.NoError(t, err)
 				require.NotNil(t, value)
 			},
@@ -669,7 +671,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 				signedIntegerType.String(),
 			),
 			func(t *testing.T) {
-				value, err := ParseLiteral(`-1`, signedIntegerType, newTestInterpreter(t))
+				value, err := ParseLiteral(`-1`, signedIntegerType, NewTestInterpreter(t))
 				require.NoError(t, err)
 				require.NotNil(t, value)
 			},
@@ -681,7 +683,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 				signedIntegerType.String(),
 			),
 			func(t *testing.T) {
-				value, err := ParseLiteral(`true`, signedIntegerType, newTestInterpreter(t))
+				value, err := ParseLiteral(`true`, signedIntegerType, NewTestInterpreter(t))
 				RequireError(t, err)
 
 				require.Nil(t, value)
@@ -696,7 +698,7 @@ func TestRuntimeParseLiteralArgumentList(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := ParseLiteralArgumentList("", nil, newTestInterpreter(t))
+		_, err := ParseLiteralArgumentList("", nil, NewTestInterpreter(t))
 		RequireError(t, err)
 
 	})
@@ -704,7 +706,7 @@ func TestRuntimeParseLiteralArgumentList(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
 
-		arguments, err := ParseLiteralArgumentList(`()`, nil, newTestInterpreter(t))
+		arguments, err := ParseLiteralArgumentList(`()`, nil, NewTestInterpreter(t))
 		require.NoError(t, err)
 		require.Equal(t, []cadence.Value{}, arguments)
 	})
@@ -717,7 +719,7 @@ func TestRuntimeParseLiteralArgumentList(t *testing.T) {
 			[]sema.Type{
 				sema.IntType,
 			},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -737,7 +739,7 @@ func TestRuntimeParseLiteralArgumentList(t *testing.T) {
 				sema.IntType,
 				sema.IntType,
 			},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
@@ -758,7 +760,7 @@ func TestRuntimeParseLiteralArgumentList(t *testing.T) {
 				sema.IntType,
 				sema.BoolType,
 			},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		RequireError(t, err)
 
@@ -772,7 +774,7 @@ func TestRuntimeParseLiteralArgumentList(t *testing.T) {
 			[]sema.Type{
 				sema.IntType,
 			},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		RequireError(t, err)
 
@@ -787,7 +789,7 @@ func TestRuntimeParseLiteralArgumentList(t *testing.T) {
 				sema.IntType,
 				sema.IntType,
 			},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		RequireError(t, err)
 
@@ -801,7 +803,7 @@ func TestRuntimeParseLiteralArgumentList(t *testing.T) {
 			[]sema.Type{
 				sema.IntType,
 			},
-			newTestInterpreter(t),
+			NewTestInterpreter(t),
 		)
 		RequireError(t, err)
 	})

--- a/runtime/nft_test.go
+++ b/runtime/nft_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 const modifiedNonFungibleTokenInterface = `
 

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"math/big"
@@ -25,10 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -59,30 +61,30 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 	  }
 	`)
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	deploy := utils.DeploymentTransaction("C", contract)
 
 	var accountCode []byte
 	var events []cadence.Event
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},

--- a/runtime/program_params_validation_test.go
+++ b/runtime/program_params_validation_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"fmt"
@@ -27,9 +27,11 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/checker"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -81,18 +83,15 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 		encodedArg, err = json.Encode(arg)
 		require.NoError(t, err)
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 		addPublicKeyValidation(runtimeInterface, nil)
 
@@ -605,22 +604,19 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 		encodedArg, err = json.Encode(arg)
 		require.NoError(t, err)
 
-		rt := newTestInterpreterRuntime()
+		rt := NewTestInterpreterRuntime()
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage:         storage,
-			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage:           storage,
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return contracts[location], nil
 			},
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 		addPublicKeyValidation(runtimeInterface, nil)
 

--- a/runtime/resource_duplicate_test.go
+++ b/runtime/resource_duplicate_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"encoding/hex"
@@ -28,10 +28,12 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/checker"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -120,7 +122,7 @@ func TestRuntimeResourceDuplicationUsingDestructorIteration(t *testing.T) {
           }
         `
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		accountCodes := map[common.Location][]byte{}
 
@@ -128,34 +130,34 @@ func TestRuntimeResourceDuplicationUsingDestructorIteration(t *testing.T) {
 
 		signerAccount := common.MustBytesToAddress([]byte{0x1})
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			getCode: func(location Location) (bytes []byte, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetCode: func(location Location) (bytes []byte, err error) {
 				return accountCodes[location], nil
 			},
-			storage: storage,
-			getSigningAccounts: func() ([]Address, error) {
+			Storage: storage,
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{signerAccount}, nil
 			},
-			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
-			emitEvent: func(event cadence.Event) error {
+			OnEmitEvent: func(event cadence.Event) error {
 				events = append(events, event)
 				return nil
 			},
-			log: func(s string) {
+			OnProgramLog: func(s string) {
 				assert.Fail(t, "we should not reach this point")
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(nil, b)
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
+			},
 		}
 
 		_, err := runtime.ExecuteScript(
@@ -226,7 +228,7 @@ func TestRuntimeResourceDuplicationUsingDestructorIteration(t *testing.T) {
           }
         `
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		accountCodes := map[common.Location][]byte{}
 
@@ -234,31 +236,31 @@ func TestRuntimeResourceDuplicationUsingDestructorIteration(t *testing.T) {
 
 		signerAccount := common.MustBytesToAddress([]byte{0x1})
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			getCode: func(location Location) (bytes []byte, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetCode: func(location Location) (bytes []byte, err error) {
 				return accountCodes[location], nil
 			},
-			storage: storage,
-			getSigningAccounts: func() ([]Address, error) {
+			Storage: storage,
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{signerAccount}, nil
 			},
-			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
-			emitEvent: func(event cadence.Event) error {
+			OnEmitEvent: func(event cadence.Event) error {
 				events = append(events, event)
 				return nil
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(nil, b)
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
+			},
 		}
 
 		_, err := runtime.ExecuteScript(
@@ -318,7 +320,7 @@ func TestRuntimeResourceDuplicationUsingDestructorIteration(t *testing.T) {
           }
         `
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		accountCodes := map[common.Location][]byte{}
 
@@ -326,31 +328,31 @@ func TestRuntimeResourceDuplicationUsingDestructorIteration(t *testing.T) {
 
 		signerAccount := common.MustBytesToAddress([]byte{0x1})
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			getCode: func(location Location) (bytes []byte, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetCode: func(location Location) (bytes []byte, err error) {
 				return accountCodes[location], nil
 			},
-			storage: storage,
-			getSigningAccounts: func() ([]Address, error) {
+			Storage: storage,
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{signerAccount}, nil
 			},
-			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
-			emitEvent: func(event cadence.Event) error {
+			OnEmitEvent: func(event cadence.Event) error {
 				events = append(events, event)
 				return nil
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(nil, b)
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
+			},
 		}
 
 		_, err := runtime.ExecuteScript(
@@ -416,7 +418,7 @@ func TestRuntimeResourceDuplicationUsingDestructorIteration(t *testing.T) {
             return v1Ref.balance
         }`
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		accountCodes := map[common.Location][]byte{}
 
@@ -424,31 +426,31 @@ func TestRuntimeResourceDuplicationUsingDestructorIteration(t *testing.T) {
 
 		signerAccount := common.MustBytesToAddress([]byte{0x1})
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			getCode: func(location Location) (bytes []byte, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetCode: func(location Location) (bytes []byte, err error) {
 				return accountCodes[location], nil
 			},
-			storage: storage,
-			getSigningAccounts: func() ([]Address, error) {
+			Storage: storage,
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{signerAccount}, nil
 			},
-			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCodes[location], nil
 			},
-			updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 				accountCodes[location] = code
 				return nil
 			},
-			emitEvent: func(event cadence.Event) error {
+			OnEmitEvent: func(event cadence.Event) error {
 				events = append(events, event)
 				return nil
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(nil, b)
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
+			},
 		}
 
 		_, err := runtime.ExecuteScript(
@@ -476,7 +478,7 @@ func TestRuntimeResourceDuplicationWithContractTransfer(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	accountCodes := map[common.Location][]byte{}
 
@@ -484,34 +486,34 @@ func TestRuntimeResourceDuplicationWithContractTransfer(t *testing.T) {
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
-	storage := newTestLedger(nil, nil)
+	storage := NewTestLedger(nil, nil)
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: storage,
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: storage,
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAccount}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-	}
-	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-		return json.Decode(nil, b)
+		OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(nil, b)
+		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy Fungible Token contract
 

--- a/runtime/resourcedictionary_test.go
+++ b/runtime/resourcedictionary_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"encoding/hex"
@@ -27,7 +27,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -93,7 +95,7 @@ func TestRuntimeResourceDictionaryValues(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
@@ -116,29 +118,29 @@ func TestRuntimeResourceDictionaryValues(t *testing.T) {
 	var events []cadence.Event
 	var loggedMessages []string
 
-	runtimeInterface := &testRuntimeInterface{
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{Address(addressValue)}, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -387,7 +389,7 @@ func TestRuntimeResourceDictionaryValues_Nested(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
@@ -479,32 +481,32 @@ func TestRuntimeResourceDictionaryValues_Nested(t *testing.T) {
 	var events []cadence.Event
 	var loggedMessages []string
 
-	runtimeInterface := &testRuntimeInterface{
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		getCode: func(_ Location) (bytes []byte, err error) {
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{Address(addressValue)}, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -592,7 +594,7 @@ func TestRuntimeResourceDictionaryValues_DictionaryTransfer(t *testing.T) {
 	signer1 := common.MustBytesToAddress([]byte{0x1})
 	signer2 := common.MustBytesToAddress([]byte{0x2})
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	contract := []byte(`
      access(all) contract Test {
@@ -673,35 +675,35 @@ func TestRuntimeResourceDictionaryValues_DictionaryTransfer(t *testing.T) {
 	var events []cadence.Event
 	var loggedMessages []string
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{
 				signer1,
 				signer2,
 			}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) (err error) {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -763,7 +765,7 @@ func TestRuntimeResourceDictionaryValues_Removal(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	contract := []byte(resourceDictionaryContract)
 
@@ -816,32 +818,32 @@ func TestRuntimeResourceDictionaryValues_Removal(t *testing.T) {
 
 	signer := common.MustBytesToAddress([]byte{0x1})
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signer}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) (err error) {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -892,7 +894,7 @@ func TestRuntimeResourceDictionaryValues_Destruction(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	contract := []byte(resourceDictionaryContract)
 
@@ -930,32 +932,32 @@ func TestRuntimeResourceDictionaryValues_Destruction(t *testing.T) {
 
 	signer := common.MustBytesToAddress([]byte{0x1})
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signer}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -1006,7 +1008,7 @@ func TestRuntimeResourceDictionaryValues_Insertion(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	contract := []byte(resourceDictionaryContract)
 
@@ -1071,32 +1073,32 @@ func TestRuntimeResourceDictionaryValues_Insertion(t *testing.T) {
 
 	signer := common.MustBytesToAddress([]byte{0x1})
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signer}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -1147,7 +1149,7 @@ func TestRuntimeResourceDictionaryValues_ValueTransferAndDestroy(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	contract := []byte(resourceDictionaryContract)
 
@@ -1225,34 +1227,34 @@ func TestRuntimeResourceDictionaryValues_ValueTransferAndDestroy(t *testing.T) {
 
 	var signers []Address
 
-	testStorage := newTestLedger(nil, nil)
+	testStorage := NewTestLedger(nil, nil)
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: testStorage,
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: testStorage,
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return signers, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	signers = []Address{signer1}
 	err := runtime.ExecuteTransaction(
@@ -1329,7 +1331,7 @@ func TestRuntimeResourceDictionaryValues_ValueTransferAndDestroy(t *testing.T) {
 
 func BenchmarkRuntimeResourceDictionaryValues(b *testing.B) {
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
@@ -1366,28 +1368,28 @@ func BenchmarkRuntimeResourceDictionaryValues(b *testing.B) {
 	var accountCode []byte
 	var events []cadence.Event
 
-	storage := newTestLedger(nil, nil)
+	storage := NewTestLedger(nil, nil)
 
-	runtimeInterface := &testRuntimeInterface{
-		resolveLocation: singleIdentifierLocationResolver(b),
-		getAccountContractCode: func(_ common.AddressLocation) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnResolveLocation: NewSingleIdentifierLocationResolver(b),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: storage,
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: storage,
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{Address(addressValue)}, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{

--- a/runtime/rlp_test.go
+++ b/runtime/rlp_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"testing"
@@ -26,7 +26,9 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -34,7 +36,7 @@ func TestRuntimeRLPDecodeString(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
 
@@ -123,14 +125,11 @@ func TestRuntimeRLPDecodeString(t *testing.T) {
 
 			t.Parallel()
 
-			runtimeInterface := &testRuntimeInterface{
-				storage: newTestLedger(nil, nil),
-				meterMemory: func(_ common.MemoryUsage) error {
-					return nil
+			runtimeInterface := &TestRuntimeInterface{
+				Storage: NewTestLedger(nil, nil),
+				OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+					return json.Decode(nil, b)
 				},
-			}
-			runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(runtimeInterface, b)
 			}
 
 			result, err := runtime.ExecuteScript(
@@ -177,7 +176,7 @@ func TestRuntimeRLPDecodeList(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
 
@@ -282,14 +281,11 @@ func TestRuntimeRLPDecodeList(t *testing.T) {
 
 			t.Parallel()
 
-			runtimeInterface := &testRuntimeInterface{
-				storage: newTestLedger(nil, nil),
-				meterMemory: func(_ common.MemoryUsage) error {
-					return nil
+			runtimeInterface := &TestRuntimeInterface{
+				Storage: NewTestLedger(nil, nil),
+				OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+					return json.Decode(nil, b)
 				},
-			}
-			runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(runtimeInterface, b)
 			}
 
 			result, err := runtime.ExecuteScript(

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -322,9 +322,9 @@ func (r *interpreterRuntime) ExecuteTransaction(script Script, context Context) 
 	return err
 }
 
-// userPanicToError Executes `f` and gracefully handle `UserError` panics.
+// UserPanicToError Executes `f` and gracefully handle `UserError` panics.
 // All on-user panics (including `InternalError` and `ExternalError`) are propagated up.
-func userPanicToError(f func()) (returnedError error) {
+func UserPanicToError(f func()) (returnedError error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err, ok := r.(error)
@@ -408,7 +408,7 @@ func validateArgumentParams(
 		}
 
 		var arg interpreter.Value
-		panicError := userPanicToError(func() {
+		panicError := UserPanicToError(func() {
 			// if importing an invalid public key, this call panics
 			arg, err = ImportValue(
 				inter,

--- a/runtime/runtime_memory_metering_test.go
+++ b/runtime/runtime_memory_metering_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"fmt"
@@ -28,9 +28,10 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
-	jsoncdc "github.com/onflow/cadence/encoding/json"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -69,20 +70,18 @@ func TestRuntimeInterpreterAddressLocationMetering(t *testing.T) {
         `
 		meter := newTestMemoryGauge()
 		var accountCode []byte
-		runtimeInterface := &testRuntimeInterface{
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			storage: newTestLedger(nil, nil),
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
-			getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+			Storage:       NewTestLedger(nil, nil),
+			OnMeterMemory: meter.MeterMemory,
+			OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 				return accountCode, nil
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -130,38 +129,38 @@ func TestRuntimeInterpreterElaborationImportMetering(t *testing.T) {
 				script = importExpressions[j] + script
 			}
 
-			runtime := newTestInterpreterRuntime()
+			runtime := NewTestInterpreterRuntime()
 
 			meter := newTestMemoryGauge()
 
 			accountCodes := map[common.Location][]byte{}
 
-			runtimeInterface := &testRuntimeInterface{
-				getCode: func(location Location) (bytes []byte, err error) {
+			runtimeInterface := &TestRuntimeInterface{
+				OnGetCode: func(location Location) (bytes []byte, err error) {
 					return accountCodes[location], nil
 				},
-				storage: newTestLedger(nil, nil),
-				getSigningAccounts: func() ([]Address, error) {
+				Storage: NewTestLedger(nil, nil),
+				OnGetSigningAccounts: func() ([]Address, error) {
 					return []Address{Address(addressValue)}, nil
 				},
-				resolveLocation: singleIdentifierLocationResolver(t),
-				updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+				OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+				OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 					accountCodes[location] = code
 					return nil
 				},
-				getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+				OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 					code = accountCodes[location]
 					return code, nil
 				},
-				meterMemory: func(usage common.MemoryUsage) error {
+				OnMeterMemory: func(usage common.MemoryUsage) error {
 					return meter.MeterMemory(usage)
 				},
-				emitEvent: func(_ cadence.Event) error {
+				OnEmitEvent: func(_ cadence.Event) error {
 					return nil
 				},
 			}
 
-			nextTransactionLocation := newTransactionLocationGenerator()
+			nextTransactionLocation := NewTransactionLocationGenerator()
 
 			for j := 0; j <= imports; j++ {
 				err := runtime.ExecuteTransaction(
@@ -214,16 +213,14 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -250,16 +247,14 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		largeBigInt := &big.Int{}
 		largeBigInt.Exp(big.NewInt(2<<33), big.NewInt(6), nil)
@@ -293,16 +288,14 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -329,16 +322,14 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -365,16 +356,14 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -401,16 +390,14 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -437,16 +424,14 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -473,16 +458,14 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -511,16 +494,14 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -547,16 +528,14 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
-			decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -581,13 +560,11 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -612,13 +589,11 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -643,13 +618,11 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -674,13 +647,11 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -705,13 +676,11 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -736,13 +705,11 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             }
         `
 		meter := newTestMemoryGauge()
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -779,23 +746,21 @@ func TestRuntimeLogFunctionStringConversionMetering(t *testing.T) {
 
 		meter := newTestMemoryGauge()
 
-		runtimeInterface := &testRuntimeInterface{
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			storage: newTestLedger(nil, nil),
-			meterMemory: func(usage common.MemoryUsage) error {
-				return meter.MeterMemory(usage)
-			},
-			getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			Storage:       NewTestLedger(nil, nil),
+			OnMeterMemory: meter.MeterMemory,
+			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCode, nil
 			},
-			log: func(s string) {
+			OnProgramLog: func(s string) {
 				loggedString = s
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -840,13 +805,13 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 
 		storageUsedInvoked := false
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			meterMemory: meter.MeterMemory,
-			getStorageUsed: func(_ Address) (uint64, error) {
+			OnMeterMemory: meter.MeterMemory,
+			OnGetStorageUsed: func(_ Address) (uint64, error) {
 				// Before the storageUsed function is invoked, the deltas must have been committed.
 				// So the encoded slabs must have been metered at this point.
 				assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindAtreeEncodedSlab))
@@ -855,7 +820,7 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -885,15 +850,15 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 
 		meter := newTestMemoryGauge()
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			meterMemory: meter.MeterMemory,
+			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -924,13 +889,13 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 		meter := newTestMemoryGauge()
 		storageUsedInvoked := false
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			meterMemory: meter.MeterMemory,
-			getStorageUsed: func(_ Address) (uint64, error) {
+			OnMeterMemory: meter.MeterMemory,
+			OnGetStorageUsed: func(_ Address) (uint64, error) {
 				// Before the storageUsed function is invoked, the deltas must have been committed.
 				// So the encoded slabs must have been metered at this point.
 				assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindAtreeEncodedSlab))
@@ -939,7 +904,7 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 			},
 		}
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -961,13 +926,13 @@ func TestRuntimeMemoryMeteringErrors(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	type memoryMeter map[common.MemoryKind]uint64
 
-	runtimeInterface := func(meter memoryMeter) *testRuntimeInterface {
-		intf := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
+	runtimeInterface := func(meter memoryMeter) *TestRuntimeInterface {
+		return &TestRuntimeInterface{
+			OnMeterMemory: func(usage common.MemoryUsage) error {
 				if usage.Kind == common.MemoryKindStringValue ||
 					usage.Kind == common.MemoryKindArrayValueBase ||
 					usage.Kind == common.MemoryKindErrorToken {
@@ -976,14 +941,13 @@ func TestRuntimeMemoryMeteringErrors(t *testing.T) {
 				}
 				return nil
 			},
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
+			},
 		}
-		intf.decodeArgument = func(b []byte, t cadence.Type) (cadence.Value, error) {
-			return jsoncdc.Decode(intf, b)
-		}
-		return intf
 	}
 
-	nextScriptLocation := newScriptLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	executeScript := func(script []byte, meter memoryMeter, args ...cadence.Value) error {
 		_, err := runtime.ExecuteScript(
@@ -1072,19 +1036,20 @@ func TestRuntimeMeterEncoding(t *testing.T) {
 
 		t.Parallel()
 
-		rt := newTestInterpreterRuntime()
-		rt.defaultConfig.AtreeValidationEnabled = false
+		config := DefaultTestInterpreterConfig
+		config.AtreeValidationEnabled = false
+		rt := NewTestInterpreterRuntimeWithConfig(config)
 
 		address := common.MustBytesToAddress([]byte{0x1})
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 		meter := newTestMemoryGauge()
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{address}, nil
 			},
-			meterMemory: meter.MeterMemory,
+			OnMeterMemory: meter.MeterMemory,
 		}
 
 		text := "A quick brown fox jumps over the lazy dog"
@@ -1115,19 +1080,20 @@ func TestRuntimeMeterEncoding(t *testing.T) {
 
 		t.Parallel()
 
-		rt := newTestInterpreterRuntime()
-		rt.defaultConfig.AtreeValidationEnabled = false
+		config := DefaultTestInterpreterConfig
+		config.AtreeValidationEnabled = false
+		rt := NewTestInterpreterRuntimeWithConfig(config)
 
 		address := common.MustBytesToAddress([]byte{0x1})
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 		meter := newTestMemoryGauge()
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{address}, nil
 			},
-			meterMemory: meter.MeterMemory,
+			OnMeterMemory: meter.MeterMemory,
 		}
 
 		text := "A quick brown fox jumps over the lazy dog"
@@ -1163,19 +1129,20 @@ func TestRuntimeMeterEncoding(t *testing.T) {
 
 		t.Parallel()
 
-		rt := newTestInterpreterRuntime()
-		rt.defaultConfig.AtreeValidationEnabled = false
+		config := DefaultTestInterpreterConfig
+		config.AtreeValidationEnabled = false
+		rt := NewTestInterpreterRuntimeWithConfig(config)
 
 		address := common.MustBytesToAddress([]byte{0x1})
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 		meter := newTestMemoryGauge()
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{address}, nil
 			},
-			meterMemory: meter.MeterMemory,
+			OnMeterMemory: meter.MeterMemory,
 		}
 
 		_, err := rt.ExecuteScript(

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -16,30 +16,24 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
-	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/onflow/atree"
-	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
-	jsoncdc "github.com/onflow/cadence/encoding/json"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	runtimeErrors "github.com/onflow/cadence/runtime/errors"
@@ -47,658 +41,15 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 	"github.com/onflow/cadence/runtime/tests/checker"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
-
-type testLedger struct {
-	storedValues         map[string][]byte
-	valueExists          func(owner, key []byte) (exists bool, err error)
-	getValue             func(owner, key []byte) (value []byte, err error)
-	setValue             func(owner, key, value []byte) (err error)
-	allocateStorageIndex func(owner []byte) (atree.StorageIndex, error)
-}
-
-var _ atree.Ledger = testLedger{}
-
-func (s testLedger) GetValue(owner, key []byte) (value []byte, err error) {
-	return s.getValue(owner, key)
-}
-
-func (s testLedger) SetValue(owner, key, value []byte) (err error) {
-	return s.setValue(owner, key, value)
-}
-
-func (s testLedger) ValueExists(owner, key []byte) (exists bool, err error) {
-	return s.valueExists(owner, key)
-}
-
-func (s testLedger) AllocateStorageIndex(owner []byte) (atree.StorageIndex, error) {
-	return s.allocateStorageIndex(owner)
-}
-
-func (s testLedger) Dump() {
-	for key, data := range s.storedValues {
-		fmt.Printf("%s:\n", strconv.Quote(key))
-		fmt.Printf("%s\n", hex.Dump(data))
-		println()
-	}
-}
-
-func newTestLedger(
-	onRead func(owner, key, value []byte),
-	onWrite func(owner, key, value []byte),
-) testLedger {
-
-	storageKey := func(owner, key string) string {
-		return strings.Join([]string{owner, key}, "|")
-	}
-
-	storedValues := map[string][]byte{}
-
-	storageIndices := map[string]uint64{}
-
-	return testLedger{
-		storedValues: storedValues,
-		valueExists: func(owner, key []byte) (bool, error) {
-			value := storedValues[storageKey(string(owner), string(key))]
-			return len(value) > 0, nil
-		},
-		getValue: func(owner, key []byte) (value []byte, err error) {
-			value = storedValues[storageKey(string(owner), string(key))]
-			if onRead != nil {
-				onRead(owner, key, value)
-			}
-			return value, nil
-		},
-		setValue: func(owner, key, value []byte) (err error) {
-			storedValues[storageKey(string(owner), string(key))] = value
-			if onWrite != nil {
-				onWrite(owner, key, value)
-			}
-			return nil
-		},
-		allocateStorageIndex: func(owner []byte) (result atree.StorageIndex, err error) {
-			index := storageIndices[string(owner)] + 1
-			storageIndices[string(owner)] = index
-			binary.BigEndian.PutUint64(result[:], index)
-			return
-		},
-	}
-}
-
-type testInterpreterRuntime struct {
-	*interpreterRuntime
-}
-
-var _ Runtime = testInterpreterRuntime{}
-
-func newTestInterpreterRuntime() testInterpreterRuntime {
-	return testInterpreterRuntime{
-		interpreterRuntime: NewInterpreterRuntime(Config{
-			AtreeValidationEnabled: true,
-		}).(*interpreterRuntime),
-	}
-}
-
-func (r testInterpreterRuntime) ExecuteTransaction(script Script, context Context) error {
-	i := context.Interface.(*testRuntimeInterface)
-	i.onTransactionExecutionStart()
-	return r.interpreterRuntime.ExecuteTransaction(script, context)
-}
-
-func (r testInterpreterRuntime) ExecuteScript(script Script, context Context) (cadence.Value, error) {
-	i := context.Interface.(*testRuntimeInterface)
-	i.onScriptExecutionStart()
-	value, err := r.interpreterRuntime.ExecuteScript(script, context)
-	// If there was a return value, let's also ensure it can be encoded
-	// TODO: also test CCF
-	if value != nil && err == nil {
-		_ = jsoncdc.MustEncode(value)
-	}
-	return value, err
-}
-
-type testRuntimeInterface struct {
-	resolveLocation  func(identifiers []Identifier, location Location) ([]ResolvedLocation, error)
-	getCode          func(_ Location) ([]byte, error)
-	getAndSetProgram func(
-		location Location,
-		load func() (*interpreter.Program, error),
-	) (*interpreter.Program, error)
-	setInterpreterSharedState func(state *interpreter.SharedState)
-	getInterpreterSharedState func() *interpreter.SharedState
-	storage                   testLedger
-	createAccount             func(payer Address) (address Address, err error)
-	addEncodedAccountKey      func(address Address, publicKey []byte) error
-	removeEncodedAccountKey   func(address Address, index int) (publicKey []byte, err error)
-	addAccountKey             func(
-		address Address,
-		publicKey *stdlib.PublicKey,
-		hashAlgo HashAlgorithm,
-		weight int,
-	) (*stdlib.AccountKey, error)
-	getAccountKey             func(address Address, index int) (*stdlib.AccountKey, error)
-	removeAccountKey          func(address Address, index int) (*stdlib.AccountKey, error)
-	accountKeysCount          func(address Address) (uint64, error)
-	updateAccountContractCode func(location common.AddressLocation, code []byte) error
-	getAccountContractCode    func(location common.AddressLocation) (code []byte, err error)
-	removeAccountContractCode func(location common.AddressLocation) (err error)
-	getSigningAccounts        func() ([]Address, error)
-	log                       func(string)
-	emitEvent                 func(cadence.Event) error
-	resourceOwnerChanged      func(
-		interpreter *interpreter.Interpreter,
-		resource *interpreter.CompositeValue,
-		oldAddress common.Address,
-		newAddress common.Address,
-	)
-	generateUUID       func() (uint64, error)
-	meterComputation   func(compKind common.ComputationKind, intensity uint) error
-	decodeArgument     func(b []byte, t cadence.Type) (cadence.Value, error)
-	programParsed      func(location Location, duration time.Duration)
-	programChecked     func(location Location, duration time.Duration)
-	programInterpreted func(location Location, duration time.Duration)
-	readRandom         func([]byte) error
-	verifySignature    func(
-		signature []byte,
-		tag string,
-		signedData []byte,
-		publicKey []byte,
-		signatureAlgorithm SignatureAlgorithm,
-		hashAlgorithm HashAlgorithm,
-	) (bool, error)
-	hash                       func(data []byte, tag string, hashAlgorithm HashAlgorithm) ([]byte, error)
-	setCadenceValue            func(owner Address, key string, value cadence.Value) (err error)
-	getAccountBalance          func(_ Address) (uint64, error)
-	getAccountAvailableBalance func(_ Address) (uint64, error)
-	getStorageUsed             func(_ Address) (uint64, error)
-	getStorageCapacity         func(_ Address) (uint64, error)
-	programs                   map[Location]*interpreter.Program
-	implementationDebugLog     func(message string) error
-	validatePublicKey          func(publicKey *stdlib.PublicKey) error
-	bLSVerifyPOP               func(pk *stdlib.PublicKey, s []byte) (bool, error)
-	blsAggregateSignatures     func(sigs [][]byte) ([]byte, error)
-	blsAggregatePublicKeys     func(keys []*stdlib.PublicKey) (*stdlib.PublicKey, error)
-	getAccountContractNames    func(address Address) ([]string, error)
-	recordTrace                func(operation string, location Location, duration time.Duration, attrs []attribute.KeyValue)
-	meterMemory                func(usage common.MemoryUsage) error
-	computationUsed            func() (uint64, error)
-	memoryUsed                 func() (uint64, error)
-	interactionUsed            func() (uint64, error)
-	updatedContractCode        bool
-	generateAccountID          func(address common.Address) (uint64, error)
-
-	uuid       uint64
-	accountIDs map[common.Address]uint64
-}
-
-// testRuntimeInterface should implement Interface
-var _ Interface = &testRuntimeInterface{}
-
-func (i *testRuntimeInterface) ResolveLocation(identifiers []Identifier, location Location) ([]ResolvedLocation, error) {
-	if i.resolveLocation == nil {
-		return []ResolvedLocation{
-			{
-				Location:    location,
-				Identifiers: identifiers,
-			},
-		}, nil
-	}
-	return i.resolveLocation(identifiers, location)
-}
-
-func (i *testRuntimeInterface) GetCode(location Location) ([]byte, error) {
-	if i.getCode == nil {
-		return nil, nil
-	}
-	return i.getCode(location)
-}
-
-func (i *testRuntimeInterface) GetOrLoadProgram(
-	location Location,
-	load func() (*interpreter.Program, error),
-) (
-	program *interpreter.Program,
-	err error,
-) {
-	if i.getAndSetProgram == nil {
-		if i.programs == nil {
-			i.programs = map[Location]*interpreter.Program{}
-		}
-
-		var ok bool
-		program, ok = i.programs[location]
-		if ok {
-			return
-		}
-
-		program, err = load()
-
-		// NOTE: important: still set empty program,
-		// even if error occurred
-
-		i.programs[location] = program
-
-		return
-	}
-
-	return i.getAndSetProgram(location, load)
-}
-
-func (i *testRuntimeInterface) SetInterpreterSharedState(state *interpreter.SharedState) {
-	if i.setInterpreterSharedState == nil {
-		return
-	}
-
-	i.setInterpreterSharedState(state)
-}
-
-func (i *testRuntimeInterface) GetInterpreterSharedState() *interpreter.SharedState {
-	if i.getInterpreterSharedState == nil {
-		return nil
-	}
-
-	return i.getInterpreterSharedState()
-}
-
-func (i *testRuntimeInterface) ValueExists(owner, key []byte) (exists bool, err error) {
-	if i.storage.valueExists == nil {
-		panic("must specify testRuntimeInterface.storage.valueExists")
-	}
-	return i.storage.ValueExists(owner, key)
-}
-
-func (i *testRuntimeInterface) GetValue(owner, key []byte) (value []byte, err error) {
-	if i.storage.getValue == nil {
-		panic("must specify testRuntimeInterface.storage.getValue")
-	}
-	return i.storage.GetValue(owner, key)
-}
-
-func (i *testRuntimeInterface) SetValue(owner, key, value []byte) (err error) {
-	if i.storage.setValue == nil {
-		panic("must specify testRuntimeInterface.storage.setValue")
-	}
-	return i.storage.SetValue(owner, key, value)
-}
-
-func (i *testRuntimeInterface) AllocateStorageIndex(owner []byte) (atree.StorageIndex, error) {
-	if i.storage.allocateStorageIndex == nil {
-		panic("must specify testRuntimeInterface.storage.allocateStorageIndex")
-	}
-	return i.storage.AllocateStorageIndex(owner)
-}
-
-func (i *testRuntimeInterface) CreateAccount(payer Address) (address Address, err error) {
-	if i.createAccount == nil {
-		panic("must specify testRuntimeInterface.createAccount")
-	}
-	return i.createAccount(payer)
-}
-
-func (i *testRuntimeInterface) AddEncodedAccountKey(address Address, publicKey []byte) error {
-	if i.addEncodedAccountKey == nil {
-		panic("must specify testRuntimeInterface.addEncodedAccountKey")
-	}
-	return i.addEncodedAccountKey(address, publicKey)
-}
-
-func (i *testRuntimeInterface) RevokeEncodedAccountKey(address Address, index int) ([]byte, error) {
-	if i.removeEncodedAccountKey == nil {
-		panic("must specify testRuntimeInterface.removeEncodedAccountKey")
-	}
-	return i.removeEncodedAccountKey(address, index)
-}
-
-func (i *testRuntimeInterface) AddAccountKey(
-	address Address,
-	publicKey *stdlib.PublicKey,
-	hashAlgo HashAlgorithm,
-	weight int,
-) (*stdlib.AccountKey, error) {
-	if i.addAccountKey == nil {
-		panic("must specify testRuntimeInterface.addAccountKey")
-	}
-	return i.addAccountKey(address, publicKey, hashAlgo, weight)
-}
-
-func (i *testRuntimeInterface) GetAccountKey(address Address, index int) (*stdlib.AccountKey, error) {
-	if i.getAccountKey == nil {
-		panic("must specify testRuntimeInterface.getAccountKey")
-	}
-	return i.getAccountKey(address, index)
-}
-
-func (i *testRuntimeInterface) AccountKeysCount(address Address) (uint64, error) {
-	if i.accountKeysCount == nil {
-		panic("must specify testRuntimeInterface.accountKeysCount")
-	}
-	return i.accountKeysCount(address)
-}
-
-func (i *testRuntimeInterface) RevokeAccountKey(address Address, index int) (*stdlib.AccountKey, error) {
-	if i.removeAccountKey == nil {
-		panic("must specify testRuntimeInterface.removeAccountKey")
-	}
-	return i.removeAccountKey(address, index)
-}
-
-func (i *testRuntimeInterface) UpdateAccountContractCode(location common.AddressLocation, code []byte) (err error) {
-	if i.updateAccountContractCode == nil {
-		panic("must specify testRuntimeInterface.updateAccountContractCode")
-	}
-
-	err = i.updateAccountContractCode(location, code)
-	if err != nil {
-		return err
-	}
-
-	i.updatedContractCode = true
-
-	return nil
-}
-
-func (i *testRuntimeInterface) GetAccountContractCode(location common.AddressLocation) (code []byte, err error) {
-	if i.getAccountContractCode == nil {
-		panic("must specify testRuntimeInterface.getAccountContractCode")
-	}
-	return i.getAccountContractCode(location)
-}
-
-func (i *testRuntimeInterface) RemoveAccountContractCode(location common.AddressLocation) (err error) {
-	if i.removeAccountContractCode == nil {
-		panic("must specify testRuntimeInterface.removeAccountContractCode")
-	}
-	return i.removeAccountContractCode(location)
-}
-
-func (i *testRuntimeInterface) GetSigningAccounts() ([]Address, error) {
-	if i.getSigningAccounts == nil {
-		return nil, nil
-	}
-	return i.getSigningAccounts()
-}
-
-func (i *testRuntimeInterface) ProgramLog(message string) error {
-	i.log(message)
-	return nil
-}
-
-func (i *testRuntimeInterface) EmitEvent(event cadence.Event) error {
-	return i.emitEvent(event)
-}
-
-func (i *testRuntimeInterface) ResourceOwnerChanged(
-	interpreter *interpreter.Interpreter,
-	resource *interpreter.CompositeValue,
-	oldOwner common.Address,
-	newOwner common.Address,
-) {
-	if i.resourceOwnerChanged != nil {
-		i.resourceOwnerChanged(
-			interpreter,
-			resource,
-			oldOwner,
-			newOwner,
-		)
-	}
-}
-
-func (i *testRuntimeInterface) GenerateUUID() (uint64, error) {
-	if i.generateUUID == nil {
-		i.uuid++
-		return i.uuid, nil
-	}
-	return i.generateUUID()
-}
-
-func (i *testRuntimeInterface) MeterComputation(compKind common.ComputationKind, intensity uint) error {
-	if i.meterComputation == nil {
-		return nil
-	}
-	return i.meterComputation(compKind, intensity)
-}
-
-func (i *testRuntimeInterface) DecodeArgument(b []byte, t cadence.Type) (cadence.Value, error) {
-	return i.decodeArgument(b, t)
-}
-
-func (i *testRuntimeInterface) ProgramParsed(location Location, duration time.Duration) {
-	if i.programParsed == nil {
-		return
-	}
-	i.programParsed(location, duration)
-}
-
-func (i *testRuntimeInterface) ProgramChecked(location Location, duration time.Duration) {
-	if i.programChecked == nil {
-		return
-	}
-	i.programChecked(location, duration)
-}
-
-func (i *testRuntimeInterface) ProgramInterpreted(location Location, duration time.Duration) {
-	if i.programInterpreted == nil {
-		return
-	}
-	i.programInterpreted(location, duration)
-}
-
-func (i *testRuntimeInterface) GetCurrentBlockHeight() (uint64, error) {
-	return 1, nil
-}
-
-func (i *testRuntimeInterface) GetBlockAtHeight(height uint64) (block stdlib.Block, exists bool, err error) {
-
-	buf := new(bytes.Buffer)
-	err = binary.Write(buf, binary.BigEndian, height)
-	if err != nil {
-		panic(err)
-	}
-
-	encoded := buf.Bytes()
-	var hash stdlib.BlockHash
-	copy(hash[sema.BlockTypeIdFieldType.Size-int64(len(encoded)):], encoded)
-
-	block = stdlib.Block{
-		Height:    height,
-		View:      height,
-		Hash:      hash,
-		Timestamp: time.Unix(int64(height), 0).UnixNano(),
-	}
-	return block, true, nil
-}
-
-func (i *testRuntimeInterface) ReadRandom(buffer []byte) error {
-	if i.readRandom == nil {
-		return nil
-	}
-	return i.readRandom(buffer)
-}
-
-func (i *testRuntimeInterface) VerifySignature(
-	signature []byte,
-	tag string,
-	signedData []byte,
-	publicKey []byte,
-	signatureAlgorithm SignatureAlgorithm,
-	hashAlgorithm HashAlgorithm,
-) (bool, error) {
-	if i.verifySignature == nil {
-		return false, nil
-	}
-	return i.verifySignature(
-		signature,
-		tag,
-		signedData,
-		publicKey,
-		signatureAlgorithm,
-		hashAlgorithm,
-	)
-}
-
-func (i *testRuntimeInterface) Hash(data []byte, tag string, hashAlgorithm HashAlgorithm) ([]byte, error) {
-	if i.hash == nil {
-		return nil, nil
-	}
-	return i.hash(data, tag, hashAlgorithm)
-}
-
-func (i *testRuntimeInterface) SetCadenceValue(owner common.Address, key string, value cadence.Value) (err error) {
-	if i.setCadenceValue == nil {
-		panic("must specify testRuntimeInterface.setCadenceValue")
-	}
-	return i.setCadenceValue(owner, key, value)
-}
-
-func (i *testRuntimeInterface) GetAccountBalance(address Address) (uint64, error) {
-	if i.getAccountBalance == nil {
-		panic("must specify testRuntimeInterface.getAccountBalance")
-	}
-	return i.getAccountBalance(address)
-}
-
-func (i *testRuntimeInterface) GetAccountAvailableBalance(address Address) (uint64, error) {
-	if i.getAccountAvailableBalance == nil {
-		panic("must specify testRuntimeInterface.getAccountAvailableBalance")
-	}
-	return i.getAccountAvailableBalance(address)
-}
-
-func (i *testRuntimeInterface) GetStorageUsed(address Address) (uint64, error) {
-	if i.getStorageUsed == nil {
-		panic("must specify testRuntimeInterface.getStorageUsed")
-	}
-	return i.getStorageUsed(address)
-}
-
-func (i *testRuntimeInterface) GetStorageCapacity(address Address) (uint64, error) {
-	if i.getStorageCapacity == nil {
-		panic("must specify testRuntimeInterface.getStorageCapacity")
-	}
-	return i.getStorageCapacity(address)
-}
-
-func (i *testRuntimeInterface) ImplementationDebugLog(message string) error {
-	if i.implementationDebugLog == nil {
-		return nil
-	}
-	return i.implementationDebugLog(message)
-}
-
-func (i *testRuntimeInterface) ValidatePublicKey(key *stdlib.PublicKey) error {
-	if i.validatePublicKey == nil {
-		return errors.New("mock defaults to public key validation failure")
-	}
-
-	return i.validatePublicKey(key)
-}
-
-func (i *testRuntimeInterface) BLSVerifyPOP(key *stdlib.PublicKey, s []byte) (bool, error) {
-	if i.bLSVerifyPOP == nil {
-		return false, nil
-	}
-
-	return i.bLSVerifyPOP(key, s)
-}
-
-func (i *testRuntimeInterface) BLSAggregateSignatures(sigs [][]byte) ([]byte, error) {
-	if i.blsAggregateSignatures == nil {
-		return []byte{}, nil
-	}
-
-	return i.blsAggregateSignatures(sigs)
-}
-
-func (i *testRuntimeInterface) BLSAggregatePublicKeys(keys []*stdlib.PublicKey) (*stdlib.PublicKey, error) {
-	if i.blsAggregatePublicKeys == nil {
-		return nil, nil
-	}
-
-	return i.blsAggregatePublicKeys(keys)
-}
-
-func (i *testRuntimeInterface) GetAccountContractNames(address Address) ([]string, error) {
-	if i.getAccountContractNames == nil {
-		return []string{}, nil
-	}
-
-	return i.getAccountContractNames(address)
-}
-
-func (i *testRuntimeInterface) GenerateAccountID(address common.Address) (uint64, error) {
-	if i.generateAccountID == nil {
-		if i.accountIDs == nil {
-			i.accountIDs = map[common.Address]uint64{}
-		}
-		i.accountIDs[address]++
-		return i.accountIDs[address], nil
-	}
-
-	return i.generateAccountID(address)
-}
-
-func (i *testRuntimeInterface) RecordTrace(operation string, location Location, duration time.Duration, attrs []attribute.KeyValue) {
-	if i.recordTrace == nil {
-		return
-	}
-	i.recordTrace(operation, location, duration, attrs)
-}
-
-func (i *testRuntimeInterface) MeterMemory(usage common.MemoryUsage) error {
-	if i.meterMemory == nil {
-		return nil
-	}
-
-	return i.meterMemory(usage)
-}
-
-func (i *testRuntimeInterface) ComputationUsed() (uint64, error) {
-	if i.computationUsed == nil {
-		return 0, nil
-	}
-
-	return i.computationUsed()
-}
-
-func (i *testRuntimeInterface) MemoryUsed() (uint64, error) {
-	if i.memoryUsed == nil {
-		return 0, nil
-	}
-
-	return i.memoryUsed()
-}
-
-func (i *testRuntimeInterface) InteractionUsed() (uint64, error) {
-	if i.interactionUsed == nil {
-		return 0, nil
-	}
-
-	return i.interactionUsed()
-}
-
-func (i *testRuntimeInterface) onTransactionExecutionStart() {
-	i.invalidateUpdatedPrograms()
-}
-
-func (i *testRuntimeInterface) onScriptExecutionStart() {
-	i.invalidateUpdatedPrograms()
-}
-
-func (i *testRuntimeInterface) invalidateUpdatedPrograms() {
-	if i.updatedContractCode {
-		for location := range i.programs {
-			delete(i.programs, location)
-		}
-		i.updatedContractCode = false
-	}
-}
 
 func TestRuntimeImport(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	importedScript := []byte(`
       access(all) fun answer(): Int {
@@ -720,8 +71,8 @@ func TestRuntimeImport(t *testing.T) {
 
 	var checkCount int
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("imported"):
 				return importedScript, nil
@@ -729,12 +80,12 @@ func TestRuntimeImport(t *testing.T) {
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
 		},
-		programChecked: func(location Location, duration time.Duration) {
+		OnProgramChecked: func(location Location, duration time.Duration) {
 			checkCount += 1
 		},
 	}
 
-	nextScriptLocation := newScriptLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	const transactionCount = 10
 	for i := 0; i < transactionCount; i++ {
@@ -759,7 +110,7 @@ func TestRuntimeConcurrentImport(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	importedScript := []byte(`
       access(all) fun answer(): Int {
@@ -783,8 +134,8 @@ func TestRuntimeConcurrentImport(t *testing.T) {
 
 	var programs sync.Map
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("imported"):
 				return importedScript, nil
@@ -792,10 +143,10 @@ func TestRuntimeConcurrentImport(t *testing.T) {
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
 		},
-		programChecked: func(location Location, duration time.Duration) {
+		OnProgramChecked: func(location Location, duration time.Duration) {
 			atomic.AddUint64(&checkCount, 1)
 		},
-		getAndSetProgram: func(
+		OnGetAndSetProgram: func(
 			location Location,
 			load func() (*interpreter.Program, error),
 		) (
@@ -819,7 +170,7 @@ func TestRuntimeConcurrentImport(t *testing.T) {
 		},
 	}
 
-	nextScriptLocation := newScriptLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	var wg sync.WaitGroup
 	const concurrency uint64 = 10
@@ -872,9 +223,9 @@ func TestRuntimeProgramSetAndGet(t *testing.T) {
 	importedScriptLocation := common.StringLocation("imported")
 	scriptLocation := common.StringLocation("placeholder")
 
-	runtime := newTestInterpreterRuntime()
-	runtimeInterface := &testRuntimeInterface{
-		getAndSetProgram: func(
+	runtime := NewTestInterpreterRuntime()
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetAndSetProgram: func(
 			location Location,
 			load func() (*interpreter.Program, error),
 		) (
@@ -899,7 +250,7 @@ func TestRuntimeProgramSetAndGet(t *testing.T) {
 
 			return
 		},
-		getCode: func(location Location) ([]byte, error) {
+		OnGetCode: func(location Location) ([]byte, error) {
 			switch location {
 			case importedScriptLocation:
 				return importedScript, nil
@@ -989,29 +340,11 @@ func TestRuntimeProgramSetAndGet(t *testing.T) {
 	})
 }
 
-func newLocationGenerator[T ~[32]byte]() func() T {
-	var count uint64
-	return func() T {
-		t := T{}
-		newCount := atomic.AddUint64(&count, 1)
-		binary.LittleEndian.PutUint64(t[:], newCount)
-		return t
-	}
-}
-
-func newTransactionLocationGenerator() func() common.TransactionLocation {
-	return newLocationGenerator[common.TransactionLocation]()
-}
-
-func newScriptLocationGenerator() func() common.ScriptLocation {
-	return newLocationGenerator[common.ScriptLocation]()
-}
-
 func TestRuntimeInvalidTransactionArgumentAccount(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       transaction {
@@ -1020,13 +353,13 @@ func TestRuntimeInvalidTransactionArgumentAccount(t *testing.T) {
       }
     `)
 
-	runtimeInterface := &testRuntimeInterface{
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -1045,7 +378,7 @@ func TestRuntimeTransactionWithAccount(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       transaction {
@@ -1057,18 +390,18 @@ func TestRuntimeTransactionWithAccount(t *testing.T) {
 
 	var loggedMessage string
 
-	runtimeInterface := &testRuntimeInterface{
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{
 				common.MustBytesToAddress([]byte{42}),
 			}, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessage = message
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -1108,9 +441,9 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
                 }
               }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(cadence.NewInt(42)),
-			},
+			args: encodeArgs([]cadence.Value{
+				cadence.NewInt(42),
+			}),
 			expectedLogs: []string{"42"},
 		},
 		{
@@ -1126,9 +459,9 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
                 }
               }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(cadence.NewInt(42)),
-			},
+			args: encodeArgs([]cadence.Value{
+				cadence.NewInt(42),
+			}),
 			authorizers:  []Address{common.MustBytesToAddress([]byte{42})},
 			expectedLogs: []string{"0x000000000000002a", "42"},
 		},
@@ -1142,10 +475,10 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
                 }
               }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(cadence.NewInt(42)),
-				jsoncdc.MustEncode(cadence.String("foo")),
-			},
+			args: encodeArgs([]cadence.Value{
+				cadence.NewInt(42),
+				cadence.String("foo"),
+			}),
 			expectedLogs: []string{"42", `"foo"`},
 		},
 		{
@@ -1171,9 +504,9 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
                 }
               }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(cadence.String("foo")),
-			},
+			args: encodeArgs([]cadence.Value{
+				cadence.String("foo"),
+			}),
 			check: func(t *testing.T, err error) {
 				RequireError(t, err)
 
@@ -1191,16 +524,14 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
                 }
               }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.BytesToAddress(
-						[]byte{
-							0x0, 0x0, 0x0, 0x0,
-							0x0, 0x0, 0x0, 0x1,
-						},
-					),
+			args: encodeArgs([]cadence.Value{
+				cadence.BytesToAddress(
+					[]byte{
+						0x0, 0x0, 0x0, 0x0,
+						0x0, 0x0, 0x0, 0x1,
+					},
 				),
-			},
+			}),
 			expectedLogs: []string{"0x0000000000000001"},
 		},
 		{
@@ -1212,17 +543,15 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
                 }
               }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.NewArray(
-						[]cadence.Value{
-							cadence.NewInt(1),
-							cadence.NewInt(2),
-							cadence.NewInt(3),
-						},
-					),
+			args: encodeArgs([]cadence.Value{
+				cadence.NewArray(
+					[]cadence.Value{
+						cadence.NewInt(1),
+						cadence.NewInt(2),
+						cadence.NewInt(3),
+					},
 				),
-			},
+			}),
 			expectedLogs: []string{"[1, 2, 3]"},
 		},
 		{
@@ -1234,18 +563,16 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
                 }
               }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.NewDictionary(
-						[]cadence.KeyValuePair{
-							{
-								Key:   cadence.String("y"),
-								Value: cadence.NewInt(42),
-							},
+			args: encodeArgs([]cadence.Value{
+				cadence.NewDictionary(
+					[]cadence.KeyValuePair{
+						{
+							Key:   cadence.String("y"),
+							Value: cadence.NewInt(42),
 						},
-					),
+					},
 				),
-			},
+			}),
 			expectedLogs: []string{"42"},
 		},
 		{
@@ -1257,18 +584,16 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
                 }
               }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.NewDictionary(
-						[]cadence.KeyValuePair{
-							{
-								Key:   cadence.String("y"),
-								Value: cadence.NewInt(42),
-							},
+			args: encodeArgs([]cadence.Value{
+				cadence.NewDictionary(
+					[]cadence.KeyValuePair{
+						{
+							Key:   cadence.String("y"),
+							Value: cadence.NewInt(42),
 						},
-					),
+					},
 				),
-			},
+			}),
 			check: func(t *testing.T, err error) {
 				RequireError(t, err)
 
@@ -1305,25 +630,23 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
                   }
               }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.
-						NewStruct([]cadence.Value{cadence.String("bar")}).
-						WithType(&cadence.StructType{
-							Location: common.AddressLocation{
-								Address: common.MustBytesToAddress([]byte{0x1}),
-								Name:    "C",
+			args: encodeArgs([]cadence.Value{
+				cadence.
+					NewStruct([]cadence.Value{cadence.String("bar")}).
+					WithType(&cadence.StructType{
+						Location: common.AddressLocation{
+							Address: common.MustBytesToAddress([]byte{0x1}),
+							Name:    "C",
+						},
+						QualifiedIdentifier: "C.Foo",
+						Fields: []cadence.Field{
+							{
+								Identifier: "y",
+								Type:       cadence.StringType,
 							},
-							QualifiedIdentifier: "C.Foo",
-							Fields: []cadence.Field{
-								{
-									Identifier: "y",
-									Type:       cadence.StringType,
-								},
-							},
-						}),
-				),
-			},
+						},
+					}),
+			}),
 			expectedLogs: []string{`"bar"`},
 		},
 		{
@@ -1354,27 +677,25 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
                 }
               }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.NewArray([]cadence.Value{
-						cadence.
-							NewStruct([]cadence.Value{cadence.String("bar")}).
-							WithType(&cadence.StructType{
-								Location: common.AddressLocation{
-									Address: common.MustBytesToAddress([]byte{0x1}),
-									Name:    "C",
+			args: encodeArgs([]cadence.Value{
+				cadence.NewArray([]cadence.Value{
+					cadence.
+						NewStruct([]cadence.Value{cadence.String("bar")}).
+						WithType(&cadence.StructType{
+							Location: common.AddressLocation{
+								Address: common.MustBytesToAddress([]byte{0x1}),
+								Name:    "C",
+							},
+							QualifiedIdentifier: "C.Foo",
+							Fields: []cadence.Field{
+								{
+									Identifier: "y",
+									Type:       cadence.StringType,
 								},
-								QualifiedIdentifier: "C.Foo",
-								Fields: []cadence.Field{
-									{
-										Identifier: "y",
-										Type:       cadence.StringType,
-									},
-								},
-							}),
-					}),
-				),
-			},
+							},
+						}),
+				}),
+			}),
 			expectedLogs: []string{`"bar"`},
 		},
 	}
@@ -1383,30 +704,27 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 
 		t.Run(tc.label, func(t *testing.T) {
 			t.Parallel()
-			rt := newTestInterpreterRuntime()
+			rt := NewTestInterpreterRuntime()
 
 			var loggedMessages []string
 
-			storage := newTestLedger(nil, nil)
+			storage := NewTestLedger(nil, nil)
 
-			runtimeInterface := &testRuntimeInterface{
-				storage: storage,
-				getSigningAccounts: func() ([]Address, error) {
+			runtimeInterface := &TestRuntimeInterface{
+				Storage: storage,
+				OnGetSigningAccounts: func() ([]Address, error) {
 					return tc.authorizers, nil
 				},
-				resolveLocation: singleIdentifierLocationResolver(t),
-				getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+				OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+				OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 					return tc.contracts[location], nil
 				},
-				log: func(message string) {
+				OnProgramLog: func(message string) {
 					loggedMessages = append(loggedMessages, message)
 				},
-				meterMemory: func(_ common.MemoryUsage) error {
-					return nil
+				OnDecodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
+					return json.Decode(nil, b)
 				},
-			}
-			runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(runtimeInterface, b)
 			}
 
 			err := rt.ExecuteTransaction(
@@ -1464,9 +782,9 @@ func TestRuntimeScriptArguments(t *testing.T) {
                     log(x)
                 }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(cadence.NewInt(42)),
-			},
+			args: encodeArgs([]cadence.Value{
+				cadence.NewInt(42),
+			}),
 			expectedLogs: []string{"42"},
 		},
 		{
@@ -1477,10 +795,10 @@ func TestRuntimeScriptArguments(t *testing.T) {
                     log(y)
                 }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(cadence.NewInt(42)),
-				jsoncdc.MustEncode(cadence.String("foo")),
-			},
+			args: encodeArgs([]cadence.Value{
+				cadence.NewInt(42),
+				cadence.String("foo"),
+			}),
 			expectedLogs: []string{"42", `"foo"`},
 		},
 		{
@@ -1506,9 +824,9 @@ func TestRuntimeScriptArguments(t *testing.T) {
                     log(x)
                 }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(cadence.String("foo")),
-			},
+			args: encodeArgs([]cadence.Value{
+				cadence.String("foo"),
+			}),
 			check: func(t *testing.T, err error) {
 				RequireError(t, err)
 
@@ -1525,16 +843,14 @@ func TestRuntimeScriptArguments(t *testing.T) {
                     log(x)
                 }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.BytesToAddress(
-						[]byte{
-							0x0, 0x0, 0x0, 0x0,
-							0x0, 0x0, 0x0, 0x1,
-						},
-					),
+			args: encodeArgs([]cadence.Value{
+				cadence.BytesToAddress(
+					[]byte{
+						0x0, 0x0, 0x0, 0x0,
+						0x0, 0x0, 0x0, 0x1,
+					},
 				),
-			},
+			}),
 			expectedLogs: []string{"0x0000000000000001"},
 		},
 		{
@@ -1544,17 +860,15 @@ func TestRuntimeScriptArguments(t *testing.T) {
                     log(x)
                 }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.NewArray(
-						[]cadence.Value{
-							cadence.NewInt(1),
-							cadence.NewInt(2),
-							cadence.NewInt(3),
-						},
-					),
+			args: encodeArgs([]cadence.Value{
+				cadence.NewArray(
+					[]cadence.Value{
+						cadence.NewInt(1),
+						cadence.NewInt(2),
+						cadence.NewInt(3),
+					},
 				),
-			},
+			}),
 			expectedLogs: []string{"[1, 2, 3]"},
 		},
 		{
@@ -1564,17 +878,15 @@ func TestRuntimeScriptArguments(t *testing.T) {
                     log(x)
                 }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.NewArray(
-						[]cadence.Value{
-							cadence.NewInt(1),
-							cadence.NewInt(2),
-							cadence.NewInt(3),
-						},
-					),
+			args: encodeArgs([]cadence.Value{
+				cadence.NewArray(
+					[]cadence.Value{
+						cadence.NewInt(1),
+						cadence.NewInt(2),
+						cadence.NewInt(3),
+					},
 				),
-			},
+			}),
 			check: func(t *testing.T, err error) {
 				RequireError(t, err)
 
@@ -1591,15 +903,13 @@ func TestRuntimeScriptArguments(t *testing.T) {
                     log(x)
                 }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.NewArray(
-						[]cadence.Value{
-							cadence.NewInt(1),
-						},
-					),
+			args: encodeArgs([]cadence.Value{
+				cadence.NewArray(
+					[]cadence.Value{
+						cadence.NewInt(1),
+					},
 				),
-			},
+			}),
 			check: func(t *testing.T, err error) {
 				RequireError(t, err)
 
@@ -1616,18 +926,16 @@ func TestRuntimeScriptArguments(t *testing.T) {
                     log(x["y"])
                 }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.NewDictionary(
-						[]cadence.KeyValuePair{
-							{
-								Key:   cadence.String("y"),
-								Value: cadence.NewInt(42),
-							},
+			args: encodeArgs([]cadence.Value{
+				cadence.NewDictionary(
+					[]cadence.KeyValuePair{
+						{
+							Key:   cadence.String("y"),
+							Value: cadence.NewInt(42),
 						},
-					),
+					},
 				),
-			},
+			}),
 			expectedLogs: []string{"42"},
 		},
 		{
@@ -1637,18 +945,16 @@ func TestRuntimeScriptArguments(t *testing.T) {
                     log(x["y"])
                 }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.NewDictionary(
-						[]cadence.KeyValuePair{
-							{
-								Key:   cadence.String("y"),
-								Value: cadence.NewInt(42),
-							},
+			args: encodeArgs([]cadence.Value{
+				cadence.NewDictionary(
+					[]cadence.KeyValuePair{
+						{
+							Key:   cadence.String("y"),
+							Value: cadence.NewInt(42),
 						},
-					),
+					},
 				),
-			},
+			}),
 			check: func(t *testing.T, err error) {
 				RequireError(t, err)
 
@@ -1673,22 +979,20 @@ func TestRuntimeScriptArguments(t *testing.T) {
                     log(x.y)
                 }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.
-						NewStruct([]cadence.Value{cadence.String("bar")}).
-						WithType(&cadence.StructType{
-							Location:            common.ScriptLocation{},
-							QualifiedIdentifier: "Foo",
-							Fields: []cadence.Field{
-								{
-									Identifier: "y",
-									Type:       cadence.StringType,
-								},
+			args: encodeArgs([]cadence.Value{
+				cadence.
+					NewStruct([]cadence.Value{cadence.String("bar")}).
+					WithType(&cadence.StructType{
+						Location:            common.ScriptLocation{},
+						QualifiedIdentifier: "Foo",
+						Fields: []cadence.Field{
+							{
+								Identifier: "y",
+								Type:       cadence.StringType,
 							},
-						}),
-				),
-			},
+						},
+					}),
+			}),
 			expectedLogs: []string{`"bar"`},
 		},
 		{
@@ -1707,24 +1011,22 @@ func TestRuntimeScriptArguments(t *testing.T) {
                     log(x.y)
                 }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(
-					cadence.NewArray([]cadence.Value{
-						cadence.
-							NewStruct([]cadence.Value{cadence.String("bar")}).
-							WithType(&cadence.StructType{
-								Location:            common.ScriptLocation{},
-								QualifiedIdentifier: "Foo",
-								Fields: []cadence.Field{
-									{
-										Identifier: "y",
-										Type:       cadence.StringType,
-									},
+			args: encodeArgs([]cadence.Value{
+				cadence.NewArray([]cadence.Value{
+					cadence.
+						NewStruct([]cadence.Value{cadence.String("bar")}).
+						WithType(&cadence.StructType{
+							Location:            common.ScriptLocation{},
+							QualifiedIdentifier: "Foo",
+							Fields: []cadence.Field{
+								{
+									Identifier: "y",
+									Type:       cadence.StringType,
 								},
-							}),
-					}),
-				),
-			},
+							},
+						}),
+				}),
+			}),
 			expectedLogs: []string{`"bar"`},
 		},
 		{
@@ -1734,12 +1036,12 @@ func TestRuntimeScriptArguments(t *testing.T) {
                     log(x)
                 }
             `,
-			args: [][]byte{
-				jsoncdc.MustEncode(cadence.Path{
+			args: encodeArgs([]cadence.Value{
+				cadence.Path{
 					Domain:     common.PathDomainStorage,
 					Identifier: "foo",
-				}),
-			},
+				},
+			}),
 			expectedLogs: []string{
 				"/storage/foo",
 			},
@@ -1752,23 +1054,20 @@ func TestRuntimeScriptArguments(t *testing.T) {
 
 			t.Parallel()
 
-			rt := newTestInterpreterRuntime()
+			rt := NewTestInterpreterRuntime()
 
 			var loggedMessages []string
 
-			storage := newTestLedger(nil, nil)
+			storage := NewTestLedger(nil, nil)
 
-			runtimeInterface := &testRuntimeInterface{
-				storage: storage,
-				log: func(message string) {
+			runtimeInterface := &TestRuntimeInterface{
+				Storage: storage,
+				OnProgramLog: func(message string) {
 					loggedMessages = append(loggedMessages, message)
 				},
-				meterMemory: func(_ common.MemoryUsage) error {
-					return nil
+				OnDecodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
+					return json.Decode(nil, b)
 				},
-			}
-			runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(runtimeInterface, b)
 			}
 
 			_, err := rt.ExecuteScript(
@@ -1800,15 +1099,15 @@ func TestRuntimeProgramWithNoTransaction(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       access(all) fun main() {}
     `)
 
-	runtimeInterface := &testRuntimeInterface{}
+	runtimeInterface := &TestRuntimeInterface{}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -1828,7 +1127,7 @@ func TestRuntimeProgramWithMultipleTransaction(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       transaction {
@@ -1839,9 +1138,9 @@ func TestRuntimeProgramWithMultipleTransaction(t *testing.T) {
       }
     `)
 
-	runtimeInterface := &testRuntimeInterface{}
+	runtimeInterface := &TestRuntimeInterface{}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -1920,7 +1219,7 @@ func TestRuntimeStorage(t *testing.T) {
 
 	for name, code := range tests {
 		t.Run(name, func(t *testing.T) {
-			runtime := newTestInterpreterRuntime()
+			runtime := NewTestInterpreterRuntime()
 
 			imported := []byte(`
               access(all) resource R {}
@@ -1946,8 +1245,8 @@ func TestRuntimeStorage(t *testing.T) {
 
 			var loggedMessages []string
 
-			runtimeInterface := &testRuntimeInterface{
-				getCode: func(location Location) ([]byte, error) {
+			runtimeInterface := &TestRuntimeInterface{
+				OnGetCode: func(location Location) ([]byte, error) {
 					switch location {
 					case common.StringLocation("imported"):
 						return imported, nil
@@ -1955,16 +1254,16 @@ func TestRuntimeStorage(t *testing.T) {
 						return nil, fmt.Errorf("unknown import location: %s", location)
 					}
 				},
-				storage: newTestLedger(nil, nil),
-				getSigningAccounts: func() ([]Address, error) {
+				Storage: NewTestLedger(nil, nil),
+				OnGetSigningAccounts: func() ([]Address, error) {
 					return []Address{{42}}, nil
 				},
-				log: func(message string) {
+				OnProgramLog: func(message string) {
 					loggedMessages = append(loggedMessages, message)
 				},
 			}
 
-			nextTransactionLocation := newTransactionLocationGenerator()
+			nextTransactionLocation := NewTransactionLocationGenerator()
 
 			err := runtime.ExecuteTransaction(
 				Script{
@@ -1986,7 +1285,7 @@ func TestRuntimeStorageMultipleTransactionsResourceWithArray(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	container := []byte(`
       access(all) resource Container {
@@ -2051,8 +1350,8 @@ func TestRuntimeStorageMultipleTransactionsResourceWithArray(t *testing.T) {
 
 	var loggedMessages []string
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("container"):
 				return container, nil
@@ -2060,16 +1359,16 @@ func TestRuntimeStorageMultipleTransactionsResourceWithArray(t *testing.T) {
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -2111,7 +1410,7 @@ func TestRuntimeStorageMultipleTransactionsResourceFunction(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	deepThought := []byte(`
       access(all) resource DeepThought {
@@ -2150,10 +1449,10 @@ func TestRuntimeStorageMultipleTransactionsResourceFunction(t *testing.T) {
 
 	var loggedMessages []string
 
-	ledger := newTestLedger(nil, nil)
+	ledger := NewTestLedger(nil, nil)
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("deep-thought"):
 				return deepThought, nil
@@ -2161,16 +1460,16 @@ func TestRuntimeStorageMultipleTransactionsResourceFunction(t *testing.T) {
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
 		},
-		storage: ledger,
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: ledger,
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -2203,7 +1502,7 @@ func TestRuntimeStorageMultipleTransactionsResourceField(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	imported := []byte(`
       access(all) resource SomeNumber {
@@ -2243,8 +1542,8 @@ func TestRuntimeStorageMultipleTransactionsResourceField(t *testing.T) {
 
 	var loggedMessages []string
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("imported"):
 				return imported, nil
@@ -2252,16 +1551,16 @@ func TestRuntimeStorageMultipleTransactionsResourceField(t *testing.T) {
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -2295,7 +1594,7 @@ func TestRuntimeCompositeFunctionInvocationFromImportingProgram(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	imported := []byte(`
       // function must have arguments
@@ -2335,8 +1634,8 @@ func TestRuntimeCompositeFunctionInvocationFromImportingProgram(t *testing.T) {
       }
     `)
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("imported"):
 				return imported, nil
@@ -2344,13 +1643,13 @@ func TestRuntimeCompositeFunctionInvocationFromImportingProgram(t *testing.T) {
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -2379,7 +1678,7 @@ func TestRuntimeResourceContractUseThroughReference(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	imported := []byte(`
       access(all) resource R {
@@ -2418,8 +1717,8 @@ func TestRuntimeResourceContractUseThroughReference(t *testing.T) {
 
 	var loggedMessages []string
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("imported"):
 				return imported, nil
@@ -2427,16 +1726,16 @@ func TestRuntimeResourceContractUseThroughReference(t *testing.T) {
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -2467,7 +1766,7 @@ func TestRuntimeResourceContractUseThroughLink(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	imported := []byte(`
       access(all) resource R {
@@ -2508,8 +1807,8 @@ func TestRuntimeResourceContractUseThroughLink(t *testing.T) {
 
 	var loggedMessages []string
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("imported"):
 				return imported, nil
@@ -2517,16 +1816,16 @@ func TestRuntimeResourceContractUseThroughLink(t *testing.T) {
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -2557,7 +1856,7 @@ func TestRuntimeResourceContractWithInterface(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	imported1 := []byte(`
       access(all) resource interface RI {
@@ -2610,8 +1909,8 @@ func TestRuntimeResourceContractWithInterface(t *testing.T) {
 
 	var loggedMessages []string
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("imported1"):
 				return imported1, nil
@@ -2621,16 +1920,16 @@ func TestRuntimeResourceContractWithInterface(t *testing.T) {
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -2662,12 +1961,12 @@ func TestRuntimeParseAndCheckProgram(t *testing.T) {
 	t.Parallel()
 
 	t.Run("ValidProgram", func(t *testing.T) {
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte("access(all) fun test(): Int { return 42 }")
-		runtimeInterface := &testRuntimeInterface{}
+		runtimeInterface := &TestRuntimeInterface{}
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		_, err := runtime.ParseAndCheckProgram(
 			script,
@@ -2680,12 +1979,12 @@ func TestRuntimeParseAndCheckProgram(t *testing.T) {
 	})
 
 	t.Run("InvalidSyntax", func(t *testing.T) {
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte("invalid syntax")
-		runtimeInterface := &testRuntimeInterface{}
+		runtimeInterface := &TestRuntimeInterface{}
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		_, err := runtime.ParseAndCheckProgram(
 			script,
@@ -2698,12 +1997,12 @@ func TestRuntimeParseAndCheckProgram(t *testing.T) {
 	})
 
 	t.Run("InvalidSemantics", func(t *testing.T) {
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`access(all) let a: Int = "b"`)
-		runtimeInterface := &testRuntimeInterface{}
+		runtimeInterface := &TestRuntimeInterface{}
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		_, err := runtime.ParseAndCheckProgram(
 			script,
@@ -2728,13 +2027,13 @@ func TestRuntimeScriptReturnSpecial(t *testing.T) {
 
 	test := func(t *testing.T, test testCase) {
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
 		}
@@ -2889,7 +2188,7 @@ func TestRuntimeScriptParameterTypeNotImportableError(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       access(all) fun main(x: fun(): Int) {
@@ -2897,8 +2196,8 @@ func TestRuntimeScriptParameterTypeNotImportableError(t *testing.T) {
       }
     `)
 
-	runtimeInterface := &testRuntimeInterface{
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
 	}
@@ -2922,7 +2221,7 @@ func TestRuntimeSyntaxError(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       access(all) fun main(): String {
@@ -2930,13 +2229,13 @@ func TestRuntimeSyntaxError(t *testing.T) {
       }
     `)
 
-	runtimeInterface := &testRuntimeInterface{
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	_, err := runtime.ExecuteScript(
 		Script{
@@ -2955,7 +2254,7 @@ func TestRuntimeStorageChanges(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	imported := []byte(`
       access(all) resource X {
@@ -3001,8 +2300,8 @@ func TestRuntimeStorageChanges(t *testing.T) {
 
 	var loggedMessages []string
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			switch location {
 			case common.StringLocation("imported"):
 				return imported, nil
@@ -3010,16 +2309,16 @@ func TestRuntimeStorageChanges(t *testing.T) {
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -3050,7 +2349,7 @@ func TestRuntimeAccountAddress(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       transaction {
@@ -3064,16 +2363,16 @@ func TestRuntimeAccountAddress(t *testing.T) {
 
 	address := common.MustBytesToAddress([]byte{42})
 
-	runtimeInterface := &testRuntimeInterface{
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{address}, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -3093,7 +2392,7 @@ func TestRuntimePublicAccountAddress(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       transaction {
@@ -3107,16 +2406,16 @@ func TestRuntimePublicAccountAddress(t *testing.T) {
 
 	address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x42})
 
-	runtimeInterface := &testRuntimeInterface{
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return nil, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -3141,7 +2440,7 @@ func TestRuntimeAccountPublishAndAccess(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	imported := []byte(`
       access(all) resource R {
@@ -3187,8 +2486,8 @@ func TestRuntimeAccountPublishAndAccess(t *testing.T) {
 
 	var loggedMessages []string
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) ([]byte, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) ([]byte, error) {
 			switch location {
 			case common.StringLocation("imported"):
 				return imported, nil
@@ -3196,16 +2495,16 @@ func TestRuntimeAccountPublishAndAccess(t *testing.T) {
 				return nil, fmt.Errorf("unknown import location: %s", location)
 			}
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{address}, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -3236,7 +2535,7 @@ func TestRuntimeTransaction_CreateAccount(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       transaction {
@@ -3248,21 +2547,21 @@ func TestRuntimeTransaction_CreateAccount(t *testing.T) {
 
 	var events []cadence.Event
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
-		createAccount: func(payer Address) (address Address, err error) {
+		OnCreateAccount: func(payer Address) (address Address, err error) {
 			return Address{42}, nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -3287,7 +2586,7 @@ func TestRuntimeContractAccount(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
@@ -3330,30 +2629,30 @@ func TestRuntimeContractAccount(t *testing.T) {
 	var accountCode []byte
 	var events []cadence.Event
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{Address(addressValue)}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
-	nextScriptLocation := newScriptLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -3403,7 +2702,7 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -3438,33 +2737,33 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 	var accountCode []byte
 	var loggedMessage string
 
-	storage := newTestLedger(nil, nil)
+	storage := NewTestLedger(nil, nil)
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: storage,
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: storage,
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{addressValue}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessage = message
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -3725,7 +3024,7 @@ func TestRuntimeContractNestedResource(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -3764,31 +3063,31 @@ func TestRuntimeContractNestedResource(t *testing.T) {
 	var accountCode []byte
 	var loggedMessage string
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{addressValue}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessage = message
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -3821,7 +3120,7 @@ func TestRuntimeStorageLoadedDestructionConcreteType(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -3862,29 +3161,29 @@ func TestRuntimeStorageLoadedDestructionConcreteType(t *testing.T) {
 	var accountCode []byte
 	var loggedMessage string
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{addressValue}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error { return nil },
-		log: func(message string) {
+		OnEmitEvent: func(event cadence.Event) error { return nil },
+		OnProgramLog: func(message string) {
 			loggedMessage = message
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -3916,7 +3215,7 @@ func TestRuntimeStorageLoadedDestructionAnyResource(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -3957,29 +3256,29 @@ func TestRuntimeStorageLoadedDestructionAnyResource(t *testing.T) {
 	var accountCode []byte
 	var loggedMessage string
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{addressValue}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error { return nil },
-		log: func(message string) {
+		OnEmitEvent: func(event cadence.Event) error { return nil },
+		OnProgramLog: func(message string) {
 			loggedMessage = message
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -4012,7 +3311,7 @@ func TestRuntimeStorageLoadedDestructionAfterRemoval(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -4053,32 +3352,32 @@ func TestRuntimeStorageLoadedDestructionAfterRemoval(t *testing.T) {
 
 	var accountCode []byte
 
-	ledger := newTestLedger(nil, nil)
+	ledger := NewTestLedger(nil, nil)
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: ledger,
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: ledger,
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{addressValue}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		removeAccountContractCode: func(_ common.AddressLocation) (err error) {
+		OnRemoveAccountContractCode: func(_ common.AddressLocation) (err error) {
 			accountCode = nil
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error { return nil },
+		OnEmitEvent: func(event cadence.Event) error { return nil },
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy the contract
 
@@ -4231,7 +3530,7 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	address1Value := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -4286,29 +3585,29 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 
 	signerAccount := address1Value
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAccount}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -4350,7 +3649,7 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	address1Value := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -4414,32 +3713,32 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 
 	signerAccount := address1Value
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		createAccount: func(payer Address) (address Address, err error) {
+		Storage: NewTestLedger(nil, nil),
+		OnCreateAccount: func(payer Address) (address Address, err error) {
 			return address2Value, nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAccount}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -4479,7 +3778,7 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	makeDeployTransaction := func(name, code string) []byte {
 		return []byte(fmt.Sprintf(
@@ -4568,34 +3867,34 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 
 	var nextAccount byte = 0x2
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		createAccount: func(payer Address) (address Address, err error) {
+		Storage: NewTestLedger(nil, nil),
+		OnCreateAccount: func(payer Address) (address Address, err error) {
 			result := interpreter.NewUnmeteredAddressValueFromBytes([]byte{nextAccount})
 			nextAccount++
 			return result.ToAddress(), nil
 		},
-		getSigningAccounts: func() ([]Address, error) {
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{0x1}}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	deployTransaction := makeDeployTransaction("TestContractInterface", contractInterfaceCode)
 	err := runtime.ExecuteTransaction(
@@ -4665,7 +3964,7 @@ func TestRuntimeBlock(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       transaction {
@@ -4689,19 +3988,19 @@ func TestRuntimeBlock(t *testing.T) {
 
 	var loggedMessages []string
 
-	storage := newTestLedger(nil, nil)
+	storage := NewTestLedger(nil, nil)
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: storage,
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: storage,
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return nil, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -4735,7 +4034,7 @@ func TestRuntimeUnsafeRandom(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       transaction {
@@ -4748,17 +4047,17 @@ func TestRuntimeUnsafeRandom(t *testing.T) {
 
 	var loggedMessages []string
 
-	runtimeInterface := &testRuntimeInterface{
-		readRandom: func(buffer []byte) error {
+	runtimeInterface := &TestRuntimeInterface{
+		OnReadRandom: func(buffer []byte) error {
 			binary.LittleEndian.PutUint64(buffer, 7558174677681708339)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -4784,7 +4083,7 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 	t.Parallel()
 
 	t.Run("transaction with function", func(t *testing.T) {
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
           access(all) fun test() {}
@@ -4792,13 +4091,13 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
           transaction {}
         `)
 
-		runtimeInterface := &testRuntimeInterface{
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return nil, nil
 			},
 		}
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -4813,7 +4112,7 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 	})
 
 	t.Run("transaction with resource", func(t *testing.T) {
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
           access(all) resource R {}
@@ -4821,13 +4120,13 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
           transaction {}
         `)
 
-		runtimeInterface := &testRuntimeInterface{
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return nil, nil
 			},
 		}
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -4855,7 +4154,7 @@ func TestRuntimeStoreIntegerTypes(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := interpreter.AddressValue{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xCA, 0xDE,
@@ -4888,28 +4187,28 @@ func TestRuntimeStoreIntegerTypes(t *testing.T) {
 			var accountCode []byte
 			var events []cadence.Event
 
-			runtimeInterface := &testRuntimeInterface{
-				getCode: func(_ Location) (bytes []byte, err error) {
+			runtimeInterface := &TestRuntimeInterface{
+				OnGetCode: func(_ Location) (bytes []byte, err error) {
 					return accountCode, nil
 				},
-				storage: newTestLedger(nil, nil),
-				getSigningAccounts: func() ([]Address, error) {
+				Storage: NewTestLedger(nil, nil),
+				OnGetSigningAccounts: func() ([]Address, error) {
 					return []Address{addressValue.ToAddress()}, nil
 				},
-				getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+				OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 					return accountCode, nil
 				},
-				updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+				OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 					accountCode = code
 					return nil
 				},
-				emitEvent: func(event cadence.Event) error {
+				OnEmitEvent: func(event cadence.Event) error {
 					events = append(events, event)
 					return nil
 				},
 			}
 
-			nextTransactionLocation := newTransactionLocationGenerator()
+			nextTransactionLocation := NewTransactionLocationGenerator()
 
 			err := runtime.ExecuteTransaction(
 				Script{
@@ -4931,7 +4230,7 @@ func TestRuntimeResourceOwnerFieldUseComposite(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	address := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -5012,50 +4311,50 @@ func TestRuntimeResourceOwnerFieldUseComposite(t *testing.T) {
 	var events []cadence.Event
 	var loggedMessages []string
 
-	storage := newTestLedger(nil, nil)
+	storage := NewTestLedger(nil, nil)
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: storage,
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: storage,
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{address}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
-		getAccountBalance: func(_ Address) (uint64, error) {
+		OnGetAccountBalance: func(_ Address) (uint64, error) {
 			// return a dummy value
 			return 12300000000, nil
 		},
-		getAccountAvailableBalance: func(_ Address) (uint64, error) {
+		OnGetAccountAvailableBalance: func(_ Address) (uint64, error) {
 			// return a dummy value
 			return 152300000000, nil
 		},
-		getStorageUsed: func(_ Address) (uint64, error) {
+		OnGetStorageUsed: func(_ Address) (uint64, error) {
 			// return a dummy value
 			return 120, nil
 		},
-		getStorageCapacity: func(_ Address) (uint64, error) {
+		OnGetStorageCapacity: func(_ Address) (uint64, error) {
 			// return a dummy value
 			return 1245, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -5126,7 +4425,7 @@ func TestRuntimeResourceOwnerFieldUseArray(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	address := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -5212,32 +4511,32 @@ func TestRuntimeResourceOwnerFieldUseArray(t *testing.T) {
 	var events []cadence.Event
 	var loggedMessages []string
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{address}, nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -5300,7 +4599,7 @@ func TestRuntimeResourceOwnerFieldUseDictionary(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	address := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -5386,32 +4685,32 @@ func TestRuntimeResourceOwnerFieldUseDictionary(t *testing.T) {
 	var events []cadence.Event
 	var loggedMessages []string
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{address}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -5474,7 +4773,7 @@ func TestRuntimeMetrics(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	imported1Location := common.StringLocation("imported1")
 
@@ -5514,7 +4813,7 @@ func TestRuntimeMetrics(t *testing.T) {
       }
     `)
 
-	storage := newTestLedger(nil, nil)
+	storage := NewTestLedger(nil, nil)
 
 	type reports struct {
 		programParsed      map[Location]int
@@ -5530,12 +4829,12 @@ func TestRuntimeMetrics(t *testing.T) {
 			programInterpreted: map[common.Location]int{},
 		}
 
-		runtimeInterface = &testRuntimeInterface{
-			storage: storage,
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface = &TestRuntimeInterface{
+			Storage: storage,
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			getCode: func(location Location) (bytes []byte, err error) {
+			OnGetCode: func(location Location) (bytes []byte, err error) {
 				switch location {
 				case imported1Location:
 					return importedScript1, nil
@@ -5545,13 +4844,13 @@ func TestRuntimeMetrics(t *testing.T) {
 					return nil, fmt.Errorf("unknown import location: %s", location)
 				}
 			},
-			programParsed: func(location common.Location, duration time.Duration) {
+			OnProgramParsed: func(location common.Location, duration time.Duration) {
 				r.programParsed[location]++
 			},
-			programChecked: func(location common.Location, duration time.Duration) {
+			OnProgramChecked: func(location common.Location, duration time.Duration) {
 				r.programChecked[location]++
 			},
-			programInterpreted: func(location common.Location, duration time.Duration) {
+			OnProgramInterpreted: func(location common.Location, duration time.Duration) {
 				r.programInterpreted[location]++
 			},
 		}
@@ -5561,7 +4860,7 @@ func TestRuntimeMetrics(t *testing.T) {
 
 	i1, r1 := newRuntimeInterface()
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	transactionLocation := nextTransactionLocation()
 	err := runtime.ExecuteTransaction(
@@ -5645,7 +4944,7 @@ func TestRuntimeContractWriteback(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
@@ -5700,32 +4999,32 @@ func TestRuntimeContractWriteback(t *testing.T) {
 		})
 	}
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, onWrite),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, onWrite),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{Address(addressValue)}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) (err error) {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) (err error) {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -5805,7 +5104,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
@@ -5846,32 +5145,32 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 		})
 	}
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, onWrite),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, onWrite),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{Address(addressValue)}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -6025,7 +5324,7 @@ func TestRuntimeExternalError(t *testing.T) {
 
 	t.Parallel()
 
-	interpreterRuntime := newTestInterpreterRuntime()
+	interpreterRuntime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       transaction {
@@ -6035,16 +5334,16 @@ func TestRuntimeExternalError(t *testing.T) {
       }
     `)
 
-	runtimeInterface := &testRuntimeInterface{
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return nil, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			panic(logPanicError{})
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := interpreterRuntime.ExecuteTransaction(
 		Script{
@@ -6065,7 +5364,7 @@ func TestRuntimeExternalNonError(t *testing.T) {
 
 	t.Parallel()
 
-	interpreterRuntime := newTestInterpreterRuntime()
+	interpreterRuntime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       transaction {
@@ -6077,16 +5376,16 @@ func TestRuntimeExternalNonError(t *testing.T) {
 
 	type logPanic struct{}
 
-	runtimeInterface := &testRuntimeInterface{
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return nil, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			panic(logPanic{})
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := interpreterRuntime.ExecuteTransaction(
 		Script{
@@ -6146,7 +5445,7 @@ func TestRuntimeDeployCodeCaching(t *testing.T) {
 
 	deployTx := DeploymentTransaction("HelloWorld", []byte(helloWorldContract))
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	accountCodes := map[common.Location][]byte{}
 	var events []cadence.Event
@@ -6155,33 +5454,33 @@ func TestRuntimeDeployCodeCaching(t *testing.T) {
 
 	var signerAddresses []Address
 
-	runtimeInterface := &testRuntimeInterface{
-		createAccount: func(payer Address) (address Address, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnCreateAccount: func(payer Address) (address Address, err error) {
 			accountCounter++
 			return Address{accountCounter}, nil
 		},
-		getCode: func(location Location) (bytes []byte, err error) {
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return signerAddresses, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// create the account
 
@@ -6280,7 +5579,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 	deployTx := DeploymentTransaction("HelloWorld", []byte(helloWorldContract1))
 	updateTx := UpdateTransaction("HelloWorld", []byte(helloWorldContract2))
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	accountCodes := map[common.Location][]byte{}
 	var events []cadence.Event
@@ -6292,37 +5591,37 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 
 	var programHits []string
 
-	runtimeInterface := &testRuntimeInterface{
-		createAccount: func(payer Address) (address Address, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnCreateAccount: func(payer Address) (address Address, err error) {
 			accountCounter++
 			return Address{accountCounter}, nil
 		},
-		getCode: func(location Location) (bytes []byte, err error) {
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return signerAddresses, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
-	nextScriptLocation := newScriptLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	// create the account
 
@@ -6362,7 +5661,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 		Name:    "HelloWorld",
 	}
 
-	require.NotContains(t, runtimeInterface.programs, location)
+	require.NotContains(t, runtimeInterface.Programs, location)
 
 	// call the initial hello function
 
@@ -6384,7 +5683,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 	// assert that it was stored in the program storage
 	// after it was parsed and checked
 
-	initialProgram := runtimeInterface.programs[location]
+	initialProgram := runtimeInterface.Programs[location]
 	require.NotNil(t, initialProgram)
 
 	// update the contract
@@ -6408,9 +5707,9 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 
 	require.Same(t,
 		initialProgram,
-		runtimeInterface.programs[location],
+		runtimeInterface.Programs[location],
 	)
-	require.NotNil(t, runtimeInterface.programs[location])
+	require.NotNil(t, runtimeInterface.Programs[location])
 
 	// call the new hello function from a script
 
@@ -6490,7 +5789,7 @@ func TestRuntimeProgramsHitForToplevelPrograms(t *testing.T) {
 
 	deployTx := DeploymentTransaction("HelloWorld", []byte(helloWorldContract))
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	accountCodes := map[common.Location][]byte{}
 	var events []cadence.Event
@@ -6503,15 +5802,15 @@ func TestRuntimeProgramsHitForToplevelPrograms(t *testing.T) {
 
 	var programsHits []Location
 
-	runtimeInterface := &testRuntimeInterface{
-		createAccount: func(payer Address) (address Address, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnCreateAccount: func(payer Address) (address Address, err error) {
 			accountCounter++
 			return Address{accountCounter}, nil
 		},
-		getCode: func(location Location) (bytes []byte, err error) {
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		getAndSetProgram: func(
+		OnGetAndSetProgram: func(
 			location Location,
 			load func() (*interpreter.Program, error),
 		) (
@@ -6535,25 +5834,25 @@ func TestRuntimeProgramsHitForToplevelPrograms(t *testing.T) {
 
 			return
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return signerAddresses, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	signerAddresses = []Address{{accountCounter}}
 
@@ -6629,7 +5928,7 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	const contract1 = `
       access(all) contract Test {
@@ -6694,15 +5993,15 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 
 	signerAddress := common.MustBytesToAddress([]byte{0x42})
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAddress}, nil
 		},
-		getCode: func(_ Location) (bytes []byte, err error) {
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		resolveLocation: func(identifiers []Identifier, location Location) ([]ResolvedLocation, error) {
+		OnResolveLocation: func(identifiers []Identifier, location Location) ([]ResolvedLocation, error) {
 			require.Empty(t, identifiers)
 			require.IsType(t, common.AddressLocation{}, location)
 
@@ -6720,20 +6019,20 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 				},
 			}, nil
 		},
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy the Test contract
 
@@ -6755,7 +6054,7 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 		Name:    "Test",
 	}
 
-	require.NotContains(t, runtimeInterface.programs, location)
+	require.NotContains(t, runtimeInterface.Programs, location)
 
 	// Use the Test contract
 
@@ -6775,7 +6074,7 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
       }
     `)
 
-	nextScriptLocation := newScriptLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	_, err = runtime.ExecuteScript(
 		Script{
@@ -6792,7 +6091,7 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 	// assert that it was stored in the program storage
 	// after it was parsed and checked
 
-	initialProgram := runtimeInterface.programs[location]
+	initialProgram := runtimeInterface.Programs[location]
 	require.NotNil(t, initialProgram)
 
 	// Update the Test contract
@@ -6815,9 +6114,9 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 
 	require.Same(t,
 		initialProgram,
-		runtimeInterface.programs[location],
+		runtimeInterface.Programs[location],
 	)
-	require.NotNil(t, runtimeInterface.programs[location])
+	require.NotNil(t, runtimeInterface.Programs[location])
 
 	// Use the new Test contract
 
@@ -6854,7 +6153,7 @@ func TestRuntimeExecuteScriptArguments(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       access(all) fun main(num: Int) {}
@@ -6872,16 +6171,13 @@ func TestRuntimeExecuteScriptArguments(t *testing.T) {
 			// NOTE: to parallelize this sub-test,
 			// access to `programs` must be made thread-safe first
 
-			storage := newTestLedger(nil, nil)
+			storage := NewTestLedger(nil, nil)
 
-			runtimeInterface := &testRuntimeInterface{
-				storage: storage,
-				meterMemory: func(_ common.MemoryUsage) error {
-					return nil
+			runtimeInterface := &TestRuntimeInterface{
+				Storage: storage,
+				OnDecodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
+					return json.Decode(nil, b)
 				},
-			}
-			runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-				return json.Decode(runtimeInterface, b)
 			}
 
 			_, err := runtime.ExecuteScript(
@@ -6915,17 +6211,17 @@ func TestRuntimeExecuteScriptArguments(t *testing.T) {
 		},
 		{
 			name: "correct number of arguments",
-			arguments: [][]byte{
-				jsoncdc.MustEncode(cadence.NewInt(1)),
-			},
+			arguments: encodeArgs([]cadence.Value{
+				cadence.NewInt(1),
+			}),
 			valid: true,
 		},
 		{
 			name: "too many arguments",
-			arguments: [][]byte{
-				jsoncdc.MustEncode(cadence.NewInt(1)),
-				jsoncdc.MustEncode(cadence.NewInt(2)),
-			},
+			arguments: encodeArgs([]cadence.Value{
+				cadence.NewInt(1),
+				cadence.NewInt(2),
+			}),
 			valid: false,
 		},
 	} {
@@ -6933,57 +6229,11 @@ func TestRuntimeExecuteScriptArguments(t *testing.T) {
 	}
 }
 
-func singleIdentifierLocationResolver(t testing.TB) func(identifiers []Identifier, location Location) ([]ResolvedLocation, error) {
-	return func(identifiers []Identifier, location Location) ([]ResolvedLocation, error) {
-		require.Len(t, identifiers, 1)
-		require.IsType(t, common.AddressLocation{}, location)
-
-		return []ResolvedLocation{
-			{
-				Location: common.AddressLocation{
-					Address: location.(common.AddressLocation).Address,
-					Name:    identifiers[0].Identifier,
-				},
-				Identifiers: identifiers,
-			},
-		}, nil
-	}
-}
-
-func multipleIdentifierLocationResolver(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
-
-	// Resolve each identifier as an address location
-
-	for _, identifier := range identifiers {
-		result = append(result, sema.ResolvedLocation{
-			Location: common.AddressLocation{
-				Address: location.(common.AddressLocation).Address,
-				Name:    identifier.Identifier,
-			},
-			Identifiers: []ast.Identifier{
-				identifier,
-			},
-		})
-	}
-
-	return
-}
-
-func TestRuntimeGetConfig(t *testing.T) {
-	t.Parallel()
-
-	rt := newTestInterpreterRuntime()
-
-	config := rt.Config()
-	expected := rt.defaultConfig
-	require.Equal(t, expected, config)
-}
-
 func TestRuntimePanics(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       access(all) fun main() {
@@ -6991,16 +6241,16 @@ func TestRuntimePanics(t *testing.T) {
       }
     `)
 
-	storage := newTestLedger(nil, nil)
+	storage := NewTestLedger(nil, nil)
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: storage,
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: storage,
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{{42}}, nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	_, err := runtime.ExecuteScript(
 		Script{
@@ -7022,7 +6272,7 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
 	t.Run("store auth account reference", func(t *testing.T) {
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
           access(all) fun main() {
@@ -7032,7 +6282,7 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
           }
         `)
 
-		runtimeInterface := &testRuntimeInterface{}
+		runtimeInterface := &TestRuntimeInterface{}
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -7051,7 +6301,7 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
           access(all) fun main() {
@@ -7061,7 +6311,7 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
           }
         `)
 
-		runtimeInterface := &testRuntimeInterface{}
+		runtimeInterface := &TestRuntimeInterface{}
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -7085,7 +6335,7 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
           access(all) fun main() {
@@ -7095,8 +6345,8 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
           }
         `)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
 		}
 
 		_, err := runtime.ExecuteScript(
@@ -7120,7 +6370,7 @@ func TestRuntimeStackOverflow(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	const contract = `
 
@@ -7143,36 +6393,33 @@ func TestRuntimeStackOverflow(t *testing.T) {
 	var signerAddress common.Address
 	accountCodes := map[common.Location]string{}
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAddress}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = string(code)
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = []byte(accountCodes[location])
 			return code, nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
-		meterMemory: func(_ common.MemoryUsage) error {
-			return nil
+		OnDecodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
+			return json.Decode(nil, b)
 		},
 	}
-	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-		return json.Decode(runtimeInterface, b)
-	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy
 
@@ -7207,10 +6454,10 @@ func TestRuntimeInternalErrors(t *testing.T) {
           }
         `)
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			log: func(message string) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnProgramLog: func(message string) {
 				// panic due to go-error in cadence implementation
 				var val any = message
 				_ = val.(int)
@@ -7242,10 +6489,10 @@ func TestRuntimeInternalErrors(t *testing.T) {
           }
         `)
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			log: func(message string) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnProgramLog: func(message string) {
 				// intentionally panic
 				panic(fmt.Errorf("panic trying to log %s", message))
 			},
@@ -7279,10 +6526,10 @@ func TestRuntimeInternalErrors(t *testing.T) {
           }
         `)
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			log: func(message string) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnProgramLog: func(message string) {
 				// panic due to Cadence implementation error
 				var val any = message
 				_ = val.(int)
@@ -7322,34 +6569,34 @@ func TestRuntimeInternalErrors(t *testing.T) {
 
 		var accountCode []byte
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{addressValue}, nil
 			},
-			resolveLocation: singleIdentifierLocationResolver(t),
-			getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 				return accountCode, nil
 			},
-			updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+			OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 				accountCode = code
 				return nil
 			},
-			emitEvent: func(_ cadence.Event) error {
+			OnEmitEvent: func(_ cadence.Event) error {
 				return nil
 			},
-			log: func(message string) {
+			OnProgramLog: func(message string) {
 				// panic due to Cadence implementation error
 				var val any = message
 				_ = val.(int)
 			},
 		}
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		deploy := DeploymentTransaction("Test", contract)
 		err := runtime.ExecuteTransaction(
@@ -7390,15 +6637,15 @@ func TestRuntimeInternalErrors(t *testing.T) {
 
 		script := []byte("access(all) fun test() {}")
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			getAndSetProgram: func(_ Location, _ func() (*interpreter.Program, error)) (*interpreter.Program, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetAndSetProgram: func(_ Location, _ func() (*interpreter.Program, error)) (*interpreter.Program, error) {
 				panic(errors.New("crash while getting/setting program"))
 			},
 		}
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 
 		_, err := runtime.ParseAndCheckProgram(
 			script,
@@ -7417,11 +6664,11 @@ func TestRuntimeInternalErrors(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: testLedger{
-				getValue: func(owner, key []byte) (value []byte, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: TestLedger{
+				OnGetValue: func(owner, key []byte) (value []byte, err error) {
 					panic(errors.New("crasher"))
 				},
 			},
@@ -7450,11 +6697,11 @@ func TestRuntimeInternalErrors(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: testLedger{
-				getValue: func(owner, key []byte) (value []byte, err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: TestLedger{
+				OnGetValue: func(owner, key []byte) (value []byte, err error) {
 					panic(errors.New("crasher"))
 				},
 			},
@@ -7485,10 +6732,10 @@ func TestRuntimeInternalErrors(t *testing.T) {
 
 		script := []byte(`access(all) fun main() {}`)
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
-		runtimeInterface := &testRuntimeInterface{
-			meterMemory: func(usage common.MemoryUsage) error {
+		runtimeInterface := &TestRuntimeInterface{
+			OnMeterMemory: func(usage common.MemoryUsage) error {
 				// panic with a non-error type
 				panic("crasher")
 			},
@@ -7592,7 +6839,7 @@ func TestRuntimeComputationMetring(t *testing.T) {
 				),
 			)
 
-			runtime := newTestInterpreterRuntime()
+			runtime := NewTestInterpreterRuntime()
 
 			compErr := errors.New("computation exceeded limit")
 			var hits, totalIntensity uint
@@ -7607,15 +6854,15 @@ func TestRuntimeComputationMetring(t *testing.T) {
 
 			address := common.MustBytesToAddress([]byte{0x1})
 
-			runtimeInterface := &testRuntimeInterface{
-				storage: newTestLedger(nil, nil),
-				getSigningAccounts: func() ([]Address, error) {
+			runtimeInterface := &TestRuntimeInterface{
+				Storage: NewTestLedger(nil, nil),
+				OnGetSigningAccounts: func() ([]Address, error) {
 					return []Address{address}, nil
 				},
-				meterComputation: meterComputationFunc,
+				OnMeterComputation: meterComputationFunc,
 			}
 
-			nextTransactionLocation := newTransactionLocationGenerator()
+			nextTransactionLocation := NewTransactionLocationGenerator()
 
 			err := runtime.ExecuteTransaction(
 				Script{
@@ -7646,28 +6893,25 @@ func TestRuntimeImportAnyStruct(t *testing.T) {
 
 	t.Parallel()
 
-	rt := newTestInterpreterRuntime()
+	rt := NewTestInterpreterRuntime()
 
 	var loggedMessages []string
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
-	storage := newTestLedger(nil, nil)
+	storage := NewTestLedger(nil, nil)
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: storage,
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: storage,
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{address}, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
-		meterMemory: func(_ common.MemoryUsage) error {
-			return nil
+		OnDecodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
+			return json.Decode(nil, b)
 		},
-	}
-	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-		return json.Decode(runtimeInterface, b)
 	}
 
 	err := rt.ExecuteTransaction(
@@ -7726,8 +6970,8 @@ func assertRuntimeErrorIsExternalError(t *testing.T, err error) {
 
 func BenchmarkRuntimeScriptNoop(b *testing.B) {
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: newTestLedger(nil, nil),
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: NewTestLedger(nil, nil),
 	}
 
 	script := Script{
@@ -7744,7 +6988,7 @@ func BenchmarkRuntimeScriptNoop(b *testing.B) {
 
 	require.NotNil(b, stdlib.CryptoChecker())
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -7758,9 +7002,9 @@ func TestRuntimeImportTestStdlib(t *testing.T) {
 
 	t.Parallel()
 
-	rt := newTestInterpreterRuntime()
+	rt := NewTestInterpreterRuntime()
 
-	runtimeInterface := &testRuntimeInterface{}
+	runtimeInterface := &TestRuntimeInterface{}
 
 	_, err := rt.ExecuteScript(
 		Script{
@@ -7791,9 +7035,9 @@ func TestRuntimeGetCurrentBlockScript(t *testing.T) {
 
 	t.Parallel()
 
-	rt := newTestInterpreterRuntime()
+	rt := NewTestInterpreterRuntime()
 
-	runtimeInterface := &testRuntimeInterface{}
+	runtimeInterface := &TestRuntimeInterface{}
 
 	_, err := rt.ExecuteScript(
 		Script{
@@ -7819,7 +7063,7 @@ func TestRuntimeTypeMismatchErrorMessage(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	address1 := common.MustBytesToAddress([]byte{0x1})
 	address2 := common.MustBytesToAddress([]byte{0x2})
@@ -7837,30 +7081,30 @@ func TestRuntimeTypeMismatchErrorMessage(t *testing.T) {
 
 	signerAccount := address1
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAccount}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
-	nextScriptLocation := newScriptLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	// Deploy same contract to two different accounts
 
@@ -7935,7 +7179,7 @@ func TestRuntimeErrorExcerpts(t *testing.T) {
 
 	t.Parallel()
 
-	rt := newTestInterpreterRuntime()
+	rt := NewTestInterpreterRuntime()
 
 	script := []byte(`
     access(all) fun main(): Int {
@@ -7950,13 +7194,13 @@ func TestRuntimeErrorExcerpts(t *testing.T) {
     }
     `)
 
-	runtimeInterface := &testRuntimeInterface{
-		getAccountBalance:          noopRuntimeUInt64Getter,
-		getAccountAvailableBalance: noopRuntimeUInt64Getter,
-		getStorageUsed:             noopRuntimeUInt64Getter,
-		getStorageCapacity:         noopRuntimeUInt64Getter,
-		accountKeysCount:           noopRuntimeUInt64Getter,
-		storage:                    newTestLedger(nil, nil),
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetAccountBalance:          noopRuntimeUInt64Getter,
+		OnGetAccountAvailableBalance: noopRuntimeUInt64Getter,
+		OnGetStorageUsed:             noopRuntimeUInt64Getter,
+		OnGetStorageCapacity:         noopRuntimeUInt64Getter,
+		OnAccountKeysCount:           noopRuntimeUInt64Getter,
+		Storage:                      NewTestLedger(nil, nil),
 	}
 
 	_, err := rt.ExecuteScript(
@@ -7986,7 +7230,7 @@ func TestRuntimeErrorExcerptsMultiline(t *testing.T) {
 
 	t.Parallel()
 
-	rt := newTestInterpreterRuntime()
+	rt := NewTestInterpreterRuntime()
 
 	script := []byte(`
     access(all) fun main(): String {
@@ -8002,13 +7246,13 @@ func TestRuntimeErrorExcerptsMultiline(t *testing.T) {
     }
     `)
 
-	runtimeInterface := &testRuntimeInterface{
-		getAccountBalance:          noopRuntimeUInt64Getter,
-		getAccountAvailableBalance: noopRuntimeUInt64Getter,
-		getStorageUsed:             noopRuntimeUInt64Getter,
-		getStorageCapacity:         noopRuntimeUInt64Getter,
-		accountKeysCount:           noopRuntimeUInt64Getter,
-		storage:                    newTestLedger(nil, nil),
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetAccountBalance:          noopRuntimeUInt64Getter,
+		OnGetAccountAvailableBalance: noopRuntimeUInt64Getter,
+		OnGetStorageUsed:             noopRuntimeUInt64Getter,
+		OnGetStorageCapacity:         noopRuntimeUInt64Getter,
+		OnAccountKeysCount:           noopRuntimeUInt64Getter,
+		Storage:                      NewTestLedger(nil, nil),
 	}
 
 	_, err := rt.ExecuteScript(
@@ -8040,7 +7284,7 @@ func TestRuntimeAccountTypeEquality(t *testing.T) {
 
 	t.Parallel()
 
-	rt := newTestInterpreterRuntime()
+	rt := NewTestInterpreterRuntime()
 
 	script := []byte(`
       access(all) fun main(address: Address): AnyStruct {
@@ -8056,12 +7300,12 @@ func TestRuntimeAccountTypeEquality(t *testing.T) {
       }
     `)
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: newTestLedger(nil, nil),
-		decodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
-			return jsoncdc.Decode(nil, b)
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: NewTestLedger(nil, nil),
+		OnDecodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
+			return json.Decode(nil, b)
 		},
-		emitEvent: func(_ cadence.Event) error {
+		OnEmitEvent: func(_ cadence.Event) error {
 			return nil
 		},
 	}
@@ -8090,7 +7334,7 @@ func TestRuntimeUserPanicToError(t *testing.T) {
 		"wrapped: %w",
 		runtimeErrors.NewDefaultUserError("user error"),
 	)
-	retErr := userPanicToError(func() { panic(err) })
+	retErr := UserPanicToError(func() { panic(err) })
 	require.Equal(t, retErr, err)
 }
 
@@ -8098,7 +7342,7 @@ func TestRuntimeDestructorReentrancyPrevention(t *testing.T) {
 
 	t.Parallel()
 
-	rt := newTestInterpreterRuntime()
+	rt := NewTestInterpreterRuntime()
 
 	script := []byte(`
       access(all) resource Vault {
@@ -8181,8 +7425,8 @@ func TestRuntimeDestructorReentrancyPrevention(t *testing.T) {
       }
     `)
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: newTestLedger(nil, nil),
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: NewTestLedger(nil, nil),
 	}
 
 	_, err := rt.ExecuteScript(
@@ -8203,7 +7447,7 @@ func TestRuntimeFlowEventTypes(t *testing.T) {
 
 	t.Parallel()
 
-	rt := newTestInterpreterRuntime()
+	rt := NewTestInterpreterRuntime()
 
 	script := []byte(`
       access(all) fun main(): Type? {
@@ -8211,8 +7455,8 @@ func TestRuntimeFlowEventTypes(t *testing.T) {
       }
     `)
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: newTestLedger(nil, nil),
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: NewTestLedger(nil, nil),
 	}
 
 	result, err := rt.ExecuteScript(
@@ -8245,7 +7489,7 @@ func TestRuntimeInvalidatedResourceUse(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -8254,29 +7498,29 @@ func TestRuntimeInvalidatedResourceUse(t *testing.T) {
 	accountCodes := map[Location][]byte{}
 	var events []cadence.Event
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return signers, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	attacker := []byte(fmt.Sprintf(`
 		import VictimContract from %s
@@ -8436,7 +7680,7 @@ func TestRuntimeInvalidatedResourceUse2(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -8445,29 +7689,29 @@ func TestRuntimeInvalidatedResourceUse2(t *testing.T) {
 	accountCodes := map[Location][]byte{}
 	var events []cadence.Event
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return signers, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) (err error) {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	attacker := []byte(fmt.Sprintf(`
         import VictimContract from %s
@@ -8642,8 +7886,9 @@ func TestRuntimeInvalidRecursiveTransferViaVariableDeclaration(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
-	runtime.defaultConfig.AtreeValidationEnabled = false
+	runtime := NewTestInterpreterRuntimeWithConfig(Config{
+		AtreeValidationEnabled: false,
+	})
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
@@ -8699,29 +7944,29 @@ func TestRuntimeInvalidRecursiveTransferViaVariableDeclaration(t *testing.T) {
 	var accountCode []byte
 	var events []cadence.Event
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{address}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy
 
@@ -8756,8 +8001,9 @@ func TestRuntimeInvalidRecursiveTransferViaFunctionArgument(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
-	runtime.defaultConfig.AtreeValidationEnabled = false
+	runtime := NewTestInterpreterRuntimeWithConfig(Config{
+		AtreeValidationEnabled: false,
+	})
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
@@ -8806,29 +8052,29 @@ func TestRuntimeInvalidRecursiveTransferViaFunctionArgument(t *testing.T) {
 	var accountCode []byte
 	var events []cadence.Event
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return accountCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{address}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			return accountCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			accountCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy
 
@@ -8903,7 +8149,7 @@ func TestRuntimeOptionalReferenceAttack(t *testing.T) {
       }
     `
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	accountCodes := map[common.Location][]byte{}
 
@@ -8911,34 +8157,34 @@ func TestRuntimeOptionalReferenceAttack(t *testing.T) {
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
-	storage := newTestLedger(nil, nil)
+	storage := NewTestLedger(nil, nil)
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: storage,
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: storage,
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAccount}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		log: func(s string) {
+		OnProgramLog: func(s string) {
 
 		},
-	}
-	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-		return json.Decode(nil, b)
+		OnDecodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
+			return json.Decode(nil, b)
+		},
 	}
 
 	_, err := runtime.ExecuteScript(
@@ -8966,7 +8212,7 @@ func TestRuntimeReturnDestroyedOptional(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	script := []byte(`
       access(all) resource Foo {}
@@ -8985,8 +8231,8 @@ func TestRuntimeReturnDestroyedOptional(t *testing.T) {
       }
     `)
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: newTestLedger(nil, nil),
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: NewTestLedger(nil, nil),
 	}
 
 	// Test
@@ -9009,7 +8255,7 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	t.Run("regular error returned", func(t *testing.T) {
 		t.Parallel()
@@ -9022,9 +8268,9 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
             }
         `)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			meterComputation: func(compKind common.ComputationKind, intensity uint) error {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnMeterComputation: func(compKind common.ComputationKind, intensity uint) error {
 				return fmt.Errorf("computation limit exceeded")
 			},
 		}
@@ -9057,9 +8303,9 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
             }
         `)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			meterComputation: func(compKind common.ComputationKind, intensity uint) error {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnMeterComputation: func(compKind common.ComputationKind, intensity uint) error {
 				panic(fmt.Errorf("computation limit exceeded"))
 			},
 		}
@@ -9092,9 +8338,9 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
             }
         `)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			meterComputation: func(compKind common.ComputationKind, intensity uint) error {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnMeterComputation: func(compKind common.ComputationKind, intensity uint) error {
 				// Cause a runtime error
 				var x any = "hello"
 				_ = x.(int)
@@ -9129,9 +8375,9 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
             }
         `)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			meterComputation: func(compKind common.ComputationKind, intensity uint) (err error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnMeterComputation: func(compKind common.ComputationKind, intensity uint) (err error) {
 				// Cause a runtime error. Catch it and return.
 				var x any = "hello"
 				defer func() {
@@ -9222,8 +8468,9 @@ func TestRuntimeWrappedErrorHandling(t *testing.T) {
         }
     `)
 
-	runtime := newTestInterpreterRuntime()
-	runtime.defaultConfig.AtreeValidationEnabled = false
+	runtime := NewTestInterpreterRuntimeWithConfig(Config{
+		AtreeValidationEnabled: false,
+	})
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
@@ -9234,30 +8481,30 @@ func TestRuntimeWrappedErrorHandling(t *testing.T) {
 
 	isContractBroken := false
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(_ Location) (bytes []byte, err error) {
 			return contractCode, nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{address}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 			if isContractBroken && contractCode != nil {
 				return brokenFoo, nil
 			}
 			return contractCode, nil
 		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
 			contractCode = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		getAndSetProgram: func(location Location, load func() (*interpreter.Program, error)) (*interpreter.Program, error) {
+		OnGetAndSetProgram: func(location Location, load func() (*interpreter.Program, error)) (*interpreter.Program, error) {
 			program, err := load()
 			if err == nil {
 				return program, nil
@@ -9266,7 +8513,7 @@ func TestRuntimeWrappedErrorHandling(t *testing.T) {
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy
 
@@ -9318,7 +8565,7 @@ func TestRuntimeWrappedErrorHandling(t *testing.T) {
 
 func BenchmarkRuntimeResourceTracking(b *testing.B) {
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	contractsAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -9326,33 +8573,33 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
 
 	signerAccount := contractsAddress
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(location Location) (bytes []byte, err error) {
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
 			return accountCodes[location], nil
 		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAccount}, nil
 		},
-		resolveLocation: singleIdentifierLocationResolver(b),
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnResolveLocation: NewSingleIdentifierLocationResolver(b),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			return accountCodes[location], nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			return nil
 		},
-	}
-	runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-		return json.Decode(runtimeInterface, b)
+		OnDecodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
+			return json.Decode(nil, b)
+		},
 	}
 
 	environment := NewBaseInterpreterEnvironment(Config{})
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy contract
 
@@ -9499,7 +8746,7 @@ func TestRuntimeEventEmission(t *testing.T) {
 	t.Run("primitive", func(t *testing.T) {
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
           access(all)
@@ -9513,15 +8760,15 @@ func TestRuntimeEventEmission(t *testing.T) {
 
 		var events []cadence.Event
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			emitEvent: func(event cadence.Event) error {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnEmitEvent: func(event cadence.Event) error {
 				events = append(events, event)
 				return nil
 			},
 		}
 
-		nextScriptLocation := newScriptLocationGenerator()
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		location := nextScriptLocation()
 
@@ -9558,7 +8805,7 @@ func TestRuntimeEventEmission(t *testing.T) {
 	t.Run("reference", func(t *testing.T) {
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
           access(all)
@@ -9572,15 +8819,15 @@ func TestRuntimeEventEmission(t *testing.T) {
 
 		var events []cadence.Event
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: newTestLedger(nil, nil),
-			emitEvent: func(event cadence.Event) error {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnEmitEvent: func(event cadence.Event) error {
 				events = append(events, event)
 				return nil
 			},
 		}
 
-		nextScriptLocation := newScriptLocationGenerator()
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		location := nextScriptLocation()
 

--- a/runtime/sharedstate_test.go
+++ b/runtime/sharedstate_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"testing"
@@ -25,8 +25,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -34,7 +36,7 @@ func TestRuntimeSharedState(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	signerAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -63,7 +65,7 @@ func TestRuntimeSharedState(t *testing.T) {
 
 	var ledgerReads []ownerKeyPair
 
-	ledger := newTestLedger(
+	ledger := NewTestLedger(
 		func(owner, key, value []byte) {
 			ledgerReads = append(
 				ledgerReads,
@@ -76,42 +78,42 @@ func TestRuntimeSharedState(t *testing.T) {
 		nil,
 	)
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: ledger,
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: ledger,
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signerAddress}, nil
 		},
-		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
 			accountCodes[location] = code
 			return nil
 		},
-		getAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 			code = accountCodes[location]
 			return code, nil
 		},
-		removeAccountContractCode: func(location common.AddressLocation) error {
+		OnRemoveAccountContractCode: func(location common.AddressLocation) error {
 			delete(accountCodes, location)
 			return nil
 		},
-		resolveLocation: multipleIdentifierLocationResolver,
-		log: func(message string) {
+		OnResolveLocation: MultipleIdentifierLocationResolver,
+		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
 		},
-		emitEvent: func(event cadence.Event) error {
+		OnEmitEvent: func(event cadence.Event) error {
 			events = append(events, event)
 			return nil
 		},
-		setInterpreterSharedState: func(state *interpreter.SharedState) {
+		OnSetInterpreterSharedState: func(state *interpreter.SharedState) {
 			interpreterState = state
 		},
-		getInterpreterSharedState: func() *interpreter.SharedState {
+		OnGetInterpreterSharedState: func() *interpreter.SharedState {
 			return interpreterState
 		},
 	}
 
 	environment := NewBaseInterpreterEnvironment(Config{})
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy contracts
 

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -35,7 +35,7 @@ const StorageDomainContract = "contract"
 
 type Storage struct {
 	*atree.PersistentSlabStorage
-	newStorageMaps  *orderedmap.OrderedMap[interpreter.StorageKey, atree.StorageIndex]
+	NewStorageMaps  *orderedmap.OrderedMap[interpreter.StorageKey, atree.StorageIndex]
 	storageMaps     map[interpreter.StorageKey]*interpreter.StorageMap
 	contractUpdates *orderedmap.OrderedMap[interpreter.StorageKey, *interpreter.CompositeValue]
 	Ledger          atree.Ledger
@@ -124,7 +124,7 @@ func (s *Storage) GetStorageMap(
 			copy(storageIndex[:], data[:])
 			storageMap = s.loadExistingStorageMap(atreeAddress, storageIndex)
 		} else if createIfNotExists {
-			storageMap = s.storeNewStorageMap(atreeAddress, domain)
+			storageMap = s.StoreNewStorageMap(atreeAddress, domain)
 		}
 
 		if storageMap != nil {
@@ -145,17 +145,17 @@ func (s *Storage) loadExistingStorageMap(address atree.Address, storageIndex atr
 	return interpreter.NewStorageMapWithRootID(s, storageID)
 }
 
-func (s *Storage) storeNewStorageMap(address atree.Address, domain string) *interpreter.StorageMap {
+func (s *Storage) StoreNewStorageMap(address atree.Address, domain string) *interpreter.StorageMap {
 	storageMap := interpreter.NewStorageMap(s.memoryGauge, s, address)
 
 	storageIndex := storageMap.StorageID().Index
 
 	storageKey := interpreter.NewStorageKey(s.memoryGauge, common.Address(address), domain)
 
-	if s.newStorageMaps == nil {
-		s.newStorageMaps = &orderedmap.OrderedMap[interpreter.StorageKey, atree.StorageIndex]{}
+	if s.NewStorageMaps == nil {
+		s.NewStorageMaps = &orderedmap.OrderedMap[interpreter.StorageKey, atree.StorageIndex]{}
 	}
-	s.newStorageMaps.Set(storageKey, storageIndex)
+	s.NewStorageMaps.Set(storageKey, storageIndex)
 
 	return storageMap
 }
@@ -244,11 +244,11 @@ func (s *Storage) Commit(inter *interpreter.Interpreter, commitContractUpdates b
 }
 
 func (s *Storage) commitNewStorageMaps() error {
-	if s.newStorageMaps == nil {
+	if s.NewStorageMaps == nil {
 		return nil
 	}
 
-	for pair := s.newStorageMaps.Oldest(); pair != nil; pair = pair.Next() {
+	for pair := s.NewStorageMaps.Oldest(); pair != nil; pair = pair.Next() {
 		var err error
 		errors.WrapPanic(func() {
 			err = s.Ledger.SetValue(
@@ -336,7 +336,7 @@ func (s *Storage) CheckHealth() error {
 			return a.Compare(b) < 0
 		})
 
-		return errors.NewUnexpectedError("slabs not referenced from account storage: %s", unreferencedRootSlabIDs)
+		return errors.NewUnexpectedError("slabs not referenced from account Storage: %s", unreferencedRootSlabIDs)
 	}
 
 	return nil

--- a/runtime/tests/runtime_utils/interpreter.go
+++ b/runtime/tests/runtime_utils/interpreter.go
@@ -1,0 +1,49 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime_utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/tests/utils"
+)
+
+func NewTestInterpreter(tb testing.TB) *interpreter.Interpreter {
+	storage := NewUnmeteredInMemoryStorage()
+
+	inter, err := interpreter.NewInterpreter(
+		nil,
+		utils.TestLocation,
+		&interpreter.Config{
+			Storage:                       storage,
+			AtreeValueValidationEnabled:   true,
+			AtreeStorageValidationEnabled: true,
+		},
+	)
+	require.NoError(tb, err)
+
+	return inter
+}
+
+func NewUnmeteredInMemoryStorage() interpreter.Storage {
+	return interpreter.NewInMemoryStorage(nil)
+}

--- a/runtime/tests/runtime_utils/location.go
+++ b/runtime/tests/runtime_utils/location.go
@@ -1,0 +1,104 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime_utils
+
+import (
+	"encoding/binary"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime"
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+func NewLocationGenerator[T ~[32]byte]() func() T {
+	var count uint64
+	return func() T {
+		t := T{}
+		newCount := atomic.AddUint64(&count, 1)
+		binary.LittleEndian.PutUint64(t[:], newCount)
+		return t
+	}
+}
+
+func NewTransactionLocationGenerator() func() common.TransactionLocation {
+	return NewLocationGenerator[common.TransactionLocation]()
+}
+
+func NewScriptLocationGenerator() func() common.ScriptLocation {
+	return NewLocationGenerator[common.ScriptLocation]()
+}
+
+func NewSingleIdentifierLocationResolver(t testing.TB) func(
+	identifiers []runtime.Identifier,
+	location runtime.Location,
+) (
+	[]runtime.ResolvedLocation,
+	error,
+) {
+	return func(
+		identifiers []runtime.Identifier,
+		location runtime.Location,
+	) (
+		[]sema.ResolvedLocation,
+		error,
+	) {
+		require.Len(t, identifiers, 1)
+		require.IsType(t, common.AddressLocation{}, location)
+
+		return []sema.ResolvedLocation{
+			{
+				Location: common.AddressLocation{
+					Address: location.(common.AddressLocation).Address,
+					Name:    identifiers[0].Identifier,
+				},
+				Identifiers: identifiers,
+			},
+		}, nil
+	}
+}
+
+func MultipleIdentifierLocationResolver(
+	identifiers []ast.Identifier,
+	location common.Location,
+) (
+	result []sema.ResolvedLocation,
+	err error,
+) {
+
+	// Resolve each identifier as an address location
+
+	for _, identifier := range identifiers {
+		result = append(result, sema.ResolvedLocation{
+			Location: common.AddressLocation{
+				Address: location.(common.AddressLocation).Address,
+				Name:    identifier.Identifier,
+			},
+			Identifiers: []ast.Identifier{
+				identifier,
+			},
+		})
+	}
+
+	return
+}

--- a/runtime/tests/runtime_utils/testinterface.go
+++ b/runtime/tests/runtime_utils/testinterface.go
@@ -589,7 +589,8 @@ func (i *TestRuntimeInterface) onScriptExecutionStart() {
 
 func (i *TestRuntimeInterface) invalidateUpdatedPrograms() {
 	if i.updatedContractCode {
-		for location := range i.Programs {
+		// iteration order does not matter
+		for location := range i.Programs { //nolint:maprange
 			delete(i.Programs, location)
 		}
 		i.updatedContractCode = false

--- a/runtime/tests/runtime_utils/testinterface.go
+++ b/runtime/tests/runtime_utils/testinterface.go
@@ -1,0 +1,597 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime_utils
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"time"
+
+	"github.com/onflow/atree"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/stdlib"
+)
+
+type TestRuntimeInterface struct {
+	Storage TestLedger
+
+	OnResolveLocation func(
+		identifiers []runtime.Identifier,
+		location runtime.Location,
+	) (
+		[]runtime.ResolvedLocation,
+		error,
+	)
+	OnGetCode          func(_ runtime.Location) ([]byte, error)
+	OnGetAndSetProgram func(
+		location runtime.Location,
+		load func() (*interpreter.Program, error),
+	) (*interpreter.Program, error)
+	OnSetInterpreterSharedState func(state *interpreter.SharedState)
+	OnGetInterpreterSharedState func() *interpreter.SharedState
+	OnCreateAccount             func(payer runtime.Address) (address runtime.Address, err error)
+	OnAddEncodedAccountKey      func(address runtime.Address, publicKey []byte) error
+	OnRemoveEncodedAccountKey   func(address runtime.Address, index int) (publicKey []byte, err error)
+	OnAddAccountKey             func(
+		address runtime.Address,
+		publicKey *stdlib.PublicKey,
+		hashAlgo runtime.HashAlgorithm,
+		weight int,
+	) (*stdlib.AccountKey, error)
+	OnGetAccountKey             func(address runtime.Address, index int) (*stdlib.AccountKey, error)
+	OnRemoveAccountKey          func(address runtime.Address, index int) (*stdlib.AccountKey, error)
+	OnAccountKeysCount          func(address runtime.Address) (uint64, error)
+	OnUpdateAccountContractCode func(location common.AddressLocation, code []byte) error
+	OnGetAccountContractCode    func(location common.AddressLocation) (code []byte, err error)
+	OnRemoveAccountContractCode func(location common.AddressLocation) (err error)
+	OnGetSigningAccounts        func() ([]runtime.Address, error)
+	OnProgramLog                func(string)
+	OnEmitEvent                 func(cadence.Event) error
+	OnResourceOwnerChanged      func(
+		interpreter *interpreter.Interpreter,
+		resource *interpreter.CompositeValue,
+		oldAddress common.Address,
+		newAddress common.Address,
+	)
+	OnGenerateUUID       func() (uint64, error)
+	OnMeterComputation   func(compKind common.ComputationKind, intensity uint) error
+	OnDecodeArgument     func(b []byte, t cadence.Type) (cadence.Value, error)
+	OnProgramParsed      func(location runtime.Location, duration time.Duration)
+	OnProgramChecked     func(location runtime.Location, duration time.Duration)
+	OnProgramInterpreted func(location runtime.Location, duration time.Duration)
+	OnReadRandom         func([]byte) error
+	OnVerifySignature    func(
+		signature []byte,
+		tag string,
+		signedData []byte,
+		publicKey []byte,
+		signatureAlgorithm runtime.SignatureAlgorithm,
+		hashAlgorithm runtime.HashAlgorithm,
+	) (bool, error)
+	OnHash func(
+		data []byte,
+		tag string,
+		hashAlgorithm runtime.HashAlgorithm,
+	) ([]byte, error)
+	OnSetCadenceValue            func(owner runtime.Address, key string, value cadence.Value) (err error)
+	OnGetAccountBalance          func(_ runtime.Address) (uint64, error)
+	OnGetAccountAvailableBalance func(_ runtime.Address) (uint64, error)
+	OnGetStorageUsed             func(_ runtime.Address) (uint64, error)
+	OnGetStorageCapacity         func(_ runtime.Address) (uint64, error)
+	Programs                     map[runtime.Location]*interpreter.Program
+	OnImplementationDebugLog     func(message string) error
+	OnValidatePublicKey          func(publicKey *stdlib.PublicKey) error
+	OnBLSVerifyPOP               func(pk *stdlib.PublicKey, s []byte) (bool, error)
+	OnBLSAggregateSignatures     func(sigs [][]byte) ([]byte, error)
+	OnBLSAggregatePublicKeys     func(keys []*stdlib.PublicKey) (*stdlib.PublicKey, error)
+	OnGetAccountContractNames    func(address runtime.Address) ([]string, error)
+	OnRecordTrace                func(
+		operation string,
+		location runtime.Location,
+		duration time.Duration,
+		attrs []attribute.KeyValue,
+	)
+	OnMeterMemory       func(usage common.MemoryUsage) error
+	OnComputationUsed   func() (uint64, error)
+	OnMemoryUsed        func() (uint64, error)
+	OnInteractionUsed   func() (uint64, error)
+	OnGenerateAccountID func(address common.Address) (uint64, error)
+
+	lastUUID            uint64
+	accountIDs          map[common.Address]uint64
+	updatedContractCode bool
+}
+
+// TestRuntimeInterface should implement Interface
+var _ runtime.Interface = &TestRuntimeInterface{}
+
+func (i *TestRuntimeInterface) ResolveLocation(
+	identifiers []runtime.Identifier,
+	location runtime.Location,
+) ([]runtime.ResolvedLocation, error) {
+	if i.OnResolveLocation == nil {
+		return []runtime.ResolvedLocation{
+			{
+				Location:    location,
+				Identifiers: identifiers,
+			},
+		}, nil
+	}
+	return i.OnResolveLocation(identifiers, location)
+}
+
+func (i *TestRuntimeInterface) GetCode(location runtime.Location) ([]byte, error) {
+	if i.OnGetCode == nil {
+		return nil, nil
+	}
+	return i.OnGetCode(location)
+}
+
+func (i *TestRuntimeInterface) GetOrLoadProgram(
+	location runtime.Location,
+	load func() (*interpreter.Program, error),
+) (
+	program *interpreter.Program,
+	err error,
+) {
+	if i.OnGetAndSetProgram == nil {
+		if i.Programs == nil {
+			i.Programs = map[runtime.Location]*interpreter.Program{}
+		}
+
+		var ok bool
+		program, ok = i.Programs[location]
+		if ok {
+			return
+		}
+
+		program, err = load()
+
+		// NOTE: important: still set empty program,
+		// even if error occurred
+
+		i.Programs[location] = program
+
+		return
+	}
+
+	return i.OnGetAndSetProgram(location, load)
+}
+
+func (i *TestRuntimeInterface) SetInterpreterSharedState(state *interpreter.SharedState) {
+	if i.OnSetInterpreterSharedState == nil {
+		return
+	}
+
+	i.OnSetInterpreterSharedState(state)
+}
+
+func (i *TestRuntimeInterface) GetInterpreterSharedState() *interpreter.SharedState {
+	if i.OnGetInterpreterSharedState == nil {
+		return nil
+	}
+
+	return i.OnGetInterpreterSharedState()
+}
+
+func (i *TestRuntimeInterface) ValueExists(owner, key []byte) (exists bool, err error) {
+	if i.Storage.OnValueExists == nil {
+		panic("must specify testRuntimeInterface.storage.valueExists")
+	}
+	return i.Storage.ValueExists(owner, key)
+}
+
+func (i *TestRuntimeInterface) GetValue(owner, key []byte) (value []byte, err error) {
+	if i.Storage.OnGetValue == nil {
+		panic("must specify testRuntimeInterface.storage.getValue")
+	}
+	return i.Storage.GetValue(owner, key)
+}
+
+func (i *TestRuntimeInterface) SetValue(owner, key, value []byte) (err error) {
+	if i.Storage.OnSetValue == nil {
+		panic("must specify testRuntimeInterface.storage.setValue")
+	}
+	return i.Storage.SetValue(owner, key, value)
+}
+
+func (i *TestRuntimeInterface) AllocateStorageIndex(owner []byte) (atree.StorageIndex, error) {
+	if i.Storage.OnAllocateStorageIndex == nil {
+		panic("must specify testRuntimeInterface.storage.allocateStorageIndex")
+	}
+	return i.Storage.AllocateStorageIndex(owner)
+}
+
+func (i *TestRuntimeInterface) CreateAccount(payer runtime.Address) (address runtime.Address, err error) {
+	if i.OnCreateAccount == nil {
+		panic("must specify testRuntimeInterface.createAccount")
+	}
+	return i.OnCreateAccount(payer)
+}
+
+func (i *TestRuntimeInterface) AddEncodedAccountKey(address runtime.Address, publicKey []byte) error {
+	if i.OnAddEncodedAccountKey == nil {
+		panic("must specify testRuntimeInterface.addEncodedAccountKey")
+	}
+	return i.OnAddEncodedAccountKey(address, publicKey)
+}
+
+func (i *TestRuntimeInterface) RevokeEncodedAccountKey(address runtime.Address, index int) ([]byte, error) {
+	if i.OnRemoveEncodedAccountKey == nil {
+		panic("must specify testRuntimeInterface.removeEncodedAccountKey")
+	}
+	return i.OnRemoveEncodedAccountKey(address, index)
+}
+
+func (i *TestRuntimeInterface) AddAccountKey(
+	address runtime.Address,
+	publicKey *stdlib.PublicKey,
+	hashAlgo runtime.HashAlgorithm,
+	weight int,
+) (*stdlib.AccountKey, error) {
+	if i.OnAddAccountKey == nil {
+		panic("must specify testRuntimeInterface.addAccountKey")
+	}
+	return i.OnAddAccountKey(address, publicKey, hashAlgo, weight)
+}
+
+func (i *TestRuntimeInterface) GetAccountKey(address runtime.Address, index int) (*stdlib.AccountKey, error) {
+	if i.OnGetAccountKey == nil {
+		panic("must specify testRuntimeInterface.getAccountKey")
+	}
+	return i.OnGetAccountKey(address, index)
+}
+
+func (i *TestRuntimeInterface) AccountKeysCount(address runtime.Address) (uint64, error) {
+	if i.OnAccountKeysCount == nil {
+		panic("must specify testRuntimeInterface.accountKeysCount")
+	}
+	return i.OnAccountKeysCount(address)
+}
+
+func (i *TestRuntimeInterface) RevokeAccountKey(address runtime.Address, index int) (*stdlib.AccountKey, error) {
+	if i.OnRemoveAccountKey == nil {
+		panic("must specify testRuntimeInterface.removeAccountKey")
+	}
+	return i.OnRemoveAccountKey(address, index)
+}
+
+func (i *TestRuntimeInterface) UpdateAccountContractCode(location common.AddressLocation, code []byte) (err error) {
+	if i.OnUpdateAccountContractCode == nil {
+		panic("must specify testRuntimeInterface.updateAccountContractCode")
+	}
+
+	err = i.OnUpdateAccountContractCode(location, code)
+	if err != nil {
+		return err
+	}
+
+	i.updatedContractCode = true
+
+	return nil
+}
+
+func (i *TestRuntimeInterface) GetAccountContractCode(location common.AddressLocation) (code []byte, err error) {
+	if i.OnGetAccountContractCode == nil {
+		panic("must specify testRuntimeInterface.getAccountContractCode")
+	}
+	return i.OnGetAccountContractCode(location)
+}
+
+func (i *TestRuntimeInterface) RemoveAccountContractCode(location common.AddressLocation) (err error) {
+	if i.OnRemoveAccountContractCode == nil {
+		panic("must specify testRuntimeInterface.removeAccountContractCode")
+	}
+	return i.OnRemoveAccountContractCode(location)
+}
+
+func (i *TestRuntimeInterface) GetSigningAccounts() ([]runtime.Address, error) {
+	if i.OnGetSigningAccounts == nil {
+		return nil, nil
+	}
+	return i.OnGetSigningAccounts()
+}
+
+func (i *TestRuntimeInterface) ProgramLog(message string) error {
+	i.OnProgramLog(message)
+	return nil
+}
+
+func (i *TestRuntimeInterface) EmitEvent(event cadence.Event) error {
+	return i.OnEmitEvent(event)
+}
+
+func (i *TestRuntimeInterface) ResourceOwnerChanged(
+	interpreter *interpreter.Interpreter,
+	resource *interpreter.CompositeValue,
+	oldOwner common.Address,
+	newOwner common.Address,
+) {
+	if i.OnResourceOwnerChanged != nil {
+		i.OnResourceOwnerChanged(
+			interpreter,
+			resource,
+			oldOwner,
+			newOwner,
+		)
+	}
+}
+
+func (i *TestRuntimeInterface) GenerateUUID() (uint64, error) {
+	if i.OnGenerateUUID == nil {
+		i.lastUUID++
+		return i.lastUUID, nil
+	}
+	return i.OnGenerateUUID()
+}
+
+func (i *TestRuntimeInterface) MeterComputation(compKind common.ComputationKind, intensity uint) error {
+	if i.OnMeterComputation == nil {
+		return nil
+	}
+	return i.OnMeterComputation(compKind, intensity)
+}
+
+func (i *TestRuntimeInterface) DecodeArgument(b []byte, t cadence.Type) (cadence.Value, error) {
+	return i.OnDecodeArgument(b, t)
+}
+
+func (i *TestRuntimeInterface) ProgramParsed(location runtime.Location, duration time.Duration) {
+	if i.OnProgramParsed == nil {
+		return
+	}
+	i.OnProgramParsed(location, duration)
+}
+
+func (i *TestRuntimeInterface) ProgramChecked(location runtime.Location, duration time.Duration) {
+	if i.OnProgramChecked == nil {
+		return
+	}
+	i.OnProgramChecked(location, duration)
+}
+
+func (i *TestRuntimeInterface) ProgramInterpreted(location runtime.Location, duration time.Duration) {
+	if i.OnProgramInterpreted == nil {
+		return
+	}
+	i.OnProgramInterpreted(location, duration)
+}
+
+func (i *TestRuntimeInterface) GetCurrentBlockHeight() (uint64, error) {
+	return 1, nil
+}
+
+func (i *TestRuntimeInterface) GetBlockAtHeight(height uint64) (block stdlib.Block, exists bool, err error) {
+
+	buf := new(bytes.Buffer)
+	err = binary.Write(buf, binary.BigEndian, height)
+	if err != nil {
+		panic(err)
+	}
+
+	encoded := buf.Bytes()
+	var hash stdlib.BlockHash
+	copy(hash[sema.BlockTypeIdFieldType.Size-int64(len(encoded)):], encoded)
+
+	block = stdlib.Block{
+		Height:    height,
+		View:      height,
+		Hash:      hash,
+		Timestamp: time.Unix(int64(height), 0).UnixNano(),
+	}
+	return block, true, nil
+}
+
+func (i *TestRuntimeInterface) ReadRandom(buffer []byte) error {
+	if i.OnReadRandom == nil {
+		return nil
+	}
+	return i.OnReadRandom(buffer)
+}
+
+func (i *TestRuntimeInterface) VerifySignature(
+	signature []byte,
+	tag string,
+	signedData []byte,
+	publicKey []byte,
+	signatureAlgorithm runtime.SignatureAlgorithm,
+	hashAlgorithm runtime.HashAlgorithm,
+) (bool, error) {
+	if i.OnVerifySignature == nil {
+		return false, nil
+	}
+	return i.OnVerifySignature(
+		signature,
+		tag,
+		signedData,
+		publicKey,
+		signatureAlgorithm,
+		hashAlgorithm,
+	)
+}
+
+func (i *TestRuntimeInterface) Hash(data []byte, tag string, hashAlgorithm runtime.HashAlgorithm) ([]byte, error) {
+	if i.OnHash == nil {
+		return nil, nil
+	}
+	return i.OnHash(data, tag, hashAlgorithm)
+}
+
+func (i *TestRuntimeInterface) SetCadenceValue(owner common.Address, key string, value cadence.Value) (err error) {
+	if i.OnSetCadenceValue == nil {
+		panic("must specify testRuntimeInterface.setCadenceValue")
+	}
+	return i.OnSetCadenceValue(owner, key, value)
+}
+
+func (i *TestRuntimeInterface) GetAccountBalance(address runtime.Address) (uint64, error) {
+	if i.OnGetAccountBalance == nil {
+		panic("must specify testRuntimeInterface.getAccountBalance")
+	}
+	return i.OnGetAccountBalance(address)
+}
+
+func (i *TestRuntimeInterface) GetAccountAvailableBalance(address runtime.Address) (uint64, error) {
+	if i.OnGetAccountAvailableBalance == nil {
+		panic("must specify testRuntimeInterface.getAccountAvailableBalance")
+	}
+	return i.OnGetAccountAvailableBalance(address)
+}
+
+func (i *TestRuntimeInterface) GetStorageUsed(address runtime.Address) (uint64, error) {
+	if i.OnGetStorageUsed == nil {
+		panic("must specify testRuntimeInterface.getStorageUsed")
+	}
+	return i.OnGetStorageUsed(address)
+}
+
+func (i *TestRuntimeInterface) GetStorageCapacity(address runtime.Address) (uint64, error) {
+	if i.OnGetStorageCapacity == nil {
+		panic("must specify testRuntimeInterface.getStorageCapacity")
+	}
+	return i.OnGetStorageCapacity(address)
+}
+
+func (i *TestRuntimeInterface) ImplementationDebugLog(message string) error {
+	if i.OnImplementationDebugLog == nil {
+		return nil
+	}
+	return i.OnImplementationDebugLog(message)
+}
+
+func (i *TestRuntimeInterface) ValidatePublicKey(key *stdlib.PublicKey) error {
+	if i.OnValidatePublicKey == nil {
+		return errors.New("mock defaults to public key validation failure")
+	}
+
+	return i.OnValidatePublicKey(key)
+}
+
+func (i *TestRuntimeInterface) BLSVerifyPOP(key *stdlib.PublicKey, s []byte) (bool, error) {
+	if i.OnBLSVerifyPOP == nil {
+		return false, nil
+	}
+
+	return i.OnBLSVerifyPOP(key, s)
+}
+
+func (i *TestRuntimeInterface) BLSAggregateSignatures(sigs [][]byte) ([]byte, error) {
+	if i.OnBLSAggregateSignatures == nil {
+		return []byte{}, nil
+	}
+
+	return i.OnBLSAggregateSignatures(sigs)
+}
+
+func (i *TestRuntimeInterface) BLSAggregatePublicKeys(keys []*stdlib.PublicKey) (*stdlib.PublicKey, error) {
+	if i.OnBLSAggregatePublicKeys == nil {
+		return nil, nil
+	}
+
+	return i.OnBLSAggregatePublicKeys(keys)
+}
+
+func (i *TestRuntimeInterface) GetAccountContractNames(address runtime.Address) ([]string, error) {
+	if i.OnGetAccountContractNames == nil {
+		return []string{}, nil
+	}
+
+	return i.OnGetAccountContractNames(address)
+}
+
+func (i *TestRuntimeInterface) GenerateAccountID(address common.Address) (uint64, error) {
+	if i.OnGenerateAccountID == nil {
+		if i.accountIDs == nil {
+			i.accountIDs = map[common.Address]uint64{}
+		}
+		i.accountIDs[address]++
+		return i.accountIDs[address], nil
+	}
+
+	return i.OnGenerateAccountID(address)
+}
+
+func (i *TestRuntimeInterface) RecordTrace(
+	operation string,
+	location runtime.Location,
+	duration time.Duration,
+	attrs []attribute.KeyValue,
+) {
+	if i.OnRecordTrace == nil {
+		return
+	}
+	i.OnRecordTrace(operation, location, duration, attrs)
+}
+
+func (i *TestRuntimeInterface) MeterMemory(usage common.MemoryUsage) error {
+	if i.OnMeterMemory == nil {
+		return nil
+	}
+
+	return i.OnMeterMemory(usage)
+}
+
+func (i *TestRuntimeInterface) ComputationUsed() (uint64, error) {
+	if i.OnComputationUsed == nil {
+		return 0, nil
+	}
+
+	return i.OnComputationUsed()
+}
+
+func (i *TestRuntimeInterface) MemoryUsed() (uint64, error) {
+	if i.OnMemoryUsed == nil {
+		return 0, nil
+	}
+
+	return i.OnMemoryUsed()
+}
+
+func (i *TestRuntimeInterface) InteractionUsed() (uint64, error) {
+	if i.OnInteractionUsed == nil {
+		return 0, nil
+	}
+
+	return i.OnInteractionUsed()
+}
+
+func (i *TestRuntimeInterface) onTransactionExecutionStart() {
+	i.invalidateUpdatedPrograms()
+}
+
+func (i *TestRuntimeInterface) onScriptExecutionStart() {
+	i.invalidateUpdatedPrograms()
+}
+
+func (i *TestRuntimeInterface) invalidateUpdatedPrograms() {
+	if i.updatedContractCode {
+		for location := range i.Programs {
+			delete(i.Programs, location)
+		}
+		i.updatedContractCode = false
+	}
+}

--- a/runtime/tests/runtime_utils/testledger.go
+++ b/runtime/tests/runtime_utils/testledger.go
@@ -1,0 +1,105 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime_utils
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/onflow/atree"
+)
+
+type TestLedger struct {
+	StoredValues           map[string][]byte
+	OnValueExists          func(owner, key []byte) (exists bool, err error)
+	OnGetValue             func(owner, key []byte) (value []byte, err error)
+	OnSetValue             func(owner, key, value []byte) (err error)
+	OnAllocateStorageIndex func(owner []byte) (atree.StorageIndex, error)
+}
+
+var _ atree.Ledger = TestLedger{}
+
+func (s TestLedger) GetValue(owner, key []byte) (value []byte, err error) {
+	return s.OnGetValue(owner, key)
+}
+
+func (s TestLedger) SetValue(owner, key, value []byte) (err error) {
+	return s.OnSetValue(owner, key, value)
+}
+
+func (s TestLedger) ValueExists(owner, key []byte) (exists bool, err error) {
+	return s.OnValueExists(owner, key)
+}
+
+func (s TestLedger) AllocateStorageIndex(owner []byte) (atree.StorageIndex, error) {
+	return s.OnAllocateStorageIndex(owner)
+}
+
+func (s TestLedger) Dump() {
+	for key, data := range s.StoredValues {
+		fmt.Printf("%s:\n", strconv.Quote(key))
+		fmt.Printf("%s\n", hex.Dump(data))
+		println()
+	}
+}
+
+func NewTestLedger(
+	onRead func(owner, key, value []byte),
+	onWrite func(owner, key, value []byte),
+) TestLedger {
+
+	storageKey := func(owner, key string) string {
+		return strings.Join([]string{owner, key}, "|")
+	}
+
+	storedValues := map[string][]byte{}
+
+	storageIndices := map[string]uint64{}
+
+	return TestLedger{
+		StoredValues: storedValues,
+		OnValueExists: func(owner, key []byte) (bool, error) {
+			value := storedValues[storageKey(string(owner), string(key))]
+			return len(value) > 0, nil
+		},
+		OnGetValue: func(owner, key []byte) (value []byte, err error) {
+			value = storedValues[storageKey(string(owner), string(key))]
+			if onRead != nil {
+				onRead(owner, key, value)
+			}
+			return value, nil
+		},
+		OnSetValue: func(owner, key, value []byte) (err error) {
+			storedValues[storageKey(string(owner), string(key))] = value
+			if onWrite != nil {
+				onWrite(owner, key, value)
+			}
+			return nil
+		},
+		OnAllocateStorageIndex: func(owner []byte) (result atree.StorageIndex, err error) {
+			index := storageIndices[string(owner)] + 1
+			storageIndices[string(owner)] = index
+			binary.BigEndian.PutUint64(result[:], index)
+			return
+		},
+	}
+}

--- a/runtime/tests/runtime_utils/testledger.go
+++ b/runtime/tests/runtime_utils/testledger.go
@@ -55,7 +55,8 @@ func (s TestLedger) AllocateStorageIndex(owner []byte) (atree.StorageIndex, erro
 }
 
 func (s TestLedger) Dump() {
-	for key, data := range s.StoredValues {
+	// Only used for testing/debugging purposes
+	for key, data := range s.StoredValues { //nolint:maprange
 		fmt.Printf("%s:\n", strconv.Quote(key))
 		fmt.Printf("%s\n", hex.Dump(data))
 		println()

--- a/runtime/tests/runtime_utils/testruntime.go
+++ b/runtime/tests/runtime_utils/testruntime.go
@@ -1,0 +1,69 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime_utils
+
+import (
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/json"
+	"github.com/onflow/cadence/runtime"
+)
+
+type TestInterpreterRuntime struct {
+	runtime.Runtime
+}
+
+var _ runtime.Runtime = TestInterpreterRuntime{}
+
+func NewTestInterpreterRuntimeWithConfig(config runtime.Config) TestInterpreterRuntime {
+	return TestInterpreterRuntime{
+		Runtime: runtime.NewInterpreterRuntime(config),
+	}
+}
+
+var DefaultTestInterpreterConfig = runtime.Config{
+	AtreeValidationEnabled: true,
+}
+
+func NewTestInterpreterRuntime() TestInterpreterRuntime {
+	return NewTestInterpreterRuntimeWithConfig(DefaultTestInterpreterConfig)
+}
+
+func NewTestInterpreterRuntimeWithAttachments() TestInterpreterRuntime {
+	config := DefaultTestInterpreterConfig
+	config.AttachmentsEnabled = true
+	return NewTestInterpreterRuntimeWithConfig(config)
+}
+
+func (r TestInterpreterRuntime) ExecuteTransaction(script runtime.Script, context runtime.Context) error {
+	i := context.Interface.(*TestRuntimeInterface)
+	i.onTransactionExecutionStart()
+	return r.Runtime.ExecuteTransaction(script, context)
+}
+
+func (r TestInterpreterRuntime) ExecuteScript(script runtime.Script, context runtime.Context) (cadence.Value, error) {
+	i := context.Interface.(*TestRuntimeInterface)
+	i.onScriptExecutionStart()
+	value, err := r.Runtime.ExecuteScript(script, context)
+	// If there was a return value, let's also ensure it can be encoded
+	// TODO: also test CCF
+	if value != nil && err == nil {
+		_ = json.MustEncode(value)
+	}
+	return value, err
+}

--- a/runtime/type_test.go
+++ b/runtime/type_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"testing"
@@ -25,14 +25,16 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 )
 
 func TestRuntimeTypeStorage(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := newTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntime()
 
 	tx1 := []byte(`
       transaction {
@@ -53,19 +55,19 @@ func TestRuntimeTypeStorage(t *testing.T) {
 
 	var loggedMessage string
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
+	runtimeInterface := &TestRuntimeInterface{
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{
 				common.MustBytesToAddress([]byte{42}),
 			}, nil
 		},
-		log: func(message string) {
+		OnProgramLog: func(message string) {
 			loggedMessage = message
 		},
 	}
 
-	nextTransactionLocation := newTransactionLocationGenerator()
+	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -100,7 +102,7 @@ func TestRuntimeBlockFieldTypes(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
             transaction {
@@ -122,19 +124,19 @@ func TestRuntimeBlockFieldTypes(t *testing.T) {
 
 		var loggedMessages []string
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return nil, nil
 			},
-			log: func(message string) {
+			OnProgramLog: func(message string) {
 				loggedMessages = append(loggedMessages, message)
 			},
 		}
 
-		nextTransactionLocation := newTransactionLocationGenerator()
+		nextTransactionLocation := NewTransactionLocationGenerator()
 		err := runtime.ExecuteTransaction(
 			Script{
 				Source: script,
@@ -160,7 +162,7 @@ func TestRuntimeBlockFieldTypes(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
             access(all) fun main(): [UFix64] {
@@ -181,13 +183,13 @@ func TestRuntimeBlockFieldTypes(t *testing.T) {
             }
         `)
 
-		storage := newTestLedger(nil, nil)
+		storage := NewTestLedger(nil, nil)
 
 		var loggedMessages []string
 
-		runtimeInterface := &testRuntimeInterface{
-			storage: storage,
-			log: func(message string) {
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: storage,
+			OnProgramLog: func(message string) {
 				loggedMessages = append(loggedMessages, message)
 			},
 		}

--- a/runtime/validation_test.go
+++ b/runtime/validation_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package runtime
+package runtime_test
 
 import (
 	"testing"
@@ -25,8 +25,10 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
+	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -42,25 +44,22 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
           transaction(value: AnyStruct) {}
         `)
 
-		runtimeInterface := &testRuntimeInterface{
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return nil, nil
 			},
-			getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+			OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 				return nil, nil
 			},
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		err := runtime.ExecuteTransaction(
@@ -92,25 +91,22 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := newTestInterpreterRuntime()
+		runtime := NewTestInterpreterRuntime()
 
 		script := []byte(`
           access(all) fun main(value: AnyStruct) {}
         `)
 
-		runtimeInterface := &testRuntimeInterface{
-			getSigningAccounts: func() ([]Address, error) {
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetSigningAccounts: func() ([]Address, error) {
 				return nil, nil
 			},
-			getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+			OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 				return nil, nil
 			},
-			meterMemory: func(_ common.MemoryUsage) error {
-				return nil
+			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+				return json.Decode(nil, b)
 			},
-		}
-		runtimeInterface.decodeArgument = func(b []byte, t cadence.Type) (value cadence.Value, err error) {
-			return json.Decode(runtimeInterface, b)
 		}
 
 		_, err := runtime.ExecuteScript(


### PR DESCRIPTION
## Description

As [discussed on Discord](https://discord.com/channels/613813861610684416/1108479699732152503/1154168994018906173), move the runtime test helpers `testRuntimeInterface` and `testInterpreterRuntime` to a separate package, `runtime/tests/runtime_utils`, so they can be used outside of the `runtime` package.

This requires exporting (renaming) the types, as well as the fields.

In addition, this also requires moving all runtime tests (tests in `runtime/*_test.go`) to a separate package (`runtime_test`), to avoid an import cycle.

This allows e.g. the migration code to live in a separate package, and use the runtime testing infrastructure we already have available.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
