### PR TITLE
Add support for injecting types into the environment

### DIFF
--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -897,8 +897,21 @@ func (e *interpreterEnvironment) newImportLocationHandler() interpreter.ImportLo
 
 func (e *interpreterEnvironment) newCompositeTypeHandler() interpreter.CompositeTypeHandlerFunc {
 	return func(location common.Location, typeID common.TypeID) *sema.CompositeType {
-		if _, ok := location.(stdlib.FlowLocation); ok {
+
+		switch location.(type) {
+		case stdlib.FlowLocation:
 			return stdlib.FlowEventTypes[typeID]
+
+		case nil:
+			qualifiedIdentifier := string(typeID)
+			ty := sema.TypeActivationNestedType(e.baseTypeActivation, qualifiedIdentifier)
+			if ty == nil {
+				return nil
+			}
+
+			if compositeType, ok := ty.(*sema.CompositeType); ok {
+				return compositeType
+			}
 		}
 
 		return nil

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -38,7 +38,8 @@ import (
 type Environment interface {
 	ArgumentDecoder
 
-	Declare(valueDeclaration stdlib.StandardLibraryValue)
+	DeclareValue(valueDeclaration stdlib.StandardLibraryValue)
+	DeclareType(typeDeclaration stdlib.StandardLibraryType)
 	Configure(
 		runtimeInterface Interface,
 		codesAndPrograms CodesAndPrograms,
@@ -78,8 +79,9 @@ type interpreterEnvironmentReconfigured struct {
 
 type interpreterEnvironment struct {
 	interpreterEnvironmentReconfigured
-	baseActivation                        *interpreter.VariableActivation
+	baseTypeActivation                    *sema.VariableActivation
 	baseValueActivation                   *sema.VariableActivation
+	baseActivation                        *interpreter.VariableActivation
 	InterpreterConfig                     *interpreter.Config
 	CheckerConfig                         *sema.Config
 	deployedContractConstructorInvocation *stdlib.DeployedContractConstructorInvocation
@@ -108,12 +110,14 @@ var _ common.MemoryGauge = &interpreterEnvironment{}
 
 func newInterpreterEnvironment(config Config) *interpreterEnvironment {
 	baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+	baseTypeActivation := sema.NewVariableActivation(sema.BaseTypeActivation)
 	baseActivation := activations.NewActivation[*interpreter.Variable](nil, interpreter.BaseActivation)
 
 	env := &interpreterEnvironment{
 		config:              config,
-		baseActivation:      baseActivation,
 		baseValueActivation: baseValueActivation,
+		baseTypeActivation:  baseTypeActivation,
+		baseActivation:      baseActivation,
 		stackDepthLimiter:   newStackDepthLimiter(config.StackDepthLimit),
 	}
 	env.InterpreterConfig = env.newInterpreterConfig()
@@ -158,6 +162,7 @@ func (e *interpreterEnvironment) newCheckerConfig() *sema.Config {
 	return &sema.Config{
 		AccessCheckMode:                  sema.AccessCheckModeStrict,
 		BaseValueActivation:              e.baseValueActivation,
+		BaseTypeActivation:               e.baseTypeActivation,
 		ValidTopLevelDeclarationsHandler: validTopLevelDeclarations,
 		LocationHandler:                  e.newLocationHandler(),
 		ImportHandler:                    e.resolveImport,
@@ -171,7 +176,7 @@ func (e *interpreterEnvironment) newCheckerConfig() *sema.Config {
 func NewBaseInterpreterEnvironment(config Config) *interpreterEnvironment {
 	env := newInterpreterEnvironment(config)
 	for _, valueDeclaration := range stdlib.DefaultStandardLibraryValues(env) {
-		env.Declare(valueDeclaration)
+		env.DeclareValue(valueDeclaration)
 	}
 	return env
 }
@@ -179,7 +184,7 @@ func NewBaseInterpreterEnvironment(config Config) *interpreterEnvironment {
 func NewScriptInterpreterEnvironment(config Config) Environment {
 	env := newInterpreterEnvironment(config)
 	for _, valueDeclaration := range stdlib.DefaultScriptStandardLibraryValues(env) {
-		env.Declare(valueDeclaration)
+		env.DeclareValue(valueDeclaration)
 	}
 	return env
 }
@@ -198,9 +203,13 @@ func (e *interpreterEnvironment) Configure(
 	e.stackDepthLimiter.depth = 0
 }
 
-func (e *interpreterEnvironment) Declare(valueDeclaration stdlib.StandardLibraryValue) {
+func (e *interpreterEnvironment) DeclareValue(valueDeclaration stdlib.StandardLibraryValue) {
 	e.baseValueActivation.DeclareValue(valueDeclaration)
 	interpreter.Declare(e.baseActivation, valueDeclaration)
+}
+
+func (e *interpreterEnvironment) DeclareType(typeDeclaration stdlib.StandardLibraryType) {
+	e.baseTypeActivation.DeclareType(typeDeclaration)
 }
 
 func (e *interpreterEnvironment) NewAuthAccountValue(address interpreter.AddressValue) interpreter.Value {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4796,16 +4796,18 @@ func (interpreter *Interpreter) GetCompositeType(
 		if compositeType != nil {
 			return compositeType, nil
 		}
-	} else {
-		config := interpreter.SharedState.Config
-		compositeTypeHandler := config.CompositeTypeHandler
-		if compositeTypeHandler != nil {
-			compositeType = compositeTypeHandler(location, typeID)
-			if compositeType != nil {
-				return compositeType, nil
-			}
-		}
+	}
 
+	config := interpreter.SharedState.Config
+	compositeTypeHandler := config.CompositeTypeHandler
+	if compositeTypeHandler != nil {
+		compositeType = compositeTypeHandler(location, typeID)
+		if compositeType != nil {
+			return compositeType, nil
+		}
+	}
+
+	if location != nil {
 		compositeType = interpreter.getUserCompositeType(location, typeID)
 		if compositeType != nil {
 			return compositeType, nil

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
-	"github.com/onflow/cadence/runtime/tests/utils"
+	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestRuntimePredeclaredValues(t *testing.T) {
@@ -61,7 +61,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 
 	runtime := newTestInterpreterRuntime()
 
-	deploy := utils.DeploymentTransaction("C", contract)
+	deploy := DeploymentTransaction("C", contract)
 
 	var accountCode []byte
 	var events []cadence.Event
@@ -132,57 +132,350 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 
 	t.Parallel()
 
-	xType := sema.IntType
+	t.Run("type alias", func(t *testing.T) {
+		t.Parallel()
 
-	valueDeclaration := stdlib.StandardLibraryValue{
-		Name:  "x",
-		Type:  xType,
-		Kind:  common.DeclarationKindConstant,
-		Value: interpreter.NewUnmeteredIntValueFromInt64(2),
-	}
+		xType := sema.IntType
 
-	typeDeclaration := stdlib.StandardLibraryType{
-		Name: "X",
-		Type: xType,
-		Kind: common.DeclarationKindType,
-	}
+		valueDeclaration := stdlib.StandardLibraryValue{
+			Name:  "x",
+			Type:  xType,
+			Kind:  common.DeclarationKindConstant,
+			Value: interpreter.NewUnmeteredIntValueFromInt64(2),
+		}
 
-	script := []byte(`
-	  pub fun main(): X {
-		  return x
-	  }
-	`)
+		typeDeclaration := stdlib.StandardLibraryType{
+			Name: "X",
+			Type: xType,
+			Kind: common.DeclarationKindType,
+		}
 
-	runtime := newTestInterpreterRuntime()
+		script := []byte(`
+          pub fun main(): X {
+              return x
+          }
+	    `)
 
-	runtimeInterface := &testRuntimeInterface{
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
-			return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
-		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-	}
+		runtime := newTestInterpreterRuntime()
 
-	// Run script
+		runtimeInterface := &testRuntimeInterface{
+			storage: newTestLedger(nil, nil),
+			getSigningAccounts: func() ([]Address, error) {
+				return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
+			},
+			resolveLocation: singleIdentifierLocationResolver(t),
+		}
 
-	scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
-	scriptEnvironment.DeclareValue(valueDeclaration)
-	scriptEnvironment.DeclareType(typeDeclaration)
+		// Run script
 
-	result, err := runtime.ExecuteScript(
-		Script{
-			Source: script,
-		},
-		Context{
-			Interface:   runtimeInterface,
-			Location:    common.ScriptLocation{},
-			Environment: scriptEnvironment,
-		},
-	)
-	require.NoError(t, err)
+		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment.DeclareValue(valueDeclaration)
+		scriptEnvironment.DeclareType(typeDeclaration)
 
-	require.Equal(t,
-		cadence.Int{Value: big.NewInt(2)},
-		result,
-	)
+		result, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				Environment: scriptEnvironment,
+			},
+		)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			cadence.Int{Value: big.NewInt(2)},
+			result,
+		)
+	})
+
+	t.Run("composite type, top-level, existing", func(t *testing.T) {
+		t.Parallel()
+
+		xType := &sema.CompositeType{
+			Identifier: "X",
+			Kind:       common.CompositeKindStructure,
+			Members:    &sema.StringMemberOrderedMap{},
+		}
+
+		valueDeclaration := stdlib.StandardLibraryValue{
+			Name: "x",
+			Type: xType,
+			Kind: common.DeclarationKindConstant,
+			Value: interpreter.NewSimpleCompositeValue(nil,
+				xType.ID(),
+				interpreter.ConvertSemaCompositeTypeToStaticCompositeType(nil, xType),
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			),
+		}
+
+		typeDeclaration := stdlib.StandardLibraryType{
+			Name: "X",
+			Type: xType,
+			Kind: common.DeclarationKindType,
+		}
+
+		script := []byte(`
+          pub fun main(): X {
+              return x
+          }
+	    `)
+
+		runtime := newTestInterpreterRuntime()
+
+		runtimeInterface := &testRuntimeInterface{
+			storage: newTestLedger(nil, nil),
+			getSigningAccounts: func() ([]Address, error) {
+				return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
+			},
+			resolveLocation: singleIdentifierLocationResolver(t),
+		}
+
+		// Run script
+
+		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment.DeclareValue(valueDeclaration)
+		scriptEnvironment.DeclareType(typeDeclaration)
+
+		result, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				Environment: scriptEnvironment,
+			},
+		)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			cadence.ValueWithCachedTypeID(
+				cadence.Struct{
+					StructType: cadence.NewStructType(nil, xType.QualifiedIdentifier(), []cadence.Field{}, nil),
+					Fields:     []cadence.Value{},
+				},
+			),
+			result,
+		)
+	})
+
+	t.Run("composite type, top-level, non-existing", func(t *testing.T) {
+		t.Parallel()
+
+		xType := &sema.CompositeType{
+			Identifier: "X",
+			Kind:       common.CompositeKindStructure,
+			Members:    &sema.StringMemberOrderedMap{},
+		}
+
+		valueDeclaration := stdlib.StandardLibraryValue{
+			Name: "x",
+			Type: xType,
+			Kind: common.DeclarationKindConstant,
+			Value: interpreter.NewSimpleCompositeValue(nil,
+				xType.ID(),
+				interpreter.ConvertSemaCompositeTypeToStaticCompositeType(nil, xType),
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			),
+		}
+
+		script := []byte(`
+          pub fun main(): AnyStruct {
+              return x
+          }
+	    `)
+
+		runtime := newTestInterpreterRuntime()
+
+		runtimeInterface := &testRuntimeInterface{
+			storage: newTestLedger(nil, nil),
+			getSigningAccounts: func() ([]Address, error) {
+				return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
+			},
+			resolveLocation: singleIdentifierLocationResolver(t),
+		}
+
+		// Run script
+
+		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment.DeclareValue(valueDeclaration)
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				Environment: scriptEnvironment,
+			},
+		)
+		RequireError(t, err)
+
+		var typeLoadingErr interpreter.TypeLoadingError
+		require.ErrorAs(t, err, &typeLoadingErr)
+	})
+
+	t.Run("composite type, nested, existing", func(t *testing.T) {
+		t.Parallel()
+
+		yType := &sema.CompositeType{
+			Identifier: "Y",
+			Kind:       common.CompositeKindStructure,
+			Members:    &sema.StringMemberOrderedMap{},
+		}
+
+		xType := &sema.CompositeType{
+			Identifier: "X",
+			Kind:       common.CompositeKindContract,
+			Members:    &sema.StringMemberOrderedMap{},
+		}
+
+		xType.SetNestedType(yType.Identifier, yType)
+
+		valueDeclaration := stdlib.StandardLibraryValue{
+			Name: "y",
+			Type: yType,
+			Kind: common.DeclarationKindConstant,
+			Value: interpreter.NewSimpleCompositeValue(nil,
+				yType.ID(),
+				interpreter.ConvertSemaCompositeTypeToStaticCompositeType(nil, yType),
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			),
+		}
+
+		typeDeclaration := stdlib.StandardLibraryType{
+			Name: "X",
+			Type: xType,
+			Kind: common.DeclarationKindType,
+		}
+
+		script := []byte(`
+          pub fun main(): X.Y {
+              return y
+          }
+	    `)
+
+		runtime := newTestInterpreterRuntime()
+
+		runtimeInterface := &testRuntimeInterface{
+			storage: newTestLedger(nil, nil),
+			getSigningAccounts: func() ([]Address, error) {
+				return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
+			},
+			resolveLocation: singleIdentifierLocationResolver(t),
+		}
+
+		// Run script
+
+		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment.DeclareValue(valueDeclaration)
+		scriptEnvironment.DeclareType(typeDeclaration)
+
+		result, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				Environment: scriptEnvironment,
+			},
+		)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			cadence.ValueWithCachedTypeID(
+				cadence.Struct{
+					StructType: cadence.NewStructType(nil, yType.QualifiedIdentifier(), []cadence.Field{}, nil),
+					Fields:     []cadence.Value{},
+				},
+			),
+			result,
+		)
+	})
+
+	t.Run("composite type, nested, non-existing", func(t *testing.T) {
+		t.Parallel()
+
+		yType := &sema.CompositeType{
+			Identifier: "Y",
+			Kind:       common.CompositeKindStructure,
+			Members:    &sema.StringMemberOrderedMap{},
+		}
+
+		xType := &sema.CompositeType{
+			Identifier: "X",
+			Kind:       common.CompositeKindContract,
+			Members:    &sema.StringMemberOrderedMap{},
+		}
+
+		xType.SetNestedType(yType.Identifier, yType)
+
+		valueDeclaration := stdlib.StandardLibraryValue{
+			Name: "y",
+			Type: yType,
+			Kind: common.DeclarationKindConstant,
+			Value: interpreter.NewSimpleCompositeValue(nil,
+				yType.ID(),
+				interpreter.ConvertSemaCompositeTypeToStaticCompositeType(nil, yType),
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			),
+		}
+
+		script := []byte(`
+          pub fun main(): AnyStruct {
+              return y
+          }
+	    `)
+
+		runtime := newTestInterpreterRuntime()
+
+		runtimeInterface := &testRuntimeInterface{
+			storage: newTestLedger(nil, nil),
+			getSigningAccounts: func() ([]Address, error) {
+				return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
+			},
+			resolveLocation: singleIdentifierLocationResolver(t),
+		}
+
+		// Run script
+
+		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment.DeclareValue(valueDeclaration)
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				Environment: scriptEnvironment,
+			},
+		)
+		RequireError(t, err)
+
+		var typeLoadingErr interpreter.TypeLoadingError
+		require.ErrorAs(t, err, &typeLoadingErr)
+	})
+
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -31,6 +31,8 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
+const TypeIDSeparator = '.'
+
 func qualifiedIdentifier(identifier string, containerType Type) string {
 	if containerType == nil {
 		return identifier
@@ -56,7 +58,7 @@ func qualifiedIdentifier(identifier string, containerType Type) string {
 	for i := len(identifiers) - 1; i >= 0; i-- {
 		sb.WriteString(identifiers[i])
 		if i != 0 {
-			sb.WriteByte('.')
+			sb.WriteByte(TypeIDSeparator)
 		}
 	}
 
@@ -227,6 +229,36 @@ func VisitThisAndNested(t Type, visit func(ty Type)) {
 	containerType.GetNestedTypes().Foreach(func(_ string, nestedType Type) {
 		VisitThisAndNested(nestedType, visit)
 	})
+}
+
+func TypeActivationNestedType(typeActivation *VariableActivation, qualifiedIdentifier string) Type {
+
+	typeIDComponents := strings.Split(qualifiedIdentifier, string(TypeIDSeparator))
+
+	rootTypeName := typeIDComponents[0]
+	variable := typeActivation.Find(rootTypeName)
+	if variable == nil {
+		return nil
+	}
+	ty := variable.Type
+
+	// Traverse nested types until the leaf type
+
+	for i := 1; i < len(typeIDComponents); i++ {
+		containerType, ok := ty.(ContainerType)
+		if !ok || !containerType.IsContainerType() {
+			return nil
+		}
+
+		typeIDComponent := typeIDComponents[i]
+
+		ty, ok = containerType.GetNestedTypes().Get(typeIDComponent)
+		if !ok {
+			return nil
+		}
+	}
+
+	return ty
 }
 
 // CompositeKindedType is a type which has a composite kind


### PR DESCRIPTION
Needed for Flex and #2760 

## Description

In addition to injecting a value, a host environment may also want to inject additional types.

Add support for declaring a `StandardLibraryType` into a `runtime.Environment`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
