### PR TITLE
Report bespoke error for restricted types parsed as type arguments

### DIFF
--- a/runtime/parser/errors.go
+++ b/runtime/parser/errors.go
@@ -318,3 +318,28 @@ func (e *CustomDestructorError) Error() string {
 func (e *CustomDestructorError) SecondaryError() string {
 	return "remove the destructor definition"
 }
+
+// RestrictedTypeError
+
+type RestrictedTypeError struct {
+	Pos ast.Position
+}
+
+var _ ParseError = &CustomDestructorError{}
+var _ errors.UserError = &CustomDestructorError{}
+
+func (*RestrictedTypeError) isParseError() {}
+
+func (*RestrictedTypeError) IsUserError() {}
+
+func (e *RestrictedTypeError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *RestrictedTypeError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Pos
+}
+
+func (e *RestrictedTypeError) Error() string {
+	return "restricted types have been removed; replace with the concrete type or an equivalent intersection type"
+}

--- a/runtime/parser/errors.go
+++ b/runtime/parser/errors.go
@@ -322,7 +322,7 @@ func (e *CustomDestructorError) SecondaryError() string {
 // RestrictedTypeError
 
 type RestrictedTypeError struct {
-	Pos ast.Position
+	ast.Range
 }
 
 var _ ParseError = &CustomDestructorError{}
@@ -331,14 +331,6 @@ var _ errors.UserError = &CustomDestructorError{}
 func (*RestrictedTypeError) isParseError() {}
 
 func (*RestrictedTypeError) IsUserError() {}
-
-func (e *RestrictedTypeError) StartPosition() ast.Position {
-	return e.Pos
-}
-
-func (e *RestrictedTypeError) EndPosition(_ common.MemoryGauge) ast.Position {
-	return e.Pos
-}
 
 func (e *RestrictedTypeError) Error() string {
 	return "restricted types have been removed; replace with the concrete type or an equivalent intersection type"

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -642,7 +642,7 @@ func defineLessThanOrTypeArgumentsExpression() {
 
 				// if the error specifically occurred during parsing restricted types,
 				// this is still an invocation and we should report that error instead
-				if strings.Contains(err.Error(), "restricted type") {
+				if _, isRestrictedTypeErr := err.(*RestrictedTypeError); isRestrictedTypeErr {
 					return nil, err, true
 				}
 

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -601,7 +601,7 @@ func defineLessThanOrTypeArgumentsExpression() {
 				return nil
 			}()
 
-			// `err` is nil means the expression is an invocation,
+			// `err` is nil means the expression is an invocation
 			if err == nil {
 
 				// The expression was determined to be an invocation.

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -601,7 +601,7 @@ func defineLessThanOrTypeArgumentsExpression() {
 				return nil
 			}()
 
-			// `err` is nil means the expression is an invocation
+			// `err` is nil means the expression is an invocation,
 			if err == nil {
 
 				// The expression was determined to be an invocation.
@@ -639,6 +639,12 @@ func defineLessThanOrTypeArgumentsExpression() {
 				return invocationExpression, nil, false
 
 			} else {
+
+				// if the error specifically occurred during parsing restricted types,
+				// this is still an invocation and we should report that error instead
+				if strings.Contains(err.Error(), "restricted type") {
+					return nil, err, true
+				}
 
 				// The previous attempt to parse an invocation failed,
 				// replay the buffered tokens.

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -4483,7 +4483,10 @@ func TestParseLessThanOrTypeArguments(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&RestrictedTypeError{
-					Pos: ast.Position{Offset: 6, Line: 1, Column: 6},
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 6, Line: 1, Column: 6},
+						EndPos:   ast.Position{Offset: 6, Line: 1, Column: 6},
+					},
 				},
 			},
 			errs,

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -4474,6 +4474,22 @@ func TestParseLessThanOrTypeArguments(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("restricted type argument", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseExpression("foo<X{T}>")
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "restricted types have been removed; replace with the concrete type or an equivalent intersection type",
+					Pos:     ast.Position{Offset: 6, Line: 1, Column: 6},
+				},
+			},
+			errs,
+		)
+	})
 }
 
 func TestParseBoolExpression(t *testing.T) {

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -4482,9 +4482,8 @@ func TestParseLessThanOrTypeArguments(t *testing.T) {
 		_, errs := testParseExpression("foo<X{T}>")
 		utils.AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "restricted types have been removed; replace with the concrete type or an equivalent intersection type",
-					Pos:     ast.Position{Offset: 6, Line: 1, Column: 6},
+				&RestrictedTypeError{
+					Pos: ast.Position{Offset: 6, Line: 1, Column: 6},
 				},
 			},
 			errs,

--- a/runtime/parser/parser_test.go
+++ b/runtime/parser/parser_test.go
@@ -538,9 +538,8 @@ func TestParseBuffering(t *testing.T) {
 
 		utils.AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "restricted types have been removed; replace with the concrete type or an equivalent intersection type",
-					Pos:     ast.Position{Offset: 138, Line: 4, Column: 55},
+				&RestrictedTypeError{
+					Pos: ast.Position{Offset: 138, Line: 4, Column: 55},
 				},
 			},
 			err.(Error).Errors,

--- a/runtime/parser/parser_test.go
+++ b/runtime/parser/parser_test.go
@@ -506,7 +506,7 @@ func TestParseBuffering(t *testing.T) {
 
           fun isneg(x: SignedFixedPoint): Bool {   /* I kinda forget what this is all about */
               return x                             /* but we probably need to figure it out */
-                     <                             /* ************/((TODO?{/*))************ *//
+                     <                             /* ************/((TODO?/*))************ *//
                     -x                             /* maybe it says NaNs are not negative?  */
           }
         `
@@ -515,7 +515,7 @@ func TestParseBuffering(t *testing.T) {
 			[]error{
 				&SyntaxError{
 					Message: "expected token identifier",
-					Pos:     ast.Position{Offset: 399, Line: 9, Column: 95},
+					Pos:     ast.Position{Offset: 398, Line: 9, Column: 94},
 				},
 			},
 			err.(Error).Errors,
@@ -539,8 +539,8 @@ func TestParseBuffering(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "expected token identifier",
-					Pos:     ast.Position{Offset: 146, Line: 4, Column: 63},
+					Message: "restricted types have been removed; replace with the concrete type or an equivalent intersection type",
+					Pos:     ast.Position{Offset: 138, Line: 4, Column: 55},
 				},
 			},
 			err.(Error).Errors,

--- a/runtime/parser/parser_test.go
+++ b/runtime/parser/parser_test.go
@@ -539,7 +539,10 @@ func TestParseBuffering(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&RestrictedTypeError{
-					Pos: ast.Position{Offset: 138, Line: 4, Column: 55},
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 138, Line: 4, Column: 55},
+						EndPos:   ast.Position{Offset: 139, Line: 4, Column: 56},
+					},
 				},
 			},
 			err.(Error).Errors,

--- a/runtime/parser/type.go
+++ b/runtime/parser/type.go
@@ -503,7 +503,7 @@ func defineIntersectionOrDictionaryType() {
 				return left, nil, true
 			}
 
-			return nil, &RestrictedTypeError{Pos: p.current.StartPos}, true
+			return nil, &RestrictedTypeError{Range: p.current.Range}, true
 		},
 	)
 }

--- a/runtime/parser/type.go
+++ b/runtime/parser/type.go
@@ -503,7 +503,7 @@ func defineIntersectionOrDictionaryType() {
 				return left, nil, true
 			}
 
-			return nil, p.syntaxError("restricted types have been removed; replace with the concrete type or an equivalent intersection type"), true
+			return nil, &RestrictedTypeError{Pos: p.current.StartPos}, true
 		},
 	)
 }

--- a/runtime/parser/type_test.go
+++ b/runtime/parser/type_test.go
@@ -555,9 +555,8 @@ func TestParseIntersectionType(t *testing.T) {
 
 		utils.AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "restricted types have been removed; replace with the concrete type or an equivalent intersection type",
-					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
+				&RestrictedTypeError{
+					Pos: ast.Position{Offset: 2, Line: 1, Column: 2},
 				},
 			},
 			errs,
@@ -571,9 +570,8 @@ func TestParseIntersectionType(t *testing.T) {
 		_, errs := testParseType("T{U}")
 		utils.AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "restricted types have been removed; replace with the concrete type or an equivalent intersection type",
-					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
+				&RestrictedTypeError{
+					Pos: ast.Position{Offset: 2, Line: 1, Column: 2},
 				},
 			},
 			errs,
@@ -587,9 +585,8 @@ func TestParseIntersectionType(t *testing.T) {
 		_, errs := testParseType("T{U , V }")
 		utils.AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "restricted types have been removed; replace with the concrete type or an equivalent intersection type",
-					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
+				&RestrictedTypeError{
+					Pos: ast.Position{Offset: 2, Line: 1, Column: 2},
 				},
 			},
 			errs,

--- a/runtime/parser/type_test.go
+++ b/runtime/parser/type_test.go
@@ -556,7 +556,10 @@ func TestParseIntersectionType(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&RestrictedTypeError{
-					Pos: ast.Position{Offset: 2, Line: 1, Column: 2},
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 2, Line: 1, Column: 2},
+						EndPos:   ast.Position{Offset: 2, Line: 1, Column: 2},
+					},
 				},
 			},
 			errs,
@@ -571,7 +574,10 @@ func TestParseIntersectionType(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&RestrictedTypeError{
-					Pos: ast.Position{Offset: 2, Line: 1, Column: 2},
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 2, Line: 1, Column: 2},
+						EndPos:   ast.Position{Offset: 2, Line: 1, Column: 2},
+					},
 				},
 			},
 			errs,
@@ -586,7 +592,10 @@ func TestParseIntersectionType(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&RestrictedTypeError{
-					Pos: ast.Position{Offset: 2, Line: 1, Column: 2},
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 2, Line: 1, Column: 2},
+						EndPos:   ast.Position{Offset: 2, Line: 1, Column: 2},
+					},
 				},
 			},
 			errs,


### PR DESCRIPTION
See discussion in https://discord.com/channels/613813861610684416/1108479699732152503/1186788225365327952

## Description

Report a better error when legacy restricted types are encountered as type arguments
______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
