### PR TITLE
Fix cadence-parser's esm package

### DIFF
--- a/npm-packages/cadence-parser/package.json
+++ b/npm-packages/cadence-parser/package.json
@@ -20,8 +20,8 @@
   "scripts": {
     "build": "npm run build:types && npm run build:esm && npm run build:cjs && GOARCH=wasm GOOS=js go build -o ./dist/cadence-parser.wasm ../../runtime/cmd/parse",
     "build:types": "tsc --emitDeclarationOnly --module system --outDir dist/types",
-    "build:esm": "tsc --module es6 --target es6 --outDir dist/esm --declaration false",
-    "build:cjs": "tsc --module commonjs --target es6 --outDir dist/cjs --declaration false",
+    "build:esm": "tsc -p tsconfig.json --declaration false",
+    "build:cjs": "tsc -p tsconfig-cjs.json --declaration false && tsconfig-to-dual-package",
     "test": "jest"
   },
   "license": "Apache-2.0",
@@ -31,6 +31,7 @@
     "jest": "^28.1.2",
     "node-fetch": "^2.6.1",
     "ts-jest": "^28.0.5",
+    "tsconfig-to-dual-package": "^1.2.0",
     "typescript": "^4.7.4"
   },
   "files": [

--- a/npm-packages/cadence-parser/src/index.ts
+++ b/npm-packages/cadence-parser/src/index.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { go } from './go'
+import { go } from './go.js'
 import WebAssemblyInstantiatedSource = WebAssembly.WebAssemblyInstantiatedSource
 
 declare global {

--- a/npm-packages/cadence-parser/tests/index.test.ts
+++ b/npm-packages/cadence-parser/tests/index.test.ts
@@ -8,114 +8,79 @@ test("parse simple", async () => {
   expect(res).toEqual({
     "program": {
       "Type": "Program",
-      "Declarations": [
-        {
-          "Access": "AccessPublic",
-          "DocString": "",
-          "EndPos": {
-            "Column": 16,
-            "Line": 1,
-            "Offset": 16,
-          },
-          "FunctionBlock": {
-            "Block": {
-              "EndPos": {
-                "Column": 16,
-                "Line": 1,
-                "Offset": 16,
-              },
-              "StartPos": {
-                "Column": 15,
-                "Line": 1,
-                "Offset": 15,
-              },
-              "Statements": null,
-              "Type": "Block",
-            },
-            "EndPos": {
-              "Column": 16,
-              "Line": 1,
-              "Offset": 16,
-            },
-            "StartPos": {
-              "Column": 15,
-              "Line": 1,
-              "Offset": 15,
-            },
-            "Type": "FunctionBlock",
-          },
-          "Identifier": {
-            "EndPos": {
-              "Column": 11,
-              "Line": 1,
-              "Offset": 11,
-            },
-            "Identifier": "main",
-            "StartPos": {
-              "Column": 8,
-              "Line": 1,
-              "Offset": 8,
-            },
-          },
+        "Declarations": [
+          {
+          "TypeParameterList": null,
           "ParameterList": {
-            "EndPos": {
-              "Column": 13,
-              "Line": 1,
-              "Offset": 13,
-            },
             "Parameters": null,
             "StartPos": {
-              "Column": 12,
-              "Line": 1,
               "Offset": 12,
-            },
-          },
-          "ReturnTypeAnnotation": {
-            "AnnotatedType": {
-              "EndPos": {
-                "Column": 12,
-                "Line": 1,
-                "Offset": 12,
-              },
-              "Identifier": {
-                "EndPos": {
-                  "Column": 12,
-                  "Line": 1,
-                  "Offset": 12,
-                },
-                "Identifier": "",
-                "StartPos": {
-                  "Column": 13,
-                  "Line": 1,
-                  "Offset": 13,
-                },
-              },
-              "StartPos": {
-                "Column": 13,
-                "Line": 1,
-                "Offset": 13,
-              },
-              "Type": "NominalType",
+              "Line": 1,
+              "Column": 12
             },
             "EndPos": {
-              "Column": 12,
-              "Line": 1,
-              "Offset": 12,
-            },
-            "IsResource": false,
-            "StartPos": {
-              "Column": 13,
-              "Line": 1,
               "Offset": 13,
+              "Line": 1,
+              "Column": 13
+            }
+          },
+          "ReturnTypeAnnotation": null,
+          "FunctionBlock": {
+            "Block": {
+              "Statements": null,
+              "StartPos": {
+                "Offset": 15,
+                "Line": 1,
+                "Column": 15
+              },
+              "EndPos": {
+                "Offset": 16,
+                "Line": 1,
+                "Column": 16
+              },
+              "Type": "Block"
             },
+            "Type": "FunctionBlock",
+            "StartPos": {
+              "Offset": 15,
+              "Line": 1,
+              "Column": 15
+            },
+            "EndPos": {
+              "Offset": 16,
+              "Line": 1,
+              "Column": 16
+            }
           },
-          "StartPos": {
-            "Column": 0,
-            "Line": 1,
-            "Offset": 0,
+          "DocString": "",
+          "Identifier": {
+            "Identifier": "main",
+            "StartPos": {
+              "Offset": 8,
+              "Line": 1,
+              "Column": 8
+            },
+            "EndPos": {
+              "Offset": 11,
+              "Line": 1,
+              "Column": 11
+            }
           },
+          "Access": "AccessPublic",
           "Type": "FunctionDeclaration",
-        },
+          "StartPos": {
+            "Offset": 0,
+            "Line": 1,
+            "Column": 0
+          },
+          "EndPos": {
+            "Offset": 16,
+            "Line": 1,
+            "Column": 16
+          },
+          "IsStatic": false,
+          "IsNative": false
+        }
       ],
     },
   })

--- a/npm-packages/cadence-parser/tsconfig-cjs.json
+++ b/npm-packages/cadence-parser/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist/cjs"
+  },
+}

--- a/npm-packages/cadence-parser/tsconfig.json
+++ b/npm-packages/cadence-parser/tsconfig.json
@@ -21,7 +21,7 @@
     ],
     "declaration": true,
     "noImplicitAny": false,
-    "outDir": "./dist"
+    "outDir": "./dist/esm"
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Closes #???

## Description

cadence-parser's build configuration is using tsc to build a dual package, however, the created esm module cannot be imported from a nodejs es module, as the `"type": "module"` is missing from the es module specific package.json.

This PR contains a way to solve this issue, although many other ways exist based on the choice of tooling. The solution included is an attempt to fix it with the smallest amount of change to the current toolings and configuration.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
