### PR TITLE
Allow contract interface types in intersection types

### DIFF
--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -982,11 +982,15 @@ func CheckIntersectionType(
 		// the type is ambiguous.
 
 		report(func(t *ast.IntersectionType) error {
-			return &AmbiguousIntersectionTypeError{Range: ast.NewRangeFromPositioned(memoryGauge, t)}
+			return &AmbiguousIntersectionTypeError{
+				Range: ast.NewRangeFromPositioned(memoryGauge, t),
+			}
 		})
 		return InvalidType
 
-	case common.CompositeKindResource, common.CompositeKindStructure:
+	case common.CompositeKindResource,
+		common.CompositeKindStructure,
+		common.CompositeKindContract:
 		break
 
 	default:
@@ -1011,8 +1015,7 @@ func (checker *Checker) convertIntersectionType(t *ast.IntersectionType) Type {
 		if ok {
 			intersectedCompositeKind = intersectedInterfaceType.CompositeKind
 		}
-		if !ok || (intersectedCompositeKind != common.CompositeKindResource &&
-			intersectedCompositeKind != common.CompositeKindStructure) {
+		if !ok || !intersectedCompositeKind.SupportsInterfaces() {
 
 			if !intersectedResult.IsInvalidType() {
 				checker.report(&InvalidIntersectedTypeError{

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -3616,7 +3616,7 @@ func (*InvalidIntersectedTypeError) IsUserError() {}
 
 func (e *InvalidIntersectedTypeError) Error() string {
 	return fmt.Sprintf(
-		"cannot restrict using non-resource/structure interface type: `%s`",
+		"cannot restrict using non-resource/structure/contract interface type: `%s`",
 		e.Type.QualifiedString(),
 	)
 }

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -3665,27 +3665,6 @@ func (e *InvalidIntersectionTypeDuplicateError) Error() string {
 	)
 }
 
-// InvalidNonConformanceIntersectionError
-
-type InvalidNonConformanceIntersectionError struct {
-	Type *InterfaceType
-	ast.Range
-}
-
-var _ SemanticError = &InvalidNonConformanceIntersectionError{}
-var _ errors.UserError = &InvalidNonConformanceIntersectionError{}
-
-func (*InvalidNonConformanceIntersectionError) isSemanticError() {}
-
-func (*InvalidNonConformanceIntersectionError) IsUserError() {}
-
-func (e *InvalidNonConformanceIntersectionError) Error() string {
-	return fmt.Sprintf(
-		"intersection type does not conform to restricting type: `%s`",
-		e.Type.QualifiedString(),
-	)
-}
-
 // IntersectionMemberClashError
 
 type IntersectionMemberClashError struct {

--- a/runtime/tests/checker/intersection_test.go
+++ b/runtime/tests/checker/intersection_test.go
@@ -264,6 +264,109 @@ func TestCheckIntersectionType(t *testing.T) {
 
 		assert.IsType(t, &sema.AmbiguousIntersectionTypeError{}, errs[0])
 	})
+
+	t.Run("contract interface", func(t *testing.T) {
+
+		_, err := ParseAndCheck(t, `
+            contract interface CI {}
+
+            fun test (_ c: {CI}) {}
+        `)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("contract", func(t *testing.T) {
+
+		_, err := ParseAndCheck(t, `
+            contract C {}
+
+            fun test (_ c: {C}) {}
+        `)
+
+		errs := RequireCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.InvalidIntersectedTypeError{}, errs[0])
+		// Checker is not able to infer valid composite kind based on intersection's types
+		assert.IsType(t, &sema.AmbiguousIntersectionTypeError{}, errs[1])
+	})
+
+	t.Run("enum", func(t *testing.T) {
+
+		_, err := ParseAndCheck(t, `
+            enum E: UInt8 {}
+
+            fun test (_ e: {E}) {}
+        `)
+
+		errs := RequireCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.InvalidIntersectedTypeError{}, errs[0])
+		// Checker is not able to infer valid composite kind based on intersection's types
+		assert.IsType(t, &sema.AmbiguousIntersectionTypeError{}, errs[1])
+	})
+
+	t.Run("event", func(t *testing.T) {
+
+		_, err := ParseAndCheck(t, `
+            event E()
+
+            fun test (_ e: {E}) {}
+        `)
+
+		errs := RequireCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.InvalidIntersectedTypeError{}, errs[0])
+		// Checker is not able to infer valid composite kind based on intersection's types
+		assert.IsType(t, &sema.AmbiguousIntersectionTypeError{}, errs[1])
+	})
+
+	t.Run("attachment", func(t *testing.T) {
+
+		_, err := ParseAndCheck(t, `
+            resource R {}
+
+            attachment A for R {}
+
+            fun test (_ a: {A}) {}
+        `)
+
+		errs := RequireCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.InvalidIntersectedTypeError{}, errs[0])
+		// Checker is not able to infer valid composite kind based on intersection's types
+		assert.IsType(t, &sema.AmbiguousIntersectionTypeError{}, errs[1])
+	})
+
+	t.Run("entitlement", func(t *testing.T) {
+
+		_, err := ParseAndCheck(t, `
+            entitlement E
+
+            fun test (_ e: {E}) {}
+        `)
+
+		errs := RequireCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.InvalidIntersectedTypeError{}, errs[0])
+		// Checker is not able to infer valid composite kind based on intersection's types
+		assert.IsType(t, &sema.AmbiguousIntersectionTypeError{}, errs[1])
+	})
+
+	t.Run("entitlement mapping", func(t *testing.T) {
+
+		_, err := ParseAndCheck(t, `
+            entitlement mapping M {}
+
+            fun test (_ m: {M}) {}
+        `)
+
+		errs := RequireCheckerErrors(t, err, 2)
+
+		assert.IsType(t, &sema.InvalidIntersectedTypeError{}, errs[0])
+		// Checker is not able to infer valid composite kind based on intersection's types
+		assert.IsType(t, &sema.AmbiguousIntersectionTypeError{}, errs[1])
+	})
 }
 
 func TestCheckIntersectionTypeMemberAccess(t *testing.T) {


### PR DESCRIPTION
Closes #3088

## Description

https://discord.com/channels/613813861610684416/621847426201944074/1205259026737266768

Forbidding contract interfaces was an oversight.

Also test other composite kinds.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
