### PR TITLE
Fix entitlements migration

### DIFF
--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -281,10 +281,11 @@ func ConvertValueToEntitlements(
 			return true
 		})
 
-		return interpreter.NewDictionaryValue(
+		return interpreter.NewDictionaryValueWithAddress(
 			inter,
 			interpreter.EmptyLocationRange,
 			dictionaryStaticType,
+			v.GetOwner(),
 			values...,
 		), nil
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -245,6 +245,12 @@ type IterableValue interface {
 	)
 }
 
+// OwnedValue is a value which has an owner
+type OwnedValue interface {
+	Value
+	GetOwner() common.Address
+}
+
 // ValueIterator is an iterator which returns values.
 // When Next returns nil, it signals the end of the iterator.
 type ValueIterator interface {


### PR DESCRIPTION
## Description

Discovered by @fxamacker in #3048 and fixed there through d0b144b1894802caaf89c5a424cba2fbc552c1e9:
New dictionaries, like other containers (e.g. arrays, which already do), need to be created in the same account as the original (source) value.

Also, defensively check that the owner of the converted value matches that of the original value (if available).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
