### PR TITLE
Add getter for field count to composite value

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -17173,7 +17173,7 @@ func (v *CompositeValue) ConformsToStaticType(
 		}
 	}
 
-	fieldsLen := int(v.dictionary.Count())
+	fieldsLen := v.FieldCount()
 
 	computedFields := v.GetComputedFields(interpreter)
 	if computedFields != nil {
@@ -17222,6 +17222,10 @@ func (v *CompositeValue) ConformsToStaticType(
 	}
 
 	return true
+}
+
+func (v *CompositeValue) FieldCount() int {
+	return int(v.dictionary.Count())
 }
 
 func (v *CompositeValue) IsStorable() bool {


### PR DESCRIPTION
## Description

Just like `DictionaryValue.Count` exposes the number of elements in the dictionary, add a similar getter to `CompositeValue` which returns the number of stored fields in the composite value.

Needed for https://github.com/onflow/flow-go/pull/5204

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
