### PR TITLE
Remove Insert-entitled access for toVariableSized

### DIFF
--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -324,7 +324,7 @@ func (checker *Checker) visitIdentifierExpressionAssignment(
 	return variable.Type
 }
 
-var mutableEntitledAccess = NewEntitlementSetAccess(
+var mutateEntitledAccess = NewEntitlementSetAccess(
 	[]*EntitlementType{MutateType},
 	Disjunction,
 )
@@ -344,10 +344,10 @@ func (checker *Checker) visitIndexExpressionAssignment(
 	indexedRefType, isReference := MaybeReferenceType(indexExprTypes.IndexedType)
 
 	if isReference &&
-		!mutableEntitledAccess.PermitsAccess(indexedRefType.Authorization) &&
+		!mutateEntitledAccess.PermitsAccess(indexedRefType.Authorization) &&
 		!insertAndRemoveEntitledAccess.PermitsAccess(indexedRefType.Authorization) {
 		checker.report(&UnauthorizedReferenceAssignmentError{
-			RequiredAccess: [2]Access{mutableEntitledAccess, insertAndRemoveEntitledAccess},
+			RequiredAccess: [2]Access{mutateEntitledAccess, insertAndRemoveEntitledAccess},
 			FoundAccess:    indexedRefType.Authorization,
 			Range:          ast.NewRangeFromPositioned(checker.memoryGauge, indexExpression),
 		})

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2516,10 +2516,9 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 					)
 				}
 
-				return NewFunctionMember(
+				return NewPublicFunctionMember(
 					memoryGauge,
 					arrayType,
-					insertableEntitledAccess,
 					identifier,
 					ArrayToVariableSizedFunctionType(elementType),
 					arrayTypeToVariableSizedFunctionDocString,

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2131,7 +2131,7 @@ Returns a new variable-sized array with the copy of the contents of the given ar
 Available if the array is constant sized and the element type is not resource-kinded.
 `
 
-var insertableEntitledAccess = NewEntitlementSetAccess(
+var insertMutateEntitledAccess = NewEntitlementSetAccess(
 	[]*EntitlementType{
 		InsertType,
 		MutateType,
@@ -2139,7 +2139,7 @@ var insertableEntitledAccess = NewEntitlementSetAccess(
 	Disjunction,
 )
 
-var removableEntitledAccess = NewEntitlementSetAccess(
+var removeMutateEntitledAccess = NewEntitlementSetAccess(
 	[]*EntitlementType{
 		RemoveType,
 		MutateType,
@@ -2341,7 +2341,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 				return NewFunctionMember(
 					memoryGauge,
 					arrayType,
-					insertableEntitledAccess,
+					insertMutateEntitledAccess,
 					identifier,
 					ArrayAppendFunctionType(elementType),
 					arrayTypeAppendFunctionDocString,
@@ -2368,7 +2368,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 				return NewFunctionMember(
 					memoryGauge,
 					arrayType,
-					insertableEntitledAccess,
+					insertMutateEntitledAccess,
 					identifier,
 					ArrayAppendAllFunctionType(arrayType),
 					arrayTypeAppendAllFunctionDocString,
@@ -2439,7 +2439,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 				return NewFunctionMember(
 					memoryGauge,
 					arrayType,
-					insertableEntitledAccess,
+					insertMutateEntitledAccess,
 					identifier,
 					ArrayInsertFunctionType(elementType),
 					arrayTypeInsertFunctionDocString,
@@ -2456,7 +2456,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 				return NewFunctionMember(
 					memoryGauge,
 					arrayType,
-					removableEntitledAccess,
+					removeMutateEntitledAccess,
 					identifier,
 					ArrayRemoveFunctionType(elementType),
 					arrayTypeRemoveFunctionDocString,
@@ -2473,7 +2473,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 				return NewFunctionMember(
 					memoryGauge,
 					arrayType,
-					removableEntitledAccess,
+					removeMutateEntitledAccess,
 					identifier,
 					ArrayRemoveFirstFunctionType(elementType),
 					arrayTypeRemoveFirstFunctionDocString,
@@ -2490,7 +2490,7 @@ func getArrayMembers(arrayType ArrayType) map[string]MemberResolver {
 				return NewFunctionMember(
 					memoryGauge,
 					arrayType,
-					removableEntitledAccess,
+					removeMutateEntitledAccess,
 					identifier,
 					ArrayRemoveLastFunctionType(elementType),
 					arrayTypeRemoveLastFunctionDocString,
@@ -6088,7 +6088,7 @@ func (t *DictionaryType) initializeMemberResolvers() {
 					return NewFunctionMember(
 						memoryGauge,
 						t,
-						insertableEntitledAccess,
+						insertMutateEntitledAccess,
 						identifier,
 						DictionaryInsertFunctionType(t),
 						dictionaryTypeInsertFunctionDocString,
@@ -6101,7 +6101,7 @@ func (t *DictionaryType) initializeMemberResolvers() {
 					return NewFunctionMember(
 						memoryGauge,
 						t,
-						removableEntitledAccess,
+						removeMutateEntitledAccess,
 						identifier,
 						DictionaryRemoveFunctionType(t),
 						dictionaryTypeRemoveFunctionDocString,


### PR DESCRIPTION
## Description

`toVariableSized` should have public access.

While at it, improve the variable names of the built-in entitlements

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
