### PR TITLE
Add computation metering to the new stdlib functions

### DIFF
--- a/runtime/common/computationkind.go
+++ b/runtime/common/computationkind.go
@@ -57,7 +57,7 @@ const (
 	ComputationKindCreateArrayValue
 	ComputationKindTransferArrayValue
 	ComputationKindDestroyArrayValue
-	_
+	ComputationKindIterateArrayValue
 	_
 	_
 	_

--- a/runtime/common/computationkind_string.go
+++ b/runtime/common/computationkind_string.go
@@ -18,6 +18,7 @@ func _() {
 	_ = x[ComputationKindCreateArrayValue-1025]
 	_ = x[ComputationKindTransferArrayValue-1026]
 	_ = x[ComputationKindDestroyArrayValue-1027]
+	_ = x[ComputationKindIterateArrayValue-1028]
 	_ = x[ComputationKindCreateDictionaryValue-1040]
 	_ = x[ComputationKindTransferDictionaryValue-1041]
 	_ = x[ComputationKindDestroyDictionaryValue-1042]
@@ -33,7 +34,7 @@ const (
 	_ComputationKind_name_0 = "Unknown"
 	_ComputationKind_name_1 = "StatementLoopFunctionInvocation"
 	_ComputationKind_name_2 = "CreateCompositeValueTransferCompositeValueDestroyCompositeValue"
-	_ComputationKind_name_3 = "CreateArrayValueTransferArrayValueDestroyArrayValue"
+	_ComputationKind_name_3 = "CreateArrayValueTransferArrayValueDestroyArrayValueIterateArrayValue"
 	_ComputationKind_name_4 = "CreateDictionaryValueTransferDictionaryValueDestroyDictionaryValue"
 	_ComputationKind_name_5 = "EncodeValue"
 	_ComputationKind_name_6 = "STDLIBPanicSTDLIBAssertSTDLIBUnsafeRandom"
@@ -43,7 +44,7 @@ const (
 var (
 	_ComputationKind_index_1 = [...]uint8{0, 9, 13, 31}
 	_ComputationKind_index_2 = [...]uint8{0, 20, 42, 63}
-	_ComputationKind_index_3 = [...]uint8{0, 16, 34, 51}
+	_ComputationKind_index_3 = [...]uint8{0, 16, 34, 51, 68}
 	_ComputationKind_index_4 = [...]uint8{0, 21, 44, 66}
 	_ComputationKind_index_6 = [...]uint8{0, 11, 23, 41}
 	_ComputationKind_index_7 = [...]uint8{0, 21, 40}
@@ -59,7 +60,7 @@ func (i ComputationKind) String() string {
 	case 1010 <= i && i <= 1012:
 		i -= 1010
 		return _ComputationKind_name_2[_ComputationKind_index_2[i]:_ComputationKind_index_2[i+1]]
-	case 1025 <= i && i <= 1027:
+	case 1025 <= i && i <= 1028:
 		i -= 1025
 		return _ComputationKind_name_3[_ComputationKind_index_3[i]:_ComputationKind_index_3[i+1]]
 	case 1040 <= i && i <= 1042:

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2986,9 +2986,6 @@ func (v *ArrayValue) Reverse(
 	count := v.Count()
 	index := count - 1
 
-	// Meter computation for iterating the array.
-	interpreter.ReportComputation(common.ComputationKindIterateArrayValue, uint(v.Count()))
-
 	return NewArrayValueWithIterator(
 		interpreter,
 		v.Type,
@@ -2998,6 +2995,9 @@ func (v *ArrayValue) Reverse(
 			if index < 0 {
 				return nil
 			}
+
+			// Meter computation for iterating the array.
+			interpreter.ReportComputation(common.ComputationKindIterateArrayValue, 1)
 
 			value := v.Get(interpreter, locationRange, index)
 			index--
@@ -3019,9 +3019,6 @@ func (v *ArrayValue) Filter(
 	locationRange LocationRange,
 	procedure FunctionValue,
 ) Value {
-
-	// Meter computation for iterating the array.
-	interpreter.ReportComputation(common.ComputationKindIterateArrayValue, uint(v.Count()))
 
 	elementTypeSlice := []sema.Type{v.semaType.ElementType(false)}
 	iterationInvocation := func(arrayElement Value) Invocation {
@@ -3052,6 +3049,9 @@ func (v *ArrayValue) Filter(
 			var value Value
 
 			for {
+				// Meter computation for iterating the array.
+				interpreter.ReportComputation(common.ComputationKindIterateArrayValue, 1)
+
 				atreeValue, err := iterator.Next()
 				if err != nil {
 					panic(errors.NewExternalError(err))
@@ -3096,9 +3096,6 @@ func (v *ArrayValue) Map(
 	procedure FunctionValue,
 	transformFunctionType *sema.FunctionType,
 ) Value {
-
-	// Meter computation for iterating the array.
-	interpreter.ReportComputation(common.ComputationKindIterateArrayValue, uint(v.Count()))
 
 	elementTypeSlice := []sema.Type{v.semaType.ElementType(false)}
 	iterationInvocation := func(arrayElement Value) Invocation {
@@ -3147,6 +3144,9 @@ func (v *ArrayValue) Map(
 		common.ZeroAddress,
 		uint64(v.Count()),
 		func() Value {
+
+			// Meter computation for iterating the array.
+			interpreter.ReportComputation(common.ComputationKindIterateArrayValue, 1)
 
 			atreeValue, err := iterator.Next()
 			if err != nil {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2986,6 +2986,9 @@ func (v *ArrayValue) Reverse(
 	count := v.Count()
 	index := count - 1
 
+	// Meter computation for iterating the array.
+	interpreter.ReportComputation(common.ComputationKindIterateArrayValue, uint(v.Count()))
+
 	return NewArrayValueWithIterator(
 		interpreter,
 		v.Type,
@@ -3016,6 +3019,9 @@ func (v *ArrayValue) Filter(
 	locationRange LocationRange,
 	procedure FunctionValue,
 ) Value {
+
+	// Meter computation for iterating the array.
+	interpreter.ReportComputation(common.ComputationKindIterateArrayValue, uint(v.Count()))
 
 	elementTypeSlice := []sema.Type{v.semaType.ElementType(false)}
 	iterationInvocation := func(arrayElement Value) Invocation {
@@ -3090,6 +3096,9 @@ func (v *ArrayValue) Map(
 	procedure FunctionValue,
 	transformFunctionType *sema.FunctionType,
 ) Value {
+
+	// Meter computation for iterating the array.
+	interpreter.ReportComputation(common.ComputationKindIterateArrayValue, uint(v.Count()))
 
 	elementTypeSlice := []sema.Type{v.semaType.ElementType(false)}
 	iterationInvocation := func(arrayElement Value) Invocation {

--- a/runtime/interpreter/value_string.go
+++ b/runtime/interpreter/value_string.go
@@ -126,6 +126,9 @@ func stringFunctionJoin(invocation Invocation) Value {
 		panic(errors.NewUnreachableError())
 	}
 
+	// Meter computation for iterating the array.
+	inter.ReportComputation(common.ComputationKindIterateArrayValue, uint(stringArray.Count()))
+
 	// NewStringMemoryUsage already accounts for empty string.
 	common.UseMemory(inter, common.NewStringMemoryUsage(0))
 	var builder strings.Builder

--- a/runtime/interpreter/value_string.go
+++ b/runtime/interpreter/value_string.go
@@ -126,15 +126,16 @@ func stringFunctionJoin(invocation Invocation) Value {
 		panic(errors.NewUnreachableError())
 	}
 
-	// Meter computation for iterating the array.
-	inter.ReportComputation(common.ComputationKindIterateArrayValue, uint(stringArray.Count()))
-
 	// NewStringMemoryUsage already accounts for empty string.
 	common.UseMemory(inter, common.NewStringMemoryUsage(0))
 	var builder strings.Builder
 	first := true
 
 	stringArray.Iterate(inter, func(element Value) (resume bool) {
+
+		// Meter computation for iterating the array.
+		inter.ReportComputation(common.ComputationKindIterateArrayValue, 1)
+
 		// Add separator
 		if !first {
 			// Construct directly instead of using NewStringMemoryUsage to avoid

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -452,7 +452,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
 		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint(4), computationMeteredValues[common.ComputationKindIterateArrayValue])
+		assert.Equal(t, uint(5), computationMeteredValues[common.ComputationKindIterateArrayValue])
 	})
 
 	t.Run("filter", func(t *testing.T) {
@@ -480,7 +480,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
 		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint(5), computationMeteredValues[common.ComputationKindIterateArrayValue])
+		assert.Equal(t, uint(6), computationMeteredValues[common.ComputationKindIterateArrayValue])
 	})
 }
 


### PR DESCRIPTION
Work towards #2879

## Description

This PR only adds computation metering for the newly added functions:
- https://github.com/onflow/cadence/pull/2762
- https://github.com/onflow/cadence/pull/2737
- https://github.com/onflow/cadence/pull/2678
- https://github.com/onflow/cadence/pull/2654

The remaining functions need to be metered in the stable-cadence branch since it can be a breaking change.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
