### PR TITLE
Fix EntitlementSetAuthorization.Equal() by making it ignore order of elements

### DIFF
--- a/encoding/json/encode.go
+++ b/encoding/json/encode.go
@@ -680,7 +680,7 @@ func prepareAuthorization(auth cadence.Authorization) jsonAuthorization {
 				TypeID: string(auth.TypeID),
 			},
 		}
-	case cadence.EntitlementSetAuthorization:
+	case *cadence.EntitlementSetAuthorization:
 		for _, entitlement := range auth.Entitlements {
 			entitlements = append(entitlements, jsonNominalType{
 				Kind:   "Entitlement",

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -2458,7 +2458,7 @@ func TestEncodeType(t *testing.T) {
 			t,
 			cadence.TypeValue{
 				StaticType: &cadence.ReferenceType{
-					Authorization: cadence.EntitlementSetAuthorization{
+					Authorization: &cadence.EntitlementSetAuthorization{
 						Kind:         cadence.Conjunction,
 						Entitlements: []common.TypeID{"X", "Y"},
 					},
@@ -2507,7 +2507,7 @@ func TestEncodeType(t *testing.T) {
 			t,
 			cadence.TypeValue{
 				StaticType: &cadence.ReferenceType{
-					Authorization: cadence.EntitlementSetAuthorization{
+					Authorization: &cadence.EntitlementSetAuthorization{
 						Kind:         cadence.Disjunction,
 						Entitlements: []common.TypeID{"X", "Y"},
 					},

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -583,7 +583,7 @@ func exportAuthorization(
 		access.Entitlements.Foreach(func(key *sema.EntitlementType, _ struct{}) {
 			entitlements = append(entitlements, key.ID())
 		})
-		return cadence.EntitlementSetAuthorization{
+		return &cadence.EntitlementSetAuthorization{
 			Entitlements: entitlements,
 			Kind:         access.SetKind,
 		}
@@ -662,7 +662,7 @@ func importAuthorization(memoryGauge common.MemoryGauge, auth cadence.Authorizat
 		return interpreter.UnauthorizedAccess
 	case cadence.EntitlementMapAuthorization:
 		return interpreter.NewEntitlementMapAuthorization(memoryGauge, auth.TypeID)
-	case cadence.EntitlementSetAuthorization:
+	case *cadence.EntitlementSetAuthorization:
 		return interpreter.NewEntitlementSetAuthorization(
 			memoryGauge,
 			func() []common.TypeID { return auth.Entitlements },

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1267,7 +1267,7 @@ func TestRuntimeImportRuntimeType(t *testing.T) {
 		{
 			label: "Entitlement Set Reference",
 			actual: &cadence.ReferenceType{
-				Authorization: cadence.EntitlementSetAuthorization{
+				Authorization: &cadence.EntitlementSetAuthorization{
 					Kind:         cadence.Conjunction,
 					Entitlements: []common.TypeID{"E", "F"},
 				},
@@ -1286,7 +1286,7 @@ func TestRuntimeImportRuntimeType(t *testing.T) {
 		{
 			label: "Reference",
 			actual: &cadence.ReferenceType{
-				Authorization: cadence.EntitlementSetAuthorization{
+				Authorization: &cadence.EntitlementSetAuthorization{
 					Kind:         cadence.Disjunction,
 					Entitlements: []common.TypeID{"E", "F"},
 				},

--- a/types.go
+++ b/types.go
@@ -1456,30 +1456,32 @@ const Conjunction = sema.Conjunction
 const Disjunction = sema.Disjunction
 
 type EntitlementSetAuthorization struct {
-	Entitlements []common.TypeID
-	Kind         EntitlementSetKind
+	Entitlements       []common.TypeID
+	Kind               EntitlementSetKind
+	entitlementSet     map[common.TypeID]struct{}
+	entitlementSetOnce sync.Once
 }
 
-var _ Authorization = EntitlementSetAuthorization{}
+var _ Authorization = &EntitlementSetAuthorization{}
 
 func NewEntitlementSetAuthorization(
 	gauge common.MemoryGauge,
 	entitlements []common.TypeID,
 	kind EntitlementSetKind,
-) EntitlementSetAuthorization {
+) *EntitlementSetAuthorization {
 	common.UseMemory(gauge, common.MemoryUsage{
 		Kind:   common.MemoryKindCadenceEntitlementSetAccess,
 		Amount: uint64(len(entitlements)),
 	})
-	return EntitlementSetAuthorization{
+	return &EntitlementSetAuthorization{
 		Entitlements: entitlements,
 		Kind:         kind,
 	}
 }
 
-func (EntitlementSetAuthorization) isAuthorization() {}
+func (*EntitlementSetAuthorization) isAuthorization() {}
 
-func (e EntitlementSetAuthorization) ID() string {
+func (e *EntitlementSetAuthorization) ID() string {
 	entitlementTypeIDs := make([]string, 0, len(e.Entitlements))
 	for _, typeID := range e.Entitlements {
 		entitlementTypeIDs = append(
@@ -1492,21 +1494,38 @@ func (e EntitlementSetAuthorization) ID() string {
 	return sema.FormatEntitlementSetTypeID(entitlementTypeIDs, e.Kind)
 }
 
-func (e EntitlementSetAuthorization) Equal(auth Authorization) bool {
+func (e *EntitlementSetAuthorization) Equal(auth Authorization) bool {
 	switch auth := auth.(type) {
-	case EntitlementSetAuthorization:
+	case *EntitlementSetAuthorization:
 		if len(e.Entitlements) != len(auth.Entitlements) {
 			return false
 		}
 
-		for i, entitlement := range e.Entitlements {
-			if auth.Entitlements[i] != entitlement {
+		// sets are equivalent if they contain the same elements, regardless of order
+		otherEntitlementSet := auth.getEntitlementSet()
+
+		for _, entitlement := range e.Entitlements {
+			if _, exist := otherEntitlementSet[entitlement]; !exist {
 				return false
 			}
 		}
 		return e.Kind == auth.Kind
 	}
 	return false
+}
+
+func (t *EntitlementSetAuthorization) initializeEntitlementSet() {
+	t.entitlementSetOnce.Do(func() {
+		t.entitlementSet = make(map[common.TypeID]struct{}, len(t.Entitlements))
+		for _, e := range t.Entitlements {
+			t.entitlementSet[e] = struct{}{}
+		}
+	})
+}
+
+func (t *EntitlementSetAuthorization) getEntitlementSet() map[common.TypeID]struct{} {
+	t.initializeEntitlementSet()
+	return t.entitlementSet
 }
 
 type EntitlementMapAuthorization struct {

--- a/types_test.go
+++ b/types_test.go
@@ -1599,6 +1599,158 @@ func TestTypeEquality(t *testing.T) {
 			assert.False(t, source.Equal(target))
 		})
 
+		t.Run("different auth conjunction set", func(t *testing.T) {
+			t.Parallel()
+
+			source := &ReferenceType{
+				Type: IntType,
+				Authorization: &EntitlementSetAuthorization{
+					Kind: Conjunction,
+					Entitlements: []common.TypeID{
+						"foo",
+					},
+				},
+			}
+			target := &ReferenceType{
+				Type: IntType,
+				Authorization: &EntitlementSetAuthorization{
+					Kind: Conjunction,
+					Entitlements: []common.TypeID{
+						"bar",
+					},
+				},
+			}
+			assert.False(t, source.Equal(target))
+		})
+
+		t.Run("different auth disjunction set", func(t *testing.T) {
+			t.Parallel()
+
+			source := &ReferenceType{
+				Type: IntType,
+				Authorization: &EntitlementSetAuthorization{
+					Kind: Disjunction,
+					Entitlements: []common.TypeID{
+						"foo",
+					},
+				},
+			}
+			target := &ReferenceType{
+				Type: IntType,
+				Authorization: &EntitlementSetAuthorization{
+					Kind: Disjunction,
+					Entitlements: []common.TypeID{
+						"bar",
+					},
+				},
+			}
+			assert.False(t, source.Equal(target))
+		})
+
+		t.Run("different auth conjunction set", func(t *testing.T) {
+			t.Parallel()
+
+			source := &ReferenceType{
+				Type: IntType,
+				Authorization: &EntitlementSetAuthorization{
+					Kind: Conjunction,
+					Entitlements: []common.TypeID{
+						"foo",
+						"bar",
+					},
+				},
+			}
+			target := &ReferenceType{
+				Type: IntType,
+				Authorization: &EntitlementSetAuthorization{
+					Kind: Conjunction,
+					Entitlements: []common.TypeID{
+						"bar",
+						"baz",
+					},
+				},
+			}
+			assert.False(t, source.Equal(target))
+		})
+
+		t.Run("different auth disjunction set", func(t *testing.T) {
+			t.Parallel()
+
+			source := &ReferenceType{
+				Type: IntType,
+				Authorization: &EntitlementSetAuthorization{
+					Kind: Disjunction,
+					Entitlements: []common.TypeID{
+						"foo",
+						"bar",
+					},
+				},
+			}
+			target := &ReferenceType{
+				Type: IntType,
+				Authorization: &EntitlementSetAuthorization{
+					Kind: Disjunction,
+					Entitlements: []common.TypeID{
+						"bar",
+						"baz",
+					},
+				},
+			}
+			assert.False(t, source.Equal(target))
+		})
+
+		t.Run("different auth conjunction set order", func(t *testing.T) {
+			t.Parallel()
+
+			source := &ReferenceType{
+				Type: IntType,
+				Authorization: &EntitlementSetAuthorization{
+					Kind: Conjunction,
+					Entitlements: []common.TypeID{
+						"foo",
+						"bar",
+					},
+				},
+			}
+			target := &ReferenceType{
+				Type: IntType,
+				Authorization: &EntitlementSetAuthorization{
+					Kind: Conjunction,
+					Entitlements: []common.TypeID{
+						"bar",
+						"foo",
+					},
+				},
+			}
+			assert.True(t, source.Equal(target))
+		})
+
+		t.Run("different auth disjunction set order", func(t *testing.T) {
+			t.Parallel()
+
+			source := &ReferenceType{
+				Type: IntType,
+				Authorization: &EntitlementSetAuthorization{
+					Kind: Disjunction,
+					Entitlements: []common.TypeID{
+						"foo",
+						"bar",
+					},
+				},
+			}
+			target := &ReferenceType{
+				Type: IntType,
+				Authorization: &EntitlementSetAuthorization{
+					Kind: Disjunction,
+					Entitlements: []common.TypeID{
+						"bar",
+						"foo",
+					},
+				},
+			}
+			assert.True(t, source.Equal(target))
+		})
+
 		t.Run("auth vs non-auth", func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
This PR makes `EntitlementSetAuthorization.Equal()` ignore the order of elements in entitlement set.

Closes #3136
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
