### PR TITLE
Issue 2827 Add improvment WebAssembly Wrap Error

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -961,6 +961,72 @@ func (RecursiveTransferError) Error() string {
 	return "recursive transfer of value"
 }
 
+// WebAssemblyNewModuleError
+type WebAssemblyNewModuleError struct {
+}
+
+var _ errors.UserError = WebAssemblyNewModuleError{}
+
+func (WebAssemblyNewModuleError) IsUserError() {}
+
+func (WebAssemblyNewModuleError) Error() string {
+	return "failed to load module with the given configuration in engine"
+}
+
+// WebAssemblyNewInstanceError
+type WebAssemblyNewInstanceError struct {
+}
+
+var _ errors.UserError = WebAssemblyNewInstanceError{}
+
+func (WebAssemblyNewInstanceError) IsUserError() {}
+
+func (WebAssemblyNewInstanceError) Error() string {
+	return "failed to Instantiate WebAssembly Module"
+}
+
+// WebAssemblyfunctionCallError
+type WebAssemblyfunctionCallError struct {
+}
+
+var _ errors.UserError = WebAssemblyfunctionCallError{}
+
+func (WebAssemblyfunctionCallError) IsUserError() {}
+
+func (WebAssemblyfunctionCallError) Error() string {
+	return "WebAssembly Call invokes Function Failed"
+}
+
+// WebAssemblystoreConsumeFuel
+type WebAssemblystoreConsumeFuel struct {
+	RemainingFuel uint64
+}
+
+var _ errors.UserError = WebAssemblystoreConsumeFuel{}
+
+func (WebAssemblystoreConsumeFuel) IsUserError() {}
+
+func (e WebAssemblystoreConsumeFuel) Error() string {
+
+	return fmt.Sprintf("WebAssembly ConsumeFuel Failed :  RemainingFuel : %d ", e.RemainingFuel)
+}
+
+// WebAssemblyStoreAddFuelError
+type WebAssemblyStoreAddFuelError struct {
+	TodoAvailableFuel uint64
+}
+
+var _ errors.UserError = WebAssemblyStoreAddFuelError{}
+
+func (WebAssemblyStoreAddFuelError) IsUserError() {
+
+}
+
+func (e WebAssemblyStoreAddFuelError) Error() string {
+
+	return fmt.Sprintf("WebAssembly AddFuel Failed :  AvailableFuel : %d ", e.TodoAvailableFuel)
+}
+
 func WrappedExternalError(err error) error {
 	switch err := err.(type) {
 	case

--- a/runtime/webassembly.go
+++ b/runtime/webassembly.go
@@ -44,8 +44,7 @@ func NewWasmtimeWebAssemblyModule(bytes []byte) (stdlib.WebAssemblyModule, error
 
 	module, err := wasmtime.NewModule(engine, bytes)
 	if err != nil {
-		// TODO: wrap error
-		return nil, err
+		return nil, interpreter.WebAssemblyNewModuleError{}
 	}
 
 	return WasmtimeWebAssemblyModule{
@@ -59,8 +58,7 @@ var _ stdlib.WebAssemblyModule = WasmtimeWebAssemblyModule{}
 func (m WasmtimeWebAssemblyModule) InstantiateWebAssemblyModule(_ common.MemoryGauge) (stdlib.WebAssemblyInstance, error) {
 	instance, err := wasmtime.NewInstance(m.Store, m.Module, nil)
 	if err != nil {
-		// TODO: wrap error
-		return nil, err
+		return nil, interpreter.WebAssemblyNewInstanceError{}
 	}
 	return WasmtimeWebAssemblyInstance{
 		Instance: instance,
@@ -191,17 +189,18 @@ func newWasmtimeFunctionWebAssemblyExport(
 
 			// TODO: get remaining computation and convert to fuel.
 			//   needs e.g. invocation.Interpreter.RemainingComputation()
-			const todoAvailableFuel = 1000
+			var todoAvailableFuel uint64 = 1000
 			err := store.AddFuel(todoAvailableFuel)
 			if err != nil {
-				// TODO: wrap error
-				panic(err)
+				panic(interpreter.WebAssemblyStoreAddFuelError{
+					TodoAvailableFuel: todoAvailableFuel,
+				})
 			}
 
 			result, err := function.Call(store, convertedArguments...)
 			if err != nil {
-				// TODO: wrap error
-				panic(err)
+
+				panic(interpreter.WebAssemblyfunctionCallError{})
 			}
 
 			fuelConsumedAfter, _ := store.FuelConsumed()
@@ -211,14 +210,16 @@ func newWasmtimeFunctionWebAssemblyExport(
 
 			remainingFuel, err := store.ConsumeFuel(0)
 			if err != nil {
-				// TODO: wrap error
-				panic(err)
+				panic(interpreter.WebAssemblystoreConsumeFuel{
+					RemainingFuel: remainingFuel,
+				})
 			}
 
 			remainingFuel, err = store.ConsumeFuel(remainingFuel)
 			if err != nil {
-				// TODO: wrap error
-				panic(err)
+				panic(interpreter.WebAssemblystoreConsumeFuel{
+					RemainingFuel: remainingFuel,
+				})
 			}
 
 			if remainingFuel != 0 {


### PR DESCRIPTION
Closes and work towards  #2827 

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Wrap user-errors produced by WebAssembly VM as Cadence user errors.
Requires defining abstract user errors that are VM-agnostic. Define in interpreter/errors.go, as errors.UserError
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
