### PR TITLE
Consider inherited interfaces when checking for member clashes in intersection types

### DIFF
--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -762,7 +762,18 @@ func (checker *Checker) declareCompositeLikeMembersAndValue(
 		checker.enterValueScope()
 		defer checker.leaveValueScope(declaration.EndPosition, false)
 
+		// Declare nested types
+
 		checker.declareCompositeLikeNestedTypes(declaration, false)
+
+		// Declare nested types' explicit conformances
+
+		for _, nestedInterfaceDeclaration := range members.Interfaces() {
+			// resolve conformances
+			nestedInterfaceType := checker.Elaboration.InterfaceDeclarationType(nestedInterfaceDeclaration)
+			nestedInterfaceType.ExplicitInterfaceConformances =
+				checker.explicitInterfaceConformances(nestedInterfaceDeclaration, nestedInterfaceType)
+		}
 
 		// NOTE: determine initializer parameter types while nested types are in scope,
 		// and after declaring nested types as the initializer may use nested type in parameters
@@ -828,12 +839,7 @@ func (checker *Checker) declareCompositeLikeMembersAndValue(
 				},
 			)
 		}
-		for _, nestedInterfaceDeclaration := range members.Interfaces() {
-			// resolve conformances
-			nestedInterfaceType := checker.Elaboration.InterfaceDeclarationType(nestedInterfaceDeclaration)
-			nestedInterfaceType.ExplicitInterfaceConformances =
-				checker.explicitInterfaceConformances(nestedInterfaceDeclaration, nestedInterfaceType)
-		}
+
 		for _, nestedCompositeDeclaration := range nestedComposites {
 			declareNestedComposite(nestedCompositeDeclaration)
 		}

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -937,40 +937,45 @@ func CheckIntersectionType(
 
 		// The intersections may not have clashing members
 
-		// TODO: also include interface conformances' members
-		//   once interfaces can have conformances
+		checkClashingMember := func(interfaceType *InterfaceType) {
+			interfaceType.Members.Foreach(func(name string, member *Member) {
 
-		interfaceType.Members.Foreach(func(name string, member *Member) {
-			if previousDeclaringInterfaceType, ok := memberSet[name]; ok {
+				if previousDeclaringInterfaceType, ok := memberSet[name]; ok {
 
-				// If there is an overlap in members, ensure the members have the same type
+					// If there is an overlap in members, ensure the members have the same type
 
-				memberType := member.TypeAnnotation.Type
+					memberType := member.TypeAnnotation.Type
 
-				prevMemberType, ok := previousDeclaringInterfaceType.Members.Get(name)
-				if !ok {
-					panic(errors.NewUnreachableError())
+					prevMemberType, ok := previousDeclaringInterfaceType.Members.Get(name)
+					if !ok {
+						panic(errors.NewUnreachableError())
+					}
+
+					previousMemberType := prevMemberType.TypeAnnotation.Type
+
+					if !memberType.IsInvalidType() &&
+						!previousMemberType.IsInvalidType() &&
+						!memberType.Equal(previousMemberType) {
+
+						report(func(t *ast.IntersectionType) error {
+							return &IntersectionMemberClashError{
+								Name:                  name,
+								RedeclaringType:       interfaceType,
+								OriginalDeclaringType: previousDeclaringInterfaceType,
+								Range:                 ast.NewRangeFromPositioned(memoryGauge, t.Types[i]),
+							}
+						})
+					}
+				} else {
+					memberSet[name] = interfaceType
 				}
+			})
+		}
 
-				previousMemberType := prevMemberType.TypeAnnotation.Type
+		checkClashingMember(interfaceType)
 
-				if !memberType.IsInvalidType() &&
-					!previousMemberType.IsInvalidType() &&
-					!memberType.Equal(previousMemberType) {
-
-					report(func(t *ast.IntersectionType) error {
-						return &IntersectionMemberClashError{
-							Name:                  name,
-							RedeclaringType:       interfaceType,
-							OriginalDeclaringType: previousDeclaringInterfaceType,
-							Range:                 ast.NewRangeFromPositioned(memoryGauge, t.Types[i]),
-						}
-					})
-				}
-			} else {
-				memberSet[name] = interfaceType
-			}
-		})
+		interfaceType.EffectiveInterfaceConformanceSet().
+			ForEach(checkClashingMember)
 	}
 
 	// If no intersection type is given, infer `AnyResource`/`AnyStruct`

--- a/runtime/tests/checker/intersection_test.go
+++ b/runtime/tests/checker/intersection_test.go
@@ -534,6 +534,25 @@ func TestCheckIntersectionTypeWithInheritanceMemberClash(t *testing.T) {
 	}
 }
 
+func TestCheckIntersectionTypeWithInheritedMember(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+	  struct interface A {
+          let n: Int
+      }
+
+      struct interface B: A {}
+
+      struct interface C: A {}
+
+      fun test(_ v: {B, C}) {}
+	`)
+
+	require.NoError(t, err)
+}
+
 func TestCheckIntersectionTypeSubtyping(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
Closes #3091

## Description

- Fix order of declaring nested types' explicit interface conformances: setting the explicit interface conformances must occur before checking members
- Consider inherited interfaces when checking for member clashes in intersection types

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
