### PR TITLE
Remove deprecated domain separation tag from Crypto contract

### DIFF
--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -67,7 +67,8 @@ func TestRuntimeCrypto_verify(t *testing.T) {
 
           return keyList.verify(
               signatureSet: signatureSet,
-              signedData: "0506".decodeHex()
+              signedData: "0506".decodeHex(),
+              domainSeparationTag: "foo"
           )
       }
     `)
@@ -88,7 +89,7 @@ func TestRuntimeCrypto_verify(t *testing.T) {
 		) (bool, error) {
 			called = true
 			assert.Equal(t, []byte{3, 4}, signature)
-			assert.Equal(t, "FLOW-V0.0-user", tag)
+			assert.Equal(t, "foo", tag)
 			assert.Equal(t, []byte{5, 6}, signedData)
 			assert.Equal(t, []byte{1, 2}, publicKey)
 			assert.Equal(t, SignatureAlgorithmECDSA_P256, signatureAlgorithm)

--- a/runtime/stdlib/contracts/crypto.cdc
+++ b/runtime/stdlib/contracts/crypto.cdc
@@ -1,20 +1,33 @@
 
 access(all) contract Crypto {
 
-    access(all) fun hash(_ data: [UInt8], algorithm: HashAlgorithm): [UInt8] {
+    access(all)
+    fun hash(_ data: [UInt8], algorithm: HashAlgorithm): [UInt8] {
         return algorithm.hash(data)
     }
 
-    access(all) fun hashWithTag(_ data: [UInt8], tag: String, algorithm: HashAlgorithm): [UInt8] {
+    access(all)
+    fun hashWithTag(_ data: [UInt8], tag: String, algorithm: HashAlgorithm): [UInt8] {
         return algorithm.hashWithTag(data, tag: tag)
     }
 
-    access(all) struct KeyListEntry {
-        access(all) let keyIndex: Int
-        access(all) let publicKey: PublicKey
-        access(all) let hashAlgorithm: HashAlgorithm
-        access(all) let weight: UFix64
-        access(all) let isRevoked: Bool
+    access(all)
+    struct KeyListEntry {
+
+        access(all)
+        let keyIndex: Int
+
+        access(all)
+        let publicKey: PublicKey
+
+        access(all)
+        let hashAlgorithm: HashAlgorithm
+
+        access(all)
+        let weight: UFix64
+
+        access(all)
+        let isRevoked: Bool
 
         init(
             keyIndex: Int,
@@ -31,16 +44,19 @@ access(all) contract Crypto {
         }
     }
 
-    access(all) struct KeyList {
+    access(all)
+    struct KeyList {
 
-        access(self) let entries: [KeyListEntry]
+        access(self)
+        let entries: [KeyListEntry]
 
         init() {
             self.entries = []
         }
 
         /// Adds a new key with the given weight
-        access(all) fun add(
+        access(all)
+        fun add(
             _ publicKey: PublicKey,
             hashAlgorithm: HashAlgorithm,
             weight: UFix64
@@ -59,8 +75,9 @@ access(all) contract Crypto {
         }
 
         /// Returns the key at the given index, if it exists.
-        /// Revoked keys are always returned, but they have `isRevoked` field set to true
-        access(all) fun get(keyIndex: Int): KeyListEntry? {
+        /// Revoked keys are always returned, but they have the `isRevoked` field set to true
+        access(all)
+        fun get(keyIndex: Int): KeyListEntry? {
             if keyIndex >= self.entries.length {
                 return nil
             }
@@ -69,10 +86,12 @@ access(all) contract Crypto {
         }
 
         /// Marks the key at the given index revoked, but does not delete it
-        access(all) fun revoke(keyIndex: Int) {
+        access(all)
+        fun revoke(keyIndex: Int) {
             if keyIndex >= self.entries.length {
                 return
             }
+
             let currentEntry = self.entries[keyIndex]
             self.entries[keyIndex] = KeyListEntry(
                 keyIndex: currentEntry.keyIndex,
@@ -84,9 +103,11 @@ access(all) contract Crypto {
         }
 
         /// Returns true if the given signatures are valid for the given signed data
-        access(all) fun verify(
+        access(all)
+        fun verify(
             signatureSet: [KeyListSignature],
-            signedData: [UInt8]
+            signedData: [UInt8],
+            domainSeparationTag: String
         ): Bool {
 
             var validWeights: UFix64 = 0.0
@@ -126,7 +147,7 @@ access(all) contract Crypto {
                 if !key.publicKey.verify(
                     signature: signature.signature,
                     signedData: signedData,
-                    domainSeparationTag: Crypto.domainSeparationTagUser,
+                    domainSeparationTag: domainSeparationTag,
                     hashAlgorithm:key.hashAlgorithm
                 ) {
                     return false
@@ -139,19 +160,18 @@ access(all) contract Crypto {
         }
     }
 
-    access(all) struct KeyListSignature {
-        access(all) let keyIndex: Int
-        access(all) let signature: [UInt8]
+    access(all)
+    struct KeyListSignature {
 
-        access(all) init(keyIndex: Int, signature: [UInt8]) {
+        access(all)
+        let keyIndex: Int
+
+        access(all)
+        let signature: [UInt8]
+
+        init(keyIndex: Int, signature: [UInt8]) {
             self.keyIndex = keyIndex
             self.signature = signature
         }
-    }
-
-    access(self) let domainSeparationTagUser: String
-
-    init() {
-        self.domainSeparationTagUser = "FLOW-V0.0-user"
     }
 }

--- a/runtime/stdlib/contracts/crypto_test.cdc
+++ b/runtime/stdlib/contracts/crypto_test.cdc
@@ -133,7 +133,8 @@ fun testKeyListVerify() {
 
     let isValid = keyList.verify(
         signatureSet: signatureSet,
-        signedData: signedData
+        signedData: signedData,
+        domainSeparationTag: "FLOW-V0.0-user"
     )
 
     Test.assert(isValid)
@@ -185,7 +186,8 @@ fun testKeyListVerifyInsufficientWeights() {
 
     let isValid = keyList.verify(
         signatureSet: signatureSet,
-        signedData: signedData
+        signedData: signedData,
+        domainSeparationTag: "FLOW-V0.0-user"
     )
 
     Test.assert(!isValid)
@@ -221,7 +223,8 @@ fun testKeyListVerifyWithRevokedKey() {
 
     let isValid = keyList.verify(
         signatureSet: signatureSet,
-        signedData: signedData
+        signedData: signedData,
+        domainSeparationTag: "FLOW-V0.0-user"
     )
 
     Test.assert(!isValid)
@@ -255,7 +258,8 @@ fun testKeyListVerifyWithMissingSignature() {
 
     let isValid = keyList.verify(
         signatureSet: signatureSet,
-        signedData: signedData
+        signedData: signedData,
+        domainSeparationTag: "FLOW-V0.0-user"
     )
 
     Test.assert(!isValid)
@@ -294,7 +298,8 @@ fun testKeyListVerifyDuplicateSignature() {
 
     let isValid = keyList.verify(
         signatureSet: signatureSet,
-        signedData: signedData
+        signedData: signedData,
+        domainSeparationTag: "FLOW-V0.0-user"
     )
 
     Test.assert(!isValid)
@@ -328,7 +333,8 @@ fun testKeyListVerifyInvalidSignature() {
 
     let isValid = keyList.verify(
         signatureSet: signatureSet,
-        signedData: signedData
+        signedData: signedData,
+        domainSeparationTag: "FLOW-V0.0-user"
     )
 
     Test.assert(!isValid)


### PR DESCRIPTION
Closes #1447

## Description

- Add `domainSeparationTag` parameter to `Crypto.KeyList.verify`
- Remove field `Crypto.domainSeparationTagUser`

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
