### PR TITLE
Introduce benchmark for the `smallIntegerValueCache`

### DIFF
--- a/runtime/interpreter/integer.go
+++ b/runtime/interpreter/integer.go
@@ -50,12 +50,12 @@ func (c *smallIntegerValueCache) Get(value int8, staticType StaticType) IntegerV
 		return existingValue.(IntegerValue)
 	}
 
-	newValue := c.new(value, staticType)
+	newValue := createNewSmallIntegerValue(value, staticType)
 	c.m.Store(key, newValue)
 	return newValue
 }
 
-// getValueForIntegerType returns a Cadence integer value
+// createNewSmallIntegerValue returns a Cadence integer value
 // of the given Cadence static type for the given Go integer value.
 //
 // It is important NOT to meter the memory usage in this function,
@@ -63,7 +63,7 @@ func (c *smallIntegerValueCache) Get(value int8, staticType StaticType) IntegerV
 // It could happen that on some execution nodes the value might be cached due to executing a
 // transaction or script that needed the value previously, while on other execution nodes it might
 // not be cached yet.
-func (c *smallIntegerValueCache) new(value int8, staticType StaticType) IntegerValue {
+func createNewSmallIntegerValue(value int8, staticType StaticType) IntegerValue {
 	switch staticType {
 	case PrimitiveStaticTypeInt:
 		return NewUnmeteredIntValueFromInt64(int64(value))

--- a/runtime/interpreter/integer_test.go
+++ b/runtime/interpreter/integer_test.go
@@ -44,7 +44,7 @@ func runBench(b *testing.B, getValue func(value int8, staticType StaticType) Int
 	bench := func() {
 		defer wg.Done()
 
-		for i := int8(0); i <= 127; i++ {
+		for i := 0; i <= math.MaxInt8; i++ {
 			for _, integerType := range sema.AllIntegerTypes {
 				switch integerType {
 				case sema.IntegerType, sema.SignedIntegerType:

--- a/runtime/interpreter/integer_test.go
+++ b/runtime/interpreter/integer_test.go
@@ -30,7 +30,7 @@ import (
 const numGoRoutines = 100
 
 func runBench(b *testing.B, getValue func(value int8, staticType StaticType) IntegerValue) {
-	semaToStaticType := make(map[sema.Type]StaticType)
+	staticTypes := make([]StaticType, 0)
 	for _, integerType := range sema.AllIntegerTypes {
 		switch integerType {
 		case sema.IntegerType, sema.SignedIntegerType:
@@ -38,7 +38,7 @@ func runBench(b *testing.B, getValue func(value int8, staticType StaticType) Int
 		}
 
 		integerStaticType := ConvertSemaToStaticType(nil, integerType)
-		semaToStaticType[integerType] = integerStaticType
+		staticTypes = append(staticTypes, integerStaticType)
 	}
 
 	var wg sync.WaitGroup
@@ -47,13 +47,8 @@ func runBench(b *testing.B, getValue func(value int8, staticType StaticType) Int
 		defer wg.Done()
 
 		for i := 0; i <= math.MaxInt8; i++ {
-			for _, integerType := range sema.AllIntegerTypes {
-				switch integerType {
-				case sema.IntegerType, sema.SignedIntegerType:
-					continue
-				}
-
-				value := getValue(int8(i), semaToStaticType[integerType])
+			for _, integerType := range staticTypes {
+				value := getValue(int8(i), integerType)
 				runtime.KeepAlive(value)
 			}
 		}

--- a/runtime/interpreter/integer_test.go
+++ b/runtime/interpreter/integer_test.go
@@ -19,6 +19,7 @@
 package interpreter
 
 import (
+	"fmt"
 	"math"
 	"runtime"
 	"sync"
@@ -49,7 +50,8 @@ func runBench(b *testing.B, getValue func(value int8, staticType StaticType) Int
 		for i := 0; i <= math.MaxInt8; i++ {
 			for _, integerType := range staticTypes {
 				value := getValue(int8(i), integerType)
-				runtime.KeepAlive(value)
+				str := fmt.Sprintf("Value = %d", value)
+				runtime.KeepAlive(str)
 			}
 		}
 	}

--- a/runtime/interpreter/integer_test.go
+++ b/runtime/interpreter/integer_test.go
@@ -1,0 +1,82 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+const numGoRoutines = 100
+
+func runBench(b *testing.B, getValue func(value int8, staticType StaticType) IntegerValue) {
+	semaToStaticType := make(map[sema.Type]StaticType)
+	for _, integerType := range sema.AllIntegerTypes {
+		switch integerType {
+		case sema.IntegerType, sema.SignedIntegerType:
+			continue
+		}
+
+		integerStaticType := ConvertSemaToStaticType(nil, integerType)
+		semaToStaticType[integerType] = integerStaticType
+	}
+
+	var wg sync.WaitGroup
+
+	bench := func() {
+		defer wg.Done()
+
+		for i := int8(0); i <= 127; i++ {
+			for _, integerType := range sema.AllIntegerTypes {
+				switch integerType {
+				case sema.IntegerType, sema.SignedIntegerType:
+					continue
+				}
+
+				value := getValue(i, semaToStaticType[integerType])
+
+				// Force a NOOP function call to ensure value isn't optimized away
+				value.isValue()
+			}
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		wg.Add(numGoRoutines)
+
+		for routineIndex := 0; routineIndex < numGoRoutines; routineIndex++ {
+			go bench()
+		}
+
+		wg.Wait()
+	}
+}
+
+func BenchmarkSmallIntegerValueCache(b *testing.B) {
+	runBench(b, GetSmallIntegerValue)
+}
+
+func BenchmarkIntegerCreationWithoutCache(b *testing.B) {
+	runBench(b, createNewSmallIntegerValue)
+}

--- a/runtime/interpreter/integer_test.go
+++ b/runtime/interpreter/integer_test.go
@@ -19,6 +19,8 @@
 package interpreter
 
 import (
+	"math"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -51,10 +53,8 @@ func runBench(b *testing.B, getValue func(value int8, staticType StaticType) Int
 					continue
 				}
 
-				value := getValue(i, semaToStaticType[integerType])
-
-				// Force a NOOP function call to ensure value isn't optimized away
-				value.isValue()
+				value := getValue(int8(i), semaToStaticType[integerType])
+				runtime.KeepAlive(value)
 			}
 		}
 	}


### PR DESCRIPTION
Work towards #2871

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Introduces benchmark for the `smallIntegerValueCache`.

Results on my machine

##### Without Cache
```
BenchmarkIntegerCreationWithoutCache-16    	      91	  15024692 ns/op	12304062 B/op	  971404 allocs/op
```

Command: `go test -benchmem -run=^$ -bench ^BenchmarkIntegerCreationWithoutCache$ github.com/onflow/cadence/runtime/interpreter`

##### With Cache
```
BenchmarkSmallIntegerValueCache-16    	      86	  13857062 ns/op	 7401608 B/op	  767457 allocs/op
```

Command: `go test -benchmem -run=^$ -bench ^BenchmarkSmallIntegerValueCache$ github.com/onflow/cadence/runtime/interpreter`
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
