### PR TITLE
Extend type bounds

### DIFF
--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -516,7 +516,12 @@ func exportFunctionType(
 			typeBound := typeParameter.TypeBound
 			var convertedParameterTypeBound cadence.Type
 			if typeBound != nil {
-				convertedParameterTypeBound = ExportMeteredType(gauge, typeBound, results)
+				convertedParameterTypeBound = ExportMeteredType(
+					gauge,
+					// TODO:
+					typeBound.(sema.SubtypeTypeBound).Type,
+					results,
+				)
 			}
 
 			// Metered above

--- a/runtime/interpreter/div_mod_test.go
+++ b/runtime/interpreter/div_mod_test.go
@@ -3388,7 +3388,7 @@ func TestNegativeMod(t *testing.T) {
 			},
 		}
 
-		for _, integerType := range sema.AllSignedIntegerTypes {
+		for _, integerType := range sema.AllLeafSignedIntegerTypes {
 			if _, ok := tests[integerType.String()]; !ok {
 				panic(fmt.Sprintf("broken test: missing %s", integerType))
 			}
@@ -3414,7 +3414,7 @@ func TestNegativeMod(t *testing.T) {
 			},
 		}
 
-		for _, integerType := range sema.AllSignedFixedPointTypes {
+		for _, integerType := range sema.AllLeafSignedFixedPointTypes {
 			if _, ok := tests[integerType.String()]; !ok {
 				panic(fmt.Sprintf("broken test: missing %s", integerType))
 			}

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -3489,13 +3489,7 @@ func TestNumberValueIntegerConversion(t *testing.T) {
 		sema.Int256Type:  NewUnmeteredInt256ValueFromInt64(42),
 	}
 
-	for _, ty := range sema.AllIntegerTypes {
-		// Only test leaf types
-		switch ty {
-		case sema.IntegerType, sema.SignedIntegerType, sema.FixedSizeUnsignedIntegerType:
-			continue
-		}
-
+	for _, ty := range sema.AllLeafIntegerTypes {
 		_, ok := testValues[ty.(*sema.NumericType)]
 		require.True(t, ok, "missing expected value for type %s", ty.String())
 	}
@@ -3794,13 +3788,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			sema.Int256Type:  NewUnmeteredInt256ValueFromInt64(42),
 		}
 
-		for _, ty := range sema.AllIntegerTypes {
-			// Only test leaf types
-			switch ty {
-			case sema.IntegerType, sema.SignedIntegerType, sema.FixedSizeUnsignedIntegerType:
-				continue
-			}
-
+		for _, ty := range sema.AllLeafIntegerTypes {
 			_, ok := testCases[ty.(*sema.NumericType)]
 			require.True(t, ok, "missing case for type %s", ty.String())
 		}
@@ -3826,13 +3814,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 			sema.Fix64Type:  NewUnmeteredFix64ValueWithInteger(42, EmptyLocationRange),
 		}
 
-		for _, ty := range sema.AllFixedPointTypes {
-			// Only test leaf types
-			switch ty {
-			case sema.FixedPointType, sema.SignedFixedPointType:
-				continue
-			}
-
+		for _, ty := range sema.AllLeafFixedPointTypes {
 			_, ok := testCases[ty.(*sema.FixedPointNumericType)]
 			require.True(t, ok, "missing case for type %s", ty.String())
 		}

--- a/runtime/literal_test.go
+++ b/runtime/literal_test.go
@@ -607,7 +607,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 		require.Nil(t, value)
 	})
 
-	for _, unsignedIntegerType := range sema.AllUnsignedIntegerTypes {
+	for _, unsignedIntegerType := range sema.AllLeafUnsignedIntegerTypes {
 
 		t.Run(
 			fmt.Sprintf(
@@ -649,7 +649,7 @@ func TestRuntimeParseLiteral(t *testing.T) {
 	}
 
 	for _, signedIntegerType := range common.Concat(
-		sema.AllSignedIntegerTypes,
+		sema.AllLeafSignedIntegerTypes,
 		[]sema.Type{
 			sema.IntegerType,
 			sema.SignedIntegerType,

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1733,10 +1733,24 @@ func TestRuntimeStorageMultipleTransactionsInclusiveRangeFunction(t *testing.T) 
 
 	errs := checker.RequireCheckerErrors(t, checkerErr, 1)
 
-	assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+	var typeBoundError *sema.TypeBoundError
+	require.ErrorAs(t, errs[0], &typeBoundError)
 
-	typeMismatchError := errs[0].(*sema.TypeMismatchError)
-	assert.Contains(t, typeMismatchError.SecondaryError(), "expected `Storable`, got `InclusiveRange<Int>`")
+	assert.Equal(
+		t,
+		sema.SubtypeTypeBound{
+			Type: sema.StorableType,
+		},
+		typeBoundError.ExpectedTypeBound,
+	)
+	assert.Equal(
+		t,
+		&sema.InclusiveRangeType{
+			MemberType: sema.IntType,
+		},
+		typeBoundError.ActualType,
+	)
+
 }
 
 func TestRuntimeResourceContractUseThroughReference(t *testing.T) {
@@ -4581,7 +4595,7 @@ func TestRuntimeRandom(t *testing.T) {
 	}
 
 	testTypes := func(t *testing.T, testType func(*testing.T, sema.Type)) {
-		for _, ty := range sema.AllFixedSizeUnsignedIntegerTypes {
+		for _, ty := range sema.AllLeafFixedSizeUnsignedIntegerTypes {
 			ty := ty
 			t.Run(ty.String(), func(t *testing.T) {
 				t.Parallel()

--- a/runtime/sema/account.gen.go
+++ b/runtime/sema/account.gen.go
@@ -128,7 +128,7 @@ const Account_StorageTypeSaveFunctionName = "save"
 
 var Account_StorageTypeSaveFunctionTypeParameterT = &TypeParameter{
 	Name:      "T",
-	TypeBound: StorableType,
+	TypeBound: SubtypeTypeBound{Type: StorableType},
 }
 
 var Account_StorageTypeSaveFunctionType = &FunctionType{
@@ -194,7 +194,7 @@ const Account_StorageTypeLoadFunctionName = "load"
 
 var Account_StorageTypeLoadFunctionTypeParameterT = &TypeParameter{
 	Name:      "T",
-	TypeBound: StorableType,
+	TypeBound: SubtypeTypeBound{Type: StorableType},
 }
 
 var Account_StorageTypeLoadFunctionType = &FunctionType{
@@ -237,7 +237,7 @@ const Account_StorageTypeCopyFunctionName = "copy"
 
 var Account_StorageTypeCopyFunctionTypeParameterT = &TypeParameter{
 	Name:      "T",
-	TypeBound: AnyStructType,
+	TypeBound: SubtypeTypeBound{Type: AnyStructType},
 }
 
 var Account_StorageTypeCopyFunctionType = &FunctionType{
@@ -280,7 +280,7 @@ const Account_StorageTypeCheckFunctionName = "check"
 
 var Account_StorageTypeCheckFunctionTypeParameterT = &TypeParameter{
 	Name:      "T",
-	TypeBound: AnyType,
+	TypeBound: SubtypeTypeBound{Type: AnyType},
 }
 
 var Account_StorageTypeCheckFunctionType = &FunctionType{
@@ -312,9 +312,11 @@ const Account_StorageTypeBorrowFunctionName = "borrow"
 
 var Account_StorageTypeBorrowFunctionTypeParameterT = &TypeParameter{
 	Name: "T",
-	TypeBound: &ReferenceType{
-		Type:          AnyType,
-		Authorization: UnauthorizedAccess,
+	TypeBound: SubtypeTypeBound{
+		Type: &ReferenceType{
+			Type:          AnyType,
+			Authorization: UnauthorizedAccess,
+		},
 	},
 }
 
@@ -735,9 +737,11 @@ const Account_ContractsTypeBorrowFunctionName = "borrow"
 
 var Account_ContractsTypeBorrowFunctionTypeParameterT = &TypeParameter{
 	Name: "T",
-	TypeBound: &ReferenceType{
-		Type:          AnyType,
-		Authorization: UnauthorizedAccess,
+	TypeBound: SubtypeTypeBound{
+		Type: &ReferenceType{
+			Type:          AnyType,
+			Authorization: UnauthorizedAccess,
+		},
 	},
 }
 
@@ -1060,9 +1064,11 @@ const Account_InboxTypeUnpublishFunctionName = "unpublish"
 
 var Account_InboxTypeUnpublishFunctionTypeParameterT = &TypeParameter{
 	Name: "T",
-	TypeBound: &ReferenceType{
-		Type:          AnyType,
-		Authorization: UnauthorizedAccess,
+	TypeBound: SubtypeTypeBound{
+		Type: &ReferenceType{
+			Type:          AnyType,
+			Authorization: UnauthorizedAccess,
+		},
 	},
 }
 
@@ -1101,9 +1107,11 @@ const Account_InboxTypeClaimFunctionName = "claim"
 
 var Account_InboxTypeClaimFunctionTypeParameterT = &TypeParameter{
 	Name: "T",
-	TypeBound: &ReferenceType{
-		Type:          AnyType,
-		Authorization: UnauthorizedAccess,
+	TypeBound: SubtypeTypeBound{
+		Type: &ReferenceType{
+			Type:          AnyType,
+			Authorization: UnauthorizedAccess,
+		},
 	},
 }
 
@@ -1214,9 +1222,11 @@ const Account_CapabilitiesTypeGetFunctionName = "get"
 
 var Account_CapabilitiesTypeGetFunctionTypeParameterT = &TypeParameter{
 	Name: "T",
-	TypeBound: &ReferenceType{
-		Type:          AnyType,
-		Authorization: UnauthorizedAccess,
+	TypeBound: SubtypeTypeBound{
+		Type: &ReferenceType{
+			Type:          AnyType,
+			Authorization: UnauthorizedAccess,
+		},
 	},
 }
 
@@ -1254,9 +1264,11 @@ const Account_CapabilitiesTypeBorrowFunctionName = "borrow"
 
 var Account_CapabilitiesTypeBorrowFunctionTypeParameterT = &TypeParameter{
 	Name: "T",
-	TypeBound: &ReferenceType{
-		Type:          AnyType,
-		Authorization: UnauthorizedAccess,
+	TypeBound: SubtypeTypeBound{
+		Type: &ReferenceType{
+			Type:          AnyType,
+			Authorization: UnauthorizedAccess,
+		},
 	},
 }
 
@@ -1446,9 +1458,11 @@ const Account_StorageCapabilitiesTypeIssueFunctionName = "issue"
 
 var Account_StorageCapabilitiesTypeIssueFunctionTypeParameterT = &TypeParameter{
 	Name: "T",
-	TypeBound: &ReferenceType{
-		Type:          AnyType,
-		Authorization: UnauthorizedAccess,
+	TypeBound: SubtypeTypeBound{
+		Type: &ReferenceType{
+			Type:          AnyType,
+			Authorization: UnauthorizedAccess,
+		},
 	},
 }
 
@@ -1669,9 +1683,11 @@ const Account_AccountCapabilitiesTypeIssueFunctionName = "issue"
 
 var Account_AccountCapabilitiesTypeIssueFunctionTypeParameterT = &TypeParameter{
 	Name: "T",
-	TypeBound: &ReferenceType{
-		Type:          AccountType,
-		Authorization: UnauthorizedAccess,
+	TypeBound: SubtypeTypeBound{
+		Type: &ReferenceType{
+			Type:          AccountType,
+			Authorization: UnauthorizedAccess,
+		},
 	},
 }
 

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -118,7 +118,7 @@ func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) 
 		// ```
 
 		if expectedType == nil ||
-			(leftType != expectedType && IsProperSubType(leftType, expectedType)) {
+			(leftType != expectedType && IsStrictSubType(leftType, expectedType)) {
 
 			expectedType = leftType
 		}

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -41,8 +41,10 @@ const ResultIdentifier = "result"
 var beforeType = func() *FunctionType {
 
 	typeParameter := &TypeParameter{
-		Name:      "T",
-		TypeBound: AnyStructType,
+		Name: "T",
+		TypeBound: SubtypeTypeBound{
+			Type: AnyStructType,
+		},
 	}
 
 	typeAnnotation := NewTypeAnnotation(
@@ -1370,11 +1372,14 @@ func (checker *Checker) typeParameters(typeParameterList *ast.TypeParameterList)
 		for i, typeParameter := range typeParameterList.TypeParameters {
 
 			typeBoundAnnotation := typeParameter.TypeBound
-			var convertedTypeBound Type
+			var convertedTypeBound TypeBound
 			if typeBoundAnnotation != nil {
+				// TODO: for now, the syntax only supports subtype type bounds
 				convertedTypeBoundAnnotation := checker.ConvertTypeAnnotation(typeBoundAnnotation)
 				checker.checkTypeAnnotation(convertedTypeBoundAnnotation, typeBoundAnnotation)
-				convertedTypeBound = convertedTypeBoundAnnotation.Type
+				convertedTypeBound = SubtypeTypeBound{
+					Type: convertedTypeBoundAnnotation.Type,
+				}
 			}
 
 			typeParameters[i] = &TypeParameter{

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -333,6 +333,35 @@ func (e *TypeMismatchWithDescriptionError) SecondaryError() string {
 	)
 }
 
+// TypeBoundError
+
+type TypeBoundError struct {
+	ExpectedTypeBound TypeBound
+	ActualType        Type
+	Expression        ast.Expression
+	ast.Range
+}
+
+var _ SemanticError = &TypeBoundError{}
+var _ errors.UserError = &TypeBoundError{}
+var _ errors.SecondaryError = &TypeBoundError{}
+
+func (*TypeBoundError) isSemanticError() {}
+
+func (*TypeBoundError) IsUserError() {}
+
+func (e *TypeBoundError) Error() string {
+	return "type bound unsatisfied"
+}
+
+func (e *TypeBoundError) SecondaryError() string {
+	return fmt.Sprintf(
+		"expected type satisfying %s, got `%s`",
+		e.ExpectedTypeBound,
+		e.ActualType.QualifiedString(),
+	)
+}
+
 // NotIndexableTypeError
 
 type NotIndexableTypeError struct {

--- a/runtime/sema/gen/main.go
+++ b/runtime/sema/gen/main.go
@@ -2086,9 +2086,22 @@ func typeParameterExpr(name string, typeBound dst.Expr) dst.Expr {
 		goKeyValue("Name", goStringLit(name)),
 	}
 	if typeBound != nil {
+		subtypeTypeBoundLit := &dst.CompositeLit{
+			Type: &dst.Ident{
+				Name: "SubtypeTypeBound",
+				Path: semaPath,
+			},
+			Elts: []dst.Expr{
+				goKeyValue("Type", typeBound),
+			},
+		}
+
 		elements = append(
 			elements,
-			goKeyValue("TypeBound", typeBound),
+			goKeyValue(
+				"TypeBound",
+				subtypeTypeBoundLit,
+			),
 		)
 	}
 

--- a/runtime/sema/gen/testdata/functions/test.golden.go
+++ b/runtime/sema/gen/testdata/functions/test.golden.go
@@ -117,9 +117,11 @@ const TestTypeTypeParamWithBoundFunctionName = "typeParamWithBound"
 
 var TestTypeTypeParamWithBoundFunctionTypeParameterT = &sema.TypeParameter{
 	Name: "T",
-	TypeBound: &sema.ReferenceType{
-		Type:          sema.AnyType,
-		Authorization: sema.UnauthorizedAccess,
+	TypeBound: sema.SubtypeTypeBound{
+		Type: &sema.ReferenceType{
+			Type:          sema.AnyType,
+			Authorization: sema.UnauthorizedAccess,
+		},
 	},
 }
 

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -2066,7 +2066,7 @@ func TestTypeInclusions(t *testing.T) {
 	t.Run("SignedInteger", func(t *testing.T) {
 		t.Parallel()
 
-		for _, typ := range AllSignedIntegerTypes {
+		for _, typ := range AllLeafSignedIntegerTypes {
 			t.Run(typ.String(), func(t *testing.T) {
 				assert.True(t, SignedIntegerTypeTag.ContainsAny(typ.Tag()))
 			})
@@ -2076,7 +2076,7 @@ func TestTypeInclusions(t *testing.T) {
 	t.Run("UnsignedInteger", func(t *testing.T) {
 		t.Parallel()
 
-		for _, typ := range AllUnsignedIntegerTypes {
+		for _, typ := range AllLeafUnsignedIntegerTypes {
 			t.Run(typ.String(), func(t *testing.T) {
 				assert.True(t, UnsignedIntegerTypeTag.ContainsAny(typ.Tag()))
 			})
@@ -2086,7 +2086,7 @@ func TestTypeInclusions(t *testing.T) {
 	t.Run("FixedSizeUnsignedInteger", func(t *testing.T) {
 		t.Parallel()
 
-		for _, typ := range AllFixedSizeUnsignedIntegerTypes {
+		for _, typ := range AllLeafFixedSizeUnsignedIntegerTypes {
 			t.Run(typ.String(), func(t *testing.T) {
 				assert.True(t, FixedSizeUnsignedIntegerTypeTag.ContainsAny(typ.Tag()))
 			})
@@ -2106,7 +2106,7 @@ func TestTypeInclusions(t *testing.T) {
 	t.Run("SignedFixedPoint", func(t *testing.T) {
 		t.Parallel()
 
-		for _, typ := range AllSignedFixedPointTypes {
+		for _, typ := range AllLeafSignedFixedPointTypes {
 			t.Run(typ.String(), func(t *testing.T) {
 				assert.True(t, SignedFixedPointTypeTag.ContainsAny(typ.Tag()))
 			})
@@ -2116,7 +2116,7 @@ func TestTypeInclusions(t *testing.T) {
 	t.Run("UnsignedFixedPoint", func(t *testing.T) {
 		t.Parallel()
 
-		for _, typ := range AllUnsignedFixedPointTypes {
+		for _, typ := range AllLeafUnsignedFixedPointTypes {
 			t.Run(typ.String(), func(t *testing.T) {
 				assert.True(t, UnsignedFixedPointTypeTag.ContainsAny(typ.Tag()))
 			})
@@ -2330,10 +2330,13 @@ func TestMapType(t *testing.T) {
 
 	t.Run("map function type", func(t *testing.T) {
 		t.Parallel()
+
 		originalTypeParam := &TypeParameter{
-			TypeBound: Int64Type,
-			Name:      "X",
-			Optional:  true,
+			TypeBound: SubtypeTypeBound{
+				Type: Int64Type,
+			},
+			Name:     "X",
+			Optional: true,
 		}
 		original := NewSimpleFunctionType(
 			FunctionPurityView,
@@ -2358,9 +2361,11 @@ func TestMapType(t *testing.T) {
 		original.TypeParameters = []*TypeParameter{originalTypeParam}
 
 		mappedTypeParam := &TypeParameter{
-			TypeBound: StringType,
-			Name:      "X",
-			Optional:  true,
+			TypeBound: SubtypeTypeBound{
+				Type: StringType,
+			},
+			Name:     "X",
+			Optional: true,
 		}
 		mapped := NewSimpleFunctionType(
 			FunctionPurityView,
@@ -2392,7 +2397,10 @@ func TestMapType(t *testing.T) {
 
 		require.Equal(t, mapped, outputFunction)
 		require.IsType(t, &GenericType{}, outputFunction.Parameters[0].TypeAnnotation.Type)
-		require.True(t, outputFunction.Parameters[0].TypeAnnotation.Type.(*GenericType).TypeParameter == outputFunction.TypeParameters[0])
+		require.Same(t,
+			outputFunction.Parameters[0].TypeAnnotation.Type.(*GenericType).TypeParameter,
+			outputFunction.TypeParameters[0],
+		)
 	})
 }
 

--- a/runtime/sema/typebound.go
+++ b/runtime/sema/typebound.go
@@ -1,0 +1,382 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+)
+
+// TypeBound
+
+type TypeBound interface {
+	isTypeBound()
+	Satisfies(ty Type) bool
+	HasInvalidType() bool
+	Equal(TypeBound) bool
+	CheckInstantiated(
+		pos ast.HasPosition,
+		memoryGauge common.MemoryGauge,
+		report func(err error),
+	)
+	Map(
+		gauge common.MemoryGauge,
+		typeParamMap map[*TypeParameter]*TypeParameter,
+		f func(Type) Type,
+	) TypeBound
+	TypeAnnotationState() TypeAnnotationState
+	RewriteWithIntersectionTypes() (result TypeBound, rewritten bool)
+}
+
+// SubtypeTypeBound
+
+type SubtypeTypeBound struct {
+	Type Type
+}
+
+var _ TypeBound = SubtypeTypeBound{}
+
+func (SubtypeTypeBound) isTypeBound() {}
+
+func (b SubtypeTypeBound) Satisfies(ty Type) bool {
+	return IsSubType(ty, b.Type)
+}
+
+func (b SubtypeTypeBound) HasInvalidType() bool {
+	return b.Type.IsInvalidType()
+}
+
+func (b SubtypeTypeBound) Equal(bound TypeBound) bool {
+	other, ok := bound.(SubtypeTypeBound)
+	if !ok {
+		return false
+	}
+	return b.Type.Equal(other.Type)
+}
+
+func (b SubtypeTypeBound) CheckInstantiated(
+	pos ast.HasPosition,
+	memoryGauge common.MemoryGauge,
+	report func(err error),
+) {
+	b.Type.CheckInstantiated(pos, memoryGauge, report)
+}
+
+func (b SubtypeTypeBound) Map(
+	gauge common.MemoryGauge,
+	typeParamMap map[*TypeParameter]*TypeParameter,
+	f func(Type) Type,
+) TypeBound {
+	return SubtypeTypeBound{
+		Type: b.Type.Map(gauge, typeParamMap, f),
+	}
+}
+
+func (b SubtypeTypeBound) TypeAnnotationState() TypeAnnotationState {
+	return b.Type.TypeAnnotationState()
+}
+
+func (b SubtypeTypeBound) RewriteWithIntersectionTypes() (result TypeBound, rewritten bool) {
+	rewrittenType, rewritten := b.Type.RewriteWithIntersectionTypes()
+	if rewritten {
+		return SubtypeTypeBound{
+			Type: rewrittenType,
+		}, true
+	}
+	return b, false
+}
+
+// StrictSubtypeTypeBound
+
+type StrictSubtypeTypeBound struct {
+	Type Type
+}
+
+var _ TypeBound = StrictSubtypeTypeBound{}
+
+func (StrictSubtypeTypeBound) isTypeBound() {}
+
+func (b StrictSubtypeTypeBound) Satisfies(ty Type) bool {
+	return IsStrictSubType(ty, b.Type)
+}
+
+func (b StrictSubtypeTypeBound) HasInvalidType() bool {
+	return b.Type.IsInvalidType()
+}
+
+func (b StrictSubtypeTypeBound) Equal(bound TypeBound) bool {
+	other, ok := bound.(StrictSubtypeTypeBound)
+	if !ok {
+		return false
+	}
+	return b.Type.Equal(other.Type)
+}
+
+func (b StrictSubtypeTypeBound) CheckInstantiated(
+	pos ast.HasPosition,
+	memoryGauge common.MemoryGauge,
+	report func(err error),
+) {
+	b.Type.CheckInstantiated(pos, memoryGauge, report)
+}
+
+func (b StrictSubtypeTypeBound) Map(
+	gauge common.MemoryGauge,
+	typeParamMap map[*TypeParameter]*TypeParameter,
+	f func(Type) Type,
+) TypeBound {
+	return SubtypeTypeBound{
+		Type: b.Type.Map(gauge, typeParamMap, f),
+	}
+}
+
+func (b StrictSubtypeTypeBound) TypeAnnotationState() TypeAnnotationState {
+	return b.Type.TypeAnnotationState()
+}
+
+func (b StrictSubtypeTypeBound) RewriteWithIntersectionTypes() (result TypeBound, rewritten bool) {
+	rewrittenType, rewritten := b.Type.RewriteWithIntersectionTypes()
+	if rewritten {
+		return StrictSubtypeTypeBound{
+			Type: rewrittenType,
+		}, true
+	}
+	return b, false
+}
+
+// ConjunctionTypeBound
+
+type ConjunctionTypeBound struct {
+	TypeBounds []TypeBound
+}
+
+var _ TypeBound = ConjunctionTypeBound{}
+
+func (ConjunctionTypeBound) isTypeBound() {}
+
+func (b ConjunctionTypeBound) Satisfies(ty Type) bool {
+	for _, typeBound := range b.TypeBounds {
+		if !typeBound.Satisfies(ty) {
+			return false
+		}
+	}
+	return true
+}
+
+func (b ConjunctionTypeBound) HasInvalidType() bool {
+	for _, typeBound := range b.TypeBounds {
+		if typeBound.HasInvalidType() {
+			return true
+		}
+	}
+	return false
+}
+
+func (b ConjunctionTypeBound) Equal(bound TypeBound) bool {
+	other, ok := bound.(ConjunctionTypeBound)
+	if !ok {
+		return false
+	}
+
+	if len(b.TypeBounds) != len(other.TypeBounds) {
+		return false
+	}
+
+	for i, typeBound := range b.TypeBounds {
+		otherTypeBound := other.TypeBounds[i]
+		if !typeBound.Equal(otherTypeBound) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (b ConjunctionTypeBound) CheckInstantiated(
+	pos ast.HasPosition,
+	memoryGauge common.MemoryGauge,
+	report func(err error),
+) {
+	for _, typeBound := range b.TypeBounds {
+		typeBound.CheckInstantiated(pos, memoryGauge, report)
+	}
+}
+
+func (b ConjunctionTypeBound) Map(
+	gauge common.MemoryGauge,
+	typeParamMap map[*TypeParameter]*TypeParameter,
+	f func(Type) Type,
+) TypeBound {
+	newTypeBounds := make([]TypeBound, 0, len(b.TypeBounds))
+	for _, typeBound := range b.TypeBounds {
+		newTypeBounds = append(
+			newTypeBounds,
+			typeBound.Map(gauge, typeParamMap, f),
+		)
+	}
+	return ConjunctionTypeBound{
+		TypeBounds: newTypeBounds,
+	}
+}
+
+func (b ConjunctionTypeBound) TypeAnnotationState() TypeAnnotationState {
+	for _, typeBound := range b.TypeBounds {
+		state := typeBound.TypeAnnotationState()
+		if state != TypeAnnotationStateValid {
+			return state
+		}
+	}
+	return TypeAnnotationStateValid
+}
+
+func (b ConjunctionTypeBound) RewriteWithIntersectionTypes() (result TypeBound, rewritten bool) {
+	rewrittenTypeBounds := make([]TypeBound, 0, len(b.TypeBounds))
+	for _, typeBound := range b.TypeBounds {
+		rewrittenTypeBound, currentRewritten := typeBound.RewriteWithIntersectionTypes()
+		if currentRewritten {
+			rewritten = true
+			rewrittenTypeBounds = append(rewrittenTypeBounds, rewrittenTypeBound)
+		} else {
+			rewrittenTypeBounds = append(rewrittenTypeBounds, typeBound)
+		}
+	}
+	if rewritten {
+		return ConjunctionTypeBound{
+			TypeBounds: rewrittenTypeBounds,
+		}, true
+	} else {
+		return b, false
+	}
+}
+
+// SupertypeTypeBound
+
+type SupertypeTypeBound struct {
+	Type Type
+}
+
+var _ TypeBound = SupertypeTypeBound{}
+
+func (SupertypeTypeBound) isTypeBound() {}
+
+func (b SupertypeTypeBound) Satisfies(ty Type) bool {
+	return IsSubType(b.Type, ty)
+}
+
+func (b SupertypeTypeBound) HasInvalidType() bool {
+	return b.Type.IsInvalidType()
+}
+
+func (b SupertypeTypeBound) Equal(bound TypeBound) bool {
+	other, ok := bound.(SupertypeTypeBound)
+	if !ok {
+		return false
+	}
+	return b.Type.Equal(other.Type)
+}
+
+func (b SupertypeTypeBound) CheckInstantiated(
+	pos ast.HasPosition,
+	memoryGauge common.MemoryGauge,
+	report func(err error),
+) {
+	b.Type.CheckInstantiated(pos, memoryGauge, report)
+}
+
+func (b SupertypeTypeBound) Map(
+	gauge common.MemoryGauge,
+	typeParamMap map[*TypeParameter]*TypeParameter,
+	f func(Type) Type,
+) TypeBound {
+	return SupertypeTypeBound{
+		Type: b.Type.Map(gauge, typeParamMap, f),
+	}
+}
+
+func (b SupertypeTypeBound) TypeAnnotationState() TypeAnnotationState {
+	return b.Type.TypeAnnotationState()
+}
+
+func (b SupertypeTypeBound) RewriteWithIntersectionTypes() (result TypeBound, rewritten bool) {
+	rewrittenType, rewritten := b.Type.RewriteWithIntersectionTypes()
+	if rewritten {
+		return SupertypeTypeBound{
+			Type: rewrittenType,
+		}, true
+	}
+	return b, false
+}
+
+// StrictSupertypeTypeBound
+
+type StrictSupertypeTypeBound struct {
+	Type Type
+}
+
+var _ TypeBound = StrictSupertypeTypeBound{}
+
+func (StrictSupertypeTypeBound) isTypeBound() {}
+
+func (b StrictSupertypeTypeBound) Satisfies(ty Type) bool {
+	return IsStrictSubType(b.Type, ty)
+}
+
+func (b StrictSupertypeTypeBound) HasInvalidType() bool {
+	return b.Type.IsInvalidType()
+}
+
+func (b StrictSupertypeTypeBound) Equal(bound TypeBound) bool {
+	other, ok := bound.(StrictSupertypeTypeBound)
+	if !ok {
+		return false
+	}
+	return b.Type.Equal(other.Type)
+}
+
+func (b StrictSupertypeTypeBound) CheckInstantiated(
+	pos ast.HasPosition,
+	memoryGauge common.MemoryGauge,
+	report func(err error),
+) {
+	b.Type.CheckInstantiated(pos, memoryGauge, report)
+}
+
+func (b StrictSupertypeTypeBound) Map(
+	gauge common.MemoryGauge,
+	typeParamMap map[*TypeParameter]*TypeParameter,
+	f func(Type) Type,
+) TypeBound {
+	return StrictSupertypeTypeBound{
+		Type: b.Type.Map(gauge, typeParamMap, f),
+	}
+}
+
+func (b StrictSupertypeTypeBound) TypeAnnotationState() TypeAnnotationState {
+	return b.Type.TypeAnnotationState()
+}
+
+func (b StrictSupertypeTypeBound) RewriteWithIntersectionTypes() (result TypeBound, rewritten bool) {
+	rewrittenType, rewritten := b.Type.RewriteWithIntersectionTypes()
+	if rewritten {
+		return StrictSupertypeTypeBound{
+			Type: rewrittenType,
+		}, true
+	}
+	return b, false
+}

--- a/runtime/sema/typebound_test.go
+++ b/runtime/sema/typebound_test.go
@@ -1,0 +1,165 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypeBound_Satisfies(t *testing.T) {
+	t.Parallel()
+
+	t.Run("subtype", func(t *testing.T) {
+
+		t.Parallel()
+
+		typeBound := SubtypeTypeBound{Type: IntegerType}
+
+		assert.True(t, typeBound.Satisfies(IntegerType))
+		assert.True(t, typeBound.Satisfies(NeverType))
+
+		for _, integerType := range AllLeafIntegerTypes {
+			assert.True(t, typeBound.Satisfies(integerType))
+		}
+	})
+
+	t.Run("strict subtype", func(t *testing.T) {
+
+		t.Parallel()
+
+		typeBound := StrictSubtypeTypeBound{Type: IntegerType}
+
+		assert.False(t, typeBound.Satisfies(IntegerType))
+		assert.True(t, typeBound.Satisfies(NeverType))
+
+		for _, integerType := range AllLeafIntegerTypes {
+			assert.Truef(t, typeBound.Satisfies(integerType), "%s should satisfy", integerType)
+		}
+	})
+
+	t.Run("supertype", func(t *testing.T) {
+
+		t.Parallel()
+
+		typeBound := SupertypeTypeBound{Type: NeverType}
+
+		assert.True(t, typeBound.Satisfies(NeverType))
+		assert.True(t, typeBound.Satisfies(IntegerType))
+
+		for _, integerType := range AllLeafIntegerTypes {
+			assert.True(t, typeBound.Satisfies(integerType))
+		}
+	})
+
+	t.Run("strict supertype", func(t *testing.T) {
+
+		t.Parallel()
+
+		typeBound := StrictSupertypeTypeBound{Type: NeverType}
+
+		assert.False(t, typeBound.Satisfies(NeverType))
+		assert.True(t, typeBound.Satisfies(IntegerType))
+
+		for _, integerType := range AllLeafIntegerTypes {
+			assert.True(t, typeBound.Satisfies(integerType))
+		}
+	})
+
+	t.Run("conjunction", func(t *testing.T) {
+
+		t.Parallel()
+
+		typeBound := ConjunctionTypeBound{
+			TypeBounds: []TypeBound{
+				StrictSupertypeTypeBound{
+					Type: NeverType,
+				},
+				StrictSubtypeTypeBound{
+					Type: FixedSizeUnsignedIntegerType,
+				},
+			},
+		}
+
+		assert.False(t, typeBound.Satisfies(FixedSizeUnsignedIntegerType))
+		assert.False(t, typeBound.Satisfies(NeverType))
+
+		for _, integerType := range AllLeafFixedSizeUnsignedIntegerTypes {
+			assert.True(t, typeBound.Satisfies(integerType))
+		}
+	})
+}
+
+func TestTypeBound_HasInvalid(t *testing.T) {
+	t.Parallel()
+
+	t.Run("subtype", func(t *testing.T) {
+
+		t.Parallel()
+
+		assert.False(t, SubtypeTypeBound{Type: IntegerType}.HasInvalidType())
+		assert.True(t, SubtypeTypeBound{Type: InvalidType}.HasInvalidType())
+	})
+
+	t.Run("strict subtype", func(t *testing.T) {
+
+		t.Parallel()
+
+		assert.False(t, StrictSubtypeTypeBound{Type: IntegerType}.HasInvalidType())
+		assert.True(t, StrictSubtypeTypeBound{Type: InvalidType}.HasInvalidType())
+	})
+
+	t.Run("supertype", func(t *testing.T) {
+
+		t.Parallel()
+
+		assert.False(t, SupertypeTypeBound{Type: IntegerType}.HasInvalidType())
+		assert.True(t, SupertypeTypeBound{Type: InvalidType}.HasInvalidType())
+	})
+
+	t.Run("strict supertype", func(t *testing.T) {
+
+		t.Parallel()
+
+		assert.False(t, StrictSupertypeTypeBound{Type: IntegerType}.HasInvalidType())
+		assert.True(t, StrictSupertypeTypeBound{Type: InvalidType}.HasInvalidType())
+	})
+
+	t.Run("conjunction", func(t *testing.T) {
+
+		t.Parallel()
+
+		assert.False(t,
+			ConjunctionTypeBound{
+				TypeBounds: []TypeBound{
+					SubtypeTypeBound{Type: IntegerType},
+				},
+			}.HasInvalidType(),
+		)
+
+		assert.True(t,
+			ConjunctionTypeBound{
+				TypeBounds: []TypeBound{
+					SubtypeTypeBound{Type: InvalidType},
+				},
+			}.HasInvalidType(),
+		)
+	})
+}

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -186,7 +186,9 @@ var getAuthAccountFunctionType = func() *sema.FunctionType {
 
 	typeParam := &sema.TypeParameter{
 		Name:      "T",
-		TypeBound: sema.AccountReferenceType,
+		TypeBound: sema.SubtypeTypeBound{
+			Type: sema.AccountReferenceType,
+		},
 	}
 
 	return &sema.FunctionType{

--- a/runtime/stdlib/random.go
+++ b/runtime/stdlib/random.go
@@ -39,7 +39,9 @@ Follow best practices to prevent security issues when using this function
 var revertibleRandomFunctionType = func() *sema.FunctionType {
 	typeParameter := &sema.TypeParameter{
 		Name:      "T",
-		TypeBound: sema.FixedSizeUnsignedIntegerType,
+		TypeBound: sema.SubtypeTypeBound{
+			Type: sema.FixedSizeUnsignedIntegerType,
+		},
 	}
 
 	typeAnnotation := sema.NewTypeAnnotation(

--- a/runtime/stdlib/random_test.go
+++ b/runtime/stdlib/random_test.go
@@ -54,7 +54,7 @@ func TestRandomBasicUniformityWithModulo(t *testing.T) {
 	}
 
 	testTypes := func(t *testing.T, testType func(*testing.T, sema.Type)) {
-		for _, ty := range sema.AllFixedSizeUnsignedIntegerTypes {
+		for _, ty := range sema.AllLeafFixedSizeUnsignedIntegerTypes {
 			tyCopy := ty
 			t.Run(ty.String(), func(t *testing.T) {
 				t.Parallel()

--- a/runtime/stdlib/range.go
+++ b/runtime/stdlib/range.go
@@ -40,7 +40,9 @@ const inclusiveRangeConstructorFunctionDocString = `
 var inclusiveRangeConstructorFunctionType = func() *sema.FunctionType {
 	typeParameter := &sema.TypeParameter{
 		Name:      "T",
-		TypeBound: sema.IntegerType,
+		TypeBound: sema.SubtypeTypeBound{
+			Type: sema.IntegerType,
+		},
 	}
 
 	typeAnnotation := sema.NewTypeAnnotation(

--- a/runtime/stdlib/test_contract.go
+++ b/runtime/stdlib/test_contract.go
@@ -233,9 +233,11 @@ const testTypeExpectFunctionName = "expect"
 
 func newTestTypeExpectFunctionType(matcherType *sema.CompositeType) *sema.FunctionType {
 	typeParameter := &sema.TypeParameter{
-		TypeBound: sema.AnyStructType,
-		Name:      "T",
-		Optional:  true,
+		TypeBound: sema.SubtypeTypeBound{
+			Type: sema.AnyStructType,
+		},
+		Name:     "T",
+		Optional: true,
 	}
 
 	return &sema.FunctionType{
@@ -399,9 +401,11 @@ const testTypeNewMatcherFunctionName = "newMatcher"
 
 func newTestTypeNewMatcherFunctionType(matcherType *sema.CompositeType) *sema.FunctionType {
 	typeParameter := &sema.TypeParameter{
-		TypeBound: sema.AnyStructType,
-		Name:      "T",
-		Optional:  true,
+		TypeBound: sema.SubtypeTypeBound{
+			Type: sema.AnyStructType,
+		},
+		Name:     "T",
+		Optional: true,
 	}
 
 	return &sema.FunctionType{
@@ -467,9 +471,11 @@ Returns a matcher that succeeds if the tested value is equal to the given value.
 
 func newTestTypeEqualFunctionType(matcherType *sema.CompositeType) *sema.FunctionType {
 	typeParameter := &sema.TypeParameter{
-		TypeBound: sema.AnyStructType,
-		Name:      "T",
-		Optional:  true,
+		TypeBound: sema.SubtypeTypeBound{
+			Type: sema.AnyStructType,
+		},
+		Name:     "T",
+		Optional: true,
 	}
 
 	return &sema.FunctionType{

--- a/runtime/stdlib/test_test.go
+++ b/runtime/stdlib/test_test.go
@@ -289,7 +289,7 @@ func TestTestNewMatcher(t *testing.T) {
 		_, err := newTestContractInterpreter(t, script)
 
 		errs := checker.RequireCheckerErrors(t, err, 1)
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeBoundError{}, errs[0])
 	})
 
 	t.Run("custom matcher with explicit type", func(t *testing.T) {
@@ -462,7 +462,7 @@ func TestTestEqualMatcher(t *testing.T) {
 		require.Error(t, err)
 
 		errs := checker.RequireCheckerErrors(t, err, 2)
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeBoundError{}, errs[0])
 		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
 	})
 
@@ -672,8 +672,8 @@ func TestTestEqualMatcher(t *testing.T) {
 		_, err := newTestContractInterpreter(t, script)
 
 		errs := checker.RequireCheckerErrors(t, err, 4)
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+		assert.IsType(t, &sema.TypeBoundError{}, errs[0])
+		assert.IsType(t, &sema.TypeBoundError{}, errs[1])
 		assert.IsType(t, &sema.TypeMismatchError{}, errs[2])
 		assert.IsType(t, &sema.TypeMismatchError{}, errs[3])
 	})
@@ -706,8 +706,8 @@ func TestTestEqualMatcher(t *testing.T) {
 		_, err := newTestContractInterpreter(t, script)
 
 		errs := checker.RequireCheckerErrors(t, err, 3)
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+		assert.IsType(t, &sema.TypeBoundError{}, errs[0])
+		assert.IsType(t, &sema.TypeBoundError{}, errs[1])
 		assert.IsType(t, &sema.TypeMismatchError{}, errs[2])
 	})
 }
@@ -1956,8 +1956,8 @@ func TestTestExpect(t *testing.T) {
 		_, err := newTestContractInterpreter(t, script)
 
 		errs := checker.RequireCheckerErrors(t, err, 2)
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[1])
+		assert.IsType(t, &sema.TypeBoundError{}, errs[0])
+		assert.IsType(t, &sema.TypeBoundError{}, errs[1])
 	})
 
 	t.Run("resource with struct matcher", func(t *testing.T) {
@@ -1982,7 +1982,7 @@ func TestTestExpect(t *testing.T) {
 		_, err := newTestContractInterpreter(t, script)
 
 		errs := checker.RequireCheckerErrors(t, err, 1)
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeBoundError{}, errs[0])
 	})
 
 	t.Run("struct with resource matcher", func(t *testing.T) {
@@ -2007,7 +2007,7 @@ func TestTestExpect(t *testing.T) {
 		_, err := newTestContractInterpreter(t, script)
 
 		errs := checker.RequireCheckerErrors(t, err, 1)
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeBoundError{}, errs[0])
 	})
 }
 

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -299,11 +299,11 @@ func TestCheckAccountStorageSave(t *testing.T) {
 			if domain == common.PathDomainStorage {
 				errs := RequireCheckerErrors(t, err, 1)
 
-				require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+				require.IsType(t, &sema.TypeBoundError{}, errs[0])
 			} else {
 				errs := RequireCheckerErrors(t, err, 2)
 
-				require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+				require.IsType(t, &sema.TypeBoundError{}, errs[0])
 				require.IsType(t, &sema.TypeMismatchError{}, errs[1])
 			}
 		})
@@ -330,11 +330,11 @@ func TestCheckAccountStorageSave(t *testing.T) {
 			if domain == common.PathDomainStorage {
 				errs := RequireCheckerErrors(t, err, 1)
 
-				require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+				require.IsType(t, &sema.TypeBoundError{}, errs[0])
 			} else {
 				errs := RequireCheckerErrors(t, err, 2)
 
-				require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+				require.IsType(t, &sema.TypeBoundError{}, errs[0])
 				require.IsType(t, &sema.TypeMismatchError{}, errs[1])
 			}
 		})
@@ -623,12 +623,12 @@ func TestCheckAccountStorageCopy(t *testing.T) {
 				if domain == common.PathDomainStorage {
 					errs := RequireCheckerErrors(t, err, 1)
 
-					require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+					require.IsType(t, &sema.TypeBoundError{}, errs[0])
 
 				} else {
 					errs := RequireCheckerErrors(t, err, 2)
 
-					require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+					require.IsType(t, &sema.TypeBoundError{}, errs[0])
 					require.IsType(t, &sema.TypeMismatchError{}, errs[1])
 				}
 			})
@@ -838,11 +838,11 @@ func TestCheckAccountStorageBorrow(t *testing.T) {
 
 					errs := RequireCheckerErrors(t, err, 1)
 
-					require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+					require.IsType(t, &sema.TypeBoundError{}, errs[0])
 				} else {
 					errs := RequireCheckerErrors(t, err, 2)
 
-					require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+					require.IsType(t, &sema.TypeBoundError{}, errs[0])
 					require.IsType(t, &sema.TypeMismatchError{}, errs[1])
 				}
 			})
@@ -868,11 +868,11 @@ func TestCheckAccountStorageBorrow(t *testing.T) {
 
 					errs := RequireCheckerErrors(t, err, 1)
 
-					require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+					require.IsType(t, &sema.TypeBoundError{}, errs[0])
 				} else {
 					errs := RequireCheckerErrors(t, err, 2)
 
-					require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+					require.IsType(t, &sema.TypeBoundError{}, errs[0])
 					require.IsType(t, &sema.TypeMismatchError{}, errs[1])
 				}
 			})

--- a/runtime/tests/checker/builtinfunctions_test.go
+++ b/runtime/tests/checker/builtinfunctions_test.go
@@ -333,15 +333,9 @@ func TestCheckRevertibleRandom(t *testing.T) {
 		})
 	}
 
-	for _, ty := range sema.AllFixedSizeUnsignedIntegerTypes {
-		switch ty {
-		case sema.FixedSizeUnsignedIntegerType:
-			continue
-
-		default:
-			runValidCaseWithoutModulo(t, ty)
-			runValidCaseWithModulo(t, ty)
-		}
+	for _, ty := range sema.AllLeafFixedSizeUnsignedIntegerTypes {
+		runValidCaseWithoutModulo(t, ty)
+		runValidCaseWithModulo(t, ty)
 	}
 
 	runInvalidCase(
@@ -349,7 +343,7 @@ func TestCheckRevertibleRandom(t *testing.T) {
 		"revertibleRandom<Int>",
 		"let rand = revertibleRandom<Int>()",
 		[]error{
-			&sema.TypeMismatchError{},
+			&sema.TypeBoundError{},
 		},
 	)
 
@@ -358,7 +352,7 @@ func TestCheckRevertibleRandom(t *testing.T) {
 		"revertibleRandom<String>",
 		`let rand = revertibleRandom<String>(modulo: "abcd")`,
 		[]error{
-			&sema.TypeMismatchError{},
+			&sema.TypeBoundError{},
 		},
 	)
 

--- a/runtime/tests/checker/capability_test.go
+++ b/runtime/tests/checker/capability_test.go
@@ -278,7 +278,7 @@ func TestCheckCapability_borrow(t *testing.T) {
 
 			errs := RequireCheckerErrors(t, err, 1)
 
-			require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+			require.IsType(t, &sema.TypeBoundError{}, errs[0])
 		})
 
 		t.Run("struct", func(t *testing.T) {
@@ -294,7 +294,7 @@ func TestCheckCapability_borrow(t *testing.T) {
 
 			errs := RequireCheckerErrors(t, err, 1)
 
-			require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+			require.IsType(t, &sema.TypeBoundError{}, errs[0])
 		})
 	})
 }
@@ -456,7 +456,7 @@ func TestCheckCapability_check(t *testing.T) {
 
 			errs := RequireCheckerErrors(t, err, 1)
 
-			require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+			require.IsType(t, &sema.TypeBoundError{}, errs[0])
 		})
 
 		t.Run("struct", func(t *testing.T) {
@@ -472,7 +472,7 @@ func TestCheckCapability_check(t *testing.T) {
 
 			errs := RequireCheckerErrors(t, err, 1)
 
-			require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+			require.IsType(t, &sema.TypeBoundError{}, errs[0])
 		})
 	})
 }

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -3284,7 +3284,7 @@ func TestCheckEntitlementTypeAnnotation(t *testing.T) {
 
 		require.IsType(t, &sema.DirectEntitlementAnnotationError{}, errs[0])
 		// entitlements are not storable either
-		require.IsType(t, &sema.TypeMismatchError{}, errs[1])
+		require.IsType(t, &sema.TypeBoundError{}, errs[1])
 	})
 
 	t.Run("intersection", func(t *testing.T) {
@@ -3526,7 +3526,7 @@ func TestCheckEntitlementMappingTypeAnnotation(t *testing.T) {
 
 		require.IsType(t, &sema.DirectEntitlementAnnotationError{}, errs[0])
 		// entitlements are not storable either
-		require.IsType(t, &sema.TypeMismatchError{}, errs[1])
+		require.IsType(t, &sema.TypeBoundError{}, errs[1])
 	})
 
 	t.Run("intersection", func(t *testing.T) {

--- a/runtime/tests/checker/fixedpoint_test.go
+++ b/runtime/tests/checker/fixedpoint_test.go
@@ -122,12 +122,7 @@ func TestCheckFixedPointLiteralRanges(t *testing.T) {
 		return RequireGlobalValue(t, checker.Elaboration, "x")
 	}
 
-	for _, ty := range sema.AllFixedPointTypes {
-		// Only test leaf types
-		switch ty {
-		case sema.FixedPointType, sema.SignedFixedPointType:
-			continue
-		}
+	for _, ty := range sema.AllLeafFixedPointTypes {
 
 		t.Run(ty.String(), func(t *testing.T) {
 
@@ -553,7 +548,7 @@ func TestCheckSignedFixedPointNegate(t *testing.T) {
 
 	t.Parallel()
 
-	for _, ty := range sema.AllSignedFixedPointTypes {
+	for _, ty := range sema.AllLeafSignedFixedPointTypes {
 		name := ty.String()
 
 		t.Run(name, func(t *testing.T) {
@@ -576,7 +571,7 @@ func TestCheckInvalidUnsignedFixedPointNegate(t *testing.T) {
 
 	t.Parallel()
 
-	for _, ty := range sema.AllUnsignedFixedPointTypes {
+	for _, ty := range sema.AllLeafUnsignedFixedPointTypes {
 
 		t.Run(ty.String(), func(t *testing.T) {
 
@@ -600,7 +595,7 @@ func TestCheckInvalidNegativeZeroUnsignedFixedPoint(t *testing.T) {
 
 	t.Parallel()
 
-	for _, ty := range sema.AllUnsignedFixedPointTypes {
+	for _, ty := range sema.AllLeafUnsignedFixedPointTypes {
 
 		t.Run(ty.String(), func(t *testing.T) {
 
@@ -623,12 +618,7 @@ func TestCheckFixedPointLiteralScales(t *testing.T) {
 
 	t.Parallel()
 
-	for _, ty := range sema.AllFixedPointTypes {
-		// Only test leaf types
-		switch ty {
-		case sema.FixedPointType, sema.SignedFixedPointType:
-			continue
-		}
+	for _, ty := range sema.AllLeafFixedPointTypes {
 
 		t.Run(ty.String(), func(t *testing.T) {
 
@@ -697,12 +687,8 @@ func TestCheckFixedPointMinMax(t *testing.T) {
 		)
 	}
 
-	for _, ty := range sema.AllFixedPointTypes {
-		// Only test leaf types
-		switch ty {
-		case sema.FixedPointType, sema.SignedFixedPointType:
-			continue
-		}
+	for _, ty := range sema.AllLeafFixedPointTypes {
+
 
 		t.Run(ty.String(), func(t *testing.T) {
 			test(t, ty)

--- a/runtime/tests/checker/for_test.go
+++ b/runtime/tests/checker/for_test.go
@@ -120,15 +120,7 @@ func TestCheckForInclusiveRange(t *testing.T) {
 		})
 	}
 
-	for _, typ := range sema.AllIntegerTypes {
-		// Only test leaf integer types
-		switch typ {
-		case sema.IntegerType,
-			sema.SignedIntegerType,
-			sema.FixedSizeUnsignedIntegerType:
-			continue
-		}
-
+	for _, typ := range sema.AllLeafIntegerTypes {
 		test(typ)
 	}
 

--- a/runtime/tests/checker/genericfunction_test.go
+++ b/runtime/tests/checker/genericfunction_test.go
@@ -567,8 +567,10 @@ func TestCheckGenericFunctionInvocation(t *testing.T) {
 		t.Parallel()
 
 		typeParameter := &sema.TypeParameter{
-			Name:      "T",
-			TypeBound: sema.NumberType,
+			Name: "T",
+			TypeBound: sema.SubtypeTypeBound{
+				Type: sema.NumberType,
+			},
 		}
 
 		checker, err := parseAndCheckWithTestValue(t,
@@ -605,8 +607,10 @@ func TestCheckGenericFunctionInvocation(t *testing.T) {
 		t.Parallel()
 
 		typeParameter := &sema.TypeParameter{
-			Name:      "T",
-			TypeBound: sema.NumberType,
+			Name: "T",
+			TypeBound: sema.SubtypeTypeBound{
+				Type: sema.NumberType,
+			},
 		}
 
 		_, err := parseAndCheckWithTestValue(t,
@@ -623,7 +627,7 @@ func TestCheckGenericFunctionInvocation(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeBoundError{}, errs[0])
 	})
 
 	t.Run("invalid: one type parameter with type bound, no type argument, one parameter, one argument: bound not satisfied", func(t *testing.T) {
@@ -631,8 +635,10 @@ func TestCheckGenericFunctionInvocation(t *testing.T) {
 		t.Parallel()
 
 		typeParameter := &sema.TypeParameter{
-			Name:      "T",
-			TypeBound: sema.NumberType,
+			Name: "T",
+			TypeBound: sema.SubtypeTypeBound{
+				Type: sema.NumberType,
+			},
 		}
 
 		_, err := parseAndCheckWithTestValue(t,
@@ -660,7 +666,7 @@ func TestCheckGenericFunctionInvocation(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeBoundError{}, errs[0])
 	})
 
 	t.Run("valid: one type parameter, one type argument, no parameters, no arguments, generic return type", func(t *testing.T) {
@@ -712,8 +718,10 @@ func TestCheckGenericFunctionInvocation(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 
 				typeParameter := &sema.TypeParameter{
-					Name:      "T",
-					TypeBound: sema.NumberType,
+					Name: "T",
+					TypeBound: sema.SubtypeTypeBound{
+						Type: sema.NumberType,
+					},
 				}
 
 				checker, err := parseAndCheckWithTestValue(t,
@@ -802,8 +810,10 @@ func TestCheckGenericFunctionInvocation(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 
 				typeParameter := &sema.TypeParameter{
-					Name:      "T",
-					TypeBound: sema.NumberType,
+					Name: "T",
+					TypeBound: sema.SubtypeTypeBound{
+						Type: sema.NumberType,
+					},
 				}
 
 				checker, err := parseAndCheckWithTestValue(t,
@@ -1115,6 +1125,6 @@ func TestCheckGenericFunctionDeclaration(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		require.IsType(t, &sema.TypeMismatchError{}, errs[0])
+		require.IsType(t, &sema.TypeBoundError{}, errs[0])
 	})
 }

--- a/runtime/tests/checker/integer_test.go
+++ b/runtime/tests/checker/integer_test.go
@@ -409,7 +409,7 @@ func TestCheckSignedIntegerNegate(t *testing.T) {
 
 	t.Parallel()
 
-	for _, ty := range sema.AllSignedIntegerTypes {
+	for _, ty := range sema.AllLeafSignedIntegerTypes {
 		name := ty.String()
 		t.Run(name, func(t *testing.T) {
 
@@ -431,7 +431,7 @@ func TestCheckInvalidUnsignedIntegerNegate(t *testing.T) {
 
 	t.Parallel()
 
-	for _, ty := range sema.AllUnsignedIntegerTypes {
+	for _, ty := range sema.AllLeafUnsignedIntegerTypes {
 		name := ty.String()
 		t.Run(name, func(t *testing.T) {
 
@@ -485,12 +485,7 @@ func TestCheckFixedPointToIntegerConversion(t *testing.T) {
 
 	t.Parallel()
 
-	for _, ty := range sema.AllIntegerTypes {
-		// Only test leaf types
-		switch ty {
-		case sema.IntegerType, sema.SignedIntegerType, sema.FixedSizeUnsignedIntegerType:
-			continue
-		}
+	for _, ty := range sema.AllLeafIntegerTypes {
 
 		t.Run(ty.String(), func(t *testing.T) {
 
@@ -565,12 +560,7 @@ func TestCheckIntegerMinMax(t *testing.T) {
 		)
 	}
 
-	for _, ty := range sema.AllIntegerTypes {
-		// Only test leaf types
-		switch ty {
-		case sema.IntegerType, sema.SignedIntegerType, sema.FixedSizeUnsignedIntegerType:
-			continue
-		}
+	for _, ty := range sema.AllLeafIntegerTypes {
 
 		t.Run(ty.String(), func(t *testing.T) {
 			numericType := ty.(*sema.NumericType)

--- a/runtime/tests/checker/operations_test.go
+++ b/runtime/tests/checker/operations_test.go
@@ -448,8 +448,8 @@ func TestCheckSaturatedArithmeticFunctions(t *testing.T) {
 	}
 
 	for _, ty := range common.Concat(
-		sema.AllSignedIntegerTypes,
-		sema.AllSignedFixedPointTypes,
+		sema.AllLeafSignedIntegerTypes,
+		sema.AllLeafSignedFixedPointTypes,
 	) {
 
 		if ty == sema.IntType {
@@ -466,8 +466,8 @@ func TestCheckSaturatedArithmeticFunctions(t *testing.T) {
 	}
 
 	for _, ty := range common.Concat(
-		sema.AllUnsignedIntegerTypes,
-		sema.AllUnsignedFixedPointTypes,
+		sema.AllLeafUnsignedIntegerTypes,
+		sema.AllLeafUnsignedFixedPointTypes,
 	) {
 
 		if ty == sema.UIntType || strings.HasPrefix(ty.String(), "Word") {

--- a/runtime/tests/checker/range_value_test.go
+++ b/runtime/tests/checker/range_value_test.go
@@ -306,14 +306,7 @@ func TestCheckInclusiveRangeConstructionInvalid(t *testing.T) {
 		})
 	}
 
-	for _, integerType := range sema.AllIntegerTypes {
-		// Only test leaf types
-		switch integerType {
-		case sema.IntegerType,
-			sema.SignedIntegerType,
-			sema.FixedSizeUnsignedIntegerType:
-			continue
-		}
+	for _, integerType := range sema.AllLeafIntegerTypes {
 
 		typeString := integerType.String()
 

--- a/runtime/tests/checker/typeargument_test.go
+++ b/runtime/tests/checker/typeargument_test.go
@@ -140,7 +140,7 @@ func TestCheckTypeArguments(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+		assert.IsType(t, &sema.TypeBoundError{}, errs[0])
 	})
 
 	t.Run("capability, instantiation with two arguments", func(t *testing.T) {
@@ -915,8 +915,10 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 			&sema.FunctionType{
 				TypeParameters: []*sema.TypeParameter{
 					{
-						Name:      "T",
-						TypeBound: &sema.InclusiveRangeType{},
+						Name: "T",
+						TypeBound: sema.SubtypeTypeBound{
+							Type: &sema.InclusiveRangeType{},
+						},
 					},
 				},
 				ReturnTypeAnnotation: sema.VoidTypeAnnotation,
@@ -936,8 +938,10 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 				TypeParameters: []*sema.TypeParameter{
 					{
 						Name: "T",
-						TypeBound: &sema.InclusiveRangeType{
-							MemberType: sema.IntType,
+						TypeBound: sema.SubtypeTypeBound{
+							Type: &sema.InclusiveRangeType{
+								MemberType: sema.IntType,
+							},
 						},
 					},
 				},

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -725,8 +725,8 @@ func TestInterpretSaturatedArithmeticFunctions(t *testing.T) {
 	// Verify all test cases exist
 
 	for _, ty := range common.Concat(
-		sema.AllSignedIntegerTypes,
-		sema.AllSignedFixedPointTypes,
+		sema.AllLeafSignedIntegerTypes,
+		sema.AllLeafSignedFixedPointTypes,
 	) {
 
 		testCase, ok := testCases[ty]
@@ -751,8 +751,8 @@ func TestInterpretSaturatedArithmeticFunctions(t *testing.T) {
 	}
 
 	for _, ty := range common.Concat(
-		sema.AllUnsignedIntegerTypes,
-		sema.AllUnsignedFixedPointTypes,
+		sema.AllLeafUnsignedIntegerTypes,
+		sema.AllLeafUnsignedFixedPointTypes,
 	) {
 
 		if strings.HasPrefix(ty.String(), "Word") {

--- a/runtime/tests/interpreter/fixedpoint_test.go
+++ b/runtime/tests/interpreter/fixedpoint_test.go
@@ -59,12 +59,7 @@ func TestInterpretFixedPointConversionAndAddition(t *testing.T) {
 		"UFix64": interpreter.NewUnmeteredUFix64Value(123000000),
 	}
 
-	for _, fixedPointType := range sema.AllFixedPointTypes {
-		// Only test leaf types
-		switch fixedPointType {
-		case sema.FixedPointType, sema.SignedFixedPointType:
-			continue
-		}
+	for _, fixedPointType := range sema.AllLeafFixedPointTypes {
 
 		if _, ok := tests[fixedPointType.String()]; !ok {
 			panic(fmt.Sprintf("broken test: missing %s", fixedPointType))
@@ -117,13 +112,7 @@ var testFixedPointValues = map[string]interpreter.Value{
 }
 
 func init() {
-	for _, fixedPointType := range sema.AllFixedPointTypes {
-		// Only test leaf types
-		switch fixedPointType {
-		case sema.FixedPointType, sema.SignedFixedPointType:
-			continue
-		}
-
+	for _, fixedPointType := range sema.AllLeafFixedPointTypes {
 		if _, ok := testFixedPointValues[fixedPointType.String()]; !ok {
 			panic(fmt.Sprintf("broken test: missing fixed-point type: %s", fixedPointType))
 		}
@@ -354,7 +343,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 	t.Run("invalid negative integer to UFix64", func(t *testing.T) {
 
-		for _, integerType := range sema.AllSignedIntegerTypes {
+		for _, integerType := range sema.AllLeafSignedIntegerTypes {
 
 			t.Run(integerType.String(), func(t *testing.T) {
 
@@ -500,7 +489,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 		const testedValue = sema.Fix64TypeMinInt - 1
 		testValueBig := big.NewInt(testedValue)
 
-		for _, integerType := range sema.AllSignedIntegerTypes {
+		for _, integerType := range sema.AllLeafSignedIntegerTypes {
 
 			// Only test for integer types that can hold testedValue
 
@@ -579,13 +568,7 @@ func TestInterpretFixedPointMinMax(t *testing.T) {
 		},
 	}
 
-	for _, ty := range sema.AllFixedPointTypes {
-		// Only test leaf types
-		switch ty {
-		case sema.FixedPointType, sema.SignedFixedPointType:
-			continue
-		}
-
+	for _, ty := range sema.AllLeafFixedPointTypes {
 		if _, ok := testCases[ty]; !ok {
 			require.Fail(t, "missing type: %s", ty.String())
 		}

--- a/runtime/tests/interpreter/for_test.go
+++ b/runtime/tests/interpreter/for_test.go
@@ -851,26 +851,14 @@ func TestInclusiveRangeForInLoop(t *testing.T) {
 		})
 	}
 
-	for _, typ := range sema.AllIntegerTypes {
-		// Only test leaf types
-		switch typ {
-		case sema.IntegerType,
-			sema.SignedIntegerType,
-			sema.FixedSizeUnsignedIntegerType:
-			continue
-		}
+	for _, typ := range sema.AllLeafIntegerTypes {
 
 		for _, testCase := range unsignedTestCases {
 			runTestCase(t, typ, testCase)
 		}
 	}
 
-	for _, typ := range sema.AllSignedIntegerTypes {
-		// Only test leaf types
-		switch typ {
-		case sema.SignedIntegerType:
-			continue
-		}
+	for _, typ := range sema.AllLeafSignedIntegerTypes {
 
 		for _, testCase := range signedTestCases {
 			runTestCase(t, typ, testCase)

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -61,13 +61,7 @@ var testIntegerTypesAndValues = map[string]interpreter.Value{
 }
 
 func init() {
-	for _, integerType := range sema.AllIntegerTypes {
-		// Only test leaf types
-		switch integerType {
-		case sema.IntegerType, sema.SignedIntegerType, sema.FixedSizeUnsignedIntegerType:
-			continue
-		}
-
+	for _, integerType := range sema.AllLeafIntegerTypes {
 		if _, ok := testIntegerTypesAndValues[integerType.String()]; !ok {
 			panic(fmt.Sprintf("broken test: missing %s", integerType))
 		}
@@ -702,13 +696,7 @@ func TestInterpretIntegerConversion(t *testing.T) {
 		},
 	}
 
-	for _, ty := range sema.AllIntegerTypes {
-		// Only test leaf types
-		switch ty {
-		case sema.IntegerType, sema.SignedIntegerType, sema.FixedSizeUnsignedIntegerType:
-			continue
-		}
-
+	for _, ty := range sema.AllLeafIntegerTypes {
 		_, ok := testValues[ty.(*sema.NumericType)]
 		require.True(t, ok, "missing expected value for type %s", ty.String())
 	}
@@ -888,13 +876,7 @@ func TestInterpretIntegerMinMax(t *testing.T) {
 		},
 	}
 
-	for _, ty := range sema.AllIntegerTypes {
-		// Only test leaf types
-		switch ty {
-		case sema.IntegerType, sema.SignedIntegerType, sema.FixedSizeUnsignedIntegerType:
-			continue
-		}
-
+	for _, ty := range sema.AllLeafIntegerTypes {
 		if _, ok := testCases[ty]; !ok {
 			require.Fail(t, "missing type: %s", ty.String())
 		}
@@ -959,7 +941,7 @@ func TestInterpretStringIntegerConversion(t *testing.T) {
 		}
 	}
 
-	for _, typ := range append(sema.AllSignedIntegerTypes, sema.AllUnsignedIntegerTypes...) {
+	for _, typ := range sema.AllLeafIntegerTypes {
 		t.Run(typ.String(), func(t *testing.T) { test(t, typ) })
 	}
 }

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -7519,12 +7519,7 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 		}
 	}
 
-	for _, fixedPointType := range sema.AllFixedPointTypes {
-
-		switch fixedPointType {
-		case sema.FixedPointType, sema.SignedFixedPointType:
-			continue
-		}
+	for _, fixedPointType := range sema.AllLeafFixedPointTypes {
 
 		if _, ok := validTypes[fixedPointType.String()]; !ok {
 			panic(fmt.Sprintf("broken test: missing %s", fixedPointType))

--- a/runtime/tests/interpreter/range_value_test.go
+++ b/runtime/tests/interpreter/range_value_test.go
@@ -529,14 +529,7 @@ func TestInclusiveRangeConstructionInvalid(t *testing.T) {
 		})
 	}
 
-	for _, integerType := range sema.AllIntegerTypes {
-		// Only test leaf types
-		switch integerType {
-		case sema.IntegerType,
-			sema.SignedIntegerType,
-			sema.FixedSizeUnsignedIntegerType:
-			continue
-		}
+	for _, integerType := range sema.AllLeafIntegerTypes {
 
 		typeString := integerType.String()
 
@@ -560,12 +553,7 @@ func TestInclusiveRangeConstructionInvalid(t *testing.T) {
 	}
 
 	// Additional invalid cases for signed integer types
-	for _, integerType := range sema.AllSignedIntegerTypes {
-		// Only test leaf types
-		switch integerType {
-		case sema.SignedIntegerType:
-			continue
-		}
+	for _, integerType := range sema.AllLeafSignedIntegerTypes {
 
 		typeString := integerType.String()
 
@@ -582,12 +570,7 @@ func TestInclusiveRangeConstructionInvalid(t *testing.T) {
 	}
 
 	// Additional invalid cases for unsigned integer types
-	for _, integerType := range sema.AllUnsignedIntegerTypes {
-		// Only test leaf types
-		switch integerType {
-		case sema.IntegerType:
-			continue
-		}
+	for _, integerType := range sema.AllLeafUnsignedIntegerTypes {
 
 		typeString := integerType.String()
 

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -1893,12 +1893,7 @@ func TestInterpretDereference(t *testing.T) {
 			sema.Int256Type:  interpreter.NewUnmeteredInt256ValueFromInt64(42),
 		}
 
-		for _, typ := range sema.AllIntegerTypes {
-			// Only test leaf types
-			switch typ {
-			case sema.IntegerType, sema.SignedIntegerType, sema.FixedSizeUnsignedIntegerType:
-				continue
-			}
+		for _, typ := range sema.AllLeafIntegerTypes {
 
 			integerType := typ
 			typString := typ.QualifiedString()
@@ -1930,12 +1925,7 @@ func TestInterpretDereference(t *testing.T) {
 			sema.Fix64Type:  interpreter.NewUnmeteredFix64Value(4224_000_000),
 		}
 
-		for _, typ := range sema.AllFixedPointTypes {
-			// Only test leaf types
-			switch typ {
-			case sema.FixedPointType, sema.SignedFixedPointType:
-				continue
-			}
+		for _, typ := range sema.AllLeafFixedPointTypes {
 
 			fixedPointType := typ
 			typString := typ.QualifiedString()
@@ -1962,12 +1952,7 @@ func TestInterpretDereference(t *testing.T) {
 	t.Run("Variable-sized array of integers", func(t *testing.T) {
 		t.Parallel()
 
-		for _, typ := range sema.AllIntegerTypes {
-			// Only test leaf types
-			switch typ {
-			case sema.IntegerType, sema.SignedIntegerType, sema.FixedSizeUnsignedIntegerType:
-				continue
-			}
+		for _, typ := range sema.AllLeafIntegerTypes {
 
 			integerType := typ
 			typString := typ.QualifiedString()
@@ -2379,12 +2364,7 @@ func TestInterpretDereference(t *testing.T) {
 	t.Run("Constant-sized array of integers", func(t *testing.T) {
 		t.Parallel()
 
-		for _, typ := range sema.AllIntegerTypes {
-			// Only test leaf types
-			switch typ {
-			case sema.IntegerType, sema.SignedIntegerType, sema.FixedSizeUnsignedIntegerType:
-				continue
-			}
+		for _, typ := range sema.AllLeafIntegerTypes {
 
 			integerType := typ
 			typString := typ.QualifiedString()


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-internal/issues/188

## Description

See https://github.com/dapperlabs/cadence-internal/issues/188#issuecomment-1906752366

Currently, type bounds for type parameters may only be subtype relationships.

Generalize the type bounds feature to support:
- Subtype relations
- Strict subtype relations
- Supertype relations
- Strict supertype relations
- Conjunctions of the above

```[tasklist]
### TODO
- [ ] Serialization in type ID / syntax
- [ ] Import/export
``` 
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
