### PR TITLE
Use `ComputationKindLoop` for internal array-value iterations

### DIFF
--- a/runtime/common/computationkind.go
+++ b/runtime/common/computationkind.go
@@ -57,7 +57,7 @@ const (
 	ComputationKindCreateArrayValue
 	ComputationKindTransferArrayValue
 	ComputationKindDestroyArrayValue
-	ComputationKindIterateArrayValue
+	_
 	_
 	_
 	_

--- a/runtime/common/computationkind_string.go
+++ b/runtime/common/computationkind_string.go
@@ -18,7 +18,6 @@ func _() {
 	_ = x[ComputationKindCreateArrayValue-1025]
 	_ = x[ComputationKindTransferArrayValue-1026]
 	_ = x[ComputationKindDestroyArrayValue-1027]
-	_ = x[ComputationKindIterateArrayValue-1028]
 	_ = x[ComputationKindCreateDictionaryValue-1040]
 	_ = x[ComputationKindTransferDictionaryValue-1041]
 	_ = x[ComputationKindDestroyDictionaryValue-1042]
@@ -34,7 +33,7 @@ const (
 	_ComputationKind_name_0 = "Unknown"
 	_ComputationKind_name_1 = "StatementLoopFunctionInvocation"
 	_ComputationKind_name_2 = "CreateCompositeValueTransferCompositeValueDestroyCompositeValue"
-	_ComputationKind_name_3 = "CreateArrayValueTransferArrayValueDestroyArrayValueIterateArrayValue"
+	_ComputationKind_name_3 = "CreateArrayValueTransferArrayValueDestroyArrayValue"
 	_ComputationKind_name_4 = "CreateDictionaryValueTransferDictionaryValueDestroyDictionaryValue"
 	_ComputationKind_name_5 = "EncodeValue"
 	_ComputationKind_name_6 = "STDLIBPanicSTDLIBAssertSTDLIBUnsafeRandom"
@@ -44,7 +43,7 @@ const (
 var (
 	_ComputationKind_index_1 = [...]uint8{0, 9, 13, 31}
 	_ComputationKind_index_2 = [...]uint8{0, 20, 42, 63}
-	_ComputationKind_index_3 = [...]uint8{0, 16, 34, 51, 68}
+	_ComputationKind_index_3 = [...]uint8{0, 16, 34, 51}
 	_ComputationKind_index_4 = [...]uint8{0, 21, 44, 66}
 	_ComputationKind_index_6 = [...]uint8{0, 11, 23, 41}
 	_ComputationKind_index_7 = [...]uint8{0, 21, 40}
@@ -60,7 +59,7 @@ func (i ComputationKind) String() string {
 	case 1010 <= i && i <= 1012:
 		i -= 1010
 		return _ComputationKind_name_2[_ComputationKind_index_2[i]:_ComputationKind_index_2[i+1]]
-	case 1025 <= i && i <= 1028:
+	case 1025 <= i && i <= 1027:
 		i -= 1025
 		return _ComputationKind_name_3[_ComputationKind_index_3[i]:_ComputationKind_index_3[i+1]]
 	case 1040 <= i && i <= 1042:

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2997,7 +2997,7 @@ func (v *ArrayValue) Reverse(
 			}
 
 			// Meter computation for iterating the array.
-			interpreter.ReportComputation(common.ComputationKindIterateArrayValue, 1)
+			interpreter.ReportComputation(common.ComputationKindLoop, 1)
 
 			value := v.Get(interpreter, locationRange, index)
 			index--
@@ -3050,7 +3050,7 @@ func (v *ArrayValue) Filter(
 
 			for {
 				// Meter computation for iterating the array.
-				interpreter.ReportComputation(common.ComputationKindIterateArrayValue, 1)
+				interpreter.ReportComputation(common.ComputationKindLoop, 1)
 
 				atreeValue, err := iterator.Next()
 				if err != nil {
@@ -3146,7 +3146,7 @@ func (v *ArrayValue) Map(
 		func() Value {
 
 			// Meter computation for iterating the array.
-			interpreter.ReportComputation(common.ComputationKindIterateArrayValue, 1)
+			interpreter.ReportComputation(common.ComputationKindLoop, 1)
 
 			atreeValue, err := iterator.Next()
 			if err != nil {

--- a/runtime/interpreter/value_string.go
+++ b/runtime/interpreter/value_string.go
@@ -134,7 +134,7 @@ func stringFunctionJoin(invocation Invocation) Value {
 	stringArray.Iterate(inter, func(element Value) (resume bool) {
 
 		// Meter computation for iterating the array.
-		inter.ReportComputation(common.ComputationKindIterateArrayValue, 1)
+		inter.ReportComputation(common.ComputationKindLoop, 1)
 
 		// Add separator
 		if !first {

--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -424,7 +424,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
 		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint(3), computationMeteredValues[common.ComputationKindIterateArrayValue])
+		assert.Equal(t, uint(3), computationMeteredValues[common.ComputationKindLoop])
 	})
 
 	t.Run("map", func(t *testing.T) {
@@ -452,7 +452,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
 		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint(5), computationMeteredValues[common.ComputationKindIterateArrayValue])
+		assert.Equal(t, uint(5), computationMeteredValues[common.ComputationKindLoop])
 	})
 
 	t.Run("filter", func(t *testing.T) {
@@ -480,7 +480,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
 		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint(6), computationMeteredValues[common.ComputationKindIterateArrayValue])
+		assert.Equal(t, uint(6), computationMeteredValues[common.ComputationKindLoop])
 	})
 }
 
@@ -509,6 +509,6 @@ func TestInterpretStdlibComputationMetering(t *testing.T) {
 		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint(4), computationMeteredValues[common.ComputationKindIterateArrayValue])
+		assert.Equal(t, uint(4), computationMeteredValues[common.ComputationKindLoop])
 	})
 }


### PR DESCRIPTION
Follow-up for #2880

## Description

Use `ComputationKindLoop` for iterating array values internally (instead of a new computation kind), so it'll be treated the same way as looping an array in a cadence code. This will also eliminate the hassle of calibrating weights for a new computation kind.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
