### PR TITLE
Bring back support for decoding published path capabilities

### DIFF
--- a/migrations/capcons/linkmigration.go
+++ b/migrations/capcons/linkmigration.go
@@ -87,7 +87,7 @@ func (m *LinkValueMigration) Migrate(
 	var borrowStaticType *interpreter.ReferenceStaticType
 
 	switch readValue := value.(type) {
-	case *interpreter.CapabilityValue:
+	case *interpreter.IDCapabilityValue:
 		// Already migrated
 		return nil, nil
 
@@ -300,7 +300,7 @@ func (m *LinkValueMigration) getPathCapabilityFinalTarget(
 					interpreter.UnauthorizedAccess,
 					nil
 
-			case *interpreter.CapabilityValue:
+			case *interpreter.IDCapabilityValue:
 
 				// Follow ID capability values which are published in the public or private domain.
 				// This is needed for two reasons:

--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -282,7 +282,7 @@ func ConvertValueToEntitlements(
 			values...,
 		), nil
 
-	case *interpreter.CapabilityValue:
+	case *interpreter.IDCapabilityValue:
 		semaType := inter.MustConvertStaticToSemaType(staticType)
 		entitledType, converted := ConvertToEntitledType(semaType)
 		if !converted {

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -1684,7 +1684,7 @@ func TestMigratePublishedValue(t *testing.T) {
 	require.Equal(t, inboxStorageMap.Count(), uint64(1))
 
 	cap1 := storageMap.ReadValue(nil, interpreter.StringStorageMapKey("cap"))
-	capValue := cap1.(*interpreter.CapabilityValue)
+	capValue := cap1.(*interpreter.IDCapabilityValue)
 	require.IsType(t, &interpreter.ReferenceStaticType{}, capValue.BorrowType)
 	ref := capValue.BorrowType.(*interpreter.ReferenceStaticType)
 	require.Equal(t,
@@ -1700,8 +1700,13 @@ func TestMigratePublishedValue(t *testing.T) {
 	)
 
 	publishedValue := inboxStorageMap.ReadValue(nil, interpreter.StringStorageMapKey("r_cap"))
+
 	require.IsType(t, &interpreter.PublishedValue{}, publishedValue)
-	capabilityValue := publishedValue.(*interpreter.PublishedValue).Value
+	publishedValueValue := publishedValue.(*interpreter.PublishedValue).Value
+
+	require.IsType(t, &interpreter.IDCapabilityValue{}, publishedValueValue)
+	capabilityValue := publishedValueValue.(*interpreter.IDCapabilityValue)
+
 	require.IsType(t, &interpreter.ReferenceStaticType{}, capabilityValue.BorrowType)
 	ref = capabilityValue.BorrowType.(*interpreter.ReferenceStaticType)
 	require.Equal(t,
@@ -1916,7 +1921,7 @@ func TestMigratePublishedValueAcrossTwoAccounts(t *testing.T) {
 	)
 
 	cap1 := storageMap.ReadValue(nil, interpreter.StringStorageMapKey("cap"))
-	capValue := cap1.(*interpreter.CapabilityValue)
+	capValue := cap1.(*interpreter.IDCapabilityValue)
 	require.IsType(t, &interpreter.ReferenceStaticType{}, capValue.BorrowType)
 	ref := capValue.BorrowType.(*interpreter.ReferenceStaticType)
 	require.Equal(t,
@@ -1932,8 +1937,13 @@ func TestMigratePublishedValueAcrossTwoAccounts(t *testing.T) {
 	)
 
 	publishedValue := inboxStorageMap.ReadValue(nil, interpreter.StringStorageMapKey("r_cap"))
+
 	require.IsType(t, &interpreter.PublishedValue{}, publishedValue)
-	capabilityValue := publishedValue.(*interpreter.PublishedValue).Value
+	publishedValueValue := publishedValue.(*interpreter.PublishedValue).Value
+
+	require.IsType(t, &interpreter.IDCapabilityValue{}, publishedValueValue)
+	capabilityValue := publishedValueValue.(*interpreter.IDCapabilityValue)
+
 	require.IsType(t, &interpreter.ReferenceStaticType{}, capabilityValue.BorrowType)
 	ref = capabilityValue.BorrowType.(*interpreter.ReferenceStaticType)
 	require.Equal(t,
@@ -2152,8 +2162,8 @@ func TestMigrateAcrossContracts(t *testing.T) {
 
 	field := tValue.GetMember(inter, interpreter.EmptyLocationRange, "cap")
 
-	require.IsType(t, &interpreter.CapabilityValue{}, field)
-	cap := field.(*interpreter.CapabilityValue)
+	require.IsType(t, &interpreter.IDCapabilityValue{}, field)
+	cap := field.(*interpreter.IDCapabilityValue)
 	require.IsType(t, &interpreter.ReferenceStaticType{}, cap.BorrowType)
 	ref := cap.BorrowType.(*interpreter.ReferenceStaticType)
 	require.Equal(t,
@@ -2382,8 +2392,8 @@ func TestMigrateArrayOfValues(t *testing.T) {
 	)
 
 	cap1 := arrValue.Get(inter, interpreter.EmptyLocationRange, 0)
-	require.IsType(t, &interpreter.CapabilityValue{}, cap1)
-	capValue := cap1.(*interpreter.CapabilityValue)
+	require.IsType(t, &interpreter.IDCapabilityValue{}, cap1)
+	capValue := cap1.(*interpreter.IDCapabilityValue)
 	require.IsType(t, &interpreter.ReferenceStaticType{}, capValue.BorrowType)
 	ref = capValue.BorrowType.(*interpreter.ReferenceStaticType)
 	require.Equal(t,
@@ -2399,8 +2409,8 @@ func TestMigrateArrayOfValues(t *testing.T) {
 	)
 
 	cap2 := arrValue.Get(inter, interpreter.EmptyLocationRange, 1)
-	require.IsType(t, &interpreter.CapabilityValue{}, cap2)
-	capValue = cap1.(*interpreter.CapabilityValue)
+	require.IsType(t, &interpreter.IDCapabilityValue{}, cap2)
+	capValue = cap1.(*interpreter.IDCapabilityValue)
 	require.IsType(t, &interpreter.ReferenceStaticType{}, capValue.BorrowType)
 	ref = capValue.BorrowType.(*interpreter.ReferenceStaticType)
 	require.Equal(t,
@@ -2631,8 +2641,8 @@ func TestMigrateDictOfValues(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("a"),
 	)
 	require.True(t, present)
-	require.IsType(t, &interpreter.CapabilityValue{}, cap1)
-	capValue := cap1.(*interpreter.CapabilityValue)
+	require.IsType(t, &interpreter.IDCapabilityValue{}, cap1)
+	capValue := cap1.(*interpreter.IDCapabilityValue)
 	require.IsType(t, &interpreter.ReferenceStaticType{}, capValue.BorrowType)
 	ref = capValue.BorrowType.(*interpreter.ReferenceStaticType)
 	require.Equal(t,
@@ -2651,8 +2661,8 @@ func TestMigrateDictOfValues(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("b"),
 	)
 	require.True(t, present)
-	require.IsType(t, &interpreter.CapabilityValue{}, cap2)
-	capValue = cap1.(*interpreter.CapabilityValue)
+	require.IsType(t, &interpreter.IDCapabilityValue{}, cap2)
+	capValue = cap1.(*interpreter.IDCapabilityValue)
 	require.IsType(t, &interpreter.ReferenceStaticType{}, capValue.BorrowType)
 	ref = capValue.BorrowType.(*interpreter.ReferenceStaticType)
 	require.Equal(t,

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -337,7 +337,7 @@ func (m *StorageMigration) MigrateNestedValue(
 			reporter,
 		)
 		if newInnerValue != nil {
-			newInnerCapability := newInnerValue.(*interpreter.CapabilityValue)
+			newInnerCapability := newInnerValue.(*interpreter.IDCapabilityValue)
 			return interpreter.NewPublishedValue(
 				m.interpreter,
 				value.Recipient,

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -172,7 +172,7 @@ func (testCapMigration) Migrate(
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
 ) (interpreter.Value, error) {
-	if value, ok := value.(*interpreter.CapabilityValue); ok {
+	if value, ok := value.(*interpreter.IDCapabilityValue); ok {
 		return interpreter.NewCapabilityValue(
 			nil,
 			value.ID+10,
@@ -419,7 +419,7 @@ func TestMultipleMigrations(t *testing.T) {
 			expectedValue: interpreter.NewSomeValueNonCopying(nil, test.expectedValue),
 		})
 
-		if _, ok := test.storedValue.(*interpreter.CapabilityValue); ok {
+		if _, ok := test.storedValue.(*interpreter.IDCapabilityValue); ok {
 
 			testCases = append(testCases, testCase{
 				name:      "published_" + test.name,
@@ -428,12 +428,12 @@ func TestMultipleMigrations(t *testing.T) {
 				storedValue: interpreter.NewPublishedValue(
 					nil,
 					interpreter.AddressValue(common.ZeroAddress),
-					test.storedValue.(*interpreter.CapabilityValue),
+					test.storedValue.(*interpreter.IDCapabilityValue),
 				),
 				expectedValue: interpreter.NewPublishedValue(
 					nil,
 					interpreter.AddressValue(common.ZeroAddress),
-					test.expectedValue.(*interpreter.CapabilityValue),
+					test.expectedValue.(*interpreter.IDCapabilityValue),
 				),
 			})
 		}

--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -72,7 +72,7 @@ func (m *StaticTypeMigration) Migrate(
 		}
 		return interpreter.NewTypeValue(nil, convertedType), nil
 
-	case *interpreter.CapabilityValue:
+	case *interpreter.IDCapabilityValue:
 		convertedBorrowType := m.maybeConvertStaticType(value.BorrowType)
 		if convertedBorrowType == nil {
 			return

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -229,7 +229,7 @@ func exportValueWithInterpreter(
 		return exportPathValue(inter, v)
 	case interpreter.TypeValue:
 		return exportTypeValue(v, inter), nil
-	case *interpreter.CapabilityValue:
+	case *interpreter.IDCapabilityValue:
 		return exportCapabilityValue(v, inter)
 	case *interpreter.EphemeralReferenceValue:
 		// Break recursion through references
@@ -683,7 +683,7 @@ func exportTypeValue(v interpreter.TypeValue, inter *interpreter.Interpreter) ca
 }
 
 func exportCapabilityValue(
-	v *interpreter.CapabilityValue,
+	v *interpreter.IDCapabilityValue,
 	inter *interpreter.Interpreter,
 ) (cadence.Capability, error) {
 	borrowType := inter.MustConvertStaticToSemaType(v.BorrowType)
@@ -1162,7 +1162,7 @@ func (i valueImporter) importCapability(
 	address cadence.Address,
 	borrowType cadence.Type,
 ) (
-	*interpreter.CapabilityValue,
+	*interpreter.IDCapabilityValue,
 	error,
 ) {
 	_, ok := borrowType.(*cadence.ReferenceType)

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -930,7 +930,7 @@ func (d StorableDecoder) decodePath() (PathValue, error) {
 	), nil
 }
 
-func (d StorableDecoder) decodeCapability() (*CapabilityValue, error) {
+func (d StorableDecoder) decodeCapability() (*IDCapabilityValue, error) {
 
 	const expectedLength = encodedCapabilityValueLength
 
@@ -1177,7 +1177,7 @@ func (d StorableDecoder) decodePublishedValue() (*PublishedValue, error) {
 		return nil, errors.NewUnexpectedError("invalid published value value encoding: %w", err)
 	}
 
-	capabilityValue, ok := value.(*CapabilityValue)
+	capabilityValue, ok := value.(CapabilityValue)
 	if !ok {
 		return nil, errors.NewUnexpectedError(
 			"invalid published value value encoding: expected capability, got %T",

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -779,7 +779,7 @@ const (
 	encodedCapabilityValueLength = 3
 )
 
-// Encode encodes CapabilityValue as
+// Encode encodes IDCapabilityValue as
 //
 //	cbor.Tag{
 //				Number: CBORTagCapabilityValue,
@@ -789,7 +789,7 @@ const (
 //						encodedCapabilityValueBorrowTypeFieldKey: StaticType(v.BorrowType),
 //					},
 //	}
-func (v *CapabilityValue) Encode(e *atree.Encoder) error {
+func (v *IDCapabilityValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2142,7 +2142,7 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 			targetBorrowType := unwrappedTargetType.BorrowType.(*sema.ReferenceType)
 
 			switch capability := value.(type) {
-			case *CapabilityValue:
+			case *IDCapabilityValue:
 				valueBorrowType := capability.BorrowType.(*ReferenceStaticType)
 				borrowType := interpreter.convertStaticType(valueBorrowType, targetBorrowType)
 				return NewCapabilityValue(
@@ -4167,7 +4167,7 @@ func (interpreter *Interpreter) checkValue(
 	//	1) The actual stored value (storage path)
 	//	2) A capability to the value at the storage (private/public paths)
 
-	if capability, ok := value.(*CapabilityValue); ok {
+	if capability, ok := value.(*IDCapabilityValue); ok {
 		// If, the value is a capability, try to load the value at the capability target.
 		// However, borrow type is not statically known.
 		// So take the borrow type from the value itself

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -21389,11 +21389,11 @@ func (PathValue) ChildStorables() []atree.Storable {
 type PublishedValue struct {
 	// NB: If `publish` and `claim` are ever extended to support arbitrary values, rather than just capabilities,
 	// this will need to be changed to `Value`, and more storage-related operations must be implemented for `PublishedValue`
-	Value     *CapabilityValue
+	Value     CapabilityValue
 	Recipient AddressValue
 }
 
-func NewPublishedValue(memoryGauge common.MemoryGauge, recipient AddressValue, value *CapabilityValue) *PublishedValue {
+func NewPublishedValue(memoryGauge common.MemoryGauge, recipient AddressValue, value CapabilityValue) *PublishedValue {
 	common.UseMemory(memoryGauge, common.PublishedValueMemoryUsage)
 	return &PublishedValue{
 		Recipient: recipient,
@@ -21502,7 +21502,7 @@ func (v *PublishedValue) Transfer(
 			remove,
 			nil,
 			preventTransfer,
-		).(*CapabilityValue)
+		).(*IDCapabilityValue)
 
 		addressValue := v.Recipient.Transfer(
 			interpreter,
@@ -21527,7 +21527,7 @@ func (v *PublishedValue) Transfer(
 func (v *PublishedValue) Clone(interpreter *Interpreter) Value {
 	return &PublishedValue{
 		Recipient: v.Recipient,
-		Value:     v.Value.Clone(interpreter).(*CapabilityValue),
+		Value:     v.Value.Clone(interpreter).(*IDCapabilityValue),
 	}
 }
 

--- a/runtime/interpreter/value_accountcapabilitycontroller.go
+++ b/runtime/interpreter/value_accountcapabilitycontroller.go
@@ -45,7 +45,7 @@ type AccountCapabilityControllerValue struct {
 	// Tags are not stored directly inside the controller
 	// to avoid unnecessary storage reads
 	// when the controller is loaded for borrowing/checking
-	GetCapability func(inter *Interpreter) *CapabilityValue
+	GetCapability func(inter *Interpreter) *IDCapabilityValue
 	GetTag        func(inter *Interpreter) *StringValue
 	SetTag        func(inter *Interpreter, tag *StringValue)
 	Delete        func(inter *Interpreter, locationRange LocationRange)

--- a/runtime/interpreter/value_capability.go
+++ b/runtime/interpreter/value_capability.go
@@ -29,7 +29,16 @@ import (
 
 // CapabilityValue
 
-type CapabilityValue struct {
+// TODO: remove once migration to Cadence 1.0 / ID capabilities is complete
+type CapabilityValue interface {
+	EquatableValue
+	atree.Storable
+	isCapabilityValue()
+}
+
+// IDCapabilityValue
+
+type IDCapabilityValue struct {
 	BorrowType StaticType
 	Address    AddressValue
 	ID         UInt64Value
@@ -39,8 +48,8 @@ func NewUnmeteredCapabilityValue(
 	id UInt64Value,
 	address AddressValue,
 	borrowType StaticType,
-) *CapabilityValue {
-	return &CapabilityValue{
+) *IDCapabilityValue {
+	return &IDCapabilityValue{
 		ID:         id,
 		Address:    address,
 		BorrowType: borrowType,
@@ -52,44 +61,47 @@ func NewCapabilityValue(
 	id UInt64Value,
 	address AddressValue,
 	borrowType StaticType,
-) *CapabilityValue {
+) *IDCapabilityValue {
 	// Constant because its constituents are already metered.
 	common.UseMemory(memoryGauge, common.CapabilityValueMemoryUsage)
 	return NewUnmeteredCapabilityValue(id, address, borrowType)
 }
 
-var _ Value = &CapabilityValue{}
-var _ atree.Storable = &CapabilityValue{}
-var _ EquatableValue = &CapabilityValue{}
-var _ MemberAccessibleValue = &CapabilityValue{}
+var _ Value = &IDCapabilityValue{}
+var _ atree.Storable = &IDCapabilityValue{}
+var _ EquatableValue = &IDCapabilityValue{}
+var _ MemberAccessibleValue = &IDCapabilityValue{}
+var _ CapabilityValue = &IDCapabilityValue{}
 
-func (*CapabilityValue) isValue() {}
+func (*IDCapabilityValue) isValue() {}
 
-func (v *CapabilityValue) Accept(interpreter *Interpreter, visitor Visitor) {
+func (*IDCapabilityValue) isCapabilityValue() {}
+
+func (v *IDCapabilityValue) Accept(interpreter *Interpreter, visitor Visitor) {
 	visitor.VisitCapabilityValue(interpreter, v)
 }
 
-func (v *CapabilityValue) Walk(_ *Interpreter, walkChild func(Value)) {
+func (v *IDCapabilityValue) Walk(_ *Interpreter, walkChild func(Value)) {
 	walkChild(v.ID)
 	walkChild(v.Address)
 }
 
-func (v *CapabilityValue) StaticType(inter *Interpreter) StaticType {
+func (v *IDCapabilityValue) StaticType(inter *Interpreter) StaticType {
 	return NewCapabilityStaticType(
 		inter,
 		v.BorrowType,
 	)
 }
 
-func (v *CapabilityValue) IsImportable(_ *Interpreter) bool {
+func (v *IDCapabilityValue) IsImportable(_ *Interpreter) bool {
 	return false
 }
 
-func (v *CapabilityValue) String() string {
+func (v *IDCapabilityValue) String() string {
 	return v.RecursiveString(SeenReferences{})
 }
 
-func (v *CapabilityValue) RecursiveString(seenReferences SeenReferences) string {
+func (v *IDCapabilityValue) RecursiveString(seenReferences SeenReferences) string {
 	return format.Capability(
 		v.BorrowType.String(),
 		v.Address.RecursiveString(seenReferences),
@@ -97,7 +109,7 @@ func (v *CapabilityValue) RecursiveString(seenReferences SeenReferences) string 
 	)
 }
 
-func (v *CapabilityValue) MeteredString(memoryGauge common.MemoryGauge, seenReferences SeenReferences) string {
+func (v *IDCapabilityValue) MeteredString(memoryGauge common.MemoryGauge, seenReferences SeenReferences) string {
 	common.UseMemory(memoryGauge, common.CapabilityValueStringMemoryUsage)
 
 	return format.Capability(
@@ -107,7 +119,7 @@ func (v *CapabilityValue) MeteredString(memoryGauge common.MemoryGauge, seenRefe
 	)
 }
 
-func (v *CapabilityValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
+func (v *IDCapabilityValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	switch name {
 	case sema.CapabilityTypeBorrowFunctionName:
 		// this function will panic already if this conversion fails
@@ -129,17 +141,17 @@ func (v *CapabilityValue) GetMember(interpreter *Interpreter, _ LocationRange, n
 	return nil
 }
 
-func (*CapabilityValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (*IDCapabilityValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	// Capabilities have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (*CapabilityValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (*IDCapabilityValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
 	// Capabilities have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (v *CapabilityValue) ConformsToStaticType(
+func (v *IDCapabilityValue) ConformsToStaticType(
 	_ *Interpreter,
 	_ LocationRange,
 	_ TypeConformanceResults,
@@ -147,8 +159,8 @@ func (v *CapabilityValue) ConformsToStaticType(
 	return true
 }
 
-func (v *CapabilityValue) Equal(interpreter *Interpreter, locationRange LocationRange, other Value) bool {
-	otherCapability, ok := other.(*CapabilityValue)
+func (v *IDCapabilityValue) Equal(interpreter *Interpreter, locationRange LocationRange, other Value) bool {
+	otherCapability, ok := other.(*IDCapabilityValue)
 	if !ok {
 		return false
 	}
@@ -158,11 +170,11 @@ func (v *CapabilityValue) Equal(interpreter *Interpreter, locationRange Location
 		otherCapability.BorrowType.Equal(v.BorrowType)
 }
 
-func (*CapabilityValue) IsStorable() bool {
+func (*IDCapabilityValue) IsStorable() bool {
 	return true
 }
 
-func (v *CapabilityValue) Storable(
+func (v *IDCapabilityValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
 	maxInlineSize uint64,
@@ -175,15 +187,15 @@ func (v *CapabilityValue) Storable(
 	)
 }
 
-func (*CapabilityValue) NeedsStoreTo(_ atree.Address) bool {
+func (*IDCapabilityValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*CapabilityValue) IsResourceKinded(_ *Interpreter) bool {
+func (*IDCapabilityValue) IsResourceKinded(_ *Interpreter) bool {
 	return false
 }
 
-func (v *CapabilityValue) Transfer(
+func (v *IDCapabilityValue) Transfer(
 	interpreter *Interpreter,
 	_ LocationRange,
 	_ atree.Address,
@@ -198,7 +210,7 @@ func (v *CapabilityValue) Transfer(
 	return v
 }
 
-func (v *CapabilityValue) Clone(interpreter *Interpreter) Value {
+func (v *IDCapabilityValue) Clone(interpreter *Interpreter) Value {
 	return NewUnmeteredCapabilityValue(
 		v.ID,
 		v.Address.Clone(interpreter).(AddressValue),
@@ -206,19 +218,19 @@ func (v *CapabilityValue) Clone(interpreter *Interpreter) Value {
 	)
 }
 
-func (v *CapabilityValue) DeepRemove(interpreter *Interpreter) {
+func (v *IDCapabilityValue) DeepRemove(interpreter *Interpreter) {
 	v.Address.DeepRemove(interpreter)
 }
 
-func (v *CapabilityValue) ByteSize() uint32 {
+func (v *IDCapabilityValue) ByteSize() uint32 {
 	return mustStorableSize(v)
 }
 
-func (v *CapabilityValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
+func (v *IDCapabilityValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
 	return v, nil
 }
 
-func (v *CapabilityValue) ChildStorables() []atree.Storable {
+func (v *IDCapabilityValue) ChildStorables() []atree.Storable {
 	return []atree.Storable{
 		v.Address,
 	}

--- a/runtime/interpreter/value_pathcapability.go
+++ b/runtime/interpreter/value_pathcapability.go
@@ -38,8 +38,11 @@ var _ Value = &PathCapabilityValue{}
 var _ atree.Storable = &PathCapabilityValue{}
 var _ EquatableValue = &PathCapabilityValue{}
 var _ MemberAccessibleValue = &PathCapabilityValue{}
+var _ CapabilityValue = &PathCapabilityValue{}
 
 func (*PathCapabilityValue) isValue() {}
+
+func (*PathCapabilityValue) isCapabilityValue() {}
 
 func (v *PathCapabilityValue) Accept(_ *Interpreter, _ Visitor) {
 	panic(errors.NewUnreachableError())

--- a/runtime/interpreter/value_storagecapabilitycontroller.go
+++ b/runtime/interpreter/value_storagecapabilitycontroller.go
@@ -61,7 +61,7 @@ type StorageCapabilityControllerValue struct {
 	// Tags are not stored directly inside the controller
 	// to avoid unnecessary storage reads
 	// when the controller is loaded for borrowing/checking
-	GetCapability func(inter *Interpreter) *CapabilityValue
+	GetCapability func(inter *Interpreter) *IDCapabilityValue
 	GetTag        func(inter *Interpreter) *StringValue
 	SetTag        func(inter *Interpreter, tag *StringValue)
 	Delete        func(inter *Interpreter, locationRange LocationRange)

--- a/runtime/interpreter/visitor.go
+++ b/runtime/interpreter/visitor.go
@@ -56,7 +56,7 @@ type Visitor interface {
 	VisitEphemeralReferenceValue(interpreter *Interpreter, value *EphemeralReferenceValue)
 	VisitAddressValue(interpreter *Interpreter, value AddressValue)
 	VisitPathValue(interpreter *Interpreter, value PathValue)
-	VisitCapabilityValue(interpreter *Interpreter, value *CapabilityValue)
+	VisitCapabilityValue(interpreter *Interpreter, value *IDCapabilityValue)
 	VisitPublishedValue(interpreter *Interpreter, value *PublishedValue)
 	VisitInterpretedFunctionValue(interpreter *Interpreter, value *InterpretedFunctionValue)
 	VisitHostFunctionValue(interpreter *Interpreter, value *HostFunctionValue)
@@ -103,7 +103,7 @@ type EmptyVisitor struct {
 	EphemeralReferenceValueVisitor          func(interpreter *Interpreter, value *EphemeralReferenceValue)
 	AddressValueVisitor                     func(interpreter *Interpreter, value AddressValue)
 	PathValueVisitor                        func(interpreter *Interpreter, value PathValue)
-	CapabilityValueVisitor                  func(interpreter *Interpreter, value *CapabilityValue)
+	CapabilityValueVisitor                  func(interpreter *Interpreter, value *IDCapabilityValue)
 	PublishedValueVisitor                   func(interpreter *Interpreter, value *PublishedValue)
 	InterpretedFunctionValueVisitor         func(interpreter *Interpreter, value *InterpretedFunctionValue)
 	HostFunctionValueVisitor                func(interpreter *Interpreter, value *HostFunctionValue)
@@ -373,7 +373,7 @@ func (v EmptyVisitor) VisitPathValue(interpreter *Interpreter, value PathValue) 
 	v.PathValueVisitor(interpreter, value)
 }
 
-func (v EmptyVisitor) VisitCapabilityValue(interpreter *Interpreter, value *CapabilityValue) {
+func (v EmptyVisitor) VisitCapabilityValue(interpreter *Interpreter, value *IDCapabilityValue) {
 	if v.CapabilityValueVisitor == nil {
 		return
 	}

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -925,7 +925,7 @@ func newAccountInboxPublishFunction(
 		gauge,
 		sema.Account_InboxTypePublishFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
-			value, ok := invocation.Arguments[0].(*interpreter.CapabilityValue)
+			value, ok := invocation.Arguments[0].(interpreter.CapabilityValue)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}
@@ -2560,7 +2560,7 @@ func checkAndIssueStorageCapabilityControllerWithType(
 	address common.Address,
 	targetPathValue interpreter.PathValue,
 	ty sema.Type,
-) *interpreter.CapabilityValue {
+) *interpreter.IDCapabilityValue {
 
 	borrowType, ok := ty.(*sema.ReferenceType)
 	if !ok {
@@ -2711,7 +2711,7 @@ func checkAndIssueAccountCapabilityControllerWithType(
 	idGenerator AccountIDGenerator,
 	address common.Address,
 	ty sema.Type,
-) *interpreter.CapabilityValue {
+) *interpreter.IDCapabilityValue {
 
 	// Get and check borrow type
 
@@ -3272,11 +3272,11 @@ func newAccountCapabilitiesPublishFunction(
 
 			// Get capability argument
 
-			var capabilityValue *interpreter.CapabilityValue
+			var capabilityValue *interpreter.IDCapabilityValue
 
 			firstValue := invocation.Arguments[0]
 			switch firstValue := firstValue.(type) {
-			case *interpreter.CapabilityValue:
+			case *interpreter.IDCapabilityValue:
 				capabilityValue = firstValue
 
 			default:
@@ -3325,7 +3325,7 @@ func newAccountCapabilitiesPublishFunction(
 				true,
 				nil,
 				nil,
-			).(*interpreter.CapabilityValue)
+			).(*interpreter.IDCapabilityValue)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}
@@ -3376,9 +3376,9 @@ func newAccountCapabilitiesUnpublishFunction(
 				return interpreter.Nil
 			}
 
-			var capabilityValue *interpreter.CapabilityValue
+			var capabilityValue *interpreter.IDCapabilityValue
 			switch readValue := readValue.(type) {
-			case *interpreter.CapabilityValue:
+			case *interpreter.IDCapabilityValue:
 				capabilityValue = readValue
 
 			default:
@@ -3392,7 +3392,7 @@ func newAccountCapabilitiesUnpublishFunction(
 				true,
 				nil,
 				nil,
-			).(*interpreter.CapabilityValue)
+			).(*interpreter.IDCapabilityValue)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}
@@ -3605,10 +3605,10 @@ func newAccountCapabilitiesGetFunction(
 				return interpreter.Nil
 			}
 
-			var readCapabilityValue *interpreter.CapabilityValue
+			var readCapabilityValue *interpreter.IDCapabilityValue
 
 			switch readValue := readValue.(type) {
-			case *interpreter.CapabilityValue:
+			case *interpreter.IDCapabilityValue:
 				readCapabilityValue = readValue
 
 			default:
@@ -4001,13 +4001,13 @@ func getCapabilityControllerTag(
 func newCapabilityControllerGetCapabilityFunction(
 	address common.Address,
 	controller interpreter.CapabilityControllerValue,
-) func(inter *interpreter.Interpreter) *interpreter.CapabilityValue {
+) func(inter *interpreter.Interpreter) *interpreter.IDCapabilityValue {
 
 	addressValue := interpreter.AddressValue(address)
 	capabilityID := controller.ControllerCapabilityID()
 	borrowType := controller.CapabilityControllerBorrowType()
 
-	return func(inter *interpreter.Interpreter) *interpreter.CapabilityValue {
+	return func(inter *interpreter.Interpreter) *interpreter.IDCapabilityValue {
 		return interpreter.NewCapabilityValue(
 			inter,
 			capabilityID,

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -3388,7 +3388,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 
 	test := func(
 		name string,
-		newCapabilityValue func(borrowType interpreter.StaticType) *interpreter.CapabilityValue,
+		newCapabilityValue func(borrowType interpreter.StaticType) *interpreter.IDCapabilityValue,
 	) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -3549,7 +3549,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 	}
 
 	test("capability",
-		func(borrowType interpreter.StaticType) *interpreter.CapabilityValue {
+		func(borrowType interpreter.StaticType) *interpreter.IDCapabilityValue {
 			return interpreter.NewUnmeteredCapabilityValue(
 				4,
 				interpreter.AddressValue{},


### PR DESCRIPTION
Closes #3102

## Description

The Cadence 1.0 migration must also migrate path capability values that were published in the account inbox.

- Renamed `CapabilityValue` to `IDCapabilityValue`
- (Re-)introduced `CapabilityValue` interface and made `IDCapabilityValue` and `PathCapabilityValue` conform to it
- Changed `PublishedValue` to `CapabilityValue`
- Generalized published value decoding to allow any `CapabilityValue`, not just `IDCapabilityValue`

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
