### PR TITLE
Restore old parenthesized type parsing behavior

### DIFF
--- a/runtime/parser/type_test.go
+++ b/runtime/parser/type_test.go
@@ -481,7 +481,7 @@ func TestParseReferenceType(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "unexpected non-function parenthesized type",
+					Message: "expected 'fun', got '&'",
 					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
 				},
 			},
@@ -497,7 +497,7 @@ func TestParseReferenceType(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "unexpected non-function parenthesized type",
+					Message: "expected 'fun', got '&'",
 					Pos:     ast.Position{Offset: 11, Line: 1, Column: 11},
 				},
 			},
@@ -513,7 +513,7 @@ func TestParseReferenceType(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "unexpected non-function parenthesized type",
+					Message: "expected 'fun', got identifier",
 					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
 				},
 			},
@@ -1134,7 +1134,7 @@ func TestParseFunctionType(t *testing.T) {
 					StartPos: ast.Position{Line: 1, Column: 12, Offset: 12},
 				},
 				Range: ast.Range{
-					StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 					EndPos:   ast.Position{Line: 1, Column: 15, Offset: 15},
 				},
 			},
@@ -1164,7 +1164,7 @@ func TestParseFunctionType(t *testing.T) {
 					StartPos: ast.Position{Line: 1, Column: 13, Offset: 13},
 				},
 				Range: ast.Range{
-					StartPos: ast.Position{Line: 1, Column: 6, Offset: 6},
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 					EndPos:   ast.Position{Line: 1, Column: 16, Offset: 16},
 				},
 			},
@@ -2493,7 +2493,7 @@ func TestParseViewFunctionTypeWithNewSyntax(t *testing.T) {
 						StartPos: ast.Position{Offset: 33, Line: 2, Column: 32},
 					},
 					Range: ast.Range{
-						StartPos: ast.Position{Offset: 17, Line: 2, Column: 16},
+						StartPos: ast.Position{Offset: 13, Line: 2, Column: 12},
 						EndPos:   ast.Position{Offset: 49, Line: 2, Column: 48},
 					},
 				},
@@ -3076,7 +3076,7 @@ func TestParseParenthesizedTypes(t *testing.T) {
 	utils.AssertEqualWithDiff(t,
 		[]error{
 			&SyntaxError{
-				Message: "unexpected non-function parenthesized type",
+				Message: "expected 'fun', got identifier",
 				Pos:     ast.Position{Offset: 8, Line: 1, Column: 8},
 			},
 		},
@@ -3092,7 +3092,7 @@ func TestParseNestedParenthesizedTypes(t *testing.T) {
 	utils.AssertEqualWithDiff(t,
 		[]error{
 			&SyntaxError{
-				Message: "unexpected non-function parenthesized type",
+				Message: "expected 'fun', got '('",
 				Pos:     ast.Position{Offset: 8, Line: 1, Column: 8},
 			},
 		},

--- a/runtime/parser/type_test.go
+++ b/runtime/parser/type_test.go
@@ -489,6 +489,22 @@ func TestParseReferenceType(t *testing.T) {
 		)
 	})
 
+	t.Run("double nested reference no parens", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseType("& &S")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "unexpected nested reference type",
+					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
+				},
+			},
+			errs,
+		)
+	})
+
 	t.Run("double nested authorized reference", func(t *testing.T) {
 
 		t.Parallel()

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -1859,7 +1859,7 @@ func TestCheckInvalidEntitlementMappingAuth(t *testing.T) {
 		_, err := ParseAndCheck(t, `
             entitlement mapping M {}
             resource interface R {
-                access(M) let foo: (auth(M) &Int)?
+                access(M) let foo: auth(M) &Int?
             }
         `)
 
@@ -1888,7 +1888,7 @@ func TestCheckInvalidEntitlementMappingAuth(t *testing.T) {
 		_, err := ParseAndCheck(t, `
             entitlement mapping M {}
             resource interface R {
-                access(M) let foo: fun((auth(M) &Int?))
+                access(M) let foo: fun(auth(M) &Int?)
             }
         `)
 
@@ -7307,7 +7307,7 @@ func TestCheckEntitlementOptionalChaining(t *testing.T) {
                 }
             }
 
-            fun bar(r: (auth(X) &S)?): (auth(Y) &Int)? {
+            fun bar(r: auth(X) &S?): auth(Y) &Int? {
                 return r?.foo
             }
         `)

--- a/runtime/tests/checker/member_test.go
+++ b/runtime/tests/checker/member_test.go
@@ -694,29 +694,11 @@ func TestCheckMemberAccess(t *testing.T) {
             fun test() {
                 let dict: {String: {String: Int}?} = {"one": {"two": 2}}
                 let dictRef = &dict as &{String: {String: Int}?}
-                var x: (&{String: Int})?? = dictRef["one"]
+                var x: &{String: Int}?? = dictRef["one"]
             }
         `)
 
 		require.NoError(t, err)
-	})
-
-	t.Run("dictionary reference, optional typed value, mismatch types", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheck(t, `
-            fun test() {
-                let dict: {String: {String: Int}?} = {"one": {"two": 2}}
-                let dictRef = &dict as &{String: {String: Int}?}
-
-                // Must return an optional reference, not a reference to an optional
-                var x: &({String: Int}??) = dictRef["one"]
-            }
-        `)
-
-		errors := RequireCheckerErrors(t, err, 1)
-		typeMismatchError := &sema.TypeMismatchError{}
-		require.ErrorAs(t, errors[0], &typeMismatchError)
 	})
 
 	t.Run("dictionary reference, primitive typed value", func(t *testing.T) {

--- a/runtime/tests/interpreter/member_test.go
+++ b/runtime/tests/interpreter/member_test.go
@@ -957,7 +957,7 @@ func TestInterpretMemberAccess(t *testing.T) {
             fun test() {
                 let dict: {String: {String: Int}?} = {"one": {"two": 2}}
                 let dictRef = &dict as &{String: {String: Int}?}
-                var x: (&{String: Int})?? = dictRef["one"]
+                var x: &{String: Int}?? = dictRef["one"]
             }
         `)
 


### PR DESCRIPTION
ad0cbfab973fa2203bd8e1afbaf8c2322d060cf5 introduced a regression by adding support for parenthesized types, but the type checker makes a number of assumptions that don't account for the possibility that types are arbitrarily nested like this change allowed them to be. In particular, reference field access assumes that references are never double-nested (it's not possible to have a reference to a reference), because prior to this point it was never possible to express such a type. This restores the old behavior, whereby only function types can be wrapped in parens. 

This also makes a minor breaking change by banning `& &T` doubly nested reference types separated by a space. 

Thanks to @oebeling for the report

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
