### PR TITLE
Replace panic with nil return in `newInjectedCompositeFieldsHandler`

### DIFF
--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -827,7 +827,7 @@ func (e *interpreterEnvironment) newInjectedCompositeFieldsHandler() interpreter
 				case common.AddressLocation:
 					address = location.Address
 				default:
-					panic(errors.NewUnreachableError())
+					return nil
 				}
 
 				addressValue := interpreter.NewAddressValue(


### PR DESCRIPTION
## Description

There is no reason to panic when the location of a `common.CompositeKindContract` is not a `common.AddressLocation`. We can simply return `nil`, as we already do for `stdlib.CryptoCheckerLocation`.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
