### PR TITLE
Remove `StandardLibraryHandler` method from `TestFramework` interface

### DIFF
--- a/runtime/stdlib/test-framework.go
+++ b/runtime/stdlib/test-framework.go
@@ -64,8 +64,6 @@ type Blockchain interface {
 		arguments []interpreter.Value,
 	) error
 
-	StandardLibraryHandler() StandardLibraryHandler
-
 	Logs() []string
 
 	ServiceAccount() (*Account, error)


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2898

## Description

This method is no longer needed as part of the `TestFramework` interface, We remove it so that downstream dependencies (test providers) are not forced to implement it.

**Note:** I will follow-up with the necessary changes on the `cadence-tools/test` repository, to complete the removal of this method.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
