### PR TITLE
[v0.39] Port internal 141: Fix swapping in resource array

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -17117,6 +17117,9 @@ func (v *DictionaryValue) SetKey(
 	case NilValue:
 		_ = v.Remove(interpreter, locationRange, keyValue)
 
+	case placeholderValue:
+		// NO-OP
+
 	default:
 		panic(errors.NewUnreachableError())
 	}

--- a/runtime/interpreter/value_placeholder.go
+++ b/runtime/interpreter/value_placeholder.go
@@ -87,6 +87,7 @@ func (f placeholderValue) Transfer(
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
+	_ map[atree.StorageID]struct{},
 ) Value {
 	// TODO: actually not needed, value is not storable
 	if remove {

--- a/runtime/interpreter/value_placeholder.go
+++ b/runtime/interpreter/value_placeholder.go
@@ -1,0 +1,104 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"github.com/onflow/atree"
+
+	"github.com/onflow/cadence/runtime/common"
+)
+
+// placeholderValue
+type placeholderValue struct{}
+
+var placeholder Value = placeholderValue{}
+
+var _ Value = placeholderValue{}
+
+func (placeholderValue) isValue() {}
+
+func (f placeholderValue) String() string {
+	return f.RecursiveString(SeenReferences{})
+}
+
+func (f placeholderValue) RecursiveString(_ SeenReferences) string {
+	return ""
+}
+
+func (f placeholderValue) MeteredString(_ common.MemoryGauge, _ SeenReferences) string {
+	return ""
+}
+
+func (f placeholderValue) Accept(_ *Interpreter, _ Visitor) {
+	// NO-OP
+}
+
+func (f placeholderValue) Walk(_ *Interpreter, _ func(Value)) {
+	// NO-OP
+}
+
+func (f placeholderValue) StaticType(_ *Interpreter) StaticType {
+	return PrimitiveStaticTypeNever
+}
+
+func (placeholderValue) IsImportable(_ *Interpreter) bool {
+	return false
+}
+
+func (f placeholderValue) ConformsToStaticType(
+	_ *Interpreter,
+	_ LocationRange,
+	_ TypeConformanceResults,
+) bool {
+	return true
+}
+
+func (f placeholderValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+	return NonStorable{Value: f}, nil
+}
+
+func (placeholderValue) NeedsStoreTo(_ atree.Address) bool {
+	return false
+}
+
+func (placeholderValue) IsResourceKinded(_ *Interpreter) bool {
+	return false
+}
+
+func (f placeholderValue) Transfer(
+	interpreter *Interpreter,
+	_ LocationRange,
+	_ atree.Address,
+	remove bool,
+	storable atree.Storable,
+) Value {
+	// TODO: actually not needed, value is not storable
+	if remove {
+		interpreter.RemoveReferencedSlab(storable)
+	}
+	return f
+}
+
+func (f placeholderValue) Clone(_ *Interpreter) Value {
+	return f
+}
+
+func (placeholderValue) DeepRemove(_ *Interpreter) {
+	// NO-OP
+}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -10948,3 +10948,115 @@ func TestInterpretConditionsWrapperFunctionType(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestInterpretSwapInSameArray(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("resources", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          resource R {
+              let value: Int
+
+              init(value: Int) {
+                  self.value = value
+              }
+          }
+
+          fun test(): [Int] {
+             let rs <- [
+                 <- create R(value: 0),
+                 <- create R(value: 1),
+                 <- create R(value: 2)
+             ]
+
+             // We swap only '0' and '1'
+             rs[0] <-> rs[1]
+
+             let values = [
+                 rs[0].value,
+                 rs[1].value,
+                 rs[2].value
+             ]
+
+             destroy rs
+
+             return values
+          }
+        `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewArrayValue(
+				inter,
+				interpreter.EmptyLocationRange,
+				interpreter.VariableSizedStaticType{
+					Type: interpreter.PrimitiveStaticTypeInt,
+				},
+				common.ZeroAddress,
+				interpreter.NewUnmeteredIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(0),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
+			),
+			value,
+		)
+	})
+
+	t.Run("structs", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          struct S {
+              let value: Int
+
+              init(value: Int) {
+                  self.value = value
+              }
+          }
+
+          fun test(): [Int] {
+             let structs = [
+                 S(value: 0),
+                 S(value: 1),
+                 S(value: 2)
+             ]
+
+             // We swap only '0' and '1'
+             structs[0] <-> structs[1]
+
+             return [
+                 structs[0].value,
+                 structs[1].value,
+                 structs[2].value
+             ]
+          }
+        `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewArrayValue(
+				inter,
+				interpreter.EmptyLocationRange,
+				interpreter.VariableSizedStaticType{
+					Type: interpreter.PrimitiveStaticTypeInt,
+				},
+				common.ZeroAddress,
+				interpreter.NewUnmeteredIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(0),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
+			),
+			value,
+		)
+	})
+}


### PR DESCRIPTION
## Description

Port https://github.com/dapperlabs/cadence-internal/pull/141

Insert a temporary placeholder value after moving the resource out, to prevent the move of the swap statement's second value to not get influenced.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
