### PR TITLE
Handle optional storage references

### DIFF
--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -328,8 +328,15 @@ func (interpreter *Interpreter) checkMemberAccess(
 		}
 	}
 
-	if _, ok := target.(*StorageReferenceValue); ok {
-		// NOTE: Storage reference value accesses are already checked in  StorageReferenceValue.dereference
+	// NOTE: accesses of (optional) storage reference values
+	// are already checked in StorageReferenceValue.dereference
+	_, isStorageReference := target.(*StorageReferenceValue)
+	if !isStorageReference {
+		if optional, ok := target.(*SomeValue); ok {
+			_, isStorageReference = optional.value.(*StorageReferenceValue)
+		}
+	}
+	if isStorageReference {
 		return
 	}
 


### PR DESCRIPTION
Closes dapperlabs/cadence-internal#193

## Description

Port of #3061 to `master`

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
