### PR TITLE
Allow built-in composite types to be storable

### DIFF
--- a/runtime/cmd/decode-state-values/main.go
+++ b/runtime/cmd/decode-state-values/main.go
@@ -228,6 +228,16 @@ func (i interpreterStorage) CheckHealth() error {
 	panic("unexpected CheckHealth call")
 }
 
+func (i interpreterStorage) RootInterpreter() *interpreter.Interpreter {
+	panic("unexpected RootInterpreter call")
+
+}
+
+func (i interpreterStorage) SetRootInterpreter(_ *interpreter.Interpreter) {
+	panic("unexpected SetRootInterpreter call")
+
+}
+
 // load
 
 func load() {

--- a/runtime/interpreter/deepcopyremove_test.go
+++ b/runtime/interpreter/deepcopyremove_test.go
@@ -100,6 +100,6 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 	require.Equal(t, 1, count)
 }
 
-func newUnmeteredInMemoryStorage() InMemoryStorage {
+func newUnmeteredInMemoryStorage() *InMemoryStorage {
 	return NewInMemoryStorage(nil)
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -244,6 +244,8 @@ type Storage interface {
 	atree.SlabStorage
 	GetStorageMap(address common.Address, domain string, createIfNotExists bool) *StorageMap
 	CheckHealth() error
+	RootInterpreter() *Interpreter
+	SetRootInterpreter(inter *Interpreter)
 }
 
 type ReferencedResourceKindedValues map[atree.StorageID]map[ReferenceTrackedResourceKindedValue]struct{}
@@ -311,6 +313,11 @@ func NewInterpreterWithSharedState(
 	}
 
 	interpreter.activations.PushNewWithParent(baseActivation)
+
+	storage := interpreter.Storage()
+	if storage != nil && storage.RootInterpreter() == nil {
+		storage.SetRootInterpreter(interpreter)
+	}
 
 	return interpreter, nil
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -5581,3 +5581,16 @@ func (interpreter *Interpreter) withResourceDestruction(
 
 	f()
 }
+
+// GetInterpreter returns the interpreter for the given location.
+// The program code might need to be loaded.
+func (interpreter *Interpreter) GetInterpreter(location common.Location) *Interpreter {
+
+	// NOTE: standard library values have no location
+
+	if location == nil || interpreter.Location == location {
+		return interpreter
+	}
+
+	return interpreter.EnsureLoaded(location)
+}

--- a/runtime/sema/authaccount.gen.go
+++ b/runtime/sema/authaccount.gen.go
@@ -858,10 +858,10 @@ const AuthAccountContractsTypeName = "Contracts"
 
 var AuthAccountContractsType = func() *CompositeType {
 	var t = &CompositeType{
-		Identifier:         AuthAccountContractsTypeName,
-		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		Identifier:        AuthAccountContractsTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
+		StorableBuiltin:   false,
 	}
 
 	return t
@@ -1035,10 +1035,10 @@ const AuthAccountKeysTypeName = "Keys"
 
 var AuthAccountKeysType = func() *CompositeType {
 	var t = &CompositeType{
-		Identifier:         AuthAccountKeysTypeName,
-		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		Identifier:        AuthAccountKeysTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
+		StorableBuiltin:   false,
 	}
 
 	return t
@@ -1205,10 +1205,10 @@ const AuthAccountInboxTypeName = "Inbox"
 
 var AuthAccountInboxType = func() *CompositeType {
 	var t = &CompositeType{
-		Identifier:         AuthAccountInboxTypeName,
-		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		Identifier:        AuthAccountInboxTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
+		StorableBuiltin:   false,
 	}
 
 	return t
@@ -1419,10 +1419,10 @@ const AuthAccountCapabilitiesTypeName = "Capabilities"
 
 var AuthAccountCapabilitiesType = func() *CompositeType {
 	var t = &CompositeType{
-		Identifier:         AuthAccountCapabilitiesTypeName,
-		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		Identifier:        AuthAccountCapabilitiesTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
+		StorableBuiltin:   false,
 	}
 
 	return t
@@ -1614,10 +1614,10 @@ const AuthAccountStorageCapabilitiesTypeName = "StorageCapabilities"
 
 var AuthAccountStorageCapabilitiesType = func() *CompositeType {
 	var t = &CompositeType{
-		Identifier:         AuthAccountStorageCapabilitiesTypeName,
-		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		Identifier:        AuthAccountStorageCapabilitiesTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
+		StorableBuiltin:   false,
 	}
 
 	return t
@@ -1770,10 +1770,10 @@ const AuthAccountAccountCapabilitiesTypeName = "AccountCapabilities"
 
 var AuthAccountAccountCapabilitiesType = func() *CompositeType {
 	var t = &CompositeType{
-		Identifier:         AuthAccountAccountCapabilitiesTypeName,
-		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		Identifier:        AuthAccountAccountCapabilitiesTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
+		StorableBuiltin:   false,
 	}
 
 	return t
@@ -1819,10 +1819,10 @@ const AuthAccountTypeName = "AuthAccount"
 
 var AuthAccountType = func() *CompositeType {
 	var t = &CompositeType{
-		Identifier:         AuthAccountTypeName,
-		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		Identifier:        AuthAccountTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
+		StorableBuiltin:   false,
 	}
 
 	t.SetNestedType(AuthAccountContractsTypeName, AuthAccountContractsType)

--- a/runtime/sema/crypto_algorithm_types.go
+++ b/runtime/sema/crypto_algorithm_types.go
@@ -278,10 +278,11 @@ func newNativeEnumType(
 	membersConstructor func(enumType *CompositeType) []*Member,
 ) *CompositeType {
 	ty := &CompositeType{
-		Identifier:  identifier,
-		EnumRawType: rawType,
-		Kind:        common.CompositeKindEnum,
-		importable:  true,
+		Identifier:        identifier,
+		EnumRawType:       rawType,
+		Kind:              common.CompositeKindEnum,
+		ImportableBuiltin: true,
+		StorableBuiltin:   false,
 	}
 
 	// Members of the enum type are *not* the enum cases!

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -1343,8 +1343,8 @@ func compositeTypeExpr(ty *typeDecl) dst.Expr {
 	// 	var t = &CompositeType{
 	// 		Identifier:         FooTypeName,
 	// 		Kind:               common.CompositeKindStructure,
-	// 		importable:         false,
-	// 		hasComputedMembers: true,
+	// 		ImportableBuiltin:  false,
+	//      StorableBuiltin:    false,
 	// 	}
 	//
 	// 	t.SetNestedType(FooBarTypeName, FooBarType)
@@ -1416,8 +1416,8 @@ func compositeTypeLiteral(ty *typeDecl) dst.Expr {
 	elements := []dst.Expr{
 		goKeyValue("Identifier", typeNameVarIdent(ty.fullTypeName)),
 		goKeyValue("Kind", kind),
-		goKeyValue("importable", goBoolLit(ty.importable)),
-		goKeyValue("hasComputedMembers", goBoolLit(true)),
+		goKeyValue("ImportableBuiltin", goBoolLit(ty.importable)),
+		goKeyValue("StorableBuiltin", goBoolLit(ty.storable)),
 	}
 
 	return &dst.UnaryExpr{

--- a/runtime/sema/gen/testdata/nested.golden.go
+++ b/runtime/sema/gen/testdata/nested.golden.go
@@ -60,10 +60,10 @@ const FooBarTypeName = "Bar"
 
 var FooBarType = func() *CompositeType {
 	var t = &CompositeType{
-		Identifier:         FooBarTypeName,
-		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		Identifier:        FooBarTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
+		StorableBuiltin:   false,
 	}
 
 	return t
@@ -88,10 +88,10 @@ const FooTypeName = "Foo"
 
 var FooType = func() *CompositeType {
 	var t = &CompositeType{
-		Identifier:         FooTypeName,
-		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		Identifier:        FooTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
+		StorableBuiltin:   false,
 	}
 
 	t.SetNestedType(FooBarTypeName, FooBarType)

--- a/runtime/sema/publicaccount.gen.go
+++ b/runtime/sema/publicaccount.gen.go
@@ -266,10 +266,10 @@ const PublicAccountContractsTypeName = "Contracts"
 
 var PublicAccountContractsType = func() *CompositeType {
 	var t = &CompositeType{
-		Identifier:         PublicAccountContractsTypeName,
-		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		Identifier:        PublicAccountContractsTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
+		StorableBuiltin:   false,
 	}
 
 	return t
@@ -371,10 +371,10 @@ const PublicAccountKeysTypeName = "Keys"
 
 var PublicAccountKeysType = func() *CompositeType {
 	var t = &CompositeType{
-		Identifier:         PublicAccountKeysTypeName,
-		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		Identifier:        PublicAccountKeysTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
+		StorableBuiltin:   false,
 	}
 
 	return t
@@ -486,10 +486,10 @@ const PublicAccountCapabilitiesTypeName = "Capabilities"
 
 var PublicAccountCapabilitiesType = func() *CompositeType {
 	var t = &CompositeType{
-		Identifier:         PublicAccountCapabilitiesTypeName,
-		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		Identifier:        PublicAccountCapabilitiesTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
+		StorableBuiltin:   false,
 	}
 
 	return t
@@ -521,10 +521,10 @@ const PublicAccountTypeName = "PublicAccount"
 
 var PublicAccountType = func() *CompositeType {
 	var t = &CompositeType{
-		Identifier:         PublicAccountTypeName,
-		Kind:               common.CompositeKindStructure,
-		importable:         false,
-		hasComputedMembers: true,
+		Identifier:        PublicAccountTypeName,
+		Kind:              common.CompositeKindStructure,
+		ImportableBuiltin: false,
+		StorableBuiltin:   false,
 	}
 
 	t.SetNestedType(PublicAccountContractsTypeName, PublicAccountContractsType)

--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
-func newUnmeteredInMemoryStorage() interpreter.InMemoryStorage {
+func newUnmeteredInMemoryStorage() *interpreter.InMemoryStorage {
 	return interpreter.NewInMemoryStorage(nil)
 }
 

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -40,6 +40,15 @@ type Storage struct {
 	contractUpdates *orderedmap.OrderedMap[interpreter.StorageKey, *interpreter.CompositeValue]
 	Ledger          atree.Ledger
 	memoryGauge     common.MemoryGauge
+	rootInterpreter *interpreter.Interpreter
+}
+
+func (s *Storage) RootInterpreter() *interpreter.Interpreter {
+	return s.rootInterpreter
+}
+
+func (s *Storage) SetRootInterpreter(inter *interpreter.Interpreter) {
+	s.rootInterpreter = inter
 }
 
 var _ atree.SlabStorage = &Storage{}

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -121,7 +121,7 @@ func testAccount(
 	getAccountValues := func() map[storageKey]interpreter.Value {
 		accountValues := make(map[storageKey]interpreter.Value)
 
-		for storageMapKey, accountStorage := range inter.Storage().(interpreter.InMemoryStorage).StorageMaps {
+		for storageMapKey, accountStorage := range inter.Storage().(*interpreter.InMemoryStorage).StorageMaps {
 			iterator := accountStorage.Iterator(inter)
 			for {
 				key, value := iterator.Next()

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -246,7 +246,7 @@ func parseCheckAndInterpretWithOptionsAndMemoryMetering(
 	return inter, err
 }
 
-func newUnmeteredInMemoryStorage() interpreter.InMemoryStorage {
+func newUnmeteredInMemoryStorage() *interpreter.InMemoryStorage {
 	return interpreter.NewInMemoryStorage(nil)
 }
 
@@ -8120,7 +8120,7 @@ func TestInterpretResourceMovingAndBorrowing(t *testing.T) {
 
 		var permanentSlabs []atree.Slab
 
-		for _, slab := range storage.(interpreter.InMemoryStorage).Slabs {
+		for _, slab := range storage.(*interpreter.InMemoryStorage).Slabs {
 			if slab.ID().Address == (atree.Address{}) {
 				continue
 			}

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -1113,7 +1113,7 @@ func (r randomValueGenerator) randomCompositeValue(
 	return testComposite, orgFields
 }
 
-func getSlabStorageSize(t *testing.T, storage interpreter.InMemoryStorage) (totalSize int, slabCounts int) {
+func getSlabStorageSize(t *testing.T, storage *interpreter.InMemoryStorage) (totalSize int, slabCounts int) {
 	slabs, err := storage.Encode()
 	require.NoError(t, err)
 


### PR DESCRIPTION
⚠️ Depends on #2878

## Description

- [Allow built-in composite **types** to be storable](https://github.com/onflow/cadence/commit/6681cdaeb6b1e559fc5cd1aae48b20602bcab8c8)
- Allow built-in composite **values** to be storable.

    As discussed in https://discord.com/channels/613813861610684416/1108479699732152503/1164334273684324402, allowing `CompositeValue.Storable` to determine if the value's type is storable, by getting the `CompositeType` for the value, is tricky, as the function is called by atree, and it does not provide access to an `Interpreter` easily.

   [Allow getting root interpreter from interpreter storage](https://github.com/onflow/cadence/commit/c1b61a42f90e944e1dcff9d9de287ebe044b947a), which is ugly and works. If you have any better ideas, please let me know – I don't like this, but couldn't find another easy workable solution. 

    For now this is tech-debt: Eventually in Stable Cadence (which cannot be used, we need this feature on master), we'll have fewer `CompositeValue`s with built-in `CompositeType`s that are non-storable (e.g. currently `AuthAccount`), and we might find a better alternative to this approach later. At least for now this unblocks the work on the EVM integration in flow-go.

    Finally, [allow built-in composite values to be storable](https://github.com/onflow/cadence/commit/02f91f009512966380460ebb2962032db1ef1744), by checking for built-in types, if the composite value's composite type is storable (some are not, e.g. `AuthAccount`). Only check built-in types, because non-built-in composite values/types are always considered storable.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
