### PR TITLE
Cleanup reference tracking

### DIFF
--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -239,10 +239,8 @@ func exportValueWithInterpreter(
 		defer delete(seenReferences, v)
 		seenReferences[v] = struct{}{}
 
-		referencedValue := v.MustReferencedValue(inter, locationRange)
-
 		return exportValueWithInterpreter(
-			referencedValue,
+			v.Value,
 			inter,
 			locationRange,
 			seenReferences,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -5158,7 +5158,7 @@ func (interpreter *Interpreter) trackReferencedResourceKindedValue(
 }
 
 // TODO: Remove the `destroyed` flag
-func (interpreter *Interpreter) invalidateReferencedResources(value Value, destroyed bool) {
+func (interpreter *Interpreter) invalidateReferencedResources(value Value) {
 	// skip non-resource typed values
 	if !value.IsResourceKinded(interpreter) {
 		return
@@ -5169,25 +5169,25 @@ func (interpreter *Interpreter) invalidateReferencedResources(value Value, destr
 	switch value := value.(type) {
 	case *CompositeValue:
 		value.ForEachLoadedField(interpreter, func(_ string, fieldValue Value) (resume bool) {
-			interpreter.invalidateReferencedResources(fieldValue, destroyed)
+			interpreter.invalidateReferencedResources(fieldValue)
 			// continue iteration
 			return true
 		})
 		storageID = value.StorageID()
 	case *DictionaryValue:
 		value.IterateLoaded(interpreter, func(_, value Value) (resume bool) {
-			interpreter.invalidateReferencedResources(value, destroyed)
+			interpreter.invalidateReferencedResources(value)
 			return true
 		})
 		storageID = value.StorageID()
 	case *ArrayValue:
 		value.IterateLoaded(interpreter, func(element Value) (resume bool) {
-			interpreter.invalidateReferencedResources(element, destroyed)
+			interpreter.invalidateReferencedResources(element)
 			return true
 		})
 		storageID = value.StorageID()
 	case *SomeValue:
-		interpreter.invalidateReferencedResources(value.value, destroyed)
+		interpreter.invalidateReferencedResources(value.value)
 		return
 	default:
 		// skip non-container typed values.

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -20487,6 +20487,21 @@ func (v *EphemeralReferenceValue) ForEach(
 	)
 }
 
+func (v *EphemeralReferenceValue) checkValidity(
+	interpreter *Interpreter,
+	locationRange LocationRange,
+) Value {
+	referencedValue := v.ReferencedValue(interpreter, locationRange, true)
+	if referencedValue == nil {
+		panic(DereferenceError{
+			Cause:         "the value being referenced has been destroyed or moved",
+			LocationRange: locationRange,
+		})
+	}
+
+	return *referencedValue
+}
+
 // AddressValue
 type AddressValue common.Address
 


### PR DESCRIPTION
Closes #???

## Description

Since https://github.com/onflow/cadence/pull/2968 introduced a check for checking the reference validity (only for ephemeral references) at the end of each expression evaluation (similar to resource validity), it is no longer required to check the validity of ephemeral references before each operation explicitly.

This PR clean-sup that tech debt.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
