### PR TITLE
[stable-cadence] Fix field assignment via references

### DIFF
--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -163,7 +163,7 @@ func (checker *Checker) enforceViewAssignment(assignment ast.Statement, target a
 			accessChain = append(accessChain, elementType)
 		case *ast.MemberExpression:
 			target = targetExp.Expression
-			memberType, _, _, _ := checker.visitMember(targetExp)
+			memberType, _, _, _ := checker.visitMember(targetExp, true)
 			accessChain = append(accessChain, memberType)
 		default:
 			inAccessChain = false
@@ -352,7 +352,7 @@ func (checker *Checker) visitMemberExpressionAssignment(
 	target *ast.MemberExpression,
 ) (memberType Type) {
 
-	_, memberType, member, isOptional := checker.visitMember(target)
+	_, memberType, member, isOptional := checker.visitMember(target, true)
 
 	if member == nil {
 		return InvalidType

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -321,7 +321,7 @@ func (checker *Checker) visitIndexExpression(
 		//   2) is container-typed,
 		// then the element type should also be a reference.
 		returnReference := false
-		if !isAssignment && shouldReturnReference(valueIndexedType, elementType) {
+		if shouldReturnReference(valueIndexedType, elementType, isAssignment) {
 			// For index expressions, element are un-authorized.
 			elementType = checker.getReferenceType(elementType, false, UnauthorizedAccess)
 

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -299,7 +299,7 @@ func (checker *Checker) checkMemberInvocationArgumentLabels(
 	invocationExpression *ast.InvocationExpression,
 	memberExpression *ast.MemberExpression,
 ) {
-	_, _, member, _ := checker.visitMember(memberExpression)
+	_, _, member, _ := checker.visitMember(memberExpression, false)
 
 	if member == nil || len(member.ArgumentLabels) == 0 {
 		return

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -25,7 +25,7 @@ import (
 
 // NOTE: only called if the member expression is *not* an assignment
 func (checker *Checker) VisitMemberExpression(expression *ast.MemberExpression) Type {
-	accessedType, memberType, member, isOptional := checker.visitMember(expression)
+	accessedType, memberType, member, isOptional := checker.visitMember(expression, false)
 
 	if !accessedType.IsInvalidType() {
 		memberAccessType := accessedType
@@ -111,7 +111,11 @@ func (checker *Checker) getReferenceType(typ Type, substituteAuthorization bool,
 	return NewReferenceType(checker.memoryGauge, auth, typ)
 }
 
-func shouldReturnReference(parentType, memberType Type) bool {
+func shouldReturnReference(parentType, memberType Type, isAssignment bool) bool {
+	if isAssignment {
+		return false
+	}
+
 	if _, isReference := referenceType(parentType); !isReference {
 		return false
 	}
@@ -125,7 +129,12 @@ func referenceType(typ Type) (*ReferenceType, bool) {
 	return refType, isReference
 }
 
-func (checker *Checker) visitMember(expression *ast.MemberExpression) (accessedType Type, resultingType Type, member *Member, isOptional bool) {
+func (checker *Checker) visitMember(expression *ast.MemberExpression, isAssignment bool) (
+	accessedType Type,
+	resultingType Type,
+	member *Member,
+	isOptional bool,
+) {
 	memberInfo, ok := checker.Elaboration.MemberExpressionMemberAccessInfo(expression)
 	if ok {
 		return memberInfo.AccessedType, memberInfo.ResultingType, memberInfo.Member, memberInfo.IsOptional
@@ -367,7 +376,7 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (accessedT
 	// i.e: `accessedSelfMember == nil`
 
 	if accessedSelfMember == nil &&
-		shouldReturnReference(accessedType, resultingType) &&
+		shouldReturnReference(accessedType, resultingType, isAssignment) &&
 		member.DeclarationKind == common.DeclarationKindField {
 
 		// Get a reference to the type

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -980,10 +980,11 @@ func TestCheckAccountContractsNames(t *testing.T) {
           }
         `)
 
-		errors := RequireCheckerErrors(t, err, 2)
+		errors := RequireCheckerErrors(t, err, 3)
 
 		assert.IsType(t, &sema.InvalidAssignmentAccessError{}, errors[0])
 		assert.IsType(t, &sema.AssignmentToConstantMemberError{}, errors[1])
+		assert.IsType(t, &sema.NonReferenceTypeReferenceError{}, errors[2])
 	})
 }
 


### PR DESCRIPTION
## Description

During assignments, field-access should return the original type of the field, rather than the reference type (where applicable). 

Currently, it returns the reference type, making it possible to assign `nil` to optional-reference-typed fields.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
