### PR TITLE
Wrap user-errors produced by WebAssembly VM as Cadence user errors

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -27,7 +27,7 @@ import (
 
 	"C"
 
-	"github.com/bytecodealliance/wasmtime-go/v12"
+	wasmtime "github.com/bytecodealliance/wasmtime-go/v12"
 
 	"github.com/onflow/cadence/runtime/interpreter"
 )

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -27,15 +27,11 @@ import (
 
 	"C"
 
-	wasmtime "github.com/bytecodealliance/wasmtime-go/v7"
+	"github.com/bytecodealliance/wasmtime-go/v12"
 
 	"github.com/onflow/cadence/runtime/interpreter"
 )
-import (
-	"errors"
-
-	"github.com/bytecodealliance/wasmtime-go/v12"
-)
+import "errors"
 
 type VM interface {
 	Invoke(name string, arguments ...interpreter.Value) (interpreter.Value, error)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -27,9 +27,14 @@ import (
 
 	"C"
 
-	"github.com/bytecodealliance/wasmtime-go/v7"
+	wasmtime "github.com/bytecodealliance/wasmtime-go/v7"
 
 	"github.com/onflow/cadence/runtime/interpreter"
+)
+import (
+	"errors"
+
+	"github.com/bytecodealliance/wasmtime-go/v12"
 )
 
 type VM interface {
@@ -50,8 +55,11 @@ func (m *vm) Invoke(name string, arguments ...interpreter.Value) (interpreter.Va
 	}
 
 	res, err := f.Call(m.store, rawArguments...)
-	if err != nil {
-		return nil, err
+
+	var trap *wasmtime.Trap
+
+	if errors.As(err, trap) {
+		return nil, trap
 	}
 
 	if res == nil {


### PR DESCRIPTION
Closes and work towards  #2827 

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Wrap user-errors produced by WebAssembly VM as Cadence user errors.
Requires defining abstract user errors that are VM-agnostic. Define in interpreter/errors.go, as errors.UserError
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
