### PR TITLE
Introduce `toConstantSized` to `VariableSizedArray` type

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2131,6 +2131,13 @@ Returns a new variable-sized array with the copy of the contents of the given ar
 Available if the array is constant sized and the element type is not resource-kinded.
 `
 
+const ArrayTypeToConstantSizedFunctionName = "toConstantSized"
+
+const arrayTypeToConstantSizedFunctionDocString = `
+Returns a new constant-sized array with the copy of the contents of the given array.
+Available if the array is constant sized and the element type is not resource-kinded.
+`
+
 var insertMutateEntitledAccess = NewEntitlementSetAccess(
 	[]*EntitlementType{
 		InsertType,
@@ -2497,6 +2504,32 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 				)
 			},
 		}
+
+		members[ArrayTypeToConstantSizedFunctionName] = MemberResolver{
+			Kind: common.DeclarationKindFunction,
+			Resolve: func(memoryGauge common.MemoryGauge, identifier string, targetRange ast.Range, report func(error)) *Member {
+				elementType := arrayType.ElementType(false)
+
+				if elementType.IsResourceType() {
+					report(
+						&InvalidResourceArrayMemberError{
+							Name:            identifier,
+							DeclarationKind: common.DeclarationKindFunction,
+							Range:           targetRange,
+						},
+					)
+				}
+
+				return NewFunctionMember(
+					memoryGauge,
+					arrayType,
+					insertableEntitledAccess,
+					identifier,
+					ArrayToConstantSizedFunctionType(elementType),
+					arrayTypeToConstantSizedFunctionDocString,
+				)
+			},
+		}
 	}
 
 	if _, ok := arrayType.(*ConstantSizedType); ok {
@@ -2675,6 +2708,62 @@ func ArrayToVariableSizedFunctionType(elementType Type) *FunctionType {
 			Type: elementType,
 		}),
 	)
+}
+
+func ArrayToConstantSizedFunctionType(elementType Type) *FunctionType {
+	// Ideally this should have a typebound of [T; _] but since we don't know
+	// the size of the ConstantSizedArray, we omit specifying the bound.
+	typeParameter := &TypeParameter{
+		Name: "T",
+	}
+
+	typeAnnotation := NewTypeAnnotation(
+		&GenericType{
+			TypeParameter: typeParameter,
+		},
+	)
+
+	return &FunctionType{
+		Purity: FunctionPurityView,
+		TypeParameters: []*TypeParameter{
+			typeParameter,
+		},
+		ReturnTypeAnnotation: NewTypeAnnotation(
+			&OptionalType{
+				Type: typeAnnotation.Type,
+			},
+		),
+		TypeArgumentsCheck: func(
+			memoryGauge common.MemoryGauge,
+			typeArguments *TypeParameterTypeOrderedMap,
+			astTypeArguments []*ast.TypeAnnotation,
+			invocationRange ast.HasPosition,
+			report func(error),
+		) {
+			typeArg, ok := typeArguments.Get(typeParameter)
+			if !ok || typeArg == nil {
+				// checker should prevent this
+				panic(errors.NewUnreachableError())
+			}
+
+			constArrayType, ok := typeArg.(*ConstantSizedType)
+			if !ok || constArrayType.Type != elementType {
+				errorRange := invocationRange
+				if len(astTypeArguments) > 0 {
+					errorRange = astTypeArguments[0]
+				}
+
+				report(&InvalidTypeArgumentError{
+					TypeArgumentName: typeParameter.Name,
+					Range:            ast.NewRangeFromPositioned(memoryGauge, errorRange),
+					Details: fmt.Sprintf(
+						"Type argument for toConstantSized must be [%s; _]",
+						elementType,
+					),
+				})
+			}
+		},
+	}
 }
 
 func ArrayReverseFunctionType(arrayType ArrayType) *FunctionType {

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2758,7 +2758,7 @@ func ArrayToConstantSizedFunctionType(elementType Type) *FunctionType {
 					Range:            ast.NewRangeFromPositioned(memoryGauge, errorRange),
 					Details: fmt.Sprintf(
 						"Type argument for %s must be [%s; _]",
-						sema.ArrayTypeToConstantSizedFunctionName,
+						ArrayTypeToConstantSizedFunctionName,
 						elementType,
 					),
 				})

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2520,10 +2520,9 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 					)
 				}
 
-				return NewFunctionMember(
+				return NewPublicFunctionMember(
 					memoryGauge,
 					arrayType,
-					insertableEntitledAccess,
 					identifier,
 					ArrayToConstantSizedFunctionType(elementType),
 					arrayTypeToConstantSizedFunctionDocString,

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2757,7 +2757,8 @@ func ArrayToConstantSizedFunctionType(elementType Type) *FunctionType {
 					TypeArgumentName: typeParameter.Name,
 					Range:            ast.NewRangeFromPositioned(memoryGauge, errorRange),
 					Details: fmt.Sprintf(
-						"Type argument for toConstantSized must be [%s; _]",
+						"Type argument for %s must be [%s; _]",
+						sema.ArrayTypeToConstantSizedFunctionName,
 						elementType,
 					),
 				})

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2135,7 +2135,7 @@ const ArrayTypeToConstantSizedFunctionName = "toConstantSized"
 
 const arrayTypeToConstantSizedFunctionDocString = `
 Returns a new constant-sized array with the copy of the contents of the given array.
-Available if the array is constant sized and the element type is not resource-kinded.
+Available if the array is variable-sized and the element type is not resource-kinded.
 `
 
 var insertMutateEntitledAccess = NewEntitlementSetAccess(

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -2551,3 +2551,109 @@ func TestCheckResourceArrayToVariableSizedInvalid(t *testing.T) {
 
 	assert.IsType(t, &sema.InvalidResourceArrayMemberError{}, errs[0])
 }
+
+func TestCheckArrayToConstantSized(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		fun testInt() {
+			let x: [Int] = [1, 2, 3, 100]
+			let y: [Int; 4]? = x.toConstantSized<[Int;4]>()
+		}
+
+		fun testString() {
+			let x: [String] = ["ab", "cd", "ef", "gh"]
+			let y: [String; 4]? = x.toConstantSized<[String; 4]>()
+			let y_incorrect_size: [String; 3]? = x.toConstantSized<[String; 3]>()
+		}
+	`)
+
+	require.NoError(t, err)
+}
+
+func TestCheckArrayToConstantSizedInvalidArgs(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		fun test() {
+			let x: [Int16] = [1, 2, 3]
+			let y = x.toConstantSized<[Int16; 3]>(100)
+		}
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.ExcessiveArgumentsError{}, errs[0])
+}
+
+func TestCheckArrayToConstantSizedInvalidTypeArgument(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		fun test() {
+			let x: [Int16] = [1, 2, 3]
+			let y = x.toConstantSized<String>()
+		}
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.InvalidTypeArgumentError{}, errs[0])
+}
+
+func TestCheckArrayToConstantSizedInvalidTypeArgumentInnerType(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		fun test() {
+			let x: [Int16] = [1, 2, 3]
+			let y = x.toConstantSized<[Int; 3]>()
+		}
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.InvalidTypeArgumentError{}, errs[0])
+}
+
+func TestCheckConstantSizedArrayToConstantSizedInvalid(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		fun test() : [Int; 3]? {
+			let xs: [Int; 3] = [1, 2, 3]
+
+			return xs.toConstantSized<[Int; 3]>()
+		}
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.NotDeclaredMemberError{}, errs[0])
+}
+
+func TestCheckResourceArrayToConstantSizedInvalid(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		resource X {}
+
+		fun test() : @[X;1]? {
+			let xs: @[X] <- [<-create X()]
+
+			let constsized_xs <- xs.toConstantSized<@[X; 1]>()
+			destroy xs
+			return <-constsized_xs
+		}
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.InvalidResourceArrayMemberError{}, errs[0])
+}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -11295,6 +11295,225 @@ func TestInterpretArrayToVariableSized(t *testing.T) {
 	})
 }
 
+func TestInterpretArrayToConstantSized(t *testing.T) {
+	t.Parallel()
+
+	runValidCase := func(
+		t *testing.T,
+		inter *interpreter.Interpreter,
+		expectedArray interpreter.Value,
+	) {
+		val, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			expectedArray,
+			val,
+		)
+	}
+
+	t.Run("with empty array", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+			let emptyVals: [Int] = []
+
+			fun test(): [Int;0] {
+				let constArray = emptyVals.toConstantSized<[Int; 0]>()
+				return constArray!
+			}
+		`)
+
+		runValidCase(
+			t,
+			inter,
+			interpreter.NewArrayValue(
+				inter,
+				interpreter.EmptyLocationRange,
+				&interpreter.ConstantSizedStaticType{
+					Type: interpreter.PrimitiveStaticTypeInt,
+					Size: 0,
+				},
+				common.ZeroAddress,
+			),
+		)
+	})
+
+	t.Run("with integer array", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+			let xs: [Int] = [1, 2, 3, 100, 201]
+
+			fun test(): [Int; 5]? {
+				return xs.toConstantSized<[Int; 5]>()
+			}
+		`)
+
+		runValidCase(
+			t,
+			inter,
+			interpreter.NewSomeValueNonCopying(
+				inter,
+				interpreter.NewArrayValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					&interpreter.ConstantSizedStaticType{
+						Type: interpreter.PrimitiveStaticTypeInt,
+						Size: 5,
+					},
+					common.ZeroAddress,
+					interpreter.NewUnmeteredIntValueFromInt64(1),
+					interpreter.NewUnmeteredIntValueFromInt64(2),
+					interpreter.NewUnmeteredIntValueFromInt64(3),
+					interpreter.NewUnmeteredIntValueFromInt64(100),
+					interpreter.NewUnmeteredIntValueFromInt64(201),
+				),
+			),
+		)
+	})
+
+	t.Run("with string array", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+			let xs: [String] = ["abc", "def"]
+
+			fun test(): [String; 2]? {
+				return xs.toConstantSized<[String; 2]>()
+			}
+		`)
+
+		runValidCase(
+			t,
+			inter,
+			interpreter.NewSomeValueNonCopying(
+				inter,
+				interpreter.NewArrayValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					&interpreter.ConstantSizedStaticType{
+						Type: interpreter.PrimitiveStaticTypeString,
+						Size: 2,
+					},
+					common.ZeroAddress,
+					interpreter.NewUnmeteredStringValue("abc"),
+					interpreter.NewUnmeteredStringValue("def"),
+				),
+			),
+		)
+	})
+
+	t.Run("with wrong size", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+			let xs: [Int] = [1, 2, 3, 100, 201]
+
+			fun test(): [Int; 4]? {
+				return xs.toConstantSized<[Int; 4]>()
+			}
+		`)
+
+		runValidCase(
+			t,
+			inter,
+			interpreter.NilOptionalValue,
+		)
+	})
+
+	t.Run("with array of struct", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+			struct TestStruct {
+				var test: Int
+
+				init(_ t: Int) {
+					self.test = t
+				}
+			}
+
+			let sa: [TestStruct] = [TestStruct(1), TestStruct(2), TestStruct(3)]
+
+			fun test(): [TestStruct;3]? {
+				return sa.toConstantSized<[TestStruct;3]>()
+			}
+		`)
+
+		location := common.Location(common.StringLocation("test"))
+		value1 := interpreter.NewCompositeValue(
+			inter,
+			interpreter.EmptyLocationRange,
+			location,
+			"TestStruct",
+			common.CompositeKindStructure,
+			[]interpreter.CompositeField{
+				{
+					Name:  "test",
+					Value: interpreter.NewUnmeteredIntValueFromInt64(1),
+				},
+			},
+			common.ZeroAddress,
+		)
+		value2 := interpreter.NewCompositeValue(
+			inter,
+			interpreter.EmptyLocationRange,
+			location,
+			"TestStruct",
+			common.CompositeKindStructure,
+			[]interpreter.CompositeField{
+				{
+					Name:  "test",
+					Value: interpreter.NewUnmeteredIntValueFromInt64(2),
+				},
+			},
+			common.ZeroAddress,
+		)
+		value3 := interpreter.NewCompositeValue(
+			inter,
+			interpreter.EmptyLocationRange,
+			location,
+			"TestStruct",
+			common.CompositeKindStructure,
+			[]interpreter.CompositeField{
+				{
+					Name:  "test",
+					Value: interpreter.NewUnmeteredIntValueFromInt64(3),
+				},
+			},
+			common.ZeroAddress,
+		)
+
+		runValidCase(
+			t,
+			inter,
+			interpreter.NewSomeValueNonCopying(
+				inter,
+				interpreter.NewArrayValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					&interpreter.ConstantSizedStaticType{
+						Type: interpreter.NewCompositeStaticType(
+							nil,
+							common.Location(common.StringLocation("test")),
+							"TestStruct",
+							"S.test.TestStruct",
+						),
+						Size: 3,
+					},
+					common.ZeroAddress,
+					value1,
+					value2,
+					value3,
+				),
+			),
+		)
+	})
+}
+
 func TestInterpretOptionalReference(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
Closes #2530

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Introduce `toConstantSized` function to `VariableSizedArray` type. This function will return a constant-sized array whose contents are copies of the original variable-sized array.

Since copy of values are involved, this is not available if the inner type of the variable-sized array is a resource.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
