### PR TITLE
Fix the entitlements migration

### DIFF
--- a/encoding/ccf/simpletype_test.go
+++ b/encoding/ccf/simpletype_test.go
@@ -52,22 +52,11 @@ func TestTypeConversion(t *testing.T) {
 	}
 
 	for ty := interpreter.PrimitiveStaticType(1); ty < interpreter.PrimitiveStaticType_Count; ty++ {
-		if !ty.IsDefined() {
+		if !ty.IsDefined() || ty.IsDeprecated() { //nolint:staticcheck
 			continue
 		}
 
 		semaType := ty.SemaType()
-
-		// Some primitive static types are deprecated,
-		// and only exist for migration purposes,
-		// so do not have an equivalent sema type
-		if semaType == nil {
-			continue
-		}
-
-		if ty.IsDeprecated() { //nolint:staticcheck
-			continue
-		}
 
 		if _, ok := semaType.(*sema.CapabilityType); ok {
 			continue

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -1204,7 +1204,7 @@ var simpleTypes = func() map[string]cadence.Type {
 	typeMap["Bytes"] = cadence.TheBytesType
 
 	for ty := interpreter.PrimitiveStaticType(1); ty < interpreter.PrimitiveStaticType_Count; ty++ {
-		if !ty.IsDefined() {
+		if !ty.IsDefined() || ty.IsDeprecated() { //nolint:staticcheck
 			continue
 		}
 
@@ -1214,13 +1214,6 @@ var simpleTypes = func() map[string]cadence.Type {
 		}
 
 		semaType := ty.SemaType()
-
-		// Some primitive static types are deprecated,
-		// and only exist for migration purposes,
-		// so do not have an equivalent sema type
-		if semaType == nil {
-			continue
-		}
 
 		typeMap[string(semaType.ID())] = cadenceType
 	}

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -3667,18 +3667,11 @@ func TestSimpleTypes(t *testing.T) {
 	}
 
 	for ty := interpreter.PrimitiveStaticType(1); ty < interpreter.PrimitiveStaticType_Count; ty++ {
-		if !ty.IsDefined() {
+		if !ty.IsDefined() || ty.IsDeprecated() { //nolint:staticcheck
 			continue
 		}
 
 		semaType := ty.SemaType()
-
-		// Some primitive static types are deprecated,
-		// and only exist for migration purposes,
-		// so do not have an equivalent sema type
-		if semaType == nil {
-			continue
-		}
 
 		cadenceType := cadence.PrimitiveType(ty)
 		if !canEncodeAsSimpleType(cadenceType) {

--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -47,8 +47,26 @@ func (EntitlementsMigration) Name() string {
 // * `ConvertToEntitledType(T) ---> T`
 // where Entitlements(I) is defined as the result of T.SupportedEntitlements()
 func ConvertToEntitledType(t sema.Type) (sema.Type, bool) {
+
 	switch t := t.(type) {
 	case *sema.ReferenceType:
+
+		// Do NOT add authorization for sema types
+		// that were converted from deprecated primitive static types
+		switch t.Type {
+
+		case sema.AccountType,
+			sema.Account_ContractsType,
+			sema.Account_KeysType,
+			sema.Account_InboxType,
+			sema.Account_StorageCapabilitiesType,
+			sema.Account_AccountCapabilitiesType,
+			sema.Account_CapabilitiesType,
+			sema.AccountKeyType:
+
+			return t, false
+		}
+
 		switch t.Authorization {
 		case sema.UnauthorizedAccess:
 			innerType, convertedInner := ConvertToEntitledType(t.Type)

--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -135,6 +135,10 @@ func ConvertValueToEntitlements(
 		staticType = v.StaticType(inter)
 	}
 
+	if staticType.IsDeprecated() {
+		return nil
+	}
+
 	// if the static type contains a legacy restricted type, convert it to a new type according to some rules:
 	// &T{I} -> auth(SupportedEntitlements(I)) &T
 	// Capability<&T{I}> -> Capability<auth(SupportedEntitlements(I)) &T>

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -2128,7 +2128,7 @@ func TestConvertDeprecatedStaticTypes(t *testing.T) {
 			t.Parallel()
 
 			inter := NewTestInterpreter(t)
-			typeValue := interpreter.NewUnmeteredCapabilityValue(
+			value := interpreter.NewUnmeteredCapabilityValue(
 				1,
 				interpreter.AddressValue(common.ZeroAddress),
 				interpreter.NewReferenceStaticType(
@@ -2138,7 +2138,7 @@ func TestConvertDeprecatedStaticTypes(t *testing.T) {
 				),
 			)
 
-			result, err := ConvertValueToEntitlements(inter, typeValue)
+			result, err := ConvertValueToEntitlements(inter, value)
 			require.Error(t, err)
 			assert.ErrorContains(t, err, "cannot migrate deprecated type")
 			require.Nil(t, result)
@@ -2187,7 +2187,7 @@ func TestConvertMigratedAccountTypes(t *testing.T) {
 
 			result, err := ConvertValueToEntitlements(inter, newValue)
 			require.NoError(t, err)
-			require.Nil(t, result)
+			require.Nilf(t, result, "expected no migration, but got %s", result)
 		})
 	}
 

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -2108,3 +2108,38 @@ func TestMigrateDictOfWithTypeValueKey(t *testing.T) {
 		ref.Authorization,
 	)
 }
+
+func TestConvertDeprecatedTypes(t *testing.T) {
+
+	t.Parallel()
+
+	test := func(ty interpreter.PrimitiveStaticType) {
+
+		t.Run(ty.String(), func(t *testing.T) {
+			t.Parallel()
+
+			inter := NewTestInterpreter(t)
+			typeValue := interpreter.NewUnmeteredCapabilityValue(
+				1,
+				interpreter.AddressValue(common.ZeroAddress),
+				interpreter.NewReferenceStaticType(
+					nil,
+					interpreter.UnauthorizedAccess,
+					ty,
+				),
+			)
+
+			result := ConvertValueToEntitlements(inter, typeValue)
+
+			require.Nil(t, result)
+		})
+	}
+
+	for ty := interpreter.PrimitiveStaticType(1); ty < interpreter.PrimitiveStaticType_Count; ty++ {
+		if !ty.IsDefined() || !ty.IsDeprecated() { //nolint:staticcheck
+			continue
+		}
+
+		test(ty)
+	}
+}

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -21,10 +21,12 @@ package entitlements
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/migrations"
+	"github.com/onflow/cadence/migrations/account_type"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -378,8 +380,15 @@ func (testEntitlementsMigration) Name() string {
 	return "Test Entitlements Migration"
 }
 
-func (m testEntitlementsMigration) Migrate(_ interpreter.AddressPath, value interpreter.Value, _ *interpreter.Interpreter) (interpreter.Value, error) {
-	return ConvertValueToEntitlements(m.inter, value), nil
+func (m testEntitlementsMigration) Migrate(
+	_ interpreter.AddressPath,
+	value interpreter.Value,
+	_ *interpreter.Interpreter,
+) (
+	interpreter.Value,
+	error,
+) {
+	return ConvertValueToEntitlements(m.inter, value)
 }
 
 func convertEntireTestValue(
@@ -394,7 +403,7 @@ func convertEntireTestValue(
 	migratedValue := storageMig.MigrateNestedValue(
 		interpreter.AddressPath{
 			Address: address,
-			Path:    interpreter.NewPathValue(nil, common.PathDomainStorage, ""),
+			Path:    interpreter.NewPathValue(nil, common.PathDomainStorage, "test"),
 		},
 		v,
 		[]migrations.ValueMigration{testMig},
@@ -2109,7 +2118,7 @@ func TestMigrateDictOfWithTypeValueKey(t *testing.T) {
 	)
 }
 
-func TestConvertDeprecatedTypes(t *testing.T) {
+func TestConvertDeprecatedStaticTypes(t *testing.T) {
 
 	t.Parallel()
 
@@ -2129,8 +2138,55 @@ func TestConvertDeprecatedTypes(t *testing.T) {
 				),
 			)
 
-			result := ConvertValueToEntitlements(inter, typeValue)
+			result, err := ConvertValueToEntitlements(inter, typeValue)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "cannot migrate deprecated type")
+			require.Nil(t, result)
+		})
+	}
 
+	for ty := interpreter.PrimitiveStaticType(1); ty < interpreter.PrimitiveStaticType_Count; ty++ {
+		if !ty.IsDefined() || !ty.IsDeprecated() { //nolint:staticcheck
+			continue
+		}
+
+		test(ty)
+	}
+}
+
+func TestConvertMigratedAccountTypes(t *testing.T) {
+
+	t.Parallel()
+
+	test := func(ty interpreter.PrimitiveStaticType) {
+
+		t.Run(ty.String(), func(t *testing.T) {
+			t.Parallel()
+
+			inter := NewTestInterpreter(t)
+			value := interpreter.NewUnmeteredCapabilityValue(
+				1,
+				interpreter.AddressValue(common.ZeroAddress),
+				interpreter.NewReferenceStaticType(
+					nil,
+					interpreter.UnauthorizedAccess,
+					ty,
+				),
+			)
+
+			newValue, err := account_type.NewAccountTypeMigration().Migrate(
+				interpreter.AddressPath{
+					Address: common.ZeroAddress,
+					Path:    interpreter.EmptyPathValue,
+				},
+				value,
+				inter,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, newValue)
+
+			result, err := ConvertValueToEntitlements(inter, newValue)
+			require.NoError(t, err)
 			require.Nil(t, result)
 		})
 	}

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -566,23 +566,6 @@ func (t PrimitiveStaticType) SemaType() sema.Type {
 	case PrimitiveStaticTypeAccountCapabilityController:
 		return sema.AccountCapabilityControllerType
 
-	case PrimitiveStaticTypeAuthAccount: //nolint:staticcheck
-		return sema.FullyEntitledAccountReferenceType
-	case PrimitiveStaticTypePublicAccount: //nolint:staticcheck
-		return sema.AccountReferenceType
-	case PrimitiveStaticTypeAuthAccountContracts, //nolint:staticcheck
-		PrimitiveStaticTypePublicAccountContracts,         //nolint:staticcheck
-		PrimitiveStaticTypeAuthAccountKeys,                //nolint:staticcheck
-		PrimitiveStaticTypePublicAccountKeys,              //nolint:staticcheck
-		PrimitiveStaticTypeAuthAccountInbox,               //nolint:staticcheck
-		PrimitiveStaticTypeAuthAccountStorageCapabilities, //nolint:staticcheck
-		PrimitiveStaticTypeAuthAccountAccountCapabilities, //nolint:staticcheck
-		PrimitiveStaticTypeAuthAccountCapabilities,        //nolint:staticcheck
-		PrimitiveStaticTypePublicAccountCapabilities,      //nolint:staticcheck
-		PrimitiveStaticTypeAccountKey:                     //nolint:staticcheck
-		// These types are deprecated, and only exist for migration purposes
-		return nil
-
 	case PrimitiveStaticTypeAccount:
 		return sema.AccountType
 	case PrimitiveStaticTypeAccount_Contracts:
@@ -664,6 +647,10 @@ func (t PrimitiveStaticType) SemaType() sema.Type {
 		return sema.CapabilitiesMappingType
 	case PrimitiveStaticTypeAccountMapping:
 		return sema.AccountMappingType
+	}
+
+	if t.IsDeprecated() {
+		panic(errors.NewUnexpectedError("cannot convert deprecated type %s", t))
 	}
 
 	panic(errors.NewUnexpectedError("missing case for %s", t))

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -913,8 +913,9 @@ func ConvertSemaToPrimitiveStaticType(
 	}
 
 	if typ == PrimitiveStaticTypeUnknown {
+		// default is 0 aka PrimitiveStaticTypeUnknown
 		return
 	}
 
-	return NewPrimitiveStaticType(memoryGauge, typ) // default is 0 aka PrimitiveStaticTypeUnknown
+	return NewPrimitiveStaticType(memoryGauge, typ)
 }

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -647,6 +647,13 @@ func (t PrimitiveStaticType) SemaType() sema.Type {
 		return sema.CapabilitiesMappingType
 	case PrimitiveStaticTypeAccountMapping:
 		return sema.AccountMappingType
+
+	case PrimitiveStaticTypeAuthAccount: //nolint:staticcheck
+		// deprecated, but needed for migration purposes
+		return sema.FullyEntitledAccountReferenceType
+	case PrimitiveStaticTypePublicAccount: //nolint:staticcheck
+		// deprecated, but needed for migration purposes
+		return sema.AccountReferenceType
 	}
 
 	if t.IsDeprecated() {

--- a/runtime/interpreter/primitivestatictype_test.go
+++ b/runtime/interpreter/primitivestatictype_test.go
@@ -29,21 +29,14 @@ func TestPrimitiveStaticTypeSemaTypeConversion(t *testing.T) {
 	t.Parallel()
 
 	test := func(ty PrimitiveStaticType) {
+		if ty.IsDeprecated() { //nolint:staticcheck
+			return
+		}
+
 		t.Run(ty.String(), func(t *testing.T) {
 			t.Parallel()
 
 			semaType := ty.SemaType()
-
-			// Some primitive static types are deprecated,
-			// and only exist for migration purposes,
-			// so do not have an equivalent sema type
-			if semaType == nil {
-				return
-			}
-
-			if ty.IsDeprecated() {
-				return
-			}
 
 			ty2 := ConvertSemaToPrimitiveStaticType(nil, semaType)
 			require.True(t, ty2.Equal(ty))
@@ -51,7 +44,7 @@ func TestPrimitiveStaticTypeSemaTypeConversion(t *testing.T) {
 	}
 
 	for ty := PrimitiveStaticType(1); ty < PrimitiveStaticType_Count; ty++ {
-		if !ty.IsDefined() {
+		if !ty.IsDefined() || ty.IsDeprecated() { //nolint:staticcheck
 			continue
 		}
 		test(ty)
@@ -71,7 +64,7 @@ func TestPrimitiveStaticType_elementSize(t *testing.T) {
 	}
 
 	for ty := PrimitiveStaticType(1); ty < PrimitiveStaticType_Count; ty++ {
-		if !ty.IsDefined() {
+		if !ty.IsDefined() || ty.IsDeprecated() { //nolint:staticcheck
 			continue
 		}
 		test(ty)

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -49,6 +49,7 @@ type StaticType interface {
 	Encode(e *cbor.StreamEncoder) error
 	MeteredString(memoryGauge common.MemoryGauge) string
 	ID() TypeID
+	IsDeprecated() bool
 }
 
 type TypeID = common.TypeID
@@ -129,6 +130,10 @@ func (t *CompositeStaticType) ID() TypeID {
 	return t.TypeID
 }
 
+func (*CompositeStaticType) IsDeprecated() bool {
+	return false
+}
+
 // InterfaceStaticType
 
 type InterfaceStaticType struct {
@@ -205,6 +210,10 @@ func (t *InterfaceStaticType) ID() TypeID {
 	return t.TypeID
 }
 
+func (*InterfaceStaticType) IsDeprecated() bool {
+	return false
+}
+
 // ArrayStaticType
 
 type ArrayStaticType interface {
@@ -269,6 +278,10 @@ func (t *VariableSizedStaticType) ID() TypeID {
 	return sema.FormatVariableSizedTypeID(t.Type.ID())
 }
 
+func (t *VariableSizedStaticType) IsDeprecated() bool {
+	return t.Type.IsDeprecated()
+}
+
 // InclusiveRangeStaticType
 
 type InclusiveRangeStaticType struct {
@@ -318,6 +331,10 @@ func (t InclusiveRangeStaticType) Equal(other StaticType) bool {
 
 func (t InclusiveRangeStaticType) ID() TypeID {
 	return sema.InclusiveRangeTypeID(string(t.ElementType.ID()))
+}
+
+func (t InclusiveRangeStaticType) IsDeprecated() bool {
+	return t.ElementType.IsDeprecated()
 }
 
 // ConstantSizedStaticType
@@ -386,6 +403,10 @@ func (t *ConstantSizedStaticType) ID() TypeID {
 	return sema.FormatConstantSizedTypeID(t.Type.ID(), t.Size)
 }
 
+func (t *ConstantSizedStaticType) IsDeprecated() bool {
+	return t.Type.IsDeprecated()
+}
+
 // DictionaryStaticType
 
 type DictionaryStaticType struct {
@@ -443,6 +464,11 @@ func (t *DictionaryStaticType) ID() TypeID {
 	)
 }
 
+func (t *DictionaryStaticType) IsDeprecated() bool {
+	return t.KeyType.IsDeprecated() ||
+		t.ValueType.IsDeprecated()
+}
+
 // OptionalStaticType
 
 type OptionalStaticType struct {
@@ -488,6 +514,10 @@ func (t *OptionalStaticType) Equal(other StaticType) bool {
 
 func (t *OptionalStaticType) ID() TypeID {
 	return sema.FormatOptionalTypeID(t.Type.ID())
+}
+
+func (t *OptionalStaticType) IsDeprecated() bool {
+	return t.Type.IsDeprecated()
 }
 
 var NilStaticType = &OptionalStaticType{
@@ -581,6 +611,16 @@ func (t *IntersectionStaticType) ID() TypeID {
 	}
 	// FormatIntersectionTypeID sorts
 	return sema.FormatIntersectionTypeID(interfaceTypeIDs)
+}
+
+func (t *IntersectionStaticType) IsDeprecated() bool {
+	for _, typ := range t.Types {
+		if typ.IsDeprecated() {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Authorization
@@ -816,6 +856,10 @@ func (t *ReferenceStaticType) ID() TypeID {
 	)
 }
 
+func (t *ReferenceStaticType) IsDeprecated() bool {
+	return t.ReferencedType.IsDeprecated()
+}
+
 // CapabilityStaticType
 
 type CapabilityStaticType struct {
@@ -879,6 +923,13 @@ func (t *CapabilityStaticType) ID() TypeID {
 		borrowTypeID = borrowType.ID()
 	}
 	return sema.FormatCapabilityTypeID(borrowTypeID)
+}
+
+func (t *CapabilityStaticType) IsDeprecated() bool {
+	if t.BorrowType == nil {
+		return false
+	}
+	return t.BorrowType.IsDeprecated()
 }
 
 // Conversion
@@ -1329,6 +1380,12 @@ func (t FunctionStaticType) Equal(other StaticType) bool {
 func (t FunctionStaticType) ID() TypeID {
 	return t.Type.ID()
 }
+
+func (FunctionStaticType) IsDeprecated() bool {
+	return false
+}
+
+// TypeParameter
 
 type TypeParameter struct {
 	TypeBound StaticType

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -2399,6 +2399,14 @@ func TestStaticType_IsDeprecated(t *testing.T) {
 			ty:       &CompositeStaticType{},
 			expected: false,
 		},
+		{
+			name: "InclusiveRange",
+			genTy: func(innerType PrimitiveStaticType) StaticType {
+				return &InclusiveRangeStaticType{
+					ElementType: innerType,
+				}
+			},
+		},
 	}
 
 	test := func(test testCase) {

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -969,10 +969,11 @@ func TestStaticTypeConversion(t *testing.T) {
 	testFunctionType := &sema.FunctionType{}
 
 	type testCase struct {
-		name         string
-		semaType     sema.Type
-		staticType   StaticType
-		getInterface func(
+		name           string
+		semaType       sema.Type
+		staticType     StaticType
+		noSemaToStatic bool
+		getInterface   func(
 			t *testing.T,
 			location common.Location,
 			qualifiedIdentifier string,
@@ -1610,6 +1611,19 @@ func TestStaticTypeConversion(t *testing.T) {
 				ElementType: PrimitiveStaticTypeInt,
 			},
 		},
+		// Deprecated primitive static types, only exist for migration purposes
+		{
+			name:           "AuthAccount",
+			semaType:       sema.FullyEntitledAccountReferenceType,
+			staticType:     PrimitiveStaticTypeAuthAccount,
+			noSemaToStatic: true,
+		},
+		{
+			name:           "PublicAccount",
+			semaType:       sema.AccountReferenceType,
+			staticType:     PrimitiveStaticTypePublicAccount,
+			noSemaToStatic: true,
+		},
 	}
 
 	test := func(test testCase) {
@@ -1619,11 +1633,13 @@ func TestStaticTypeConversion(t *testing.T) {
 
 			// Test sema to static
 
-			convertedStaticType := ConvertSemaToStaticType(nil, test.semaType)
-			require.Equal(t,
-				test.staticType,
-				convertedStaticType,
-			)
+			if !test.noSemaToStatic {
+				convertedStaticType := ConvertSemaToStaticType(nil, test.semaType)
+				require.Equal(t,
+					test.staticType,
+					convertedStaticType,
+				)
+			}
 
 			// Test static to sema
 

--- a/runtime/interpreter/statictype_test.go
+++ b/runtime/interpreter/statictype_test.go
@@ -969,11 +969,10 @@ func TestStaticTypeConversion(t *testing.T) {
 	testFunctionType := &sema.FunctionType{}
 
 	type testCase struct {
-		name           string
-		semaType       sema.Type
-		staticType     StaticType
-		noSemaToStatic bool
-		getInterface   func(
+		name         string
+		semaType     sema.Type
+		staticType   StaticType
+		getInterface func(
 			t *testing.T,
 			location common.Location,
 			qualifiedIdentifier string,
@@ -1602,70 +1601,6 @@ func TestStaticTypeConversion(t *testing.T) {
 			semaType:   sema.HashableStructType,
 			staticType: PrimitiveStaticTypeHashableStruct,
 		},
-
-		// Deprecated primitive static types, only exist for migration purposes
-		{
-			name:           "AuthAccount",
-			semaType:       sema.FullyEntitledAccountReferenceType,
-			staticType:     PrimitiveStaticTypeAuthAccount,
-			noSemaToStatic: true,
-		},
-		{
-			name:           "PublicAccount",
-			semaType:       sema.AccountReferenceType,
-			staticType:     PrimitiveStaticTypePublicAccount,
-			noSemaToStatic: true,
-		},
-		{
-			name:       "AuthAccount.Contracts",
-			staticType: PrimitiveStaticTypeAuthAccountContracts,
-			semaType:   nil,
-		},
-		{
-			name:       "PublicAccount.Contracts",
-			staticType: PrimitiveStaticTypePublicAccountContracts,
-			semaType:   nil,
-		},
-		{
-			name:       "AuthAccount.Keys",
-			staticType: PrimitiveStaticTypeAuthAccountKeys,
-			semaType:   nil,
-		},
-		{
-			name:       "PublicAccount.Keys",
-			staticType: PrimitiveStaticTypePublicAccountKeys,
-			semaType:   nil,
-		},
-		{
-			name:       "AuthAccount.Inbox",
-			staticType: PrimitiveStaticTypeAuthAccountInbox,
-			semaType:   nil,
-		},
-		{
-			name:       "AuthAccount.StorageCapabilities",
-			staticType: PrimitiveStaticTypeAuthAccountStorageCapabilities,
-			semaType:   nil,
-		},
-		{
-			name:       "AuthAccount.AccountCapabilities",
-			staticType: PrimitiveStaticTypeAuthAccountAccountCapabilities,
-			semaType:   nil,
-		},
-		{
-			name:       "AuthAccount.Capabilities",
-			staticType: PrimitiveStaticTypeAuthAccountCapabilities,
-			semaType:   nil,
-		},
-		{
-			name:       "PublicAccount.Capabilities",
-			staticType: PrimitiveStaticTypePublicAccountCapabilities,
-			semaType:   nil,
-		},
-		{
-			name:       "AccountKey",
-			staticType: PrimitiveStaticTypeAccountKey,
-			semaType:   nil,
-		},
 		{
 			name: "InclusiveRange",
 			semaType: &sema.InclusiveRangeType{
@@ -1684,13 +1619,11 @@ func TestStaticTypeConversion(t *testing.T) {
 
 			// Test sema to static
 
-			if test.semaType != nil && !test.noSemaToStatic {
-				convertedStaticType := ConvertSemaToStaticType(nil, test.semaType)
-				require.Equal(t,
-					test.staticType,
-					convertedStaticType,
-				)
-			}
+			convertedStaticType := ConvertSemaToStaticType(nil, test.semaType)
+			require.Equal(t,
+				test.staticType,
+				convertedStaticType,
+			)
 
 			// Test static to sema
 
@@ -1758,7 +1691,7 @@ func TestStaticTypeConversion(t *testing.T) {
 	}
 
 	for ty := PrimitiveStaticType(1); ty < PrimitiveStaticType_Count; ty++ {
-		if !ty.IsDefined() {
+		if !ty.IsDefined() || ty.IsDeprecated() { //nolint:staticcheck
 			continue
 		}
 		if _, ok := testedStaticTypes[ty]; !ok {

--- a/runtime/tests/checker/member_test.go
+++ b/runtime/tests/checker/member_test.go
@@ -940,18 +940,11 @@ func TestCheckMemberAccess(t *testing.T) {
 
 		// Test all built-in composite types
 		for ty := interpreter.PrimitiveStaticType(1); ty < interpreter.PrimitiveStaticType_Count; ty++ {
-			if !ty.IsDefined() {
+			if !ty.IsDefined() || ty.IsDeprecated() { //nolint:staticcheck
 				continue
 			}
 
 			semaType := ty.SemaType()
-
-			// Some primitive static types are deprecated,
-			// and only exist for migration purposes,
-			// so do not have an equivalent sema type
-			if semaType == nil {
-				continue
-			}
 
 			if !semaType.ContainFieldsOrElements() ||
 				semaType.IsResourceType() {

--- a/runtime/tests/interpreter/member_test.go
+++ b/runtime/tests/interpreter/member_test.go
@@ -1127,18 +1127,11 @@ func TestInterpretMemberAccess(t *testing.T) {
 
 		// Test all built-in composite types
 		for ty := interpreter.PrimitiveStaticType(1); ty < interpreter.PrimitiveStaticType_Count; ty++ {
-			if !ty.IsDefined() {
+			if !ty.IsDefined() || ty.IsDeprecated() { //nolint:staticcheck
 				continue
 			}
 
 			semaType := ty.SemaType()
-
-			// Some primitive static types are deprecated,
-			// and only exist for migration purposes,
-			// so do not have an equivalent sema type
-			if semaType == nil {
-				continue
-			}
 
 			if !semaType.ContainFieldsOrElements() ||
 				semaType.IsResourceType() {

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -9055,6 +9055,10 @@ func TestInterpretStaticTypeStringConversion(t *testing.T) {
 
 		for primitiveStaticType := range interpreter.PrimitiveStaticTypes {
 
+			if !primitiveStaticType.IsDefined() || primitiveStaticType.IsDeprecated() { //nolint:staticcheck
+				continue
+			}
+
 			switch primitiveStaticType {
 			case interpreter.PrimitiveStaticTypeAny,
 				interpreter.PrimitiveStaticTypeUnknown,
@@ -9063,13 +9067,6 @@ func TestInterpretStaticTypeStringConversion(t *testing.T) {
 			}
 
 			semaType := primitiveStaticType.SemaType()
-
-			// Some primitive static types are deprecated,
-			// and only exist for migration purposes,
-			// so do not have an equivalent sema type
-			if semaType == nil {
-				continue
-			}
 
 			switch semaType.(type) {
 			case *sema.EntitlementType,


### PR DESCRIPTION
## Description

Fix the entitlements migration by not adding authorizations to reference types which were previously converted from deprecated primitive static types. Otherwise it incorrectly migrates e.g. `PublicAccount` to `auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account` (via `PublicAccount` to `&Account` through the account types migration).

Also:
- Add `StaticType.IsDeprecated` to enable the fix above
- Improve `PrimitiveStaticType.SemaType()` to not just return `nil`, but panic for deprecated types. This prevents e.g. accidentally constructing invalid types like "`&nil`" when converting types boxing deprecated primitive types.
- Improve cap con migration tests, as they rely on the cases in `PrimitiveStaticType.SemaType` to convert the deprecated account types `PublicAccount` and `AuthAccount` to sema types


______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
