### PR TITLE
Issue 2827

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,7 +1,7 @@
 name: Reporting a Problem/Bug
 description: Reporting a Problem/Bug
 labels: [Bug, Feedback]
-assignees: turbolent, SupunS, dsainati1, dreamsmasher
+assignees: onflow/cadence
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,7 +1,7 @@
 name: Requesting a Feature or Improvement
 description: For feature requests. Please search for existing issues first. Also see CONTRIBUTING.
 labels: [Feature, Feedback]
-assignees: turbolent
+assignees: onflow/cadence
 body:
   - type: markdown
     attributes:

--- a/runtime/common/computationkind.go
+++ b/runtime/common/computationkind.go
@@ -142,4 +142,8 @@ const (
 	// RLP
 	ComputationKindSTDLIBRLPDecodeString
 	ComputationKindSTDLIBRLPDecodeList
+	_
+	_
+	// WebAssembly
+	ComputationKindWebAssemblyFuel
 )

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -37,4 +37,6 @@ type Config struct {
 	CoverageReport *CoverageReport
 	// AttachmentsEnabled specifies if attachments are enabled
 	AttachmentsEnabled bool
+	// WebAssemblyEnabled specifies if the WebAssembly API is enabled
+	WebAssemblyEnabled bool
 }

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -38,7 +38,8 @@ import (
 type Environment interface {
 	ArgumentDecoder
 
-	Declare(valueDeclaration stdlib.StandardLibraryValue)
+	DeclareValue(valueDeclaration stdlib.StandardLibraryValue)
+	DeclareType(typeDeclaration stdlib.StandardLibraryType)
 	Configure(
 		runtimeInterface Interface,
 		codesAndPrograms CodesAndPrograms,
@@ -77,8 +78,9 @@ type interpreterEnvironmentReconfigured struct {
 
 type interpreterEnvironment struct {
 	interpreterEnvironmentReconfigured
-	baseActivation                        *interpreter.VariableActivation
+	baseTypeActivation                    *sema.VariableActivation
 	baseValueActivation                   *sema.VariableActivation
+	baseActivation                        *interpreter.VariableActivation
 	InterpreterConfig                     *interpreter.Config
 	CheckerConfig                         *sema.Config
 	deployedContractConstructorInvocation *stdlib.DeployedContractConstructorInvocation
@@ -106,16 +108,24 @@ var _ common.MemoryGauge = &interpreterEnvironment{}
 
 func newInterpreterEnvironment(config Config) *interpreterEnvironment {
 	baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+	baseTypeActivation := sema.NewVariableActivation(sema.BaseTypeActivation)
 	baseActivation := activations.NewActivation[*interpreter.Variable](nil, interpreter.BaseActivation)
 
 	env := &interpreterEnvironment{
 		config:              config,
-		baseActivation:      baseActivation,
 		baseValueActivation: baseValueActivation,
+		baseTypeActivation:  baseTypeActivation,
+		baseActivation:      baseActivation,
 		stackDepthLimiter:   newStackDepthLimiter(config.StackDepthLimit),
 	}
 	env.InterpreterConfig = env.newInterpreterConfig()
 	env.CheckerConfig = env.newCheckerConfig()
+
+	if config.WebAssemblyEnabled {
+		env.DeclareValue(stdlib.NewWebAssemblyContract(nil, env))
+		env.DeclareType(stdlib.WebAssemblyContractType)
+	}
+
 	return env
 }
 
@@ -154,6 +164,7 @@ func (e *interpreterEnvironment) newCheckerConfig() *sema.Config {
 	return &sema.Config{
 		AccessCheckMode:                  sema.AccessCheckModeStrict,
 		BaseValueActivation:              e.baseValueActivation,
+		BaseTypeActivation:               e.baseTypeActivation,
 		ValidTopLevelDeclarationsHandler: validTopLevelDeclarations,
 		LocationHandler:                  e.newLocationHandler(),
 		ImportHandler:                    e.resolveImport,
@@ -165,7 +176,7 @@ func (e *interpreterEnvironment) newCheckerConfig() *sema.Config {
 func NewBaseInterpreterEnvironment(config Config) *interpreterEnvironment {
 	env := newInterpreterEnvironment(config)
 	for _, valueDeclaration := range stdlib.DefaultStandardLibraryValues(env) {
-		env.Declare(valueDeclaration)
+		env.DeclareValue(valueDeclaration)
 	}
 	return env
 }
@@ -173,7 +184,7 @@ func NewBaseInterpreterEnvironment(config Config) *interpreterEnvironment {
 func NewScriptInterpreterEnvironment(config Config) Environment {
 	env := newInterpreterEnvironment(config)
 	for _, valueDeclaration := range stdlib.DefaultScriptStandardLibraryValues(env) {
-		env.Declare(valueDeclaration)
+		env.DeclareValue(valueDeclaration)
 	}
 	return env
 }
@@ -192,9 +203,13 @@ func (e *interpreterEnvironment) Configure(
 	e.stackDepthLimiter.depth = 0
 }
 
-func (e *interpreterEnvironment) Declare(valueDeclaration stdlib.StandardLibraryValue) {
+func (e *interpreterEnvironment) DeclareValue(valueDeclaration stdlib.StandardLibraryValue) {
 	e.baseValueActivation.DeclareValue(valueDeclaration)
 	interpreter.Declare(e.baseActivation, valueDeclaration)
+}
+
+func (e *interpreterEnvironment) DeclareType(typeDeclaration stdlib.StandardLibraryType) {
+	e.baseTypeActivation.DeclareType(typeDeclaration)
 }
 
 func (e *interpreterEnvironment) MeterMemory(usage common.MemoryUsage) error {
@@ -847,8 +862,21 @@ func (e *interpreterEnvironment) newImportLocationHandler() interpreter.ImportLo
 
 func (e *interpreterEnvironment) newCompositeTypeHandler() interpreter.CompositeTypeHandlerFunc {
 	return func(location common.Location, typeID common.TypeID) *sema.CompositeType {
-		if _, ok := location.(stdlib.FlowLocation); ok {
+
+		switch location.(type) {
+		case stdlib.FlowLocation:
 			return stdlib.FlowEventTypes[typeID]
+
+		case nil:
+			qualifiedIdentifier := string(typeID)
+			ty := sema.TypeActivationNestedType(e.baseTypeActivation, qualifiedIdentifier)
+			if ty == nil {
+				return nil
+			}
+
+			if compositeType, ok := ty.(*sema.CompositeType); ok {
+				return compositeType
+			}
 		}
 
 		return nil

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -961,6 +961,79 @@ func (RecursiveTransferError) Error() string {
 	return "recursive transfer of value"
 }
 
+// WebAssemblyNewModuleError
+type WebAssemblyNewModuleError struct {
+}
+
+var _ errors.UserError = WebAssemblyNewModuleError{}
+
+func (WebAssemblyNewModuleError) IsUserError() {}
+
+func (WebAssemblyNewModuleError) Error() string {
+	return fmt.Sprint("failed to load module with the given configuration in engine.")
+}
+
+// WebAssemblyNewInstance
+type WebAssemblyNewInstanceError struct {
+}
+
+var _ errors.UserError = WebAssemblyNewInstanceError{}
+
+func (WebAssemblyNewInstanceError) IsUserError() {}
+
+func (WebAssemblyNewInstanceError) Error() string {
+	return fmt.Sprintf("failed to Instantiate WebAssembly Module")
+}
+
+type WebAssemblyStoreFuel struct {
+}
+
+var _ errors.UserError = WebAssemblyStoreFuel{}
+
+func (WebAssemblyStoreFuel) IsUserError() {}
+
+func (WebAssemblyStoreFuel) Error() string {
+	return ""
+}
+
+type WebAssemblyfunctionCallError struct {
+}
+
+var _ errors.UserError = WebAssemblyfunctionCallError{}
+
+func (WebAssemblyfunctionCallError) IsUserError() {}
+
+func (WebAssemblyfunctionCallError) Error() string {
+	return "WebAssembly Call invokes Function Failed"
+}
+
+type WebAssemblystoreConsumeFuel struct {
+	RemainingFuel uint64
+}
+
+var _ errors.UserError = WebAssemblystoreConsumeFuel{}
+
+func (WebAssemblystoreConsumeFuel) IsUserError() {}
+
+func (e WebAssemblystoreConsumeFuel) Error() string {
+
+	return fmt.Sprintf("WebAssembly ConsumeFuel Failed :  RemainingFuel :%d ", e.RemainingFuel)
+}
+
+type WebAssemblyStoreAddFuelError struct {
+	TodoAvailableFuel uint64
+}
+
+var _ errors.UserError = WebAssemblyStoreAddFuelError{}
+
+func (WebAssemblyStoreAddFuelError) IsUserError() {
+
+}
+
+func (e WebAssemblyStoreAddFuelError) Error() string {
+
+	return fmt.Sprintf("WebAssembly AddFuel Failed :  AvailableFuel :%d ", e.TodoAvailableFuel)
+}
 func WrappedExternalError(err error) error {
 	switch err := err.(type) {
 	case

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4558,16 +4558,18 @@ func (interpreter *Interpreter) GetCompositeType(
 		if compositeType != nil {
 			return compositeType, nil
 		}
-	} else {
-		config := interpreter.SharedState.Config
-		compositeTypeHandler := config.CompositeTypeHandler
-		if compositeTypeHandler != nil {
-			compositeType = compositeTypeHandler(location, typeID)
-			if compositeType != nil {
-				return compositeType, nil
-			}
-		}
+	}
 
+	config := interpreter.SharedState.Config
+	compositeTypeHandler := config.CompositeTypeHandler
+	if compositeTypeHandler != nil {
+		compositeType = compositeTypeHandler(location, typeID)
+		if compositeType != nil {
+			return compositeType, nil
+		}
+	}
+
+	if location != nil {
 		compositeType = interpreter.getUserCompositeType(location, typeID)
 		if compositeType != nil {
 			return compositeType, nil

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
-	"github.com/onflow/cadence/runtime/tests/utils"
+	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestRuntimePredeclaredValues(t *testing.T) {
@@ -41,7 +41,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 	valueDeclaration := stdlib.StandardLibraryValue{
 		Name:  "foo",
 		Type:  sema.IntType,
-		Kind:  common.DeclarationKindFunction,
+		Kind:  common.DeclarationKindConstant,
 		Value: interpreter.NewUnmeteredIntValueFromInt64(2),
 	}
 
@@ -63,7 +63,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 
 	runtime := NewTestInterpreterRuntime()
 
-	deploy := utils.DeploymentTransaction("C", contract)
+	deploy := DeploymentTransaction("C", contract)
 
 	var accountCode []byte
 	var events []cadence.Event
@@ -93,7 +93,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 	// Run transaction
 
 	transactionEnvironment := NewBaseInterpreterEnvironment(Config{})
-	transactionEnvironment.Declare(valueDeclaration)
+	transactionEnvironment.DeclareValue(valueDeclaration)
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -110,7 +110,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 	// Run script
 
 	scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
-	scriptEnvironment.Declare(valueDeclaration)
+	scriptEnvironment.DeclareValue(valueDeclaration)
 
 	result, err := runtime.ExecuteScript(
 		Script{
@@ -128,4 +128,357 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 		cadence.Int{Value: big.NewInt(4)},
 		result,
 	)
+}
+
+func TestRuntimePredeclaredTypes(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("type alias", func(t *testing.T) {
+		t.Parallel()
+
+		xType := sema.IntType
+
+		valueDeclaration := stdlib.StandardLibraryValue{
+			Name:  "x",
+			Type:  xType,
+			Kind:  common.DeclarationKindConstant,
+			Value: interpreter.NewUnmeteredIntValueFromInt64(2),
+		}
+
+		typeDeclaration := stdlib.StandardLibraryType{
+			Name: "X",
+			Type: xType,
+			Kind: common.DeclarationKindType,
+		}
+
+		script := []byte(`
+          access(all)
+          fun main(): X {
+              return x
+          }
+	    `)
+
+		runtime := NewTestInterpreterRuntime()
+
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
+				return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
+			},
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		}
+
+		// Run script
+
+		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment.DeclareValue(valueDeclaration)
+		scriptEnvironment.DeclareType(typeDeclaration)
+
+		result, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				Environment: scriptEnvironment,
+			},
+		)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			cadence.Int{Value: big.NewInt(2)},
+			result,
+		)
+	})
+
+	t.Run("composite type, top-level, existing", func(t *testing.T) {
+		t.Parallel()
+
+		xType := &sema.CompositeType{
+			Identifier: "X",
+			Kind:       common.CompositeKindStructure,
+			Members:    &sema.StringMemberOrderedMap{},
+		}
+
+		valueDeclaration := stdlib.StandardLibraryValue{
+			Name: "x",
+			Type: xType,
+			Kind: common.DeclarationKindConstant,
+			Value: interpreter.NewSimpleCompositeValue(nil,
+				xType.ID(),
+				interpreter.ConvertSemaCompositeTypeToStaticCompositeType(nil, xType),
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			),
+		}
+
+		typeDeclaration := stdlib.StandardLibraryType{
+			Name: "X",
+			Type: xType,
+			Kind: common.DeclarationKindType,
+		}
+
+		script := []byte(`
+          access(all)
+          fun main(): X {
+              return x
+          }
+	    `)
+
+		runtime := NewTestInterpreterRuntime()
+
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
+				return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
+			},
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		}
+
+		// Run script
+
+		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment.DeclareValue(valueDeclaration)
+		scriptEnvironment.DeclareType(typeDeclaration)
+
+		result, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				Environment: scriptEnvironment,
+			},
+		)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			cadence.Struct{
+				StructType: cadence.NewStructType(nil, xType.QualifiedIdentifier(), []cadence.Field{}, nil),
+				Fields:     []cadence.Value{},
+			},
+			result,
+		)
+	})
+
+	t.Run("composite type, top-level, non-existing", func(t *testing.T) {
+		t.Parallel()
+
+		xType := &sema.CompositeType{
+			Identifier: "X",
+			Kind:       common.CompositeKindStructure,
+			Members:    &sema.StringMemberOrderedMap{},
+		}
+
+		valueDeclaration := stdlib.StandardLibraryValue{
+			Name: "x",
+			Type: xType,
+			Kind: common.DeclarationKindConstant,
+			Value: interpreter.NewSimpleCompositeValue(nil,
+				xType.ID(),
+				interpreter.ConvertSemaCompositeTypeToStaticCompositeType(nil, xType),
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			),
+		}
+
+		script := []byte(`
+          access(all)
+          fun main(): AnyStruct {
+              return x
+          }
+	    `)
+
+		runtime := NewTestInterpreterRuntime()
+
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
+				return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
+			},
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		}
+
+		// Run script
+
+		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment.DeclareValue(valueDeclaration)
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				Environment: scriptEnvironment,
+			},
+		)
+		RequireError(t, err)
+
+		var typeLoadingErr interpreter.TypeLoadingError
+		require.ErrorAs(t, err, &typeLoadingErr)
+	})
+
+	t.Run("composite type, nested, existing", func(t *testing.T) {
+		t.Parallel()
+
+		yType := &sema.CompositeType{
+			Identifier: "Y",
+			Kind:       common.CompositeKindStructure,
+			Members:    &sema.StringMemberOrderedMap{},
+		}
+
+		xType := &sema.CompositeType{
+			Identifier: "X",
+			Kind:       common.CompositeKindContract,
+			Members:    &sema.StringMemberOrderedMap{},
+		}
+
+		xType.SetNestedType(yType.Identifier, yType)
+
+		valueDeclaration := stdlib.StandardLibraryValue{
+			Name: "y",
+			Type: yType,
+			Kind: common.DeclarationKindConstant,
+			Value: interpreter.NewSimpleCompositeValue(nil,
+				yType.ID(),
+				interpreter.ConvertSemaCompositeTypeToStaticCompositeType(nil, yType),
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			),
+		}
+
+		typeDeclaration := stdlib.StandardLibraryType{
+			Name: "X",
+			Type: xType,
+			Kind: common.DeclarationKindType,
+		}
+
+		script := []byte(`
+          access(all)
+          fun main(): X.Y {
+              return y
+          }
+	    `)
+
+		runtime := NewTestInterpreterRuntime()
+
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
+				return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
+			},
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		}
+
+		// Run script
+
+		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment.DeclareValue(valueDeclaration)
+		scriptEnvironment.DeclareType(typeDeclaration)
+
+		result, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				Environment: scriptEnvironment,
+			},
+		)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			cadence.Struct{
+				StructType: cadence.NewStructType(nil, yType.QualifiedIdentifier(), []cadence.Field{}, nil),
+				Fields:     []cadence.Value{},
+			},
+			result,
+		)
+	})
+
+	t.Run("composite type, nested, non-existing", func(t *testing.T) {
+		t.Parallel()
+
+		yType := &sema.CompositeType{
+			Identifier: "Y",
+			Kind:       common.CompositeKindStructure,
+			Members:    &sema.StringMemberOrderedMap{},
+		}
+
+		xType := &sema.CompositeType{
+			Identifier: "X",
+			Kind:       common.CompositeKindContract,
+			Members:    &sema.StringMemberOrderedMap{},
+		}
+
+		xType.SetNestedType(yType.Identifier, yType)
+
+		valueDeclaration := stdlib.StandardLibraryValue{
+			Name: "y",
+			Type: yType,
+			Kind: common.DeclarationKindConstant,
+			Value: interpreter.NewSimpleCompositeValue(nil,
+				yType.ID(),
+				interpreter.ConvertSemaCompositeTypeToStaticCompositeType(nil, yType),
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			),
+		}
+
+		script := []byte(`
+          access(all)
+          fun main(): AnyStruct {
+              return y
+          }
+	    `)
+
+		runtime := NewTestInterpreterRuntime()
+
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
+				return []Address{common.MustBytesToAddress([]byte{0x1})}, nil
+			},
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		}
+
+		// Run script
+
+		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment.DeclareValue(valueDeclaration)
+
+		_, err := runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				Environment: scriptEnvironment,
+			},
+		)
+		RequireError(t, err)
+
+		var typeLoadingErr interpreter.TypeLoadingError
+		require.ErrorAs(t, err, &typeLoadingErr)
+	})
+
 }

--- a/runtime/sema/check_remove_statement.go
+++ b/runtime/sema/check_remove_statement.go
@@ -33,6 +33,7 @@ func (checker *Checker) VisitRemoveStatement(statement *ast.RemoveStatement) (_ 
 
 	nominalType := checker.convertNominalType(statement.Attachment)
 	base := checker.VisitExpression(statement.Value, nil)
+	checker.checkUnusedExpressionResourceLoss(base, statement.Value)
 
 	if nominalType == InvalidType {
 		return

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -34,6 +34,8 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
+const TypeIDSeparator = '.'
+
 func qualifiedIdentifier(identifier string, containerType Type) string {
 	if containerType == nil {
 		return identifier
@@ -59,7 +61,7 @@ func qualifiedIdentifier(identifier string, containerType Type) string {
 	for i := len(identifiers) - 1; i >= 0; i-- {
 		sb.WriteString(identifiers[i])
 		if i != 0 {
-			sb.WriteByte('.')
+			sb.WriteByte(TypeIDSeparator)
 		}
 	}
 
@@ -267,6 +269,36 @@ func VisitThisAndNested(t Type, visit func(ty Type)) {
 	containerType.GetNestedTypes().Foreach(func(_ string, nestedType Type) {
 		VisitThisAndNested(nestedType, visit)
 	})
+}
+
+func TypeActivationNestedType(typeActivation *VariableActivation, qualifiedIdentifier string) Type {
+
+	typeIDComponents := strings.Split(qualifiedIdentifier, string(TypeIDSeparator))
+
+	rootTypeName := typeIDComponents[0]
+	variable := typeActivation.Find(rootTypeName)
+	if variable == nil {
+		return nil
+	}
+	ty := variable.Type
+
+	// Traverse nested types until the leaf type
+
+	for i := 1; i < len(typeIDComponents); i++ {
+		containerType, ok := ty.(ContainerType)
+		if !ok || !containerType.IsContainerType() {
+			return nil
+		}
+
+		typeIDComponent := typeIDComponents[i]
+
+		ty, ok = containerType.GetNestedTypes().Get(typeIDComponent)
+		if !ok {
+			return nil
+		}
+	}
+
+	return ty
 }
 
 // CompositeKindedType is a type which has a composite kind

--- a/runtime/stdlib/builtin.go
+++ b/runtime/stdlib/builtin.go
@@ -34,7 +34,6 @@ type StandardLibraryHandler interface {
 	BLSPublicKeyAggregator
 	BLSSignatureAggregator
 	Hasher
-	WebAssemblyContractHandler
 }
 
 func DefaultStandardLibraryValues(handler StandardLibraryHandler) []StandardLibraryValue {
@@ -52,7 +51,6 @@ func DefaultStandardLibraryValues(handler StandardLibraryHandler) []StandardLibr
 		NewPublicKeyConstructor(handler, handler, handler),
 		NewBLSContract(nil, handler),
 		NewHashAlgorithmConstructor(handler),
-		NewWebAssemblyContract(nil, handler),
 	}
 }
 

--- a/runtime/stdlib/webassembly.go
+++ b/runtime/stdlib/webassembly.go
@@ -217,3 +217,9 @@ func NewWebAssemblyContract(
 		Kind:  common.DeclarationKindContract,
 	}
 }
+
+var WebAssemblyContractType = StandardLibraryType{
+	Name: WebAssemblyTypeName,
+	Type: WebAssemblyType,
+	Kind: common.DeclarationKindContract,
+}

--- a/runtime/webassembly.go
+++ b/runtime/webassembly.go
@@ -1,0 +1,249 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/bytecodealliance/wasmtime-go/v12"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/stdlib"
+)
+
+type WasmtimeWebAssemblyModule struct {
+	Module *wasmtime.Module
+	Store  *wasmtime.Store
+}
+
+func NewWasmtimeWebAssemblyModule(bytes []byte) (stdlib.WebAssemblyModule, error) {
+	config := wasmtime.NewConfig()
+	config.SetConsumeFuel(true)
+
+	engine := wasmtime.NewEngineWithConfig(config)
+	store := wasmtime.NewStore(engine)
+
+	module, err := wasmtime.NewModule(engine, bytes)
+	if err != nil {
+		return nil, interpreter.WebAssemblyNewModuleError{}
+	}
+
+	return WasmtimeWebAssemblyModule{
+		Store:  store,
+		Module: module,
+	}, nil
+}
+
+var _ stdlib.WebAssemblyModule = WasmtimeWebAssemblyModule{}
+
+func (m WasmtimeWebAssemblyModule) InstantiateWebAssemblyModule(_ common.MemoryGauge) (stdlib.WebAssemblyInstance, error) {
+	instance, err := wasmtime.NewInstance(m.Store, m.Module, nil)
+	if err != nil {
+		return nil, interpreter.WebAssemblyNewInstanceError{}
+	}
+	return WasmtimeWebAssemblyInstance{
+		Instance: instance,
+		Store:    m.Store,
+	}, nil
+}
+
+type WasmtimeWebAssemblyInstance struct {
+	Instance *wasmtime.Instance
+	Store    *wasmtime.Store
+}
+
+var _ stdlib.WebAssemblyInstance = WasmtimeWebAssemblyInstance{}
+
+func wasmtimeValKindToSemaType(valKind wasmtime.ValKind) sema.Type {
+	switch valKind {
+	case wasmtime.KindI32:
+		return sema.Int32Type
+
+	case wasmtime.KindI64:
+		return sema.Int64Type
+
+	default:
+		return nil
+	}
+}
+
+func (i WasmtimeWebAssemblyInstance) GetExport(gauge common.MemoryGauge, name string) (*stdlib.WebAssemblyExport, error) {
+	extern := i.Instance.GetExport(i.Store, name)
+	if extern == nil {
+		return nil, nil
+	}
+
+	if function := extern.Func(); function != nil {
+		return newWasmtimeFunctionWebAssemblyExport(gauge, function, i.Store)
+	}
+
+	return nil, fmt.Errorf("unsupported export")
+}
+
+func newWasmtimeFunctionWebAssemblyExport(
+	gauge common.MemoryGauge,
+	function *wasmtime.Func,
+	store *wasmtime.Store,
+) (
+	*stdlib.WebAssemblyExport,
+	error,
+) {
+	funcType := function.Type(store)
+
+	functionType := &sema.FunctionType{}
+
+	// Parameters
+
+	for _, paramType := range funcType.Params() {
+		paramKind := paramType.Kind()
+		parameterType := wasmtimeValKindToSemaType(paramKind)
+		if parameterType == nil {
+			return nil, fmt.Errorf(
+				"unsupported export: function with unsupported parameter type '%s'",
+				paramKind,
+			)
+		}
+		functionType.Parameters = append(
+			functionType.Parameters,
+			sema.Parameter{
+				TypeAnnotation: sema.NewTypeAnnotation(parameterType),
+			},
+		)
+	}
+
+	// Result
+
+	results := funcType.Results()
+	switch len(results) {
+	case 0:
+		functionType.ReturnTypeAnnotation = sema.VoidTypeAnnotation
+
+	case 1:
+		result := results[0]
+		resultKind := result.Kind()
+		returnType := wasmtimeValKindToSemaType(resultKind)
+		if returnType == nil {
+			return nil, fmt.Errorf(
+				"unsupported export: function with unsupported result type '%s'",
+				resultKind,
+			)
+		}
+		functionType.ReturnTypeAnnotation = sema.NewTypeAnnotation(returnType)
+
+	default:
+		return nil, fmt.Errorf("unsupported export: function has more than one result")
+	}
+
+	hostFunctionValue := interpreter.NewHostFunctionValue(
+		gauge,
+		functionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			arguments := invocation.Arguments
+			inter := invocation.Interpreter
+
+			// Convert the arguments
+
+			convertedArguments := make([]any, 0, len(arguments))
+
+			for i, argument := range arguments {
+				ty := functionType.Parameters[i].TypeAnnotation.Type
+
+				var convertedArgument any
+
+				switch ty {
+				case sema.Int32Type:
+					convertedArgument = int32(argument.(interpreter.Int32Value))
+
+				case sema.Int64Type:
+					convertedArgument = int64(argument.(interpreter.Int64Value))
+
+				default:
+					panic(errors.NewUnreachableError())
+				}
+
+				convertedArguments = append(convertedArguments, convertedArgument)
+			}
+
+			// Call the function, with metering
+
+			fuelConsumedBefore, _ := store.FuelConsumed()
+
+			// TODO: get remaining computation and convert to fuel.
+			//   needs e.g. invocation.Interpreter.RemainingComputation()
+			var todoAvailableFuel uint64 = 1000
+			err := store.AddFuel(todoAvailableFuel)
+			if err != nil {
+				panic(interpreter.WebAssemblyStoreAddFuelError{
+					TodoAvailableFuel: todoAvailableFuel,
+				})
+			}
+
+			result, err := function.Call(store, convertedArguments...)
+			if err != nil {
+
+				panic(interpreter.WebAssemblyfunctionCallError{})
+			}
+
+			fuelConsumedAfter, _ := store.FuelConsumed()
+			fuelDelta := fuelConsumedAfter - fuelConsumedBefore
+
+			inter.ReportComputation(common.ComputationKindWebAssemblyFuel, uint(fuelDelta))
+
+			remainingFuel, err := store.ConsumeFuel(0)
+			if err != nil {
+				panic(interpreter.WebAssemblystoreConsumeFuel{
+					RemainingFuel: remainingFuel,
+				})
+			}
+
+			remainingFuel, err = store.ConsumeFuel(remainingFuel)
+			if err != nil {
+				panic(interpreter.WebAssemblystoreConsumeFuel{
+					RemainingFuel: remainingFuel,
+				})
+			}
+
+			if remainingFuel != 0 {
+				panic(errors.NewUnreachableError())
+			}
+
+			// Return the result
+
+			switch result := result.(type) {
+			case int32:
+				return interpreter.Int32Value(result)
+
+			case int64:
+				return interpreter.Int64Value(result)
+
+			default:
+				panic(errors.NewUnreachableError())
+
+			}
+		},
+	)
+
+	return &stdlib.WebAssemblyExport{
+		Type:  functionType,
+		Value: hostFunctionValue,
+	}, nil
+}

--- a/runtime/webassembly_test.go
+++ b/runtime/webassembly_test.go
@@ -19,10 +19,8 @@
 package runtime_test
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/bytecodealliance/wasmtime-go/v12"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -30,178 +28,31 @@ import (
 	"github.com/onflow/cadence/encoding/json"
 	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/errors"
-	"github.com/onflow/cadence/runtime/interpreter"
-	"github.com/onflow/cadence/runtime/sema"
+
 	"github.com/onflow/cadence/runtime/stdlib"
 	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
+	. "github.com/onflow/cadence/runtime/tests/utils"
 )
 
-type WasmtimeModule struct {
-	Module *wasmtime.Module
-	Store  *wasmtime.Store
-}
-
-var _ stdlib.WebAssemblyModule = WasmtimeModule{}
-
-func (m WasmtimeModule) InstantiateWebAssemblyModule(_ common.MemoryGauge) (stdlib.WebAssemblyInstance, error) {
-	instance, err := wasmtime.NewInstance(m.Store, m.Module, nil)
-	if err != nil {
-		return nil, err
-	}
-	return WasmtimeInstance{
-		Instance: instance,
-		Store:    m.Store,
-	}, nil
-}
-
-type WasmtimeInstance struct {
-	Instance *wasmtime.Instance
-	Store    *wasmtime.Store
-}
-
-var _ stdlib.WebAssemblyInstance = WasmtimeInstance{}
-
-func wasmtimeValKindToSemaType(valKind wasmtime.ValKind) sema.Type {
-	switch valKind {
-	case wasmtime.KindI32:
-		return sema.Int32Type
-
-	case wasmtime.KindI64:
-		return sema.Int64Type
-
-	default:
-		return nil
-	}
-}
-
-func (i WasmtimeInstance) GetExport(gauge common.MemoryGauge, name string) (*stdlib.WebAssemblyExport, error) {
-	extern := i.Instance.GetExport(i.Store, name)
-	if extern == nil {
-		return nil, nil
-	}
-
-	if function := extern.Func(); function != nil {
-		return newWasmtimeFunctionWebAssemblyExport(gauge, function, i.Store)
-	}
-
-	return nil, fmt.Errorf("unsupported export")
-}
-
-func newWasmtimeFunctionWebAssemblyExport(
-	gauge common.MemoryGauge,
-	function *wasmtime.Func,
-	store *wasmtime.Store,
-) (
-	*stdlib.WebAssemblyExport,
-	error,
-) {
-	funcType := function.Type(store)
-
-	functionType := &sema.FunctionType{}
-
-	// Parameters
-
-	for _, paramType := range funcType.Params() {
-		paramKind := paramType.Kind()
-		parameterType := wasmtimeValKindToSemaType(paramKind)
-		if parameterType == nil {
-			return nil, fmt.Errorf(
-				"unsupported export: function with unsupported parameter type '%s'",
-				paramKind,
-			)
-		}
-		functionType.Parameters = append(
-			functionType.Parameters,
-			sema.Parameter{
-				TypeAnnotation: sema.NewTypeAnnotation(parameterType),
-			},
-		)
-	}
-
-	// Result
-
-	results := funcType.Results()
-	switch len(results) {
-	case 0:
-		break
-
-	case 1:
-		result := results[0]
-		resultKind := result.Kind()
-		returnType := wasmtimeValKindToSemaType(resultKind)
-		if returnType == nil {
-			return nil, fmt.Errorf(
-				"unsupported export: function with unsupported result type '%s'",
-				resultKind,
-			)
-		}
-		functionType.ReturnTypeAnnotation = sema.NewTypeAnnotation(returnType)
-
-	default:
-		return nil, fmt.Errorf("unsupported export: function has more than one result")
-	}
-
-	hostFunctionValue := interpreter.NewHostFunctionValue(
-		gauge,
-		functionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			arguments := invocation.Arguments
-
-			convertedArguments := make([]any, 0, len(arguments))
-
-			for i, argument := range arguments {
-				ty := functionType.Parameters[i].TypeAnnotation.Type
-
-				var convertedArgument any
-
-				switch ty {
-				case sema.Int32Type:
-					convertedArgument = int32(argument.(interpreter.Int32Value))
-
-				case sema.Int64Type:
-					convertedArgument = int64(argument.(interpreter.Int64Value))
-
-				default:
-					panic(errors.NewUnreachableError())
-				}
-
-				convertedArguments = append(convertedArguments, convertedArgument)
-			}
-
-			result, err := function.Call(store, convertedArguments...)
-			if err != nil {
-				panic(err)
-			}
-
-			switch result := result.(type) {
-			case int32:
-				return interpreter.Int32Value(result)
-
-			case int64:
-				return interpreter.Int64Value(result)
-
-			default:
-				panic(errors.NewUnreachableError())
-
-			}
-		},
-	)
-
-	return &stdlib.WebAssemblyExport{
-		Type:  functionType,
-		Value: hostFunctionValue,
-	}, nil
-}
-
-func TestRuntimeWebAssembly(t *testing.T) {
+func TestRuntimeWebAssemblyAdd(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestInterpreterRuntimeWithConfig(Config{
+		WebAssemblyEnabled: true,
+	})
 
 	// A simple program which exports a function `add` with type `(i32, i32) -> i32`,
-	// which sums the arguments and returns the result
+	// which sums the arguments and returns the result:
+	//
+	//  (module
+	//    (type (;0;) (func (param i32 i32) (result i32)))
+	//    (func (;0;) (type 0) (param i32 i32) (result i32)
+	//      local.get 0
+	//      local.get 1
+	//      i32.add)
+	//    (export "add" (func 0)))
+	//
 	addProgram := []byte{
 		0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01, 0x60,
 		0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x07, 0x01,
@@ -215,26 +66,31 @@ func TestRuntimeWebAssembly(t *testing.T) {
       fun main(program: [UInt8], a: Int32, b: Int32): Int32 {
           let instance = WebAssembly.compileAndInstantiate(bytes: program).instance
           let add = instance.getExport<fun(Int32, Int32): Int32>(name: "add")
-          return add(a, b)
+          return add(a, b) + add(a, b)
       }
     `)
+
+	var webAssemblyFuelComputationMeterings []uint
 
 	runtimeInterface := &TestRuntimeInterface{
 		Storage: NewTestLedger(nil, nil),
 		OnCompileWebAssembly: func(bytes []byte) (stdlib.WebAssemblyModule, error) {
-			store := wasmtime.NewStore(wasmtime.NewEngine())
-			module, err := wasmtime.NewModule(store.Engine, bytes)
-			if err != nil {
-				return nil, err
-			}
-
-			return WasmtimeModule{
-				Store:  store,
-				Module: module,
-			}, nil
+			return NewWasmtimeWebAssemblyModule(bytes)
 		},
 		OnDecodeArgument: func(b []byte, _ cadence.Type) (cadence.Value, error) {
 			return json.Decode(nil, b)
+		},
+		OnMeterComputation: func(compKind common.ComputationKind, intensity uint) error {
+			if compKind != common.ComputationKindWebAssemblyFuel {
+				return nil
+			}
+
+			webAssemblyFuelComputationMeterings = append(
+				webAssemblyFuelComputationMeterings,
+				intensity,
+			)
+
+			return nil
 		},
 	}
 
@@ -255,7 +111,41 @@ func TestRuntimeWebAssembly(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t,
-		cadence.Int32(3),
+		cadence.Int32(6),
 		result,
 	)
+	assert.Equal(t,
+		[]uint{4, 4},
+		webAssemblyFuelComputationMeterings,
+	)
+}
+
+func TestRuntimeWebAssemblyDisabled(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := NewTestInterpreterRuntimeWithConfig(Config{
+		WebAssemblyEnabled: false,
+	})
+
+	// language=cadence
+	script := []byte(`
+      access(all)
+      fun main() {
+          WebAssembly
+      }
+    `)
+
+	runtimeInterface := &TestRuntimeInterface{}
+
+	_, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  common.ScriptLocation{},
+		},
+	)
+	RequireError(t, err)
 }


### PR DESCRIPTION
Closes and work towards  #2827 

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Wrap user-errors produced by WebAssembly VM as Cadence user errors.
Requires defining abstract user errors that are VM-agnostic. Define in interpreter/errors.go, as errors.UserError
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
