### PR TITLE
Fix transaction resource-typed field move

### DIFF
--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -22,7 +22,6 @@ import (
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/format"
 	"github.com/onflow/cadence/runtime/sema"
 )
@@ -147,9 +146,10 @@ func (v *SimpleCompositeValue) GetMember(
 	return nil
 }
 
-func (*SimpleCompositeValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
-	// Simple composite values have no removable members (fields / functions)
-	panic(errors.NewUnreachableError())
+func (v *SimpleCompositeValue) RemoveMember(_ *Interpreter, _ LocationRange, name string) Value {
+	value := v.Fields[name]
+	delete(v.Fields, name)
+	return value
 }
 
 func (v *SimpleCompositeValue) SetMember(_ *Interpreter, _ LocationRange, name string, value Value) bool {


### PR DESCRIPTION
## Description

Transaction values are `SimpleCompositeValue`s.

Implement `RemoveMember`, as it is now called in an invalidating move from transaction `execute` blocks.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
