### PR TITLE
Allow different base activations per location in checker and interpreter

### DIFF
--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -92,8 +92,10 @@ func DefaultCheckerConfig(
 	baseValueActivation.DeclareValue(stdlib.NewLogFunction(StandardOutputLogger{}))
 
 	return &sema.Config{
-		BaseValueActivation: baseValueActivation,
-		AccessCheckMode:     sema.AccessCheckModeStrict,
+		BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+			return baseValueActivation
+		},
+		AccessCheckMode: sema.AccessCheckModeStrict,
 		ImportHandler: func(
 			checker *sema.Checker,
 			importedLocation common.Location,
@@ -192,8 +194,10 @@ func PrepareInterpreter(filename string, debugger *interpreter.Debugger) (*inter
 	interpreter.Declare(baseActivation, stdlib.NewLogFunction(StandardOutputLogger{}))
 
 	config := &interpreter.Config{
-		BaseActivation: baseActivation,
-		Storage:        storage,
+		BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+			return baseActivation
+		},
+		Storage: storage,
 		UUIDHandler: func() (uint64, error) {
 			defer func() { uuid++ }()
 			return uuid, nil

--- a/runtime/interpreter/config.go
+++ b/runtime/interpreter/config.go
@@ -50,9 +50,9 @@ type Config struct {
 	// UUIDHandler is used to handle the generation of UUIDs
 	UUIDHandler UUIDHandlerFunc
 	// CompositeTypeHandler is used to load composite types
-	CompositeTypeHandler CompositeTypeHandlerFunc
-	BaseActivation       *VariableActivation
-	Debugger             *Debugger
+	CompositeTypeHandler  CompositeTypeHandlerFunc
+	BaseActivationHandler func(location common.Location) *VariableActivation
+	Debugger              *Debugger
 	// OnStatement is triggered when a statement is about to be executed
 	OnStatement OnStatementFunc
 	// OnLoopIteration is triggered when a loop iteration is about to be executed

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -296,9 +296,15 @@ func NewInterpreterWithSharedState(
 		sharedState.allInterpreters[location] = interpreter
 	}
 
+	// Initialize activations
+
 	interpreter.activations = activations.NewActivations[*Variable](interpreter)
 
-	baseActivation := sharedState.Config.BaseActivation
+	var baseActivation *VariableActivation
+	baseActivationHandler := sharedState.Config.BaseActivationHandler
+	if baseActivationHandler != nil {
+		baseActivation = baseActivationHandler(location)
+	}
 	if baseActivation == nil {
 		baseActivation = BaseActivation
 	}

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
@@ -29,6 +30,7 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/cadence/runtime/tests/checker"
 	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
@@ -36,96 +38,214 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 
 	t.Parallel()
 
-	valueDeclaration := stdlib.StandardLibraryValue{
-		Name:  "foo",
-		Type:  sema.IntType,
-		Kind:  common.DeclarationKindConstant,
-		Value: interpreter.NewUnmeteredIntValueFromInt64(2),
+	const contractName = "C"
+	address := common.MustBytesToAddress([]byte{0x1})
+	contractLocation := common.AddressLocation{
+		Address: address,
+		Name:    contractName,
 	}
 
-	contract := []byte(`
-	  pub contract C {
-	      pub fun foo(): Int {
-	          return foo
-	      }
-	  }
-	`)
+	test := func(
+		t *testing.T,
+		contract string,
+		script string,
+		valueDeclarations map[common.Location]stdlib.StandardLibraryValue,
+		checkTransaction func(err error) bool,
+		checkScript func(result cadence.Value, err error),
+	) {
 
-	script := []byte(`
-	  import C from 0x1
+		runtime := newTestInterpreterRuntime()
 
-	  pub fun main(): Int {
-		  return foo + C.foo()
-	  }
-	`)
+		deploy := DeploymentTransaction(contractName, []byte(contract))
 
-	runtime := newTestInterpreterRuntime()
+		var accountCode []byte
+		var events []cadence.Event
 
-	deploy := DeploymentTransaction("C", contract)
+		runtimeInterface := &testRuntimeInterface{
+			getCode: func(_ Location) (bytes []byte, err error) {
+				return accountCode, nil
+			},
+			storage: newTestLedger(nil, nil),
+			getSigningAccounts: func() ([]Address, error) {
+				return []Address{address}, nil
+			},
+			resolveLocation: singleIdentifierLocationResolver(t),
+			getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
+				return accountCode, nil
+			},
+			updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+				accountCode = code
+				return nil
+			},
+			emitEvent: func(event cadence.Event) error {
+				events = append(events, event)
+				return nil
+			},
+		}
 
-	var accountCode []byte
-	var events []cadence.Event
+		prepareEnvironment := func(env Environment) {
+			for location, valueDeclaration := range valueDeclarations {
+				env.DeclareValue(valueDeclaration, location)
+			}
+		}
 
-	runtimeInterface := &testRuntimeInterface{
-		getCode: func(_ Location) (bytes []byte, err error) {
-			return accountCode, nil
-		},
-		storage: newTestLedger(nil, nil),
-		getSigningAccounts: func() ([]Address, error) {
-			return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
-		},
-		resolveLocation: singleIdentifierLocationResolver(t),
-		getAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
-			return accountCode, nil
-		},
-		updateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
-			accountCode = code
-			return nil
-		},
-		emitEvent: func(event cadence.Event) error {
-			events = append(events, event)
-			return nil
-		},
+		// Run deploy transaction
+
+		transactionEnvironment := NewBaseInterpreterEnvironment(Config{})
+		prepareEnvironment(transactionEnvironment)
+
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: deploy,
+			},
+			Context{
+				Interface:   runtimeInterface,
+				Location:    common.TransactionLocation{},
+				Environment: transactionEnvironment,
+			},
+		)
+
+		if checkTransaction(err) {
+
+			scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+			prepareEnvironment(scriptEnvironment)
+
+			checkScript(runtime.ExecuteScript(
+				Script{
+					Source: []byte(script),
+				},
+				Context{
+					Interface:   runtimeInterface,
+					Location:    common.ScriptLocation{},
+					Environment: scriptEnvironment,
+				},
+			))
+		}
 	}
 
-	// Run transaction
+	t.Run("everywhere", func(t *testing.T) {
+		t.Parallel()
 
-	transactionEnvironment := NewBaseInterpreterEnvironment(Config{})
-	transactionEnvironment.DeclareValue(valueDeclaration)
+		test(t,
+			`
+	          pub contract C {
+	              pub fun foo(): Int {
+	                  return foo
+	              }
+	          }
+	        `,
+			`
+	          import C from 0x1
 
-	err := runtime.ExecuteTransaction(
-		Script{
-			Source: deploy,
-		},
-		Context{
-			Interface:   runtimeInterface,
-			Location:    common.TransactionLocation{},
-			Environment: transactionEnvironment,
-		},
-	)
-	require.NoError(t, err)
+	          pub fun main(): Int {
+	        	  return foo + C.foo()
+	          }
+	        `,
+			map[common.Location]stdlib.StandardLibraryValue{
+				nil: {
+					Name:  "foo",
+					Type:  sema.IntType,
+					Kind:  common.DeclarationKindConstant,
+					Value: interpreter.NewUnmeteredIntValueFromInt64(2),
+				},
+			},
+			func(err error) bool {
+				return assert.NoError(t, err)
+			},
+			func(result cadence.Value, err error) {
 
-	// Run script
+				require.NoError(t, err)
 
-	scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
-	scriptEnvironment.DeclareValue(valueDeclaration)
+				require.Equal(t,
+					cadence.Int{Value: big.NewInt(4)},
+					result,
+				)
+			},
+		)
+	})
 
-	result, err := runtime.ExecuteScript(
-		Script{
-			Source: script,
-		},
-		Context{
-			Interface:   runtimeInterface,
-			Location:    common.ScriptLocation{},
-			Environment: scriptEnvironment,
-		},
-	)
-	require.NoError(t, err)
+	t.Run("only contract, no use in script", func(t *testing.T) {
+		t.Parallel()
 
-	require.Equal(t,
-		cadence.Int{Value: big.NewInt(4)},
-		result,
-	)
+		test(t,
+			`
+	          pub contract C {
+	              pub fun foo(): Int {
+	                  return foo
+	              }
+	          }
+	        `,
+			`
+	          import C from 0x1
+
+	          pub fun main(): Int {
+	        	  return C.foo()
+	          }
+	        `,
+			map[common.Location]stdlib.StandardLibraryValue{
+				contractLocation: {
+					Name:  "foo",
+					Type:  sema.IntType,
+					Kind:  common.DeclarationKindConstant,
+					Value: interpreter.NewUnmeteredIntValueFromInt64(2),
+				},
+			},
+			func(err error) bool {
+				return assert.NoError(t, err)
+			},
+			func(result cadence.Value, err error) {
+
+				require.NoError(t, err)
+
+				require.Equal(t,
+					cadence.Int{Value: big.NewInt(2)},
+					result,
+				)
+			},
+		)
+	})
+
+	t.Run("only contract, use in script", func(t *testing.T) {
+		t.Parallel()
+
+		test(t,
+			`
+	          pub contract C {
+	              pub fun foo(): Int {
+	                  return foo
+	              }
+	          }
+	        `,
+			`
+	          import C from 0x1
+
+	          pub fun main(): Int {
+	        	  return foo + C.foo()
+	          }
+	        `,
+			map[common.Location]stdlib.StandardLibraryValue{
+				contractLocation: {
+					Name:  "foo",
+					Type:  sema.IntType,
+					Kind:  common.DeclarationKindConstant,
+					Value: interpreter.NewUnmeteredIntValueFromInt64(2),
+				},
+			},
+			func(err error) bool {
+				return assert.NoError(t, err)
+			},
+			func(result cadence.Value, err error) {
+				RequireError(t, err)
+
+				errs := checker.RequireCheckerErrors(t, err, 1)
+
+				var notDeclaredErr *sema.NotDeclaredError
+				require.ErrorAs(t, errs[0], &notDeclaredErr)
+				require.Equal(t, "foo", notDeclaredErr.Name)
+			},
+		)
+	})
+
 }
 
 func TestRuntimePredeclaredTypes(t *testing.T) {
@@ -169,8 +289,8 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 		// Run script
 
 		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
-		scriptEnvironment.DeclareValue(valueDeclaration)
-		scriptEnvironment.DeclareType(typeDeclaration)
+		scriptEnvironment.DeclareValue(valueDeclaration, nil)
+		scriptEnvironment.DeclareType(typeDeclaration, nil)
 
 		result, err := runtime.ExecuteScript(
 			Script{
@@ -239,8 +359,8 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 		// Run script
 
 		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
-		scriptEnvironment.DeclareValue(valueDeclaration)
-		scriptEnvironment.DeclareType(typeDeclaration)
+		scriptEnvironment.DeclareValue(valueDeclaration, nil)
+		scriptEnvironment.DeclareType(typeDeclaration, nil)
 
 		result, err := runtime.ExecuteScript(
 			Script{
@@ -308,7 +428,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 		// Run script
 
 		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
-		scriptEnvironment.DeclareValue(valueDeclaration)
+		scriptEnvironment.DeclareValue(valueDeclaration, nil)
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -383,8 +503,8 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 		// Run script
 
 		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
-		scriptEnvironment.DeclareValue(valueDeclaration)
-		scriptEnvironment.DeclareType(typeDeclaration)
+		scriptEnvironment.DeclareValue(valueDeclaration, nil)
+		scriptEnvironment.DeclareType(typeDeclaration, nil)
 
 		result, err := runtime.ExecuteScript(
 			Script{
@@ -460,7 +580,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 		// Run script
 
 		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
-		scriptEnvironment.DeclareValue(valueDeclaration)
+		scriptEnvironment.DeclareValue(valueDeclaration, nil)
 
 		_, err := runtime.ExecuteScript(
 			Script{

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -237,6 +237,10 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 			func(result cadence.Value, err error) {
 				RequireError(t, err)
 
+				var checkerErr *sema.CheckerError
+				require.ErrorAs(t, err, &checkerErr)
+				assert.Equal(t, common.ScriptLocation{}, checkerErr.Location)
+
 				errs := checker.RequireCheckerErrors(t, err, 1)
 
 				var notDeclaredErr *sema.NotDeclaredError

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -80,7 +80,9 @@ func NewREPL() (*REPL, error) {
 			defer func() { uuid++ }()
 			return uuid, nil
 		},
-		BaseActivation: baseActivation,
+		BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+			return baseActivation
+		},
 	}
 
 	inter, err := interpreter.NewInterpreter(

--- a/runtime/sema/config.go
+++ b/runtime/sema/config.go
@@ -26,10 +26,10 @@ type Config struct {
 	// ValidTopLevelDeclarationsHandler is used to determine the kinds of declarations
 	// which are valid at the top-level for a given location
 	ValidTopLevelDeclarationsHandler ValidTopLevelDeclarationsHandlerFunc
-	BaseTypeActivation               *VariableActivation
+	BaseTypeActivationHandler        ActivationHandlerFunc
+	BaseValueActivationHandler       ActivationHandlerFunc
 	// ImportHandler is used to resolve unresolved imports
-	ImportHandler       ImportHandlerFunc
-	BaseValueActivation *VariableActivation
+	ImportHandler ImportHandlerFunc
 	// CheckHandler is the function which is used for the checking of a program
 	CheckHandler CheckHandlerFunc
 	// LocationHandler is used to resolve locations

--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/onflow/cadence/runtime/activations"
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/tests/checker"
 
 	"github.com/stretchr/testify/assert"
@@ -55,8 +56,10 @@ func newInterpreter(t *testing.T, code string, valueDeclarations ...StandardLibr
 		utils.TestLocation,
 		nil,
 		&sema.Config{
-			BaseValueActivation: baseValueActivation,
-			AccessCheckMode:     sema.AccessCheckModeStrict,
+			BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+				return baseValueActivation
+			},
+			AccessCheckMode: sema.AccessCheckModeStrict,
 		},
 	)
 	require.NoError(t, err)
@@ -75,8 +78,10 @@ func newInterpreter(t *testing.T, code string, valueDeclarations ...StandardLibr
 		interpreter.ProgramFromChecker(checker),
 		checker.Location,
 		&interpreter.Config{
-			Storage:        storage,
-			BaseActivation: baseActivation,
+			Storage: storage,
+			BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+				return baseActivation
+			},
 		},
 	)
 	require.NoError(t, err)
@@ -99,7 +104,9 @@ func TestCheckAssert(t *testing.T) {
 			code,
 			checker.ParseAndCheckOptions{
 				Config: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
 		)
@@ -215,7 +222,9 @@ func TestCheckPanic(t *testing.T) {
 			code,
 			checker.ParseAndCheckOptions{
 				Config: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
 		)

--- a/runtime/stdlib/test_contract.go
+++ b/runtime/stdlib/test_contract.go
@@ -965,8 +965,10 @@ func newTestContractType() *TestContractType {
 		TestContractLocation,
 		nil,
 		&sema.Config{
-			BaseValueActivation: activation,
-			AccessCheckMode:     sema.AccessCheckModeStrict,
+			BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+				return activation
+			},
+			AccessCheckMode: sema.AccessCheckModeStrict,
 		},
 	)
 	if err != nil {

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -40,15 +40,14 @@ func ParseAndCheckAccountWithConfig(t *testing.T, code string, config sema.Confi
 		}
 	}
 
-	baseValueActivation := config.BaseValueActivation
-	if baseValueActivation == nil {
-		baseValueActivation = sema.BaseValueActivation
-	}
-
-	baseValueActivation = sema.NewVariableActivation(baseValueActivation)
+	baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
 	baseValueActivation.DeclareValue(constantDeclaration("authAccount", sema.AuthAccountType))
 	baseValueActivation.DeclareValue(constantDeclaration("publicAccount", sema.PublicAccountType))
-	config.BaseValueActivation = baseValueActivation
+
+	require.Nil(t, config.BaseValueActivationHandler)
+	config.BaseValueActivationHandler = func(_ common.Location) *sema.VariableActivation {
+		return baseValueActivation
+	}
 
 	return ParseAndCheckWithOptions(t,
 		code,

--- a/runtime/tests/checker/assert_test.go
+++ b/runtime/tests/checker/assert_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 )
@@ -42,7 +43,9 @@ func TestCheckAssertWithoutMessage(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -65,7 +68,9 @@ func TestCheckAssertWithMessage(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)

--- a/runtime/tests/checker/capability_controller_test.go
+++ b/runtime/tests/checker/capability_controller_test.go
@@ -44,7 +44,9 @@ func TestCheckStorageCapabilityController(t *testing.T) {
 			code,
 			ParseAndCheckOptions{
 				Config: &sema.Config{
-					BaseValueActivation: baseActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 		)
@@ -105,7 +107,9 @@ func TestCheckAccountCapabilityController(t *testing.T) {
 			code,
 			ParseAndCheckOptions{
 				Config: &sema.Config{
-					BaseValueActivation: baseActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 		)

--- a/runtime/tests/checker/crypto_test.go
+++ b/runtime/tests/checker/crypto_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 )
@@ -48,7 +49,9 @@ func TestCheckHashAlgorithmCases(t *testing.T) {
 			),
 			ParseAndCheckOptions{
 				Config: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
 		)
@@ -74,7 +77,9 @@ func TestCheckHashAlgorithmConstructor(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -97,7 +102,9 @@ func TestCheckHashAlgorithmHashFunctions(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -123,7 +130,9 @@ func TestCheckSignatureAlgorithmCases(t *testing.T) {
 			),
 			ParseAndCheckOptions{
 				Config: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
 		)
@@ -149,7 +158,9 @@ func TestCheckSignatureAlgorithmConstructor(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -176,7 +187,9 @@ func TestCheckVerifyPoP(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -203,7 +216,9 @@ func TestCheckVerifyPoPInvalidArgument(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -227,7 +242,9 @@ func TestCheckBLSAggregateSignatures(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -248,7 +265,9 @@ func TestCheckInvalidBLSAggregateSignatures(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -279,7 +298,9 @@ func TestCheckBLSAggregatePublicKeys(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -302,7 +323,9 @@ func TestCheckInvalidBLSAggregatePublicKeys(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -45,7 +45,9 @@ func parseAndCheckWithTestValue(t *testing.T, code string, ty sema.Type) (*sema.
 		code,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)

--- a/runtime/tests/checker/interface_test.go
+++ b/runtime/tests/checker/interface_test.go
@@ -1893,6 +1893,13 @@ func BenchmarkCheckContractInterfaceFungibleTokenConformance(b *testing.B) {
 	baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
 	baseValueActivation.DeclareValue(stdlib.PanicFunction)
 
+	config := &sema.Config{
+		AccessCheckMode: sema.AccessCheckModeNotSpecifiedUnrestricted,
+		BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+			return baseValueActivation
+		},
+	}
+
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -1901,10 +1908,7 @@ func BenchmarkCheckContractInterfaceFungibleTokenConformance(b *testing.B) {
 			program,
 			TestLocation,
 			nil,
-			&sema.Config{
-				AccessCheckMode:     sema.AccessCheckModeNotSpecifiedUnrestricted,
-				BaseValueActivation: baseValueActivation,
-			},
+			config,
 		)
 		if err != nil {
 			b.Fatal(err)

--- a/runtime/tests/checker/invocation_test.go
+++ b/runtime/tests/checker/invocation_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 )
@@ -332,7 +333,9 @@ func TestCheckInvocationWithOnlyVarargs(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)

--- a/runtime/tests/checker/nesting_test.go
+++ b/runtime/tests/checker/nesting_test.go
@@ -320,7 +320,9 @@ func TestCheckNestedTypeInvalidChildType(t *testing.T) {
 				`let u: T.U = nil`,
 				ParseAndCheckOptions{
 					Config: &sema.Config{
-						BaseTypeActivation: baseTypeActivation,
+						BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseTypeActivation
+						},
 					},
 				},
 			)

--- a/runtime/tests/checker/nft_test.go
+++ b/runtime/tests/checker/nft_test.go
@@ -1003,7 +1003,9 @@ func TestCheckTopShotContract(t *testing.T) {
 						Elaboration: nftChecker.Elaboration,
 					}, nil
 				},
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)

--- a/runtime/tests/checker/predeclaredvalues_test.go
+++ b/runtime/tests/checker/predeclaredvalues_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 )
@@ -53,7 +54,9 @@ func TestCheckPredeclaredValues(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)

--- a/runtime/tests/checker/return_test.go
+++ b/runtime/tests/checker/return_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 )
@@ -209,7 +210,9 @@ func testExits(t *testing.T, test exitTest) {
 		code,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)

--- a/runtime/tests/checker/rlp_test.go
+++ b/runtime/tests/checker/rlp_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 )
@@ -40,7 +41,9 @@ func TestCheckRLPDecodeString(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -60,7 +63,9 @@ func TestCheckInvalidRLPDecodeString(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -84,7 +89,9 @@ func TestCheckRLPDecodeList(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -104,7 +111,9 @@ func TestCheckInvalidRLPDecodeList(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)

--- a/runtime/tests/checker/storable_test.go
+++ b/runtime/tests/checker/storable_test.go
@@ -44,8 +44,10 @@ func TestCheckStorable(t *testing.T) {
 			code,
 			ParseAndCheckOptions{
 				Config: &sema.Config{
-					BaseValueActivation: baseValueActivation,
-					AttachmentsEnabled:  true,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
+					AttachmentsEnabled: true,
 				},
 			},
 		)

--- a/runtime/tests/checker/utils_test.go
+++ b/runtime/tests/checker/utils_test.go
@@ -35,7 +35,9 @@ func ParseAndCheckWithPanic(t *testing.T, code string) (*sema.Checker, error) {
 		code,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -54,7 +56,9 @@ func ParseAndCheckWithAny(t *testing.T, code string) (*sema.Checker, error) {
 		code,
 		ParseAndCheckOptions{
 			Config: &sema.Config{
-				BaseTypeActivation: baseTypeActivation,
+				BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseTypeActivation
+				},
 			},
 		},
 	)

--- a/runtime/tests/interpreter/attachments_test.go
+++ b/runtime/tests/interpreter/attachments_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/onflow/cadence/runtime/activations"
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
@@ -1965,11 +1966,15 @@ func TestInterpretBuiltinCompositeAttachment(t *testing.T) {
         `,
 		ParseCheckAndInterpretOptions{
 			CheckerConfig: &sema.Config{
-				BaseValueActivation: baseValueActivation,
-				AttachmentsEnabled:  true,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
+				AttachmentsEnabled: true,
 			},
 			Config: &interpreter.Config{
-				BaseActivation: baseActivation,
+				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+					return baseActivation
+				},
 			},
 		},
 	)

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -145,8 +145,12 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 		code,
 		ParseCheckAndInterpretOptions{
 			CheckerConfig: &sema.Config{
-				BaseValueActivation: baseValueActivation,
-				BaseTypeActivation:  baseTypeActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
+				BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseTypeActivation
+				},
 				CheckHandler: func(checker *sema.Checker, check func()) {
 					if checker.Location == TestLocation {
 						checker.Elaboration.SetCompositeType(
@@ -158,8 +162,10 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 				},
 			},
 			Config: &interpreter.Config{
-				Storage:        storage,
-				BaseActivation: baseActivation,
+				Storage: storage,
+				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+					return baseActivation
+				},
 			},
 		},
 	)

--- a/runtime/tests/interpreter/condition_test.go
+++ b/runtime/tests/interpreter/condition_test.go
@@ -1174,10 +1174,14 @@ func TestInterpretFunctionWithPostConditionAndResourceResult(t *testing.T) {
         `,
 		ParseCheckAndInterpretOptions{
 			CheckerConfig: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 			Config: &interpreter.Config{
-				BaseActivation: baseActivation,
+				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+					return baseActivation
+				},
 			},
 		},
 	)

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -336,10 +336,14 @@ func TestArrayMutation(t *testing.T) {
             }`,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 		)
@@ -475,10 +479,14 @@ func TestArrayMutation(t *testing.T) {
             `,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 		)
@@ -726,10 +734,14 @@ func TestDictionaryMutation(t *testing.T) {
             }`,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 		)
@@ -865,10 +877,14 @@ func TestDictionaryMutation(t *testing.T) {
            `,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 		)

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -3544,10 +3544,14 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 
 			options := ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			}
 

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -73,10 +73,14 @@ func TestInterpretEquality(t *testing.T) {
 		    `,
 			ParseCheckAndInterpretOptions{
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
 		)
@@ -127,10 +131,14 @@ func TestInterpretEquality(t *testing.T) {
 		    `,
 			ParseCheckAndInterpretOptions{
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
 		)

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -116,10 +116,14 @@ func parseCheckAndInterpretWithLogs(
 		code,
 		ParseCheckAndInterpretOptions{
 			Config: &interpreter.Config{
-				BaseActivation: baseActivation,
+				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+					return baseActivation
+				},
 			},
 			CheckerConfig: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 			HandleCheckerError: nil,
 		},
@@ -146,7 +150,9 @@ func parseCheckAndInterpretWithMemoryMetering(
 		code,
 		ParseCheckAndInterpretOptions{
 			CheckerConfig: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 		memoryGauge,
@@ -1984,8 +1990,10 @@ func TestInterpretHostFunction(t *testing.T) {
 		TestLocation,
 		nil,
 		&sema.Config{
-			BaseValueActivation: baseValueActivation,
-			AccessCheckMode:     sema.AccessCheckModeStrict,
+			BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+				return baseValueActivation
+			},
+			AccessCheckMode: sema.AccessCheckModeStrict,
 		},
 	)
 	require.NoError(t, err)
@@ -2002,8 +2010,10 @@ func TestInterpretHostFunction(t *testing.T) {
 		interpreter.ProgramFromChecker(checker),
 		checker.Location,
 		&interpreter.Config{
-			Storage:        storage,
-			BaseActivation: baseActivation,
+			Storage: storage,
+			BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+				return baseActivation
+			},
 		},
 	)
 	require.NoError(t, err)
@@ -2093,8 +2103,10 @@ func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
 		TestLocation,
 		nil,
 		&sema.Config{
-			BaseValueActivation: baseValueActivation,
-			AccessCheckMode:     sema.AccessCheckModeStrict,
+			BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+				return baseValueActivation
+			},
+			AccessCheckMode: sema.AccessCheckModeStrict,
 		},
 	)
 	require.NoError(t, err)
@@ -2111,8 +2123,10 @@ func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
 		interpreter.ProgramFromChecker(checker),
 		checker.Location,
 		&interpreter.Config{
-			Storage:        storage,
-			BaseActivation: baseActivation,
+			Storage: storage,
+			BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+				return baseActivation
+			},
 		},
 	)
 	require.NoError(t, err)
@@ -2197,8 +2211,10 @@ func TestInterpretHostFunctionWithOptionalArguments(t *testing.T) {
 		TestLocation,
 		nil,
 		&sema.Config{
-			BaseValueActivation: baseValueActivation,
-			AccessCheckMode:     sema.AccessCheckModeStrict,
+			BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+				return baseValueActivation
+			},
+			AccessCheckMode: sema.AccessCheckModeStrict,
 		},
 	)
 	require.NoError(t, err)
@@ -2215,8 +2231,10 @@ func TestInterpretHostFunctionWithOptionalArguments(t *testing.T) {
 		interpreter.ProgramFromChecker(checker),
 		checker.Location,
 		&interpreter.Config{
-			Storage:        storage,
-			BaseActivation: baseActivation,
+			Storage: storage,
+			BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+				return baseActivation
+			},
 		},
 	)
 	require.NoError(t, err)
@@ -4200,7 +4218,9 @@ func TestInterpretImportError(t *testing.T) {
 			checker.ParseAndCheckOptions{
 				Location: location,
 				Config: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 					ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 						switch importedLocation {
 						case importedLocation1:
@@ -4260,8 +4280,10 @@ func TestInterpretImportError(t *testing.T) {
 		interpreter.ProgramFromChecker(mainChecker),
 		mainChecker.Location,
 		&interpreter.Config{
-			Storage:        storage,
-			BaseActivation: baseActivation,
+			Storage: storage,
+			BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+				return baseActivation
+			},
 			ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 				var importedChecker *sema.Checker
 				switch location {
@@ -5203,11 +5225,15 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
             `,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					Storage:        storage,
-					BaseActivation: baseActivation,
+					Storage: storage,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 		)
@@ -7564,8 +7590,12 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 			inter, err := parseCheckAndInterpretWithOptions(
 				t, code, ParseCheckAndInterpretOptions{
 					CheckerConfig: &sema.Config{
-						BaseValueActivation: baseValueActivation,
-						BaseTypeActivation:  baseTypeActivation,
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
+						BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseTypeActivation
+						},
 					},
 					Config: &interpreter.Config{
 						Storage: storage,
@@ -8373,10 +8403,14 @@ func TestInterpretOptionalChainingFieldReadAndNilCoalescing(t *testing.T) {
         `,
 		ParseCheckAndInterpretOptions{
 			CheckerConfig: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 			Config: &interpreter.Config{
-				BaseActivation: baseActivation,
+				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+					return baseActivation
+				},
 			},
 		},
 	)
@@ -8413,10 +8447,14 @@ func TestInterpretOptionalChainingFunctionCallAndNilCoalescing(t *testing.T) {
         `,
 		ParseCheckAndInterpretOptions{
 			CheckerConfig: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 			Config: &interpreter.Config{
-				BaseActivation: baseActivation,
+				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+					return baseActivation
+				},
 			},
 		},
 	)
@@ -8610,11 +8648,15 @@ func TestInterpretFungibleTokenContract(t *testing.T) {
 		code,
 		ParseCheckAndInterpretOptions{
 			Config: &interpreter.Config{
-				BaseActivation:       baseActivation,
+				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+					return baseActivation
+				},
 				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 			CheckerConfig: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
 	)
@@ -9102,10 +9144,14 @@ func TestInterpretHexDecode(t *testing.T) {
             `,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 		)
@@ -9448,10 +9494,14 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 		code,
 		ParseCheckAndInterpretOptions{
 			CheckerConfig: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 			Config: &interpreter.Config{
-				BaseActivation: baseActivation,
+				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+					return baseActivation
+				},
 				PublicAccountHandler: func(address interpreter.AddressValue) interpreter.Value {
 					return newTestPublicAccountValue(nil, address)
 				},
@@ -11724,10 +11774,14 @@ func TestInterpretNilCoalesceReference(t *testing.T) {
         `,
 		ParseCheckAndInterpretOptions{
 			CheckerConfig: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 			Config: &interpreter.Config{
-				BaseActivation: baseActivation,
+				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+					return baseActivation
+				},
 			},
 		},
 	)

--- a/runtime/tests/interpreter/invocation_test.go
+++ b/runtime/tests/interpreter/invocation_test.go
@@ -84,7 +84,7 @@ func TestInterpretSelfDeclaration(t *testing.T) {
 
 		inter, err := parseCheckAndInterpretWithOptions(t, code, ParseCheckAndInterpretOptions{
 			Config: &interpreter.Config{
-				Storage:        newUnmeteredInMemoryStorage(),
+				Storage: newUnmeteredInMemoryStorage(),
 				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 					return baseActivation
 				},
@@ -93,7 +93,7 @@ func TestInterpretSelfDeclaration(t *testing.T) {
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
-				AccessCheckMode:     sema.AccessCheckModeNotSpecifiedUnrestricted,
+				AccessCheckMode: sema.AccessCheckModeNotSpecifiedUnrestricted,
 			},
 		})
 		require.NoError(t, err)

--- a/runtime/tests/interpreter/invocation_test.go
+++ b/runtime/tests/interpreter/invocation_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/activations"
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
@@ -84,10 +85,14 @@ func TestInterpretSelfDeclaration(t *testing.T) {
 		inter, err := parseCheckAndInterpretWithOptions(t, code, ParseCheckAndInterpretOptions{
 			Config: &interpreter.Config{
 				Storage:        newUnmeteredInMemoryStorage(),
-				BaseActivation: baseActivation,
+				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+					return baseActivation
+				},
 			},
 			CheckerConfig: &sema.Config{
-				BaseValueActivation: baseValueActivation,
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 				AccessCheckMode:     sema.AccessCheckModeNotSpecifiedUnrestricted,
 			},
 		})

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -1066,10 +1066,14 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 			script,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 			meter,
@@ -1115,10 +1119,14 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 			script,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 			meter,
@@ -1169,10 +1177,14 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 			script,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 			meter,
@@ -8766,10 +8778,14 @@ func TestInterpretValueStringConversion(t *testing.T) {
 		inter, err := parseCheckAndInterpretWithOptionsAndMemoryMetering(t, script,
 			ParseCheckAndInterpretOptions{
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
 			meter,
@@ -9128,10 +9144,14 @@ func TestInterpretStaticTypeStringConversion(t *testing.T) {
 		inter, err := parseCheckAndInterpretWithOptionsAndMemoryMetering(t, script,
 			ParseCheckAndInterpretOptions{
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
 			meter,

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -142,10 +142,14 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
             `,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 		)
@@ -198,10 +202,14 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
             `,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 		)
@@ -287,10 +295,14 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
             `,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 		)
@@ -440,10 +452,14 @@ func TestInterpretIsInstance(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			inter, err := parseCheckAndInterpretWithOptions(t, testCase.code, ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			})
 			require.NoError(t, err)
@@ -580,10 +596,14 @@ func TestInterpretMetaTypeIsSubtype(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			inter, err := parseCheckAndInterpretWithOptions(t, testCase.code, ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseValueActivation: baseValueActivation,
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			})
 			require.NoError(t, err)
@@ -793,11 +813,15 @@ func TestInterpretGetType(t *testing.T) {
 				testCase.code,
 				ParseCheckAndInterpretOptions{
 					CheckerConfig: &sema.Config{
-						BaseValueActivation: baseValueActivation,
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 					Config: &interpreter.Config{
-						Storage:        storage,
-						BaseActivation: baseActivation,
+						Storage: storage,
+						BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+							return baseActivation
+						},
 					},
 				},
 			)

--- a/runtime/tests/interpreter/transfer_test.go
+++ b/runtime/tests/interpreter/transfer_test.go
@@ -76,11 +76,17 @@ func TestInterpretTransferCheck(t *testing.T) {
             `,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
-					BaseTypeActivation:  baseTypeActivation,
-					BaseValueActivation: baseValueActivation,
+					BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseTypeActivation
+					},
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 				Config: &interpreter.Config{
-					BaseActivation: baseActivation,
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
 				},
 			},
 		)

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -109,8 +109,10 @@ func (programs Programs) check(
 		location,
 		nil,
 		&sema.Config{
-			BaseValueActivation: baseValueActivation,
-			AccessCheckMode:     sema.AccessCheckModeStrict,
+			BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+				return baseValueActivation
+			},
+			AccessCheckMode: sema.AccessCheckModeStrict,
 			LocationHandler: sema.AddressLocationHandlerFunc(
 				config.ResolveAddressContractNames,
 			),


### PR DESCRIPTION
## Description

Allow types and values of an environment to be declared in specific locations.

Change the checker and interpreters configurations from values to handlers, which can return different base activations for different locations.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
