### PR TITLE
Fix FunctionType.Equal() to check Purity equality

### DIFF
--- a/types.go
+++ b/types.go
@@ -1418,6 +1418,12 @@ func (t *FunctionType) Equal(other Type) bool {
 		}
 	}
 
+	// Purity
+
+	if t.Purity != otherType.Purity {
+		return false
+	}
+
 	return t.ReturnType.Equal(otherType.ReturnType)
 }
 

--- a/types_test.go
+++ b/types_test.go
@@ -150,6 +150,16 @@ func TestType_ID(t *testing.T) {
 			"fun(Int):String",
 		},
 		{
+			&FunctionType{
+				Parameters: []Parameter{
+					{Type: IntType},
+				},
+				ReturnType: StringType,
+				Purity:     FunctionPurityView,
+			},
+			"view fun(Int):String",
+		},
+		{
 			&EventType{
 				QualifiedIdentifier: "Event",
 			},
@@ -1524,6 +1534,36 @@ func TestTypeEquality(t *testing.T) {
 				},
 			}
 			target := AnyType
+			assert.False(t, source.Equal(target))
+		})
+
+		t.Run("different purity", func(t *testing.T) {
+			t.Parallel()
+
+			source := &FunctionType{
+				Purity:     FunctionPurityView,
+				ReturnType: StringType,
+				Parameters: []Parameter{
+					{
+						Type: IntType,
+					},
+					{
+						Type: BoolType,
+					},
+				},
+			}
+			target := &FunctionType{
+				Purity:     FunctionPurityUnspecified, // default
+				ReturnType: StringType,
+				Parameters: []Parameter{
+					{
+						Type: IntType,
+					},
+					{
+						Type: BoolType,
+					},
+				},
+			}
 			assert.False(t, source.Equal(target))
 		})
 	})


### PR DESCRIPTION
This PR adds checks for `Purity` equality in `FunctionType.Equal()`.

Also added more tests for `FunctionType`.

Closes #3104 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
