### PR TITLE
Use old parser for contract upgrades when legacy upgrade config option is set

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -37,4 +37,6 @@ type Config struct {
 	CoverageReport *CoverageReport
 	// AttachmentsEnabled specifies if attachments are enabled
 	AttachmentsEnabled bool
+	// LegacyContractUpgradeEnabled enabled specifies whether to use the old parser when parsing an old contract
+	LegacyContractUpgradeEnabled bool
 }

--- a/runtime/contract_update_test.go
+++ b/runtime/contract_update_test.go
@@ -680,3 +680,118 @@ func TestRuntimeContractRedeploymentInSeparateTransactions(t *testing.T) {
 	)
 	require.NoError(t, err)
 }
+
+func TestRuntimeLegacyContractUpdate(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewTestInterpreterRuntimeWithConfig(Config{
+		AtreeValidationEnabled:       true,
+		LegacyContractUpgradeEnabled: true,
+	})
+
+	accountCodes := map[common.Location][]byte{}
+	signerAccount := common.MustBytesToAddress([]byte{0x1})
+	fooLocation := common.AddressLocation{
+		Address: signerAccount,
+		Name:    "Foo",
+	}
+	var checkGetAndSetProgram, getProgramCalled bool
+
+	programs := map[Location]*interpreter.Program{}
+	clearPrograms := func() {
+		for l := range programs {
+			delete(programs, l)
+		}
+	}
+
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
+			return accountCodes[location], nil
+		},
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
+			return []Address{signerAccount}, nil
+		},
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			return accountCodes[location], nil
+		},
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			accountCodes[location] = code
+			return nil
+		},
+		OnEmitEvent: func(event cadence.Event) error {
+			return nil
+		},
+		OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
+			return json.Decode(nil, b)
+		},
+		OnGetAndSetProgram: func(
+			location Location,
+			load func() (*interpreter.Program, error),
+		) (
+			program *interpreter.Program,
+			err error,
+		) {
+			_, isTransactionLocation := location.(common.TransactionLocation)
+			if checkGetAndSetProgram && !isTransactionLocation {
+				require.Equal(t, location, fooLocation)
+				require.False(t, getProgramCalled)
+			}
+
+			var ok bool
+			program, ok = programs[location]
+			if ok {
+				return
+			}
+
+			program, err = load()
+
+			// NOTE: important: still set empty program,
+			// even if error occurred
+
+			programs[location] = program
+
+			return
+		},
+	}
+
+	nextTransactionLocation := NewTransactionLocationGenerator()
+
+	const fooContractV1 = `
+		pub contract Foo {
+            init() {}
+            pub fun hello() {}
+        }
+    `
+
+	const fooContractV2 = `
+        access(all) contract Foo {
+            init() {}
+            access(all) fun hello() {}
+        }
+    `
+
+	// Mock the deploy of the old 'Foo' contract
+	accountCodes[fooLocation] = []byte(fooContractV1)
+
+	// Programs are only valid during the transaction
+	clearPrograms()
+
+	// Update 'Foo' contract to Cadence 1.0 version
+
+	signerAccount = common.MustBytesToAddress([]byte{0x1})
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: UpdateTransaction("Foo", []byte(fooContractV2)),
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+
+	// Programs are only valid during the transaction
+	clearPrograms()
+}

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -192,6 +192,7 @@ func (e *interpreterEnvironment) newInterpreterConfig() *interpreter.Config {
 		OnInvokedFunctionReturn:       e.newOnInvokedFunctionReturnHandler(),
 		CapabilityBorrowHandler:       stdlib.BorrowCapabilityController,
 		CapabilityCheckHandler:        stdlib.CheckCapabilityController,
+		LegacyContractUpgradeEnabled:  e.config.LegacyContractUpgradeEnabled,
 	}
 }
 

--- a/runtime/interpreter/config.go
+++ b/runtime/interpreter/config.go
@@ -68,4 +68,6 @@ type Config struct {
 	CapabilityCheckHandler CapabilityCheckHandlerFunc
 	// CapabilityBorrowHandler is used to borrow ID capabilities
 	CapabilityBorrowHandler CapabilityBorrowHandlerFunc
+	// LegacyContractUpgradeEnabled specifies whether to fall back to the old parser when attempting a contract upgrade
+	LegacyContractUpgradeEnabled bool
 }

--- a/runtime/stdlib/contract_update_validation.go
+++ b/runtime/stdlib/contract_update_validation.go
@@ -27,6 +27,10 @@ import (
 	"github.com/onflow/cadence/runtime/errors"
 )
 
+type UpdateValidator interface {
+	Validate() error
+}
+
 type ContractUpdateValidator struct {
 	TypeComparator
 
@@ -40,6 +44,7 @@ type ContractUpdateValidator struct {
 
 // ContractUpdateValidator should implement ast.TypeEqualityChecker
 var _ ast.TypeEqualityChecker = &ContractUpdateValidator{}
+var _ UpdateValidator = &ContractUpdateValidator{}
 
 // NewContractUpdateValidator initializes and returns a validator, without performing any validation.
 // Invoke the `Validate()` method of the validator returned, to start validating the contract.
@@ -607,4 +612,38 @@ func (e *MissingDeclarationError) Error() string {
 		e.Kind,
 		e.Name,
 	)
+}
+
+type LegacyContractUpdateValidator struct {
+	TypeComparator
+
+	location     common.Location
+	contractName string
+	oldProgram   *ast.Program
+	newProgram   *ast.Program
+}
+
+// NewContractUpdateValidator initializes and returns a validator, without performing any validation.
+// Invoke the `Validate()` method of the validator returned, to start validating the contract.
+func NewLegacyContractUpdateValidator(
+	location common.Location,
+	contractName string,
+	oldProgram *ast.Program,
+	newProgram *ast.Program,
+) *LegacyContractUpdateValidator {
+
+	return &LegacyContractUpdateValidator{
+		location:     location,
+		oldProgram:   oldProgram,
+		newProgram:   newProgram,
+		contractName: contractName,
+	}
+}
+
+var _ UpdateValidator = &LegacyContractUpdateValidator{}
+
+// Validate validates the contract update, and returns an error if it is an invalid update.
+// TODO: for now this is empty until we determine what validation is necessary for a Cadence 1.0 upgrade
+func (validator *LegacyContractUpdateValidator) Validate() error {
+	return nil
 }


### PR DESCRIPTION
Part of https://github.com/onflow/cadence/issues/2947

This option causes the contract update checker to fall back to using the old parser if the new one fails. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
