### PR TITLE
Properly track attachment references created during iteration

### DIFF
--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -214,6 +214,7 @@ func PrepareInterpreter(filename string, debugger *interpreter.Debugger) (*inter
 		ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 			panic("Importing programs is not supported yet")
 		},
+		InvalidatedResourceValidationEnabled: true,
 	}
 
 	inter, err := interpreter.NewInterpreter(

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -17868,7 +17868,6 @@ func attachmentBaseAndSelfValues(
 
 	// in attachment functions, self is a reference value
 	self = NewEphemeralReferenceValue(interpreter, attachmentReferenceAuth, v, interpreter.MustSemaTypeOfValue(v))
-	interpreter.trackReferencedResourceKindedValue(v.StorageID(), v)
 
 	return
 }
@@ -17895,6 +17894,8 @@ func (v *CompositeValue) forEachAttachment(interpreter *Interpreter, _ LocationR
 		}
 		if strings.HasPrefix(string(key.(StringAtreeValue)), attachmentNamePrefix) {
 			attachment, ok := MustConvertStoredValue(interpreter, value).(*CompositeValue)
+			interpreter.trackReferencedResourceKindedValue(attachment.StorageID(), attachment)
+
 			if !ok {
 				panic(errors.NewExternalError(err))
 			}

--- a/runtime/tests/interpreter/attachments_test.go
+++ b/runtime/tests/interpreter/attachments_test.go
@@ -2326,3 +2326,145 @@ func TestInterpretBuiltinCompositeAttachment(t *testing.T) {
 	_, err = inter.Invoke("main")
 	require.NoError(t, err)
 }
+
+func TestInterpretAttachmentSelfInvalidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+        access(all) resource Vault {
+            access(all) var balance: UFix64
+            init(balance: UFix64) {
+                self.balance = balance
+            }
+            access(all) fun withdraw(amount: UFix64): @Vault {
+                self.balance = self.balance - amount
+                return <-create Vault(balance: amount)
+            }
+            access(all) fun deposit(from: @Vault) {
+                self.balance = self.balance + from.balance
+                destroy from
+            }
+        }
+        access(all) resource R{
+            access(all) var ref: &A?
+            access(all) let collectorVault: @Vault
+            init(_ collector: @Vault) {
+                self.collectorVault <- collector
+                self.ref = nil
+            }
+            access(all) fun setRef(_ new: &A) {
+                self.ref = new
+            }
+            destroy() {
+                destroy self.collectorVault
+            }
+        }
+        access(all) attachment A for R{
+            access(all) var vault: @Vault
+            access(all) fun zombieFunction(target: &Vault) {
+                var c  <- self.vault.withdraw(amount: self.vault.balance)
+                target.deposit(from: <- c)
+            }
+            init(vault: @Vault) {
+                self.vault <- vault
+                base.setRef(self)
+            }
+            destroy() {
+                base.collectorVault.deposit(from: <- self.vault)
+            }
+        }
+        access(all) fun doubleVault(_ v: @Vault): @Vault{
+            var res <- v.withdraw(amount: 0.0)
+            var r <- create R(<- v.withdraw(amount: 0.0))
+            var r2 <- attach A(vault: <- v) to <- r
+            remove A from r2
+            // Should not succeed, the attachment pointed to by r2.ref was destroyed 
+            r2.ref!.zombieFunction(target: &res as &Vault)
+            res.deposit(from: <- r2.collectorVault.withdraw(amount: r2.collectorVault.balance))
+            destroy r2
+            return <- res
+        }
+        access(all) fun main() {
+            let v <- create Vault(balance: 10.0)
+            let double <- doubleVault(<- v)
+            destroy double
+        }
+        `)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+	})
+
+	t.Run("with iteration", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            access(all) resource Vault {
+                access(all) var balance: UFix64
+                init(balance: UFix64) {
+                    self.balance = balance
+                }
+                access(all) fun withdraw(amount: UFix64): @Vault {
+                        self.balance = self.balance - amount
+                        return <-create Vault(balance: amount)
+                }
+                access(all) fun deposit(from: @Vault) {
+                        self.balance = self.balance + from.balance
+                        destroy from
+                }
+            }
+            access(all) resource R{
+                access(all) let collectorVault: @Vault
+                init(_ collector: @Vault) {
+                    self.collectorVault <- collector
+                }
+                destroy() {
+                    destroy self.collectorVault
+                }
+            }
+            access(all) attachment A for R{
+                access(all) var vault: @Vault
+                access(all) fun zombieFunction(target: &Vault) {
+                    var c  <- self.vault.withdraw(amount: self.vault.balance)
+                    target.deposit(from: <- c)
+                }
+                init(vault: @Vault) {
+                    self.vault <- vault
+                }
+                destroy() {
+                    base.collectorVault.deposit(from: <- self.vault)
+                }
+            }
+            access(all) fun doubleVault(_ v: @Vault): @Vault{
+                var res <- v.withdraw(amount: 0.0)
+                var r <- create R(<- v.withdraw(amount: 0.0))
+                var r2 <- attach A(vault: <- v) to <- r
+                var aRef: &A? = nil
+                r2.forEachAttachment(fun(a: &AnyResourceAttachment) {
+                    aRef = (a as! &A)
+                })
+                remove A from r2
+                
+                // Should not succeed, the attachment pointed to by aRef was destroyed
+                aRef!.zombieFunction(target: &res as &Vault)
+                res.deposit(from: <- r2.collectorVault.withdraw(amount: r2.collectorVault.balance))
+                destroy r2
+                return <- res
+            }
+            
+            access(all) fun main() {
+                let v <- create Vault(balance: 10.0)
+                let double <-  doubleVault(<- v)
+                destroy double
+            }
+        `)
+
+		_, err := inter.Invoke("main")
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Attachment references created during attachment iteration were not being properly tracked. Thanks to @oebeling for the report

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
