### PR TITLE
Check `before` statements in `view` contexts

### DIFF
--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -344,7 +344,10 @@ func (checker *Checker) visitWithPostConditions(postConditions *ast.Conditions, 
 
 		checker.Elaboration.SetPostConditionsRewrite(postConditions, rewriteResult)
 
-		checker.visitStatements(rewriteResult.BeforeStatements)
+		// all condition blocks are `view`
+		checker.InNewPurityScope(true, func() {
+			checker.visitStatements(rewriteResult.BeforeStatements)
+		})
 	}
 
 	body()

--- a/runtime/tests/checker/conditions_test.go
+++ b/runtime/tests/checker/conditions_test.go
@@ -1025,6 +1025,8 @@ func TestCheckBeforeConditions(t *testing.T) {
 
 	t.Run("function call", func(t *testing.T) {
 
+		t.Parallel()
+
 		_, err := ParseAndCheck(t, `
       fun impure(): Int { 
         return 0
@@ -1044,6 +1046,8 @@ func TestCheckBeforeConditions(t *testing.T) {
 
 	t.Run("view function call", func(t *testing.T) {
 
+		t.Parallel()
+
 		_, err := ParseAndCheck(t, `
             view fun pure(): Int { 
                 return 0
@@ -1060,6 +1064,8 @@ func TestCheckBeforeConditions(t *testing.T) {
 	})
 
 	t.Run("nested function call", func(t *testing.T) {
+
+		t.Parallel()
 
 		_, err := ParseAndCheck(t, `
             view fun pure(): Int { 
@@ -1083,6 +1089,8 @@ func TestCheckBeforeConditions(t *testing.T) {
 	})
 
 	t.Run("nested pure function call", func(t *testing.T) {
+
+		t.Parallel()
 
 		_, err := ParseAndCheck(t, `
             view fun pure(): Int { 

--- a/runtime/tests/checker/conditions_test.go
+++ b/runtime/tests/checker/conditions_test.go
@@ -1018,3 +1018,84 @@ func TestCheckRewrittenPostConditions(t *testing.T) {
 
 	})
 }
+
+func TestCheckBeforeConditions(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("function call", func(t *testing.T) {
+
+		_, err := ParseAndCheck(t, `
+      fun impure(): Int { 
+        return 0
+      }
+
+      fun test() {
+          post {
+            before(impure()) > 0
+          }
+      }
+    `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.PurityError{}, errs[0])
+	})
+
+	t.Run("view function call", func(t *testing.T) {
+
+		_, err := ParseAndCheck(t, `
+            view fun pure(): Int { 
+                return 0
+            }
+
+            fun test() {
+                post {
+                    before(pure()) > 0
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("nested function call", func(t *testing.T) {
+
+		_, err := ParseAndCheck(t, `
+            view fun pure(): Int { 
+                return 0
+            }
+
+            fun impure(): Int { 
+                return 0
+            }
+
+            fun test() {
+                post {
+                    before(before(impure())) > pure()
+                }
+            }
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.PurityError{}, errs[0])
+	})
+
+	t.Run("nested pure function call", func(t *testing.T) {
+
+		_, err := ParseAndCheck(t, `
+            view fun pure(): Int { 
+                return 0
+            }
+
+            fun test() {
+                post {
+                    before(before(pure())) > 0 
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
+}

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -5673,9 +5673,10 @@ func TestCheckInvalidationInPostConditionBefore(t *testing.T) {
       }
     `)
 
-	errs := RequireCheckerErrors(t, err, 1)
+	errs := RequireCheckerErrors(t, err, 2)
 
-	assert.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[0])
+	assert.IsType(t, &sema.PurityError{}, errs[0])
+	assert.IsType(t, &sema.ResourceUseAfterInvalidationError{}, errs[1])
 }
 
 func TestCheckInvalidationInPostCondition(t *testing.T) {


### PR DESCRIPTION
`before` statements were not being `view`-enforced in post conditions because they are handled separately from all other condition code. This fixes that.

Thanks to @bluesign for the report. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
