### PR TITLE
Add type assertion on values passed to `Test.assertEqual`

### DIFF
--- a/runtime/stdlib/test_contract.go
+++ b/runtime/stdlib/test_contract.go
@@ -140,11 +140,25 @@ var testTypeAssertEqualFunction = interpreter.NewUnmeteredHostFunctionValue(
 			panic(errors.NewUnreachableError())
 		}
 
-		inter := invocation.Interpreter
-
 		actual, ok := invocation.Arguments[1].(interpreter.EquatableValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
+		}
+
+		inter := invocation.Interpreter
+
+		expectedType := expected.StaticType(inter)
+		actualType := actual.StaticType(inter)
+		if !expectedType.Equal(actualType) {
+			message := fmt.Sprintf(
+				"not equal types: expected: %s, actual: %s",
+				expectedType,
+				actualType,
+			)
+			panic(AssertionError{
+				Message:       message,
+				LocationRange: invocation.LocationRange,
+			})
 		}
 
 		equal := expected.Equal(

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -726,7 +726,7 @@ func TestAssertEqual(t *testing.T) {
             fun test() {
                 Test.assertEqual("this string", "this string")
             }
-        `
+		`
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -745,7 +745,7 @@ func TestAssertEqual(t *testing.T) {
             fun test() {
                 Test.assertEqual(15, 21)
             }
-        `
+		`
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -760,7 +760,7 @@ func TestAssertEqual(t *testing.T) {
 		)
 	})
 
-	t.Run("different types", func(t *testing.T) {
+	t.Run("fail with value equality on optional type", func(t *testing.T) {
 		t.Parallel()
 
 		script := `
@@ -768,9 +768,11 @@ func TestAssertEqual(t *testing.T) {
 
             access(all)
             fun test() {
-                Test.assertEqual(true, 1)
+                let expected: Int = 15
+                let actual: Int? = 15
+                Test.assertEqual(expected, actual)
             }
-        `
+		`
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -781,7 +783,32 @@ func TestAssertEqual(t *testing.T) {
 		assert.ErrorContains(
 			t,
 			err,
-			"assertion failed: not equal: expected: true, actual: 1",
+			"assertion failed: not equal types: expected: Int, actual: Int?",
+		)
+	})
+
+	t.Run("different types", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+            import Test
+
+            access(all)
+            fun test() {
+                Test.assertEqual(true, 1)
+            }
+		`
+
+		inter, err := newTestContractInterpreter(t, script)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &AssertionError{})
+		assert.ErrorContains(
+			t,
+			err,
+			"assertion failed: not equal types: expected: Bool, actual: Int",
 		)
 	})
 
@@ -804,7 +831,7 @@ func TestAssertEqual(t *testing.T) {
                 let actual = Address(0xee82856bf20e2aa6)
                 Test.assertEqual(expected, actual)
             }
-        `
+		`
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -852,7 +879,7 @@ func TestAssertEqual(t *testing.T) {
                 let actual = Foo(answer: 420)
                 Test.assertEqual(expected, actual)
             }
-        `
+		`
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -889,7 +916,7 @@ func TestAssertEqual(t *testing.T) {
                 let actual = [1, 2]
                 Test.assertEqual(expected, actual)
             }
-        `
+		`
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -926,7 +953,7 @@ func TestAssertEqual(t *testing.T) {
                 let actual = {1: true, 2: true}
                 Test.assertEqual(expected, actual)
             }
-        `
+		`
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -959,7 +986,7 @@ func TestAssertEqual(t *testing.T) {
 
             access(all)
             resource Foo {}
-        `
+		`
 
 		_, err := newTestContractInterpreter(t, script)
 
@@ -985,7 +1012,7 @@ func TestAssertEqual(t *testing.T) {
             resource Foo {}
             access(all)
             struct Bar {}
-        `
+		`
 
 		_, err := newTestContractInterpreter(t, script)
 
@@ -1003,14 +1030,14 @@ func TestAssertEqual(t *testing.T) {
             fun test() {
                 let foo = Foo()
                 let bar <- create Bar()
-                Test.expect(foo, Test.equal(<-bar))
+                Test.assertEqual(foo, <-bar)
             }
 
             access(all)
             struct Foo {}
             access(all)
             resource Bar {}
-        `
+		`
 
 		_, err := newTestContractInterpreter(t, script)
 

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -726,7 +726,7 @@ func TestAssertEqual(t *testing.T) {
             fun test() {
                 Test.assertEqual("this string", "this string")
             }
-		`
+        `
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -745,7 +745,7 @@ func TestAssertEqual(t *testing.T) {
             fun test() {
                 Test.assertEqual(15, 21)
             }
-		`
+        `
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -772,7 +772,7 @@ func TestAssertEqual(t *testing.T) {
                 let actual: Int? = 15
                 Test.assertEqual(expected, actual)
             }
-		`
+        `
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -797,7 +797,7 @@ func TestAssertEqual(t *testing.T) {
             fun test() {
                 Test.assertEqual(true, 1)
             }
-		`
+        `
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -831,7 +831,7 @@ func TestAssertEqual(t *testing.T) {
                 let actual = Address(0xee82856bf20e2aa6)
                 Test.assertEqual(expected, actual)
             }
-		`
+        `
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -879,7 +879,7 @@ func TestAssertEqual(t *testing.T) {
                 let actual = Foo(answer: 420)
                 Test.assertEqual(expected, actual)
             }
-		`
+        `
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -916,7 +916,7 @@ func TestAssertEqual(t *testing.T) {
                 let actual = [1, 2]
                 Test.assertEqual(expected, actual)
             }
-		`
+        `
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -953,7 +953,7 @@ func TestAssertEqual(t *testing.T) {
                 let actual = {1: true, 2: true}
                 Test.assertEqual(expected, actual)
             }
-		`
+        `
 
 		inter, err := newTestContractInterpreter(t, script)
 		require.NoError(t, err)
@@ -986,7 +986,7 @@ func TestAssertEqual(t *testing.T) {
 
             access(all)
             resource Foo {}
-		`
+        `
 
 		_, err := newTestContractInterpreter(t, script)
 
@@ -1012,7 +1012,7 @@ func TestAssertEqual(t *testing.T) {
             resource Foo {}
             access(all)
             struct Bar {}
-		`
+        `
 
 		_, err := newTestContractInterpreter(t, script)
 
@@ -1037,7 +1037,7 @@ func TestAssertEqual(t *testing.T) {
             struct Foo {}
             access(all)
             resource Bar {}
-		`
+        `
 
 		_, err := newTestContractInterpreter(t, script)
 


### PR DESCRIPTION
## Description

The `Test.assertEqual` method did not handle the case where the given inputs were equal in value, but had different types, e.g.:
```cadence
import Test

access(all)
fun test() {
    let expected: Int = 15
    let actual: Int? = 15
    Test.assertEqual(expected, actual)
}
```
The assertion message from above would be:

```bash
assertion failed: not equal: expected: 15, actual: 15
```
Which is quite confusing to developers.

Before performing value equality, we perform a type equality, so the assertion message now becomes:

```bash
assertion failed: not equal types: expected: Int, actual: Int?
```
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
