### PR TITLE
Gracefully handle runtime panics in migration

### DIFF
--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -139,6 +139,25 @@ func (m *StorageMigration) MigrateNestedValue(
 	valueMigrations []ValueMigration,
 	reporter Reporter,
 ) (newValue interpreter.Value) {
+
+	defer func() {
+		if r := recover(); r != nil {
+			switch r := r.(type) {
+			case error:
+				if reporter != nil {
+					reporter.Error(
+						storageKey,
+						storageMapKey,
+						"StorageMigration",
+						r,
+					)
+				}
+			default:
+				panic(r)
+			}
+		}
+	}()
+
 	switch value := value.(type) {
 	case *interpreter.SomeValue:
 		innerValue := value.InnerValue(m.interpreter, emptyLocationRange)

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/cadence/runtime/tests/checker"
 	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -946,4 +947,149 @@ func TestContractMigration(t *testing.T) {
 		cadence.String("updated_bar"),
 		value,
 	)
+}
+
+func TestMigrationPanics(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("composite dictionary", func(t *testing.T) {
+		t.Parallel()
+
+		ledger := NewTestLedger(nil, nil)
+		account := common.Address{0x42}
+
+		t.Run("prepare", func(t *testing.T) {
+
+			fooContractLocation := common.NewAddressLocation(nil, account, "Foo")
+
+			storage := runtime.NewStorage(ledger, nil)
+			locationRange := interpreter.EmptyLocationRange
+
+			contractChecker, err := checker.ParseAndCheckWithOptions(t, `
+                access(all) contract Foo {
+                    access(all) struct Bar {}
+                }`,
+				checker.ParseAndCheckOptions{
+					Location: fooContractLocation,
+				},
+			)
+			require.NoError(t, err)
+
+			inter, err := interpreter.NewInterpreter(
+				nil,
+				utils.TestLocation,
+				&interpreter.Config{
+					Storage:                       storage,
+					AtreeValueValidationEnabled:   false,
+					AtreeStorageValidationEnabled: false,
+					ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
+						program := interpreter.ProgramFromChecker(contractChecker)
+						subInterpreter, err := inter.NewSubInterpreter(program, location)
+						if err != nil {
+							panic(err)
+						}
+
+						return interpreter.InterpreterImport{
+							Interpreter: subInterpreter,
+						}
+					},
+				},
+			)
+			require.NoError(t, err)
+
+			const fooBarQualifiedIdentifier = "Foo.Bar"
+
+			dictionaryAnyStructStaticType :=
+				interpreter.NewDictionaryStaticType(
+					nil,
+					interpreter.PrimitiveStaticTypeString,
+					interpreter.NewCompositeStaticTypeComputeTypeID(
+						nil,
+						fooContractLocation,
+						fooBarQualifiedIdentifier,
+					),
+				)
+
+			storedValue := interpreter.NewDictionaryValue(
+				inter,
+				emptyLocationRange,
+				dictionaryAnyStructStaticType,
+			)
+
+			transferredValue := storedValue.Transfer(
+				inter,
+				locationRange,
+				atree.Address(account),
+				false,
+				nil,
+				nil,
+			)
+
+			inter.WriteStored(
+				account,
+				common.PathDomainStorage.Identifier(),
+				interpreter.StringStorageMapKey("dictionary_value"),
+				transferredValue,
+			)
+
+			err = storage.Commit(inter, true)
+			require.NoError(t, err)
+		})
+
+		t.Run("migrate", func(t *testing.T) {
+			storage := runtime.NewStorage(ledger, nil)
+
+			inter, err := interpreter.NewInterpreter(
+				nil,
+				utils.TestLocation,
+				&interpreter.Config{
+					Storage:                       storage,
+					AtreeValueValidationEnabled:   false,
+					AtreeStorageValidationEnabled: false,
+					ImportLocationHandler: func(_ *interpreter.Interpreter, _ common.Location) interpreter.Import {
+						// During the migration, treat the imported `Foo` contract as un-migrated.
+						panic(errors.New("type checking error in Foo"))
+					},
+				},
+			)
+			require.NoError(t, err)
+
+			migration := NewStorageMigration(inter, storage)
+
+			reporter := newTestReporter()
+
+			migration.Migrate(
+				&AddressSliceIterator{
+					Addresses: []common.Address{
+						account,
+					},
+				},
+				migration.NewValueMigrationsPathMigrator(
+					reporter,
+					testStringMigration{},
+					testInt8Migration{},
+					testCapMigration{},
+				),
+			)
+
+			err = migration.Commit()
+			require.NoError(t, err)
+
+			expectedErrors := map[struct {
+				interpreter.StorageKey
+				interpreter.StorageMapKey
+			}][]string{
+				{
+					StorageKey: interpreter.StorageKey{
+						Key:     common.PathDomainStorage.Identifier(),
+						Address: account,
+					},
+					StorageMapKey: interpreter.StringStorageMapKey("dictionary_value"),
+				}: {"StorageMigration"},
+			}
+
+			assert.Equal(t, expectedErrors, reporter.errored)
+		})
+	})
 }


### PR DESCRIPTION
Work towards #3063

## Description

Dictionary/array iteration can fail with a panic if the element/key type refers to a un-migrated contract.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
