### PR TITLE
Improve parsing for backward compatibility rules

### DIFF
--- a/runtime/parser/declaration.go
+++ b/runtime/parser/declaration.go
@@ -215,7 +215,10 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 				continue
 
 			case KeywordPub:
-				handlePub(p)
+				err := handlePub(p)
+				if err != nil {
+					return nil, err
+				}
 				continue
 
 			case KeywordPriv:
@@ -1695,7 +1698,10 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 				continue
 
 			case KeywordPub:
-				handlePub(p)
+				err := handlePub(p)
+				if err != nil {
+					return nil, err
+				}
 				continue
 
 			case KeywordPriv:

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -9700,17 +9700,12 @@ func TestParseDeprecatedAccessModifiers(t *testing.T) {
 		_, errs := testParseDeclarations(" pub(set) fun foo ( ) { }")
 		utils.AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxErrorWithSuggestedReplacement{
-					Message: "`pub` is no longer a valid access keyword",
-					Range: ast.Range{
-						StartPos: ast.Position{Offset: 1, Line: 1, Column: 1},
-						EndPos:   ast.Position{Offset: 3, Line: 1, Column: 3},
-					},
-					SuggestedFix: "`access(all)`",
+				&SyntaxError{
+					Message: "`pub(set)` is no longer a valid access keyword",
+					Pos:     ast.Position{Offset: 1, Line: 1, Column: 1},
 				},
 			},
 			errs,
 		)
-
 	})
 }

--- a/runtime/parser/type.go
+++ b/runtime/parser/type.go
@@ -922,7 +922,7 @@ func defineIdentifierTypes() {
 					p.skipSpaceAndComments()
 
 					var err error
-					authorization, err = parseAuthorization(p, authorization)
+					authorization, err = parseAuthorization(p)
 					if err != nil {
 						return nil, err
 					}
@@ -977,7 +977,7 @@ func defineIdentifierTypes() {
 	)
 }
 
-func parseAuthorization(p *parser, authorization ast.Authorization) (ast.Authorization, error) {
+func parseAuthorization(p *parser) (auth ast.Authorization, err error) {
 	keyword := p.currentTokenSource()
 	switch string(keyword) {
 	case KeywordMapping:
@@ -989,7 +989,7 @@ func parseAuthorization(p *parser, authorization ast.Authorization) (ast.Authori
 		if err != nil {
 			return nil, err
 		}
-		authorization = ast.NewMappedAccess(entitlementMapName, keywordPos)
+		auth = ast.NewMappedAccess(entitlementMapName, keywordPos)
 		p.skipSpaceAndComments()
 
 	default:
@@ -997,15 +997,15 @@ func parseAuthorization(p *parser, authorization ast.Authorization) (ast.Authori
 		if err != nil {
 			return nil, err
 		}
-		authorization = entitlements
+		auth = entitlements
 	}
 
-	_, err := p.mustOne(lexer.TokenParenClose)
+	_, err = p.mustOne(lexer.TokenParenClose)
 	if err != nil {
 		return nil, err
 	}
 
-	return authorization, nil
+	return auth, nil
 }
 
 // parse a function type starting after the `fun` keyword.

--- a/runtime/parser/type_test.go
+++ b/runtime/parser/type_test.go
@@ -305,7 +305,7 @@ func TestParseReferenceType(t *testing.T) {
 		utils.AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
-					Message: "expected token '('",
+					Message: "expected authorization (entitlement list)",
 					Pos:     ast.Position{Offset: 5, Line: 1, Column: 5},
 				},
 			},
@@ -2897,7 +2897,7 @@ func TestParseAuthorizedReferenceTypeWithNoEntitlements(t *testing.T) {
 	utils.AssertEqualWithDiff(t,
 		[]error{
 			&SyntaxError{
-				Message: "expected token '('",
+				Message: "expected authorization (entitlement list)",
 				Pos:     ast.Position{Offset: 20, Line: 2, Column: 19},
 			},
 		},


### PR DESCRIPTION

## Description

Improve experience when migrating pre-1.0 code by improving the parser rules
- When encountering the deprecated `pub`, `priv`, and `pub(set)` access modifiers, ignore them and keep parsing. This reports more errors which reduces error fatigue (fix one error just to get another error; instead report as many errors as possible immediately, so they can get fixed in one go)
  - This requires restoring `pub(set)` parsing, but ignoring the result (taken from https://github.com/onflow/cadence/pull/2540/files#diff-2bb30711dcbbeff876d376da405eb28f46fc79172cb2b72c88e762f659440c26L359-L394)
- When encountering the `auth` keyword without a authorization (entitlement list), provide a better error message describing what is missing
- When encountering a duplicate `view` modifier, ignore it and keep parsing

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
