### PR TITLE
Issue 2827 error

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -961,6 +961,7 @@ func (RecursiveTransferError) Error() string {
 	return "recursive transfer of value"
 }
 
+// WasmtimeNewModule
 type WasmtimeNewModule struct {
 }
 

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -961,16 +961,16 @@ func (RecursiveTransferError) Error() string {
 	return "recursive transfer of value"
 }
 
-// WebAssemblyNewModule
-type WebAssemblyNewModule struct {
+// WebAssemblyNewModuleError
+type WebAssemblyNewModuleError struct {
 }
 
-var _ errors.UserError = WebAssemblyNewModule{}
+var _ errors.UserError = WebAssemblyNewModuleError{}
 
-func (WebAssemblyNewModule) IsUserError() {}
+func (WebAssemblyNewModuleError) IsUserError() {}
 
-func (WebAssemblyNewModule) Error() string {
-	return ""
+func (WebAssemblyNewModuleError) Error() string {
+	return fmt.Sprint("failed to load module with the given configuration in engine.")
 }
 
 // WebAssemblyNewInstance
@@ -982,7 +982,7 @@ var _ errors.UserError = WebAssemblyNewInstanceError{}
 func (WebAssemblyNewInstanceError) IsUserError() {}
 
 func (WebAssemblyNewInstanceError) Error() string {
-	return fmt.Sprint("failed to Instantiate WebAssembly Module")
+	return fmt.Sprintf("failed to Instantiate WebAssembly Module")
 }
 
 type WebAssemblyStoreFuel struct {
@@ -1008,39 +1008,31 @@ func (WebAssemblyfunctionCall) Error() string {
 }
 
 type WebAssemblystoreConsumeFuel struct {
-	remainingFuel uint64
+	RemainingFuel uint64
 }
 
 var _ errors.UserError = WebAssemblystoreConsumeFuel{}
 
 func (WebAssemblystoreConsumeFuel) IsUserError() {}
 
-func (WebAssemblystoreConsumeFuel) Error() string {
+func (e WebAssemblystoreConsumeFuel) Error() string {
 
-	/*
-		return fmt.Sprintf(
-			"incorrect number of arguments: expected %d, got %d",
-			e.ParameterCount,
-			e.ArgumentCount,
-		)
-	*/
-
-	return ""
+	return fmt.Sprintf("WebAssembly ConsumeFuel Failed :  RemainingFuel :%d ", e.RemainingFuel)
 }
 
-type WebAssemblyStoreAddFuel struct {
+type WebAssemblyStoreAddFuelError struct {
 	TodoAvailableFuel uint64
 }
 
-var _ errors.UserError = WebAssemblyStoreAddFuel{}
+var _ errors.UserError = WebAssemblyStoreAddFuelError{}
 
-func (WebAssemblyStoreAddFuel) IsUserError() {
+func (WebAssemblyStoreAddFuelError) IsUserError() {
 
 }
 
-func (e WebAssemblyStoreAddFuel) Error() string {
+func (e WebAssemblyStoreAddFuelError) Error() string {
 
-	return fmt.Sprintf("", e.TodoAvailableFuel)
+	return fmt.Sprintf("WebAssembly AddFuel Failed :  AvailableFuel :%d ", e.TodoAvailableFuel)
 }
 func WrappedExternalError(err error) error {
 	switch err := err.(type) {

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -974,15 +974,15 @@ func (WebAssemblyNewModule) Error() string {
 }
 
 // WebAssemblyNewInstance
-type WebAssemblyNewInstance struct {
+type WebAssemblyNewInstanceError struct {
 }
 
-var _ errors.UserError = WebAssemblyNewInstance{}
+var _ errors.UserError = WebAssemblyNewInstanceError{}
 
-func (WebAssemblyNewInstance) IsUserError() {}
+func (WebAssemblyNewInstanceError) IsUserError() {}
 
-func (WebAssemblyNewInstance) Error() string {
-	return fmt.Sprintf("Instantiate WebAssembly Module error:")
+func (WebAssemblyNewInstanceError) Error() string {
+	return fmt.Sprint("failed to Instantiate WebAssembly Module")
 }
 
 type WebAssemblyStoreFuel struct {

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -1008,6 +1008,7 @@ func (WebAssemblyfunctionCall) Error() string {
 }
 
 type WebAssemblystoreConsumeFuel struct {
+	remainingFuel uint64
 }
 
 var _ errors.UserError = WebAssemblystoreConsumeFuel{}
@@ -1015,9 +1016,32 @@ var _ errors.UserError = WebAssemblystoreConsumeFuel{}
 func (WebAssemblystoreConsumeFuel) IsUserError() {}
 
 func (WebAssemblystoreConsumeFuel) Error() string {
+
+	/*
+		return fmt.Sprintf(
+			"incorrect number of arguments: expected %d, got %d",
+			e.ParameterCount,
+			e.ArgumentCount,
+		)
+	*/
+
 	return ""
 }
 
+type WebAssemblyStoreAddFuel struct {
+	TodoAvailableFuel uint64
+}
+
+var _ errors.UserError = WebAssemblyStoreAddFuel{}
+
+func (WebAssemblyStoreAddFuel) IsUserError() {
+
+}
+
+func (e WebAssemblyStoreAddFuel) Error() string {
+
+	return fmt.Sprintf("", e.TodoAvailableFuel)
+}
 func WrappedExternalError(err error) error {
 	switch err := err.(type) {
 	case

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -961,12 +961,15 @@ func (RecursiveTransferError) Error() string {
 	return "recursive transfer of value"
 }
 
-var _ error.UserError = WasmtimeNewModule{}
+type WasmtimeNewModule struct {
+}
+
+var _ errors.UserError = WasmtimeNewModule{}
 
 func (WasmtimeNewModule) IsUserError() {}
 
 func (WasmtimeNewModule) Error() string {
-
+	return ""
 }
 
 func WrappedExternalError(err error) error {

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -961,15 +961,60 @@ func (RecursiveTransferError) Error() string {
 	return "recursive transfer of value"
 }
 
-// WasmtimeNewModule
-type WasmtimeNewModule struct {
+// WebAssemblyNewModule
+type WebAssemblyNewModule struct {
 }
 
-var _ errors.UserError = WasmtimeNewModule{}
+var _ errors.UserError = WebAssemblyNewModule{}
 
-func (WasmtimeNewModule) IsUserError() {}
+func (WebAssemblyNewModule) IsUserError() {}
 
-func (WasmtimeNewModule) Error() string {
+func (WebAssemblyNewModule) Error() string {
+	return ""
+}
+
+// WebAssemblyNewInstance
+type WebAssemblyNewInstance struct {
+}
+
+var _ errors.UserError = WebAssemblyNewInstance{}
+
+func (WebAssemblyNewInstance) IsUserError() {}
+
+func (WebAssemblyNewInstance) Error() string {
+	return ""
+}
+
+type WebAssemblyStoreFuel struct {
+}
+
+var _ errors.UserError = WebAssemblyNewInstance{}
+
+func (WebAssemblyStoreFuel) IsUserError() {}
+
+func (WebAssemblyStoreFuel) Error() string {
+	return ""
+}
+
+type WebAssemblyfunctionCall struct {
+}
+
+var _ errors.UserError = WebAssemblyfunctionCall{}
+
+func (WebAssemblyfunctionCall) IsUserError() {}
+
+func (WebAssemblyfunctionCall) Error() string {
+	return ""
+}
+
+type WebAssemblystoreConsumeFuel struct {
+}
+
+var _ errors.UserError = WebAssemblystoreConsumeFuel{}
+
+func (WebAssemblystoreConsumeFuel) IsUserError() {}
+
+func (WebAssemblystoreConsumeFuel) Error() string {
 	return ""
 }
 

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -961,6 +961,14 @@ func (RecursiveTransferError) Error() string {
 	return "recursive transfer of value"
 }
 
+var _ error.UserError = WasmtimeNewModule{}
+
+func (WasmtimeNewModule) IsUserError() {}
+
+func (WasmtimeNewModule) Error() string {
+
+}
+
 func WrappedExternalError(err error) error {
 	switch err := err.(type) {
 	case

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -982,13 +982,13 @@ var _ errors.UserError = WebAssemblyNewInstance{}
 func (WebAssemblyNewInstance) IsUserError() {}
 
 func (WebAssemblyNewInstance) Error() string {
-	return ""
+	return fmt.Sprintf("Instantiate WebAssembly Module error:")
 }
 
 type WebAssemblyStoreFuel struct {
 }
 
-var _ errors.UserError = WebAssemblyNewInstance{}
+var _ errors.UserError = WebAssemblyStoreFuel{}
 
 func (WebAssemblyStoreFuel) IsUserError() {}
 

--- a/runtime/webassembly.go
+++ b/runtime/webassembly.go
@@ -44,8 +44,7 @@ func NewWasmtimeWebAssemblyModule(bytes []byte) (stdlib.WebAssemblyModule, error
 
 	module, err := wasmtime.NewModule(engine, bytes)
 	if err != nil {
-		// TODO: wrap error
-		return nil, err
+		return nil, interpreter.WebAssemblyNewModuleError{}
 	}
 
 	return WasmtimeWebAssemblyModule{
@@ -59,7 +58,6 @@ var _ stdlib.WebAssemblyModule = WasmtimeWebAssemblyModule{}
 func (m WasmtimeWebAssemblyModule) InstantiateWebAssemblyModule(_ common.MemoryGauge) (stdlib.WebAssemblyInstance, error) {
 	instance, err := wasmtime.NewInstance(m.Store, m.Module, nil)
 	if err != nil {
-		// TODO: wrap error
 		return nil, interpreter.WebAssemblyNewInstanceError{}
 	}
 	return WasmtimeWebAssemblyInstance{
@@ -191,11 +189,13 @@ func newWasmtimeFunctionWebAssemblyExport(
 
 			// TODO: get remaining computation and convert to fuel.
 			//   needs e.g. invocation.Interpreter.RemainingComputation()
-			const todoAvailableFuel = 1000
+			var todoAvailableFuel uint64 = 1000
 			err := store.AddFuel(todoAvailableFuel)
 			if err != nil {
-				// TODO: wrap error
-				panic(err)
+				return interpreter.WebAssemblyStoreAddFuelError{
+					TodoAvailableFuel: todoAvailableFuel,
+				}
+
 			}
 
 			result, err := function.Call(store, convertedArguments...)
@@ -211,14 +211,16 @@ func newWasmtimeFunctionWebAssemblyExport(
 
 			remainingFuel, err := store.ConsumeFuel(0)
 			if err != nil {
-				// TODO: wrap error
-				panic(err)
+				panic(interpreter.WebAssemblystoreConsumeFuel{
+					RemainingFuel: remainingFuel,
+				})
 			}
 
 			remainingFuel, err = store.ConsumeFuel(remainingFuel)
 			if err != nil {
-				// TODO: wrap error
-				panic(err)
+				panic(interpreter.WebAssemblystoreConsumeFuel{
+					RemainingFuel: remainingFuel,
+				})
 			}
 
 			if remainingFuel != 0 {

--- a/runtime/webassembly.go
+++ b/runtime/webassembly.go
@@ -60,7 +60,7 @@ func (m WasmtimeWebAssemblyModule) InstantiateWebAssemblyModule(_ common.MemoryG
 	instance, err := wasmtime.NewInstance(m.Store, m.Module, nil)
 	if err != nil {
 		// TODO: wrap error
-		return nil, err
+		return nil, interpreter.WebAssemblyNewInstanceError{}
 	}
 	return WasmtimeWebAssemblyInstance{
 		Instance: instance,


### PR DESCRIPTION
Closes and work towards  #2827 

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Wrap user-errors produced by WebAssembly VM as Cadence user errors.
Requires defining abstract user errors that are VM-agnostic. Define in interpreter/errors.go, as errors.UserError
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
