### PR TITLE
Add support iterating references to iterables

### DIFF
--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -338,7 +338,7 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) S
 		panic(errors.NewUnreachableError())
 	}
 
-	iterator := iterable.Iterator(interpreter)
+	iterator := iterable.Iterator(interpreter, locationRange)
 
 	var index IntValue
 	if statement.Index != nil {

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -338,7 +338,8 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) S
 		panic(errors.NewUnreachableError())
 	}
 
-	iterator := iterable.Iterator(interpreter, locationRange)
+	forStmtTypes := interpreter.Program.Elaboration.ForStatementType(statement)
+	iterator := iterable.Iterator(interpreter, forStmtTypes.ValueVariableType, locationRange)
 
 	var index IntValue
 	if statement.Index != nil {

--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -329,7 +329,7 @@ func (checker *Checker) visitIndexExpressionAssignment(
 	elementType = checker.visitIndexExpression(indexExpression, true)
 
 	indexExprTypes := checker.Elaboration.IndexExpressionTypes(indexExpression)
-	indexedRefType, isReference := GetReferenceType(indexExprTypes.IndexedType)
+	indexedRefType, isReference := MaybeReferenceType(indexExprTypes.IndexedType)
 
 	if isReference &&
 		!mutableEntitledAccess.PermitsAccess(indexedRefType.Authorization) &&

--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -329,7 +329,7 @@ func (checker *Checker) visitIndexExpressionAssignment(
 	elementType = checker.visitIndexExpression(indexExpression, true)
 
 	indexExprTypes := checker.Elaboration.IndexExpressionTypes(indexExpression)
-	indexedRefType, isReference := referenceType(indexExprTypes.IndexedType)
+	indexedRefType, isReference := GetReferenceType(indexExprTypes.IndexedType)
 
 	if isReference &&
 		!mutableEntitledAccess.PermitsAccess(indexedRefType.Authorization) &&

--- a/runtime/sema/check_for.go
+++ b/runtime/sema/check_for.go
@@ -43,41 +43,17 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) (_ struct
 
 	valueType := checker.VisitExpression(valueExpression, expectedType)
 
-	var elementType Type = InvalidType
-
-	if !valueType.IsInvalidType() {
-
-		// Only get the element type if the array is not a resource array.
-		// Otherwise, in addition to the `UnsupportedResourceForLoopError`,
-		// the loop variable will be declared with the resource-typed element type,
-		// leading to an additional `ResourceLossError`.
-
-		if valueType.IsResourceType() {
-			checker.report(
-				&UnsupportedResourceForLoopError{
-					Range: ast.NewRangeFromPositioned(checker.memoryGauge, valueExpression),
-				},
-			)
-		} else if arrayType, ok := valueType.(ArrayType); ok {
-			elementType = arrayType.ElementType(false)
-		} else if valueType == StringType {
-			elementType = CharacterType
-		} else {
-			checker.report(
-				&TypeMismatchWithDescriptionError{
-					ExpectedTypeDescription: "array",
-					ActualType:              valueType,
-					Range:                   ast.NewRangeFromPositioned(checker.memoryGauge, valueExpression),
-				},
-			)
-		}
-	}
+	// Only get the element type if the array is not a resource array.
+	// Otherwise, in addition to the `UnsupportedResourceForLoopError`,
+	// the loop variable will be declared with the resource-typed element type,
+	// leading to an additional `ResourceLossError`.
+	loopVariableType := checker.loopVariableType(valueType, valueExpression)
 
 	identifier := statement.Identifier.Identifier
 
 	variable, err := checker.valueActivations.declare(variableDeclaration{
 		identifier:               identifier,
-		ty:                       elementType,
+		ty:                       loopVariableType,
 		kind:                     common.DeclarationKindConstant,
 		pos:                      statement.Identifier.Pos,
 		isConstant:               true,
@@ -122,4 +98,69 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) (_ struct
 	})
 
 	return
+}
+
+func (checker *Checker) loopVariableType(valueType Type, hasPosition ast.HasPosition) Type {
+	if valueType.IsInvalidType() {
+		return InvalidType
+	}
+
+	// Resources cannot be looped.
+	if valueType.IsResourceType() {
+		checker.report(
+			&UnsupportedResourceForLoopError{
+				Range: ast.NewRangeFromPositioned(checker.memoryGauge, hasPosition),
+			},
+		)
+		return InvalidType
+	}
+
+	// If it's a reference, check whether the referenced type is iterable.
+	// If yes, then determine the loop-var type depending on the
+	// element-type of the referenced type.
+	// If that element type is:
+	//  a) A container type, then the loop-var is also a reference-type.
+	//  b) A primitive type, then the loop-var is the concrete type itself.
+
+	if referenceType, ok := valueType.(*ReferenceType); ok {
+		referencedType := referenceType.Type
+		referencedIterableElementType := checker.iterableElementType(referencedType, hasPosition)
+
+		if referencedIterableElementType.IsInvalidType() {
+			return referencedIterableElementType
+		}
+
+		// Case (a): Element type is a container type.
+		// Then the loop-var must also be a reference type.
+		if referencedIterableElementType.ContainFieldsOrElements() {
+			return NewReferenceType(checker.memoryGauge, UnauthorizedAccess, referencedIterableElementType)
+		}
+
+		// Case (b): Element type is a primitive type.
+		// Then the loop-var must be the concrete type.
+		return referencedIterableElementType
+	}
+
+	// If it's not a reference, then simply get the element type.
+	return checker.iterableElementType(valueType, hasPosition)
+}
+
+func (checker *Checker) iterableElementType(valueType Type, hasPosition ast.HasPosition) Type {
+	if arrayType, ok := valueType.(ArrayType); ok {
+		return arrayType.ElementType(false)
+	}
+
+	if valueType == StringType {
+		return CharacterType
+	}
+
+	checker.report(
+		&TypeMismatchWithDescriptionError{
+			ExpectedTypeDescription: "array",
+			ActualType:              valueType,
+			Range:                   ast.NewRangeFromPositioned(checker.memoryGauge, hasPosition),
+		},
+	)
+
+	return InvalidType
 }

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -116,14 +116,14 @@ func shouldReturnReference(parentType, memberType Type, isAssignment bool) bool 
 		return false
 	}
 
-	if _, isReference := GetReferenceType(parentType); !isReference {
+	if _, isReference := MaybeReferenceType(parentType); !isReference {
 		return false
 	}
 
 	return memberType.ContainFieldsOrElements()
 }
 
-func GetReferenceType(typ Type) (*ReferenceType, bool) {
+func MaybeReferenceType(typ Type) (*ReferenceType, bool) {
 	unwrappedType := UnwrapOptionalType(typ)
 	refType, isReference := unwrappedType.(*ReferenceType)
 	return refType, isReference

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -116,14 +116,14 @@ func shouldReturnReference(parentType, memberType Type, isAssignment bool) bool 
 		return false
 	}
 
-	if _, isReference := referenceType(parentType); !isReference {
+	if _, isReference := GetReferenceType(parentType); !isReference {
 		return false
 	}
 
 	return memberType.ContainFieldsOrElements()
 }
 
-func referenceType(typ Type) (*ReferenceType, bool) {
+func GetReferenceType(typ Type) (*ReferenceType, bool) {
 	unwrappedType := UnwrapOptionalType(typ)
 	refType, isReference := unwrappedType.(*ReferenceType)
 	return refType, isReference

--- a/runtime/sema/check_variable_declaration.go
+++ b/runtime/sema/check_variable_declaration.go
@@ -264,7 +264,7 @@ func (checker *Checker) recordReference(targetVariable *Variable, expr ast.Expre
 		return
 	}
 
-	if _, isReference := GetReferenceType(targetVariable.Type); !isReference {
+	if _, isReference := MaybeReferenceType(targetVariable.Type); !isReference {
 		return
 	}
 

--- a/runtime/sema/check_variable_declaration.go
+++ b/runtime/sema/check_variable_declaration.go
@@ -264,7 +264,7 @@ func (checker *Checker) recordReference(targetVariable *Variable, expr ast.Expre
 		return
 	}
 
-	if _, isReference := referenceType(targetVariable.Type); !isReference {
+	if _, isReference := GetReferenceType(targetVariable.Type); !isReference {
 		return
 	}
 

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -111,6 +111,11 @@ type ExpressionTypes struct {
 	ExpectedType Type
 }
 
+type ForStatementTypes struct {
+	IndexVariableType Type
+	ValueVariableType Type
+}
+
 type Elaboration struct {
 	interfaceTypesAndDeclarationsBiMap      *bimap.BiMap[*InterfaceType, *ast.InterfaceDeclaration]
 	entitlementTypesAndDeclarationsBiMap    *bimap.BiMap[*EntitlementType, *ast.EntitlementDeclaration]
@@ -118,6 +123,7 @@ type Elaboration struct {
 
 	fixedPointExpressionTypes         map[*ast.FixedPointExpression]Type
 	swapStatementTypes                map[*ast.SwapStatement]SwapStatementTypes
+	forStatementTypes                 map[*ast.ForStatement]ForStatementTypes
 	assignmentStatementTypes          map[*ast.AssignmentStatement]AssignmentStatementTypes
 	compositeDeclarationTypes         map[ast.CompositeLikeDeclaration]*CompositeType
 	compositeTypeDeclarations         map[*CompositeType]ast.CompositeLikeDeclaration
@@ -1031,4 +1037,18 @@ func (e *Elaboration) GetSemanticAccess(access ast.Access) (semaAccess Access, p
 	}
 	semaAccess, present = e.semanticAccesses[access]
 	return
+}
+
+func (e *Elaboration) SetForStatementType(statement *ast.ForStatement, types ForStatementTypes) {
+	if e.forStatementTypes == nil {
+		e.forStatementTypes = map[*ast.ForStatement]ForStatementTypes{}
+	}
+	e.forStatementTypes[statement] = types
+}
+
+func (e *Elaboration) ForStatementType(statement *ast.ForStatement) (types ForStatementTypes) {
+	if e.forStatementTypes == nil {
+		return
+	}
+	return e.forStatementTypes[statement]
 }

--- a/runtime/tests/checker/for_test.go
+++ b/runtime/tests/checker/for_test.go
@@ -375,4 +375,21 @@ func TestCheckReferencesInForLoop(t *testing.T) {
 		errors := RequireCheckerErrors(t, err, 1)
 		assert.IsType(t, &sema.TypeMismatchWithDescriptionError{}, errors[0])
 	})
+
+	t.Run("Non existing type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            fun main() {
+                var foo = Foo()
+                var fooRef = &foo as &Foo
+
+                for element in fooRef {}
+            }
+        `)
+
+		errors := RequireCheckerErrors(t, err, 2)
+		assert.IsType(t, &sema.NotDeclaredError{}, errors[0])
+		assert.IsType(t, &sema.NotDeclaredError{}, errors[1])
+	})
 }

--- a/runtime/tests/checker/for_test.go
+++ b/runtime/tests/checker/for_test.go
@@ -431,4 +431,23 @@ func TestCheckReferencesInForLoop(t *testing.T) {
 		errors := RequireCheckerErrors(t, err, 1)
 		assert.IsType(t, &sema.TypeMismatchError{}, errors[0])
 	})
+
+	t.Run("Optional array", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct Foo{}
+
+            fun main() {
+                var array: [Foo?] = [Foo(), Foo()]
+                var arrayRef = &array as &[Foo?]
+
+                for element in arrayRef {
+                    let e: &Foo? = element    // Should be an optional reference
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
 }

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -386,6 +386,26 @@ func TestInterpretEphemeralReferencesInForLoop(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
 	})
+
+	t.Run("Auth ref", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            struct Foo{}
+
+            fun main() {
+                var array = [Foo(), Foo()]
+                var arrayRef = &array as auth(Mutate) &[Foo]
+
+                for element in arrayRef {
+                    let e: &Foo = element    // Should be non-auth
+                }
+            }
+        `)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+	})
 }
 
 func TestInterpretStorageReferencesInForLoop(t *testing.T) {


### PR DESCRIPTION
Closes #2784

## Description

Allow using array references in for loops.
```cadence
for v in arrayRef {}
```

For an array of type `[T]`, the type of the loop-variable `v` would be:

- The concrete type `T`, if the array element type `T` is a primitive.
- A reference type `&T`, if the array element is a container type.

This is to be consistent with the member access semantics: https://github.com/onflow/flips/blob/120b8aa473e5040db2b99034d2118fb78d053cdf/cadence/20230517-member-access-semnatics.md

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
