### PR TITLE
Add support for `FunctionType.Purity` in CCF codec

### DIFF
--- a/encoding/ccf/encode.go
+++ b/encoding/ccf/encode.go
@@ -1184,13 +1184,14 @@ func (e *Encoder) encodeCapability(capability cadence.Capability) error {
 //		    ]
 //	 ]
 //	 return-type: type-value
+//	 purity: int
 //
 // ]
 func (e *Encoder) encodeFunction(typ *cadence.FunctionType, visited ccfTypeIDByCadenceType) error {
-	// Encode array head of length 3.
+	// Encode array head of length 4.
 	err := e.enc.EncodeRawBytes([]byte{
-		// array, 3 items follow
-		0x83,
+		// array, 4 items follow
+		0x84,
 	})
 	if err != nil {
 		return err
@@ -1209,7 +1210,13 @@ func (e *Encoder) encodeFunction(typ *cadence.FunctionType, visited ccfTypeIDByC
 	}
 
 	// element 2: return type as type-value.
-	return e.encodeTypeValue(typ.ReturnType, visited)
+	err = e.encodeTypeValue(typ.ReturnType, visited)
+	if err != nil {
+		return err
+	}
+
+	// element 3: purity as int.
+	return e.enc.EncodeInt(int(typ.Purity))
 }
 
 // encodeTypeValue encodes cadence.Type as

--- a/types.go
+++ b/types.go
@@ -1308,7 +1308,17 @@ type FunctionPurity int
 const (
 	FunctionPurityUnspecified FunctionPurity = iota
 	FunctionPurityView
+
+	// DO NOT add item after maxFunctionPurity
+	maxFunctionPurity
 )
+
+func NewFunctionaryPurity(rawPurity int) (FunctionPurity, error) {
+	if rawPurity < 0 || rawPurity >= int(maxFunctionPurity) {
+		return FunctionPurityUnspecified, fmt.Errorf("failed to convert %d to FunctionPurity", rawPurity)
+	}
+	return FunctionPurity(rawPurity), nil
+}
 
 type FunctionType struct {
 	TypeParameters []TypeParameter


### PR DESCRIPTION
This PR adds support for encoding and decoding `FunctionType.Purity` in CCF.

For backward compability, decoded `FunctionType.Purity` defaults to `FunctionPurityUnspecified` if it isn't encoded explicitly.

Closes #2457

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
