### PR TITLE
Allow injection of functions into composite values, refactor PublicKey based on it

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -459,69 +459,62 @@ func exportCompositeValue(
 		structure, err := cadence.NewMeteredStruct(
 			inter,
 			len(fieldNames),
-			func() ([]cadence.Value, error) {
-				return makeFields()
-			},
+			makeFields,
 		)
 		if err != nil {
 			return nil, err
 		}
 		return structure.WithType(t.(*cadence.StructType)), nil
+
 	case common.CompositeKindResource:
 		resource, err := cadence.NewMeteredResource(
 			inter,
 			len(fieldNames),
-			func() ([]cadence.Value, error) {
-				return makeFields()
-			},
+			makeFields,
 		)
 		if err != nil {
 			return nil, err
 		}
 		return resource.WithType(t.(*cadence.ResourceType)), nil
+
 	case common.CompositeKindAttachment:
 		attachment, err := cadence.NewMeteredAttachment(
 			inter,
 			len(fieldNames),
-			func() ([]cadence.Value, error) {
-				return makeFields()
-			},
+			makeFields,
 		)
 		if err != nil {
 			return nil, err
 		}
 		return attachment.WithType(t.(*cadence.AttachmentType)), nil
+
 	case common.CompositeKindEvent:
 		event, err := cadence.NewMeteredEvent(
 			inter,
 			len(fieldNames),
-			func() ([]cadence.Value, error) {
-				return makeFields()
-			},
+			makeFields,
 		)
 		if err != nil {
 			return nil, err
 		}
 		return event.WithType(t.(*cadence.EventType)), nil
+
 	case common.CompositeKindContract:
 		contract, err := cadence.NewMeteredContract(
 			inter,
 			len(fieldNames),
-			func() ([]cadence.Value, error) {
-				return makeFields()
-			},
+			makeFields,
 		)
 		if err != nil {
 			return nil, err
 		}
 		return contract.WithType(t.(*cadence.ContractType)), nil
+
 	case common.CompositeKindEnum:
 		enum, err := cadence.NewMeteredEnum(
 			inter,
 			len(fieldNames),
-			func() ([]cadence.Value, error) {
-				return makeFields()
-			},
+			makeFields,
 		)
 		if err != nil {
 			return nil, err
@@ -1535,8 +1528,6 @@ func (i valueImporter) importPublicKey(
 		i.locationRange,
 		publicKeyValue,
 		signAlgoValue,
-		i.standardLibraryHandler,
-		i.standardLibraryHandler,
 		i.standardLibraryHandler,
 	), nil
 }

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -412,10 +412,8 @@ func exportCompositeValue(
 
 			case *interpreter.CompositeValue:
 				fieldValue = v.GetField(inter, locationRange, fieldName)
-				if fieldValue == nil && v.ComputedFields != nil {
-					if computedField, ok := v.ComputedFields[fieldName]; ok {
-						fieldValue = computedField(inter, locationRange)
-					}
+				if fieldValue == nil {
+					fieldValue = v.GetComputedField(inter, locationRange, fieldName)
 				}
 			}
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -437,8 +437,6 @@ func TestExportValue(t *testing.T) {
 							PublicKey: []byte{1, 2, 3},
 							SignAlgo:  2,
 						},
-						nil,
-						nil,
 					),
 					hashAlgorithm,
 					interpreter.NewUnmeteredUFix64ValueWithInteger(10, interpreter.EmptyLocationRange),

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -939,6 +939,7 @@ func (e *interpreterEnvironment) newCompositeTypeHandler() interpreter.Composite
 func (e *interpreterEnvironment) newCompositeValueFunctionsHandler() interpreter.CompositeValueFunctionsHandlerFunc {
 	return func(
 		inter *interpreter.Interpreter,
+		locationRange interpreter.LocationRange,
 		compositeValue *interpreter.CompositeValue,
 	) map[string]interpreter.FunctionValue {
 
@@ -947,7 +948,7 @@ func (e *interpreterEnvironment) newCompositeValueFunctionsHandler() interpreter
 			return nil
 		}
 
-		return handler(inter, compositeValue)
+		return handler(inter, locationRange, compositeValue)
 	}
 }
 

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -141,6 +141,7 @@ func (e *interpreterEnvironment) newInterpreterConfig() *interpreter.Config {
 		OnRecordTrace:                        e.newOnRecordTraceHandler(),
 		OnResourceOwnerChange:                e.newResourceOwnerChangedHandler(),
 		CompositeTypeHandler:                 e.newCompositeTypeHandler(),
+		CompositeValueFunctionsHandler:       e.newCompositeValueFunctionsHandler(),
 		TracingEnabled:                       e.config.TracingEnabled,
 		AtreeValueValidationEnabled:          e.config.AtreeValidationEnabled,
 		// NOTE: ignore e.config.AtreeValidationEnabled here,
@@ -916,6 +917,25 @@ func (e *interpreterEnvironment) newCompositeTypeHandler() interpreter.Composite
 			if compositeType, ok := ty.(*sema.CompositeType); ok {
 				return compositeType
 			}
+		}
+
+		return nil
+	}
+}
+
+func (e *interpreterEnvironment) newCompositeValueFunctionsHandler() interpreter.CompositeValueFunctionsHandlerFunc {
+
+	stdlibHandler := stdlib.DefaultStandardLibraryCompositeValueFunctions(e)
+
+	return func(
+		inter *interpreter.Interpreter,
+		location common.Location,
+		typeID common.TypeID,
+	) map[string]interpreter.FunctionValue {
+
+		functions := stdlibHandler(inter, location, typeID)
+		if functions != nil {
+			return functions
 		}
 
 		return nil

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -41,7 +41,7 @@ type Environment interface {
 	SetCompositeValueFunctionsHandler(
 		typeID common.TypeID,
 		handler stdlib.CompositeValueFunctionsHandler,
-  )
+	)
 	DeclareValue(
 		valueDeclaration stdlib.StandardLibraryValue,
 		location common.Location,

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -939,16 +939,15 @@ func (e *interpreterEnvironment) newCompositeTypeHandler() interpreter.Composite
 func (e *interpreterEnvironment) newCompositeValueFunctionsHandler() interpreter.CompositeValueFunctionsHandlerFunc {
 	return func(
 		inter *interpreter.Interpreter,
-		location common.Location,
-		typeID common.TypeID,
+		compositeValue *interpreter.CompositeValue,
 	) map[string]interpreter.FunctionValue {
 
-		handler := e.compositeValueFunctionsHandlers[typeID]
+		handler := e.compositeValueFunctionsHandlers[compositeValue.TypeID()]
 		if handler == nil {
 			return nil
 		}
 
-		return handler(inter)
+		return handler(inter, compositeValue)
 	}
 }
 

--- a/runtime/interpreter/config.go
+++ b/runtime/interpreter/config.go
@@ -51,6 +51,8 @@ type Config struct {
 	UUIDHandler UUIDHandlerFunc
 	// CompositeTypeHandler is used to load composite types
 	CompositeTypeHandler CompositeTypeHandlerFunc
+	// CompositeValueFunctionsHandler is used to load composite value functions
+	CompositeValueFunctionsHandler CompositeValueFunctionsHandlerFunc
 	BaseActivation       *VariableActivation
 	Debugger             *Debugger
 	// OnStatement is triggered when a statement is about to be executed

--- a/runtime/interpreter/config.go
+++ b/runtime/interpreter/config.go
@@ -53,8 +53,8 @@ type Config struct {
 	CompositeTypeHandler CompositeTypeHandlerFunc
 	// CompositeValueFunctionsHandler is used to load composite value functions
 	CompositeValueFunctionsHandler CompositeValueFunctionsHandlerFunc
-	BaseActivation       *VariableActivation
-	Debugger             *Debugger
+	BaseActivation                 *VariableActivation
+	Debugger                       *Debugger
 	// OnStatement is triggered when a statement is about to be executed
 	OnStatement OnStatementFunc
 	// OnLoopIteration is triggered when a loop iteration is about to be executed

--- a/runtime/interpreter/config.go
+++ b/runtime/interpreter/config.go
@@ -53,7 +53,7 @@ type Config struct {
 	CompositeTypeHandler CompositeTypeHandlerFunc
 	// CompositeValueFunctionsHandler is used to load composite value functions
 	CompositeValueFunctionsHandler CompositeValueFunctionsHandlerFunc
-	BaseActivationHandler func(location common.Location) *VariableActivation
+	BaseActivationHandler          func(location common.Location) *VariableActivation
 	Debugger                       *Debugger
 	// OnStatement is triggered when a statement is about to be executed
 	OnStatement OnStatementFunc

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -185,6 +185,7 @@ type CompositeTypeHandlerFunc func(location common.Location, typeID TypeID) *sem
 // CompositeValueFunctionsHandlerFunc is a function that loads composite value functions.
 type CompositeValueFunctionsHandlerFunc func(
 	inter *Interpreter,
+	locationRange LocationRange,
 	compositeValue *CompositeValue,
 ) map[string]FunctionValue
 
@@ -4842,7 +4843,10 @@ func (interpreter *Interpreter) GetCompositeValueInjectedFields(v *CompositeValu
 	)
 }
 
-func (interpreter *Interpreter) GetCompositeValueFunctions(v *CompositeValue) map[string]FunctionValue {
+func (interpreter *Interpreter) GetCompositeValueFunctions(
+	v *CompositeValue,
+	locationRange LocationRange,
+) map[string]FunctionValue {
 
 	var functions map[string]FunctionValue
 
@@ -4852,7 +4856,7 @@ func (interpreter *Interpreter) GetCompositeValueFunctions(v *CompositeValue) ma
 
 	compositeValueFunctionsHandler := sharedState.Config.CompositeValueFunctionsHandler
 	if compositeValueFunctionsHandler != nil {
-		functions = compositeValueFunctionsHandler(interpreter, v)
+		functions = compositeValueFunctionsHandler(interpreter, locationRange, v)
 		if functions != nil {
 			return functions
 		}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -185,8 +185,7 @@ type CompositeTypeHandlerFunc func(location common.Location, typeID TypeID) *sem
 // CompositeValueFunctionsHandlerFunc is a function that loads composite value functions.
 type CompositeValueFunctionsHandlerFunc func(
 	inter *Interpreter,
-	location common.Location,
-	typeID TypeID,
+	compositeValue *CompositeValue,
 ) map[string]FunctionValue
 
 // CompositeTypeCode contains the "prepared" / "callable" "code"
@@ -4853,7 +4852,7 @@ func (interpreter *Interpreter) GetCompositeValueFunctions(v *CompositeValue) ma
 
 	compositeValueFunctionsHandler := sharedState.Config.CompositeValueFunctionsHandler
 	if compositeValueFunctionsHandler != nil {
-		functions = compositeValueFunctionsHandler(interpreter, v.Location, typeID)
+		functions = compositeValueFunctionsHandler(interpreter, v)
 		if functions != nil {
 			return functions
 		}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -16628,7 +16628,7 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, locationRange Locat
 		return injectedField
 	}
 
-	if function := v.GetFunction(interpreter, name); function != nil {
+	if function := v.GetFunction(interpreter, locationRange, name); function != nil {
 		return function
 	}
 
@@ -16688,9 +16688,9 @@ func (v *CompositeValue) GetInjectedField(interpreter *Interpreter, name string)
 	return value
 }
 
-func (v *CompositeValue) GetFunction(interpreter *Interpreter, name string) FunctionValue {
+func (v *CompositeValue) GetFunction(interpreter *Interpreter, locationRange LocationRange, name string) FunctionValue {
 	if v.Functions == nil {
-		v.Functions = interpreter.GetCompositeValueFunctions(v)
+		v.Functions = interpreter.GetCompositeValueFunctions(v, locationRange)
 	}
 
 	function, ok := v.Functions[name]

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -16235,8 +16235,8 @@ type CompositeValue struct {
 	Location        common.Location
 	staticType      StaticType
 	Stringer        func(gauge common.MemoryGauge, value *CompositeValue, seenReferences SeenReferences) string
-	InjectedFields  map[string]Value
-	ComputedFields  map[string]ComputedField
+	injectedFields  map[string]Value
+	computedFields  map[string]ComputedField
 	NestedVariables map[string]*Variable
 	Functions       map[string]FunctionValue
 	dictionary      *atree.OrderedMap
@@ -16598,19 +16598,15 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, locationRange Locat
 		return builtin
 	}
 
-	storable, err := v.dictionary.Get(
-		StringAtreeValueComparator,
-		StringAtreeValueHashInput,
-		StringAtreeValue(name),
-	)
-	if err != nil {
-		var keyNotFoundError *atree.KeyNotFoundError
-		if !goerrors.As(err, &keyNotFoundError) {
-			panic(errors.NewExternalError(err))
+	// Give computed fields precedence over stored fields for built-in types
+	if v.Location == nil {
+		if computedField := v.GetComputedField(interpreter, locationRange, name); computedField != nil {
+			return computedField
 		}
 	}
-	if storable != nil {
-		return StoredValue(interpreter, storable, config.Storage)
+
+	if field := v.GetField(interpreter, locationRange, name); field != nil {
+		return field
 	}
 
 	if v.NestedVariables != nil {
@@ -16622,42 +16618,18 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, locationRange Locat
 
 	interpreter = v.getInterpreter(interpreter)
 
-	if v.ComputedFields != nil {
-		if computedField, ok := v.ComputedFields[name]; ok {
-			return computedField(interpreter, locationRange)
-		}
+	// Dynamically link in the computed fields, injected fields, and functions
+
+	if computedField := v.GetComputedField(interpreter, locationRange, name); computedField != nil {
+		return computedField
 	}
 
-	// If the composite value was deserialized, dynamically link in the functions
-	// and get injected fields
-
-	v.InitializeFunctions(interpreter)
-
-	injectedCompositeFieldsHandler := config.InjectedCompositeFieldsHandler
-	if v.InjectedFields == nil && injectedCompositeFieldsHandler != nil {
-		v.InjectedFields = injectedCompositeFieldsHandler(
-			interpreter,
-			v.Location,
-			v.QualifiedIdentifier,
-			v.Kind,
-		)
+	if injectedField := v.GetInjectedField(interpreter, name); injectedField != nil {
+		return injectedField
 	}
 
-	if v.InjectedFields != nil {
-		value, ok := v.InjectedFields[name]
-		if ok {
-			return value
-		}
-	}
-
-	function, ok := v.Functions[name]
-	if ok {
-		var base *EphemeralReferenceValue
-		var self MemberAccessibleValue = v
-		if v.Kind == common.CompositeKindAttachment {
-			base, self = attachmentBaseAndSelfValues(interpreter, v)
-		}
-		return NewBoundFunctionValue(interpreter, function, &self, base)
+	if function := v.GetFunction(interpreter, name); function != nil {
+		return function
 	}
 
 	return nil
@@ -16685,12 +16657,53 @@ func (v *CompositeValue) getInterpreter(interpreter *Interpreter) *Interpreter {
 	return interpreter.EnsureLoaded(v.Location)
 }
 
-func (v *CompositeValue) InitializeFunctions(interpreter *Interpreter) {
-	if v.Functions != nil {
-		return
+func (v *CompositeValue) GetComputedFields(interpreter *Interpreter) map[string]ComputedField {
+	if v.computedFields == nil {
+		v.computedFields = interpreter.GetCompositeValueComputedFields(v)
+	}
+	return v.computedFields
+}
+
+func (v *CompositeValue) GetComputedField(interpreter *Interpreter, locationRange LocationRange, name string) Value {
+	computedFields := v.GetComputedFields(interpreter)
+
+	computedField, ok := computedFields[name]
+	if !ok {
+		return nil
 	}
 
-	v.Functions = interpreter.SharedState.typeCodes.CompositeCodes[v.TypeID()].CompositeFunctions
+	return computedField(interpreter, locationRange)
+}
+
+func (v *CompositeValue) GetInjectedField(interpreter *Interpreter, name string) Value {
+	if v.injectedFields == nil {
+		v.injectedFields = interpreter.GetCompositeValueInjectedFields(v)
+	}
+
+	value, ok := v.injectedFields[name]
+	if !ok {
+		return nil
+	}
+
+	return value
+}
+
+func (v *CompositeValue) GetFunction(interpreter *Interpreter, name string) FunctionValue {
+	if v.Functions == nil {
+		v.Functions = interpreter.GetCompositeValueFunctions(v)
+	}
+
+	function, ok := v.Functions[name]
+	if !ok {
+		return nil
+	}
+
+	var base *EphemeralReferenceValue
+	var self MemberAccessibleValue = v
+	if v.Kind == common.CompositeKindAttachment {
+		base, self = attachmentBaseAndSelfValues(interpreter, v)
+	}
+	return NewBoundFunctionValue(interpreter, function, &self, base)
 }
 
 func (v *CompositeValue) OwnerValue(interpreter *Interpreter, locationRange LocationRange) OptionalValue {
@@ -17065,22 +17078,26 @@ func (v *CompositeValue) ConformsToStaticType(
 	}
 
 	fieldsLen := int(v.dictionary.Count())
-	if v.ComputedFields != nil {
-		fieldsLen += len(v.ComputedFields)
+
+	computedFields := v.GetComputedFields(interpreter)
+	if computedFields != nil {
+		fieldsLen += len(computedFields)
 	}
 
-	if fieldsLen != len(compositeType.Fields) {
+	// The composite might store additional fields
+	// which are not statically declared in the composite type.
+	if fieldsLen < len(compositeType.Fields) {
 		return false
 	}
 
 	for _, fieldName := range compositeType.Fields {
 		value := v.GetField(interpreter, locationRange, fieldName)
 		if value == nil {
-			if v.ComputedFields == nil {
+			if computedFields == nil {
 				return false
 			}
 
-			fieldGetter, ok := v.ComputedFields[fieldName]
+			fieldGetter, ok := computedFields[fieldName]
 			if !ok {
 				return false
 			}
@@ -17332,8 +17349,8 @@ func (v *CompositeValue) Transfer(
 			v.Kind,
 		)
 		res = newCompositeValueFromOrderedMap(dictionary, info)
-		res.InjectedFields = v.InjectedFields
-		res.ComputedFields = v.ComputedFields
+		res.injectedFields = v.injectedFields
+		res.computedFields = v.computedFields
 		res.NestedVariables = v.NestedVariables
 		res.Functions = v.Functions
 		res.Destructor = v.Destructor
@@ -17418,8 +17435,8 @@ func (v *CompositeValue) Clone(interpreter *Interpreter) Value {
 		Location:            v.Location,
 		QualifiedIdentifier: v.QualifiedIdentifier,
 		Kind:                v.Kind,
-		InjectedFields:      v.InjectedFields,
-		ComputedFields:      v.ComputedFields,
+		injectedFields:      v.injectedFields,
+		computedFields:      v.computedFields,
 		NestedVariables:     v.NestedVariables,
 		Functions:           v.Functions,
 		Destructor:          v.Destructor,

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -19260,7 +19260,7 @@ func (v *SomeValue) RecursiveString(seenReferences SeenReferences) string {
 	return v.value.RecursiveString(seenReferences)
 }
 
-func (v SomeValue) MeteredString(memoryGauge common.MemoryGauge, seenReferences SeenReferences) string {
+func (v *SomeValue) MeteredString(memoryGauge common.MemoryGauge, seenReferences SeenReferences) string {
 	return v.value.MeteredString(memoryGauge, seenReferences)
 }
 

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -3518,8 +3518,6 @@ func TestPublicKeyValue(t *testing.T) {
 			func(interpreter *Interpreter, locationRange LocationRange, publicKey *CompositeValue) error {
 				return nil
 			},
-			nil,
-			nil,
 		)
 
 		require.Equal(t,
@@ -3574,8 +3572,6 @@ func TestPublicKeyValue(t *testing.T) {
 					func(interpreter *Interpreter, locationRange LocationRange, publicKey *CompositeValue) error {
 						return fakeError
 					},
-					nil,
-					nil,
 				)
 			})
 	})

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -565,7 +565,12 @@ func TestRuntimePredeclaredTypeWithInjectedFunctions(t *testing.T) {
 	scriptEnvironment.DeclareType(xTypeDeclaration)
 	scriptEnvironment.SetCompositeValueFunctionsHandler(
 		xType.ID(),
-		func(inter *interpreter.Interpreter) map[string]interpreter.FunctionValue {
+		func(
+			inter *interpreter.Interpreter,
+			compositeValue *interpreter.CompositeValue,
+		) map[string]interpreter.FunctionValue {
+			require.NotNil(t, compositeValue)
+
 			return map[string]interpreter.FunctionValue{
 				fooFunctionName: interpreter.NewHostFunctionValue(
 					inter,

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -567,6 +567,7 @@ func TestRuntimePredeclaredTypeWithInjectedFunctions(t *testing.T) {
 		xType.ID(),
 		func(
 			inter *interpreter.Interpreter,
+			locationRange interpreter.LocationRange,
 			compositeValue *interpreter.CompositeValue,
 		) map[string]interpreter.FunctionValue {
 			require.NotNil(t, compositeValue)

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -685,8 +685,8 @@ func TestRuntimePredeclaredTypeWithInjectedFunctions(t *testing.T) {
 	// Run script
 
 	scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
-	scriptEnvironment.DeclareValue(xConstructorDeclaration)
-	scriptEnvironment.DeclareType(xTypeDeclaration)
+	scriptEnvironment.DeclareValue(xConstructorDeclaration, nil)
+	scriptEnvironment.DeclareType(xTypeDeclaration, nil)
 	scriptEnvironment.SetCompositeValueFunctionsHandler(
 		xType.ID(),
 		func(

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -20,6 +20,7 @@ package runtime
 
 import (
 	"math/big"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -477,5 +478,124 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 		var typeLoadingErr interpreter.TypeLoadingError
 		require.ErrorAs(t, err, &typeLoadingErr)
 	})
+
+}
+
+func TestRuntimePredeclaredTypeWithInjectedFunctions(t *testing.T) {
+
+	t.Parallel()
+
+	xType := &sema.CompositeType{
+		Identifier: "X",
+		Kind:       common.CompositeKindStructure,
+		Members:    &sema.StringMemberOrderedMap{},
+	}
+
+	const fooFunctionName = "foo"
+	fooFunctionType := &sema.FunctionType{
+		Parameters: []sema.Parameter{
+			{
+				Identifier:     "bar",
+				TypeAnnotation: sema.NewTypeAnnotation(sema.UInt8Type),
+			},
+		},
+		ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.StringType),
+	}
+
+	fooFunctionMember := sema.NewPublicFunctionMember(
+		nil,
+		xType,
+		fooFunctionName,
+		fooFunctionType,
+		"",
+	)
+	xType.Members.Set(fooFunctionName, fooFunctionMember)
+
+	xConstructorType := &sema.FunctionType{
+		ReturnTypeAnnotation: sema.NewTypeAnnotation(xType),
+	}
+
+	xConstructorDeclaration := stdlib.StandardLibraryValue{
+		Name: "X",
+		Type: xConstructorType,
+		Kind: common.DeclarationKindConstant,
+		Value: interpreter.NewHostFunctionValue(
+			nil,
+			xConstructorType,
+			func(invocation interpreter.Invocation) interpreter.Value {
+				return interpreter.NewCompositeValue(
+					invocation.Interpreter,
+					invocation.LocationRange,
+					xType.Location,
+					xType.QualifiedIdentifier(),
+					xType.Kind,
+					nil,
+					common.ZeroAddress,
+				)
+			},
+		),
+	}
+
+	xTypeDeclaration := stdlib.StandardLibraryType{
+		Name: "X",
+		Type: xType,
+		Kind: common.DeclarationKindType,
+	}
+
+	script := []byte(`
+      pub fun main(): String {
+          return X().foo(bar: 1)
+      }
+	`)
+
+	runtime := newTestInterpreterRuntime()
+
+	runtimeInterface := &testRuntimeInterface{
+		storage: newTestLedger(nil, nil),
+		getSigningAccounts: func() ([]Address, error) {
+			return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
+		},
+		resolveLocation: singleIdentifierLocationResolver(t),
+	}
+
+	// Run script
+
+	scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+	scriptEnvironment.DeclareValue(xConstructorDeclaration)
+	scriptEnvironment.DeclareType(xTypeDeclaration)
+	scriptEnvironment.SetCompositeValueFunctionsHandler(
+		xType.ID(),
+		func(inter *interpreter.Interpreter) map[string]interpreter.FunctionValue {
+			return map[string]interpreter.FunctionValue{
+				fooFunctionName: interpreter.NewHostFunctionValue(
+					inter,
+					fooFunctionType,
+					func(invocation interpreter.Invocation) interpreter.Value {
+						arg := invocation.Arguments[0]
+						require.IsType(t, interpreter.UInt8Value(0), arg)
+
+						return interpreter.NewUnmeteredStringValue(strconv.Itoa(int(arg.(interpreter.UInt8Value) + 1)))
+					},
+				),
+			}
+		},
+	)
+
+	result, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface:   runtimeInterface,
+			Location:    common.ScriptLocation{},
+			Environment: scriptEnvironment,
+		},
+	)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		cadence.String("2"),
+		result,
+	)
 
 }

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -638,8 +638,6 @@ func newAccountKeysAddFunction(
 				locationRange,
 				accountKey,
 				handler,
-				handler,
-				handler,
 			)
 		},
 	)
@@ -710,8 +708,6 @@ func newAccountKeysGetFunction(
 					locationRange,
 					accountKey,
 					provider,
-					provider,
-					provider,
 				),
 			)
 		},
@@ -760,8 +756,6 @@ func newAccountKeysForEachFunction(
 					inter,
 					locationRange,
 					key,
-					provider,
-					provider,
 					provider,
 				)
 			}
@@ -910,8 +904,6 @@ func newAccountKeysRevokeFunction(
 					inter,
 					locationRange,
 					accountKey,
-					handler,
-					handler,
 					handler,
 				),
 			)
@@ -2152,8 +2144,6 @@ func NewAccountKeyValue(
 	inter *interpreter.Interpreter,
 	locationRange interpreter.LocationRange,
 	accountKey *AccountKey,
-	publicKeySignatureVerifier PublicKeySignatureVerifier,
-	blsPoPVerifier BLSPoPVerifier,
 	hasher Hasher,
 ) interpreter.Value {
 
@@ -2170,8 +2160,6 @@ func NewAccountKeyValue(
 			inter,
 			locationRange,
 			accountKey.PublicKey,
-			publicKeySignatureVerifier,
-			blsPoPVerifier,
 		),
 		hashAlgorithm,
 		interpreter.NewUFix64ValueWithInteger(

--- a/runtime/stdlib/bls.go
+++ b/runtime/stdlib/bls.go
@@ -172,8 +172,6 @@ func newBLSAggregatePublicKeysFunction(
 				inter,
 				locationRange,
 				aggregatedPublicKey,
-				aggregator,
-				aggregator,
 			)
 
 			return interpreter.NewSomeValueNonCopying(

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -64,7 +64,10 @@ func DefaultScriptStandardLibraryValues(handler StandardLibraryHandler) []Standa
 	)
 }
 
-type CompositeValueFunctionsHandler func(inter *interpreter.Interpreter) map[string]interpreter.FunctionValue
+type CompositeValueFunctionsHandler func(
+	inter *interpreter.Interpreter,
+	compositeValue *interpreter.CompositeValue,
+) map[string]interpreter.FunctionValue
 
 type CompositeValueFunctionsHandlers map[common.TypeID]CompositeValueFunctionsHandler
 
@@ -72,7 +75,10 @@ func DefaultStandardLibraryCompositeValueFunctionHandlers(
 	handler StandardLibraryHandler,
 ) CompositeValueFunctionsHandlers {
 	return CompositeValueFunctionsHandlers{
-		sema.PublicKeyType.ID(): func(inter *interpreter.Interpreter) map[string]interpreter.FunctionValue {
+		sema.PublicKeyType.ID(): func(
+			inter *interpreter.Interpreter,
+			_ *interpreter.CompositeValue,
+		) map[string]interpreter.FunctionValue {
 			return PublicKeyFunctions(inter, handler)
 		},
 	}

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -66,6 +66,7 @@ func DefaultScriptStandardLibraryValues(handler StandardLibraryHandler) []Standa
 
 type CompositeValueFunctionsHandler func(
 	inter *interpreter.Interpreter,
+	locationRange interpreter.LocationRange,
 	compositeValue *interpreter.CompositeValue,
 ) map[string]interpreter.FunctionValue
 
@@ -77,6 +78,7 @@ func DefaultStandardLibraryCompositeValueFunctionHandlers(
 	return CompositeValueFunctionsHandlers{
 		sema.PublicKeyType.ID(): func(
 			inter *interpreter.Interpreter,
+			_ interpreter.LocationRange,
 			_ *interpreter.CompositeValue,
 		) map[string]interpreter.FunctionValue {
 			return PublicKeyFunctions(inter, handler)

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -45,7 +45,7 @@ func DefaultStandardLibraryValues(handler StandardLibraryHandler) []StandardLibr
 		NewGetCurrentBlockFunction(handler),
 		NewGetAccountFunction(handler),
 		NewAuthAccountConstructor(handler),
-		NewPublicKeyConstructor(handler, handler, handler),
+		NewPublicKeyConstructor(handler),
 		NewBLSContract(nil, handler),
 		NewHashAlgorithmConstructor(handler),
 	}

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -64,20 +64,16 @@ func DefaultScriptStandardLibraryValues(handler StandardLibraryHandler) []Standa
 	)
 }
 
-func DefaultStandardLibraryCompositeValueFunctions(
+type CompositeValueFunctionsHandler func(inter *interpreter.Interpreter) map[string]interpreter.FunctionValue
+
+type CompositeValueFunctionsHandlers map[common.TypeID]CompositeValueFunctionsHandler
+
+func DefaultStandardLibraryCompositeValueFunctionHandlers(
 	handler StandardLibraryHandler,
-) interpreter.CompositeValueFunctionsHandlerFunc {
-	return func(
-		inter *interpreter.Interpreter,
-		location common.Location,
-		typeID interpreter.TypeID,
-	) map[string]interpreter.FunctionValue {
-
-		switch typeID {
-		case sema.PublicKeyType.ID():
+) CompositeValueFunctionsHandlers {
+	return CompositeValueFunctionsHandlers{
+		sema.PublicKeyType.ID(): func(inter *interpreter.Interpreter) map[string]interpreter.FunctionValue {
 			return PublicKeyFunctions(inter, handler)
-		}
-
-		return nil
+		},
 	}
 }

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -18,6 +18,12 @@
 
 package stdlib
 
+import (
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
 type StandardLibraryHandler interface {
 	Logger
 	UnsafeRandomGenerator
@@ -56,4 +62,22 @@ func DefaultScriptStandardLibraryValues(handler StandardLibraryHandler) []Standa
 		DefaultStandardLibraryValues(handler),
 		NewGetAuthAccountFunction(handler),
 	)
+}
+
+func DefaultStandardLibraryCompositeValueFunctions(
+	handler StandardLibraryHandler,
+) interpreter.CompositeValueFunctionsHandlerFunc {
+	return func(
+		inter *interpreter.Interpreter,
+		location common.Location,
+		typeID interpreter.TypeID,
+	) map[string]interpreter.FunctionValue {
+
+		switch typeID {
+		case sema.PublicKeyType.ID():
+			return PublicKeyFunctions(inter, handler)
+		}
+
+		return nil
+	}
 }

--- a/runtime/stdlib/publickey.go
+++ b/runtime/stdlib/publickey.go
@@ -76,8 +76,6 @@ func newPublicKeyValidationHandler(validator PublicKeyValidator) interpreter.Pub
 
 func NewPublicKeyConstructor(
 	publicKeyValidator PublicKeyValidator,
-	publicKeySignatureVerifier PublicKeySignatureVerifier,
-	blsPoPVerifier BLSPoPVerifier,
 ) StandardLibraryValue {
 	return NewStandardLibraryFunction(
 		sema.PublicKeyTypeName,
@@ -104,8 +102,6 @@ func NewPublicKeyConstructor(
 				publicKey,
 				signAlgo,
 				publicKeyValidator,
-				publicKeySignatureVerifier,
-				blsPoPVerifier,
 			)
 		},
 	)
@@ -117,8 +113,6 @@ func NewPublicKeyFromFields(
 	publicKey *interpreter.ArrayValue,
 	signAlgo *interpreter.SimpleCompositeValue,
 	publicKeyValidator PublicKeyValidator,
-	publicKeySignatureVerifier PublicKeySignatureVerifier,
-	blsPoPVerifier BLSPoPVerifier,
 ) *interpreter.CompositeValue {
 	return interpreter.NewPublicKeyValue(
 		inter,
@@ -126,8 +120,6 @@ func NewPublicKeyFromFields(
 		publicKey,
 		signAlgo,
 		newPublicKeyValidationHandler(publicKeyValidator),
-		newPublicKeyVerifySignatureFunction(inter, publicKeySignatureVerifier),
-		newPublicKeyVerifyPoPFunction(inter, blsPoPVerifier),
 	)
 }
 
@@ -139,8 +131,6 @@ func NewPublicKeyValue(
 	inter *interpreter.Interpreter,
 	locationRange interpreter.LocationRange,
 	publicKey *PublicKey,
-	publicKeySignatureVerifier PublicKeySignatureVerifier,
-	blsPoPVerifier BLSPoPVerifier,
 ) *interpreter.CompositeValue {
 	return interpreter.NewPublicKeyValue(
 		inter,
@@ -154,8 +144,6 @@ func NewPublicKeyValue(
 		),
 		// public keys converted from "native" (non-interpreter) keys are assumed to be already validated
 		assumePublicKeyIsValid,
-		newPublicKeyVerifySignatureFunction(inter, publicKeySignatureVerifier),
-		newPublicKeyVerifyPoPFunction(inter, blsPoPVerifier),
 	)
 }
 

--- a/runtime/stdlib/publickey.go
+++ b/runtime/stdlib/publickey.go
@@ -211,7 +211,7 @@ type PublicKeySignatureVerifier interface {
 
 func newPublicKeyVerifySignatureFunction(
 	gauge common.MemoryGauge,
-	verififier PublicKeySignatureVerifier,
+	verifier PublicKeySignatureVerifier,
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
 		gauge,
@@ -270,7 +270,7 @@ func newPublicKeyVerifySignatureFunction(
 
 			var valid bool
 			errors.WrapPanic(func() {
-				valid, err = verififier.VerifySignature(
+				valid, err = verifier.VerifySignature(
 					signature,
 					domainSeparationTag,
 					signedData,
@@ -339,4 +339,19 @@ func newPublicKeyVerifyPoPFunction(
 			return interpreter.AsBoolValue(valid)
 		},
 	)
+}
+
+type PublicKeyFunctionsHandler interface {
+	PublicKeySignatureVerifier
+	BLSPoPVerifier
+}
+
+func PublicKeyFunctions(
+	gauge common.MemoryGauge,
+	handler PublicKeyFunctionsHandler,
+) map[string]interpreter.FunctionValue {
+	return map[string]interpreter.FunctionValue{
+		sema.PublicKeyTypeVerifyFunctionName:    newPublicKeyVerifySignatureFunction(gauge, handler),
+		sema.PublicKeyTypeVerifyPoPFunctionName: newPublicKeyVerifyPoPFunction(gauge, handler),
+	}
 }

--- a/runtime/stdlib/test_emulatorbackend.go
+++ b/runtime/stdlib/test_emulatorbackend.go
@@ -303,7 +303,6 @@ func (t *testEmulatorBackendType) newCreateAccountFunction(
 			locationRange := invocation.LocationRange
 
 			return newTestAccountValue(
-				blockchain,
 				inter,
 				locationRange,
 				account,
@@ -313,7 +312,6 @@ func (t *testEmulatorBackendType) newCreateAccountFunction(
 }
 
 func newTestAccountValue(
-	blockchain Blockchain,
 	inter *interpreter.Interpreter,
 	locationRange interpreter.LocationRange,
 	account *Account,
@@ -322,14 +320,10 @@ func newTestAccountValue(
 	// Create address value
 	address := interpreter.NewAddressValue(nil, account.Address)
 
-	standardLibraryHandler := blockchain.StandardLibraryHandler()
-
 	publicKey := NewPublicKeyValue(
 		inter,
 		locationRange,
 		account.PublicKey,
-		standardLibraryHandler,
-		standardLibraryHandler,
 	)
 
 	// Create an 'Account' by calling its constructor.
@@ -382,7 +376,6 @@ func (t *testEmulatorBackendType) newGetAccountFunction(
 			locationRange := invocation.LocationRange
 
 			return newTestAccountValue(
-				blockchain,
 				inter,
 				locationRange,
 				account,
@@ -645,7 +638,6 @@ func (t *testEmulatorBackendType) newServiceAccountFunction(
 			}
 
 			return newTestAccountValue(
-				blockchain,
 				invocation.Interpreter,
 				invocation.LocationRange,
 				serviceAccount,

--- a/runtime/tests/interpreter/attachments_test.go
+++ b/runtime/tests/interpreter/attachments_test.go
@@ -1937,8 +1937,6 @@ func TestInterpretBuiltinCompositeAttachment(t *testing.T) {
 	for _, valueDeclaration := range []stdlib.StandardLibraryValue{
 		stdlib.NewPublicKeyConstructor(
 			assumeValidPublicKeyValidator{},
-			nil,
-			nil,
 		),
 		stdlib.SignatureAlgorithmConstructor,
 	} {

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7266,10 +7266,6 @@ func TestInterpretEmitEvent(t *testing.T) {
 		),
 	}
 
-	for _, event := range expectedEvents {
-		event.(*interpreter.CompositeValue).InitializeFunctions(inter)
-	}
-
 	AssertValueSlicesEqual(
 		t,
 		inter,
@@ -7607,14 +7603,9 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 				),
 			}
 
-			for _, event := range expectedEvents {
-				event.(*interpreter.CompositeValue).InitializeFunctions(inter)
-			}
-
 			AssertValueSlicesEqual(
 				t,
 				inter,
-
 				expectedEvents,
 				actualEvents,
 			)

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -1127,7 +1127,7 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		// 1 host function created for 'decodeHex' of String value
-		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindHostFunctionValue))
+		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindHostFunctionValue))
 	})
 
 	t.Run("multiple public key creation", func(t *testing.T) {
@@ -1179,7 +1179,7 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		// 2 = 2x 1 host function created for 'decodeHex' of String value
-		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindHostFunctionValue))
+		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindHostFunctionValue))
 	})
 }
 

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -1100,8 +1100,6 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 		for _, valueDeclaration := range []stdlib.StandardLibraryValue{
 			stdlib.NewPublicKeyConstructor(
 				assumeValidPublicKeyValidator{},
-				nil,
-				nil,
 			),
 			stdlib.SignatureAlgorithmConstructor,
 		} {
@@ -1154,8 +1152,6 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 		for _, valueDeclaration := range []stdlib.StandardLibraryValue{
 			stdlib.NewPublicKeyConstructor(
 				assumeValidPublicKeyValidator{},
-				nil,
-				nil,
 			),
 			stdlib.SignatureAlgorithmConstructor,
 		} {


### PR DESCRIPTION
Closes #2874 

## Description

The host might want composite values of certain types to have native functions. Add a function `SetCompositeValueFunctionsHandler` to the environment which allows that.

Extend the `CompositeValue.GetMember` implementation, from only linking in interpreted functions, to also querying a handler set in the interpreter configuration.

As the built-in `PublicKey` type has native functions (e.g. `verify`) and is already implemented as a `CompositeValue`, refactor its existing implementation from injecting the native functions at construction time, to using the new injection mechanism added in this PR.

This essentially allows making the `PublicKey` type storable (in a follow-up PR), because the native functions get linked in even after a public key value got loaded from storage. `PublicKey` values are not yet storable exactly because of this missing function injection feature.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
