### PR TITLE
Port internal fix 145: Prevent re-deploy in same transaction

### DIFF
--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -307,6 +307,8 @@ func TestRuntimeContract(t *testing.T) {
 			)
 			RequireError(t, err)
 
+			require.ErrorContains(t, err, "cannot overwrite existing contract")
+
 			// the deployed code should not have been updated,
 			// and no events should have been emitted,
 			// as the deployment should fail
@@ -448,6 +450,8 @@ func TestRuntimeContract(t *testing.T) {
 			} else {
 				RequireError(t, err)
 
+				require.ErrorContains(t, err, "cannot overwrite existing contract")
+
 				require.Empty(t, deployedCode)
 				require.Empty(t, events)
 				require.Empty(t, loggedMessages)
@@ -473,9 +477,11 @@ func TestRuntimeContract(t *testing.T) {
 					Location:  nextTransactionLocation(),
 				},
 			)
-			require.NoError(t, err)
+			RequireError(t, err)
 
-			require.Equal(t, []byte(tc.code2), deployedCode)
+			require.ErrorContains(t, err, "cannot overwrite existing contract")
+
+			require.Empty(t, deployedCode)
 
 			require.Equal(t,
 				[]string{
@@ -484,20 +490,18 @@ func TestRuntimeContract(t *testing.T) {
 					`"Test"`,
 					codeArrayString,
 					`nil`,
-					`"Test"`,
-					code2ArrayString,
-					`"Test"`,
-					code2ArrayString,
 				},
 				loggedMessages,
 			)
 
-			require.Len(t, events, 2)
-			assert.EqualValues(t, stdlib.AccountContractRemovedEventType.ID(), events[0].Type().ID())
-			assert.EqualValues(t, stdlib.AccountContractAddedEventType.ID(), events[1].Type().ID())
+			require.Len(t, events, 1)
+			assert.EqualValues(t,
+				stdlib.AccountContractRemovedEventType.ID(),
+				events[0].Type().ID(),
+			)
 
 			contractValueExists := getContractValueExists()
-
+			// contract still exists (from previous transaction), if not interface
 			if tc.isInterface {
 				require.False(t, contractValueExists)
 			} else {

--- a/runtime/contract_update_test.go
+++ b/runtime/contract_update_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
-	"github.com/onflow/cadence/runtime/tests/utils"
+	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestContractUpdateWithDependencies(t *testing.T) {
@@ -142,7 +142,7 @@ func TestContractUpdateWithDependencies(t *testing.T) {
 
 	err := runtime.ExecuteTransaction(
 		Script{
-			Source: utils.DeploymentTransaction(
+			Source: DeploymentTransaction(
 				"Foo",
 				[]byte(fooContractV1),
 			),
@@ -163,7 +163,7 @@ func TestContractUpdateWithDependencies(t *testing.T) {
 
 	err = runtime.ExecuteTransaction(
 		Script{
-			Source: utils.DeploymentTransaction(
+			Source: DeploymentTransaction(
 				"Bar",
 				[]byte(barContractV1),
 			),
@@ -234,4 +234,106 @@ func TestContractUpdateWithDependencies(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+}
+
+func TestRuntimeInvalidContractRedeploy(t *testing.T) {
+
+	t.Parallel()
+
+	foo1 := []byte(`
+        access(all)
+        contract Foo {
+
+            access(all)
+            resource R {
+
+                access(all)
+                var x: Int
+
+                init() {
+                    self.x = 0
+                }
+            }
+
+            access(all)
+            fun createR(): @R {
+                return <-create R()
+            }
+        }
+    `)
+
+	foo2 := []byte(`
+        access(all)
+        contract Foo {
+
+            access(all)
+            struct R {
+                access(all)
+                var x: Int
+
+                init() {
+                    self.x = 0
+                }
+            }
+        }
+    `)
+
+	tx := []byte(`
+      transaction(foo1: String, foo2: String) {
+          prepare(signer: AuthAccount) {
+              signer.contracts.add(name: "Foo", code: foo1.utf8)
+              signer.contracts.add(name: "Foo", code: foo2.utf8)
+          }
+      }
+    `)
+
+	runtime := newTestInterpreterRuntime()
+	runtime.defaultConfig.AtreeValidationEnabled = false
+
+	address := common.MustBytesToAddress([]byte{0x1})
+
+	var events []cadence.Event
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: newTestLedger(nil, nil),
+		getSigningAccounts: func() ([]Address, error) {
+			return []Address{address}, nil
+		},
+		getAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
+			return nil, nil
+		},
+		resolveLocation: singleIdentifierLocationResolver(t),
+		updateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			// "delay"
+			return nil
+		},
+		emitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
+		},
+		decodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(nil, b)
+		},
+	}
+
+	nextTransactionLocation := newTransactionLocationGenerator()
+
+	// Deploy
+
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: tx,
+			Arguments: encodeArgs([]cadence.Value{
+				cadence.String(foo1),
+				cadence.String(foo2),
+			}),
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	RequireError(t, err)
+
+	require.ErrorContains(t, err, "cannot overwrite existing contract")
 }

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -340,6 +340,10 @@ func (e *interpreterEnvironment) RecordContractUpdate(
 	e.storage.recordContractUpdate(location, contractValue)
 }
 
+func (e *interpreterEnvironment) ContractUpdateRecorded(location common.AddressLocation) bool {
+	return e.storage.contractUpdateRecorded(location)
+}
+
 func (e *interpreterEnvironment) TemporarilyRecordCode(location common.AddressLocation, code []byte) {
 	e.codesAndPrograms.setCode(location, code)
 }

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -1431,7 +1431,11 @@ type AccountContractAdditionHandler interface {
 	) (*interpreter.Program, error)
 	// UpdateAccountContractCode updates the code associated with an account contract.
 	UpdateAccountContractCode(location common.AddressLocation, code []byte) error
-	RecordContractUpdate(location common.AddressLocation, value *interpreter.CompositeValue)
+	RecordContractUpdate(
+		location common.AddressLocation,
+		value *interpreter.CompositeValue,
+	)
+	ContractUpdateRecorded(location common.AddressLocation) bool
 	InterpretContract(
 		location common.AddressLocation,
 		program *interpreter.Program,
@@ -1514,9 +1518,10 @@ func newAuthAccountContractsChangeFunction(
 
 			} else {
 				// We are adding a new contract.
-				// Ensure that no contract/contract interface with the given name exists already
+				// Ensure that no contract/contract interface with the given name exists already,
+				// and no contract deploy or update was recorded before
 
-				if len(existingCode) > 0 {
+				if len(existingCode) > 0 || handler.ContractUpdateRecorded(location) {
 					panic(errors.NewDefaultUserError(
 						"cannot overwrite existing contract with name %q in account %s",
 						contractName,

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -175,6 +175,17 @@ func (s *Storage) recordContractUpdate(
 	s.contractUpdates.Set(key, contractValue)
 }
 
+func (s *Storage) contractUpdateRecorded(
+	location common.AddressLocation,
+) bool {
+	if s.contractUpdates == nil {
+		return false
+	}
+
+	key := interpreter.NewStorageKey(s.memoryGauge, location.Address, location.Name)
+	return s.contractUpdates.Contains(key)
+}
+
 type ContractUpdate struct {
 	ContractValue *interpreter.CompositeValue
 	Key           interpreter.StorageKey


### PR DESCRIPTION
## Description

A transaction may attempt to re-deploy a contract in the same transaction.

Reject it by checking if a previous deployment was recorded.

(Contract updates are not performed immediately, but delayed until the end of the transaction).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
