### PR TITLE
Pass location-range to value-interface methods

### DIFF
--- a/runtime/cmd/decode-state-values/main.go
+++ b/runtime/cmd/decode-state-values/main.go
@@ -268,6 +268,8 @@ func load() {
 
 	var slabNotFoundErrCount int
 
+	locationRange := interpreter.EmptyLocationRange
+
 	for storageKey, data := range storage { //nolint:maprange
 		_ = bar.Add(1)
 
@@ -277,7 +279,15 @@ func load() {
 		var address atree.Address
 		copy(address[:], storageKey[0])
 
-		err := loadStorageKey(key, address, data, inter, slabStorage)
+		err := loadStorageKey(
+			key,
+			address,
+			data,
+			inter,
+			slabStorage,
+			locationRange,
+		)
+
 		var slabNotFoundErr *atree.SlabNotFoundError
 		if errors.As(err, &slabNotFoundErr) {
 			slabNotFoundErrCount++
@@ -293,6 +303,7 @@ func loadStorageKey(
 	data []byte,
 	inter *interpreter.Interpreter,
 	slabStorage *slabStorage,
+	locationRange interpreter.LocationRange,
 ) (err error) {
 
 	defer func() {
@@ -387,6 +398,7 @@ func loadStorageKey(
 
 					return true
 				},
+				locationRange,
 			)
 
 			if *checkValuesFlag {

--- a/runtime/interpreter/inspect.go
+++ b/runtime/interpreter/inspect.go
@@ -28,6 +28,11 @@ func (f valueInspector) WalkValue(_ *Interpreter, value Value) ValueWalker {
 	return nil
 }
 
-func InspectValue(interpreter *Interpreter, value Value, f func(Value) bool) {
-	WalkValue(interpreter, valueInspector(f), value)
+func InspectValue(interpreter *Interpreter, value Value, f func(Value) bool, locationRange LocationRange) {
+	WalkValue(
+		interpreter,
+		valueInspector(f),
+		value,
+		locationRange,
+	)
 }

--- a/runtime/interpreter/inspect_test.go
+++ b/runtime/interpreter/inspect_test.go
@@ -91,6 +91,7 @@ func TestInspectValue(t *testing.T) {
 				inspectedValues = append(inspectedValues, value)
 				return true
 			},
+			EmptyLocationRange,
 		)
 
 		AssertValueSlicesEqual(
@@ -119,6 +120,7 @@ func TestInspectValue(t *testing.T) {
 				inspectedValues = append(inspectedValues, value)
 				return true
 			},
+			EmptyLocationRange,
 		)
 
 		AssertValueSlicesEqual(

--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -71,7 +71,7 @@ func NewSimpleCompositeValue(
 
 func (*SimpleCompositeValue) isValue() {}
 
-func (v *SimpleCompositeValue) Accept(interpreter *Interpreter, visitor Visitor) {
+func (v *SimpleCompositeValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
 	visitor.VisitSimpleCompositeValue(interpreter, v)
 }
 
@@ -90,7 +90,7 @@ func (v *SimpleCompositeValue) ForEachField(
 
 // Walk iterates over all field values of the composite value.
 // It does NOT walk the computed fields and functions!
-func (v *SimpleCompositeValue) Walk(_ *Interpreter, walkChild func(Value)) {
+func (v *SimpleCompositeValue) Walk(_ *Interpreter, walkChild func(Value), _ LocationRange) {
 	v.ForEachField(func(_ string, fieldValue Value) (resume bool) {
 		walkChild(fieldValue)
 

--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -103,7 +103,7 @@ func (v *SimpleCompositeValue) StaticType(_ *Interpreter) StaticType {
 	return v.staticType
 }
 
-func (v *SimpleCompositeValue) IsImportable(inter *Interpreter) bool {
+func (v *SimpleCompositeValue) IsImportable(inter *Interpreter, locationRange LocationRange) bool {
 	// Check type is importable
 	staticType := v.StaticType(inter)
 	semaType := inter.MustConvertStaticToSemaType(staticType)
@@ -114,7 +114,7 @@ func (v *SimpleCompositeValue) IsImportable(inter *Interpreter) bool {
 	// Check all field values are importable
 	importable := true
 	v.ForEachField(func(_ string, value Value) (resume bool) {
-		if !value.IsImportable(inter) {
+		if !value.IsImportable(inter, locationRange) {
 			importable = false
 			// stop iteration
 			return false

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -141,7 +141,7 @@ type Value interface {
 	// NOTE: not used by interpreter, but used externally (e.g. state migration)
 	// NOTE: memory metering is unnecessary for Clone methods
 	Clone(interpreter *Interpreter) Value
-	IsImportable(interpreter *Interpreter) bool
+	IsImportable(interpreter *Interpreter, locationRange LocationRange) bool
 }
 
 // ValueIndexableValue
@@ -350,7 +350,7 @@ func (TypeValue) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeMetaType)
 }
 
-func (TypeValue) IsImportable(_ *Interpreter) bool {
+func (TypeValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return sema.MetaType.Importable
 }
 
@@ -558,7 +558,7 @@ func (VoidValue) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeVoid)
 }
 
-func (VoidValue) IsImportable(_ *Interpreter) bool {
+func (VoidValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return sema.VoidType.Importable
 }
 
@@ -667,7 +667,7 @@ func (BoolValue) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeBool)
 }
 
-func (BoolValue) IsImportable(_ *Interpreter) bool {
+func (BoolValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return sema.BoolType.Importable
 }
 
@@ -857,7 +857,7 @@ func (CharacterValue) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeCharacter)
 }
 
-func (CharacterValue) IsImportable(_ *Interpreter) bool {
+func (CharacterValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return sema.CharacterType.Importable
 }
 
@@ -1090,7 +1090,7 @@ func (*StringValue) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeString)
 }
 
-func (*StringValue) IsImportable(_ *Interpreter) bool {
+func (*StringValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return sema.StringType.Importable
 }
 
@@ -1946,12 +1946,12 @@ func (v *ArrayValue) StaticType(_ *Interpreter) StaticType {
 	return v.Type
 }
 
-func (v *ArrayValue) IsImportable(inter *Interpreter) bool {
+func (v *ArrayValue) IsImportable(inter *Interpreter, locationRange LocationRange) bool {
 	importable := true
 	v.Iterate(
 		inter,
 		func(element Value) (resume bool) {
-			if !element.IsImportable(inter) {
+			if !element.IsImportable(inter, locationRange) {
 				importable = false
 				// stop iteration
 				return false
@@ -1961,8 +1961,7 @@ func (v *ArrayValue) IsImportable(inter *Interpreter) bool {
 			return true
 		},
 		false,
-		// TODO: Not supposed to panic with container mutation error.
-		EmptyLocationRange,
+		locationRange,
 	)
 
 	return importable
@@ -3705,7 +3704,7 @@ func (IntValue) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeInt)
 }
 
-func (IntValue) IsImportable(_ *Interpreter) bool {
+func (IntValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -4266,7 +4265,7 @@ func (Int8Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeInt8)
 }
 
-func (Int8Value) IsImportable(_ *Interpreter) bool {
+func (Int8Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -4907,7 +4906,7 @@ func (Int16Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeInt16)
 }
 
-func (Int16Value) IsImportable(_ *Interpreter) bool {
+func (Int16Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -5549,7 +5548,7 @@ func (Int32Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeInt32)
 }
 
-func (Int32Value) IsImportable(_ *Interpreter) bool {
+func (Int32Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -6189,7 +6188,7 @@ func (Int64Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeInt64)
 }
 
-func (Int64Value) IsImportable(_ *Interpreter) bool {
+func (Int64Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -6840,7 +6839,7 @@ func (Int128Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeInt128)
 }
 
-func (Int128Value) IsImportable(_ *Interpreter) bool {
+func (Int128Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -7584,7 +7583,7 @@ func (Int256Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeInt256)
 }
 
-func (Int256Value) IsImportable(_ *Interpreter) bool {
+func (Int256Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -8366,7 +8365,7 @@ func (UIntValue) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeUInt)
 }
 
-func (v UIntValue) IsImportable(_ *Interpreter) bool {
+func (v UIntValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -8937,7 +8936,7 @@ func (UInt8Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeUInt8)
 }
 
-func (UInt8Value) IsImportable(_ *Interpreter) bool {
+func (UInt8Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -9523,7 +9522,7 @@ func (UInt16Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeUInt16)
 }
 
-func (UInt16Value) IsImportable(_ *Interpreter) bool {
+func (UInt16Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -10064,7 +10063,7 @@ func (UInt32Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeUInt32)
 }
 
-func (UInt32Value) IsImportable(_ *Interpreter) bool {
+func (UInt32Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -10612,7 +10611,7 @@ func (UInt64Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeUInt64)
 }
 
-func (UInt64Value) IsImportable(_ *Interpreter) bool {
+func (UInt64Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -11194,7 +11193,7 @@ func (UInt128Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeUInt128)
 }
 
-func (UInt128Value) IsImportable(_ *Interpreter) bool {
+func (UInt128Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -11869,7 +11868,7 @@ func (UInt256Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeUInt256)
 }
 
-func (UInt256Value) IsImportable(_ *Interpreter) bool {
+func (UInt256Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -12528,7 +12527,7 @@ func (Word8Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeWord8)
 }
 
-func (Word8Value) IsImportable(_ *Interpreter) bool {
+func (Word8Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -12965,7 +12964,7 @@ func (Word16Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeWord16)
 }
 
-func (Word16Value) IsImportable(_ *Interpreter) bool {
+func (Word16Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -13403,7 +13402,7 @@ func (Word32Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeWord32)
 }
 
-func (Word32Value) IsImportable(_ *Interpreter) bool {
+func (Word32Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -13848,7 +13847,7 @@ func (Word64Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeWord64)
 }
 
-func (Word64Value) IsImportable(_ *Interpreter) bool {
+func (Word64Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -14322,7 +14321,7 @@ func (Word128Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeWord128)
 }
 
-func (Word128Value) IsImportable(_ *Interpreter) bool {
+func (Word128Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -14902,7 +14901,7 @@ func (Word256Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeWord256)
 }
 
-func (Word256Value) IsImportable(_ *Interpreter) bool {
+func (Word256Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -15497,7 +15496,7 @@ func (Fix64Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeFix64)
 }
 
-func (Fix64Value) IsImportable(_ *Interpreter) bool {
+func (Fix64Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -16068,7 +16067,7 @@ func (UFix64Value) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeUFix64)
 }
 
-func (UFix64Value) IsImportable(_ *Interpreter) bool {
+func (UFix64Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -16791,7 +16790,7 @@ func (v *CompositeValue) StaticType(interpreter *Interpreter) StaticType {
 	return v.staticType
 }
 
-func (v *CompositeValue) IsImportable(inter *Interpreter) bool {
+func (v *CompositeValue) IsImportable(inter *Interpreter, locationRange LocationRange) bool {
 	// Check type is importable
 	staticType := v.StaticType(inter)
 	semaType := inter.MustConvertStaticToSemaType(staticType)
@@ -16802,7 +16801,7 @@ func (v *CompositeValue) IsImportable(inter *Interpreter) bool {
 	// Check all field values are importable
 	importable := true
 	v.ForEachField(inter, func(_ string, value Value) (resume bool) {
-		if !value.IsImportable(inter) {
+		if !value.IsImportable(inter, locationRange) {
 			importable = false
 			// stop iteration
 			return false
@@ -18707,10 +18706,10 @@ func (v *DictionaryValue) StaticType(_ *Interpreter) StaticType {
 	return v.Type
 }
 
-func (v *DictionaryValue) IsImportable(inter *Interpreter) bool {
+func (v *DictionaryValue) IsImportable(inter *Interpreter, locationRange LocationRange) bool {
 	importable := true
 	v.Iterate(inter, func(key, value Value) (resume bool) {
-		if !key.IsImportable(inter) || !value.IsImportable(inter) {
+		if !key.IsImportable(inter, locationRange) || !value.IsImportable(inter, locationRange) {
 			importable = false
 			// stop iteration
 			return false
@@ -19750,7 +19749,7 @@ func (NilValue) StaticType(interpreter *Interpreter) StaticType {
 	)
 }
 
-func (NilValue) IsImportable(_ *Interpreter) bool {
+func (NilValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -19931,8 +19930,8 @@ func (v *SomeValue) StaticType(inter *Interpreter) StaticType {
 	)
 }
 
-func (v *SomeValue) IsImportable(inter *Interpreter) bool {
-	return v.value.IsImportable(inter)
+func (v *SomeValue) IsImportable(inter *Interpreter, locationRange LocationRange) bool {
+	return v.value.IsImportable(inter, locationRange)
 }
 
 func (*SomeValue) isOptionalValue() {}
@@ -20319,7 +20318,7 @@ func (v *StorageReferenceValue) GetAuthorization() Authorization {
 	return v.Authorization
 }
 
-func (*StorageReferenceValue) IsImportable(_ *Interpreter) bool {
+func (*StorageReferenceValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return false
 }
 
@@ -20752,7 +20751,7 @@ func (v *EphemeralReferenceValue) GetAuthorization() Authorization {
 	return v.Authorization
 }
 
-func (*EphemeralReferenceValue) IsImportable(_ *Interpreter) bool {
+func (*EphemeralReferenceValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return false
 }
 
@@ -21056,7 +21055,7 @@ func (AddressValue) StaticType(interpreter *Interpreter) StaticType {
 	return NewPrimitiveStaticType(interpreter, PrimitiveStaticTypeAddress)
 }
 
-func (AddressValue) IsImportable(_ *Interpreter) bool {
+func (AddressValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return true
 }
 
@@ -21293,7 +21292,7 @@ func (v PathValue) StaticType(interpreter *Interpreter) StaticType {
 	}
 }
 
-func (v PathValue) IsImportable(_ *Interpreter) bool {
+func (v PathValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	switch v.Domain {
 	case common.PathDomainStorage:
 		return sema.StoragePathType.Importable
@@ -21531,7 +21530,7 @@ func (v *PublishedValue) StaticType(interpreter *Interpreter) StaticType {
 	return v.Value.StaticType(interpreter)
 }
 
-func (*PublishedValue) IsImportable(_ *Interpreter) bool {
+func (*PublishedValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return false
 }
 

--- a/runtime/interpreter/value_accountcapabilitycontroller.go
+++ b/runtime/interpreter/value_accountcapabilitycontroller.go
@@ -88,11 +88,11 @@ func (v *AccountCapabilityControllerValue) CapabilityControllerBorrowType() *Ref
 	return v.BorrowType
 }
 
-func (v *AccountCapabilityControllerValue) Accept(interpreter *Interpreter, visitor Visitor) {
+func (v *AccountCapabilityControllerValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
 	visitor.VisitAccountCapabilityControllerValue(interpreter, v)
 }
 
-func (v *AccountCapabilityControllerValue) Walk(_ *Interpreter, walkChild func(Value)) {
+func (v *AccountCapabilityControllerValue) Walk(_ *Interpreter, walkChild func(Value), _ LocationRange) {
 	walkChild(v.CapabilityID)
 }
 

--- a/runtime/interpreter/value_accountcapabilitycontroller.go
+++ b/runtime/interpreter/value_accountcapabilitycontroller.go
@@ -100,7 +100,7 @@ func (v *AccountCapabilityControllerValue) StaticType(_ *Interpreter) StaticType
 	return PrimitiveStaticTypeAccountCapabilityController
 }
 
-func (*AccountCapabilityControllerValue) IsImportable(_ *Interpreter) bool {
+func (*AccountCapabilityControllerValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return false
 }
 

--- a/runtime/interpreter/value_capability.go
+++ b/runtime/interpreter/value_capability.go
@@ -77,11 +77,11 @@ func (*IDCapabilityValue) isValue() {}
 
 func (*IDCapabilityValue) isCapabilityValue() {}
 
-func (v *IDCapabilityValue) Accept(interpreter *Interpreter, visitor Visitor) {
+func (v *IDCapabilityValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
 	visitor.VisitCapabilityValue(interpreter, v)
 }
 
-func (v *IDCapabilityValue) Walk(_ *Interpreter, walkChild func(Value)) {
+func (v *IDCapabilityValue) Walk(_ *Interpreter, walkChild func(Value), _ LocationRange) {
 	walkChild(v.ID)
 	walkChild(v.Address)
 }

--- a/runtime/interpreter/value_capability.go
+++ b/runtime/interpreter/value_capability.go
@@ -93,7 +93,7 @@ func (v *IDCapabilityValue) StaticType(inter *Interpreter) StaticType {
 	)
 }
 
-func (v *IDCapabilityValue) IsImportable(_ *Interpreter) bool {
+func (v *IDCapabilityValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return false
 }
 

--- a/runtime/interpreter/value_function.go
+++ b/runtime/interpreter/value_function.go
@@ -95,11 +95,11 @@ func (f *InterpretedFunctionValue) MeteredString(memoryGauge common.MemoryGauge,
 	return f.String()
 }
 
-func (f *InterpretedFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
+func (f *InterpretedFunctionValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
 	visitor.VisitInterpretedFunctionValue(interpreter, f)
 }
 
-func (f *InterpretedFunctionValue) Walk(_ *Interpreter, _ func(Value)) {
+func (f *InterpretedFunctionValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 
@@ -225,11 +225,11 @@ var _ ContractValue = &HostFunctionValue{}
 
 func (*HostFunctionValue) isValue() {}
 
-func (f *HostFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
+func (f *HostFunctionValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
 	visitor.VisitHostFunctionValue(interpreter, f)
 }
 
-func (f *HostFunctionValue) Walk(_ *Interpreter, _ func(Value)) {
+func (f *HostFunctionValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 
@@ -378,11 +378,11 @@ func (f BoundFunctionValue) MeteredString(memoryGauge common.MemoryGauge, seenRe
 	return f.Function.MeteredString(memoryGauge, seenReferences)
 }
 
-func (f BoundFunctionValue) Accept(interpreter *Interpreter, visitor Visitor) {
+func (f BoundFunctionValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
 	visitor.VisitBoundFunctionValue(interpreter, f)
 }
 
-func (f BoundFunctionValue) Walk(_ *Interpreter, _ func(Value)) {
+func (f BoundFunctionValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/runtime/interpreter/value_function.go
+++ b/runtime/interpreter/value_function.go
@@ -107,7 +107,7 @@ func (f *InterpretedFunctionValue) StaticType(interpreter *Interpreter) StaticTy
 	return ConvertSemaToStaticType(interpreter, f.Type)
 }
 
-func (*InterpretedFunctionValue) IsImportable(_ *Interpreter) bool {
+func (*InterpretedFunctionValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return false
 }
 
@@ -237,7 +237,7 @@ func (f *HostFunctionValue) StaticType(interpreter *Interpreter) StaticType {
 	return ConvertSemaToStaticType(interpreter, f.Type)
 }
 
-func (*HostFunctionValue) IsImportable(_ *Interpreter) bool {
+func (*HostFunctionValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return false
 }
 
@@ -390,7 +390,7 @@ func (f BoundFunctionValue) StaticType(inter *Interpreter) StaticType {
 	return f.Function.StaticType(inter)
 }
 
-func (BoundFunctionValue) IsImportable(_ *Interpreter) bool {
+func (BoundFunctionValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return false
 }
 

--- a/runtime/interpreter/value_link.go
+++ b/runtime/interpreter/value_link.go
@@ -52,11 +52,11 @@ func (PathLinkValue) isValue() {}
 
 func (PathLinkValue) isLinkValue() {}
 
-func (v PathLinkValue) Accept(_ *Interpreter, _ Visitor) {
+func (v PathLinkValue) Accept(_ *Interpreter, _ Visitor, _ LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 
-func (v PathLinkValue) Walk(_ *Interpreter, _ func(Value)) {
+func (v PathLinkValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 
@@ -176,11 +176,11 @@ func (AccountLinkValue) isValue() {}
 
 func (AccountLinkValue) isLinkValue() {}
 
-func (v AccountLinkValue) Accept(_ *Interpreter, _ Visitor) {
+func (v AccountLinkValue) Accept(_ *Interpreter, _ Visitor, _ LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 
-func (AccountLinkValue) Walk(_ *Interpreter, _ func(Value)) {
+func (AccountLinkValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 

--- a/runtime/interpreter/value_link.go
+++ b/runtime/interpreter/value_link.go
@@ -71,7 +71,7 @@ func (v PathLinkValue) StaticType(interpreter *Interpreter) StaticType {
 	return NewCapabilityStaticType(interpreter, v.Type)
 }
 
-func (PathLinkValue) IsImportable(_ *Interpreter) bool {
+func (PathLinkValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	panic(errors.NewUnreachableError())
 }
 
@@ -202,7 +202,7 @@ func (v AccountLinkValue) StaticType(interpreter *Interpreter) StaticType {
 	)
 }
 
-func (AccountLinkValue) IsImportable(_ *Interpreter) bool {
+func (AccountLinkValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	panic(errors.NewUnreachableError())
 }
 

--- a/runtime/interpreter/value_pathcapability.go
+++ b/runtime/interpreter/value_pathcapability.go
@@ -59,7 +59,7 @@ func (v *PathCapabilityValue) StaticType(inter *Interpreter) StaticType {
 	)
 }
 
-func (v *PathCapabilityValue) IsImportable(_ *Interpreter) bool {
+func (v *PathCapabilityValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	panic(errors.NewUnreachableError())
 }
 

--- a/runtime/interpreter/value_pathcapability.go
+++ b/runtime/interpreter/value_pathcapability.go
@@ -44,11 +44,11 @@ func (*PathCapabilityValue) isValue() {}
 
 func (*PathCapabilityValue) isCapabilityValue() {}
 
-func (v *PathCapabilityValue) Accept(_ *Interpreter, _ Visitor) {
+func (v *PathCapabilityValue) Accept(_ *Interpreter, _ Visitor, _ LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 
-func (v *PathCapabilityValue) Walk(_ *Interpreter, _ func(Value)) {
+func (v *PathCapabilityValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 

--- a/runtime/interpreter/value_placeholder.go
+++ b/runtime/interpreter/value_placeholder.go
@@ -45,11 +45,11 @@ func (f placeholderValue) MeteredString(_ common.MemoryGauge, _ SeenReferences) 
 	return ""
 }
 
-func (f placeholderValue) Accept(_ *Interpreter, _ Visitor) {
+func (f placeholderValue) Accept(_ *Interpreter, _ Visitor, _ LocationRange) {
 	// NO-OP
 }
 
-func (f placeholderValue) Walk(_ *Interpreter, _ func(Value)) {
+func (f placeholderValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/runtime/interpreter/value_placeholder.go
+++ b/runtime/interpreter/value_placeholder.go
@@ -57,7 +57,7 @@ func (f placeholderValue) StaticType(_ *Interpreter) StaticType {
 	return PrimitiveStaticTypeNever
 }
 
-func (placeholderValue) IsImportable(_ *Interpreter) bool {
+func (placeholderValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return false
 }
 

--- a/runtime/interpreter/value_storagecapabilitycontroller.go
+++ b/runtime/interpreter/value_storagecapabilitycontroller.go
@@ -109,11 +109,11 @@ func (v *StorageCapabilityControllerValue) CapabilityControllerBorrowType() *Ref
 	return v.BorrowType
 }
 
-func (v *StorageCapabilityControllerValue) Accept(interpreter *Interpreter, visitor Visitor) {
+func (v *StorageCapabilityControllerValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
 	visitor.VisitStorageCapabilityControllerValue(interpreter, v)
 }
 
-func (v *StorageCapabilityControllerValue) Walk(_ *Interpreter, walkChild func(Value)) {
+func (v *StorageCapabilityControllerValue) Walk(_ *Interpreter, walkChild func(Value), _ LocationRange) {
 	walkChild(v.TargetPath)
 	walkChild(v.CapabilityID)
 }

--- a/runtime/interpreter/value_storagecapabilitycontroller.go
+++ b/runtime/interpreter/value_storagecapabilitycontroller.go
@@ -122,7 +122,7 @@ func (v *StorageCapabilityControllerValue) StaticType(_ *Interpreter) StaticType
 	return PrimitiveStaticTypeStorageCapabilityController
 }
 
-func (*StorageCapabilityControllerValue) IsImportable(_ *Interpreter) bool {
+func (*StorageCapabilityControllerValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 	return false
 }
 

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -1209,7 +1209,7 @@ func TestVisitor(t *testing.T) {
 		common.ZeroAddress,
 	)
 
-	value.Accept(inter, visitor)
+	value.Accept(inter, visitor, EmptyLocationRange)
 
 	require.Equal(t, 1, intVisits)
 	require.Equal(t, 1, stringVisits)

--- a/runtime/interpreter/walk.go
+++ b/runtime/interpreter/walk.go
@@ -32,14 +32,23 @@ type ValueWalker interface {
 // followed by a call of WalkValue(nil) on the returned walker.
 //
 // The initial walker may not be nil.
-func WalkValue(interpreter *Interpreter, walker ValueWalker, value Value) {
+func WalkValue(interpreter *Interpreter, walker ValueWalker, value Value, locationRange LocationRange) {
 	if walker = walker.WalkValue(interpreter, value); walker == nil {
 		return
 	}
 
-	value.Walk(interpreter, func(child Value) {
-		WalkValue(interpreter, walker, child)
-	})
+	value.Walk(
+		interpreter,
+		func(child Value) {
+			WalkValue(
+				interpreter,
+				walker,
+				child,
+				locationRange,
+			)
+		},
+		locationRange,
+	)
 
 	walker.WalkValue(interpreter, nil)
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -436,7 +436,7 @@ func validateArgumentParams(
 		// Ensure the argument is of an importable type
 		argType := arg.StaticType(inter)
 
-		if !arg.IsImportable(inter) {
+		if !arg.IsImportable(inter, locationRange) {
 			return nil, &ArgumentNotImportableError{
 				Type: argType,
 			}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -467,17 +467,22 @@ func validateArgumentParams(
 		}
 
 		// Ensure static type info is available for all values
-		interpreter.InspectValue(inter, arg, func(value interpreter.Value) bool {
-			if value == nil {
+		interpreter.InspectValue(
+			inter,
+			arg,
+			func(value interpreter.Value) bool {
+				if value == nil {
+					return true
+				}
+
+				if !hasValidStaticType(inter, value) {
+					panic(errors.NewUnexpectedError("invalid static type for argument: %d", parameterIndex))
+				}
+
 				return true
-			}
-
-			if !hasValidStaticType(inter, value) {
-				panic(errors.NewUnexpectedError("invalid static type for argument: %d", parameterIndex))
-			}
-
-			return true
-		})
+			},
+			locationRange,
+		)
 
 		argumentValues[parameterIndex] = arg
 	}


### PR DESCRIPTION
## Description

Follow-up on https://github.com/onflow/cadence/pull/3126#discussion_r1499393979.
Passes the `LocationRange` to the methods of the `Value` interface where necessary.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
