### PR TITLE
Allow issuing capability controllers using type values

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -1051,3 +1051,22 @@ func (e InclusiveRangeConstructionError) Error() string {
 	}
 	return fmt.Sprintf("%s: %s", message, e.Message)
 }
+
+// InvalidCapabilityIssueTypeError
+type InvalidCapabilityIssueTypeError struct {
+	ExpectedTypeDescription string
+	ActualType              sema.Type
+	LocationRange
+}
+
+var _ errors.UserError = InvalidCapabilityIssueTypeError{}
+
+func (InvalidCapabilityIssueTypeError) IsUserError() {}
+
+func (e InvalidCapabilityIssueTypeError) Error() string {
+	return fmt.Sprintf(
+		"invalid type: expected %s, got `%s`",
+		e.ExpectedTypeDescription,
+		e.ActualType.QualifiedString(),
+	)
+}

--- a/runtime/interpreter/value_account_accountcapabilities.go
+++ b/runtime/interpreter/value_account_accountcapabilities.go
@@ -38,6 +38,7 @@ func NewAccountAccountCapabilitiesValue(
 	getControllersFunction FunctionValue,
 	forEachControllerFunction FunctionValue,
 	issueFunction FunctionValue,
+	issueWithTypeFunction FunctionValue,
 ) Value {
 
 	fields := map[string]Value{
@@ -45,6 +46,7 @@ func NewAccountAccountCapabilitiesValue(
 		sema.Account_AccountCapabilitiesTypeGetControllersFunctionName:    getControllersFunction,
 		sema.Account_AccountCapabilitiesTypeForEachControllerFunctionName: forEachControllerFunction,
 		sema.Account_AccountCapabilitiesTypeIssueFunctionName:             issueFunction,
+		sema.Account_AccountCapabilitiesTypeIssueWithTypeFunctionName:     issueWithTypeFunction,
 	}
 
 	var str string

--- a/runtime/interpreter/value_account_storagecapabilities.go
+++ b/runtime/interpreter/value_account_storagecapabilities.go
@@ -38,6 +38,7 @@ func NewAccountStorageCapabilitiesValue(
 	getControllersFunction FunctionValue,
 	forEachControllerFunction FunctionValue,
 	issueFunction FunctionValue,
+	issueWithTypeFunction FunctionValue,
 ) Value {
 
 	fields := map[string]Value{
@@ -45,6 +46,7 @@ func NewAccountStorageCapabilitiesValue(
 		sema.Account_StorageCapabilitiesTypeGetControllersFunctionName:    getControllersFunction,
 		sema.Account_StorageCapabilitiesTypeForEachControllerFunctionName: forEachControllerFunction,
 		sema.Account_StorageCapabilitiesTypeIssueFunctionName:             issueFunction,
+		sema.Account_StorageCapabilitiesTypeIssueWithTypeFunctionName:     issueWithTypeFunction,
 	}
 
 	var str string

--- a/runtime/sema/account.cdc
+++ b/runtime/sema/account.cdc
@@ -362,6 +362,10 @@ struct Account {
         access(Capabilities | StorageCapabilities | IssueStorageCapabilityController)
         fun issue<T: &Any>(_ path: StoragePath): Capability<T>
 
+        /// Issue/create a new storage capability.
+       access(Capabilities | StorageCapabilities | IssueStorageCapabilityController)
+       fun issueWithType(_ path: StoragePath, type: Type): Capability
+
         /// Get the storage capability controller for the capability with the specified ID.
         ///
         /// Returns nil if the ID does not reference an existing storage capability.
@@ -391,9 +395,14 @@ struct Account {
 
     access(all)
     struct AccountCapabilities {
+
         /// Issue/create a new account capability.
         access(Capabilities | AccountCapabilities | IssueAccountCapabilityController)
         fun issue<T: &Account>(): Capability<T>
+
+        /// Issue/create a new account capability.
+        access(Capabilities | AccountCapabilities | IssueAccountCapabilityController)
+        fun issueWithType(_ type: Type): Capability
 
         /// Get capability controller for capability with the specified ID.
         ///

--- a/runtime/sema/account.gen.go
+++ b/runtime/sema/account.gen.go
@@ -1477,6 +1477,29 @@ const Account_StorageCapabilitiesTypeIssueFunctionDocString = `
 Issue/create a new storage capability.
 `
 
+const Account_StorageCapabilitiesTypeIssueWithTypeFunctionName = "issueWithType"
+
+var Account_StorageCapabilitiesTypeIssueWithTypeFunctionType = &FunctionType{
+	Parameters: []Parameter{
+		{
+			Label:          ArgumentLabelNotRequired,
+			Identifier:     "path",
+			TypeAnnotation: NewTypeAnnotation(StoragePathType),
+		},
+		{
+			Identifier:     "type",
+			TypeAnnotation: NewTypeAnnotation(MetaType),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&CapabilityType{},
+	),
+}
+
+const Account_StorageCapabilitiesTypeIssueWithTypeFunctionDocString = `
+Issue/create a new storage capability.
+`
+
 const Account_StorageCapabilitiesTypeGetControllerFunctionName = "getController"
 
 var Account_StorageCapabilitiesTypeGetControllerFunctionType = &FunctionType{
@@ -1599,6 +1622,16 @@ func init() {
 		NewUnmeteredFunctionMember(
 			Account_StorageCapabilitiesType,
 			newEntitlementAccess(
+				[]Type{CapabilitiesType, StorageCapabilitiesType, IssueStorageCapabilityControllerType},
+				Disjunction,
+			),
+			Account_StorageCapabilitiesTypeIssueWithTypeFunctionName,
+			Account_StorageCapabilitiesTypeIssueWithTypeFunctionType,
+			Account_StorageCapabilitiesTypeIssueWithTypeFunctionDocString,
+		),
+		NewUnmeteredFunctionMember(
+			Account_StorageCapabilitiesType,
+			newEntitlementAccess(
 				[]Type{CapabilitiesType, StorageCapabilitiesType, GetStorageCapabilityControllerType},
 				Disjunction,
 			),
@@ -1657,6 +1690,25 @@ var Account_AccountCapabilitiesTypeIssueFunctionType = &FunctionType{
 }
 
 const Account_AccountCapabilitiesTypeIssueFunctionDocString = `
+Issue/create a new account capability.
+`
+
+const Account_AccountCapabilitiesTypeIssueWithTypeFunctionName = "issueWithType"
+
+var Account_AccountCapabilitiesTypeIssueWithTypeFunctionType = &FunctionType{
+	Parameters: []Parameter{
+		{
+			Label:          ArgumentLabelNotRequired,
+			Identifier:     "type",
+			TypeAnnotation: NewTypeAnnotation(MetaType),
+		},
+	},
+	ReturnTypeAnnotation: NewTypeAnnotation(
+		&CapabilityType{},
+	),
+}
+
+const Account_AccountCapabilitiesTypeIssueWithTypeFunctionDocString = `
 Issue/create a new account capability.
 `
 
@@ -1767,6 +1819,16 @@ func init() {
 			Account_AccountCapabilitiesTypeIssueFunctionName,
 			Account_AccountCapabilitiesTypeIssueFunctionType,
 			Account_AccountCapabilitiesTypeIssueFunctionDocString,
+		),
+		NewUnmeteredFunctionMember(
+			Account_AccountCapabilitiesType,
+			newEntitlementAccess(
+				[]Type{CapabilitiesType, AccountCapabilitiesType, IssueAccountCapabilityControllerType},
+				Disjunction,
+			),
+			Account_AccountCapabilitiesTypeIssueWithTypeFunctionName,
+			Account_AccountCapabilitiesTypeIssueWithTypeFunctionType,
+			Account_AccountCapabilitiesTypeIssueWithTypeFunctionDocString,
 		),
 		NewUnmeteredFunctionMember(
 			Account_AccountCapabilitiesType,


### PR DESCRIPTION
Closes #1617 

## Description

Add new functions `issueWithType` to `Account.StorageCapabilities` and `Account.AccountCapabilities`, which allow issuing capability controllers using run-time type values (`Type`). 

Reuse the existing issuing implementation by refactoring the shared logic.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
