### PR TITLE
throw error on the creation of a nested reference

### DIFF
--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -262,7 +262,7 @@ func (executor *interpreterContractFunctionExecutor) convertArgument(
 				authorization,
 				accountValue,
 				sema.AccountType,
-				interpreter.EmptyLocationRange,
+				locationRange,
 			)
 
 			return accountReferenceValue, nil

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -262,6 +262,7 @@ func (executor *interpreterContractFunctionExecutor) convertArgument(
 				authorization,
 				accountValue,
 				sema.AccountType,
+				interpreter.EmptyLocationRange,
 			)
 
 			return accountReferenceValue, nil

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -905,6 +905,7 @@ func (e *interpreterEnvironment) newInjectedCompositeFieldsHandler() interpreter
 						e,
 						addressValue,
 						interpreter.FullyEntitledAccountAccess,
+						interpreter.EmptyLocationRange,
 					),
 				}
 			}

--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -1015,3 +1015,20 @@ func (e CapabilityAddressPublishingError) Error() string {
 		e.AccountAddress.String(),
 	)
 }
+
+// NestedReferenceError
+type NestedReferenceError struct {
+	Value *EphemeralReferenceValue
+	LocationRange
+}
+
+var _ errors.UserError = NestedReferenceError{}
+
+func (NestedReferenceError) IsUserError() {}
+
+func (e NestedReferenceError) Error() string {
+	return fmt.Sprintf(
+		"cannot create a nested reference to %s",
+		e.Value.String(),
+	)
+}

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -252,7 +252,7 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *a
 			// This is pre-computed at the checker.
 			if memberAccessInfo.ReturnReference {
 				// Get a reference to the value
-				resultValue = interpreter.getReferenceValue(resultValue, memberAccessInfo.ResultingType)
+				resultValue = interpreter.getReferenceValue(resultValue, memberAccessInfo.ResultingType, locationRange)
 			}
 
 			return resultValue
@@ -270,14 +270,14 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(memberExpression *a
 // This has to be done recursively for nested optionals.
 // e.g.1: Given type T, this method returns &T.
 // e.g.2: Given T?, this returns (&T)?
-func (interpreter *Interpreter) getReferenceValue(value Value, resultType sema.Type) Value {
+func (interpreter *Interpreter) getReferenceValue(value Value, resultType sema.Type, locationRange LocationRange) Value {
 	switch value := value.(type) {
 	case NilValue, ReferenceValue:
 		// Reference to a nil, should return a nil.
 		// If the value is already a reference then return the same reference.
 		return value
 	case *SomeValue:
-		innerValue := interpreter.getReferenceValue(value.value, resultType)
+		innerValue := interpreter.getReferenceValue(value.value, resultType, locationRange)
 		return NewSomeValueNonCopying(interpreter, innerValue)
 	}
 
@@ -290,7 +290,7 @@ func (interpreter *Interpreter) getReferenceValue(value Value, resultType sema.T
 
 	auth := interpreter.getEffectiveAuthorization(referenceType)
 
-	return NewEphemeralReferenceValue(interpreter, auth, value, referenceType.Type)
+	return NewEphemeralReferenceValue(interpreter, auth, value, referenceType.Type, locationRange)
 }
 
 func (interpreter *Interpreter) getEffectiveAuthorization(referenceType *sema.ReferenceType) Authorization {
@@ -956,8 +956,12 @@ func (interpreter *Interpreter) maybeGetReference(
 	if indexExpressionTypes.ReturnReference {
 		expectedType := indexExpressionTypes.ResultType
 
+		locationRange := LocationRange{
+			Location:    interpreter.Location,
+			HasPosition: expression,
+		}
 		// Get a reference to the value
-		memberValue = interpreter.getReferenceValue(memberValue, expectedType)
+		memberValue = interpreter.getReferenceValue(memberValue, expectedType, locationRange)
 	}
 
 	return memberValue
@@ -1256,11 +1260,17 @@ func (interpreter *Interpreter) VisitReferenceExpression(referenceExpression *as
 		// of that mapped access in the body of the function should be replaced with the computed output of the map
 		auth := interpreter.getEffectiveAuthorization(typ)
 
+		locationRange := LocationRange{
+			Location:    interpreter.Location,
+			HasPosition: referenceExpression,
+		}
+
 		return NewEphemeralReferenceValue(
 			interpreter,
 			auth,
 			value,
 			typ.Type,
+			locationRange,
 		)
 	}
 
@@ -1420,6 +1430,7 @@ func (interpreter *Interpreter) VisitAttachExpression(attachExpression *ast.Atta
 		auth,
 		base,
 		interpreter.MustSemaTypeOfValue(base).(*sema.CompositeType),
+		locationRange,
 	)
 
 	attachment, ok := interpreter.visitInvocationExpressionWithImplicitArgument(

--- a/runtime/interpreter/interpreter_invocation.go
+++ b/runtime/interpreter/interpreter_invocation.go
@@ -153,13 +153,14 @@ func (interpreter *Interpreter) invokeInterpretedFunction(
 		}()
 	}
 
-	return interpreter.invokeInterpretedFunctionActivated(function, invocation.Arguments)
+	return interpreter.invokeInterpretedFunctionActivated(function, invocation.Arguments, invocation.LocationRange)
 }
 
 // NOTE: assumes the function's activation (or an extension of it) is pushed!
 func (interpreter *Interpreter) invokeInterpretedFunctionActivated(
 	function *InterpretedFunctionValue,
 	arguments []Value,
+	declarationLocationRange LocationRange,
 ) Value {
 	defer func() {
 		// Only unwind the call stack if there was no error
@@ -182,6 +183,7 @@ func (interpreter *Interpreter) invokeInterpretedFunctionActivated(
 		},
 		function.PostConditions,
 		function.Type.ReturnTypeAnnotation.Type,
+		declarationLocationRange,
 	)
 }
 

--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -490,7 +490,7 @@ func (interpreter *Interpreter) VisitRemoveStatement(removeStatement *ast.Remove
 
 	if attachment.IsResourceKinded(interpreter) {
 		// this attachment is no longer attached to its base, but the `base` variable is still available in the destructor
-		attachment.setBaseValue(interpreter, base)
+		attachment.setBaseValue(interpreter, base, locationRange)
 		attachment.Destroy(interpreter, locationRange)
 	}
 

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -132,12 +132,18 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 				preConditions = *declaration.PreConditions
 			}
 
+			declarationLocationRange := LocationRange{
+				Location:    interpreter.Location,
+				HasPosition: declaration,
+			}
+
 			return interpreter.visitFunctionBody(
 				postConditionsRewrite.BeforeStatements,
 				preConditions,
 				body,
 				postConditionsRewrite.RewrittenPostConditions,
 				sema.VoidType,
+				declarationLocationRange,
 			)
 		},
 	}

--- a/runtime/interpreter/value_accountcapabilitycontroller.go
+++ b/runtime/interpreter/value_accountcapabilitycontroller.go
@@ -316,6 +316,8 @@ func (v *AccountCapabilityControllerValue) ReferenceValue(
 		authorization,
 		account,
 		resultBorrowType.Type,
+		// okay to pass an empty range here because the account value is never a reference, so this can't fail
+		EmptyLocationRange,
 	)
 }
 

--- a/runtime/interpreter/value_accountcapabilitycontroller.go
+++ b/runtime/interpreter/value_accountcapabilitycontroller.go
@@ -295,6 +295,7 @@ func (v *AccountCapabilityControllerValue) ReferenceValue(
 	interpreter *Interpreter,
 	capabilityAddress common.Address,
 	resultBorrowType *sema.ReferenceType,
+	locationRange LocationRange,
 ) ReferenceValue {
 	config := interpreter.SharedState.Config
 
@@ -316,8 +317,7 @@ func (v *AccountCapabilityControllerValue) ReferenceValue(
 		authorization,
 		account,
 		resultBorrowType.Type,
-		// okay to pass an empty range here because the account value is never a reference, so this can't fail
-		EmptyLocationRange,
+		locationRange,
 	)
 }
 

--- a/runtime/interpreter/value_storagecapabilitycontroller.go
+++ b/runtime/interpreter/value_storagecapabilitycontroller.go
@@ -35,6 +35,7 @@ type CapabilityControllerValue interface {
 		interpreter *Interpreter,
 		capabilityAddress common.Address,
 		resultBorrowType *sema.ReferenceType,
+		locationRange LocationRange,
 	) ReferenceValue
 	ControllerCapabilityID() UInt64Value
 }
@@ -329,6 +330,7 @@ func (v *StorageCapabilityControllerValue) ReferenceValue(
 	interpreter *Interpreter,
 	capabilityAddress common.Address,
 	resultBorrowType *sema.ReferenceType,
+	_ LocationRange,
 ) ReferenceValue {
 	authorization := ConvertSemaAccessToStaticAuthorization(
 		interpreter,

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -1123,6 +1123,7 @@ func TestStringer(t *testing.T) {
 					&sema.VariableSizedType{
 						Type: sema.AnyStructType,
 					},
+					EmptyLocationRange,
 				)
 
 				array.Insert(inter, EmptyLocationRange, 0, arrayRef)
@@ -3857,6 +3858,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 					UnauthorizedAccess,
 					TrueValue,
 					sema.BoolType,
+					EmptyLocationRange,
 				)
 			},
 			true,
@@ -3868,6 +3870,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 					UnauthorizedAccess,
 					TrueValue,
 					sema.StringType,
+					EmptyLocationRange,
 				)
 			},
 			false,

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -157,6 +157,7 @@ func NewAccountConstructor(creator AccountCreator) StandardLibraryValue {
 				creator,
 				addressValue,
 				interpreter.FullyEntitledAccountAccess,
+				invocation.LocationRange,
 			)
 		},
 	)
@@ -230,6 +231,7 @@ func NewGetAuthAccountFunction(handler AccountHandler) StandardLibraryValue {
 				handler,
 				accountAddress,
 				authorization,
+				invocation.LocationRange,
 			)
 		},
 	)
@@ -240,6 +242,7 @@ func NewAccountReferenceValue(
 	handler AccountHandler,
 	addressValue interpreter.AddressValue,
 	authorization interpreter.Authorization,
+	locationRange interpreter.LocationRange,
 ) interpreter.Value {
 	account := NewAccountValue(inter, handler, addressValue)
 	return interpreter.NewEphemeralReferenceValue(
@@ -247,8 +250,7 @@ func NewAccountReferenceValue(
 		authorization,
 		account,
 		sema.AccountType,
-		// okay to pass an empty range here because the account value is never a reference, so this can't fail
-		interpreter.EmptyLocationRange,
+		locationRange,
 	)
 }
 
@@ -2068,6 +2070,7 @@ func NewGetAccountFunction(handler AccountHandler) StandardLibraryValue {
 				handler,
 				accountAddress,
 				interpreter.UnauthorizedAccess,
+				invocation.LocationRange,
 			)
 		},
 	)
@@ -2208,7 +2211,7 @@ func newAccountStorageCapabilitiesGetControllerFunction(
 
 			capabilityID := uint64(capabilityIDValue)
 
-			referenceValue := getStorageCapabilityControllerReference(inter, address, capabilityID)
+			referenceValue := getStorageCapabilityControllerReference(inter, address, capabilityID, invocation.LocationRange)
 			if referenceValue == nil {
 				return interpreter.Nil
 			}
@@ -2267,7 +2270,7 @@ func newAccountStorageCapabilitiesGetControllersFunction(
 						return nil
 					}
 
-					referenceValue := getStorageCapabilityControllerReference(inter, address, capabilityID)
+					referenceValue := getStorageCapabilityControllerReference(inter, address, capabilityID, invocation.LocationRange)
 					if referenceValue == nil {
 						panic(errors.NewUnreachableError())
 					}
@@ -2343,7 +2346,7 @@ func newAccountStorageCapabilitiesForEachControllerFunction(
 					break
 				}
 
-				referenceValue := getStorageCapabilityControllerReference(inter, address, capabilityID)
+				referenceValue := getStorageCapabilityControllerReference(inter, address, capabilityID, invocation.LocationRange)
 				if referenceValue == nil {
 					panic(errors.NewUnreachableError())
 				}
@@ -2684,6 +2687,7 @@ func getStorageCapabilityControllerReference(
 	inter *interpreter.Interpreter,
 	address common.Address,
 	capabilityID uint64,
+	locationRange interpreter.LocationRange,
 ) *interpreter.EphemeralReferenceValue {
 
 	capabilityController := getCapabilityController(inter, address, capabilityID)
@@ -2701,8 +2705,7 @@ func getStorageCapabilityControllerReference(
 		interpreter.UnauthorizedAccess,
 		storageCapabilityController,
 		sema.StorageCapabilityControllerType,
-		// okay to pass an empty range here because the account value is never a reference, so this can't fail
-		interpreter.EmptyLocationRange,
+		locationRange,
 	)
 }
 
@@ -3238,6 +3241,7 @@ func getCheckedCapabilityControllerReference(
 	capabilityIDValue interpreter.UInt64Value,
 	wantedBorrowType *sema.ReferenceType,
 	capabilityBorrowType *sema.ReferenceType,
+	locationRange interpreter.LocationRange,
 ) interpreter.ReferenceValue {
 	controller, resultBorrowType := getCheckedCapabilityController(
 		inter,
@@ -3256,6 +3260,7 @@ func getCheckedCapabilityControllerReference(
 		inter,
 		capabilityAddress,
 		resultBorrowType,
+		locationRange,
 	)
 }
 
@@ -3273,6 +3278,7 @@ func BorrowCapabilityController(
 		capabilityID,
 		wantedBorrowType,
 		capabilityBorrowType,
+		locationRange,
 	)
 	if referenceValue == nil {
 		return nil
@@ -3308,6 +3314,7 @@ func CheckCapabilityController(
 		capabilityID,
 		wantedBorrowType,
 		capabilityBorrowType,
+		locationRange,
 	)
 	if referenceValue == nil {
 		return interpreter.FalseValue
@@ -3487,6 +3494,7 @@ func getAccountCapabilityControllerReference(
 	inter *interpreter.Interpreter,
 	address common.Address,
 	capabilityID uint64,
+	locationRange interpreter.LocationRange,
 ) *interpreter.EphemeralReferenceValue {
 
 	capabilityController := getCapabilityController(inter, address, capabilityID)
@@ -3504,8 +3512,7 @@ func getAccountCapabilityControllerReference(
 		interpreter.UnauthorizedAccess,
 		accountCapabilityController,
 		sema.AccountCapabilityControllerType,
-		// okay to pass an empty range here because the account value is never a reference, so this can't fail
-		interpreter.EmptyLocationRange,
+		locationRange,
 	)
 }
 
@@ -3530,7 +3537,7 @@ func newAccountAccountCapabilitiesGetControllerFunction(
 
 			capabilityID := uint64(capabilityIDValue)
 
-			referenceValue := getAccountCapabilityControllerReference(inter, address, capabilityID)
+			referenceValue := getAccountCapabilityControllerReference(inter, address, capabilityID, invocation.LocationRange)
 			if referenceValue == nil {
 				return interpreter.Nil
 			}
@@ -3582,7 +3589,7 @@ func newAccountAccountCapabilitiesGetControllersFunction(
 						return nil
 					}
 
-					referenceValue := getAccountCapabilityControllerReference(inter, address, capabilityID)
+					referenceValue := getAccountCapabilityControllerReference(inter, address, capabilityID, invocation.LocationRange)
 					if referenceValue == nil {
 						panic(errors.NewUnreachableError())
 					}
@@ -3663,7 +3670,7 @@ func newAccountAccountCapabilitiesForEachControllerFunction(
 					break
 				}
 
-				referenceValue := getAccountCapabilityControllerReference(inter, address, capabilityID)
+				referenceValue := getAccountCapabilityControllerReference(inter, address, capabilityID, invocation.LocationRange)
 				if referenceValue == nil {
 					panic(errors.NewUnreachableError())
 				}

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -247,6 +247,8 @@ func NewAccountReferenceValue(
 		authorization,
 		account,
 		sema.AccountType,
+		// okay to pass an empty range here because the account value is never a reference, so this can't fail
+		interpreter.EmptyLocationRange,
 	)
 }
 
@@ -1320,6 +1322,7 @@ func newAccountContractsBorrowFunction(
 				interpreter.UnauthorizedAccess,
 				contractValue,
 				referenceType.Type,
+				invocation.LocationRange,
 			)
 
 			return interpreter.NewSomeValueNonCopying(
@@ -2698,6 +2701,8 @@ func getStorageCapabilityControllerReference(
 		interpreter.UnauthorizedAccess,
 		storageCapabilityController,
 		sema.StorageCapabilityControllerType,
+		// okay to pass an empty range here because the account value is never a reference, so this can't fail
+		interpreter.EmptyLocationRange,
 	)
 }
 
@@ -3499,6 +3504,8 @@ func getAccountCapabilityControllerReference(
 		interpreter.UnauthorizedAccess,
 		accountCapabilityController,
 		sema.AccountCapabilityControllerType,
+		// okay to pass an empty range here because the account value is never a reference, so this can't fail
+		interpreter.EmptyLocationRange,
 	)
 }
 

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -157,7 +157,7 @@ func NewAccountConstructor(creator AccountCreator) StandardLibraryValue {
 				creator,
 				addressValue,
 				interpreter.FullyEntitledAccountAccess,
-				invocation.LocationRange,
+				locationRange,
 			)
 		},
 	)
@@ -208,6 +208,7 @@ func NewGetAuthAccountFunction(handler AccountHandler) StandardLibraryValue {
 			}
 
 			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
 
 			typeParameterPair := invocation.TypeParameterTypes.Oldest()
 			if typeParameterPair == nil {
@@ -231,7 +232,7 @@ func NewGetAuthAccountFunction(handler AccountHandler) StandardLibraryValue {
 				handler,
 				accountAddress,
 				authorization,
-				invocation.LocationRange,
+				locationRange,
 			)
 		},
 	)
@@ -1268,6 +1269,7 @@ func newAccountContractsBorrowFunction(
 		func(invocation interpreter.Invocation) interpreter.Value {
 
 			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
 
 			nameValue, ok := invocation.Arguments[0].(*interpreter.StringValue)
 			if !ok {
@@ -1324,7 +1326,7 @@ func newAccountContractsBorrowFunction(
 				interpreter.UnauthorizedAccess,
 				contractValue,
 				referenceType.Type,
-				invocation.LocationRange,
+				locationRange,
 			)
 
 			return interpreter.NewSomeValueNonCopying(
@@ -2060,17 +2062,21 @@ func NewGetAccountFunction(handler AccountHandler) StandardLibraryValue {
 		getAccountFunctionType,
 		getAccountFunctionDocString,
 		func(invocation interpreter.Invocation) interpreter.Value {
+
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
 			accountAddress, ok := invocation.Arguments[0].(interpreter.AddressValue)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}
 
 			return NewAccountReferenceValue(
-				invocation.Interpreter,
+				inter,
 				handler,
 				accountAddress,
 				interpreter.UnauthorizedAccess,
-				invocation.LocationRange,
+				locationRange,
 			)
 		},
 	)
@@ -2201,6 +2207,7 @@ func newAccountStorageCapabilitiesGetControllerFunction(
 		func(invocation interpreter.Invocation) interpreter.Value {
 
 			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
 
 			// Get capability ID argument
 
@@ -2211,7 +2218,7 @@ func newAccountStorageCapabilitiesGetControllerFunction(
 
 			capabilityID := uint64(capabilityIDValue)
 
-			referenceValue := getStorageCapabilityControllerReference(inter, address, capabilityID, invocation.LocationRange)
+			referenceValue := getStorageCapabilityControllerReference(inter, address, capabilityID, locationRange)
 			if referenceValue == nil {
 				return interpreter.Nil
 			}
@@ -2239,6 +2246,7 @@ func newAccountStorageCapabilitiesGetControllersFunction(
 		func(invocation interpreter.Invocation) interpreter.Value {
 
 			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
 
 			// Get path argument
 
@@ -2270,7 +2278,7 @@ func newAccountStorageCapabilitiesGetControllersFunction(
 						return nil
 					}
 
-					referenceValue := getStorageCapabilityControllerReference(inter, address, capabilityID, invocation.LocationRange)
+					referenceValue := getStorageCapabilityControllerReference(inter, address, capabilityID, locationRange)
 					if referenceValue == nil {
 						panic(errors.NewUnreachableError())
 					}
@@ -2346,7 +2354,7 @@ func newAccountStorageCapabilitiesForEachControllerFunction(
 					break
 				}
 
-				referenceValue := getStorageCapabilityControllerReference(inter, address, capabilityID, invocation.LocationRange)
+				referenceValue := getStorageCapabilityControllerReference(inter, address, capabilityID, locationRange)
 				if referenceValue == nil {
 					panic(errors.NewUnreachableError())
 				}
@@ -3527,6 +3535,7 @@ func newAccountAccountCapabilitiesGetControllerFunction(
 		func(invocation interpreter.Invocation) interpreter.Value {
 
 			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
 
 			// Get capability ID argument
 
@@ -3537,7 +3546,7 @@ func newAccountAccountCapabilitiesGetControllerFunction(
 
 			capabilityID := uint64(capabilityIDValue)
 
-			referenceValue := getAccountCapabilityControllerReference(inter, address, capabilityID, invocation.LocationRange)
+			referenceValue := getAccountCapabilityControllerReference(inter, address, capabilityID, locationRange)
 			if referenceValue == nil {
 				return interpreter.Nil
 			}
@@ -3565,6 +3574,7 @@ func newAccountAccountCapabilitiesGetControllersFunction(
 		func(invocation interpreter.Invocation) interpreter.Value {
 
 			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
 
 			// Get capability controllers iterator
 
@@ -3589,7 +3599,12 @@ func newAccountAccountCapabilitiesGetControllersFunction(
 						return nil
 					}
 
-					referenceValue := getAccountCapabilityControllerReference(inter, address, capabilityID, invocation.LocationRange)
+					referenceValue := getAccountCapabilityControllerReference(
+						inter,
+						address,
+						capabilityID,
+						locationRange,
+					)
 					if referenceValue == nil {
 						panic(errors.NewUnreachableError())
 					}
@@ -3670,7 +3685,7 @@ func newAccountAccountCapabilitiesForEachControllerFunction(
 					break
 				}
 
-				referenceValue := getAccountCapabilityControllerReference(inter, address, capabilityID, invocation.LocationRange)
+				referenceValue := getAccountCapabilityControllerReference(inter, address, capabilityID, locationRange)
 				if referenceValue == nil {
 					panic(errors.NewUnreachableError())
 				}

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -397,6 +397,7 @@ func testAccountWithErrorHandler(
 			interpreter.FullyEntitledAccountAccess,
 			account,
 			sema.AccountType,
+			interpreter.EmptyLocationRange,
 		),
 		Kind: common.DeclarationKindConstant,
 	}
@@ -412,6 +413,7 @@ func testAccountWithErrorHandler(
 			interpreter.UnauthorizedAccess,
 			account,
 			sema.AccountType,
+			interpreter.EmptyLocationRange,
 		),
 		Kind: common.DeclarationKindConstant,
 	}

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -939,6 +939,7 @@ func TestInterpretDictionaryMutation(t *testing.T) {
 			nil,
 			interpreter.AddressValue{1},
 			interpreter.UnauthorizedAccess,
+			interpreter.EmptyLocationRange,
 		)
 
 		_, err := inter.Invoke("test", owner)

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -8537,6 +8537,7 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 							nil,
 							addressValue,
 							interpreter.FullyEntitledAccountAccess,
+							interpreter.EmptyLocationRange,
 						)
 
 						return map[string]interpreter.Value{
@@ -9095,6 +9096,7 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 			nil,
 			interpreter.AddressValue(address),
 			interpreter.FullyEntitledAccountAccess,
+			interpreter.EmptyLocationRange,
 		),
 		Kind: common.DeclarationKindConstant,
 	}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7308,6 +7308,7 @@ func TestInterpretReferenceEventParameter(t *testing.T) {
 		interpreter.UnauthorizedAccess,
 		arrayValue,
 		inter.MustConvertStaticToSemaType(arrayStaticType),
+		interpreter.EmptyLocationRange,
 	)
 
 	_, err = inter.Invoke("test", ref)

--- a/runtime/tests/interpreter/member_test.go
+++ b/runtime/tests/interpreter/member_test.go
@@ -409,7 +409,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
 
-				ref := interpreter.NewUnmeteredEphemeralReferenceValue(interpreter.UnauthorizedAccess, value, sType)
+				ref := interpreter.NewUnmeteredEphemeralReferenceValue(interpreter.UnauthorizedAccess, value, sType, interpreter.EmptyLocationRange)
 
 				_, err = inter.Invoke("get", ref)
 				require.NoError(t, err)
@@ -456,7 +456,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
 
-				ref := interpreter.NewUnmeteredEphemeralReferenceValue(interpreter.UnauthorizedAccess, value, sType)
+				ref := interpreter.NewUnmeteredEphemeralReferenceValue(interpreter.UnauthorizedAccess, value, sType, interpreter.EmptyLocationRange)
 
 				_, err = inter.Invoke("get", ref)
 				RequireError(t, err)
@@ -498,7 +498,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
 
-				ref := interpreter.NewUnmeteredEphemeralReferenceValue(interpreter.UnauthorizedAccess, value, sType)
+				ref := interpreter.NewUnmeteredEphemeralReferenceValue(interpreter.UnauthorizedAccess, value, sType, interpreter.EmptyLocationRange)
 
 				_, err = inter.Invoke(
 					"get",
@@ -543,7 +543,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				sType := checker.RequireGlobalType(t, inter.Program.Elaboration, "S")
 
-				ref := interpreter.NewUnmeteredEphemeralReferenceValue(interpreter.UnauthorizedAccess, value, sType)
+				ref := interpreter.NewUnmeteredEphemeralReferenceValue(interpreter.UnauthorizedAccess, value, sType, interpreter.EmptyLocationRange)
 
 				_, err = inter.Invoke(
 					"get",

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -710,6 +710,7 @@ func TestInterpretSimpleCompositeMetering(t *testing.T) {
 			nil,
 			interpreter.AddressValue(address),
 			interpreter.UnauthorizedAccess,
+			interpreter.EmptyLocationRange,
 		)
 
 		_, err := inter.Invoke("main", account)
@@ -6687,7 +6688,7 @@ func TestInterpretStorageReferenceValueMetering(t *testing.T) {
 			1,
 			sema.Conjunction,
 		)
-		account := stdlib.NewAccountReferenceValue(inter, nil, interpreter.AddressValue(address), authorization)
+		account := stdlib.NewAccountReferenceValue(inter, nil, interpreter.AddressValue(address), authorization, interpreter.EmptyLocationRange)
 
 		_, err := inter.Invoke("main", account)
 		require.NoError(t, err)
@@ -8637,6 +8638,7 @@ func TestInterpretStorageMapMetering(t *testing.T) {
 		nil,
 		address,
 		authorization,
+		interpreter.EmptyLocationRange,
 	)
 
 	_, err := inter.Invoke("main", account)

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -1761,4 +1761,21 @@ func TestInterpretReferenceToReference(t *testing.T) {
 
 		require.ErrorAs(t, err, &interpreter.NestedReferenceError{})
 	})
+
+	t.Run("optional", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            fun main() {
+                let x: (&Int)? = &1 as &Int
+                let y: (&(&Int))? = &x 
+            }
+        `)
+
+		_, err := inter.Invoke("main")
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.NestedReferenceError{})
+	})
 }

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -658,6 +658,7 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 			&sema.VariableSizedType{
 				Type: rType,
 			},
+			interpreter.EmptyLocationRange,
 		)
 
 		_, err := inter.Invoke("test", arrayRef)
@@ -763,6 +764,7 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 			&sema.VariableSizedType{
 				Type: rType,
 			},
+			interpreter.EmptyLocationRange,
 		)
 
 		// Resource array in account 0x02
@@ -787,6 +789,7 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 			&sema.VariableSizedType{
 				Type: rType,
 			},
+			interpreter.EmptyLocationRange,
 		)
 
 		_, err := inter.Invoke("test", arrayRef1, arrayRef2)
@@ -858,6 +861,7 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 			&sema.VariableSizedType{
 				Type: rType,
 			},
+			interpreter.EmptyLocationRange,
 		)
 
 		_, err := inter.Invoke("test", arrayRef)
@@ -982,6 +986,7 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 			&sema.VariableSizedType{
 				Type: rType,
 			},
+			interpreter.EmptyLocationRange,
 		)
 
 		_, err = inter.Invoke("setup", arrayRef)
@@ -1718,4 +1723,42 @@ func TestInterpretInvalidatedReferenceToOptional(t *testing.T) {
 
 	_, err := inter.Invoke("main")
 	require.NoError(t, err)
+}
+
+func TestInterpretReferenceToReference(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            fun main() {
+                let x = &1 as &Int
+                let y = &x as & &Int
+            }
+        `)
+
+		_, err := inter.Invoke("main")
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.NestedReferenceError{})
+	})
+
+	t.Run("upcast to anystruct", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            fun main() {
+                let x = &1 as &Int as AnyStruct
+                let y = &x as &AnyStruct
+            }
+        `)
+
+		_, err := inter.Invoke("main")
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.NestedReferenceError{})
+	})
 }

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -252,8 +252,8 @@ func TestInterpretTransactions(t *testing.T) {
           }
         `)
 
-		signer1 := stdlib.NewAccountReferenceValue(nil, nil, interpreter.AddressValue{1}, interpreter.UnauthorizedAccess)
-		signer2 := stdlib.NewAccountReferenceValue(nil, nil, interpreter.AddressValue{2}, interpreter.UnauthorizedAccess)
+		signer1 := stdlib.NewAccountReferenceValue(nil, nil, interpreter.AddressValue{1}, interpreter.UnauthorizedAccess, interpreter.EmptyLocationRange)
+		signer2 := stdlib.NewAccountReferenceValue(nil, nil, interpreter.AddressValue{2}, interpreter.UnauthorizedAccess, interpreter.EmptyLocationRange)
 
 		// first transaction
 		err := inter.InvokeTransaction(0, signer1)
@@ -293,6 +293,7 @@ func TestInterpretTransactions(t *testing.T) {
 			nil,
 			interpreter.AddressValue(address),
 			interpreter.UnauthorizedAccess,
+			interpreter.EmptyLocationRange,
 		)
 
 		prepareArguments := []interpreter.Value{account}

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -223,6 +223,8 @@ func (executor *interpreterTransactionExecutor) authorizerValues(
 			authorization,
 			accountValue,
 			sema.AccountType,
+			// okay to pass an empty range here because the account value is never a reference, so this can't fail
+			interpreter.EmptyLocationRange,
 		)
 
 		authorizerValues = append(authorizerValues, accountReferenceValue)


### PR DESCRIPTION
Part of https://github.com/onflow/cadence/issues/2873

Throw a runtime error when attempting to create an `EphemeralReferenceValue` whose underlying value is also an `EphemeralReferenceValue`.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
