### PR TITLE
Expose checker in analysis

### DIFF
--- a/tools/analysis/analysis_test.go
+++ b/tools/analysis/analysis_test.go
@@ -25,12 +25,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/cadence/runtime/parser"
-	"github.com/onflow/cadence/runtime/tests/checker"
-
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/tests/checker"
 	"github.com/onflow/cadence/tools/analysis"
 )
 
@@ -102,7 +101,7 @@ func TestNeedSyntaxAndImport(t *testing.T) {
 
 	for _, program := range programs {
 		require.NotNil(t, program.Program)
-		require.NotNil(t, program.Elaboration)
+		require.NotNil(t, program.Checker)
 
 		// Run a simple analysis: Detect unnecessary cast
 
@@ -114,7 +113,7 @@ func TestNeedSyntaxAndImport(t *testing.T) {
 				return true
 			}
 
-			types := program.Elaboration.CastingExpressionTypes(castingExpression)
+			types := program.Checker.Elaboration.CastingExpressionTypes(castingExpression)
 			leftHandType := types.StaticValueType
 			rightHandType := types.TargetType
 

--- a/tools/analysis/program.go
+++ b/tools/analysis/program.go
@@ -27,10 +27,10 @@ import (
 )
 
 type Program struct {
-	Location    common.Location
-	Program     *ast.Program
-	Elaboration *sema.Elaboration
-	Code        []byte
+	Location common.Location
+	Program  *ast.Program
+	Checker  *sema.Checker
+	Code     []byte
 }
 
 // Run runs the given DAG of analyzers in parallel

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -72,19 +72,19 @@ func (programs Programs) load(
 		return wrapError(err)
 	}
 
-	var elaboration *sema.Elaboration
+	var checker *sema.Checker
 	if config.Mode&NeedTypes != 0 {
-		elaboration, err = programs.check(config, program, location, seenImports)
+		checker, err = programs.check(config, program, location, seenImports)
 		if err != nil {
 			return wrapError(err)
 		}
 	}
 
 	programs[location] = &Program{
-		Location:    location,
-		Code:        code,
-		Program:     program,
-		Elaboration: elaboration,
+		Location: location,
+		Code:     code,
+		Program:  program,
+		Checker:  checker,
 	}
 
 	return nil
@@ -96,7 +96,7 @@ func (programs Programs) check(
 	location common.Location,
 	seenImports importResolutionResults,
 ) (
-	*sema.Elaboration,
+	*sema.Checker,
 	error,
 ) {
 	baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
@@ -145,7 +145,7 @@ func (programs Programs) check(
 						return nil, err
 					}
 
-					elaboration = programs[importedLocation].Elaboration
+					elaboration = programs[importedLocation].Checker.Elaboration
 				}
 
 				return sema.ElaborationImport{
@@ -163,5 +163,5 @@ func (programs Programs) check(
 		return nil, err
 	}
 
-	return checker.Elaboration, nil
+	return checker, nil
 }


### PR DESCRIPTION
Work towards #2989 

## Description

Instead of just exposing the program's elaboration, expose the whole checker.

This allows users of the analysis framework to make use of the checker functionality, like looking up types by name, and converting AST types to sema types, and through that static types. 

The latter mentioned functionality is going to be used in the state migration for the core contracts, which requires rewriting (static) types.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
