### PR TITLE
Allow dereferencing references to containers of non-resources

### DIFF
--- a/runtime/sema/check_unary_expression.go
+++ b/runtime/sema/check_unary_expression.go
@@ -89,12 +89,11 @@ func (checker *Checker) VisitUnaryExpression(expression *ast.UnaryExpression) Ty
 
 		innerType := referenceType.Type
 
-		// Allow primitives or containers of primitives.
-		if !IsPrimitiveOrContainerOfPrimitive(innerType) {
+		if !IsPrimitiveOrNonResourceContainer(innerType) {
 			checker.report(
 				&InvalidUnaryOperandError{
 					Operation:               expression.Operation,
-					ExpectedTypeDescription: "primitive or container of primitives",
+					ExpectedTypeDescription: "primitive or non-resource container",
 					ActualType:              innerType,
 					Range: ast.NewRangeFromPositioned(
 						checker.memoryGauge,

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -7059,16 +7059,13 @@ func (t *AddressType) initializeMemberResolvers() {
 	})
 }
 
-func IsPrimitiveOrContainerOfPrimitive(ty Type) bool {
-	switch ty := ty.(type) {
-	case *VariableSizedType:
-		return IsPrimitiveOrContainerOfPrimitive(ty.Type)
-
-	case *ConstantSizedType:
-		return IsPrimitiveOrContainerOfPrimitive(ty.Type)
+func IsPrimitiveOrNonResourceContainer(referencedType Type) bool {
+	switch ty := referencedType.(type) {
+	case ArrayType:
+		return !ty.IsResourceType()
 
 	case *DictionaryType:
-		return IsPrimitiveOrContainerOfPrimitive(ty.ValueType)
+		return !ty.IsResourceType()
 
 	default:
 		return ty.IsPrimitiveType()


### PR DESCRIPTION
## Description

Given that dereferencing is not recursive, containers' element type does not have to be primitive, but still must be non-resource kinded. 

Based on this discussion: https://github.com/onflow/cadence/pull/3028#discussion_r1458218461

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
