### PR TITLE
Improve member resolvers

### DIFF
--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -207,8 +207,12 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression, isAssignme
 			return
 		}
 
-		targetRange := ast.NewRangeFromPositioned(checker.memoryGauge, expression.Expression)
-		member = resolver.Resolve(checker.memoryGauge, identifier, targetRange, checker.report)
+		member = resolver.Resolve(
+			checker.memoryGauge,
+			identifier,
+			expression.Expression,
+			checker.report,
+		)
 		resultingType = member.TypeAnnotation.Type
 	}
 

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -384,7 +384,7 @@ func TestIntersectionType_GetMember(t *testing.T) {
 
 		require.Contains(t, actualMembers, fieldName)
 
-		actualMember := actualMembers[fieldName].Resolve(nil, fieldName, ast.Range{}, nil)
+		actualMember := actualMembers[fieldName].Resolve(nil, fieldName, ast.EmptyRange, nil)
 
 		assert.Same(t, interfaceMember, actualMember)
 	})

--- a/runtime/tests/interpreter/memory_metering_test.go
+++ b/runtime/tests/interpreter/memory_metering_test.go
@@ -8449,8 +8449,8 @@ func TestInterpretASTMetering(t *testing.T) {
 		_, err := inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(201), meter.getMemory(common.MemoryKindPosition))
-		assert.Equal(t, uint64(110), meter.getMemory(common.MemoryKindRange))
+		assert.Equal(t, uint64(200), meter.getMemory(common.MemoryKindPosition))
+		assert.Equal(t, uint64(109), meter.getMemory(common.MemoryKindRange))
 	})
 
 	t.Run("locations", func(t *testing.T) {


### PR DESCRIPTION
## Description

Lazily construct AST range if needed

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
