### PR TITLE
Improve type inference

### DIFF
--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -578,21 +578,46 @@ func (checker *Checker) checkInvocationRequiredArgument(
 
 	var argumentType Type
 
-	if len(functionType.TypeParameters) == 0 {
-		// If the function doesn't use generic types, then the
-		// param types can be used to infer the types for arguments.
+	typeParameterCount := len(functionType.TypeParameters)
+
+	// If all type parameters have been bound to a type,
+	// then resolve the parameter type with the type arguments,
+	// and propose the parameter type as the expected type for the argument.
+	if typeParameters.Len() == typeParameterCount {
+
+		// Optimization: only resolve if there are type parameters.
+		// This avoids unnecessary work for non-generic functions.
+		if typeParameterCount > 0 {
+			parameterType = parameterType.Resolve(typeParameters)
+			// If the type parameter could not be resolved, use the invalid type.
+			if parameterType == nil {
+				parameterType = InvalidType
+			}
+		}
+
 		argumentType = checker.VisitExpression(argument.Expression, parameterType)
+
 	} else {
-		// TODO: pass the expected type to support for parameters
+		// If there are still type parameters that have not been bound to a type,
+		// then check the argument without an expected type.
+		//
+		// We will then have to manually check that the argument type is compatible
+		// with the parameter type (see below).
+
 		argumentType = checker.VisitExpression(argument.Expression, nil)
 
 		// Try to unify the parameter type with the argument type.
 		// If unification fails, fall back to the parameter type for now.
 
-		argumentRange := ast.NewRangeFromPositioned(checker.memoryGauge, argument.Expression)
-
-		if parameterType.Unify(argumentType, typeParameters, checker.report, argumentRange) {
+		if parameterType.Unify(
+			argumentType,
+			typeParameters,
+			checker.report,
+			checker.memoryGauge,
+			argument.Expression,
+		) {
 			parameterType = parameterType.Resolve(typeParameters)
+			// If the type parameter could not be resolved, use the invalid type.
 			if parameterType == nil {
 				parameterType = InvalidType
 			}
@@ -600,7 +625,6 @@ func (checker *Checker) checkInvocationRequiredArgument(
 
 		// Check that the type of the argument matches the type of the parameter.
 
-		// TODO: remove this once type inferring support for parameters is added
 		checker.checkInvocationArgumentParameterTypeCompatibility(
 			argument.Expression,
 			argumentType,
@@ -695,7 +719,7 @@ func (checker *Checker) checkAndBindGenericTypeParameterTypeArguments(
 		// If the type parameter corresponding to the type argument has a type bound,
 		// then check that the argument is a subtype of the type bound.
 
-		err := typeParameter.checkTypeBound(ty, ast.NewRangeFromPositioned(checker.memoryGauge, rawTypeArgument))
+		err := typeParameter.checkTypeBound(ty, checker.memoryGauge, rawTypeArgument)
 		checker.report(err)
 
 		// Bind the type argument to the type parameter

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2475,7 +2475,8 @@ func (checker *Checker) convertInstantiationType(t *ast.InstantiationType) Type 
 
 				err := typeParameter.checkTypeBound(
 					typeArgument,
-					ast.NewRangeFromPositioned(checker.memoryGauge, rawTypeArgument),
+					checker.memoryGauge,
+					rawTypeArgument,
 				)
 				checker.report(err)
 			}

--- a/runtime/sema/simple_type.go
+++ b/runtime/sema/simple_type.go
@@ -123,7 +123,13 @@ func (t *SimpleType) RewriteWithIntersectionTypes() (Type, bool) {
 	return t, false
 }
 
-func (*SimpleType) Unify(_ Type, _ *TypeParameterTypeOrderedMap, _ func(err error), _ ast.Range) bool {
+func (*SimpleType) Unify(
+	_ Type,
+	_ *TypeParameterTypeOrderedMap,
+	_ func(err error),
+	_ common.MemoryGauge,
+	_ ast.HasPosition,
+) bool {
 	return false
 }
 

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -334,9 +334,9 @@ func TestTestNewMatcher(t *testing.T) {
 
 		_, err := newTestContractInterpreter(t, script)
 
-		errs := checker.RequireCheckerErrors(t, err, 2)
-		assert.IsType(t, &sema.TypeParameterTypeMismatchError{}, errs[0])
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+		errs := checker.RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 	})
 
 	t.Run("combined matcher mismatching types", func(t *testing.T) {
@@ -499,9 +499,9 @@ func TestTestEqualMatcher(t *testing.T) {
 
 		_, err := newTestContractInterpreter(t, script)
 
-		errs := checker.RequireCheckerErrors(t, err, 2)
-		assert.IsType(t, &sema.TypeParameterTypeMismatchError{}, errs[0])
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+		errs := checker.RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 	})
 
 	t.Run("matcher or", func(t *testing.T) {
@@ -1904,9 +1904,9 @@ func TestTestExpect(t *testing.T) {
 
 		_, err := newTestContractInterpreter(t, script)
 
-		errs := checker.RequireCheckerErrors(t, err, 2)
-		assert.IsType(t, &sema.TypeParameterTypeMismatchError{}, errs[0])
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+		errs := checker.RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 	})
 
 	t.Run("resource with resource matcher", func(t *testing.T) {

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -219,16 +219,14 @@ func TestCheckAccountStorageSave(t *testing.T) {
 
 			if domain == common.PathDomainStorage {
 
+				errs := RequireCheckerErrors(t, err, 1)
+
+				require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+			} else {
 				errs := RequireCheckerErrors(t, err, 2)
 
-				require.IsType(t, &sema.TypeParameterTypeMismatchError{}, errs[0])
+				require.IsType(t, &sema.TypeMismatchError{}, errs[0])
 				require.IsType(t, &sema.TypeMismatchError{}, errs[1])
-			} else {
-				errs := RequireCheckerErrors(t, err, 3)
-
-				require.IsType(t, &sema.TypeParameterTypeMismatchError{}, errs[0])
-				require.IsType(t, &sema.TypeMismatchError{}, errs[1])
-				require.IsType(t, &sema.TypeMismatchError{}, errs[2])
 			}
 		})
 
@@ -254,16 +252,14 @@ func TestCheckAccountStorageSave(t *testing.T) {
 
 			if domain == common.PathDomainStorage {
 
+				errs := RequireCheckerErrors(t, err, 1)
+
+				require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+			} else {
 				errs := RequireCheckerErrors(t, err, 2)
 
-				require.IsType(t, &sema.TypeParameterTypeMismatchError{}, errs[0])
+				require.IsType(t, &sema.TypeMismatchError{}, errs[0])
 				require.IsType(t, &sema.TypeMismatchError{}, errs[1])
-			} else {
-				errs := RequireCheckerErrors(t, err, 3)
-
-				require.IsType(t, &sema.TypeParameterTypeMismatchError{}, errs[0])
-				require.IsType(t, &sema.TypeMismatchError{}, errs[1])
-				require.IsType(t, &sema.TypeMismatchError{}, errs[2])
 			}
 		})
 	}

--- a/runtime/tests/checker/builtinfunctions_test.go
+++ b/runtime/tests/checker/builtinfunctions_test.go
@@ -292,7 +292,7 @@ func TestCheckRevertibleRandom(t *testing.T) {
 		}
 	}
 
-	runCase := func(t *testing.T, ty sema.Type, code string) {
+	runValidCase := func(t *testing.T, ty sema.Type, code string) {
 
 		checker, err := ParseAndCheckWithOptions(t, code, newOptions())
 
@@ -307,7 +307,7 @@ func TestCheckRevertibleRandom(t *testing.T) {
 			t.Parallel()
 
 			code := fmt.Sprintf("let rand = revertibleRandom<%s>()", ty)
-			runCase(t, ty, code)
+			runValidCase(t, ty, code)
 		})
 	}
 
@@ -316,7 +316,7 @@ func TestCheckRevertibleRandom(t *testing.T) {
 			t.Parallel()
 
 			code := fmt.Sprintf("let rand = revertibleRandom<%[1]s>(modulo: %[1]s(1))", ty)
-			runCase(t, ty, code)
+			runValidCase(t, ty, code)
 		})
 	}
 
@@ -394,7 +394,6 @@ func TestCheckRevertibleRandom(t *testing.T) {
 		"modulo type mismatch",
 		"let rand = revertibleRandom<UInt256>(modulo: UInt128(1))",
 		[]error{
-			&sema.TypeParameterTypeMismatchError{},
 			&sema.TypeMismatchError{},
 		},
 	)
@@ -404,18 +403,17 @@ func TestCheckRevertibleRandom(t *testing.T) {
 		"string modulo",
 		`let rand = revertibleRandom<UInt256>(modulo: "abcd")`,
 		[]error{
-			&sema.TypeParameterTypeMismatchError{},
 			&sema.TypeMismatchError{},
 		},
 	)
 
-	// This is an error since we do not support type inference of function arguments.
-	runInvalidCase(
-		t,
-		"missing type inference",
-		"let rand = revertibleRandom<UInt256>(modulo: 1)",
-		[]error{
-			&sema.TypeParameterTypeMismatchError{},
-		},
-	)
+	t.Run("type parameter used for argument", func(t *testing.T) {
+		t.Parallel()
+
+		runValidCase(
+			t,
+			sema.UInt256Type,
+			"let rand = revertibleRandom<UInt256>(modulo: 1)",
+		)
+	})
 }

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -283,10 +283,9 @@ func TestCheckGenericFunctionInvocation(t *testing.T) {
 			},
 		)
 
-		errs := RequireCheckerErrors(t, err, 2)
+		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.TypeParameterTypeMismatchError{}, errs[0])
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 	})
 
 	t.Run("valid: one type parameter, one type argument, one parameter, one arguments", func(t *testing.T) {
@@ -423,10 +422,9 @@ func TestCheckGenericFunctionInvocation(t *testing.T) {
 			},
 		)
 
-		errs := RequireCheckerErrors(t, err, 2)
+		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.TypeParameterTypeMismatchError{}, errs[0])
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
 	})
 
 	t.Run("invalid: one type parameter, no type argument, no parameters, no arguments, return type", func(t *testing.T) {

--- a/runtime/tests/checker/range_value_test.go
+++ b/runtime/tests/checker/range_value_test.go
@@ -330,13 +330,17 @@ func TestCheckInclusiveRangeConstructionInvalid(t *testing.T) {
 			t,
 			typeString,
 			fmt.Sprintf("let r = InclusiveRange(%s(1), %s(2))", typeString, differentTypeString),
-			[]error{&sema.TypeParameterTypeMismatchError{}, &sema.TypeMismatchError{}},
+			[]error{
+				&sema.TypeMismatchError{},
+			},
 		)
 		runInvalidCase(
 			t,
 			typeString,
 			fmt.Sprintf("let r = InclusiveRange(%s(1), %s(10), step: %s(2))", typeString, typeString, differentTypeString),
-			[]error{&sema.TypeParameterTypeMismatchError{}, &sema.TypeMismatchError{}},
+			[]error{
+				&sema.TypeMismatchError{},
+			},
 		)
 
 		// Not enough arguments


### PR DESCRIPTION
⚠️ Depends on `feature/range-type`

Closes #2886

## Description

Use bound type parameters for argument expected type.

This makes the following programs check:

```cadence
let r = InclusiveRange<Int8>(0, 10)  // `r` has type `InclusiveRange<Int8>`
```

```cadence
let r = InclusiveRange(0 as UInt8, 10)  // `r` has type `InclusiveRange<UInt8>`
```

This is currently based on top of the range feature branch, but I can also rebase on master.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
