### PR TITLE
Add native function declarations for all relevant `Test` contract functions

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4294,11 +4294,7 @@ func (t *CompositeType) GetMembers() map[string]MemberResolver {
 }
 
 func (t *CompositeType) initializeMemberResolvers() {
-	t.memberResolversOnce.Do(t.initializerMemberResolversFunc())
-}
-
-func (t *CompositeType) initializerMemberResolversFunc() func() {
-	return func() {
+	t.memberResolversOnce.Do(func() {
 		memberResolvers := MembersMapAsResolvers(t.Members)
 
 		// Check conformances.
@@ -4317,13 +4313,7 @@ func (t *CompositeType) initializerMemberResolversFunc() func() {
 			})
 
 		t.memberResolvers = withBuiltinMembers(t, memberResolvers)
-	}
-}
-
-func (t *CompositeType) ResolveMembers() {
-	if t.Members.Len() != len(t.GetMembers()) {
-		t.initializerMemberResolversFunc()()
-	}
+	})
 }
 
 func (t *CompositeType) FieldPosition(name string, declaration ast.CompositeLikeDeclaration) ast.Position {

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -437,4 +437,87 @@ access(all) contract Test {
         assert(found, message: "the error message did not contain the given sub-string")
     }
 
+    /// Creates a matcher with a test function.
+    /// The test function is of type '((T): Bool)',
+    /// where 'T' is bound to 'AnyStruct'.
+    ///
+    access(all)
+    native fun newMatcher<T: AnyStruct>(_ test: ((T): Bool)): Test.Matcher {}
+
+    /// Wraps a function call in a closure, and expects it to fail with
+    /// an error message that contains the given error message portion.
+    ///
+    access(all)
+    native fun expectFailure(
+        _ functionWrapper: ((): Void),
+        errorMessageSubstring: String
+    ) {}
+
+    /// Expect function tests a value against a matcher
+    /// and fails the test if it's not a match.
+    ///
+    access(all)
+    native fun expect<T: AnyStruct>(_ value: T, _ matcher: Test.Matcher) {}
+
+    /// Returns a matcher that succeeds if the tested
+    /// value is equal to the given value.
+    ///
+    access(all)
+    native fun equal<T: AnyStruct>(_ value: T): Test.Matcher {}
+
+    /// Fails the test-case if the given values are not equal, and
+    /// reports a message which explains how the two values differ.
+    ///
+    access(all)
+    native fun assertEqual(_ expected: AnyStruct, _ actual: AnyStruct) {}
+
+    /// Returns a matcher that succeeds if the tested value is
+    /// an array or dictionary and the tested value contains
+    /// no elements.
+    ///
+    access(all)
+    native fun beEmpty(): Test.Matcher {}
+
+    /// Returns a matcher that succeeds if the tested value is
+    /// an array or dictionary and has the given number of elements.
+    ///
+    access(all)
+    native fun haveElementCount(_ count: Int): Test.Matcher {}
+
+    /// Returns a matcher that succeeds if the tested value is
+    /// an array that contains a value that is equal to the given
+    /// value, or the tested value is a dictionary that contains
+    /// an entry where the key is equal to the given value.
+    ///
+    access(all)
+    native fun contain(_ element: AnyStruct): Test.Matcher {}
+
+    /// Returns a matcher that succeeds if the tested value
+    /// is a number and greater than the given number.
+    ///
+    access(all)
+    native fun beGreaterThan(_ value: Number): Test.Matcher {}
+
+    /// Returns a matcher that succeeds if the tested value
+    /// is a number and less than the given number.
+    ///
+    access(all)
+    native fun beLessThan(_ value: Number): Test.Matcher {}
+
+    /// Read a local file, and return the content as a string.
+    ///
+    access(all)
+    native fun readFile(_ path: String): String {}
+
+    /// Fails the test-case if the given condition is false,
+    /// and reports a message which explains how the condition is false.
+    ///
+    access(all)
+    native fun assert(_ condition: Bool, message: String): Void {}
+
+    /// Fails the test-case with a message.
+    ///
+    access(all)
+    native fun fail(message: String): Void {}
+
 }

--- a/runtime/stdlib/test_contract.go
+++ b/runtime/stdlib/test_contract.go
@@ -1193,7 +1193,6 @@ func newTestContractType() *TestContractType {
 	ty.expectFailureFunction = newTestTypeExpectFailureFunction(
 		expectFailureFunctionType,
 	)
-	compositeType.ResolveMembers()
 
 	return ty
 }

--- a/runtime/stdlib/test_contract.go
+++ b/runtime/stdlib/test_contract.go
@@ -950,7 +950,10 @@ func newTestContractType() *TestContractType {
 	program, err := parser.ParseProgram(
 		nil,
 		contracts.TestContract,
-		parser.Config{},
+		parser.Config{
+			NativeModifierEnabled: true,
+			TypeParametersEnabled: true,
+		},
 	)
 	if err != nil {
 		panic(err)
@@ -965,8 +968,9 @@ func newTestContractType() *TestContractType {
 		TestContractLocation,
 		nil,
 		&sema.Config{
-			BaseValueActivation: activation,
-			AccessCheckMode:     sema.AccessCheckModeStrict,
+			BaseValueActivation:     activation,
+			AccessCheckMode:         sema.AccessCheckModeStrict,
+			AllowNativeDeclarations: true,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2822

## Description


With the introduction of https://github.com/onflow/cadence/pull/2821, we can now declare native functions inside the `Test` contract, and remove the workaround that used `CompositeType.ResolveMembers()`.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
