### PR TITLE
Skip adding malformed entitlement relations to maps

### DIFF
--- a/runtime/sema/check_interface_declaration.go
+++ b/runtime/sema/check_interface_declaration.go
@@ -529,6 +529,7 @@ func (checker *Checker) declareEntitlementMappingType(declaration *ast.Entitleme
 			checker.report(&InvalidNonEntitlementTypeInMapError{
 				Pos: association.Input.Identifier.Pos,
 			})
+			continue
 		}
 
 		output := checker.convertNominalType(association.Output)
@@ -538,6 +539,7 @@ func (checker *Checker) declareEntitlementMappingType(declaration *ast.Entitleme
 			checker.report(&InvalidNonEntitlementTypeInMapError{
 				Pos: association.Output.Identifier.Pos,
 			})
+			continue
 		}
 
 		entitlementRelations = append(

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -7334,15 +7334,15 @@ func TestCheckEntitlementMissingInMap(t *testing.T) {
             access(M) var foo: auth(M) &Int
             init() {
                 self.foo = &3 as auth(X) &Int
-                var selfRef = &self as auth(X) &S;
-                selfRef.foo;
+                var selfRef = &self as auth(X) &S
+                selfRef.foo
             }
         }
     `)
 
 		errors := RequireCheckerErrors(t, err, 2)
-		require.IsType(t, errors[0], &sema.NotDeclaredError{})
-		require.IsType(t, errors[1], &sema.InvalidNonEntitlementTypeInMapError{})
+		require.IsType(t, &sema.NotDeclaredError{}, errors[0])
+		require.IsType(t, &sema.InvalidNonEntitlementTypeInMapError{}, errors[1])
 	})
 
 	t.Run("non entitlement type", func(t *testing.T) {
@@ -7359,13 +7359,13 @@ func TestCheckEntitlementMissingInMap(t *testing.T) {
             access(M) var foo: auth(M) &Int
             init() {
                 self.foo = &3 as auth(X) &Int
-                var selfRef = &self as auth(X) &S;
-                selfRef.foo;
+                var selfRef = &self as auth(X) &S
+                selfRef.foo
             }
         }
     `)
 
 		errors := RequireCheckerErrors(t, err, 1)
-		require.IsType(t, errors[0], &sema.InvalidNonEntitlementTypeInMapError{})
+		require.IsType(t, &sema.InvalidNonEntitlementTypeInMapError{}, errors[0])
 	})
 }


### PR DESCRIPTION
When a non-entitlement type was used in an entitlement mapping relation, we would properly report an error here, but add the "relation" to the map anyways. This could cause issues later in the checker when attempting to check code that used the map. Instead, just skip adding the malformed relation. 

Thanks to @oebeling for the report

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
