### PR TITLE
Add native function declarations for all relevant `Test` contract functions

### DIFF
--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -877,7 +877,7 @@ func parseEventDeclaration(
 
 	// if this is a `ResourceDestroyed` event (i.e., a default event declaration), parse default arguments
 	parseDefaultArguments := ast.IsResourceDestructionDefaultEvent(identifier.Identifier)
-	parameterList, err := parseParameterList(p, parseDefaultArguments)
+	parameterList, err := parseParameterList(p, parseDefaultArguments, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1889,7 +1889,7 @@ func parseSpecialFunctionDeclaration(
 	startPos := ast.EarliestPosition(identifier.Pos, accessPos, purityPos, staticPos, nativePos)
 
 	parameterList, returnTypeAnnotation, functionBlock, err :=
-		parseFunctionParameterListAndRest(p, functionBlockIsOptional)
+		parseFunctionParameterListAndRest(p, functionBlockIsOptional, nativePos != nil)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -389,7 +389,7 @@ func TestParseParameterList(t *testing.T) {
 			nil,
 			[]byte(input),
 			func(p *parser) (*ast.ParameterList, error) {
-				return parseParameterList(p, false)
+				return parseParameterList(p, false, false)
 			},
 			Config{},
 		)

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -846,7 +846,7 @@ func defineIdentifierExpression() {
 
 func parseFunctionExpression(p *parser, token lexer.Token, purity ast.FunctionPurity) (*ast.FunctionExpression, error) {
 	parameterList, returnTypeAnnotation, functionBlock, err :=
-		parseFunctionParameterListAndRest(p, false)
+		parseFunctionParameterListAndRest(p, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/parser/statement.go
+++ b/runtime/parser/statement.go
@@ -205,7 +205,7 @@ func parseFunctionDeclarationOrFunctionExpressionStatement(
 		}
 
 		parameterList, returnTypeAnnotation, functionBlock, err :=
-			parseFunctionParameterListAndRest(p, false)
+			parseFunctionParameterListAndRest(p, false, false)
 
 		if err != nil {
 			return nil, err
@@ -227,7 +227,7 @@ func parseFunctionDeclarationOrFunctionExpressionStatement(
 		), nil
 	} else {
 		parameterList, returnTypeAnnotation, functionBlock, err :=
-			parseFunctionParameterListAndRest(p, false)
+			parseFunctionParameterListAndRest(p, false, false)
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/parser/transaction.go
+++ b/runtime/parser/transaction.go
@@ -52,7 +52,7 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 	var err error
 
 	if p.current.Is(lexer.TokenParenOpen) {
-		parameterList, err = parseParameterList(p, false)
+		parameterList, err = parseParameterList(p, false, false)
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4738,11 +4738,7 @@ func (t *CompositeType) GetMembers() map[string]MemberResolver {
 }
 
 func (t *CompositeType) initializeMemberResolvers() {
-	t.memberResolversOnce.Do(t.initializerMemberResolversFunc())
-}
-
-func (t *CompositeType) initializerMemberResolversFunc() func() {
-	return func() {
+	t.memberResolversOnce.Do(func() {
 		memberResolvers := MembersMapAsResolvers(t.Members)
 
 		// Check conformances.
@@ -4777,13 +4773,7 @@ func (t *CompositeType) initializerMemberResolversFunc() func() {
 		}
 
 		t.memberResolvers = withBuiltinMembers(t, memberResolvers)
-	}
-}
-
-func (t *CompositeType) ResolveMembers() {
-	if t.Members.Len() != len(t.GetMembers()) {
-		t.initializerMemberResolversFunc()()
-	}
+	})
 }
 
 func (t *CompositeType) FieldPosition(name string, declaration ast.CompositeLikeDeclaration) ast.Position {

--- a/runtime/stdlib/contracts/test.cdc
+++ b/runtime/stdlib/contracts/test.cdc
@@ -473,4 +473,87 @@ contract Test {
 
         assert(found, message: "the error message did not contain the given sub-string")
     }
+
+    /// Creates a matcher with a test function.
+    /// The test function is of type 'fun(T): Bool',
+    /// where 'T' is bound to 'AnyStruct'.
+    ///
+    access(all)
+    native fun newMatcher<T: AnyStruct>(_ test: fun(T): Bool): Test.Matcher {}
+
+    /// Wraps a function call in a closure, and expects it to fail with
+    /// an error message that contains the given error message portion.
+    ///
+    access(all)
+    native fun expectFailure(
+        _ functionWrapper: fun(): Void,
+        errorMessageSubstring: String
+    ) {}
+
+    /// Expect function tests a value against a matcher
+    /// and fails the test if it's not a match.
+    ///
+    access(all)
+    native fun expect<T: AnyStruct>(_ value: T, _ matcher: Test.Matcher) {}
+
+    /// Returns a matcher that succeeds if the tested
+    /// value is equal to the given value.
+    ///
+    access(all)
+    native fun equal<T: AnyStruct>(_ value: T): Test.Matcher {}
+
+    /// Fails the test-case if the given values are not equal, and
+    /// reports a message which explains how the two values differ.
+    ///
+    access(all)
+    native fun assertEqual(_ expected: AnyStruct, _ actual: AnyStruct) {}
+
+    /// Returns a matcher that succeeds if the tested value is
+    /// an array or dictionary and the tested value contains
+    /// no elements.
+    ///
+    access(all)
+    native fun beEmpty(): Test.Matcher {}
+
+    /// Returns a matcher that succeeds if the tested value is
+    /// an array or dictionary and has the given number of elements.
+    ///
+    access(all)
+    native fun haveElementCount(_ count: Int): Test.Matcher {}
+
+    /// Returns a matcher that succeeds if the tested value is
+    /// an array that contains a value that is equal to the given
+    /// value, or the tested value is a dictionary that contains
+    /// an entry where the key is equal to the given value.
+    ///
+    access(all)
+    native fun contain(_ element: AnyStruct): Test.Matcher {}
+
+    /// Returns a matcher that succeeds if the tested value
+    /// is a number and greater than the given number.
+    ///
+    access(all)
+    native fun beGreaterThan(_ value: Number): Test.Matcher {}
+
+    /// Returns a matcher that succeeds if the tested value
+    /// is a number and less than the given number.
+    ///
+    access(all)
+    native fun beLessThan(_ value: Number): Test.Matcher {}
+
+    /// Read a local file, and return the content as a string.
+    ///
+    access(all)
+    native fun readFile(_ path: String): String {}
+
+    /// Fails the test-case if the given condition is false,
+    /// and reports a message which explains how the condition is false.
+    ///
+    access(all)
+    native fun assert(_ condition: Bool, message: String = ""): Void {}
+
+    /// Fails the test-case with a message.
+    ///
+    access(all)
+    native fun fail(message: String = ""): Void {}
 }

--- a/runtime/stdlib/test_contract.go
+++ b/runtime/stdlib/test_contract.go
@@ -64,13 +64,12 @@ var testTypeAssertFunctionType = &sema.FunctionType{
 			TypeAnnotation: sema.BoolTypeAnnotation,
 		},
 		{
-			Identifier:     "message",
-			TypeAnnotation: sema.StringTypeAnnotation,
+			Identifier:      "message",
+			TypeAnnotation:  sema.StringTypeAnnotation,
+			DefaultArgument: sema.StringType,
 		},
 	},
 	ReturnTypeAnnotation: sema.VoidTypeAnnotation,
-	// `message` parameter is optional
-	Arity: &sema.Arity{Min: 1, Max: 2},
 }
 
 var testTypeAssertFunction = interpreter.NewUnmeteredHostFunctionValue(
@@ -181,13 +180,12 @@ var testTypeFailFunctionType = &sema.FunctionType{
 	Purity: sema.FunctionPurityView,
 	Parameters: []sema.Parameter{
 		{
-			Identifier:     "message",
-			TypeAnnotation: sema.StringTypeAnnotation,
+			Identifier:      "message",
+			TypeAnnotation:  sema.StringTypeAnnotation,
+			DefaultArgument: sema.StringType,
 		},
 	},
 	ReturnTypeAnnotation: sema.VoidTypeAnnotation,
-	// `message` parameter is optional
-	Arity: &sema.Arity{Min: 0, Max: 1},
 }
 
 var testTypeFailFunction = interpreter.NewUnmeteredHostFunctionValue(
@@ -915,7 +913,10 @@ func newTestContractType() *TestContractType {
 	program, err := parser.ParseProgram(
 		nil,
 		contracts.TestContract,
-		parser.Config{},
+		parser.Config{
+			NativeModifierEnabled: true,
+			TypeParametersEnabled: true,
+		},
 	)
 	if err != nil {
 		panic(err)
@@ -933,7 +934,8 @@ func newTestContractType() *TestContractType {
 			BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 				return activation
 			},
-			AccessCheckMode: sema.AccessCheckModeStrict,
+			AccessCheckMode:         sema.AccessCheckModeStrict,
+			AllowNativeDeclarations: true,
 		},
 	)
 	if err != nil {
@@ -1160,7 +1162,6 @@ func newTestContractType() *TestContractType {
 	ty.expectFailureFunction = newTestTypeExpectFailureFunction(
 		expectFailureFunctionType,
 	)
-	compositeType.ResolveMembers()
 
 	return ty
 }


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2822

## Description

With the introduction of https://github.com/onflow/cadence/pull/2821, we can now declare native functions inside the `Test` contract, and remove the workaround that used `CompositeType.ResolveMembers()`.

To do that, we also had to enable default arguments for native functions, since `Test.assert` and `Test.fail` both have an optional `message` argument.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
