### PR TITLE
Don't skip invalid entitlements when creating errors

### DIFF
--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2119,8 +2119,9 @@ func (checker *Checker) accessFromAstAccess(access ast.Access) (result Access) {
 						)
 					}
 				}
-				semanticEntitlements = append(semanticEntitlements, NewEntitlementType(checker.memoryGauge, checker.Location, "<<INVALID>>"))
-				continue
+				// construct a new "entitlement" type from the nominal type in the AST, but mark it as invalid for better error messages
+				entitlementType = NewEntitlementType(checker.memoryGauge, checker.Location, entitlement.Identifier.Identifier)
+				entitlementType.isInvalid = true
 			}
 			semanticEntitlements = append(semanticEntitlements, entitlementType)
 		}

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2119,8 +2119,8 @@ func (checker *Checker) accessFromAstAccess(access ast.Access) (result Access) {
 						)
 					}
 				}
-				result = PrimitiveAccess(ast.AccessNotSpecified)
-				return
+				semanticEntitlements = append(semanticEntitlements, NewEntitlementType(checker.memoryGauge, checker.Location, "<<INVALID>>"))
+				continue
 			}
 			semanticEntitlements = append(semanticEntitlements, entitlementType)
 		}

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -8767,6 +8767,7 @@ type EntitlementType struct {
 	Location      common.Location
 	containerType Type
 	Identifier    string
+	isInvalid     bool
 }
 
 var _ Type = &EntitlementType{}
@@ -8836,8 +8837,8 @@ func (*EntitlementType) IsPrimitiveType() bool {
 	return false
 }
 
-func (*EntitlementType) IsInvalidType() bool {
-	return false
+func (t *EntitlementType) IsInvalidType() bool {
+	return t.isInvalid
 }
 
 func (*EntitlementType) IsOrContainsReferenceType() bool {


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/3047

When creating an entitlement set where some of the elements are invalid types (i.e. because they are not declared), instead of defaulting to a `not specified` access, create an "invalid" entitlement type in their place for cleaner error messages. 
______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
