### PR TITLE
Allow `InclusiveRange<T>` in a for-in loop

### DIFF
--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -342,7 +342,7 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) S
 	}
 
 	for {
-		value := iterator.Next(interpreter)
+		value := iterator.Next(interpreter, locationRange)
 		if value == nil {
 			return nil
 		}

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -331,7 +331,7 @@ func (interpreter *Interpreter) VisitForStatement(statement *ast.ForStatement) S
 		panic(errors.NewUnreachableError())
 	}
 
-	iterator := iterable.Iterator(interpreter)
+	iterator := iterable.Iterator(interpreter, locationRange)
 
 	var indexVariable *Variable
 	if statement.Index != nil {

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -17813,7 +17813,7 @@ func NewInclusiveRangeIterator(
 	v *CompositeValue,
 	typ InclusiveRangeStaticType,
 ) *InclusiveRangeIterator {
-	startValue := v.GetField(interpreter, EmptyLocationRange, sema.InclusiveRangeTypeStartFieldName).(IntegerValue)
+	startValue := getFieldAsIntegerValue(interpreter, EmptyLocationRange, sema.InclusiveRangeTypeStartFieldName)
 
 	zeroValue := GetSmallIntegerValue(0, typ.ElementType)
 	endValue := getFieldAsIntegerValue(interpreter, v, EmptyLocationRange, sema.InclusiveRangeTypeEndFieldName)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -17810,8 +17810,8 @@ var _ ValueIterator = &InclusiveRangeIterator{}
 func (i *InclusiveRangeIterator) Next(interpreter *Interpreter) Value {
 	valueToReturn := i.next
 
-	end := GetFieldAsIntegerValue(i.rangeValue, interpreter, EmptyLocationRange, sema.InclusiveRangeTypeEndFieldName)
-	step := GetFieldAsIntegerValue(i.rangeValue, interpreter, EmptyLocationRange, sema.InclusiveRangeTypeStepFieldName)
+	end := getFieldAsIntegerValue(i.rangeValue, interpreter, EmptyLocationRange, sema.InclusiveRangeTypeEndFieldName)
+	step := getFieldAsIntegerValue(i.rangeValue, interpreter, EmptyLocationRange, sema.InclusiveRangeTypeStepFieldName)
 
 	staticType := i.rangeValue.StaticType(interpreter)
 	var elementType StaticType

--- a/runtime/interpreter/value_range.go
+++ b/runtime/interpreter/value_range.go
@@ -189,9 +189,9 @@ func rangeContains(
 	locationRange LocationRange,
 	needleValue IntegerValue,
 ) BoolValue {
-	start := getFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeStartFieldName)
-	end := getFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeEndFieldName)
-	step := getFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeStepFieldName)
+	start := GetFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeStartFieldName)
+	end := GetFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeEndFieldName)
+	step := GetFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeStepFieldName)
 
 	result := start.Equal(interpreter, locationRange, needleValue) ||
 		end.Equal(interpreter, locationRange, needleValue)
@@ -219,7 +219,7 @@ func rangeContains(
 	return AsBoolValue(result)
 }
 
-func getFieldAsIntegerValue(
+func GetFieldAsIntegerValue(
 	rangeValue *CompositeValue,
 	interpreter *Interpreter,
 	locationRange LocationRange,

--- a/runtime/interpreter/value_range.go
+++ b/runtime/interpreter/value_range.go
@@ -189,9 +189,9 @@ func rangeContains(
 	locationRange LocationRange,
 	needleValue IntegerValue,
 ) BoolValue {
-	start := GetFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeStartFieldName)
-	end := GetFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeEndFieldName)
-	step := GetFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeStepFieldName)
+	start := getFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeStartFieldName)
+	end := getFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeEndFieldName)
+	step := getFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeStepFieldName)
 
 	result := start.Equal(interpreter, locationRange, needleValue) ||
 		end.Equal(interpreter, locationRange, needleValue)
@@ -219,7 +219,7 @@ func rangeContains(
 	return AsBoolValue(result)
 }
 
-func GetFieldAsIntegerValue(
+func getFieldAsIntegerValue(
 	rangeValue *CompositeValue,
 	interpreter *Interpreter,
 	locationRange LocationRange,

--- a/runtime/interpreter/value_range.go
+++ b/runtime/interpreter/value_range.go
@@ -189,9 +189,9 @@ func rangeContains(
 	locationRange LocationRange,
 	needleValue IntegerValue,
 ) BoolValue {
-	start := getFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeStartFieldName)
-	end := getFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeEndFieldName)
-	step := getFieldAsIntegerValue(rangeValue, interpreter, locationRange, sema.InclusiveRangeTypeStepFieldName)
+	start := getFieldAsIntegerValue(interpreter, rangeValue, locationRange, sema.InclusiveRangeTypeStartFieldName)
+	end := getFieldAsIntegerValue(interpreter, rangeValue, locationRange, sema.InclusiveRangeTypeEndFieldName)
+	step := getFieldAsIntegerValue(interpreter, rangeValue, locationRange, sema.InclusiveRangeTypeStepFieldName)
 
 	result := start.Equal(interpreter, locationRange, needleValue) ||
 		end.Equal(interpreter, locationRange, needleValue)
@@ -220,8 +220,8 @@ func rangeContains(
 }
 
 func getFieldAsIntegerValue(
-	rangeValue *CompositeValue,
 	interpreter *Interpreter,
+	rangeValue *CompositeValue,
 	locationRange LocationRange,
 	name string,
 ) IntegerValue {

--- a/runtime/sema/check_for.go
+++ b/runtime/sema/check_for.go
@@ -62,6 +62,8 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) (_ struct
 			elementType = arrayType.ElementType(false)
 		} else if valueType == StringType {
 			elementType = CharacterType
+		} else if inclusiveRangeType, ok := valueType.(*InclusiveRangeType); ok {
+			elementType = inclusiveRangeType.MemberType
 		} else {
 			checker.report(
 				&TypeMismatchWithDescriptionError{

--- a/runtime/tests/checker/for_test.go
+++ b/runtime/tests/checker/for_test.go
@@ -88,12 +88,14 @@ func TestCheckForInclusiveRange(t *testing.T) {
 	for _, typ := range sema.AllIntegerTypes {
 		code := fmt.Sprintf(`
             fun test() {
-                let s : %[1]s = 1
-                let e : %[1]s = 2
+                let start : %[1]s = 1
+                let end : %[1]s = 2
                 let step : %[1]s = 1
-                let r: InclusiveRange<%[1]s> = InclusiveRange(s, e, step: step)
+                let range: InclusiveRange<%[1]s> = InclusiveRange(start, end, step: step)
                 
-                for c in r {}
+                for value in range {
+                    var typedValue: %[1]s = value
+                }
             }
         `, typ.String())
 

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -347,7 +347,7 @@ func TestInclusiveRangeForInLoop(t *testing.T) {
 			count := 0
 			iterator := (loopElements).(*interpreter.ArrayValue).Iterator(inter, interpreter.EmptyLocationRange)
 			for {
-				elem := iterator.Next(inter)
+				elem := iterator.Next(inter, interpreter.EmptyLocationRange)
 				if elem == nil {
 					break
 				}

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -345,7 +345,7 @@ func TestInclusiveRangeForInLoop(t *testing.T) {
 			)
 
 			count := 0
-			iterator := (loopElements).(*interpreter.ArrayValue).Iterator(inter)
+			iterator := (loopElements).(*interpreter.ArrayValue).Iterator(inter, interpreter.EmptyLocationRange)
 			for {
 				elem := iterator.Next(inter)
 				if elem == nil {

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -261,7 +261,7 @@ func TestInterpretForString(t *testing.T) {
 }
 
 type inclusiveRangeForInLoopTest struct {
-	s, e, step        int8
+	start, end, step        int8
 	expectedLoopCount int
 	onlySignedTest    bool
 }


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/2482
Work towards https://github.com/onflow/flips/pull/96
Work towards https://github.com/onflow/developer-grants/issues/179

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Add support to use an `InclusiveRange<T>` in a `for-in` loop
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
