### PR TITLE
Remove unused composite type to interface type conversion function

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4607,20 +4607,6 @@ func (t *CompositeType) RewriteWithIntersectionTypes() (result Type, rewritten b
 	return t, false
 }
 
-func (t *CompositeType) InterfaceType() *InterfaceType {
-	return &InterfaceType{
-		Location:              t.Location,
-		Identifier:            t.Identifier,
-		CompositeKind:         t.Kind,
-		Members:               t.Members,
-		Fields:                t.Fields,
-		InitializerParameters: t.ConstructorParameters,
-		InitializerPurity:     t.ConstructorPurity,
-		containerType:         t.containerType,
-		NestedTypes:           t.NestedTypes,
-	}
-}
-
 func (*CompositeType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
 	// TODO:
 	return false


### PR DESCRIPTION
## Description

With the removal of nested type requirements, the function to convert a composite type to an interface type is no longer needed.

Remove the function.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
