### PR TITLE
Introduce `toVariableSized` to ConstantSizedArray type

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2576,6 +2576,22 @@ func (v *ArrayValue) GetMember(interpreter *Interpreter, locationRange LocationR
 				)
 			},
 		)
+
+	case sema.ArrayTypeToVariableSizedFunctionName:
+		return NewHostFunctionValue(
+			interpreter,
+			sema.ArrayToVariableSizedFunctionType(
+				v.SemaType(interpreter).ElementType(false),
+			),
+			func(invocation Invocation) Value {
+				interpreter := invocation.Interpreter
+
+				return v.ToVariableSized(
+					interpreter,
+					invocation.LocationRange,
+				)
+			},
+		)
 	}
 
 	return nil
@@ -3223,6 +3239,59 @@ func (v *ArrayValue) ForEach(
 	_ LocationRange,
 ) {
 	v.Iterate(interpreter, function)
+}
+
+func (v *ArrayValue) ToVariableSized(
+	interpreter *Interpreter,
+	locationRange LocationRange,
+) Value {
+	var returnArrayStaticType ArrayStaticType
+	switch v.Type.(type) {
+	case *ConstantSizedStaticType:
+		returnArrayStaticType = NewVariableSizedStaticType(
+			interpreter,
+			v.Type.ElementType(),
+		)
+	default:
+		panic(errors.NewUnreachableError())
+	}
+
+	iterator, err := v.array.Iterator()
+	if err != nil {
+		panic(errors.NewExternalError(err))
+	}
+
+	return NewArrayValueWithIterator(
+		interpreter,
+		returnArrayStaticType,
+		common.ZeroAddress,
+		uint64(v.Count()),
+		func() Value {
+
+			// Meter computation for iterating the array.
+			interpreter.ReportComputation(common.ComputationKindLoop, 1)
+
+			atreeValue, err := iterator.Next()
+			if err != nil {
+				panic(errors.NewExternalError(err))
+			}
+
+			if atreeValue == nil {
+				return nil
+			}
+
+			value := MustConvertStoredValue(interpreter, atreeValue)
+
+			return value.Transfer(
+				interpreter,
+				locationRange,
+				atree.Address{},
+				false,
+				nil,
+				nil,
+			)
+		},
+	)
 }
 
 // NumberValue

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2571,7 +2571,7 @@ func ArraySliceFunctionType(elementType Type) *FunctionType {
 
 func ArrayToVariableSizedFunctionType(elementType Type) *FunctionType {
 	return NewSimpleFunctionType(
-		FunctionPurityImpure,
+		FunctionPurityView,
 		[]Parameter{},
 		NewTypeAnnotation(&VariableSizedType{
 			Type: elementType,

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2028,7 +2028,7 @@ Available if the array element type is not resource-kinded.
 const ArrayTypeToVariableSizedFunctionName = "toVariableSized"
 
 const arrayTypeToVariableSizedFunctionDocString = `
-Returns a new variable sized array with the same content.
+Returns a new variable-sized array with the copy of the contents of the given array.
 Available if the array is constant sized and the element type is not resource-kinded.
 `
 

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -2519,8 +2519,6 @@ func TestCheckVariableSizedArrayToVariableSizedInvalid(t *testing.T) {
 	t.Parallel()
 
 	_, err := ParseAndCheck(t, `
-		resource X {}
-
 		fun test() : [Int] {
 			let xs: [Int] = [1, 2, 3]
 


### PR DESCRIPTION
Work towards #2530

## Description
Introduce `toVariableSized` function to `ConstantSizedArray` type. This function will return a variable sized array whose contents are copies of the original constant sized array.

Since copy of values are involved, this is not available if the inner type of the constant sized array is a resource.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
