### PR TITLE
Add atRoot parameter to `Value.DeepRemove`

### DIFF
--- a/runtime/interpreter/deepcopyremove_test.go
+++ b/runtime/interpreter/deepcopyremove_test.go
@@ -85,7 +85,7 @@ func TestValueDeepCopyAndDeepRemove(t *testing.T) {
 		optionalValue,
 	)
 
-	compositeValue.DeepRemove(inter)
+	compositeValue.DeepRemove(inter, true)
 
 	// Only count non-temporary slabs,
 	// i.e. ones which have a non-empty address

--- a/runtime/interpreter/interpreter_tracing_test.go
+++ b/runtime/interpreter/interpreter_tracing_test.go
@@ -79,7 +79,7 @@ func TestInterpreterTracing(t *testing.T) {
 
 		cloned := array.Clone(inter)
 		require.NotNil(t, cloned)
-		cloned.DeepRemove(inter)
+		cloned.DeepRemove(inter, true)
 		require.Equal(t, len(traceOps), 2)
 		require.Equal(t, traceOps[1], "array.deepRemove")
 
@@ -109,7 +109,7 @@ func TestInterpreterTracing(t *testing.T) {
 
 		cloned := dict.Clone(inter)
 		require.NotNil(t, cloned)
-		cloned.DeepRemove(inter)
+		cloned.DeepRemove(inter, true)
 		require.Equal(t, len(traceOps), 2)
 		require.Equal(t, traceOps[1], "dictionary.deepRemove")
 
@@ -132,7 +132,7 @@ func TestInterpreterTracing(t *testing.T) {
 
 		cloned := value.Clone(inter)
 		require.NotNil(t, cloned)
-		cloned.DeepRemove(inter)
+		cloned.DeepRemove(inter, true)
 		require.Equal(t, len(traceOps), 2)
 		require.Equal(t, traceOps[1], "composite.deepRemove")
 

--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -291,6 +291,6 @@ func (v *SimpleCompositeValue) Clone(interpreter *Interpreter) Value {
 	}
 }
 
-func (v *SimpleCompositeValue) DeepRemove(_ *Interpreter) {
+func (v *SimpleCompositeValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }

--- a/runtime/interpreter/storagemap.go
+++ b/runtime/interpreter/storagemap.go
@@ -130,7 +130,7 @@ func (s StorageMap) SetValue(interpreter *Interpreter, key StorageMapKey, value 
 	existed = existingStorable != nil
 	if existed {
 		existingValue := StoredValue(interpreter, existingStorable, interpreter.Storage())
-		existingValue.DeepRemove(interpreter)
+		existingValue.DeepRemove(interpreter, true)
 		interpreter.RemoveReferencedSlab(existingStorable)
 	}
 	return
@@ -165,7 +165,7 @@ func (s StorageMap) RemoveValue(interpreter *Interpreter, key StorageMapKey) (ex
 	existed = existingValueStorable != nil
 	if existed {
 		existingValue := StoredValue(interpreter, existingValueStorable, interpreter.Storage())
-		existingValue.DeepRemove(interpreter)
+		existingValue.DeepRemove(interpreter, true)
 		interpreter.RemoveReferencedSlab(existingValueStorable)
 	}
 	return

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -135,7 +135,7 @@ type Value interface {
 		storable atree.Storable,
 		preventTransfer map[atree.ValueID]struct{},
 	) Value
-	DeepRemove(interpreter *Interpreter)
+	DeepRemove(interpreter *Interpreter, atRoot bool)
 	// Clone returns a new value that is equal to this value.
 	// NOTE: not used by interpreter, but used externally (e.g. state migration)
 	// NOTE: memory metering is unnecessary for Clone methods
@@ -495,7 +495,7 @@ func (v TypeValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (TypeValue) DeepRemove(_ *Interpreter) {
+func (TypeValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -615,7 +615,7 @@ func (v VoidValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (VoidValue) DeepRemove(_ *Interpreter) {
+func (VoidValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -788,7 +788,7 @@ func (v BoolValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (BoolValue) DeepRemove(_ *Interpreter) {
+func (BoolValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -962,7 +962,7 @@ func (v CharacterValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (CharacterValue) DeepRemove(_ *Interpreter) {
+func (CharacterValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -1443,7 +1443,7 @@ func (v *StringValue) Clone(_ *Interpreter) Value {
 	return NewUnmeteredStringValue(v.Str)
 }
 
-func (*StringValue) DeepRemove(_ *Interpreter) {
+func (*StringValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -2017,7 +2017,7 @@ func (v *ArrayValue) Set(interpreter *Interpreter, locationRange LocationRange, 
 
 	existingValue := StoredValue(interpreter, existingStorable, interpreter.Storage())
 
-	existingValue.DeepRemove(interpreter)
+	existingValue.DeepRemove(interpreter, true)
 
 	interpreter.RemoveReferencedSlab(existingStorable)
 }
@@ -2848,7 +2848,7 @@ func (v *ArrayValue) Clone(interpreter *Interpreter) Value {
 	}
 }
 
-func (v *ArrayValue) DeepRemove(interpreter *Interpreter) {
+func (v *ArrayValue) DeepRemove(interpreter *Interpreter, atRoot bool) {
 	config := interpreter.SharedState.Config
 
 	if config.TracingEnabled {
@@ -2872,13 +2872,15 @@ func (v *ArrayValue) DeepRemove(interpreter *Interpreter) {
 
 	err := v.array.PopIterate(func(storable atree.Storable) {
 		value := StoredValue(interpreter, storable, storage)
-		value.DeepRemove(interpreter)
+		value.DeepRemove(interpreter, false)
 		interpreter.RemoveReferencedSlab(storable)
 	})
 	if err != nil {
 		panic(errors.NewExternalError(err))
 	}
-	interpreter.maybeValidateAtreeValue(v.array)
+	if atRoot {
+		interpreter.maybeValidateAtreeValue(v.array)
+	}
 }
 
 func (v *ArrayValue) SlabID() atree.SlabID {
@@ -3910,7 +3912,7 @@ func (v IntValue) Clone(_ *Interpreter) Value {
 	return NewUnmeteredIntValueFromBigInt(v.BigInt)
 }
 
-func (IntValue) DeepRemove(_ *Interpreter) {
+func (IntValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -4550,7 +4552,7 @@ func (v Int8Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Int8Value) DeepRemove(_ *Interpreter) {
+func (Int8Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -5192,7 +5194,7 @@ func (v Int16Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Int16Value) DeepRemove(_ *Interpreter) {
+func (Int16Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -5834,7 +5836,7 @@ func (v Int32Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Int32Value) DeepRemove(_ *Interpreter) {
+func (Int32Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -6468,7 +6470,7 @@ func (v Int64Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Int64Value) DeepRemove(_ *Interpreter) {
+func (Int64Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -7212,7 +7214,7 @@ func (v Int128Value) Clone(_ *Interpreter) Value {
 	return NewUnmeteredInt128ValueFromBigInt(v.BigInt)
 }
 
-func (Int128Value) DeepRemove(_ *Interpreter) {
+func (Int128Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -7953,7 +7955,7 @@ func (v Int256Value) Clone(_ *Interpreter) Value {
 	return NewUnmeteredInt256ValueFromBigInt(v.BigInt)
 }
 
-func (Int256Value) DeepRemove(_ *Interpreter) {
+func (Int256Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -8582,7 +8584,7 @@ func (v UIntValue) Clone(_ *Interpreter) Value {
 	return NewUnmeteredUIntValueFromBigInt(v.BigInt)
 }
 
-func (UIntValue) DeepRemove(_ *Interpreter) {
+func (UIntValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -9168,7 +9170,7 @@ func (v UInt8Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (UInt8Value) DeepRemove(_ *Interpreter) {
+func (UInt8Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -9709,7 +9711,7 @@ func (v UInt16Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (UInt16Value) DeepRemove(_ *Interpreter) {
+func (UInt16Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -10251,7 +10253,7 @@ func (v UInt32Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (UInt32Value) DeepRemove(_ *Interpreter) {
+func (UInt32Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -10822,7 +10824,7 @@ func (v UInt64Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (UInt64Value) DeepRemove(_ *Interpreter) {
+func (UInt64Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -11497,7 +11499,7 @@ func (v UInt128Value) Clone(_ *Interpreter) Value {
 	return NewUnmeteredUInt128ValueFromBigInt(v.BigInt)
 }
 
-func (UInt128Value) DeepRemove(_ *Interpreter) {
+func (UInt128Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -12171,7 +12173,7 @@ func (v UInt256Value) Clone(_ *Interpreter) Value {
 	return NewUnmeteredUInt256ValueFromBigInt(v.BigInt)
 }
 
-func (UInt256Value) DeepRemove(_ *Interpreter) {
+func (UInt256Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -12608,7 +12610,7 @@ func (v Word8Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Word8Value) DeepRemove(_ *Interpreter) {
+func (Word8Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -13046,7 +13048,7 @@ func (v Word16Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Word16Value) DeepRemove(_ *Interpreter) {
+func (Word16Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -13485,7 +13487,7 @@ func (v Word32Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Word32Value) DeepRemove(_ *Interpreter) {
+func (Word32Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -13954,7 +13956,7 @@ func (v Word64Value) ByteSize() uint32 {
 	return cborTagSize + getUintCBORSize(uint64(v))
 }
 
-func (Word64Value) DeepRemove(_ *Interpreter) {
+func (Word64Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -14530,7 +14532,7 @@ func (v Word128Value) Clone(_ *Interpreter) Value {
 	return NewUnmeteredWord128ValueFromBigInt(v.BigInt)
 }
 
-func (Word128Value) DeepRemove(_ *Interpreter) {
+func (Word128Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -15111,7 +15113,7 @@ func (v Word256Value) Clone(_ *Interpreter) Value {
 	return NewUnmeteredWord256ValueFromBigInt(v.BigInt)
 }
 
-func (Word256Value) DeepRemove(_ *Interpreter) {
+func (Word256Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -15688,7 +15690,7 @@ func (v Fix64Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Fix64Value) DeepRemove(_ *Interpreter) {
+func (Fix64Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -16222,7 +16224,7 @@ func (v UFix64Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (UFix64Value) DeepRemove(_ *Interpreter) {
+func (UFix64Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -16852,7 +16854,7 @@ func (v *CompositeValue) SetMember(
 	if existingStorable != nil {
 		existingValue := StoredValue(interpreter, existingStorable, config.Storage)
 
-		existingValue.DeepRemove(interpreter)
+		existingValue.DeepRemove(interpreter, true)
 
 		interpreter.RemoveReferencedSlab(existingStorable)
 		return true
@@ -17449,7 +17451,7 @@ func (v *CompositeValue) Clone(interpreter *Interpreter) Value {
 	}
 }
 
-func (v *CompositeValue) DeepRemove(interpreter *Interpreter) {
+func (v *CompositeValue) DeepRemove(interpreter *Interpreter, atRoot bool) {
 	config := interpreter.SharedState.Config
 
 	if config.TracingEnabled {
@@ -17479,13 +17481,15 @@ func (v *CompositeValue) DeepRemove(interpreter *Interpreter) {
 		interpreter.RemoveReferencedSlab(nameStorable)
 
 		value := StoredValue(interpreter, valueStorable, storage)
-		value.DeepRemove(interpreter)
+		value.DeepRemove(interpreter, false)
 		interpreter.RemoveReferencedSlab(valueStorable)
 	})
 	if err != nil {
 		panic(errors.NewExternalError(err))
 	}
-	interpreter.maybeValidateAtreeValue(v.dictionary)
+	if atRoot {
+		interpreter.maybeValidateAtreeValue(v.dictionary)
+	}
 }
 
 func (v *CompositeValue) GetOwner() common.Address {
@@ -17554,7 +17558,7 @@ func (v *CompositeValue) RemoveField(
 
 	// Value
 	existingValue := StoredValue(interpreter, existingValueStorable, interpreter.Storage())
-	existingValue.DeepRemove(interpreter)
+	existingValue.DeepRemove(interpreter, true)
 	interpreter.RemoveReferencedSlab(existingValueStorable)
 }
 
@@ -18519,7 +18523,7 @@ func (v *DictionaryValue) Remove(
 	// Key
 
 	existingKeyValue := StoredValue(interpreter, existingKeyStorable, storage)
-	existingKeyValue.DeepRemove(interpreter)
+	existingKeyValue.DeepRemove(interpreter, true)
 	interpreter.RemoveReferencedSlab(existingKeyStorable)
 
 	// Value
@@ -18986,7 +18990,7 @@ func (v *DictionaryValue) Clone(interpreter *Interpreter) Value {
 	}
 }
 
-func (v *DictionaryValue) DeepRemove(interpreter *Interpreter) {
+func (v *DictionaryValue) DeepRemove(interpreter *Interpreter, atRoot bool) {
 
 	config := interpreter.SharedState.Config
 
@@ -19012,17 +19016,19 @@ func (v *DictionaryValue) DeepRemove(interpreter *Interpreter) {
 	err := v.dictionary.PopIterate(func(keyStorable atree.Storable, valueStorable atree.Storable) {
 
 		key := StoredValue(interpreter, keyStorable, storage)
-		key.DeepRemove(interpreter)
+		key.DeepRemove(interpreter, false)
 		interpreter.RemoveReferencedSlab(keyStorable)
 
 		value := StoredValue(interpreter, valueStorable, storage)
-		value.DeepRemove(interpreter)
+		value.DeepRemove(interpreter, false)
 		interpreter.RemoveReferencedSlab(valueStorable)
 	})
 	if err != nil {
 		panic(errors.NewExternalError(err))
 	}
-	interpreter.maybeValidateAtreeValue(v.dictionary)
+	if atRoot {
+		interpreter.maybeValidateAtreeValue(v.dictionary)
+	}
 }
 
 func (v *DictionaryValue) GetOwner() common.Address {
@@ -19213,7 +19219,7 @@ func (v NilValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (NilValue) DeepRemove(_ *Interpreter) {
+func (NilValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -19598,8 +19604,8 @@ func (v *SomeValue) Clone(interpreter *Interpreter) Value {
 	return NewUnmeteredSomeValueNonCopying(innerValue)
 }
 
-func (v *SomeValue) DeepRemove(interpreter *Interpreter) {
-	v.value.DeepRemove(interpreter)
+func (v *SomeValue) DeepRemove(interpreter *Interpreter, _ bool) {
+	v.value.DeepRemove(interpreter, false)
 	if v.valueStorable != nil {
 		interpreter.RemoveReferencedSlab(v.valueStorable)
 	}
@@ -20035,7 +20041,7 @@ func (v *StorageReferenceValue) Clone(_ *Interpreter) Value {
 	)
 }
 
-func (*StorageReferenceValue) DeepRemove(_ *Interpreter) {
+func (*StorageReferenceValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -20365,7 +20371,7 @@ func (v *EphemeralReferenceValue) Clone(_ *Interpreter) Value {
 	return NewUnmeteredEphemeralReferenceValue(v.Authorized, v.Value, v.BorrowedType)
 }
 
-func (*EphemeralReferenceValue) DeepRemove(_ *Interpreter) {
+func (*EphemeralReferenceValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -20582,7 +20588,7 @@ func (v AddressValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (AddressValue) DeepRemove(_ *Interpreter) {
+func (AddressValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -20868,7 +20874,7 @@ func (v PathValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (PathValue) DeepRemove(_ *Interpreter) {
+func (PathValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -21077,7 +21083,7 @@ func (v *PathCapabilityValue) Transfer(
 	_ map[atree.ValueID]struct{},
 ) Value {
 	if remove {
-		v.DeepRemove(interpreter)
+		v.DeepRemove(interpreter, true)
 		interpreter.RemoveReferencedSlab(storable)
 	}
 	return v
@@ -21091,9 +21097,9 @@ func (v *PathCapabilityValue) Clone(interpreter *Interpreter) Value {
 	)
 }
 
-func (v *PathCapabilityValue) DeepRemove(interpreter *Interpreter) {
-	v.Address.DeepRemove(interpreter)
-	v.Path.DeepRemove(interpreter)
+func (v *PathCapabilityValue) DeepRemove(interpreter *Interpreter, _ bool) {
+	v.Address.DeepRemove(interpreter, false)
+	v.Path.DeepRemove(interpreter, false)
 }
 
 func (v *PathCapabilityValue) ByteSize() uint32 {
@@ -21279,7 +21285,7 @@ func (v *IDCapabilityValue) Transfer(
 	_ map[atree.ValueID]struct{},
 ) Value {
 	if remove {
-		v.DeepRemove(interpreter)
+		v.DeepRemove(interpreter, true)
 		interpreter.RemoveReferencedSlab(storable)
 	}
 	return v
@@ -21293,8 +21299,8 @@ func (v *IDCapabilityValue) Clone(interpreter *Interpreter) Value {
 	)
 }
 
-func (v *IDCapabilityValue) DeepRemove(interpreter *Interpreter) {
-	v.Address.DeepRemove(interpreter)
+func (v *IDCapabilityValue) DeepRemove(interpreter *Interpreter, _ bool) {
+	v.Address.DeepRemove(interpreter, false)
 }
 
 func (v *IDCapabilityValue) ByteSize() uint32 {
@@ -21440,7 +21446,7 @@ func (v PathLinkValue) Clone(interpreter *Interpreter) Value {
 	}
 }
 
-func (PathLinkValue) DeepRemove(_ *Interpreter) {
+func (PathLinkValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -21605,7 +21611,7 @@ func (v *PublishedValue) Clone(interpreter *Interpreter) Value {
 	}
 }
 
-func (*PublishedValue) DeepRemove(_ *Interpreter) {
+func (*PublishedValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -21736,7 +21742,7 @@ func (AccountLinkValue) Clone(_ *Interpreter) Value {
 	return AccountLinkValue{}
 }
 
-func (AccountLinkValue) DeepRemove(_ *Interpreter) {
+func (AccountLinkValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 

--- a/runtime/interpreter/value_accountcapabilitycontroller.go
+++ b/runtime/interpreter/value_accountcapabilitycontroller.go
@@ -192,7 +192,7 @@ func (v *AccountCapabilityControllerValue) Clone(_ *Interpreter) Value {
 	}
 }
 
-func (v *AccountCapabilityControllerValue) DeepRemove(_ *Interpreter) {
+func (v *AccountCapabilityControllerValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 

--- a/runtime/interpreter/value_accountreference.go
+++ b/runtime/interpreter/value_accountreference.go
@@ -292,7 +292,7 @@ func (v *AccountReferenceValue) Clone(_ *Interpreter) Value {
 	)
 }
 
-func (*AccountReferenceValue) DeepRemove(_ *Interpreter) {
+func (*AccountReferenceValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 

--- a/runtime/interpreter/value_function.go
+++ b/runtime/interpreter/value_function.go
@@ -165,7 +165,7 @@ func (f *InterpretedFunctionValue) Clone(_ *Interpreter) Value {
 	return f
 }
 
-func (*InterpretedFunctionValue) DeepRemove(_ *Interpreter) {
+func (*InterpretedFunctionValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -314,7 +314,7 @@ func (f *HostFunctionValue) Clone(_ *Interpreter) Value {
 	return f
 }
 
-func (*HostFunctionValue) DeepRemove(_ *Interpreter) {
+func (*HostFunctionValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
@@ -441,6 +441,6 @@ func (f BoundFunctionValue) Clone(_ *Interpreter) Value {
 	return f
 }
 
-func (BoundFunctionValue) DeepRemove(_ *Interpreter) {
+func (BoundFunctionValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }

--- a/runtime/interpreter/value_placeholder.go
+++ b/runtime/interpreter/value_placeholder.go
@@ -100,6 +100,6 @@ func (f placeholderValue) Clone(_ *Interpreter) Value {
 	return f
 }
 
-func (placeholderValue) DeepRemove(_ *Interpreter) {
+func (placeholderValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }

--- a/runtime/interpreter/value_storagecapabilitycontroller.go
+++ b/runtime/interpreter/value_storagecapabilitycontroller.go
@@ -217,7 +217,7 @@ func (v *StorageCapabilityControllerValue) Clone(interpreter *Interpreter) Value
 	}
 }
 
-func (v *StorageCapabilityControllerValue) DeepRemove(_ *Interpreter) {
+func (v *StorageCapabilityControllerValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 

--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -173,7 +173,7 @@ func TestRandomMapOperations(t *testing.T) {
 	})
 
 	t.Run("deep remove", func(t *testing.T) {
-		copyOfTestMap.DeepRemove(inter)
+		copyOfTestMap.DeepRemove(inter, true)
 		err = storage.Remove(copyOfTestMap.SlabID())
 		require.NoError(t, err)
 
@@ -622,7 +622,7 @@ func TestRandomArrayOperations(t *testing.T) {
 	})
 
 	t.Run("deep removal", func(t *testing.T) {
-		copyOfTestArray.DeepRemove(inter)
+		copyOfTestArray.DeepRemove(inter, true)
 		err = storage.Remove(copyOfTestArray.SlabID())
 		require.NoError(t, err)
 
@@ -967,7 +967,7 @@ func TestRandomCompositeValueOperations(t *testing.T) {
 	})
 
 	t.Run("deep remove", func(t *testing.T) {
-		copyOfTestComposite.DeepRemove(inter)
+		copyOfTestComposite.DeepRemove(inter, true)
 		err = storage.Remove(copyOfTestComposite.SlabID())
 		require.NoError(t, err)
 
@@ -1694,7 +1694,7 @@ func TestCheckStorageHealthInMiddleOfDeepRemove(t *testing.T) {
 	)
 
 	// DeepRemove removes all elements (childArray1 and childArray2) recursively in array.
-	array.DeepRemove(inter)
+	array.DeepRemove(inter, true)
 
 	// As noted earlier in comments at the top of this test:
 	// storage.CheckHealth() should be called after array.DeepRemove(), not in the middle of array.DeepRemove().


### PR DESCRIPTION
Work towards #2882, in particular https://github.com/onflow/cadence/pull/2882/commits/593ceada94c96e4a6361c73f56fd3ad42b6ae6de

## Description

- Allow `Value.DeepRemove` implementations to differentiate when a call is at the root level, or if it is a recursive call, by adding a parameter `atRoot bool`.
- Only validate the atree value of interpreter values backed by atree values (`CompositeValue`, `DictionaryValue`, and `ArrayValue`) at the root level

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
