### PR TITLE
Support milliseconds for time delta in `Test.moveTime`

### DIFF
--- a/runtime/stdlib/test-framework.go
+++ b/runtime/stdlib/test-framework.go
@@ -75,7 +75,7 @@ type Blockchain interface {
 
 	Reset(uint64)
 
-	MoveTime(int64)
+	MoveTime(float64)
 
 	CreateSnapshot(string) error
 

--- a/runtime/stdlib/test_emulatorbackend.go
+++ b/runtime/stdlib/test_emulatorbackend.go
@@ -726,7 +726,7 @@ func (t *testEmulatorBackendType) newMoveTimeFunction(
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}
-			blockchain.MoveTime(int64(timeDelta.ToInt(invocation.LocationRange)))
+			blockchain.MoveTime(float64(timeDelta) / sema.Fix64Factor)
 			return interpreter.Void
 		},
 	)

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -2366,18 +2366,18 @@ func TestBlockchain(t *testing.T) {
                 // timeDelta is the representation of 35 days,
                 // in the form of seconds.
                 let timeDelta = Fix64(35 * 24 * 60 * 60)
-                Test.moveTime(by: timeDelta)
+                Test.moveTime(by: timeDelta + 0.5)
             }
-        `
+		`
 
 		moveTimeInvoked := false
 
 		testFramework := &mockedTestFramework{
 			emulatorBackend: func() Blockchain {
 				return &mockedBlockchain{
-					moveTime: func(timeDelta int64) {
+					moveTime: func(timeDelta float64) {
 						moveTimeInvoked = true
-						assert.Equal(t, int64(3024000), timeDelta)
+						assert.Equal(t, 3024000.5, timeDelta)
 					},
 				}
 			},
@@ -2405,16 +2405,16 @@ func TestBlockchain(t *testing.T) {
                 let timeDelta = Fix64(35 * 24 * 60 * 60) * -1.0
                 Test.moveTime(by: timeDelta)
             }
-        `
+		`
 
 		moveTimeInvoked := false
 
 		testFramework := &mockedTestFramework{
 			emulatorBackend: func() Blockchain {
 				return &mockedBlockchain{
-					moveTime: func(timeDelta int64) {
+					moveTime: func(timeDelta float64) {
 						moveTimeInvoked = true
-						assert.Equal(t, int64(-3024000), timeDelta)
+						assert.Equal(t, -3024000.0, timeDelta)
 					},
 				}
 			},
@@ -2439,14 +2439,14 @@ func TestBlockchain(t *testing.T) {
             fun testMoveTime() {
                 Test.moveTime(by: 3000)
             }
-        `
+		`
 
 		moveTimeInvoked := false
 
 		testFramework := &mockedTestFramework{
 			emulatorBackend: func() Blockchain {
 				return &mockedBlockchain{
-					moveTime: func(timeDelta int64) {
+					moveTime: func(timeDelta float64) {
 						moveTimeInvoked = true
 					},
 				}
@@ -2876,7 +2876,7 @@ type mockedBlockchain struct {
 	serviceAccount     func() (*Account, error)
 	events             func(inter *interpreter.Interpreter, eventType interpreter.StaticType) interpreter.Value
 	reset              func(uint64)
-	moveTime           func(int64)
+	moveTime           func(float64)
 	createSnapshot     func(string) error
 	loadSnapshot       func(string) error
 }
@@ -2989,7 +2989,7 @@ func (m mockedBlockchain) Reset(height uint64) {
 	m.reset(height)
 }
 
-func (m mockedBlockchain) MoveTime(timeDelta int64) {
+func (m mockedBlockchain) MoveTime(timeDelta float64) {
 	if m.moveTime == nil {
 		panic("'SetTimestamp' is not implemented")
 	}


### PR DESCRIPTION
## Description

Although the `timeDelta` in `Test.moveTime` accepts a `Fix64` value, under the hood it would truncate the value to `int64`.
We change this to deal with `float64`, so that we can support millisecond granularity.
Relevant issue: https://github.com/onflow/cadence-tools/issues/264#issuecomment-1881355919

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
