### PR TITLE
prevent creation of nested storage references

### DIFF
--- a/runtime/interpreter/errors.go
+++ b/runtime/interpreter/errors.go
@@ -1018,7 +1018,7 @@ func (e CapabilityAddressPublishingError) Error() string {
 
 // NestedReferenceError
 type NestedReferenceError struct {
-	Value *EphemeralReferenceValue
+	Value ReferenceValue
 	LocationRange
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -20197,7 +20197,7 @@ func NewUnmeteredEphemeralReferenceValue(
 	borrowedType sema.Type,
 	locationRange LocationRange,
 ) *EphemeralReferenceValue {
-	if reference, isReference := value.(*EphemeralReferenceValue); isReference {
+	if reference, isReference := value.(ReferenceValue); isReference {
 		panic(NestedReferenceError{
 			Value:         reference,
 			LocationRange: locationRange,


### PR DESCRIPTION
It was possible to create a nested reference when the inner reference was a storage reference. 

Thanks to @oebeling for the report
______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
