### PR TITLE
Properly set base on loaded attachments during attachment iteration

### DIFF
--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -473,7 +473,7 @@ func (interpreter *Interpreter) VisitRemoveStatement(removeStatement *ast.Remove
 
 	if attachment.IsResourceKinded(interpreter) {
 		// this attachment is no longer attached to its base, but the `base` variable is still available in the destructor
-		attachment.setBaseValue(interpreter, base, attachmentBaseAuthorization(interpreter, attachment))
+		attachment.setBaseValue(interpreter, base)
 		attachment.Destroy(interpreter, locationRange)
 	}
 


### PR DESCRIPTION
The `base` value was not being properly set on attachment values loaded during iteration. 

Thanks @oebeling for the report

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
