### PR TITLE
Allow analysis.Load to continue with parsing/checking errors

### DIFF
--- a/tools/analysis/analysis_test.go
+++ b/tools/analysis/analysis_test.go
@@ -76,8 +76,8 @@ func TestNeedSyntaxAndImport(t *testing.T) {
 				return []byte(contractCode), nil
 
 			default:
-				require.FailNow(t,
-					"import of unknown location: %s",
+				require.FailNowf(t,
+					"import of unknown location",
 					"location: %s",
 					location,
 				)
@@ -192,12 +192,9 @@ func TestParseError(t *testing.T) {
 			importRange ast.Range,
 		) ([]byte, error) {
 			switch location {
-			case contractLocation:
-				return []byte(contractCode), nil
-
 			default:
-				require.FailNow(t,
-					"import of unknown location: %s",
+				require.FailNowf(t,
+					"import of unknown location",
 					"location: %s",
 					location,
 				)
@@ -242,8 +239,8 @@ func TestCheckError(t *testing.T) {
 				return []byte(contractCode), nil
 
 			default:
-				require.FailNow(t,
-					"import of unknown location: %s",
+				require.FailNowf(t,
+					"import of unknown location",
 					"location: %s",
 					location,
 				)
@@ -276,6 +273,7 @@ func TestHandledParserError(t *testing.T) {
 	  }
 	`
 
+	handlerCalls := 0
 	config := &analysis.Config{
 		Mode: analysis.NeedSyntax,
 		ResolveCode: func(
@@ -288,8 +286,8 @@ func TestHandledParserError(t *testing.T) {
 				return []byte(contractCode), nil
 
 			default:
-				require.FailNow(t,
-					"import of unknown location: %s",
+				require.FailNowf(t,
+					"import of unknown location",
 					"location: %s",
 					location,
 				)
@@ -297,9 +295,13 @@ func TestHandledParserError(t *testing.T) {
 			}
 		},
 		HandleParserError: func(err analysis.ParsingCheckingError, _ *ast.Program) error {
+			require.Error(t, err)
+			handlerCalls++
 			return nil
 		},
 	}
+
+	require.Equal(t, 1, handlerCalls)
 
 	programs, err := analysis.Load(config, contractLocation)
 	require.NoError(t, err)
@@ -325,6 +327,7 @@ func TestHandledCheckerError(t *testing.T) {
 	  }
 	`
 
+	handlerCalls := 0
 	config := &analysis.Config{
 		Mode: analysis.NeedTypes,
 		ResolveCode: func(
@@ -336,8 +339,8 @@ func TestHandledCheckerError(t *testing.T) {
 			case contractLocation:
 				return []byte(contractCode), nil
 			default:
-				require.FailNow(t,
-					"import of unknown location: %s",
+				require.FailNowf(t,
+					"import of unknown location",
 					"location: %s",
 					location,
 				)
@@ -345,9 +348,13 @@ func TestHandledCheckerError(t *testing.T) {
 			}
 		},
 		HandleCheckerError: func(err analysis.ParsingCheckingError, _ *sema.Checker) error {
+			require.Error(t, err)
+			handlerCalls++
 			return nil
 		},
 	}
+
+	require.Equal(t, 1, handlerCalls)
 
 	programs, err := analysis.Load(config, contractLocation)
 	require.NoError(t, err)
@@ -387,6 +394,7 @@ func TestHandledLoadErrorImportedProgram(t *testing.T) {
 	  }
 	`
 
+	handlerCalls := 0
 	config := &analysis.Config{
 		Mode: analysis.NeedTypes,
 		ResolveCode: func(
@@ -400,8 +408,8 @@ func TestHandledLoadErrorImportedProgram(t *testing.T) {
 			case contract2Location:
 				return []byte(contract2Code), nil
 			default:
-				require.FailNow(t,
-					"import of unknown location: %s",
+				require.FailNowf(t,
+					"import of unknown location",
 					"location: %s",
 					location,
 				)
@@ -409,9 +417,13 @@ func TestHandledLoadErrorImportedProgram(t *testing.T) {
 			}
 		},
 		HandleCheckerError: func(err analysis.ParsingCheckingError, _ *sema.Checker) error {
+			require.Error(t, err)
+			handlerCalls++
 			return nil
 		},
 	}
+
+	require.Equal(t, 2, handlerCalls)
 
 	programs, err := analysis.Load(config, contract1Location)
 	require.NoError(t, err)
@@ -452,8 +464,8 @@ func TestStdlib(t *testing.T) {
 				return []byte(code), nil
 
 			default:
-				require.FailNow(t,
-					"import of unknown location: %s",
+				require.FailNowf(t,
+					"import of unknown location",
 					"location: %s",
 					location,
 				)
@@ -518,8 +530,8 @@ func TestCyclicImports(t *testing.T) {
 				return []byte(barContractCode), nil
 
 			default:
-				require.FailNow(t,
-					"import of unknown location: %s",
+				require.FailNowf(t,
+					"import of unknown location",
 					"location: %s",
 					location,
 				)

--- a/tools/analysis/analysis_test.go
+++ b/tools/analysis/analysis_test.go
@@ -380,7 +380,7 @@ func TestHandledLoadErrorImportedProgram(t *testing.T) {
 		Name:    "ContractB",
 	}
 	const contract2Code = `
-	  access(all) contract ContractA {
+	  access(all) contract ContractB {
 	    init() {
 	      X
 	    }
@@ -419,6 +419,13 @@ func TestHandledLoadErrorImportedProgram(t *testing.T) {
 	var checkerError *sema.CheckerError
 	require.ErrorAs(t, programs[contract1Location].LoadError, &checkerError)
 	require.ErrorAs(t, programs[contract2Location].LoadError, &checkerError)
+
+	loadErr := programs[contract1Location].LoadError.(analysis.ParsingCheckingError)
+	unwrapedErr := loadErr.Unwrap().(*sema.CheckerError)
+
+	var importedProgramErr *sema.ImportedProgramError
+	require.Len(t, unwrapedErr.ChildErrors(), 1)
+	require.ErrorAs(t, unwrapedErr.ChildErrors()[0], &importedProgramErr)
 }
 
 func TestStdlib(t *testing.T) {

--- a/tools/analysis/analysis_test.go
+++ b/tools/analysis/analysis_test.go
@@ -420,10 +420,10 @@ func TestHandledLoadErrorImportedProgram(t *testing.T) {
 	require.ErrorAs(t, programs[contract1Location].LoadError, &checkerError)
 	require.ErrorAs(t, programs[contract2Location].LoadError, &checkerError)
 
+	// Validate that parent checker receives the imported program error despite it being handled
+	var importedProgramErr *sema.ImportedProgramError
 	loadErr := programs[contract1Location].LoadError.(analysis.ParsingCheckingError)
 	unwrapedErr := loadErr.Unwrap().(*sema.CheckerError)
-
-	var importedProgramErr *sema.ImportedProgramError
 	require.Len(t, unwrapedErr.ChildErrors(), 1)
 	require.ErrorAs(t, unwrapedErr.ChildErrors()[0], &importedProgramErr)
 }

--- a/tools/analysis/config.go
+++ b/tools/analysis/config.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
 )
 
 // A Config specifies details about how programs should be loaded.
@@ -41,9 +42,9 @@ type Config struct {
 	// Mode controls the level of information returned for each program
 	Mode LoadMode
 	// HandleParserError is called when a parser error occurs instead of returning it
-	HandleParserError func(err ParsingCheckingError) error
+	HandleParserError func(err ParsingCheckingError, program *ast.Program, importingLocation common.Location) error
 	// HandleCheckerError is called when a checker error occurs instead of returning it
-	HandleCheckerError func(err ParsingCheckingError) error
+	HandleCheckerError func(err ParsingCheckingError, checker *sema.Checker, importingLocation common.Location) error
 }
 
 func NewSimpleConfig(

--- a/tools/analysis/config.go
+++ b/tools/analysis/config.go
@@ -42,9 +42,9 @@ type Config struct {
 	// Mode controls the level of information returned for each program
 	Mode LoadMode
 	// HandleParserError is called when a parser error occurs instead of returning it
-	HandleParserError func(err ParsingCheckingError, program *ast.Program, importingLocation common.Location) error
+	HandleParserError func(err ParsingCheckingError, program *ast.Program) error
 	// HandleCheckerError is called when a checker error occurs instead of returning it
-	HandleCheckerError func(err ParsingCheckingError, checker *sema.Checker, importingLocation common.Location) error
+	HandleCheckerError func(err ParsingCheckingError, checker *sema.Checker) error
 }
 
 func NewSimpleConfig(

--- a/tools/analysis/config.go
+++ b/tools/analysis/config.go
@@ -40,6 +40,10 @@ type Config struct {
 	) ([]byte, error)
 	// Mode controls the level of information returned for each program
 	Mode LoadMode
+	// HandleParserError is called when a parser error occurs instead of returning it
+	HandleParserError func(err ParsingCheckingError) error
+	// HandleCheckerError is called when a checker error occurs instead of returning it
+	HandleCheckerError func(err ParsingCheckingError) error
 }
 
 func NewSimpleConfig(

--- a/tools/analysis/program.go
+++ b/tools/analysis/program.go
@@ -27,10 +27,11 @@ import (
 )
 
 type Program struct {
-	Location common.Location
-	Program  *ast.Program
-	Checker  *sema.Checker
-	Code     []byte
+	Location  common.Location
+	Program   *ast.Program
+	Checker   *sema.Checker
+	Code      []byte
+	loadError error
 }
 
 // Run runs the given DAG of analyzers in parallel

--- a/tools/analysis/program.go
+++ b/tools/analysis/program.go
@@ -31,7 +31,7 @@ type Program struct {
 	Program   *ast.Program
 	Checker   *sema.Checker
 	Code      []byte
-	loadError error
+	LoadError error
 }
 
 // Run runs the given DAG of analyzers in parallel

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -69,16 +69,12 @@ func (programs Programs) load(
 
 	program, err := parser.ParseProgram(nil, code, parser.Config{})
 	if err != nil {
-		// If a parser error handler is set and the error is non-fatal
-		// use handler to handle the error (e.g. to report it and continue analysis)
-		// This will only be used for the entry point program (e.g not an imported program)
 		wrappedErr := wrapError(err)
-		if loadError == nil {
-			loadError = wrappedErr
-		}
+		loadError = wrappedErr
 
+		// If a custom error handler is set, use it to potentially handle the error
 		if config.HandleParserError != nil && program != nil && importingLocation == nil {
-			err = config.HandleParserError(wrappedErr)
+			err = config.HandleParserError(wrappedErr, program, importingLocation)
 			if err != nil {
 				return err
 			}
@@ -96,11 +92,9 @@ func (programs Programs) load(
 				loadError = wrappedErr
 			}
 
-			// If a custom error handler is set, and the error is non-fatal
-			// use handler to handle the error (e.g. to report it and continue analysis)
-			// This will only be used for the entry point program (e.g not an imported program)
-			if config.HandleCheckerError != nil && checker != nil && importingLocation == nil {
-				err = config.HandleCheckerError(wrappedErr)
+			// If a custom error handler is set, use it to potentially handle the error
+			if config.HandleCheckerError != nil {
+				err = config.HandleCheckerError(wrappedErr, checker, importingLocation)
 				if err != nil {
 					return err
 				}

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -149,7 +149,9 @@ func (programs Programs) check(
 				importRange ast.Range,
 			) (sema.Import, error) {
 
-				var imp *sema.ElaborationImport
+				var elaboration *sema.Elaboration
+				var loadError error
+
 				switch importedLocation {
 				case stdlib.CryptoCheckerLocation:
 					cryptoChecker := stdlib.CryptoChecker()
@@ -172,16 +174,16 @@ func (programs Programs) check(
 
 					// If the imported program has a checker, use its elaboration for the import
 					if programs[importedLocation].Checker != nil {
-						elaboration := programs[importedLocation].Checker.Elaboration
-						imp = &sema.ElaborationImport{
-							Elaboration: elaboration,
-						}
+						elaboration = programs[importedLocation].Checker.Elaboration
 					}
+
+					// If the imported program had an error while loading, record it
+					loadError = programs[importedLocation].loadError
 				}
 
-				// If the imported program had an error while loading, return it
-				loadError := programs[importedLocation].loadError
-				return imp, loadError
+				return &sema.ElaborationImport{
+					Elaboration: elaboration,
+				}, loadError
 			},
 		},
 	)

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -180,8 +180,9 @@ func (programs Programs) check(
 					// This may happen if a program is both imported and the entry point
 					// and has an error that was handled by a custom error handler
 					// However, we still want this error in the import resolution
-					if programs[importedLocation].loadError != nil {
-						return nil, programs[importedLocation].loadError
+					loadError := programs[importedLocation].loadError
+					if loadError != nil {
+						return nil, loadError
 					}
 
 					elaboration = programs[importedLocation].Checker.Elaboration

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -181,9 +181,13 @@ func (programs Programs) check(
 					loadError = programs[importedLocation].LoadError
 				}
 
-				return &sema.ElaborationImport{
+				if loadError != nil {
+					return nil, loadError
+				}
+
+				return sema.ElaborationImport{
 					Elaboration: elaboration,
-				}, loadError
+				}, nil
 			},
 		},
 	)

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -109,7 +109,7 @@ func (programs Programs) load(
 		Code:      code,
 		Program:   program,
 		Checker:   checker,
-		loadError: loadError,
+		LoadError: loadError,
 	}
 
 	return nil
@@ -178,7 +178,7 @@ func (programs Programs) check(
 					}
 
 					// If the imported program had an error while loading, record it
-					loadError = programs[importedLocation].loadError
+					loadError = programs[importedLocation].LoadError
 				}
 
 				return &sema.ElaborationImport{

--- a/tools/analysis/programs.go
+++ b/tools/analysis/programs.go
@@ -172,13 +172,16 @@ func (programs Programs) check(
 						return nil, err
 					}
 
+					program := programs[importedLocation]
+					checker := program.Checker
+
 					// If the imported program has a checker, use its elaboration for the import
-					if programs[importedLocation].Checker != nil {
-						elaboration = programs[importedLocation].Checker.Elaboration
+					if checker != nil {
+						elaboration = checker.Elaboration
 					}
 
 					// If the imported program had an error while loading, record it
-					loadError = programs[importedLocation].LoadError
+					loadError = program.LoadError
 				}
 
 				if loadError != nil {


### PR DESCRIPTION
Closes #3087

## Description

Allow for custom checker/parser handlers to be configured in the analysis tool. These errors may be non-fatal & this gives the option to choose whether to suppress them and continue analysis.

Unblocks https://github.com/onflow/cadence-tools/pull/285. Pre-cadence 1.0 code is not semantically valid in cadence 1.0 checker so these errors will be present. In order to run the cadence 1.0 analyzer, a mechanism needs to exist to suppress these errors. This is similar to the behaviour that already exists in the language server.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
