### PR TITLE
Add test for container mutation while iterating

### DIFF
--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -971,6 +971,169 @@ func TestInterpretContainerMutationAfterNilCoalescing(t *testing.T) {
 	)
 }
 
+func TestInterpretContainerMutationWhileIterating(t *testing.T) {
+
+	t.Run("array, append", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            fun test(): [String] {
+                let array: [String] = ["foo", "bar"]
+
+                var i = 0
+                for element in array {
+                    if i == 0 {
+                        array.append("baz")
+                    }
+                    array[i] = "hello"
+                    i = i + 1
+                }
+
+                return array
+            }
+        `)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		RequireValuesEqual(
+			t,
+			inter,
+			interpreter.NewArrayValue(
+				inter,
+				interpreter.EmptyLocationRange,
+				interpreter.VariableSizedStaticType{
+					Type: interpreter.PrimitiveStaticTypeString,
+				},
+				common.ZeroAddress,
+				interpreter.NewUnmeteredStringValue("hello"), // updated
+				interpreter.NewUnmeteredStringValue("hello"), // updated
+				interpreter.NewUnmeteredStringValue("baz"),   // NOT updated
+			),
+			result,
+		)
+	})
+
+	t.Run("array, remove", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            fun test() {
+                let array: [String] = ["foo", "bar", "baz"]
+
+                var i = 0
+                for element in array {
+                    if i == 0 {
+                        array.remove(at: 1)
+                    }
+                }
+            }
+        `)
+
+		_, err := inter.Invoke("test")
+		RequireError(t, err)
+		assert.ErrorAs(t, err, &interpreter.ArrayIndexOutOfBoundsError{})
+	})
+
+	t.Run("dictionary, add", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            fun test(): {String: String} {
+                let dictionary: {String: String} = {"a": "foo", "b": "bar"}
+
+                var i = 0
+                dictionary.forEachKey(fun (key: String): Bool {
+                    if i == 0 {
+                        dictionary["c"] = "baz"
+                    }
+
+                    dictionary[key] = "hello"
+                    return true
+                })
+
+                return dictionary
+            }
+        `)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		require.IsType(t, &interpreter.DictionaryValue{}, result)
+		dictionary := result.(*interpreter.DictionaryValue)
+
+		require.Equal(t, 3, dictionary.Count())
+
+		val, present := dictionary.Get(
+			inter,
+			interpreter.EmptyLocationRange,
+			interpreter.NewUnmeteredStringValue("a"),
+		)
+		assert.True(t, present)
+		assert.Equal(t, interpreter.NewUnmeteredStringValue("hello"), val) // Updated
+
+		val, present = dictionary.Get(
+			inter,
+			interpreter.EmptyLocationRange,
+			interpreter.NewUnmeteredStringValue("b"),
+		)
+		assert.True(t, present)
+		assert.Equal(t, interpreter.NewUnmeteredStringValue("hello"), val) // Updated
+
+		val, present = dictionary.Get(
+			inter,
+			interpreter.EmptyLocationRange,
+			interpreter.NewUnmeteredStringValue("c"),
+		)
+		assert.True(t, present)
+		assert.Equal(t, interpreter.NewUnmeteredStringValue("baz"), val) // Not Updated
+	})
+
+	t.Run("dictionary, remove", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            fun test(): {String: String} {
+                let dictionary: {String: String} = {"a": "foo", "b": "bar", "c": "baz"}
+
+                var i = 0
+                dictionary.forEachKey(fun (key: String): Bool {
+                    if i == 0 {
+                        dictionary.remove(key: "b")
+                    }
+                    return true
+                })
+
+                return dictionary
+            }
+        `)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		require.IsType(t, &interpreter.DictionaryValue{}, result)
+		dictionary := result.(*interpreter.DictionaryValue)
+
+		require.Equal(t, 2, dictionary.Count())
+
+		val, present := dictionary.Get(
+			inter,
+			interpreter.EmptyLocationRange,
+			interpreter.NewUnmeteredStringValue("a"),
+		)
+		assert.True(t, present)
+		assert.Equal(t, interpreter.NewUnmeteredStringValue("foo"), val)
+
+		val, present = dictionary.Get(
+			inter,
+			interpreter.EmptyLocationRange,
+			interpreter.NewUnmeteredStringValue("c"),
+		)
+		assert.True(t, present)
+		assert.Equal(t, interpreter.NewUnmeteredStringValue("baz"), val)
+	})
+}
+
 func TestInterpretInnerContainerMutationWhileIteratingOuter(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
## Description

Porting https://github.com/dapperlabs/cadence-internal/pull/142

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
