### PR TITLE
Report a proper error for swapping a resource to itself 

### DIFF
--- a/runtime/interpreter/interpreter_statement.go
+++ b/runtime/interpreter/interpreter_statement.go
@@ -588,12 +588,14 @@ func (interpreter *Interpreter) VisitSwapStatement(swap *ast.SwapStatement) Stat
 	// Set right value to left target,
 	// and left value to right target
 
+	interpreter.checkInvalidatedResourceOrResourceReference(rightValue, swap.Right)
 	locationRange := LocationRange{
 		Location:    interpreter.Location,
 		HasPosition: swap.Right,
 	}
 	transferredRightValue := interpreter.transferAndConvert(rightValue, rightType, leftType, locationRange)
 
+	interpreter.checkInvalidatedResourceOrResourceReference(leftValue, swap.Left)
 	locationRange = LocationRange{
 		Location:    interpreter.Location,
 		HasPosition: swap.Left,


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-internal/issues/207

## Description

Check whether the value is an invalidated resource before transferring during swap. While this fixes the  https://github.com/dapperlabs/cadence-internal/issues/207, added validation can also be a defensive check for future proofing.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
