### PR TITLE
Add Unwrap method for ParentErrors - v0.42 backport

### DIFF
--- a/runtime/parser/errors.go
+++ b/runtime/parser/errors.go
@@ -50,6 +50,10 @@ func (e Error) ChildErrors() []error {
 	return e.Errors
 }
 
+func (e Error) Unwrap() []error {
+	return e.Errors
+}
+
 // ParserError
 
 type ParseError interface {

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -148,6 +148,10 @@ func (e CheckerError) ChildErrors() []error {
 	return e.Errors
 }
 
+func (e CheckerError) Unwrap() []error {
+	return e.Errors
+}
+
 func (e CheckerError) ImportLocation() common.Location {
 	return e.Location
 }

--- a/runtime/sema/errors_test.go
+++ b/runtime/sema/errors_test.go
@@ -19,9 +19,13 @@
 package sema
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/cadence/runtime/parser"
 )
 
 func TestErrorMessageExpectedActualTypes(t *testing.T) {
@@ -65,5 +69,61 @@ func TestErrorMessageExpectedActualTypes(t *testing.T) {
 		assert.Equal(t, "A.0000000000000001.Bar.Foo", expected)
 		assert.Equal(t, "A.0000000000000002.Bar.Foo", actual)
 
+	})
+}
+
+func TestUnwrappingCheckerError(t *testing.T) {
+	t.Parallel()
+
+	targetErr := fmt.Errorf("target error")
+
+	t.Run("unwrap matches child", func(t *testing.T) {
+		t.Parallel()
+
+		err := CheckerError{
+			Errors: []error{
+				fmt.Errorf("first error"),
+				targetErr,
+			},
+		}
+
+		assert.True(t, errors.Is(err, targetErr))
+	})
+
+	t.Run("unwrap matches wrapped child", func(t *testing.T) {
+		t.Parallel()
+
+		err := CheckerError{
+			Errors: []error{
+				fmt.Errorf("first error"),
+				fmt.Errorf("wrapped error: %w", &InvalidPragmaError{}),
+			},
+		}
+
+		var pragmaErr *InvalidPragmaError
+		assert.True(t, errors.As(err, &pragmaErr))
+	})
+
+	t.Run("unwrap finds wrapped grandchild", func(t *testing.T) {
+		t.Parallel()
+
+		err := CheckerError{
+			Errors: []error{
+				fmt.Errorf("first error"),
+				fmt.Errorf("wrapped error: %w", &parser.Error{
+					Errors: []error{
+						fmt.Errorf("first parser error"),
+						targetErr,
+					},
+				}),
+			},
+		}
+
+		var parserErr *parser.Error
+		assert.True(t, errors.As(err, &parserErr))
+		assert.True(t, errors.Is(err, targetErr))
+
+		var pragmaErr *InvalidPragmaError
+		assert.False(t, errors.As(err, &pragmaErr))
 	})
 }

--- a/runtime/stdlib/contract_update_validation.go
+++ b/runtime/stdlib/contract_update_validation.go
@@ -415,6 +415,10 @@ func (e *ContractUpdateError) ChildErrors() []error {
 	return e.Errors
 }
 
+func (e *ContractUpdateError) Unwrap() []error {
+	return e.Errors
+}
+
 func (e *ContractUpdateError) ImportLocation() common.Location {
 	return e.Location
 }


### PR DESCRIPTION
Backports: https://github.com/onflow/cadence/pull/3052

## Description

This PR updates `ParentError` error types that previously did not have an `Unwrap()` method, to include one. This allows FVM to search these child errors to detect the root cause of a runtime error.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
