### PR TITLE
Improve error handling in migrations

### DIFF
--- a/migrations/account_type/migration.go
+++ b/migrations/account_type/migration.go
@@ -44,21 +44,21 @@ func (AccountTypeMigration) Migrate(
 	_ interpreter.AddressPath,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
-) (newValue interpreter.Value) {
+) (newValue interpreter.Value, err error) {
 	switch value := value.(type) {
 	case interpreter.TypeValue:
 		convertedType := maybeConvertAccountType(value.Type)
 		if convertedType == nil {
 			return
 		}
-		return interpreter.NewTypeValue(nil, convertedType)
+		return interpreter.NewTypeValue(nil, convertedType), nil
 
 	case *interpreter.CapabilityValue:
 		convertedBorrowType := maybeConvertAccountType(value.BorrowType)
 		if convertedBorrowType == nil {
 			return
 		}
-		return interpreter.NewUnmeteredCapabilityValue(value.ID, value.Address, convertedBorrowType)
+		return interpreter.NewUnmeteredCapabilityValue(value.ID, value.Address, convertedBorrowType), nil
 
 	case *interpreter.AccountCapabilityControllerValue:
 		convertedBorrowType := maybeConvertAccountType(value.BorrowType)
@@ -66,7 +66,7 @@ func (AccountTypeMigration) Migrate(
 			return
 		}
 		borrowType := convertedBorrowType.(*interpreter.ReferenceStaticType)
-		return interpreter.NewUnmeteredAccountCapabilityControllerValue(borrowType, value.CapabilityID)
+		return interpreter.NewUnmeteredAccountCapabilityControllerValue(borrowType, value.CapabilityID), nil
 
 	case *interpreter.StorageCapabilityControllerValue:
 		// Note: A storage capability with Account type shouldn't be possible theoretically.
@@ -79,7 +79,7 @@ func (AccountTypeMigration) Migrate(
 			borrowType,
 			value.CapabilityID,
 			value.TargetPath,
-		)
+		), nil
 	}
 
 	return

--- a/migrations/account_type/migration_test.go
+++ b/migrations/account_type/migration_test.go
@@ -46,11 +46,18 @@ func newTestReporter() *testReporter {
 	}
 }
 
-func (t *testReporter) Report(
+func (t *testReporter) Migrated(
 	addressPath interpreter.AddressPath,
 	_ string,
 ) {
 	t.migratedPaths[addressPath] = struct{}{}
+}
+
+func (t *testReporter) Error(
+	_ interpreter.AddressPath,
+	_ string,
+	_ error,
+) {
 }
 
 func TestTypeValueMigration(t *testing.T) {
@@ -366,7 +373,8 @@ func TestTypeValueMigration(t *testing.T) {
 		),
 	)
 
-	migration.Commit()
+	err = migration.Commit()
+	require.NoError(t, err)
 
 	// Check reported migrated paths
 	for identifier, test := range testCases {
@@ -689,7 +697,8 @@ func TestNestedTypeValueMigration(t *testing.T) {
 		),
 	)
 
-	migration.Commit()
+	err = migration.Commit()
+	require.NoError(t, err)
 
 	// Assert: Traverse through the storage and see if the values are updated now.
 
@@ -834,7 +843,8 @@ func TestValuesWithStaticTypeMigration(t *testing.T) {
 		),
 	)
 
-	migration.Commit()
+	err = migration.Commit()
+	require.NoError(t, err)
 
 	// Assert: Traverse through the storage and see if the values are updated now.
 

--- a/migrations/capcons/capabilitymigration.go
+++ b/migrations/capcons/capabilitymigration.go
@@ -63,7 +63,7 @@ func (m *CapabilityValueMigration) Migrate(
 	addressPath interpreter.AddressPath,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
-) interpreter.Value {
+) (interpreter.Value, error) {
 	reporter := m.Reporter
 
 	switch value := value.(type) {
@@ -109,8 +109,8 @@ func (m *CapabilityValueMigration) Migrate(
 			)
 		}
 
-		return newCapability
+		return newCapability, nil
 	}
 
-	return nil
+	return nil, nil
 }

--- a/migrations/capcons/linkmigration.go
+++ b/migrations/capcons/linkmigration.go
@@ -55,13 +55,13 @@ func (m *LinkValueMigration) Migrate(
 	addressPath interpreter.AddressPath,
 	value interpreter.Value,
 	inter *interpreter.Interpreter,
-) interpreter.Value {
+) (interpreter.Value, error) {
 
 	pathDomain := addressPath.Path.Domain
 	if pathDomain != common.PathDomainPublic &&
 		pathDomain != common.PathDomainPrivate {
 
-		return nil
+		return nil, nil
 	}
 
 	accountAddress := addressPath.Address
@@ -77,7 +77,7 @@ func (m *LinkValueMigration) Migrate(
 	switch readValue := value.(type) {
 	case *interpreter.CapabilityValue:
 		// Already migrated
-		return nil
+		return nil, nil
 
 	case interpreter.PathLinkValue: //nolint:staticcheck
 		var ok bool
@@ -122,10 +122,10 @@ func (m *LinkValueMigration) Migrate(
 			}
 
 			// TODO: really leave as-is? or still convert?
-			return nil
+			return nil, nil
 		}
 
-		panic(err)
+		return nil, err
 	}
 
 	// Issue appropriate capability controller
@@ -139,7 +139,7 @@ func (m *LinkValueMigration) Migrate(
 		}
 
 		// TODO: really leave as-is? or still convert?
-		return nil
+		return nil, nil
 
 	case pathCapabilityTarget:
 
@@ -184,7 +184,7 @@ func (m *LinkValueMigration) Migrate(
 		capabilityID,
 		addressValue,
 		borrowStaticType,
-	)
+	), nil
 }
 
 var authAccountReferenceStaticType = interpreter.NewReferenceStaticType(

--- a/migrations/capcons/migration_test.go
+++ b/migrations/capcons/migration_test.go
@@ -462,7 +462,8 @@ func testPathCapabilityValueMigration(
 		),
 	)
 
-	migration.Commit()
+	err = migration.Commit()
+	require.NoError(t, err)
 
 	// Check migrated capabilities
 
@@ -1179,7 +1180,8 @@ func testLinkMigration(
 		),
 	)
 
-	migration.Commit()
+	err = migration.Commit()
+	require.NoError(t, err)
 
 	// Assert
 
@@ -1683,7 +1685,8 @@ func TestClearPrivateDomain(t *testing.T) {
 		ClearPrivateDomain,
 	)
 
-	migration.Commit()
+	err = migration.Commit()
+	require.NoError(t, err)
 
 	// Assert
 

--- a/migrations/migration_reporter.go
+++ b/migrations/migration_reporter.go
@@ -21,5 +21,6 @@ package migrations
 import "github.com/onflow/cadence/runtime/interpreter"
 
 type Reporter interface {
-	Report(addressPath interpreter.AddressPath, migration string)
+	Migrated(addressPath interpreter.AddressPath, migration string)
+	Error(addressPath interpreter.AddressPath, migration string, err error)
 }

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -19,6 +19,7 @@
 package migrations
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -35,20 +36,33 @@ import (
 
 type testReporter struct {
 	migratedPaths map[interpreter.AddressPath][]string
+	erroredPaths  map[interpreter.AddressPath][]string
 }
 
 func newTestReporter() *testReporter {
 	return &testReporter{
 		migratedPaths: map[interpreter.AddressPath][]string{},
+		erroredPaths:  map[interpreter.AddressPath][]string{},
 	}
 }
 
-func (t *testReporter) Report(
+func (t *testReporter) Migrated(
 	addressPath interpreter.AddressPath,
 	migration string,
 ) {
 	t.migratedPaths[addressPath] = append(
 		t.migratedPaths[addressPath],
+		migration,
+	)
+}
+
+func (t *testReporter) Error(
+	addressPath interpreter.AddressPath,
+	migration string,
+	_ error,
+) {
+	t.erroredPaths[addressPath] = append(
+		t.erroredPaths[addressPath],
 		migration,
 	)
 }
@@ -65,32 +79,39 @@ func (testStringMigration) Migrate(
 	_ interpreter.AddressPath,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
-) interpreter.Value {
+) (interpreter.Value, error) {
 	if value, ok := value.(*interpreter.StringValue); ok {
-		return interpreter.NewUnmeteredStringValue(fmt.Sprintf("updated_%s", value.Str))
+		return interpreter.NewUnmeteredStringValue(fmt.Sprintf("updated_%s", value.Str)), nil
 	}
 
-	return nil
+	return nil, nil
 }
 
 // testInt8Migration
 
-type testInt8Migration struct{}
+type testInt8Migration struct {
+	mustError bool
+}
 
 func (testInt8Migration) Name() string {
 	return "testInt8Migration"
 }
 
-func (testInt8Migration) Migrate(
+func (m testInt8Migration) Migrate(
 	_ interpreter.AddressPath,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
-) interpreter.Value {
-	if value, ok := value.(interpreter.Int8Value); ok {
-		return interpreter.NewUnmeteredInt8Value(int8(value) + 10)
+) (interpreter.Value, error) {
+	int8Value, ok := value.(interpreter.Int8Value)
+	if !ok {
+		return nil, nil
 	}
 
-	return nil
+	if m.mustError {
+		return nil, errors.New("error occurred while migrating int8")
+	}
+
+	return interpreter.NewUnmeteredInt8Value(int8(int8Value) + 10), nil
 }
 
 var _ ValueMigration = testStringMigration{}
@@ -131,7 +152,8 @@ func TestMultipleMigrations(t *testing.T) {
 			expectedValue: interpreter.NewUnmeteredInt8Value(15),
 		},
 		"int16_value": {
-			storedValue: interpreter.NewUnmeteredInt16Value(5),
+			storedValue:   interpreter.NewUnmeteredInt16Value(5),
+			expectedValue: interpreter.NewUnmeteredInt16Value(5),
 		},
 	}
 
@@ -177,7 +199,8 @@ func TestMultipleMigrations(t *testing.T) {
 		),
 	)
 
-	migration.Commit()
+	err = migration.Commit()
+	require.NoError(t, err)
 
 	// Assert: Traverse through the storage and see if the values are updated now.
 
@@ -193,13 +216,7 @@ func TestMultipleMigrations(t *testing.T) {
 		t.Run(identifier, func(t *testing.T) {
 			testCase, ok := testCases[identifier]
 			require.True(t, ok)
-
-			expectedStoredValue := testCase.expectedValue
-			if expectedStoredValue == nil {
-				expectedStoredValue = testCase.storedValue
-			}
-
-			utils.AssertValuesEqual(t, inter, expectedStoredValue, value)
+			utils.AssertValuesEqual(t, inter, testCase.expectedValue, value)
 		})
 	}
 
@@ -226,5 +243,144 @@ func TestMultipleMigrations(t *testing.T) {
 			},
 		},
 		reporter.migratedPaths,
+	)
+}
+
+func TestMigrationError(t *testing.T) {
+	t.Parallel()
+
+	account := common.Address{0x42}
+	pathDomain := common.PathDomainPublic
+
+	type testCase struct {
+		storedValue   interpreter.Value
+		expectedValue interpreter.Value
+	}
+
+	ledger := NewTestLedger(nil, nil)
+	storage := runtime.NewStorage(ledger, nil)
+	locationRange := interpreter.EmptyLocationRange
+
+	inter, err := interpreter.NewInterpreter(
+		nil,
+		utils.TestLocation,
+		&interpreter.Config{
+			Storage:                       storage,
+			AtreeValueValidationEnabled:   false,
+			AtreeStorageValidationEnabled: false,
+		},
+	)
+	require.NoError(t, err)
+
+	testCases := map[string]testCase{
+		"string_value": {
+			storedValue:   interpreter.NewUnmeteredStringValue("hello"),
+			expectedValue: interpreter.NewUnmeteredStringValue("updated_hello"),
+		},
+		// Since Int8 migration expected to produce error,
+		// int8 value should not have been migrated.
+		"int8_value": {
+			storedValue:   interpreter.NewUnmeteredInt8Value(5),
+			expectedValue: interpreter.NewUnmeteredInt8Value(5),
+		},
+	}
+
+	// Store values
+
+	for name, testCase := range testCases {
+		transferredValue := testCase.storedValue.Transfer(
+			inter,
+			locationRange,
+			atree.Address(account),
+			false,
+			nil,
+			nil,
+		)
+
+		inter.WriteStored(
+			account,
+			pathDomain.Identifier(),
+			interpreter.StringStorageMapKey(name),
+			transferredValue,
+		)
+	}
+
+	err = storage.Commit(inter, true)
+	require.NoError(t, err)
+
+	// Migrate
+
+	migration := NewStorageMigration(inter, storage)
+
+	reporter := newTestReporter()
+
+	migration.Migrate(
+		&AddressSliceIterator{
+			Addresses: []common.Address{
+				account,
+			},
+		},
+		migration.NewValueMigrationsPathMigrator(
+			reporter,
+			testStringMigration{},
+
+			// Int8 migration should produce errors
+			testInt8Migration{
+				mustError: true,
+			},
+		),
+	)
+
+	err = migration.Commit()
+	require.NoError(t, err)
+
+	// Assert: Traverse through the storage and see if the values are updated now.
+
+	storageMap := storage.GetStorageMap(account, pathDomain.Identifier(), false)
+	require.NotNil(t, storageMap)
+	require.Greater(t, storageMap.Count(), uint64(0))
+
+	iterator := storageMap.Iterator(inter)
+
+	for key, value := iterator.Next(); key != nil; key, value = iterator.Next() {
+		identifier := string(key.(interpreter.StringAtreeValue))
+
+		t.Run(identifier, func(t *testing.T) {
+			testCase, ok := testCases[identifier]
+			require.True(t, ok)
+			utils.AssertValuesEqual(t, inter, testCase.expectedValue, value)
+		})
+	}
+
+	// Check the reporter.
+	// Since Int8 migration produces an error, only the string value must have been migrated.
+	require.Equal(t,
+		map[interpreter.AddressPath][]string{
+			{
+				Address: account,
+				Path: interpreter.PathValue{
+					Domain:     pathDomain,
+					Identifier: "string_value",
+				},
+			}: {
+				"testStringMigration",
+			},
+		},
+		reporter.migratedPaths,
+	)
+
+	require.Equal(t,
+		map[interpreter.AddressPath][]string{
+			{
+				Address: account,
+				Path: interpreter.PathValue{
+					Domain:     pathDomain,
+					Identifier: "int8_value",
+				},
+			}: {
+				"testInt8Migration",
+			},
+		},
+		reporter.erroredPaths,
 	)
 }

--- a/migrations/string_normalization/migration.go
+++ b/migrations/string_normalization/migration.go
@@ -39,15 +39,14 @@ func (StringNormalizingMigration) Migrate(
 	_ interpreter.AddressPath,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
-) interpreter.Value {
-
+) (interpreter.Value, error) {
 	switch value := value.(type) {
 	case *interpreter.StringValue:
-		return interpreter.NewUnmeteredStringValue(value.Str)
+		return interpreter.NewUnmeteredStringValue(value.Str), nil
 
 	case interpreter.CharacterValue:
-		return interpreter.NewUnmeteredCharacterValue(string(value))
+		return interpreter.NewUnmeteredCharacterValue(string(value)), nil
 	}
 
-	return nil
+	return nil, nil
 }

--- a/migrations/string_normalization/migration_test.go
+++ b/migrations/string_normalization/migration_test.go
@@ -255,7 +255,8 @@ func TestStringNormalizingMigration(t *testing.T) {
 		),
 	)
 
-	migration.Commit()
+	err = migration.Commit()
+	require.NoError(t, err)
 
 	// Assert: Traverse through the storage and see if the values are updated now.
 

--- a/migrations/type_value/migration.go
+++ b/migrations/type_value/migration.go
@@ -41,14 +41,14 @@ func (TypeValueMigration) Migrate(
 	_ interpreter.AddressPath,
 	value interpreter.Value,
 	inter *interpreter.Interpreter,
-) (newValue interpreter.Value) {
+) (newValue interpreter.Value, err error) {
 	switch value := value.(type) {
 	case interpreter.TypeValue:
 		convertedType := maybeConvertType(value.Type, inter)
 		if convertedType == nil {
 			return
 		}
-		return interpreter.NewTypeValue(nil, convertedType)
+		return interpreter.NewTypeValue(nil, convertedType), nil
 	}
 
 	return

--- a/migrations/type_value/migration_test.go
+++ b/migrations/type_value/migration_test.go
@@ -45,11 +45,18 @@ func newTestReporter() *testReporter {
 	}
 }
 
-func (t *testReporter) Report(
+func (t *testReporter) Migrated(
 	addressPath interpreter.AddressPath,
 	_ string,
 ) {
 	t.migratedPaths[addressPath] = struct{}{}
+}
+
+func (t *testReporter) Error(
+	_ interpreter.AddressPath,
+	_ string,
+	_ error,
+) {
 }
 
 const fooBarQualifiedIdentifier = "Foo.Bar"
@@ -426,7 +433,8 @@ func TestTypeValueMigration(t *testing.T) {
 		),
 	)
 
-	migration.Commit()
+	err = migration.Commit()
+	require.NoError(t, err)
 
 	// Check reported migrated paths
 	for identifier, test := range testCases {
@@ -605,7 +613,8 @@ func TestRehash(t *testing.T) {
 			),
 		)
 
-		migration.Commit()
+		err := migration.Commit()
+		require.NoError(t, err)
 
 		require.Equal(t,
 			map[interpreter.AddressPath]struct{}{
@@ -762,7 +771,8 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 				),
 			)
 
-			migration.Commit()
+			err := migration.Commit()
+			require.NoError(t, err)
 
 			require.Equal(t,
 				map[interpreter.AddressPath]struct{}{
@@ -894,7 +904,8 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 				),
 			)
 
-			migration.Commit()
+			err := migration.Commit()
+			require.NoError(t, err)
 
 			require.Equal(t,
 				map[interpreter.AddressPath]struct{}{


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/2990

Required for https://github.com/onflow/flow-go/pull/5192

## Description

Return errors wherever possible, and handle runtime panics gracefully to return panics also as errors.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
