### PR TITLE
Add types to parsed array and dictionary literals

### DIFF
--- a/runtime/literal.go
+++ b/runtime/literal.go
@@ -312,7 +312,8 @@ func LiteralValue(inter *interpreter.Interpreter, expression ast.Expression, ty 
 		if !ok {
 			return nil, LiteralExpressionTypeError
 		}
-		return array.WithType(cadence.NewMeteredVariableSizedArrayType(inter, arrayType.Element())), err
+		arrayCadenceType := cadence.NewMeteredVariableSizedArrayType(inter, arrayType.Element())
+		return array.WithType(arrayCadenceType), err
 
 	case *sema.ConstantSizedType:
 		expression, ok := expression.(*ast.ArrayExpression)
@@ -326,7 +327,8 @@ func LiteralValue(inter *interpreter.Interpreter, expression ast.Expression, ty 
 		if !ok {
 			return nil, LiteralExpressionTypeError
 		}
-		return array.WithType(cadence.NewMeteredConstantSizedArrayType(inter, uint(ty.Size), arrayType.Element())), err
+		arrayCadenceType := cadence.NewMeteredConstantSizedArrayType(inter, uint(ty.Size), arrayType.Element())
+		return array.WithType(arrayCadenceType), err
 
 	case *sema.OptionalType:
 		if _, ok := expression.(*ast.NilExpression); ok {
@@ -386,7 +388,8 @@ func LiteralValue(inter *interpreter.Interpreter, expression ast.Expression, ty 
 			return nil, err
 		}
 
-		return dictionaryValue.WithType(cadence.NewMeteredDictionaryType(inter, dictionaryType.KeyType, dictionaryType.ElementType)), nil
+		dictionaryCadenceType := cadence.NewMeteredDictionaryType(inter, dictionaryType.KeyType, dictionaryType.ElementType)
+		return dictionaryValue.WithType(dictionaryCadenceType), nil
 
 	case *sema.AddressType:
 		expression, ok := expression.(*ast.IntegerExpression)

--- a/runtime/literal_test.go
+++ b/runtime/literal_test.go
@@ -151,7 +151,7 @@ func TestParseLiteral(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t,
-			cadence.NewArray([]cadence.Value{}),
+			cadence.NewArray([]cadence.Value{}).WithType(cadence.NewVariableSizedArrayType(cadence.BoolType{})),
 			value,
 		)
 	})
@@ -166,7 +166,7 @@ func TestParseLiteral(t *testing.T) {
 		require.Equal(t,
 			cadence.NewArray([]cadence.Value{
 				cadence.NewBool(true),
-			}),
+			}).WithType(cadence.NewVariableSizedArrayType(cadence.BoolType{})),
 			value,
 		)
 	})
@@ -190,22 +190,25 @@ func TestParseLiteral(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t,
-			cadence.NewArray([]cadence.Value{}),
+			cadence.NewArray(
+				[]cadence.Value{},
+			).WithType(cadence.NewConstantSizedArrayType(0, cadence.BoolType{})),
 			value,
 		)
+
 	})
 
 	t.Run("ConstantSizedArray, one element", func(t *testing.T) {
 		value, err := ParseLiteral(
 			`[true]`,
-			&sema.ConstantSizedType{Type: sema.BoolType},
+			&sema.ConstantSizedType{Type: sema.BoolType, Size: 1},
 			newTestInterpreter(t),
 		)
 		require.NoError(t, err)
 		require.Equal(t,
 			cadence.NewArray([]cadence.Value{
 				cadence.NewBool(true),
-			}),
+			}).WithType(cadence.NewConstantSizedArrayType(1, cadence.BoolType{})),
 			value,
 		)
 	})
@@ -232,7 +235,7 @@ func TestParseLiteral(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t,
-			cadence.NewDictionary([]cadence.KeyValuePair{}),
+			cadence.NewDictionary([]cadence.KeyValuePair{}).WithType(cadence.NewDictionaryType(cadence.StringType{}, cadence.BoolType{})),
 			value,
 		)
 	})
@@ -253,7 +256,7 @@ func TestParseLiteral(t *testing.T) {
 					Key:   cadence.String("hello"),
 					Value: cadence.NewBool(true),
 				},
-			}),
+			}).WithType(cadence.NewDictionaryType(cadence.StringType{}, cadence.BoolType{})),
 			value,
 		)
 	})


### PR DESCRIPTION
## Description

I am not 100% it is correct approach, but I tried to fix literal parsing for dictionary and arrays. ( which was causing issues on flow-cli https://github.com/onflow/flow-cli/issues/1254 )

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
