### PR TITLE
Prevent use of non-attachment type names in default arguments

### DIFF
--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -1992,9 +1992,13 @@ func (checker *Checker) checkDefaultDestroyParamExpressionKind(
 			break
 		}
 
+		idTypeVariable := checker.typeActivations.Find(identifier)
+
 		// if it's an attachment, then it's also okay
-		if checker.typeActivations.Find(identifier) != nil {
-			break
+		if idTypeVariable != nil {
+			if compositeType, isComposite := idTypeVariable.Type.(*CompositeType); isComposite && compositeType.Kind == common.CompositeKindAttachment {
+				break
+			}
 		}
 		checker.report(&DefaultDestroyInvalidArgumentError{
 			Range: ast.NewRangeFromPositioned(checker.memoryGauge, arg),

--- a/runtime/tests/checker/events_test.go
+++ b/runtime/tests/checker/events_test.go
@@ -784,9 +784,10 @@ func TestCheckDefaultEventParamChecking(t *testing.T) {
 				event ResourceDestroyed(name: Type = R)
 			}
         `)
-		errs := RequireCheckerErrors(t, err, 2)
+		errs := RequireCheckerErrors(t, err, 3)
 		require.IsType(t, &sema.TypeMismatchError{}, errs[0])
 		require.IsType(t, &sema.DefaultDestroyInvalidParameterError{}, errs[1])
+		require.IsType(t, &sema.DefaultDestroyInvalidArgumentError{}, errs[2])
 	})
 
 	t.Run("address expr", func(t *testing.T) {
@@ -1379,6 +1380,52 @@ func TestCheckDefaultEventParamChecking(t *testing.T) {
 			access(all) var dummy: @R <- globalArray.removeLast() // invalidate the ref
 			access(all) resource IndestructibleTroll {
 				// Reference the fake "base" variable
+				access(all) event ResourceDestroyed( x: Int? = base.i)
+			}
+			access(all) fun main() {
+				var troll <- create IndestructibleTroll()
+				destroy troll
+			}
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+		require.IsType(t, &sema.DefaultDestroyInvalidArgumentError{}, errs[0])
+		require.Equal(t, errs[0].(*sema.DefaultDestroyInvalidArgumentError).Kind, sema.InvalidIdentifier)
+	})
+
+	t.Run("non-attachment type name", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			access(all) contract Contract {
+				access(all) var i: Int
+				access(all) init() { self.i = 1}
+			}
+			access(all) resource IndestructibleTroll {
+				access(all) event ResourceDestroyed( x: Int? = Contract.i)
+			}
+			access(all) fun main() {
+				var troll <- create IndestructibleTroll()
+				destroy troll
+			}
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+		require.IsType(t, &sema.DefaultDestroyInvalidArgumentError{}, errs[0])
+		require.Equal(t, errs[0].(*sema.DefaultDestroyInvalidArgumentError).Kind, sema.InvalidIdentifier)
+	})
+
+	t.Run("base contract type name", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			access(all) contract base {
+				access(all) var i: Int
+				access(all) init() { self.i = 1}
+			}
+			access(all) resource IndestructibleTroll {
 				access(all) event ResourceDestroyed( x: Int? = base.i)
 			}
 			access(all) fun main() {


### PR DESCRIPTION
We previously (mistakenly) allowed non-attachment type names to be used in default destroy arguments, which could cause issues with Contract-kinded composites being used as variables, since these declarations create both a type and a value at the same time.  

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
