### PR TITLE
Require added entitlements to be equal to migrated entitlements rather than supertypes

### DIFF
--- a/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validation_test.go
+++ b/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validation_test.go
@@ -539,7 +539,8 @@ func TestContractUpgradeFieldType(t *testing.T) {
 
 		err := testContractUpdate(t, oldCode, newCode)
 
-		require.NoError(t, err)
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertFieldAuthorizationMismatchError(t, cause, "Test", "a", "E, F", "E")
 	})
 
 	t.Run("capability reference auth disjunctive entitlements", func(t *testing.T) {
@@ -579,7 +580,8 @@ func TestContractUpgradeFieldType(t *testing.T) {
 
 		err := testContractUpdate(t, oldCode, newCode)
 
-		require.NoError(t, err)
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertFieldAuthorizationMismatchError(t, cause, "Test", "a", "E, F", "E | F")
 	})
 
 	t.Run("changing to a non-storable types", func(t *testing.T) {
@@ -934,7 +936,7 @@ func TestContractUpgradeIntersectionAuthorization(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("change field type capability reference auth allowed multiple intersected fewer entitlements", func(t *testing.T) {
+	t.Run("change field type capability reference auth disallowed multiple intersected fewer entitlements", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -984,7 +986,8 @@ func TestContractUpgradeIntersectionAuthorization(t *testing.T) {
 
 		err := testContractUpdate(t, oldCode, newCode)
 
-		require.NoError(t, err)
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertFieldAuthorizationMismatchError(t, cause, "Test", "a", "E, F", "E")
 	})
 
 	t.Run("change field type capability reference auth multiple intersected with too many entitlements", func(t *testing.T) {

--- a/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validator.go
+++ b/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validator.go
@@ -215,12 +215,12 @@ func (validator *CadenceV042ToV1ContractUpdateValidator) getIntersectedInterface
 	return
 }
 
-func (validator *CadenceV042ToV1ContractUpdateValidator) requirePermitsAccess(
+func (validator *CadenceV042ToV1ContractUpdateValidator) requireEqualAccess(
 	expected sema.Access,
 	found sema.EntitlementSetAccess,
 	foundType ast.Type,
 ) error {
-	if !found.PermitsAccess(expected) {
+	if !found.Equal(expected) {
 		return &AuthorizationMismatchError{
 			FoundAuthorization:    found,
 			ExpectedAuthorization: expected,
@@ -283,11 +283,11 @@ func (validator *CadenceV042ToV1ContractUpdateValidator) checkEntitlementsUpgrad
 	// a lone nominal type must be a composite
 	case *ast.NominalType:
 		expectedAccess := validator.expectedAuthorizationOfComposite(newReferencedType)
-		return validator.requirePermitsAccess(expectedAccess, foundEntitlementSet, newReferencedType)
+		return validator.requireEqualAccess(expectedAccess, foundEntitlementSet, newReferencedType)
 
 	case *ast.IntersectionType:
 		expectedAccess := validator.expectedAuthorizationOfIntersection(newReferencedType.Types)
-		return validator.requirePermitsAccess(expectedAccess, foundEntitlementSet, newReferencedType)
+		return validator.requireEqualAccess(expectedAccess, foundEntitlementSet, newReferencedType)
 	}
 
 	return nil


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/3128
______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
