### PR TITLE
Entitlement mapping escape fixes

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -671,6 +671,23 @@ func (e ValueTransferTypeError) Error() string {
 	)
 }
 
+// UnexpectedMappedEntitlementError
+type UnexpectedMappedEntitlementError struct {
+	Type sema.Type
+	LocationRange
+}
+
+var _ errors.InternalError = UnexpectedMappedEntitlementError{}
+
+func (UnexpectedMappedEntitlementError) IsInternalError() {}
+
+func (e UnexpectedMappedEntitlementError) Error() string {
+	return fmt.Sprintf(
+		"invalid transfer of value: found an unexpected runtime mapped entitlement `%s`",
+		e.Type.QualifiedString(),
+	)
+}
+
 // ResourceConstructionError
 type ResourceConstructionError struct {
 	CompositeType *sema.CompositeType

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2115,6 +2115,14 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 			// transferring a reference at runtime does not change its entitlements; this is so that an upcast reference
 			// can later be downcast back to its original entitlement set
 
+			// check defensively that we never create a runtime mapped entitlement value
+			if _, isMappedAuth := unwrappedTargetType.Authorization.(*sema.EntitlementMapAccess); isMappedAuth {
+				panic(UnexpectedMappedEntitlementError{
+					Type:          unwrappedTargetType,
+					LocationRange: locationRange,
+				})
+			}
+
 			switch ref := value.(type) {
 			case *EphemeralReferenceValue:
 				return NewEphemeralReferenceValue(

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -187,20 +187,23 @@ func (checker *Checker) checkFunction(
 			functionActivation.InitializationInfo = initializationInfo
 
 			if functionBlock != nil {
-				oldMappedAccess := checker.entitlementMappingInScope
-				if mappedAccess, isMappedAccess := access.(*EntitlementMapAccess); isMappedAccess {
-					checker.entitlementMappingInScope = mappedAccess.Type
-				}
+				func() {
+					oldMappedAccess := checker.entitlementMappingInScope
+					if mappedAccess, isMappedAccess := access.(*EntitlementMapAccess); isMappedAccess {
+						checker.entitlementMappingInScope = mappedAccess.Type
+					} else {
+						checker.entitlementMappingInScope = nil
+					}
+					defer func() { checker.entitlementMappingInScope = oldMappedAccess }()
 
-				checker.InNewPurityScope(functionType.Purity == FunctionPurityView, func() {
-					checker.visitFunctionBlock(
-						functionBlock,
-						functionType.ReturnTypeAnnotation,
-						checkResourceLoss,
-					)
-				})
-
-				checker.entitlementMappingInScope = oldMappedAccess
+					checker.InNewPurityScope(functionType.Purity == FunctionPurityView, func() {
+						checker.visitFunctionBlock(
+							functionBlock,
+							functionType.ReturnTypeAnnotation,
+							checkResourceLoss,
+						)
+					})
+				}()
 
 				if mustExit {
 					returnType := functionType.ReturnTypeAnnotation.Type

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -187,6 +187,7 @@ func (checker *Checker) checkFunction(
 			functionActivation.InitializationInfo = initializationInfo
 
 			if functionBlock != nil {
+				oldMappedAccess := checker.entitlementMappingInScope
 				if mappedAccess, isMappedAccess := access.(*EntitlementMapAccess); isMappedAccess {
 					checker.entitlementMappingInScope = mappedAccess.Type
 				}
@@ -199,7 +200,7 @@ func (checker *Checker) checkFunction(
 					)
 				})
 
-				checker.entitlementMappingInScope = nil
+				checker.entitlementMappingInScope = oldMappedAccess
 
 				if mustExit {
 					returnType := functionType.ReturnTypeAnnotation.Type

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -319,16 +319,7 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (accessedT
 	shouldSubstituteAuthorization := !member.Access.Equal(resultingAuthorization)
 
 	if shouldSubstituteAuthorization {
-		switch ty := resultingType.(type) {
-		case *FunctionType:
-			resultingType = NewSimpleFunctionType(
-				ty.Purity,
-				ty.Parameters,
-				ty.ReturnTypeAnnotation.Map(checker.memoryGauge, make(map[*TypeParameter]*TypeParameter), substituteConcreteAuthorization),
-			)
-		default:
-			resultingType = resultingType.Map(checker.memoryGauge, make(map[*TypeParameter]*TypeParameter), substituteConcreteAuthorization)
-		}
+		resultingType = resultingType.Map(checker.memoryGauge, make(map[*TypeParameter]*TypeParameter), substituteConcreteAuthorization)
 	}
 
 	// Check that the member access is not to a function of resource type

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -312,12 +312,6 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (accessedT
 		switch ty := resultingType.(type) {
 		case *ReferenceType:
 			return NewReferenceType(checker.memoryGauge, resultingAuthorization, ty.Type)
-		case *OptionalType:
-			switch innerTy := ty.Type.(type) {
-			case *ReferenceType:
-				return NewOptionalType(checker.memoryGauge,
-					NewReferenceType(checker.memoryGauge, resultingAuthorization, innerTy.Type))
-			}
 		}
 		return resultingType
 	}

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -330,10 +330,10 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression) (accessedT
 			resultingType = NewSimpleFunctionType(
 				ty.Purity,
 				ty.Parameters,
-				NewTypeAnnotation(substituteConcreteAuthorization(ty.ReturnTypeAnnotation.Type)),
+				ty.ReturnTypeAnnotation.Map(checker.memoryGauge, make(map[*TypeParameter]*TypeParameter), substituteConcreteAuthorization),
 			)
 		default:
-			resultingType = substituteConcreteAuthorization(resultingType)
+			resultingType = resultingType.Map(checker.memoryGauge, make(map[*TypeParameter]*TypeParameter), substituteConcreteAuthorization)
 		}
 	}
 

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1263,6 +1263,7 @@ func (checker *Checker) functionType(
 	} else {
 		checker.entitlementMappingInScope = nil
 	}
+	defer func() { checker.entitlementMappingInScope = oldMappedAccess }()
 
 	convertedParameters := checker.parameters(parameterList)
 
@@ -1271,7 +1272,6 @@ func (checker *Checker) functionType(
 		convertedReturnTypeAnnotation =
 			checker.ConvertTypeAnnotation(returnTypeAnnotation)
 	}
-	checker.entitlementMappingInScope = oldMappedAccess
 
 	return &FunctionType{
 		Purity:               PurityFromAnnotation(purity),

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -1256,20 +1256,22 @@ func (checker *Checker) functionType(
 	parameterList *ast.ParameterList,
 	returnTypeAnnotation *ast.TypeAnnotation,
 ) *FunctionType {
+
+	oldMappedAccess := checker.entitlementMappingInScope
+	if mapAccess, isMapAccess := access.(*EntitlementMapAccess); isMapAccess {
+		checker.entitlementMappingInScope = mapAccess.Type
+	} else {
+		checker.entitlementMappingInScope = nil
+	}
+
 	convertedParameters := checker.parameters(parameterList)
 
 	convertedReturnTypeAnnotation := VoidTypeAnnotation
 	if returnTypeAnnotation != nil {
-		// to allow entitlement mapping types to be used in the return annotation only of
-		// a mapped accessor function, we introduce a "variable" into the typing scope while
-		// checking the return
-		if mapAccess, isMapAccess := access.(*EntitlementMapAccess); isMapAccess {
-			checker.entitlementMappingInScope = mapAccess.Type
-		}
 		convertedReturnTypeAnnotation =
 			checker.ConvertTypeAnnotation(returnTypeAnnotation)
-		checker.entitlementMappingInScope = nil
 	}
+	checker.entitlementMappingInScope = oldMappedAccess
 
 	return &FunctionType{
 		Purity:               PurityFromAnnotation(purity),

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -7587,50 +7587,6 @@ func TestCheckEntitlementMappingComplexFields(t *testing.T) {
 		require.IsType(t, &sema.TypeMismatchError{}, errors[0])
 	})
 
-	t.Run("lambda escape", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := ParseAndCheck(t, `
-            entitlement Inner1
-            entitlement Inner2
-            entitlement Outer1
-            entitlement Outer2
-
-            entitlement mapping MyMap {
-                Outer1 -> Inner1
-                Outer2 -> Inner2
-            }
-            struct InnerObj {
-                access(Inner1) fun first(): Int{ return 9999 }
-                access(Inner2) fun second(): Int{ return 8888 }
-            }
-
-            struct Carrier{
-                access(MyMap) let arr: [auth(MyMap) &InnerObj]
-                init() {
-                    self.arr = [&InnerObj()]
-                }
-            }   
-            
-            struct FuncGenerator {
-                access(MyMap) fun generate(): auth(MyMap) &Int? {
-                    fun innerFunc(_ param: auth(MyMap) &InnerObj): Int {
-                        return 123;
-                    }
-                    var f = innerFunc; // will fail if we're called via a reference
-                    return nil;
-                }
-            }      
-
-            fun foo() {
-                (&FuncGenerator() as auth(Outer1) &FuncGenerator).generate()
-            }
-        `)
-
-		errors := RequireCheckerErrors(t, err, 1)
-		require.IsType(t, &sema.TypeMismatchError{}, errors[0])
-	})
-
 	t.Run("dictionary mapped field", func(t *testing.T) {
 		t.Parallel()
 

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -7547,6 +7547,90 @@ func TestCheckEntitlementMappingComplexFields(t *testing.T) {
 		require.IsType(t, &sema.InvalidMappedEntitlementMemberError{}, errors[0])
 	})
 
+	t.Run("array mapped field escape", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            entitlement Inner1
+            entitlement Inner2
+            entitlement Outer1
+            entitlement Outer2
+
+            entitlement mapping MyMap {
+                Outer1 -> Inner1
+                Outer2 -> Inner2
+            }
+            struct InnerObj {
+                access(Inner1) fun first(): Int{ return 9999 }
+                access(Inner2) fun second(): Int{ return 8888 }
+            }
+
+            struct Carrier{
+                access(MyMap) let arr: [auth(MyMap) &InnerObj]
+                init() {
+                    self.arr = [&InnerObj()]
+                }
+            }   
+            
+            struct TranslatorStruct {
+                access(self) var carrier: &Carrier;
+                access(MyMap) fun translate(): auth(MyMap) &InnerObj {
+                    return self.carrier.arr[0] // type mismatch
+                }
+                init(_ carrier: &Carrier) {
+                    self.carrier = carrier 
+                }
+            }    
+        `)
+
+		errors := RequireCheckerErrors(t, err, 1)
+		require.IsType(t, &sema.TypeMismatchError{}, errors[0])
+	})
+
+	t.Run("lambda escape", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            entitlement Inner1
+            entitlement Inner2
+            entitlement Outer1
+            entitlement Outer2
+
+            entitlement mapping MyMap {
+                Outer1 -> Inner1
+                Outer2 -> Inner2
+            }
+            struct InnerObj {
+                access(Inner1) fun first(): Int{ return 9999 }
+                access(Inner2) fun second(): Int{ return 8888 }
+            }
+
+            struct Carrier{
+                access(MyMap) let arr: [auth(MyMap) &InnerObj]
+                init() {
+                    self.arr = [&InnerObj()]
+                }
+            }   
+            
+            struct FuncGenerator {
+                access(MyMap) fun generate(): auth(MyMap) &Int? {
+                    fun innerFunc(_ param: auth(MyMap) &InnerObj): Int {
+                        return 123;
+                    }
+                    var f = innerFunc; // will fail if we're called via a reference
+                    return nil;
+                }
+            }      
+
+            fun foo() {
+                (&FuncGenerator() as auth(Outer1) &FuncGenerator).generate()
+            }
+        `)
+
+		errors := RequireCheckerErrors(t, err, 1)
+		require.IsType(t, &sema.TypeMismatchError{}, errors[0])
+	})
+
 	t.Run("dictionary mapped field", func(t *testing.T) {
 		t.Parallel()
 

--- a/runtime/tests/interpreter/entitlements_test.go
+++ b/runtime/tests/interpreter/entitlements_test.go
@@ -3439,13 +3439,6 @@ func TestInterpretEntitlementMappingComplexFields(t *testing.T) {
 				access(Inner2) fun second(): Int{ return 8888 }
 			}
 
-			struct Carrier{
-				access(MyMap) let arr: [auth(MyMap) &InnerObj]
-				init() {
-					self.arr = [&InnerObj()]
-				}
-			}   
-			
 			struct FuncGenerator {
 				access(MyMap) fun generate(): auth(MyMap) &Int? {
 					fun innerFunc(_ param: auth(MyMap) &InnerObj): Int {


### PR DESCRIPTION
@oebeling reported a couple of cases where entitlement mappings could "escape" (a la generics) their defining contexts. This cleans up those issues with a few related changes. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
