### PR TITLE
Allow native functions to have type parameters

### DIFF
--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -1783,7 +1783,12 @@ func (checker *Checker) defaultMembersAndOrigins(
 
 		identifier := function.Identifier.Identifier
 
-		functionType := checker.functionType(function.ParameterList, function.ReturnTypeAnnotation)
+		functionType := checker.functionType(
+			function.IsNative(),
+			function.TypeParameterList,
+			function.ParameterList,
+			function.ReturnTypeAnnotation,
+		)
 
 		argumentLabels := function.ParameterList.EffectiveArgumentLabels()
 

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -95,7 +95,13 @@ func (checker *Checker) visitFunctionDeclaration(
 
 	functionType := checker.Elaboration.FunctionDeclarationFunctionType(declaration)
 	if functionType == nil {
-		functionType = checker.functionType(declaration.ParameterList, declaration.ReturnTypeAnnotation)
+
+		functionType = checker.functionType(
+			declaration.IsNative(),
+			declaration.TypeParameterList,
+			declaration.ParameterList,
+			declaration.ReturnTypeAnnotation,
+		)
 
 		if options.declareFunction {
 			checker.declareFunctionDeclaration(declaration, functionType)
@@ -430,7 +436,12 @@ func (checker *Checker) declareBefore() {
 func (checker *Checker) VisitFunctionExpression(expression *ast.FunctionExpression) Type {
 
 	// TODO: infer
-	functionType := checker.functionType(expression.ParameterList, expression.ReturnTypeAnnotation)
+	functionType := checker.functionType(
+		false,
+		nil,
+		expression.ParameterList,
+		expression.ReturnTypeAnnotation,
+	)
 
 	checker.Elaboration.SetFunctionExpressionFunctionType(expression, functionType)
 

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -4194,3 +4194,20 @@ func (*AttachmentsNotEnabledError) IsUserError() {}
 func (e *AttachmentsNotEnabledError) Error() string {
 	return "attachments are not enabled and cannot be used in this environment"
 }
+
+// InvalidTypeParameterizedNonNativeFunctionError
+
+type InvalidTypeParameterizedNonNativeFunctionError struct {
+	ast.Range
+}
+
+var _ SemanticError = &InvalidTypeParameterizedNonNativeFunctionError{}
+var _ errors.UserError = &InvalidTypeParameterizedNonNativeFunctionError{}
+
+func (*InvalidTypeParameterizedNonNativeFunctionError) isSemanticError() {}
+
+func (*InvalidTypeParameterizedNonNativeFunctionError) IsUserError() {}
+
+func (e *InvalidTypeParameterizedNonNativeFunctionError) Error() string {
+	return "invalid type parameters in non-native function"
+}

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 )
@@ -50,7 +51,7 @@ func parseAndCheckWithTestValue(t *testing.T, code string, ty sema.Type) (*sema.
 	)
 }
 
-func TestCheckGenericFunction(t *testing.T) {
+func TestCheckGenericFunctionInvocation(t *testing.T) {
 
 	t.Parallel()
 
@@ -896,7 +897,7 @@ func TestCheckBorrowOfCapabilityWithoutTypeArgument(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestCheckUnparameterizedTypeInstantiationE(t *testing.T) {
+func TestCheckInvalidUnparameterizedTypeInstantiation(t *testing.T) {
 
 	t.Parallel()
 
@@ -909,4 +910,212 @@ func TestCheckUnparameterizedTypeInstantiationE(t *testing.T) {
 	errs := RequireCheckerErrors(t, err, 1)
 
 	assert.IsType(t, &sema.UnparameterizedTypeInstantiationError{}, errs[0])
+}
+
+func TestCheckGenericFunctionDeclaration(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("global, non-native", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t, `
+              fun head<T>(_ items: [T]): T? { return nil }
+
+              let x: Int? = head([1, 2, 3])
+            `,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					AllowNativeDeclarations: false,
+				},
+				ParseOptions: parser.Config{
+					NativeModifierEnabled: false,
+					TypeParametersEnabled: true,
+				},
+			},
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.InvalidTypeParameterizedNonNativeFunctionError{}, errs[0])
+	})
+
+	t.Run("global, native", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t, `
+              native fun head<T>(_ items: [T]): T? {}
+
+              let x: Int? = head([1, 2, 3])
+            `,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					AllowNativeDeclarations: true,
+				},
+				ParseOptions: parser.Config{
+					NativeModifierEnabled: true,
+					TypeParametersEnabled: true,
+				},
+			},
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("composite function, non-native", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t, `
+	          struct S {
+	              fun head<T>(_ items: [T]): T? { return nil }
+	          }
+
+	          let x: Int? = S().head([1, 2, 3])
+	        `,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					AllowNativeDeclarations: false,
+				},
+				ParseOptions: parser.Config{
+					NativeModifierEnabled: false,
+					TypeParametersEnabled: true,
+				},
+			},
+		)
+
+		errs := RequireCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.InvalidTypeParameterizedNonNativeFunctionError{}, errs[0])
+		assert.IsType(t, &sema.InvalidTypeParameterizedNonNativeFunctionError{}, errs[1])
+	})
+
+	t.Run("composite function, non-native", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t, `
+	          struct S {
+	              native fun head<T>(_ items: [T]): T? {}
+	          }
+
+	          let x: Int? = S().head([1, 2, 3])
+	        `,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					AllowNativeDeclarations: true,
+				},
+				ParseOptions: parser.Config{
+					NativeModifierEnabled: true,
+					TypeParametersEnabled: true,
+				},
+			},
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("too many type arguments", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+	          native fun test<T>() {}
+
+	          let x = test<Int, Bool>()
+	        `,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					AllowNativeDeclarations: true,
+				},
+				ParseOptions: parser.Config{
+					NativeModifierEnabled: true,
+					TypeParametersEnabled: true,
+				},
+			},
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.InvalidTypeArgumentCountError{}, errs[0])
+	})
+
+	t.Run("too few type arguments", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+	          native fun test<T, U>() {}
+
+	          let x = test<Int>()
+	        `,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					AllowNativeDeclarations: true,
+				},
+				ParseOptions: parser.Config{
+					NativeModifierEnabled: true,
+					TypeParametersEnabled: true,
+				},
+			},
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.TypeParameterTypeInferenceError{}, errs[0])
+	})
+
+	t.Run("type parameter usage in following type parameter", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+	          native fun test<T, U: T>(_ u: U): U {}
+	        `,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					AllowNativeDeclarations: true,
+				},
+				ParseOptions: parser.Config{
+					NativeModifierEnabled: true,
+					TypeParametersEnabled: true,
+				},
+			},
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+	})
+
+	t.Run("type bound is checked", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+	          native fun test<T: @AnyResource>() {}
+
+	          let x = test<Int>()
+	        `,
+			ParseAndCheckOptions{
+				Config: &sema.Config{
+					AllowNativeDeclarations: true,
+				},
+				ParseOptions: parser.Config{
+					NativeModifierEnabled: true,
+					TypeParametersEnabled: true,
+				},
+			},
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+	})
 }


### PR DESCRIPTION
## Description

Even though supporting "user functions" to have type parameters [still needs more work](https://github.com/onflow/cadence/pull/2463), at least allow native functions to have type parameters. 

We already declare and implement built-in functions with type parameters, manually or using the Go type code generator. This PR just extends the existing support to the type checker, so it can be used for checking native/built-in functions.

This PR is basically a subset of #2463, but instead of allowing any function to be generic, it restricts it to native functions, and keeps support for parsing type parameters in function declarations behind a feature flag.

This will allow us to declare more of the built-in types and functions in Cadence code, instead of manually declaring types in Go code, or using the Go type code generator. Concretely, this feature is planned to be used in the `Test` contract, to improve its API.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
