### PR TITLE
Fix string atree value comparison: handle storage as slab

### DIFF
--- a/runtime/interpreter/stringatreevalue.go
+++ b/runtime/interpreter/stringatreevalue.go
@@ -61,7 +61,11 @@ func StringAtreeValueHashInput(v atree.Value, _ []byte) ([]byte, error) {
 	return []byte(v.(StringAtreeValue)), nil
 }
 
-func StringAtreeValueComparator(_ atree.SlabStorage, value atree.Value, otherStorable atree.Storable) (bool, error) {
-	result := value.(StringAtreeValue) == otherStorable.(StringAtreeValue)
+func StringAtreeValueComparator(storage atree.SlabStorage, value atree.Value, otherStorable atree.Storable) (bool, error) {
+	otherValue, err := otherStorable.StoredValue(storage)
+	if err != nil {
+		return false, err
+	}
+	result := value.(StringAtreeValue) == otherValue.(StringAtreeValue)
 	return result, nil
 }

--- a/runtime/interpreter/stringatreevalue_test.go
+++ b/runtime/interpreter/stringatreevalue_test.go
@@ -1,0 +1,65 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/common"
+)
+
+func TestLargeStringAtreeValueInSeparateSlab(t *testing.T) {
+
+	t.Parallel()
+
+	// Ensure that StringAtreeValue handles the case where it is stored in a separate slab,
+	// when the string is very large
+
+	storage := NewInMemoryStorage(nil)
+
+	storageMap := storage.GetStorageMap(
+		common.MustBytesToAddress([]byte{0x1}),
+		common.PathDomainStorage.Identifier(),
+		true,
+	)
+
+	inter, err := NewInterpreter(
+		nil,
+		common.StringLocation("test"),
+		&Config{
+			Storage: storage,
+		},
+	)
+	require.NoError(t, err)
+
+	// Generate a large key to force the string to get stored in a separate slab
+	keyValue := NewStringAtreeValue(nil, strings.Repeat("x", 10_000))
+
+	key := StringStorageMapKey(keyValue)
+
+	expected := NewUnmeteredUInt8Value(42)
+	storageMap.SetValue(inter, key, expected)
+
+	actual := storageMap.ReadValue(nil, key)
+
+	require.Equal(t, expected, actual)
+}


### PR DESCRIPTION
## Description

`StringAtreeValue` might end up getting stored in a separate slab, if it is very large.

Fix `StringAtreeValueComparator` to not assume it is stored inline, by loading the value for the storable (it might be a `StorageIDStorable` pointing to the slab).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
