### PR TITLE
properly access-check optional chaining with entitlements

### DIFF
--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -419,6 +419,8 @@ func (checker *Checker) isReadableMember(accessedType Type, member *Member, resu
 		}
 	case EntitlementSetAccess:
 		switch ty := accessedType.(type) {
+		case *OptionalType:
+			return checker.isReadableMember(ty.Type, member, resultingType, accessRange)
 		case *ReferenceType:
 			// when accessing a member on a reference, the read is allowed if
 			// the member's access permits the reference's authorization

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -7266,6 +7266,27 @@ func TestCheckEntitlementOptionalChaining(t *testing.T) {
 		require.ErrorAs(t, errs[0], &invalidAccessErr)
 	})
 
+	t.Run("optional chain non reference", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAndCheck(t, `
+            entitlement X
+            entitlement Y
+
+            struct S {
+                access(X, Y) let foo: Int
+                init() {
+                    self.foo = 0
+                }
+            }
+
+            fun bar(r: S?) {
+                r?.foo
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+
 	t.Run("optional chain mapping", func(t *testing.T) {
 		t.Parallel()
 		_, err := ParseAndCheck(t, `


### PR DESCRIPTION
Fixes an issue where optional-chaining accesses were not being properly access-checked for entitlements. 

Thanks to @bluesign for the report

______

<!-- Complete: -->

- [] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
