### PR TITLE
Use old hash/ID generation to remove keys

### DIFF
--- a/migrations/legacy_intersection_type.go
+++ b/migrations/legacy_intersection_type.go
@@ -1,0 +1,56 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package migrations
+
+import (
+	"strings"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+)
+
+// LegacyIntersectionType simulates the old, incorrect restricted-type type-ID generation,
+// which did not sort the type IDs of the interface types.
+type LegacyIntersectionType struct {
+	*interpreter.IntersectionStaticType
+}
+
+var _ interpreter.StaticType = &LegacyIntersectionType{}
+
+func (t *LegacyIntersectionType) ID() common.TypeID {
+	interfaceTypeIDs := make([]string, 0, len(t.Types))
+	for _, interfaceType := range t.Types {
+		interfaceTypeIDs = append(
+			interfaceTypeIDs,
+			string(interfaceType.ID()),
+		)
+	}
+
+	var result strings.Builder
+	result.WriteByte('{')
+	// NOTE: no sorting
+	for i, interfaceTypeID := range interfaceTypeIDs {
+		if i > 0 {
+			result.WriteByte(',')
+		}
+		result.WriteString(interfaceTypeID)
+	}
+	result.WriteByte('}')
+	return common.TypeID(result.String())
+}

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -248,11 +248,13 @@ func (m *StorageMigration) migrateNestedValue(
 				// Key was migrated.
 				// Remove the old value at the old key.
 				// This old value will be inserted again with the new key, unless the value is also migrated.
+				existingKey = legacyKey(existingKey)
 				oldValue := dictionary.Remove(
 					m.interpreter,
 					emptyLocationRange,
 					existingKey,
 				)
+
 				if _, ok := oldValue.(*interpreter.SomeValue); !ok {
 					panic(errors.NewUnreachableError())
 				}
@@ -299,4 +301,73 @@ func (m *StorageMigration) migrateNestedValue(
 
 		return
 	}
+}
+
+// legacyKey return the same type with the "old" hash/ID generation algo.
+func legacyKey(key interpreter.Value) interpreter.Value {
+	typeValue, isTypeValue := key.(interpreter.TypeValue)
+	if !isTypeValue {
+		return key
+	}
+
+	legacyType := legacyType(typeValue.Type)
+	if legacyType == nil {
+		return key
+	}
+
+	return interpreter.NewUnmeteredTypeValue(legacyType)
+}
+
+func legacyType(staticType interpreter.StaticType) interpreter.StaticType {
+	switch typ := staticType.(type) {
+	case *interpreter.IntersectionStaticType:
+		return &LegacyIntersectionType{
+			IntersectionStaticType: typ,
+		}
+
+	case *interpreter.ConstantSizedStaticType:
+		legacyType := legacyType(typ.Type)
+		if legacyType != nil {
+			return interpreter.NewConstantSizedStaticType(nil, legacyType, typ.Size)
+		}
+
+	case *interpreter.VariableSizedStaticType:
+		legacyType := legacyType(typ.Type)
+		if legacyType != nil {
+			return interpreter.NewVariableSizedStaticType(nil, legacyType)
+		}
+
+	case *interpreter.DictionaryStaticType:
+		legacyKeyType := legacyType(typ.KeyType)
+		legacyValueType := legacyType(typ.ValueType)
+		if legacyKeyType != nil && legacyValueType != nil {
+			return interpreter.NewDictionaryStaticType(nil, legacyKeyType, legacyValueType)
+		}
+		if legacyKeyType != nil {
+			return interpreter.NewDictionaryStaticType(nil, legacyKeyType, typ.ValueType)
+		}
+		if legacyValueType != nil {
+			return interpreter.NewDictionaryStaticType(nil, typ.KeyType, legacyValueType)
+		}
+
+	case *interpreter.OptionalStaticType:
+		legacyInnerType := legacyType(typ.Type)
+		if legacyInnerType != nil {
+			return interpreter.NewOptionalStaticType(nil, legacyInnerType)
+		}
+
+	case *interpreter.CapabilityStaticType:
+		legacyBorrowType := legacyType(typ.BorrowType)
+		if legacyBorrowType != nil {
+			return interpreter.NewCapabilityStaticType(nil, legacyBorrowType)
+		}
+
+	case *interpreter.ReferenceStaticType:
+		legacyReferencedType := legacyType(typ.ReferencedType)
+		if legacyReferencedType != nil {
+			return interpreter.NewReferenceStaticType(nil, typ.Authorization, legacyReferencedType)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Depends on https://github.com/onflow/cadence/pull/2981

## Description

Solves https://github.com/onflow/cadence/pull/2981#issuecomment-1865328400, (i.e: uses the 'old' hashing mechanism) by overriding the `ID` method (using a wrapper) to use the old hashing mechanism, just before the removal. So the removal would use the old hash, and hence the removal would succeed.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
