### PR TITLE
Check native function declarations

### DIFF
--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -76,6 +76,21 @@ func (checker *Checker) visitFunctionDeclaration(
 		declaration.Identifier,
 	)
 
+	functionBlock := declaration.FunctionBlock
+
+	if declaration.IsNative() {
+		if !functionBlock.IsEmpty() {
+			checker.report(&NativeFunctionWithImplementationError{
+				Range: ast.NewRangeFromPositioned(
+					checker.memoryGauge,
+					functionBlock,
+				),
+			})
+		}
+
+		functionBlock = nil
+	}
+
 	// global functions were previously declared, see `declareFunctionDeclaration`
 
 	functionType := checker.Elaboration.FunctionDeclarationFunctionType(declaration)
@@ -93,7 +108,7 @@ func (checker *Checker) visitFunctionDeclaration(
 		declaration.ParameterList,
 		declaration.ReturnTypeAnnotation,
 		functionType,
-		declaration.FunctionBlock,
+		functionBlock,
 		options.mustExit,
 		nil,
 		options.checkResourceLoss,

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -878,6 +878,23 @@ func (e *InvalidNativeModifierError) Error() string {
 	return "invalid native modifier for declaration"
 }
 
+// NativeFunctionWithImplementationError
+
+type NativeFunctionWithImplementationError struct {
+	ast.Range
+}
+
+var _ SemanticError = &NativeFunctionWithImplementationError{}
+var _ errors.UserError = &NativeFunctionWithImplementationError{}
+
+func (*NativeFunctionWithImplementationError) isSemanticError() {}
+
+func (*NativeFunctionWithImplementationError) IsUserError() {}
+
+func (e *NativeFunctionWithImplementationError) Error() string {
+	return "native function may not have an implementation"
+}
+
 // InvalidNameError
 
 type InvalidNameError struct {

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -892,7 +892,7 @@ func (*NativeFunctionWithImplementationError) isSemanticError() {}
 func (*NativeFunctionWithImplementationError) IsUserError() {}
 
 func (e *NativeFunctionWithImplementationError) Error() string {
-	return "native function may not have an implementation"
+	return "native function must not have an implementation"
 }
 
 // InvalidNameError

--- a/runtime/tests/checker/function_test.go
+++ b/runtime/tests/checker/function_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/sema"
 )
@@ -507,6 +509,55 @@ func TestCheckNativeFunctionDeclaration(t *testing.T) {
 		errs := RequireCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.NativeFunctionWithImplementationError{}, errs[0])
+	})
+
+	t.Run("enabled, composite", func(t *testing.T) {
+
+		t.Parallel()
+
+		checker, err := ParseAndCheckWithOptions(t,
+			`
+              struct S {
+                  native fun test(foo: String): Int {}
+              }
+            `,
+			ParseAndCheckOptions{
+				ParseOptions: parser.Config{
+					NativeModifierEnabled: true,
+				},
+				Config: &sema.Config{
+					AllowNativeDeclarations: true,
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		sType := RequireGlobalType(t, checker.Elaboration, "S")
+		require.NotNil(t, sType)
+
+		const testFunctionIdentifier = "test"
+		testMemberResolver, ok := sType.GetMembers()[testFunctionIdentifier]
+		require.True(t, ok)
+
+		assert.Equal(t,
+			common.DeclarationKindFunction,
+			testMemberResolver.Kind,
+		)
+
+		member := testMemberResolver.Resolve(nil, testFunctionIdentifier, ast.EmptyRange, nil)
+
+		assert.Equal(t,
+			sema.NewTypeAnnotation(&sema.FunctionType{
+				Parameters: []sema.Parameter{
+					{
+						Identifier:     "foo",
+						TypeAnnotation: sema.NewTypeAnnotation(sema.StringType),
+					},
+				},
+				ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.IntType),
+			}),
+			member.TypeAnnotation,
+		)
 	})
 }
 


### PR DESCRIPTION
## Description

Previously, the parser gained support for parsing the `native` modifier for functions, and the checker rejected the modifier, gated behind a configuration option.

Complete support for checking native functions, by requiring that if native functions are enabled, the function body is empty, and ignore checking it. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
