### PR TITLE
Add support for migrating path capability values in entitlements and static type migrations

### DIFF
--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -298,6 +298,21 @@ func ConvertValueToEntitlements(
 			capabilityStaticType,
 		), nil
 
+	case *interpreter.PathCapabilityValue: //nolint:staticcheck
+		semaType := inter.MustConvertStaticToSemaType(staticType)
+		entitledType, converted := ConvertToEntitledType(semaType)
+		if !converted {
+			return nil, nil
+		}
+
+		entitledCapabilityValue := entitledType.(*sema.CapabilityType)
+		capabilityStaticType := interpreter.ConvertSemaToStaticType(inter, entitledCapabilityValue.BorrowType)
+		return &interpreter.PathCapabilityValue{ //nolint:staticcheck
+			Path:       v.Path,
+			Address:    v.Address,
+			BorrowType: capabilityStaticType,
+		}, nil
+
 	case interpreter.TypeValue:
 		if v.Type == nil {
 			return nil, nil

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -1029,6 +1029,19 @@ func TestConvertToEntitledValue(t *testing.T) {
 			Name: "Capability<&S>",
 		},
 		{
+			Input: &interpreter.PathCapabilityValue{ //nolint:staticcheck
+				Address:    interpreter.NewAddressValue(inter, testAddress),
+				Path:       testPathValue,
+				BorrowType: unentitledSRefStaticType,
+			},
+			Output: &interpreter.PathCapabilityValue{ //nolint:staticcheck
+				Address:    interpreter.NewAddressValue(inter, testAddress),
+				Path:       testPathValue,
+				BorrowType: entitledSRefStaticType,
+			},
+			Name: "PathCapability<&S>",
+		},
+		{
 			Input: interpreter.NewCapabilityValue(
 				inter,
 				0,

--- a/migrations/statictypes/account_type_migration_test.go
+++ b/migrations/statictypes/account_type_migration_test.go
@@ -835,6 +835,18 @@ func TestMigratingValuesWithAccountStaticType(t *testing.T) {
 			storedValue:   interpreter.AccountLinkValue{}, //nolint:staticcheck
 			expectedValue: interpreter.AccountLinkValue{}, //nolint:staticcheck
 		},
+		"path_capability_value": {
+			storedValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
+				Address:    interpreter.NewAddressValue(nil, common.Address{0x42}),
+				Path:       interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
+				BorrowType: interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
+			},
+			expectedValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
+				Address:    interpreter.NewAddressValue(nil, common.Address{0x42}),
+				Path:       interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
+				BorrowType: unauthorizedAccountReferenceType,
+			},
+		},
 	}
 
 	// Store values

--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -77,6 +77,17 @@ func (m *StaticTypeMigration) Migrate(
 		}
 		return interpreter.NewUnmeteredCapabilityValue(value.ID, value.Address, convertedBorrowType), nil
 
+	case *interpreter.PathCapabilityValue: //nolint:staticcheck
+		convertedBorrowType := m.maybeConvertStaticType(value.BorrowType)
+		if convertedBorrowType == nil {
+			return
+		}
+		return &interpreter.PathCapabilityValue{ //nolint:staticcheck
+			BorrowType: convertedBorrowType,
+			Path:       value.Path,
+			Address:    value.Address,
+		}, nil
+
 	case interpreter.PathLinkValue: //nolint:staticcheck
 		convertedBorrowType := m.maybeConvertStaticType(value.Type)
 		if convertedBorrowType == nil {

--- a/runtime/interpreter/value_pathcapability.go
+++ b/runtime/interpreter/value_pathcapability.go
@@ -152,8 +152,12 @@ func (v *PathCapabilityValue) Transfer(
 	return v
 }
 
-func (v *PathCapabilityValue) Clone(_ *Interpreter) Value {
-	panic(errors.NewUnreachableError())
+func (v *PathCapabilityValue) Clone(interpreter *Interpreter) Value {
+	return &PathCapabilityValue{
+		BorrowType: v.BorrowType,
+		Path:       v.Path.Clone(interpreter).(PathValue),
+		Address:    v.Address.Clone(interpreter).(AddressValue),
+	}
 }
 
 func (v *PathCapabilityValue) DeepRemove(interpreter *Interpreter) {


### PR DESCRIPTION
## Description

If we want to run the cap con migration after the other migrations (static type, entitlements, etc.), those migrations need to be able to migrate path capability values.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
