### PR TITLE
Make checkParameterizedTypeIsInstantiated recursive

### DIFF
--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2101,9 +2101,6 @@ func (checker *Checker) checkParameterizedTypeIsInstantiated(ty Type, pos ast.Ha
 		if t.EnumRawType != nil {
 			checker.checkParameterizedTypeIsInstantiated(t.EnumRawType, pos)
 		}
-		if t.containerType != nil {
-			checker.checkParameterizedTypeIsInstantiated(t.containerType, pos)
-		}
 		if t.baseType != nil {
 			checker.checkParameterizedTypeIsInstantiated(t.baseType, pos)
 		}
@@ -2117,10 +2114,6 @@ func (checker *Checker) checkParameterizedTypeIsInstantiated(ty Type, pos ast.Ha
 		}
 
 	case *InterfaceType:
-		if t.containerType != nil {
-			checker.checkParameterizedTypeIsInstantiated(t.containerType, pos)
-		}
-
 		for _, param := range t.InitializerParameters {
 			checker.checkParameterizedTypeIsInstantiated(param.TypeAnnotation.Type, pos)
 		}

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2048,7 +2048,7 @@ func (checker *Checker) checkTypeAnnotation(typeAnnotation TypeAnnotation, pos a
 	}
 
 	checker.checkInvalidInterfaceAsType(typeAnnotation.Type, pos)
-	checker.checkParameterizedTypeIsInstantiated(typeAnnotation.Type, pos)
+	typeAnnotation.Type.CheckInstantiated(pos, checker.memoryGauge, checker.report)
 }
 
 func (checker *Checker) checkInvalidInterfaceAsType(ty Type, pos ast.HasPosition) {
@@ -2065,95 +2065,6 @@ func (checker *Checker) checkInvalidInterfaceAsType(ty Type, pos ast.HasPosition
 				),
 			},
 		)
-	}
-}
-
-func (checker *Checker) checkParameterizedTypeIsInstantiated(ty Type, pos ast.HasPosition) {
-	switch t := ty.(type) {
-	case *OptionalType:
-		checker.checkParameterizedTypeIsInstantiated(t.Type, pos)
-
-	case ArrayType:
-		checker.checkParameterizedTypeIsInstantiated(t.ElementType(false), pos)
-
-	case *DictionaryType:
-		checker.checkParameterizedTypeIsInstantiated(t.KeyType, pos)
-		checker.checkParameterizedTypeIsInstantiated(t.ValueType, pos)
-
-	case *ReferenceType:
-		checker.checkParameterizedTypeIsInstantiated(t.Type, pos)
-
-	case *FunctionType:
-		for _, tyParam := range t.TypeParameters {
-			checker.checkParameterizedTypeIsInstantiated(tyParam.TypeBound, pos)
-		}
-
-		for _, param := range t.Parameters {
-			checker.checkParameterizedTypeIsInstantiated(param.TypeAnnotation.Type, pos)
-		}
-
-		checker.checkParameterizedTypeIsInstantiated(t.ReturnTypeAnnotation.Type, pos)
-
-	case *RestrictedType:
-		checker.checkParameterizedTypeIsInstantiated(t.Type, pos)
-
-	case *CompositeType:
-		if t.EnumRawType != nil {
-			checker.checkParameterizedTypeIsInstantiated(t.EnumRawType, pos)
-		}
-		if t.baseType != nil {
-			checker.checkParameterizedTypeIsInstantiated(t.baseType, pos)
-		}
-
-		for _, typ := range t.ImplicitTypeRequirementConformances {
-			checker.checkParameterizedTypeIsInstantiated(typ, pos)
-		}
-
-		for _, typ := range t.ExplicitInterfaceConformances {
-			checker.checkParameterizedTypeIsInstantiated(typ, pos)
-		}
-
-	case *InterfaceType:
-		for _, param := range t.InitializerParameters {
-			checker.checkParameterizedTypeIsInstantiated(param.TypeAnnotation.Type, pos)
-		}
-
-	case ParameterizedType:
-		typeArgs := t.TypeArguments()
-		typeParameters := t.TypeParameters()
-
-		typeArgumentCount := len(typeArgs)
-		typeParameterCount := len(typeParameters)
-
-		if typeArgumentCount != typeParameterCount {
-			checker.report(
-				&InvalidTypeArgumentCountError{
-					TypeParameterCount: typeParameterCount,
-					TypeArgumentCount:  typeArgumentCount,
-					Range: ast.NewRange(
-						checker.memoryGauge,
-						pos.StartPosition(),
-						pos.EndPosition(checker.memoryGauge),
-					),
-				},
-			)
-		}
-
-		// Ensure that each non-optional typeparameter is non-nil.
-		for index, typeParam := range typeParameters {
-			if !typeParam.Optional && typeArgs[index] == nil {
-				checker.report(
-					&MissingTypeArgumentError{
-						TypeArgumentName: typeParam.Name,
-						Range: ast.NewRange(
-							checker.memoryGauge,
-							pos.StartPosition(),
-							pos.EndPosition(checker.memoryGauge),
-						),
-					},
-				)
-			}
-		}
 	}
 }
 

--- a/runtime/sema/simple_type.go
+++ b/runtime/sema/simple_type.go
@@ -168,3 +168,6 @@ func (t *SimpleType) CompositeKind() common.CompositeKind {
 		return common.CompositeKindStructure
 	}
 }
+
+func (t *SimpleType) CheckInstantiated(pos ast.HasPosition, memoryGauge common.MemoryGauge, report func(err error)) {
+}

--- a/runtime/sema/simple_type.go
+++ b/runtime/sema/simple_type.go
@@ -169,5 +169,6 @@ func (t *SimpleType) CompositeKind() common.CompositeKind {
 	}
 }
 
-func (t *SimpleType) CheckInstantiated(pos ast.HasPosition, memoryGauge common.MemoryGauge, report func(err error)) {
+func (t *SimpleType) CheckInstantiated(_ ast.HasPosition, _ common.MemoryGauge, _ func(err error)) {
+	// NO-OP
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -1229,7 +1229,8 @@ func (t *NumericType) IsSuperType() bool {
 	return t.isSuperType
 }
 
-func (*NumericType) CheckInstantiated(pos ast.HasPosition, memoryGauge common.MemoryGauge, report func(err error)) {
+func (*NumericType) CheckInstantiated(_ ast.HasPosition, _ common.MemoryGauge, _ func(err error)) {
+	// NO-OP
 }
 
 // FixedPointNumericType represents all the types in the fixed-point range.
@@ -1425,7 +1426,8 @@ func (t *FixedPointNumericType) IsSuperType() bool {
 	return t.isSuperType
 }
 
-func (*FixedPointNumericType) CheckInstantiated(pos ast.HasPosition, memoryGauge common.MemoryGauge, report func(err error)) {
+func (*FixedPointNumericType) CheckInstantiated(_ ast.HasPosition, _ common.MemoryGauge, _ func(err error)) {
+	// NO-OP
 }
 
 // Numeric types
@@ -6017,7 +6019,8 @@ func (t *AddressType) Resolve(_ *TypeParameterTypeOrderedMap) Type {
 	return t
 }
 
-func (*AddressType) CheckInstantiated(pos ast.HasPosition, memoryGauge common.MemoryGauge, report func(err error)) {
+func (*AddressType) CheckInstantiated(_ ast.HasPosition, _ common.MemoryGauge, _ func(err error)) {
+	// NO-OP
 }
 
 const AddressTypeToBytesFunctionName = `toBytes`

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -304,22 +304,7 @@ func CheckParameterizedTypeInstantiated(
 	typeArgs := t.TypeArguments()
 	typeParameters := t.TypeParameters()
 
-	typeArgumentCount := len(typeArgs)
-	typeParameterCount := len(typeParameters)
-
-	if typeArgumentCount != typeParameterCount {
-		report(
-			&InvalidTypeArgumentCountError{
-				TypeParameterCount: typeParameterCount,
-				TypeArgumentCount:  typeArgumentCount,
-				Range: ast.NewRange(
-					memoryGauge,
-					pos.StartPosition(),
-					pos.EndPosition(memoryGauge),
-				),
-			},
-		)
-	}
+	// The check for the argument and parameter count already happens in the checker, so we skip that here.
 
 	// Ensure that each non-optional typeparameter is non-nil.
 	for index, typeParam := range typeParameters {

--- a/runtime/tests/checker/range_value_test.go
+++ b/runtime/tests/checker/range_value_test.go
@@ -404,13 +404,15 @@ func TestInclusiveRangeNonLeafIntegerTypes(t *testing.T) {
 
 	t.Parallel()
 
-	baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
-	baseValueActivation.DeclareValue(stdlib.InclusiveRangeConstructorFunction)
+	newOptions := func() ParseAndCheckOptions {
+		baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+		baseValueActivation.DeclareValue(stdlib.InclusiveRangeConstructorFunction)
 
-	options := ParseAndCheckOptions{
-		Config: &sema.Config{
-			BaseValueActivation: baseValueActivation,
-		},
+		return ParseAndCheckOptions{
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
+			},
+		}
 	}
 
 	test := func(t *testing.T, ty sema.Type) {
@@ -421,7 +423,7 @@ func TestInclusiveRangeNonLeafIntegerTypes(t *testing.T) {
 				let a: %[1]s = 0
 				let b: %[1]s = 10
 				var range = InclusiveRange<%[1]s>(a, b)
-			`, ty), options)
+			`, ty), newOptions())
 
 			errs := RequireCheckerErrors(t, err, 1)
 			assert.IsType(t, &sema.InvalidTypeArgumentError{}, errs[0])
@@ -434,7 +436,7 @@ func TestInclusiveRangeNonLeafIntegerTypes(t *testing.T) {
 				let a: %[1]s = 0
 				let b: %[1]s = 10
 				var range: InclusiveRange<%[1]s> = InclusiveRange<%[1]s>(a, b)
-			`, ty), options)
+			`, ty), newOptions())
 
 			// One for the invocation and another for the type.
 			errs := RequireCheckerErrors(t, err, 2)
@@ -448,7 +450,7 @@ func TestInclusiveRangeNonLeafIntegerTypes(t *testing.T) {
 			_, err := ParseAndCheckWithOptions(t, fmt.Sprintf(`
 				let a: InclusiveRange<Int> = InclusiveRange(0, 10)
 				let b: InclusiveRange<%s> = a
-			`, ty), options)
+			`, ty), newOptions())
 
 			errs := RequireCheckerErrors(t, err, 1)
 			assert.IsType(t, &sema.InvalidTypeArgumentError{}, errs[0])

--- a/runtime/tests/checker/typeargument_test.go
+++ b/runtime/tests/checker/typeargument_test.go
@@ -183,6 +183,20 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("InclusiveRange<Int, UInt>", func(t *testing.T) {
+
+		t.Parallel()
+
+		err := test(t,
+			"let inclusiveRange: InclusiveRange<Int, UInt> = InclusiveRange(1, 10)",
+		)
+
+		errs := RequireCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.InvalidTypeArgumentCountError{}, errs[0])
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[1])
+	})
+
 	t.Run("InclusiveRange", func(t *testing.T) {
 
 		t.Parallel()

--- a/runtime/tests/checker/typeargument_test.go
+++ b/runtime/tests/checker/typeargument_test.go
@@ -545,6 +545,44 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("Contract with StructInterface with InclusiveRange<Int>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				contract C {
+					struct interface Foo {
+						fun getRange(): InclusiveRange<Int>
+					}
+				}
+			`,
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Contract with StructInterface with InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				contract C {
+					struct interface Foo {
+						fun getRange(): InclusiveRange
+					}
+				}
+			`,
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
 	t.Run("Resource with InclusiveRange", func(t *testing.T) {
 
 		t.Parallel()
@@ -657,6 +695,44 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 			`
 				resource interface Bar {
 					fun getRange(): InclusiveRange
+				}
+			`,
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("Contract with ResourceInterface with InclusiveRange<Int>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				contract C {
+					resource interface Foo {
+						fun getRange(): InclusiveRange<Int>
+					}
+				}
+			`,
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Contract with ResourceInterface with InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				contract C {
+					resource interface Foo {
+						fun getRange(): InclusiveRange
+					}
 				}
 			`,
 			options,

--- a/runtime/tests/checker/typeargument_test.go
+++ b/runtime/tests/checker/typeargument_test.go
@@ -159,21 +159,25 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 	t.Parallel()
 
-	baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
-	baseValueActivation.DeclareValue(stdlib.InclusiveRangeConstructorFunction)
-	options := ParseAndCheckOptions{
-		Config: &sema.Config{
-			BaseValueActivation: baseValueActivation,
-		},
+	test := func(t *testing.T, code string) error {
+		baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+		baseValueActivation.DeclareValue(stdlib.InclusiveRangeConstructorFunction)
+		options := ParseAndCheckOptions{
+			Config: &sema.Config{
+				BaseValueActivation: baseValueActivation,
+			},
+		}
+
+		_, err := ParseAndCheckWithOptions(t, code, options)
+		return err
 	}
 
 	t.Run("InclusiveRange<Int>", func(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			"let inclusiveRange: InclusiveRange<Int> = InclusiveRange(1, 10)",
-			options,
 		)
 
 		require.NoError(t, err)
@@ -183,9 +187,8 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			"let inclusiveRange: InclusiveRange = InclusiveRange(1, 10)",
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -197,9 +200,8 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			"let r: [InclusiveRange<Int8>] = []",
-			options,
 		)
 
 		require.NoError(t, err)
@@ -209,9 +211,8 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			"let r: [InclusiveRange] = []",
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -223,9 +224,8 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			"let r: [InclusiveRange<Int>; 2] = [InclusiveRange(1, 2), InclusiveRange(3, 4)]",
-			options,
 		)
 
 		require.NoError(t, err)
@@ -235,9 +235,8 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			"let r: [InclusiveRange; 2] = [InclusiveRange(1, 2), InclusiveRange(3, 4)]",
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -249,9 +248,8 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			"let r: InclusiveRange<Int>? = nil",
-			options,
 		)
 
 		require.NoError(t, err)
@@ -261,9 +259,8 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			"let r: InclusiveRange? = nil",
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -275,9 +272,8 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			"let r: {Int: InclusiveRange<UInt128>} = {}",
-			options,
 		)
 
 		require.NoError(t, err)
@@ -287,9 +283,8 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			"let r: {Int: InclusiveRange} = {}",
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -301,7 +296,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				struct Foo {
 					let a: InclusiveRange<Int>
@@ -311,7 +306,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		require.NoError(t, err)
@@ -321,7 +315,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				struct Foo {
 					let a: InclusiveRange
@@ -331,7 +325,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -343,7 +336,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				struct Bar {
 					let a: InclusiveRange<Int>
@@ -361,7 +354,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		require.NoError(t, err)
@@ -371,7 +363,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				struct Bar {
 					let a: InclusiveRange
@@ -389,7 +381,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -401,7 +392,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				contract C {
 					struct Foo {
@@ -413,7 +404,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		require.NoError(t, err)
@@ -423,7 +413,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				contract C {
 					struct Foo {
@@ -435,7 +425,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -447,7 +436,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				struct Bar {
 					let f: ((): InclusiveRange<Int>)
@@ -459,7 +448,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		require.NoError(t, err)
@@ -469,7 +457,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				struct Bar {
 					let f: ((): InclusiveRange)
@@ -481,7 +469,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 2)
@@ -495,13 +482,12 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				struct interface Bar {
 					fun getRange(): InclusiveRange<UInt>
 				}
 			`,
-			options,
 		)
 
 		require.NoError(t, err)
@@ -511,13 +497,12 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				struct interface Bar {
 					fun getRange(): InclusiveRange
 				}
 			`,
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -529,7 +514,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				resource Foo {
 					let a: InclusiveRange<Int>
@@ -539,7 +524,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		require.NoError(t, err)
@@ -549,7 +533,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				contract C {
 					struct interface Foo {
@@ -557,7 +541,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		require.NoError(t, err)
@@ -567,7 +550,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				contract C {
 					struct interface Foo {
@@ -575,7 +558,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -587,7 +569,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				resource Foo {
 					let a: InclusiveRange
@@ -597,7 +579,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -609,7 +590,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				resource Bar {
 					let a: InclusiveRange<Int>
@@ -631,7 +612,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		require.NoError(t, err)
@@ -641,7 +621,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				resource Bar {
 					let a: InclusiveRange
@@ -663,7 +643,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -675,13 +654,12 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				resource interface Bar {
 					fun getRange(): InclusiveRange<UInt>
 				}
 			`,
-			options,
 		)
 
 		require.NoError(t, err)
@@ -691,13 +669,12 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				resource interface Bar {
 					fun getRange(): InclusiveRange
 				}
 			`,
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -709,7 +686,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				contract C {
 					resource interface Foo {
@@ -717,7 +694,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		require.NoError(t, err)
@@ -727,7 +703,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				contract C {
 					resource interface Foo {
@@ -735,7 +711,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -747,13 +722,12 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				pub fun main(): Type {
 					return Type<InclusiveRange<Word256>>()
 				}
 			`,
-			options,
 		)
 
 		require.NoError(t, err)
@@ -763,13 +737,12 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				pub fun main(): Type {
 					return Type<InclusiveRange>()
 				}
 			`,
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -781,9 +754,8 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			"event Foo(bar: InclusiveRange<Int>)",
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 1)
@@ -795,9 +767,8 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			"event Foo(bar: InclusiveRange)",
-			options,
 		)
 
 		errs := RequireCheckerErrors(t, err, 2)
@@ -810,7 +781,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		t.Parallel()
 
-		_, err := ParseAndCheckWithOptions(t,
+		err := test(t,
 			`
 				pub fun main(): Direction {
 					return Direction.RIGHT
@@ -823,7 +794,6 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					pub case RIGHT
 				}
 			`,
-			options,
 		)
 
 		require.NoError(t, err)

--- a/runtime/tests/checker/typeargument_test.go
+++ b/runtime/tests/checker/typeargument_test.go
@@ -155,11 +155,6 @@ func TestCheckTypeArguments(t *testing.T) {
 	})
 }
 
-type checkParameterizedTypeIsInstantiatedTestCase struct {
-	name string
-	code string
-}
-
 func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 	t.Parallel()
@@ -170,6 +165,11 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 		Config: &sema.Config{
 			BaseValueActivation: baseValueActivation,
 		},
+	}
+
+	type checkParameterizedTypeIsInstantiatedTestCase struct {
+		name string
+		code string
 	}
 
 	runTestCase := func(t *testing.T, testCase checkParameterizedTypeIsInstantiatedTestCase) {

--- a/runtime/tests/checker/typeargument_test.go
+++ b/runtime/tests/checker/typeargument_test.go
@@ -486,7 +486,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 2)
 
-		// 2 errors for the two occurences of InclusiveRange.
+		// 2 errors for the two occurrences of InclusiveRange.
 		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
 		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[1])
 	})

--- a/runtime/tests/checker/typeargument_test.go
+++ b/runtime/tests/checker/typeargument_test.go
@@ -167,51 +167,162 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 		},
 	}
 
-	type checkParameterizedTypeIsInstantiatedTestCase struct {
-		name string
-		code string
-	}
+	t.Run("InclusiveRange<Int>", func(t *testing.T) {
 
-	runTestCase := func(t *testing.T, testCase checkParameterizedTypeIsInstantiatedTestCase) {
-		t.Run(testCase.name, func(t *testing.T) {
+		t.Parallel()
 
-			t.Parallel()
+		_, err := ParseAndCheckWithOptions(t,
+			"let inclusiveRange: InclusiveRange<Int> = InclusiveRange(1, 10)",
+			options,
+		)
 
-			_, err := ParseAndCheckWithOptions(t,
-				testCase.code,
-				options,
-			)
+		require.NoError(t, err)
+	})
 
-			errs := RequireCheckerErrors(t, err, 1)
+	t.Run("InclusiveRange", func(t *testing.T) {
 
-			assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
-		})
-	}
+		t.Parallel()
 
-	testCases := []checkParameterizedTypeIsInstantiatedTestCase{
-		{
-			name: "InclusiveRange",
-			code: "let inclusiveRange: InclusiveRange = InclusiveRange(1, 10)",
-		},
-		{
-			name: "VariableSizedArray with InclusiveRange",
-			code: "let r: [InclusiveRange] = []",
-		},
-		{
-			name: "ConstantSizedType with InclusiveRange",
-			code: "let r: [InclusiveRange; 2] = [InclusiveRange(1, 2), InclusiveRange(3, 4)]",
-		},
-		{
-			name: "OptionalType with InclusiveRange",
-			code: "let r: InclusiveRange? = nil",
-		},
-		{
-			name: "DictionaryType with InclusiveRange",
-			code: "let r: {Int: InclusiveRange} = {}",
-		},
-		{
-			name: "Struct with InclusiveRange",
-			code: `
+		_, err := ParseAndCheckWithOptions(t,
+			"let inclusiveRange: InclusiveRange = InclusiveRange(1, 10)",
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("VariableSizedArray with InclusiveRange<Int8>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			"let r: [InclusiveRange<Int8>] = []",
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("VariableSizedArray with InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			"let r: [InclusiveRange] = []",
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("ConstantSizedType with InclusiveRange<Int>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			"let r: [InclusiveRange<Int>; 2] = [InclusiveRange(1, 2), InclusiveRange(3, 4)]",
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("ConstantSizedType with InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			"let r: [InclusiveRange; 2] = [InclusiveRange(1, 2), InclusiveRange(3, 4)]",
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("OptionalType with InclusiveRange<Int>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			"let r: InclusiveRange<Int>? = nil",
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("OptionalType with InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			"let r: InclusiveRange? = nil",
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("DictionaryType with InclusiveRange<UInt128>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			"let r: {Int: InclusiveRange<UInt128>} = {}",
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("DictionaryType with InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			"let r: {Int: InclusiveRange} = {}",
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("Struct with InclusiveRange<Int>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				struct Foo {
+					let a: InclusiveRange<Int>
+
+					init() {
+						self.a = InclusiveRange(1, 10)
+					}
+				}
+			`,
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Struct with InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
 				struct Foo {
 					let a: InclusiveRange
 
@@ -220,12 +331,427 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 					}
 				}
 			`,
-		},
-	}
+			options,
+		)
 
-	for _, test := range testCases {
-		runTestCase(t, test)
-	}
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("Nested Struct with InclusiveRange<Int>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				struct Bar {
+					let a: InclusiveRange<Int>
+
+					init() {
+						self.a = InclusiveRange(1, 10)
+					}
+				}
+
+				struct Foo {
+					let bar: Bar
+
+					init(b : Bar) {
+						self.bar = b
+					}
+				}
+			`,
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Nested Struct with InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				struct Bar {
+					let a: InclusiveRange
+
+					init() {
+						self.a = InclusiveRange(1, 10)
+					}
+				}
+
+				struct Foo {
+					let bar: Bar
+
+					init(b : Bar) {
+						self.bar = b
+					}
+				}
+			`,
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("Contract with Struct with InclusiveRange<Int>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				contract C {
+					struct Foo {
+						let a: InclusiveRange<Int>
+	
+						init() {
+							self.a = InclusiveRange(1, 10)
+						}
+					}
+				}
+			`,
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Contract with Struct with InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				contract C {
+					struct Foo {
+						let a: InclusiveRange
+	
+						init() {
+							self.a = InclusiveRange(1, 10)
+						}
+					}
+				}
+			`,
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("Struct with function returning InclusiveRange<Int>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				struct Bar {
+					let f: ((): InclusiveRange<Int>)
+
+					init() {
+						self.f = fun () : InclusiveRange<Int> {
+							return InclusiveRange(1, 10)
+						}
+					}
+				}
+			`,
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Struct with function returning InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				struct Bar {
+					let f: ((): InclusiveRange)
+
+					init() {
+						self.f = fun () : InclusiveRange {
+							return InclusiveRange(1, 10)
+						}
+					}
+				}
+			`,
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 2)
+
+		// 2 errors for the two occurences of InclusiveRange.
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[1])
+	})
+
+	t.Run("StructInterface with function returning InclusiveRange<UInt>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				struct interface Bar {
+					fun getRange(): InclusiveRange<UInt>
+				}
+			`,
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("StructInterface with function returning InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				struct interface Bar {
+					fun getRange(): InclusiveRange
+				}
+			`,
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("Resource with InclusiveRange<Int>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				resource Foo {
+					let a: InclusiveRange<Int>
+
+					init() {
+						self.a = InclusiveRange(1, 10)
+					}
+				}
+			`,
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Resource with InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				resource Foo {
+					let a: InclusiveRange
+
+					init() {
+						self.a = InclusiveRange(1, 10)
+					}
+				}
+			`,
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("Nested Resource with InclusiveRange<Int>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				resource Bar {
+					let a: InclusiveRange<Int>
+
+					init() {
+						self.a = InclusiveRange(1, 10)
+					}
+				}
+
+				resource Foo {
+					let bar: @Bar
+
+					init(b : @Bar) {
+						self.bar <- b
+					}
+
+					destroy() {
+						destroy self.bar
+					}
+				}
+			`,
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Nested Resource with InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				resource Bar {
+					let a: InclusiveRange
+
+					init() {
+						self.a = InclusiveRange(1, 10)
+					}
+				}
+
+				resource Foo {
+					let bar: @Bar
+
+					init(b : @Bar) {
+						self.bar <- b
+					}
+
+					destroy() {
+						destroy self.bar
+					}
+				}
+			`,
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("ResourceInterface with function returning InclusiveRange<UInt>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				resource interface Bar {
+					fun getRange(): InclusiveRange<UInt>
+				}
+			`,
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("ResourceInterface with function returning InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				resource interface Bar {
+					fun getRange(): InclusiveRange
+				}
+			`,
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("Type with InclusiveRange<Word256>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				pub fun main(): Type {
+					return Type<InclusiveRange<Word256>>()
+				}
+			`,
+			options,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Type with InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				pub fun main(): Type {
+					return Type<InclusiveRange>()
+				}
+			`,
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+	})
+
+	t.Run("Event with InclusiveRange<Int>", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			"event Foo(bar: InclusiveRange<Int>)",
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.InvalidEventParameterTypeError{}, errs[0])
+	})
+
+	t.Run("Event with InclusiveRange", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			"event Foo(bar: InclusiveRange)",
+			options,
+		)
+
+		errs := RequireCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.MissingTypeArgumentError{}, errs[0])
+		assert.IsType(t, &sema.InvalidEventParameterTypeError{}, errs[1])
+	})
+
+	t.Run("Enum Declaration", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheckWithOptions(t,
+			`
+				pub fun main(): Direction {
+					return Direction.RIGHT
+				}
+
+				pub enum Direction: Int {
+					pub case UP
+					pub case DOWN
+					pub case LEFT
+					pub case RIGHT
+				}
+			`,
+			options,
+		)
+
+		require.NoError(t, err)
+	})
 }
 
 func TestCheckTypeArgumentSubtyping(t *testing.T) {

--- a/runtime/tests/checker/typeargument_test.go
+++ b/runtime/tests/checker/typeargument_test.go
@@ -1033,36 +1033,15 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 
 		t.Parallel()
 
-		checker, err := parseAndCheckWithTestValue(t,
+		_, err := parseAndCheckWithTestValue(t,
 			`
               let cap: Capability = test
               let cap2: Capability<&Int> = cap
             `,
 			&sema.CapabilityType{},
 		)
-		require.NoError(t, err)
-
-		capType := RequireGlobalValue(t, checker.Elaboration, "cap")
-		require.IsType(t,
-			&sema.CapabilityType{},
-			capType,
-		)
-		require.Nil(t, capType.(*sema.CapabilityType).BorrowType)
-
-		cap2Type := RequireGlobalValue(t, checker.Elaboration, "cap2")
-		require.IsType(t,
-			&sema.CapabilityType{},
-			cap2Type,
-		)
-		require.Equal(t,
-			&sema.ReferenceType{
-				Type: sema.IntType,
-			},
-			cap2Type.(*sema.CapabilityType).BorrowType,
-		)
 
 		errs := RequireCheckerErrors(t, err, 1)
-
 		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 	})
 
@@ -1070,7 +1049,7 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 
 		t.Parallel()
 
-		checker, err := parseAndCheckWithTestValue(t,
+		_, err := parseAndCheckWithTestValue(t,
 			`
               let cap: Capability<&String> = test
               let cap2: Capability<&Int> = cap
@@ -1081,28 +1060,8 @@ func TestCheckTypeArgumentSubtyping(t *testing.T) {
 				},
 			},
 		)
-		require.NoError(t, err)
-
-		assert.Equal(t,
-			&sema.CapabilityType{
-				BorrowType: &sema.ReferenceType{
-					Type: sema.StringType,
-				},
-			},
-			RequireGlobalValue(t, checker.Elaboration, "cap"),
-		)
-
-		assert.Equal(t,
-			&sema.CapabilityType{
-				BorrowType: &sema.ReferenceType{
-					Type: sema.IntType,
-				},
-			},
-			RequireGlobalValue(t, checker.Elaboration, "cap2"),
-		)
 
 		errs := RequireCheckerErrors(t, err, 1)
-
 		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 	})
 }

--- a/runtime/tests/checker/typeargument_test.go
+++ b/runtime/tests/checker/typeargument_test.go
@@ -212,8 +212,8 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 		{
 			name: "Struct with InclusiveRange",
 			code: `
-				pub struct Foo {
-					pub let a: InclusiveRange
+				struct Foo {
+					let a: InclusiveRange
 
 					init() {
 						self.a = InclusiveRange(1, 10)


### PR DESCRIPTION
Closes #2884

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR makes the checker function `checkParameterizedTypeIsInstantiated` recursive so that a non-instantiated type parameter is caught even if it is inside a container.

See linked issue for more.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
