### PR TITLE
Fixes links to new docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ Check out the [Cadence Docs](https://docs.onflow.org/cadence/language/).
 
 If you would like to contribute to Cadence, have a look at the [contributing guide](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md).
 
-Development documentation can be found in the [/docs directory](https://github.com/onflow/flow/tree/master/docs).
+Development documentation can be found in the [cadence-lang.org repo](https://github.com/onflow/cadence-lang.org).
 For example, it contains the source for the language reference.

--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ Check out the [Cadence Docs](https://docs.onflow.org/cadence/language/).
 
 If you would like to contribute to Cadence, have a look at the [contributing guide](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md).
 
-Development documentation can be found in the [cadence-lang.org repo](https://github.com/onflow/cadence-lang.org).
+Development documentation can be found in the [`/docs` directory](https://github.com/onflow/cadence/tree/master/docs).
 For example, it contains the source for the language reference.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,6 @@
 
 This directory documention for contributors to/developers of Cadence.
 
-If you are looking for documentation for Cadence, it can be found at https://developers.flow.com/cadence.
+If you are looking for documentation for Cadence, it can be found at https://cadence-lang.org/.
 
-The source for the user documentation is at https://github.com/onflow/docs/tree/main/docs/cadence, not in this repository.
+The source for the user documentation is at https://github.com/onflow/cadence-lang.org, not in this repository.

--- a/docs/anti-patterns.mdx
+++ b/docs/anti-patterns.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/anti-patterns.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/anti-patterns.mdx

--- a/docs/contract-upgrades.mdx
+++ b/docs/contract-upgrades.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/contract-upgrades.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/contract-upgrades.mdx

--- a/docs/design-patterns.mdx
+++ b/docs/design-patterns.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/design-patterns.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/design-patterns.mdx

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/intro.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/intro.md

--- a/docs/json-cadence-spec.md
+++ b/docs/json-cadence-spec.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/json-cadence-spec.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/json-cadence-spec.md

--- a/docs/language/access-control.md
+++ b/docs/language/access-control.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/access-control.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/access-control.md

--- a/docs/language/accounts.mdx
+++ b/docs/language/accounts.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/accounts.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/accounts.mdx

--- a/docs/language/attachments.md
+++ b/docs/language/attachments.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/attachments.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/attachments.mdx

--- a/docs/language/built-in-functions.mdx
+++ b/docs/language/built-in-functions.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/built-in-functions.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/built-in-functions.mdx

--- a/docs/language/capability-based-access-control.md
+++ b/docs/language/capability-based-access-control.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/capability-based-access-control.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/capabilities.md

--- a/docs/language/composite-types.mdx
+++ b/docs/language/composite-types.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/composite-types.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/composite-types.mdx

--- a/docs/language/constants-and-variables.md
+++ b/docs/language/constants-and-variables.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/constants-and-variables.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/constants-and-variables.md

--- a/docs/language/contract-updatability.md
+++ b/docs/language/contract-updatability.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/contract-updatability.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/contract-updatability.md

--- a/docs/language/contracts.mdx
+++ b/docs/language/contracts.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/contracts.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/contracts.mdx

--- a/docs/language/control-flow.md
+++ b/docs/language/control-flow.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/control-flow.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/control-flow.md

--- a/docs/language/core-events.md
+++ b/docs/language/core-events.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/core-events.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/core-events.md

--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/crypto.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/crypto.mdx

--- a/docs/language/enumerations.md
+++ b/docs/language/enumerations.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/enumerations.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/enumerations.md

--- a/docs/language/environment-information.md
+++ b/docs/language/environment-information.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/environment-information.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/environment-information.md

--- a/docs/language/events.md
+++ b/docs/language/events.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/events.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/events.md

--- a/docs/language/functions.mdx
+++ b/docs/language/functions.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/functions.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/functions.mdx

--- a/docs/language/glossary.md
+++ b/docs/language/glossary.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/glossary.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/glossary.mdx

--- a/docs/language/imports.mdx
+++ b/docs/language/imports.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/imports.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/imports.mdx

--- a/docs/language/index.md
+++ b/docs/language/index.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/index.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/index.md

--- a/docs/language/interfaces.mdx
+++ b/docs/language/interfaces.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/interfaces.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/interfaces.mdx

--- a/docs/language/operators.md
+++ b/docs/language/operators.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/operators.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/operators.md

--- a/docs/language/references.mdx
+++ b/docs/language/references.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/references.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/references.md

--- a/docs/language/resources.mdx
+++ b/docs/language/resources.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/resources.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/resources.mdx

--- a/docs/language/restricted-types.md
+++ b/docs/language/restricted-types.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/restricted-types.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/restricted-types.md

--- a/docs/language/run-time-types.md
+++ b/docs/language/run-time-types.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/run-time-types.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/run-time-types.md

--- a/docs/language/scope.md
+++ b/docs/language/scope.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/scope.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/scope.md

--- a/docs/language/syntax.md
+++ b/docs/language/syntax.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/syntax.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/syntax.md

--- a/docs/language/transactions.md
+++ b/docs/language/transactions.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/transactions.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/transactions.md

--- a/docs/language/type-annotations.md
+++ b/docs/language/type-annotations.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/type-annotations.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/type-annotations.md

--- a/docs/language/type-hierarchy.md
+++ b/docs/language/type-hierarchy.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/type-hierarchy.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/type-hierarchy.md

--- a/docs/language/type-inference.md
+++ b/docs/language/type-inference.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/type-inference.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/type-inference.md

--- a/docs/language/type-safety.md
+++ b/docs/language/type-safety.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/type-safety.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/type-safety.md

--- a/docs/language/values-and-types.mdx
+++ b/docs/language/values-and-types.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/language/values-and-types.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/language/values-and-types.mdx

--- a/docs/measuring-time.mdx
+++ b/docs/measuring-time.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/measuring-time.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/measuring-time.mdx

--- a/docs/security-best-practices.mdx
+++ b/docs/security-best-practices.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/security-best-practices.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/security-best-practices.mdx

--- a/docs/solidity-to-cadence.mdx
+++ b/docs/solidity-to-cadence.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/solidity-to-cadence.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/solidity-to-cadence.mdx

--- a/docs/testing-framework.mdx
+++ b/docs/testing-framework.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/testing-framework.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/testing-framework.mdx

--- a/docs/tutorial/01-first-steps.mdx
+++ b/docs/tutorial/01-first-steps.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/tutorial/01-first-steps.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/tutorial/01-first-steps.mdx

--- a/docs/tutorial/02-hello-world.mdx
+++ b/docs/tutorial/02-hello-world.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/tutorial/02-hello-world.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/tutorial/02-hello-world.mdx

--- a/docs/tutorial/03-resources.mdx
+++ b/docs/tutorial/03-resources.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/tutorial/03-resources.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/tutorial/03-resources.mdx

--- a/docs/tutorial/04-capabilities.mdx
+++ b/docs/tutorial/04-capabilities.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/tutorial/04-capabilities.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/tutorial/04-capabilities.mdx

--- a/docs/tutorial/05-non-fungible-tokens-1.mdx
+++ b/docs/tutorial/05-non-fungible-tokens-1.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/tutorial/05-non-fungible-tokens-1.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/tutorial/05-non-fungible-tokens-1.mdx

--- a/docs/tutorial/05-non-fungible-tokens-2.mdx
+++ b/docs/tutorial/05-non-fungible-tokens-2.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/tutorial/05-non-fungible-tokens-2.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/tutorial/05-non-fungible-tokens-2.mdx

--- a/docs/tutorial/06-fungible-tokens.mdx
+++ b/docs/tutorial/06-fungible-tokens.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/tutorial/06-fungible-tokens.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/tutorial/06-fungible-tokens.mdx

--- a/docs/tutorial/07-marketplace-setup.mdx
+++ b/docs/tutorial/07-marketplace-setup.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/tutorial/07-marketplace-setup.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/tutorial/07-marketplace-setup.mdx

--- a/docs/tutorial/08-marketplace-compose.mdx
+++ b/docs/tutorial/08-marketplace-compose.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/tutorial/08-marketplace-compose.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/tutorial/08-marketplace-compose.mdx

--- a/docs/tutorial/09-voting.mdx
+++ b/docs/tutorial/09-voting.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/tutorial/09-voting.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/tutorial/09-voting.mdx

--- a/docs/tutorial/10-resources-compose.mdx
+++ b/docs/tutorial/10-resources-compose.mdx
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/tutorial/10-resources-compose.mdx
+https://github.com/onflow/cadence-lang.org/tree/main/docs/tutorial/10-resources-compose.mdx

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,3 +1,3 @@
 # This document has been moved to a new location:
 
-https://github.com/onflow/docs/tree/main/docs/cadence/why.md
+https://github.com/onflow/cadence-lang.org/tree/main/docs/why.md


### PR DESCRIPTION
## Description

Many of the links to the cadence docs were still pointing to developers.onflow.org, so I changed them to cadence-lang.org.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
