### PR TITLE
Introduce `String.replaceAll` instance function

### DIFF
--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -116,6 +116,12 @@ func init() {
 				StringTypeSplitFunctionType,
 				StringTypeSplitFunctionDocString,
 			),
+			NewUnmeteredPublicFunctionMember(
+				t,
+				StringTypeReplaceAllFunctionName,
+				StringTypeReplaceAllFunctionType,
+				StringTypeReplaceAllFunctionDocString,
+			),
 		})
 	}
 }
@@ -161,6 +167,13 @@ Returns a new string containing the slice of the characters in the given string 
 This function creates a new string whose length is ` + "`upTo - from`" + `.
 It does not modify the original string.
 If either of the parameters are out of the bounds of the string, or the indices are invalid (` + "`from > upTo`" + `), then the function will fail
+`
+
+const StringTypeReplaceAllFunctionName = "replaceAll"
+const StringTypeReplaceAllFunctionDocString = `
+Returns a new string after replacing all the occurrences of parameter ` + "`of` with the parameter `with`" + `.
+
+If with is empty, it matches at the beginning of the string and after each UTF-8 sequence, yielding up to k+1 replacements for a k-rune string.
 `
 
 // ByteArrayType represents the type [UInt8]
@@ -360,4 +373,19 @@ var StringTypeSplitFunctionType = NewSimpleFunctionType(
 			Type: StringType,
 		},
 	),
+)
+
+var StringTypeReplaceAllFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]Parameter{
+		{
+			Identifier:     "of",
+			TypeAnnotation: StringTypeAnnotation,
+		},
+		{
+			Identifier:     "with",
+			TypeAnnotation: StringTypeAnnotation,
+		},
+	},
+	StringTypeAnnotation,
 )

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -173,7 +173,7 @@ const StringTypeReplaceAllFunctionName = "replaceAll"
 const StringTypeReplaceAllFunctionDocString = `
 Returns a new string after replacing all the occurrences of parameter ` + "`of` with the parameter `with`" + `.
 
-If with is empty, it matches at the beginning of the string and after each UTF-8 sequence, yielding up to k+1 replacements for a k-rune string.
+If with is empty, it matches at the beginning of the string and after each UTF-8 sequence, yielding k+1 replacements for a string of length k.
 `
 
 // ByteArrayType represents the type [UInt8]

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -173,7 +173,7 @@ const StringTypeReplaceAllFunctionName = "replaceAll"
 const StringTypeReplaceAllFunctionDocString = `
 Returns a new string after replacing all the occurrences of parameter ` + "`of` with the parameter `with`" + `.
 
-If with is empty, it matches at the beginning of the string and after each UTF-8 sequence, yielding k+1 replacements for a string of length k.
+If ` + "`with`" + ` is empty, it matches at the beginning of the string and after each UTF-8 sequence, yielding k+1 replacements for a string of length k.
 `
 
 // ByteArrayType represents the type [UInt8]

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -493,6 +493,22 @@ func TestCheckStringReplaceAllTypeMismatchWith(t *testing.T) {
 	assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 }
 
+func TestCheckStringReplaceAllTypeMismatchCharacters(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		let a: Character = "x"
+		let b: Character = "y"
+		let s = "Abc:1".replaceAll(of: a, with: b)
+	`)
+
+	errs := RequireCheckerErrors(t, err, 2)
+
+	assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+	assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+}
+
 func TestCheckStringReplaceAllTypeMissingArgumentLabelOf(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -451,3 +451,70 @@ func TestCheckStringSplitTypeMissingArgumentLabelSeparator(t *testing.T) {
 
 	assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[0])
 }
+
+func TestCheckStringReplaceAll(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+		let s = "👪.❤️.Abc".replaceAll(of: "❤️", with: "|")
+	`)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		sema.StringType,
+		RequireGlobalValue(t, checker.Elaboration, "s"),
+	)
+}
+
+func TestCheckStringReplaceAllTypeMismatchOf(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		let s = "Abc:1".replaceAll(of: 1234, with: "/")
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+}
+
+func TestCheckStringReplaceAllTypeMismatchWith(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		let s = "Abc:1".replaceAll(of: "1", with: true)
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+}
+
+func TestCheckStringReplaceAllTypeMissingArgumentLabelOf(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+	let s = "👪Abc".replaceAll("/", with: "abc")
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[0])
+}
+
+func TestCheckStringReplaceAllTypeMissingArgumentLabelWith(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+	let s = "👪Abc".replaceAll(of: "/", "abc")
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[0])
+}

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -596,3 +596,50 @@ func TestInterpretStringSplit(t *testing.T) {
 		),
 	)
 }
+
+func TestInterpretStringReplaceAll(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+		fun replaceAll(): String {
+			return "👪////❤️".replaceAll(of: "////", with: "||")
+		}
+		fun replaceAllSpaceWithDoubleSpace(): String {
+			return "👪 ❤️ Abc6 ;123".replaceAll(of: " ", with: "  ")
+		}
+		fun replaceAllWithUnicodeEquivalence(): String {
+			return "Caf\u{65}\u{301}ABc".replaceAll(of: "\u{e9}", with: "X")
+		}
+		fun testEmptyString(): String {
+			return "".replaceAll(of: "//", with: "abc")
+		}
+		fun testEmptyOf(): String {
+			return "abc".replaceAll(of: "", with: "1")
+		}
+		fun testNoMatch(): String {
+			return "pqrS;asdf".replaceAll(of: ";;", with: "does_not_matter")
+		}
+	`)
+
+	testCase := func(t *testing.T, funcName string, expected *interpreter.StringValue) {
+		t.Run(funcName, func(t *testing.T) {
+			result, err := inter.Invoke(funcName)
+			require.NoError(t, err)
+
+			RequireValuesEqual(
+				t,
+				inter,
+				expected,
+				result,
+			)
+		})
+	}
+
+	testCase(t, "replaceAll", interpreter.NewUnmeteredStringValue("👪||❤️"))
+	testCase(t, "replaceAllSpaceWithDoubleSpace", interpreter.NewUnmeteredStringValue("👪  ❤️  Abc6  ;123"))
+	testCase(t, "replaceAllWithUnicodeEquivalence", interpreter.NewUnmeteredStringValue("CafXABc"))
+	testCase(t, "testEmptyString", interpreter.NewUnmeteredStringValue(""))
+	testCase(t, "testEmptyOf", interpreter.NewUnmeteredStringValue("1a1b1c1"))
+	testCase(t, "testNoMatch", interpreter.NewUnmeteredStringValue("pqrS;asdf"))
+}


### PR DESCRIPTION
Work towards #2813

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Adds `str.replaceAll(_ of: String, _ with: String): String` function to Cadence.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
