### PR TITLE
Add more information to analysis.Diagnostic

### DIFF
--- a/tools/analysis/diagnostic.go
+++ b/tools/analysis/diagnostic.go
@@ -28,15 +28,6 @@ type SuggestedFix = errors.SuggestedFix[ast.TextEdit]
 
 type TextEdit = ast.TextEdit
 
-type Severity uint8
-
-const (
-	SeverityUnknown Severity = iota
-	SeverityInfo
-	SeverityError
-	SeverityWarning
-)
-
 type Diagnostic struct {
 	Location         common.Location
 	Category         string

--- a/tools/analysis/diagnostic.go
+++ b/tools/analysis/diagnostic.go
@@ -43,7 +43,7 @@ type Diagnostic struct {
 	Severity         Severity
 	Message          string
 	SecondaryMessage string
-	Code             string // Diangostic code (e.g. "unused-variable")
+	Code             string // Diagnostic code (e.g. "unused-variable")
 	DocURL           string // URL to documentation
 	SuggestedFixes   []SuggestedFix
 	ast.Range

--- a/tools/analysis/diagnostic.go
+++ b/tools/analysis/diagnostic.go
@@ -28,11 +28,23 @@ type SuggestedFix = errors.SuggestedFix[ast.TextEdit]
 
 type TextEdit = ast.TextEdit
 
+type Severity uint8
+
+const (
+	SeverityUnknown Severity = iota
+	SeverityInfo
+	SeverityError
+	SeverityWarning
+)
+
 type Diagnostic struct {
 	Location         common.Location
 	Category         string
+	Severity         Severity
 	Message          string
 	SecondaryMessage string
+	Code             string // Diangostic code (e.g. "unused-variable")
+	DocURL           string // URL to documentation
 	SuggestedFixes   []SuggestedFix
 	ast.Range
 }

--- a/tools/analysis/diagnostic.go
+++ b/tools/analysis/diagnostic.go
@@ -40,11 +40,10 @@ const (
 type Diagnostic struct {
 	Location         common.Location
 	Category         string
-	Severity         Severity
 	Message          string
 	SecondaryMessage string
 	Code             string // Diagnostic code (e.g. "unused-variable")
-	DocURL           string // URL to documentation
+	URL              string // URL to documentation
 	SuggestedFixes   []SuggestedFix
 	ast.Range
 }


### PR DESCRIPTION
Closes #3086 

## Description

This PR adds more information to analysis.Diagnostic
 - Severity
 - Code (diagnostic/error code)
 - DocUrl (link to relevant documentation related to error code)
 
This allows for more sophisticated analyzers and unblocks https://github.com/onflow/cadence-tools/pull/285 which needs these changes in order to display relevant information related to Cadence 1.0 contract updates.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
