### PR TITLE
Add support for Attachment and AttachmentType in CCF codec

### DIFF
--- a/encoding/ccf/ccf_type_id.go
+++ b/encoding/ccf/ccf_type_id.go
@@ -49,7 +49,7 @@ func (id ccfTypeID) next() ccfTypeID {
 	if id == math.MaxUint64 {
 		panic(fmt.Errorf("failed to create next CCF type id: reached max limit for id"))
 	}
-	return ccfTypeID(id + 1)
+	return id + 1
 }
 
 // ccfTypeIDByCadenceType maps a Cadence type ID to a CCF type ID
@@ -115,10 +115,6 @@ func (ids *cadenceTypeByCCFTypeID) typ(id ccfTypeID) (cadence.Type, error) {
 func (ids *cadenceTypeByCCFTypeID) has(id ccfTypeID) bool {
 	_, ok := ids.types[id]
 	return ok
-}
-
-func (ids *cadenceTypeByCCFTypeID) count() int {
-	return len(ids.types)
 }
 
 func (ids *cadenceTypeByCCFTypeID) hasUnreferenced() bool {

--- a/encoding/ccf/consts.go
+++ b/encoding/ccf/consts.go
@@ -86,7 +86,7 @@ const (
 	CBORTagEventType
 	CBORTagContractType
 	CBORTagEnumType
-	_
+	CBORTagAttachmentType
 	_
 	_
 	_
@@ -141,7 +141,7 @@ const (
 	CBORTagEventTypeValue
 	CBORTagContractTypeValue
 	CBORTagEnumTypeValue
-	_
+	CBORTagAttachmentTypeValue
 	_
 	_
 	_

--- a/encoding/ccf/decode_typedef.go
+++ b/encoding/ccf/decode_typedef.go
@@ -45,6 +45,7 @@ type rawFieldsWithCCFTypeID struct {
 //		  / contract-type
 //		  / event-type
 //		  / enum-type
+//		  / attachment-type
 //		  / struct-interface-type
 //		  / resource-interface-type
 //		  / contract-interface-type
@@ -169,6 +170,11 @@ func (d *Decoder) decodeTypeDefs() (*cadenceTypeByCCFTypeID, error) {
 //	; cbor-tag-enum-type
 //	#6.164(composite-type)
 //
+// attachment-type =
+//
+//	; cbor-tag-attachment-type
+//	#6.165(composite-type)
+//
 // struct-interface-type =
 //
 //	; cbor-tag-struct-interface-type
@@ -252,6 +258,19 @@ func (d *Decoder) decodeTypeDef(
 				location,
 				identifier,
 				nil,
+				nil,
+				nil,
+			)
+		}
+		return d.decodeCompositeType(types, ctr)
+
+	case CBORTagAttachmentType:
+		ctr := func(location common.Location, identifier string) cadence.Type {
+			return cadence.NewMeteredAttachmentType(
+				d.gauge,
+				location,
+				nil,
+				identifier,
 				nil,
 				nil,
 			)

--- a/encoding/ccf/encode_typedef.go
+++ b/encoding/ccf/encode_typedef.go
@@ -50,6 +50,11 @@ import (
 //	; cbor-tag-enum-type
 //	#6.164(composite-type)
 //
+// attachment-type =
+//
+//	; cbor-tag-attachment-type
+//	#6.165(composite-type)
+//
 // composite-type = [
 //
 //	id: id,
@@ -85,6 +90,9 @@ func (e *Encoder) encodeCompositeType(typ cadence.CompositeType, tids ccfTypeIDB
 
 	case *cadence.EnumType:
 		cborTagNum = CBORTagEnumType
+
+	case *cadence.AttachmentType:
+		cborTagNum = CBORTagAttachmentType
 
 	default:
 		panic(cadenceErrors.NewUnexpectedError("unexpected composite type %s (%T)", typ.ID(), typ))

--- a/encoding/ccf/traverse_value.go
+++ b/encoding/ccf/traverse_value.go
@@ -116,6 +116,10 @@ func (ct *compositeTypes) traverseValue(v cadence.Value) {
 			ct.traverseValue(field)
 		}
 
+	case cadence.Attachment:
+		for _, field := range v.Fields {
+			ct.traverseValue(field)
+		}
 	}
 }
 
@@ -152,7 +156,7 @@ func (ct *compositeTypes) traverseType(typ cadence.Type) (checkRuntimeType bool)
 		}
 		return check
 
-	case cadence.CompositeType: // struct, resource, event, contract, enum
+	case cadence.CompositeType: // struct, resource, event, contract, enum, attachment
 		newType := ct.add(typ)
 		if !newType {
 			return ct.abstractTypes[typ.ID()]


### PR DESCRIPTION
Updates #2379

Add support in CCF codec:
- encode/decode `Attachment` value
- encode/decode `TypeValue` of `AttachmentType`

`Attachment` is encoded as `composite-value`, same as other composite values (e.g. `Enum`).

`TypeValue` of `AttachmentType` is encoded as `composite-type-value`, same as other composite type values (e.g. `EnumType`)  with the exception that `EnumType` has `RawType` while `AttachmentType` has `BaseType`.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
