### PR TITLE
Fix GetNativeCompositeValueComputedFields

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4601,11 +4601,15 @@ func (interpreter *Interpreter) GetContractComposite(contractLocation common.Add
 	return contractValue, nil
 }
 
-func GetNativeCompositeValueComputedFields(v *CompositeValue) map[string]ComputedField {
-	switch v.QualifiedIdentifier {
+func GetNativeCompositeValueComputedFields(qualifiedIdentifier string) map[string]ComputedField {
+	switch qualifiedIdentifier {
 	case sema.PublicKeyType.Identifier:
 		return map[string]ComputedField{
-			sema.PublicKeyTypePublicKeyFieldName: func(interpreter *Interpreter, locationRange LocationRange) Value {
+			sema.PublicKeyTypePublicKeyFieldName: func(
+				interpreter *Interpreter,
+				locationRange LocationRange,
+				v *CompositeValue,
+			) Value {
 				publicKeyValue := v.GetField(interpreter, locationRange, sema.PublicKeyTypePublicKeyFieldName)
 				return publicKeyValue.Transfer(
 					interpreter,
@@ -4626,7 +4630,7 @@ func (interpreter *Interpreter) GetCompositeValueComputedFields(v *CompositeValu
 
 	var computedFields map[string]ComputedField
 	if v.Location == nil {
-		computedFields = GetNativeCompositeValueComputedFields(v)
+		computedFields = GetNativeCompositeValueComputedFields(v.QualifiedIdentifier)
 		if computedFields != nil {
 			return computedFields
 		}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -16312,7 +16312,7 @@ type CompositeValue struct {
 	isDestroyed         bool
 }
 
-type ComputedField func(*Interpreter, LocationRange) Value
+type ComputedField func(*Interpreter, LocationRange, *CompositeValue) Value
 
 type CompositeField struct {
 	Value Value
@@ -16744,7 +16744,7 @@ func (v *CompositeValue) GetComputedField(interpreter *Interpreter, locationRang
 		return nil
 	}
 
-	return computedField(interpreter, locationRange)
+	return computedField(interpreter, locationRange, v)
 }
 
 func (v *CompositeValue) GetInjectedField(interpreter *Interpreter, name string) Value {
@@ -17198,7 +17198,7 @@ func (v *CompositeValue) ConformsToStaticType(
 				return false
 			}
 
-			value = fieldGetter(interpreter, locationRange)
+			value = fieldGetter(interpreter, locationRange, v)
 		}
 
 		member, ok := compositeType.Members.Get(fieldName)


### PR DESCRIPTION

## Description

Pass and use the current composite value, do not keep using the "cached" initial value.
This is necessary, because `CompositeValue.Transfer` also transfers (for a struct, copies) `computedFields` (and also `injectedFields`), which previously effectively kept referring to the source value, not the transferred value.  

Discovered while updating the Emulator to the latest Cadence commit.

Sill wondering how to test the bug and prevent a regression.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
