### PR TITLE
Static check to prevent nested references

### DIFF
--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -84,12 +84,19 @@ func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.Refere
 	referencedType, actualType := checker.visitExpression(referencedExpression, expectedLeftType)
 
 	// check that the type of the referenced value is not itself a reference
-	if nestedReference, isNestedReference := actualType.(*ReferenceType); isNestedReference {
-		checker.report(&NestedReferenceError{
-			Type:  nestedReference,
-			Range: checker.expressionRange(referenceExpression),
-		})
+	var requireNoReferenceNesting func(actualType Type)
+	requireNoReferenceNesting = func(actualType Type) {
+		switch nestedReference := actualType.(type) {
+		case *ReferenceType:
+			checker.report(&NestedReferenceError{
+				Type:  nestedReference,
+				Range: checker.expressionRange(referenceExpression),
+			})
+		case *OptionalType:
+			requireNoReferenceNesting(nestedReference.Type)
+		}
 	}
+	requireNoReferenceNesting(actualType)
 
 	hasErrors := len(checker.errors) > beforeErrors
 	if !hasErrors {

--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -83,6 +83,14 @@ func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.Refere
 
 	referencedType, actualType := checker.visitExpression(referencedExpression, expectedLeftType)
 
+	// check that the type of the referenced value is not itself a reference
+	if nestedReference, isNestedReference := actualType.(*ReferenceType); isNestedReference {
+		checker.report(&NestedReferenceError{
+			Type:  nestedReference,
+			Range: checker.expressionRange(referenceExpression),
+		})
+	}
+
 	hasErrors := len(checker.errors) > beforeErrors
 	if !hasErrors {
 		// If the reference type was an optional type,

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -4694,3 +4694,20 @@ func (*InvalidTypeParameterizedNonNativeFunctionError) IsUserError() {}
 func (e *InvalidTypeParameterizedNonNativeFunctionError) Error() string {
 	return "invalid type parameters in non-native function"
 }
+
+// NestedReferenceError
+type NestedReferenceError struct {
+	Type *ReferenceType
+	ast.Range
+}
+
+var _ SemanticError = &NestedReferenceError{}
+var _ errors.UserError = &NestedReferenceError{}
+
+func (*NestedReferenceError) isSemanticError() {}
+
+func (*NestedReferenceError) IsUserError() {}
+
+func (e *NestedReferenceError) Error() string {
+	return fmt.Sprintf("cannot create a nested reference to value of type %s", e.Type.QualifiedString())
+}

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -3106,4 +3106,18 @@ func TestCheckNestedReference(t *testing.T) {
 		errors := RequireCheckerErrors(t, err, 1)
 		require.IsType(t, &sema.NestedReferenceError{}, errors[0])
 	})
+
+	t.Run("nested optional", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            fun main() {
+                let x: &Int?? = &1 as &Int
+                let y = &x as &AnyStruct?
+            }
+        `)
+
+		errors := RequireCheckerErrors(t, err, 1)
+		require.IsType(t, &sema.NestedReferenceError{}, errors[0])
+	})
 }

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -1747,7 +1747,7 @@ func TestInterpretReferenceToReference(t *testing.T) {
         `, ParseCheckAndInterpretOptions{
 			HandleCheckerError: func(err error) {
 				errs := checker.RequireCheckerErrors(t, err, 1)
-				require.IsType(t, errs[0], &sema.NestedReferenceError{})
+				require.IsType(t, &sema.NestedReferenceError{}, errs[0])
 			},
 		})
 		require.NoError(t, err)

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -1779,10 +1779,33 @@ func TestInterpretReferenceToReference(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter, err := parseCheckAndInterpretWithOptions(t, `
             fun main() {
                 let x: (&Int)? = &1 as &Int
                 let y: (&(&Int))? = &x 
+            }
+        `, ParseCheckAndInterpretOptions{
+			HandleCheckerError: func(err error) {
+				errs := checker.RequireCheckerErrors(t, err, 1)
+				require.IsType(t, &sema.NestedReferenceError{}, errs[0])
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("main")
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.NestedReferenceError{})
+	})
+
+	t.Run("upcast to optional anystruct", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            fun main() {
+                let x = &1 as &Int as AnyStruct?
+                let y = &x as &AnyStruct?
             }
         `)
 


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2873

While we cannot prevent the creation of nested references entirely at runtime, we can do a best effort static check here to catch as many cases as possible.

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
