### PR TITLE
Disallow InclusiveRange<T> if T is a non-leaf integer

### DIFF
--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2244,7 +2244,16 @@ func (checker *Checker) convertInstantiationType(t *ast.InstantiationType) Type 
 		return ty
 	}
 
-	return parameterizedType.Instantiate(typeArguments, checker.report)
+	astRange := ast.NewRange(
+		checker.memoryGauge,
+		t.TypeArgumentsStartPos,
+		t.EndPos,
+	)
+	return parameterizedType.Instantiate(
+		typeArguments,
+		checker.report,
+		&astRange,
+	)
 }
 
 func (checker *Checker) VisitExpression(expr ast.Expression, expectedType Type) Type {

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -3735,6 +3735,29 @@ func (e *MissingTypeArgumentError) Error() string {
 	return fmt.Sprintf("non-optional type argument %s missing", e.TypeArgumentName)
 }
 
+// InvalidTypeArgumentError
+
+type InvalidTypeArgumentError struct {
+	TypeArgumentName string
+	Details          string
+	ast.Range
+}
+
+var _ SemanticError = &InvalidTypeArgumentError{}
+var _ errors.UserError = &InvalidTypeArgumentError{}
+
+func (e *InvalidTypeArgumentError) isSemanticError() {}
+
+func (*InvalidTypeArgumentError) IsUserError() {}
+
+func (e *InvalidTypeArgumentError) Error() string {
+	return fmt.Sprintf("type argument %s invalid", e.TypeArgumentName)
+}
+
+func (e *InvalidTypeArgumentError) SecondaryError() string {
+	return e.Details
+}
+
 // TypeParameterTypeInferenceError
 
 type TypeParameterTypeInferenceError struct {


### PR DESCRIPTION
Closes #2885

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Disallow InclusiveRange<T> if T is a non-leaf integer. At the moment, the two non-leaf integer types are - `Integer` and `SignedInteger`.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
