### PR TITLE
Improve migrations

### DIFF
--- a/migrations/capcons/migration_test.go
+++ b/migrations/capcons/migration_test.go
@@ -514,18 +514,11 @@ func testPathCapabilityValueMigration(
 	err = migration.Commit()
 	require.NoError(t, err)
 
-	err = storage.CheckHealth()
-	require.NoError(t, err)
-
-	// Check migrated capabilities
+	// Assert
 
 	assert.Equal(t,
 		expectedMigrations,
 		reporter.migrations,
-	)
-	assert.Equal(t,
-		expectedErrors,
-		reporter.errors,
 	)
 	assert.Equal(t,
 		expectedPathMigrations,
@@ -535,6 +528,13 @@ func testPathCapabilityValueMigration(
 		expectedMissingCapabilityIDs,
 		reporter.missingCapabilityIDs,
 	)
+	require.Equal(t,
+		expectedErrors,
+		reporter.errors,
+	)
+
+	err = storage.CheckHealth()
+	require.NoError(t, err)
 
 	if len(expectedMissingCapabilityIDs) == 0 {
 
@@ -1351,18 +1351,11 @@ func testLinkMigration(
 	err = migration.Commit()
 	require.NoError(t, err)
 
-	err = storage.CheckHealth()
-	require.NoError(t, err)
-
 	// Assert
 
 	assert.Equal(t,
 		expectedMigrations,
 		reporter.migrations,
-	)
-	assert.Equal(t,
-		expectedErrors,
-		reporter.errors,
 	)
 	assert.Equal(t,
 		expectedLinkMigrations,
@@ -1376,6 +1369,13 @@ func testLinkMigration(
 		expectedMissingTargets,
 		reporter.missingTargets,
 	)
+	require.Equal(t,
+		expectedErrors,
+		reporter.errors,
+	)
+
+	err = storage.CheckHealth()
+	require.NoError(t, err)
 }
 
 func TestLinkMigration(t *testing.T) {
@@ -2079,23 +2079,22 @@ func TestPublishedPathCapabilityValueMigration(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
-	err = storage.CheckHealth()
-	require.NoError(t, err)
-
-	// Check migrated capabilities
+	// Assert
 
 	assert.Equal(t,
 		expectedMigrations,
 		reporter.migrations,
 	)
-	assert.Empty(t, reporter.errors)
 	assert.Equal(t,
 		expectedPathMigrations,
 		reporter.pathCapabilityMigrations,
 	)
 	require.Nil(t, reporter.missingCapabilityIDs)
 
-	// Check
+	require.Empty(t, reporter.errors)
+
+	err = storage.CheckHealth()
+	require.NoError(t, err)
 
 	// language=cadence
 	checkScript := `
@@ -2329,21 +2328,22 @@ func TestUntypedPathCapabilityValueMigration(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
-	err = storage.CheckHealth()
-	require.NoError(t, err)
-
-	// Check migrated capabilities
+	// Assert
 
 	assert.Equal(t,
 		expectedMigrations,
 		reporter.migrations,
 	)
-	assert.Empty(t, reporter.errors)
 	assert.Equal(t,
 		expectedPathMigrations,
 		reporter.pathCapabilityMigrations,
 	)
 	require.Nil(t, reporter.missingCapabilityIDs)
+
+	require.Empty(t, reporter.errors)
+
+	err = storage.CheckHealth()
+	require.NoError(t, err)
 
 	// Check
 

--- a/migrations/capcons/migration_test.go
+++ b/migrations/capcons/migration_test.go
@@ -514,6 +514,9 @@ func testPathCapabilityValueMigration(
 	err = migration.Commit()
 	require.NoError(t, err)
 
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
 	// Check migrated capabilities
 
 	assert.Equal(t,
@@ -1348,13 +1351,16 @@ func testLinkMigration(
 	err = migration.Commit()
 	require.NoError(t, err)
 
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
 	// Assert
 
 	assert.Equal(t,
 		expectedMigrations,
 		reporter.migrations,
 	)
-	assert.Empty(t,
+	assert.Equal(t,
 		expectedErrors,
 		reporter.errors,
 	)
@@ -2073,6 +2079,9 @@ func TestPublishedPathCapabilityValueMigration(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
 	// Check migrated capabilities
 
 	assert.Equal(t,
@@ -2320,18 +2329,21 @@ func TestUntypedPathCapabilityValueMigration(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
 	// Check migrated capabilities
 
 	assert.Equal(t,
 		expectedMigrations,
 		reporter.migrations,
 	)
+	assert.Empty(t, reporter.errors)
 	assert.Equal(t,
 		expectedPathMigrations,
 		reporter.pathCapabilityMigrations,
 	)
 	require.Nil(t, reporter.missingCapabilityIDs)
-	require.Empty(t, reporter.errors)
 
 	// Check
 

--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -241,16 +241,10 @@ func ConvertValueToEntitlements(
 			return nil, nil
 		}
 
-		iterator := v.Iterator(inter, interpreter.EmptyLocationRange)
-
-		return interpreter.NewArrayValueWithIterator(
+		return v.NewWithType(
 			inter,
+			interpreter.EmptyLocationRange,
 			entitledElementType.(interpreter.ArrayStaticType),
-			v.GetOwner(),
-			uint64(v.Count()),
-			func() interpreter.Value {
-				return iterator.Next(inter, interpreter.EmptyLocationRange)
-			},
 		), nil
 
 	case *interpreter.DictionaryValue:

--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -21,11 +21,8 @@ package entitlements
 import (
 	"fmt"
 
-	"github.com/onflow/atree"
-
 	"github.com/onflow/cadence/migrations"
 	"github.com/onflow/cadence/migrations/statictypes"
-	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 )
@@ -268,57 +265,11 @@ func ConvertValueToEntitlements(
 			return nil, nil
 		}
 
-		newDictionary := interpreter.NewDictionaryValueWithAddress(
+		return v.NewWithType(
 			inter,
 			interpreter.EmptyLocationRange,
 			entitledElementType.(*interpreter.DictionaryStaticType),
-			v.GetOwner(),
-		)
-
-		var keys []atree.Value
-
-		iterator := v.Iterator()
-
-		for {
-			key := iterator.NextKeyUnconverted()
-			if key == nil {
-				break
-			}
-
-			keys = append(keys, key)
-		}
-
-		storage := inter.Storage()
-
-		for _, key := range keys {
-			existingKeyStorable, existingValueStorable := v.RemoveWithoutTransfer(
-				inter,
-				interpreter.EmptyLocationRange,
-				key,
-			)
-			if existingKeyStorable == nil || existingValueStorable == nil {
-				panic(errors.NewUnreachableError())
-			}
-
-			newKey, err := existingKeyStorable.StoredValue(storage)
-			if err != nil {
-				panic(err)
-			}
-
-			newValue, err := existingValueStorable.StoredValue(storage)
-			if err != nil {
-				panic(err)
-			}
-
-			newDictionary.InsertWithoutTransfer(
-				inter,
-				interpreter.EmptyLocationRange,
-				newKey,
-				newValue,
-			)
-		}
-
-		return newDictionary, nil
+		), nil
 
 	case *interpreter.IDCapabilityValue:
 		borrowType := v.BorrowType

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -1494,11 +1494,20 @@ func TestMigrateSimpleContract(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
+		transferredValue := testCase.storedValue.Transfer(
+			inter,
+			interpreter.EmptyLocationRange,
+			atree.Address(account),
+			false,
+			nil,
+			nil,
+		)
+
 		inter.WriteStored(
 			account,
 			storageIdentifier,
 			interpreter.StringStorageMapKey(name),
-			testCase.storedValue,
+			transferredValue,
 		)
 	}
 

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -3100,7 +3100,8 @@ func TestRehash(t *testing.T) {
 			nil,
 			utils.TestLocation,
 			&interpreter.Config{
-				Storage:                       storage,
+				Storage: storage,
+				// NOTE: disabled, because encoded and decoded values are expected to not match
 				AtreeValueValidationEnabled:   false,
 				AtreeStorageValidationEnabled: true,
 			},

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -719,9 +719,12 @@ func convertEntireTestValue(
 	err := migration.Commit()
 	require.NoError(t, err)
 
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
 	// Assert
 
-	assert.Len(t, reporter.errors, 0)
+	assert.Empty(t, reporter.errors)
 
 	if migratedValue == nil {
 		return v
@@ -1313,8 +1316,12 @@ func TestConvertToEntitledValue(t *testing.T) {
 		},
 	}
 
-	test := func(testCase testCase, valueGenerator valueGenerator, typeGenerator typeGenerator) {
-
+	test := func(
+		t *testing.T,
+		testCase testCase,
+		valueGenerator valueGenerator,
+		typeGenerator typeGenerator,
+	) {
 		input := valueGenerator.wrap(typeGenerator.wrap(testCase.Input))
 		if input == nil {
 			return
@@ -1323,6 +1330,9 @@ func TestConvertToEntitledValue(t *testing.T) {
 		expectedValue := valueGenerator.wrap(typeGenerator.wrap(testCase.Output))
 
 		convertedValue := convertEntireTestValue(t, inter, storage, testAddress, input)
+
+		err := storage.CheckHealth()
+		require.NoError(t, err)
 
 		switch convertedValue := convertedValue.(type) {
 		case interpreter.EquatableValue:
@@ -1346,7 +1356,7 @@ func TestConvertToEntitledValue(t *testing.T) {
 					for _, typeGenerator := range typeGenerators {
 						t.Run(typeGenerator.name, func(t *testing.T) {
 
-							test(testCase, valueGenerator, typeGenerator)
+							test(t, testCase, valueGenerator, typeGenerator)
 						})
 					}
 				})
@@ -1517,7 +1527,10 @@ func TestMigrateSimpleContract(t *testing.T) {
 
 	// Assert
 
-	assert.Len(t, reporter.errors, 0)
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
+	assert.Empty(t, reporter.errors)
 
 	storageMap := storage.GetStorageMap(account, storageIdentifier, false)
 	require.NotNil(t, storageMap)
@@ -1701,7 +1714,11 @@ func TestMigratePublishedValue(t *testing.T) {
 
 	// Assert
 
-	assert.Len(t, reporter.errors, 0)
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
+	assert.Empty(t, reporter.errors)
+
 	assert.Equal(t,
 		map[struct {
 			interpreter.StorageKey
@@ -1955,7 +1972,11 @@ func TestMigratePublishedValueAcrossTwoAccounts(t *testing.T) {
 
 	// Assert
 
-	assert.Len(t, reporter.errors, 0)
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
+	assert.Empty(t, reporter.errors)
+
 	assert.Equal(t,
 		map[struct {
 			interpreter.StorageKey
@@ -2404,7 +2425,11 @@ func TestMigrateArrayOfValues(t *testing.T) {
 
 	// Assert
 
-	assert.Len(t, reporter.errors, 0)
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
+	assert.Empty(t, reporter.errors)
+
 	assert.Equal(t,
 		map[struct {
 			interpreter.StorageKey
@@ -2651,7 +2676,11 @@ func TestMigrateDictOfValues(t *testing.T) {
 
 	// Assert
 
-	assert.Len(t, reporter.errors, 0)
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
+	assert.Empty(t, reporter.errors)
+
 	assert.Equal(t,
 		map[struct {
 			interpreter.StorageKey
@@ -2970,7 +2999,10 @@ func TestMigrateCapConsAcrossTwoAccounts(t *testing.T) {
 
 	// Assert
 
-	assert.Len(t, reporter.errors, 0)
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
+	assert.Empty(t, reporter.errors)
 	assert.Len(t, reporter.migrated, 1)
 
 	// TODO: assert
@@ -3150,6 +3182,9 @@ func TestRehash(t *testing.T) {
 
 		err := storage.Commit(inter, false)
 		require.NoError(t, err)
+
+		err = storage.CheckHealth()
+		require.NoError(t, err)
 	})
 
 	t.Run("migrate", func(t *testing.T) {
@@ -3196,6 +3231,11 @@ func TestRehash(t *testing.T) {
 		err := migration.Commit()
 		require.NoError(t, err)
 
+		err = storage.CheckHealth()
+		require.NoError(t, err)
+
+		assert.Empty(t, reporter.errors)
+
 		require.Equal(t,
 			map[struct {
 				interpreter.StorageKey
@@ -3216,6 +3256,9 @@ func TestRehash(t *testing.T) {
 	t.Run("load", func(t *testing.T) {
 
 		storage, inter := newStorageAndInterpreter(t)
+
+		err := storage.CheckHealth()
+		require.NoError(t, err)
 
 		storageMap := storage.GetStorageMap(
 			testAddress,

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -719,12 +719,12 @@ func convertEntireTestValue(
 	err := migration.Commit()
 	require.NoError(t, err)
 
-	err = storage.CheckHealth()
-	require.NoError(t, err)
-
 	// Assert
 
-	assert.Empty(t, reporter.errors)
+	require.Empty(t, reporter.errors)
+
+	err = storage.CheckHealth()
+	require.NoError(t, err)
 
 	if migratedValue == nil {
 		return v
@@ -1536,10 +1536,10 @@ func TestMigrateSimpleContract(t *testing.T) {
 
 	// Assert
 
+	require.Empty(t, reporter.errors)
+
 	err = storage.CheckHealth()
 	require.NoError(t, err)
-
-	assert.Empty(t, reporter.errors)
 
 	storageMap := storage.GetStorageMap(account, storageIdentifier, false)
 	require.NotNil(t, storageMap)
@@ -1723,10 +1723,10 @@ func TestMigratePublishedValue(t *testing.T) {
 
 	// Assert
 
+	require.Empty(t, reporter.errors)
+
 	err = storage.CheckHealth()
 	require.NoError(t, err)
-
-	assert.Empty(t, reporter.errors)
 
 	assert.Equal(t,
 		map[struct {
@@ -1981,10 +1981,10 @@ func TestMigratePublishedValueAcrossTwoAccounts(t *testing.T) {
 
 	// Assert
 
+	require.Empty(t, reporter.errors)
+
 	err = storage.CheckHealth()
 	require.NoError(t, err)
-
-	assert.Empty(t, reporter.errors)
 
 	assert.Equal(t,
 		map[struct {
@@ -2434,10 +2434,10 @@ func TestMigrateArrayOfValues(t *testing.T) {
 
 	// Assert
 
+	require.Empty(t, reporter.errors)
+
 	err = storage.CheckHealth()
 	require.NoError(t, err)
-
-	assert.Empty(t, reporter.errors)
 
 	assert.Equal(t,
 		map[struct {
@@ -2685,10 +2685,10 @@ func TestMigrateDictOfValues(t *testing.T) {
 
 	// Assert
 
+	require.Empty(t, reporter.errors)
+
 	err = storage.CheckHealth()
 	require.NoError(t, err)
-
-	assert.Empty(t, reporter.errors)
 
 	assert.Equal(t,
 		map[struct {
@@ -3008,10 +3008,11 @@ func TestMigrateCapConsAcrossTwoAccounts(t *testing.T) {
 
 	// Assert
 
+	require.Empty(t, reporter.errors)
+
 	err = storage.CheckHealth()
 	require.NoError(t, err)
 
-	assert.Empty(t, reporter.errors)
 	assert.Len(t, reporter.migrated, 1)
 
 	// TODO: assert
@@ -3240,6 +3241,8 @@ func TestRehash(t *testing.T) {
 
 		err := migration.Commit()
 		require.NoError(t, err)
+
+		// Assert
 
 		err = storage.CheckHealth()
 		require.NoError(t, err)

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -321,13 +321,6 @@ func (m *StorageMigration) MigrateNestedValue(
 				keyToSet = newKey
 			}
 
-			if newValue == nil {
-				valueToSet = existingValue
-			} else {
-				// Value was migrated
-				valueToSet = newValue
-			}
-
 			existingKey = legacyKey(existingKey)
 			existingKeyStorable, existingValueStorable := dictionary.RemoveWithoutTransfer(
 				m.interpreter,
@@ -342,9 +335,16 @@ func (m *StorageMigration) MigrateNestedValue(
 				))
 			}
 
-			interpreter.StoredValue(m.interpreter, existingValueStorable, m.storage).
-				DeepRemove(m.interpreter)
-			m.interpreter.RemoveReferencedSlab(existingValueStorable)
+			if newValue == nil {
+				valueToSet = existingValue
+			} else {
+				// Value was migrated
+				valueToSet = newValue
+
+				interpreter.StoredValue(m.interpreter, existingValueStorable, m.storage).
+					DeepRemove(m.interpreter)
+				m.interpreter.RemoveReferencedSlab(existingValueStorable)
+			}
 
 			dictionary.InsertWithoutTransfer(
 				m.interpreter,

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -252,7 +252,7 @@ func (m *StorageMigration) MigrateNestedValue(
 				continue
 			}
 
-			composite.SetMember(
+			composite.SetMemberWithoutTransfer(
 				m.interpreter,
 				emptyLocationRange,
 				fieldName,

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -518,12 +518,12 @@ func TestMultipleMigrations(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
+	// Assert
+
+	require.Empty(t, reporter.errored)
+
 	err = storage.CheckHealth()
 	require.NoError(t, err)
-
-	assert.Empty(t, reporter.errored)
-
-	// Assert: Traverse through the storage and see if the values are updated now.
 
 	for _, testCase := range testCases {
 
@@ -665,9 +665,6 @@ func TestMigrationError(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
-	err = storage.CheckHealth()
-	require.NoError(t, err)
-
 	assert.Equal(t,
 		map[struct {
 			interpreter.StorageKey
@@ -683,6 +680,9 @@ func TestMigrationError(t *testing.T) {
 		},
 		reporter.errored,
 	)
+
+	err = storage.CheckHealth()
+	require.NoError(t, err)
 
 	// Assert: Traverse through the storage and see if the values are updated now.
 
@@ -946,12 +946,13 @@ func TestContractMigration(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
+	// Assert
+
+	require.Empty(t, reporter.errored)
+
 	err = storage.CheckHealth()
 	require.NoError(t, err)
 
-	// Assert
-
-	assert.Empty(t, reporter.errored)
 	assert.Len(t, reporter.migrated, 1)
 
 	value, err := rt.ExecuteScript(

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -518,6 +518,11 @@ func TestMultipleMigrations(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
+	assert.Empty(t, reporter.errored)
+
 	// Assert: Traverse through the storage and see if the values are updated now.
 
 	for _, testCase := range testCases {
@@ -659,6 +664,25 @@ func TestMigrationError(t *testing.T) {
 
 	err = migration.Commit()
 	require.NoError(t, err)
+
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		map[struct {
+			interpreter.StorageKey
+			interpreter.StorageMapKey
+		}][]string{
+			{
+				StorageKey: interpreter.StorageKey{
+					Address: account,
+					Key:     pathDomain.Identifier(),
+				},
+				StorageMapKey: interpreter.StringStorageMapKey("int8_value"),
+			}: {"testInt8Migration"},
+		},
+		reporter.errored,
+	)
 
 	// Assert: Traverse through the storage and see if the values are updated now.
 
@@ -804,9 +828,12 @@ func TestCapConMigration(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
 	// Assert
 
-	assert.Len(t, reporter.errored, 0)
+	assert.Empty(t, reporter.errored)
 	assert.Len(t, reporter.migrated, 2)
 
 	storageMap = storage.GetStorageMap(
@@ -919,9 +946,12 @@ func TestContractMigration(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
 	// Assert
 
-	assert.Len(t, reporter.errored, 0)
+	assert.Empty(t, reporter.errored)
 	assert.Len(t, reporter.migrated, 1)
 
 	value, err := rt.ExecuteScript(

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -242,8 +242,8 @@ func TestMultipleMigrations(t *testing.T) {
 		utils.TestLocation,
 		&interpreter.Config{
 			Storage:                       storage,
-			AtreeValueValidationEnabled:   false,
-			AtreeStorageValidationEnabled: false,
+			AtreeValueValidationEnabled:   true,
+			AtreeStorageValidationEnabled: true,
 		},
 	)
 	require.NoError(t, err)
@@ -597,8 +597,8 @@ func TestMigrationError(t *testing.T) {
 		utils.TestLocation,
 		&interpreter.Config{
 			Storage:                       storage,
-			AtreeValueValidationEnabled:   false,
-			AtreeStorageValidationEnabled: false,
+			AtreeValueValidationEnabled:   true,
+			AtreeStorageValidationEnabled: true,
 		},
 	)
 	require.NoError(t, err)

--- a/migrations/statictypes/account_type_migration_test.go
+++ b/migrations/statictypes/account_type_migration_test.go
@@ -485,6 +485,9 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 			err = migration.Commit()
 			require.NoError(t, err)
 
+			err = storage.CheckHealth()
+			require.NoError(t, err)
+
 			require.Empty(t, reporter.errors)
 
 			storageMapKey := interpreter.StringStorageMapKey(name)
@@ -812,6 +815,8 @@ func TestAccountTypeInNestedTypeValueMigration(t *testing.T) {
 
 	migration := migrations.NewStorageMigration(inter, storage)
 
+	reporter := newTestReporter()
+
 	migration.Migrate(
 		&migrations.AddressSliceIterator{
 			Addresses: []common.Address{
@@ -819,13 +824,18 @@ func TestAccountTypeInNestedTypeValueMigration(t *testing.T) {
 			},
 		},
 		migration.NewValueMigrationsPathMigrator(
-			nil,
+			reporter,
 			NewStaticTypeMigration(),
 		),
 	)
 
 	err = migration.Commit()
 	require.NoError(t, err)
+
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
+	require.Empty(t, reporter.errors)
 
 	// Assert: Traverse through the storage and see if the values are updated now.
 
@@ -1064,6 +1074,8 @@ func TestMigratingValuesWithAccountStaticType(t *testing.T) {
 
 	migration := migrations.NewStorageMigration(inter, storage)
 
+	reporter := newTestReporter()
+
 	migration.Migrate(
 		&migrations.AddressSliceIterator{
 			Addresses: []common.Address{
@@ -1071,13 +1083,18 @@ func TestMigratingValuesWithAccountStaticType(t *testing.T) {
 			},
 		},
 		migration.NewValueMigrationsPathMigrator(
-			nil,
+			reporter,
 			NewStaticTypeMigration(),
 		),
 	)
 
 	err = migration.Commit()
 	require.NoError(t, err)
+
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
+	require.Empty(t, reporter.errors)
 
 	// Assert: Traverse through the storage and see if the values are updated now.
 
@@ -1218,6 +1235,9 @@ func TestAccountTypeRehash(t *testing.T) {
 		)
 
 		err := migration.Commit()
+		require.NoError(t, err)
+
+		err = storage.CheckHealth()
 		require.NoError(t, err)
 
 		require.Empty(t, reporter.errors)

--- a/migrations/statictypes/account_type_migration_test.go
+++ b/migrations/statictypes/account_type_migration_test.go
@@ -485,10 +485,12 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 			err = migration.Commit()
 			require.NoError(t, err)
 
-			err = storage.CheckHealth()
-			require.NoError(t, err)
+			// Assert
 
 			require.Empty(t, reporter.errors)
+
+			err = storage.CheckHealth()
+			require.NoError(t, err)
 
 			storageMapKey := interpreter.StringStorageMapKey(name)
 
@@ -581,284 +583,327 @@ func TestAccountTypeInNestedTypeValueMigration(t *testing.T) {
 	pathDomain := common.PathDomainPublic
 
 	type testCase struct {
-		storedValue   interpreter.Value
-		expectedValue interpreter.Value
+		storedValue   func(inter *interpreter.Interpreter) interpreter.Value
+		expectedValue func(inter *interpreter.Interpreter) interpreter.Value
+		validateValue bool
 	}
 
 	storedAccountTypeValue := interpreter.NewTypeValue(nil, interpreter.PrimitiveStaticTypePublicAccount) //nolint:staticcheck
 	expectedAccountTypeValue := interpreter.NewTypeValue(nil, unauthorizedAccountReferenceType)
 	stringTypeValue := interpreter.NewTypeValue(nil, interpreter.PrimitiveStaticTypeString)
 
-	ledger := NewTestLedger(nil, nil)
-	storage := runtime.NewStorage(ledger, nil)
-	locationRange := interpreter.EmptyLocationRange
-
-	inter, err := interpreter.NewInterpreter(
-		nil,
-		utils.TestLocation,
-		&interpreter.Config{
-			Storage:                       storage,
-			AtreeValueValidationEnabled:   false,
-			AtreeStorageValidationEnabled: false,
-		},
-	)
-	require.NoError(t, err)
-
 	fooAddressLocation := common.NewAddressLocation(nil, account, "Foo")
 	const fooBarQualifiedIdentifier = "Foo.Bar"
 
 	testCases := map[string]testCase{
 		"account_some_value": {
-			storedValue:   interpreter.NewUnmeteredSomeValueNonCopying(storedAccountTypeValue),
-			expectedValue: interpreter.NewUnmeteredSomeValueNonCopying(expectedAccountTypeValue),
+			storedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewUnmeteredSomeValueNonCopying(storedAccountTypeValue)
+			},
+			expectedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewUnmeteredSomeValueNonCopying(expectedAccountTypeValue)
+			},
+			validateValue: true,
 		},
 		"int8_some_value": {
-			storedValue: interpreter.NewUnmeteredSomeValueNonCopying(stringTypeValue),
+			storedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewUnmeteredSomeValueNonCopying(stringTypeValue)
+			},
+			expectedValue: nil,
+			validateValue: true,
 		},
 		"account_array": {
-			storedValue: interpreter.NewArrayValue(
-				inter,
-				locationRange,
-				interpreter.NewVariableSizedStaticType(nil, interpreter.PrimitiveStaticTypeAnyStruct),
-				common.ZeroAddress,
-				stringTypeValue,
-				storedAccountTypeValue,
-				stringTypeValue,
-				stringTypeValue,
-				storedAccountTypeValue,
-			),
-			expectedValue: interpreter.NewArrayValue(
-				inter,
-				locationRange,
-				interpreter.NewVariableSizedStaticType(nil, interpreter.PrimitiveStaticTypeAnyStruct),
-				common.ZeroAddress,
-				stringTypeValue,
-				expectedAccountTypeValue,
-				stringTypeValue,
-				stringTypeValue,
-				expectedAccountTypeValue,
-			),
+			storedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewArrayValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewVariableSizedStaticType(nil, interpreter.PrimitiveStaticTypeAnyStruct),
+					common.ZeroAddress,
+					stringTypeValue,
+					storedAccountTypeValue,
+					stringTypeValue,
+					stringTypeValue,
+					storedAccountTypeValue,
+				)
+			},
+			expectedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewArrayValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewVariableSizedStaticType(nil, interpreter.PrimitiveStaticTypeAnyStruct),
+					common.ZeroAddress,
+					stringTypeValue,
+					expectedAccountTypeValue,
+					stringTypeValue,
+					stringTypeValue,
+					expectedAccountTypeValue,
+				)
+			},
+			validateValue: true,
 		},
 		"non_account_array": {
-			storedValue: interpreter.NewArrayValue(
-				inter,
-				locationRange,
-				interpreter.NewVariableSizedStaticType(nil, interpreter.PrimitiveStaticTypeAnyStruct),
-				common.ZeroAddress,
-				stringTypeValue,
-				stringTypeValue,
-				stringTypeValue,
-			),
+			storedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewArrayValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewVariableSizedStaticType(nil, interpreter.PrimitiveStaticTypeAnyStruct),
+					common.ZeroAddress,
+					stringTypeValue,
+					stringTypeValue,
+					stringTypeValue,
+				)
+			},
+			expectedValue: nil,
+			validateValue: true,
 		},
 		"dictionary_with_account_type_value": {
-			storedValue: interpreter.NewDictionaryValue(
-				inter,
-				locationRange,
-				interpreter.NewDictionaryStaticType(
-					nil,
-					interpreter.PrimitiveStaticTypeInt8,
-					interpreter.PrimitiveStaticTypeAnyStruct,
-				),
-				interpreter.NewUnmeteredInt8Value(4),
-				storedAccountTypeValue,
-				interpreter.NewUnmeteredInt8Value(5),
-				interpreter.NewUnmeteredStringValue("hello"),
-			),
-			expectedValue: interpreter.NewDictionaryValue(
-				inter,
-				locationRange,
-				interpreter.NewDictionaryStaticType(
-					nil,
-					interpreter.PrimitiveStaticTypeInt8,
-					interpreter.PrimitiveStaticTypeAnyStruct,
-				),
-				interpreter.NewUnmeteredInt8Value(4),
-				expectedAccountTypeValue,
-				interpreter.NewUnmeteredInt8Value(5),
-				interpreter.NewUnmeteredStringValue("hello"),
-			),
+			storedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewDictionaryValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeInt8,
+						interpreter.PrimitiveStaticTypeAnyStruct,
+					),
+					interpreter.NewUnmeteredInt8Value(4),
+					storedAccountTypeValue,
+					interpreter.NewUnmeteredInt8Value(5),
+					interpreter.NewUnmeteredStringValue("hello"),
+				)
+			},
+			expectedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewDictionaryValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeInt8,
+						interpreter.PrimitiveStaticTypeAnyStruct,
+					),
+					interpreter.NewUnmeteredInt8Value(4),
+					expectedAccountTypeValue,
+					interpreter.NewUnmeteredInt8Value(5),
+					interpreter.NewUnmeteredStringValue("hello"),
+				)
+			},
+			validateValue: true,
 		},
 		"dictionary_with_optional_account_type_value": {
-			storedValue: interpreter.NewDictionaryValue(
-				inter,
-				locationRange,
-				interpreter.NewDictionaryStaticType(
-					nil,
-					interpreter.PrimitiveStaticTypeInt8,
-					interpreter.NewOptionalStaticType(nil, interpreter.PrimitiveStaticTypeMetaType),
-				),
-				interpreter.NewUnmeteredInt8Value(4),
-				interpreter.NewUnmeteredSomeValueNonCopying(storedAccountTypeValue),
-			),
-			expectedValue: interpreter.NewDictionaryValue(
-				inter,
-				locationRange,
-				interpreter.NewDictionaryStaticType(
-					nil,
-					interpreter.PrimitiveStaticTypeInt8,
-					interpreter.NewOptionalStaticType(nil, interpreter.PrimitiveStaticTypeMetaType),
-				),
-				interpreter.NewUnmeteredInt8Value(4),
-				interpreter.NewUnmeteredSomeValueNonCopying(expectedAccountTypeValue),
-			),
+			storedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewDictionaryValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeInt8,
+						interpreter.NewOptionalStaticType(nil, interpreter.PrimitiveStaticTypeMetaType),
+					),
+					interpreter.NewUnmeteredInt8Value(4),
+					interpreter.NewUnmeteredSomeValueNonCopying(storedAccountTypeValue),
+				)
+			},
+			expectedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewDictionaryValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeInt8,
+						interpreter.NewOptionalStaticType(nil, interpreter.PrimitiveStaticTypeMetaType),
+					),
+					interpreter.NewUnmeteredInt8Value(4),
+					interpreter.NewUnmeteredSomeValueNonCopying(expectedAccountTypeValue),
+				)
+			},
+			validateValue: true,
 		},
 		"dictionary_with_account_type_key": {
-			storedValue: interpreter.NewDictionaryValue(
-				inter,
-				locationRange,
-				interpreter.NewDictionaryStaticType(
-					nil,
-					interpreter.PrimitiveStaticTypeMetaType,
-					interpreter.PrimitiveStaticTypeInt8,
-				),
-				interpreter.NewTypeValue(
-					nil,
-					dummyStaticType{
-						PrimitiveStaticType: interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
-					},
-				),
-				interpreter.NewUnmeteredInt8Value(4),
-			),
-			expectedValue: interpreter.NewDictionaryValue(
-				inter,
-				locationRange,
-				interpreter.NewDictionaryStaticType(
-					nil,
-					interpreter.PrimitiveStaticTypeMetaType,
-					interpreter.PrimitiveStaticTypeInt8,
-				),
-				expectedAccountTypeValue,
-				interpreter.NewUnmeteredInt8Value(4),
-			),
+			storedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewDictionaryValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeMetaType,
+						interpreter.PrimitiveStaticTypeInt8,
+					),
+					interpreter.NewTypeValue(
+						nil,
+						dummyStaticType{
+							PrimitiveStaticType: interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
+						},
+					),
+					interpreter.NewUnmeteredInt8Value(4),
+				)
+			},
+			expectedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewDictionaryValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeMetaType,
+						interpreter.PrimitiveStaticTypeInt8,
+					),
+					expectedAccountTypeValue,
+					interpreter.NewUnmeteredInt8Value(4),
+				)
+			},
+			validateValue: false,
 		},
 		"dictionary_with_account_type_key_and_value": {
-			storedValue: interpreter.NewDictionaryValue(
-				inter,
-				locationRange,
-				interpreter.NewDictionaryStaticType(
-					nil,
-					interpreter.PrimitiveStaticTypeMetaType,
-					interpreter.PrimitiveStaticTypeMetaType,
-				),
-				interpreter.NewTypeValue(
-					nil,
-					dummyStaticType{
-						PrimitiveStaticType: interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
-					},
-				),
-				storedAccountTypeValue,
-			),
-			expectedValue: interpreter.NewDictionaryValue(
-				inter,
-				locationRange,
-				interpreter.NewDictionaryStaticType(
-					nil,
-					interpreter.PrimitiveStaticTypeMetaType,
-					interpreter.PrimitiveStaticTypeMetaType,
-				),
-				expectedAccountTypeValue,
-				expectedAccountTypeValue,
-			),
+			storedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewDictionaryValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeMetaType,
+						interpreter.PrimitiveStaticTypeMetaType,
+					),
+					interpreter.NewTypeValue(
+						nil,
+						dummyStaticType{
+							PrimitiveStaticType: interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
+						},
+					),
+					storedAccountTypeValue,
+				)
+			},
+			expectedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewDictionaryValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeMetaType,
+						interpreter.PrimitiveStaticTypeMetaType,
+					),
+					expectedAccountTypeValue,
+					expectedAccountTypeValue,
+				)
+			},
+			validateValue: false,
 		},
 		"composite_with_account_type": {
-			storedValue: interpreter.NewCompositeValue(
-				inter,
-				interpreter.EmptyLocationRange,
-				fooAddressLocation,
-				fooBarQualifiedIdentifier,
-				common.CompositeKindResource,
-				[]interpreter.CompositeField{
-					interpreter.NewUnmeteredCompositeField("field1", storedAccountTypeValue),
-					interpreter.NewUnmeteredCompositeField("field2", interpreter.NewUnmeteredStringValue("hello")),
-				},
-				common.Address{},
-			),
-			expectedValue: interpreter.NewCompositeValue(
-				inter,
-				interpreter.EmptyLocationRange,
-				fooAddressLocation,
-				fooBarQualifiedIdentifier,
-				common.CompositeKindResource,
-				[]interpreter.CompositeField{
-					interpreter.NewUnmeteredCompositeField("field1", expectedAccountTypeValue),
-					interpreter.NewUnmeteredCompositeField("field2", interpreter.NewUnmeteredStringValue("hello")),
-				},
-				common.Address{},
-			),
+			storedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewCompositeValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					fooAddressLocation,
+					fooBarQualifiedIdentifier,
+					common.CompositeKindResource,
+					[]interpreter.CompositeField{
+						interpreter.NewUnmeteredCompositeField("field1", storedAccountTypeValue),
+						interpreter.NewUnmeteredCompositeField("field2", interpreter.NewUnmeteredStringValue("hello")),
+					},
+					common.Address{},
+				)
+			},
+			expectedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewCompositeValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					fooAddressLocation,
+					fooBarQualifiedIdentifier,
+					common.CompositeKindResource,
+					[]interpreter.CompositeField{
+						interpreter.NewUnmeteredCompositeField("field1", expectedAccountTypeValue),
+						interpreter.NewUnmeteredCompositeField("field2", interpreter.NewUnmeteredStringValue("hello")),
+					},
+					common.Address{},
+				)
+			},
+			validateValue: true,
 		},
 	}
 
 	// Store values
 
-	for name, testCase := range testCases {
-		transferredValue := testCase.storedValue.Transfer(
-			inter,
-			locationRange,
-			atree.Address(account),
-			false,
-			nil,
-			nil,
-		)
+	test := func(name string, testCase testCase) {
 
-		inter.WriteStored(
-			account,
-			pathDomain.Identifier(),
-			interpreter.StringStorageMapKey(name),
-			transferredValue,
-		)
-	}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	err = storage.Commit(inter, true)
-	require.NoError(t, err)
+			ledger := NewTestLedger(nil, nil)
+			storage := runtime.NewStorage(ledger, nil)
 
-	// Migrate
+			inter, err := interpreter.NewInterpreter(
+				nil,
+				utils.TestLocation,
+				&interpreter.Config{
+					Storage:                       storage,
+					AtreeValueValidationEnabled:   testCase.validateValue,
+					AtreeStorageValidationEnabled: true,
+				},
+			)
+			require.NoError(t, err)
 
-	migration := migrations.NewStorageMigration(inter, storage)
+			transferredValue := testCase.storedValue(inter).Transfer(
+				inter,
+				interpreter.EmptyLocationRange,
+				atree.Address(account),
+				false,
+				nil,
+				nil,
+			)
 
-	reporter := newTestReporter()
-
-	migration.Migrate(
-		&migrations.AddressSliceIterator{
-			Addresses: []common.Address{
+			inter.WriteStored(
 				account,
-			},
-		},
-		migration.NewValueMigrationsPathMigrator(
-			reporter,
-			NewStaticTypeMigration(),
-		),
-	)
+				pathDomain.Identifier(),
+				interpreter.StringStorageMapKey(name),
+				transferredValue,
+			)
 
-	err = migration.Commit()
-	require.NoError(t, err)
+			err = storage.Commit(inter, true)
+			require.NoError(t, err)
 
-	err = storage.CheckHealth()
-	require.NoError(t, err)
+			// Migrate
 
-	require.Empty(t, reporter.errors)
+			migration := migrations.NewStorageMigration(inter, storage)
 
-	// Assert: Traverse through the storage and see if the values are updated now.
+			reporter := newTestReporter()
 
-	storageMap := storage.GetStorageMap(account, pathDomain.Identifier(), false)
-	require.NotNil(t, storageMap)
-	require.Greater(t, storageMap.Count(), uint64(0))
+			migration.Migrate(
+				&migrations.AddressSliceIterator{
+					Addresses: []common.Address{
+						account,
+					},
+				},
+				migration.NewValueMigrationsPathMigrator(
+					reporter,
+					NewStaticTypeMigration(),
+				),
+			)
 
-	iterator := storageMap.Iterator(inter)
+			err = migration.Commit()
+			require.NoError(t, err)
 
-	for key, value := iterator.Next(); key != nil; key, value = iterator.Next() {
-		identifier := string(key.(interpreter.StringAtreeValue))
+			// Assert
 
-		t.Run(identifier, func(t *testing.T) {
-			testCase, ok := testCases[identifier]
-			require.True(t, ok)
+			require.Empty(t, reporter.errors)
+
+			err = storage.CheckHealth()
+			require.NoError(t, err)
+
+			storageMap := storage.GetStorageMap(account, pathDomain.Identifier(), false)
+			require.NotNil(t, storageMap)
+			require.Equal(t, uint64(1), storageMap.Count())
+
+			value := storageMap.ReadValue(nil, interpreter.StringStorageMapKey(name))
 
 			expectedStoredValue := testCase.expectedValue
 			if expectedStoredValue == nil {
 				expectedStoredValue = testCase.storedValue
 			}
 
-			utils.AssertValuesEqual(t, inter, expectedStoredValue, value)
+			utils.AssertValuesEqual(t, inter, expectedStoredValue(inter), value)
 		})
+	}
+
+	for name, testCase := range testCases {
+		test(name, testCase)
 	}
 }
 
@@ -870,254 +915,305 @@ func TestMigratingValuesWithAccountStaticType(t *testing.T) {
 	pathDomain := common.PathDomainPublic
 
 	type testCase struct {
-		storedValue   interpreter.Value
-		expectedValue interpreter.Value
+		storedValue     func(inter *interpreter.Interpreter) interpreter.Value
+		expectedValue   func(inter *interpreter.Interpreter) interpreter.Value
+		validateStorage bool
 	}
-
-	ledger := NewTestLedger(nil, nil)
-	storage := runtime.NewStorage(ledger, nil)
-	locationRange := interpreter.EmptyLocationRange
-
-	inter, err := interpreter.NewInterpreter(
-		nil,
-		utils.TestLocation,
-		&interpreter.Config{
-			Storage:                       storage,
-			AtreeValueValidationEnabled:   false,
-			AtreeStorageValidationEnabled: false,
-		},
-	)
-	require.NoError(t, err)
 
 	testCases := map[string]testCase{
 		"dictionary_value": {
-			storedValue: interpreter.NewDictionaryValue(
-				inter,
-				locationRange,
-				interpreter.NewDictionaryStaticType(
-					nil,
-					interpreter.PrimitiveStaticTypeString,
-					interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
-				),
-			),
-			expectedValue: interpreter.NewDictionaryValue(
-				inter,
-				locationRange,
-				interpreter.NewDictionaryStaticType(
-					nil,
-					interpreter.PrimitiveStaticTypeString,
-					unauthorizedAccountReferenceType,
-				),
-			),
+			storedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewDictionaryValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeString,
+						interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
+					),
+				)
+			},
+			expectedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewDictionaryValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeString,
+						unauthorizedAccountReferenceType,
+					),
+				)
+			},
+			// NOTE: disabled, as storage is not expected to be always valid _during_ migration
+			validateStorage: false,
 		},
 		"array_value": {
-			storedValue: interpreter.NewArrayValue(
-				inter,
-				locationRange,
-				interpreter.NewVariableSizedStaticType(
-					nil,
-					interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
-				),
-				common.Address{},
-			),
-			expectedValue: interpreter.NewArrayValue(
-				inter,
-				locationRange,
-				interpreter.NewVariableSizedStaticType(
-					nil,
-					unauthorizedAccountReferenceType,
-				),
-				common.Address{},
-			),
-		},
-		"account_capability_value": {
-			storedValue: interpreter.NewUnmeteredCapabilityValue(
-				123,
-				interpreter.NewAddressValue(nil, common.Address{0x42}),
-				interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
-			),
-			expectedValue: interpreter.NewUnmeteredCapabilityValue(
-				123,
-				interpreter.NewAddressValue(nil, common.Address{0x42}),
-				unauthorizedAccountReferenceType,
-			),
-		},
-		"string_capability_value": {
-			storedValue: interpreter.NewUnmeteredCapabilityValue(
-				123,
-				interpreter.NewAddressValue(nil, common.Address{0x42}),
-				interpreter.PrimitiveStaticTypeString,
-			),
-		},
-		"account_capability_controller": {
-			storedValue: interpreter.NewUnmeteredAccountCapabilityControllerValue(
-				interpreter.NewReferenceStaticType(
-					nil,
-					interpreter.UnauthorizedAccess,
-					interpreter.PrimitiveStaticTypeAuthAccount, //nolint:staticcheck,
-				),
-				1234,
-			),
-			expectedValue: interpreter.NewUnmeteredAccountCapabilityControllerValue(
-				authAccountReferenceType,
-				1234,
-			),
-		},
-		"storage_capability_controller": {
-			storedValue: interpreter.NewUnmeteredStorageCapabilityControllerValue(
-				interpreter.NewReferenceStaticType(
-					nil,
-					interpreter.UnauthorizedAccess,
-					interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck,
-				),
-				1234,
-				interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
-			),
-			expectedValue: interpreter.NewUnmeteredStorageCapabilityControllerValue(
-				unauthorizedAccountReferenceType,
-				1234,
-				interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
-			),
-		},
-		"path_link_value": {
-			storedValue: interpreter.PathLinkValue{ //nolint:staticcheck
-				TargetPath: interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
-				Type:       interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
-			},
-			expectedValue: interpreter.PathLinkValue{ //nolint:staticcheck
-				TargetPath: interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
-				Type:       unauthorizedAccountReferenceType,
-			},
-		},
-		"account_link_value": {
-			storedValue:   interpreter.AccountLinkValue{}, //nolint:staticcheck
-			expectedValue: interpreter.AccountLinkValue{}, //nolint:staticcheck
-		},
-		"path_capability_value": {
-			storedValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				Address:    interpreter.NewAddressValue(nil, common.Address{0x42}),
-				Path:       interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
-				BorrowType: interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
-			},
-			expectedValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				Address:    interpreter.NewAddressValue(nil, common.Address{0x42}),
-				Path:       interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
-				BorrowType: unauthorizedAccountReferenceType,
-			},
-		},
-		"capability_dictionary": {
-			storedValue: interpreter.NewDictionaryValue(
-				inter,
-				locationRange,
-				interpreter.NewDictionaryStaticType(
-					nil,
-					interpreter.PrimitiveStaticTypeString,
-					interpreter.NewCapabilityStaticType(
+			storedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewArrayValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewVariableSizedStaticType(
 						nil,
 						interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
 					),
-				),
-				interpreter.NewUnmeteredStringValue("key"),
-				interpreter.NewCapabilityValue(
-					nil,
-					interpreter.NewUnmeteredUInt64Value(1234),
-					interpreter.NewAddressValue(nil, common.Address{}),
-					interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
-				),
-			),
-			expectedValue: interpreter.NewDictionaryValue(
-				inter,
-				locationRange,
-				interpreter.NewDictionaryStaticType(
-					nil,
-					interpreter.PrimitiveStaticTypeString,
-					interpreter.NewCapabilityStaticType(
+					common.Address{},
+				)
+			},
+			expectedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewArrayValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewVariableSizedStaticType(
 						nil,
 						unauthorizedAccountReferenceType,
 					),
-				),
-				interpreter.NewUnmeteredStringValue("key"),
-				interpreter.NewCapabilityValue(
-					nil,
-					interpreter.NewUnmeteredUInt64Value(1234),
-					interpreter.NewAddressValue(nil, common.Address{}),
-					unauthorizedAccountReferenceType,
-				),
-			),
-		},
-	}
-
-	// Store values
-
-	for name, testCase := range testCases {
-		transferredValue := testCase.storedValue.Transfer(
-			inter,
-			locationRange,
-			atree.Address(account),
-			false,
-			nil,
-			nil,
-		)
-
-		inter.WriteStored(
-			account,
-			pathDomain.Identifier(),
-			interpreter.StringStorageMapKey(name),
-			transferredValue,
-		)
-	}
-
-	err = storage.Commit(inter, true)
-	require.NoError(t, err)
-
-	// Migrate
-
-	migration := migrations.NewStorageMigration(inter, storage)
-
-	reporter := newTestReporter()
-
-	migration.Migrate(
-		&migrations.AddressSliceIterator{
-			Addresses: []common.Address{
-				account,
+					common.Address{},
+				)
 			},
+			// NOTE: disabled, as storage is not expected to be always valid _during_ migration
+			validateStorage: false,
 		},
-		migration.NewValueMigrationsPathMigrator(
-			reporter,
-			NewStaticTypeMigration(),
-		),
-	)
+		"account_capability_value": {
+			storedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewUnmeteredCapabilityValue(
+					123,
+					interpreter.NewAddressValue(nil, common.Address{0x42}),
+					interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
+				)
+			},
+			expectedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewUnmeteredCapabilityValue(
+					123,
+					interpreter.NewAddressValue(nil, common.Address{0x42}),
+					unauthorizedAccountReferenceType,
+				)
+			},
+			validateStorage: true,
+		},
+		"string_capability_value": {
+			storedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewUnmeteredCapabilityValue(
+					123,
+					interpreter.NewAddressValue(nil, common.Address{0x42}),
+					interpreter.PrimitiveStaticTypeString,
+				)
+			},
+			validateStorage: true,
+		},
+		"account_capability_controller": {
+			storedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewUnmeteredAccountCapabilityControllerValue(
+					interpreter.NewReferenceStaticType(
+						nil,
+						interpreter.UnauthorizedAccess,
+						interpreter.PrimitiveStaticTypeAuthAccount, //nolint:staticcheck,
+					),
+					1234,
+				)
+			},
+			expectedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewUnmeteredAccountCapabilityControllerValue(
+					authAccountReferenceType,
+					1234,
+				)
+			},
+			validateStorage: true,
+		},
+		"storage_capability_controller": {
+			storedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewUnmeteredStorageCapabilityControllerValue(
+					interpreter.NewReferenceStaticType(
+						nil,
+						interpreter.UnauthorizedAccess,
+						interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck,
+					),
+					1234,
+					interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
+				)
+			},
+			expectedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewUnmeteredStorageCapabilityControllerValue(
+					unauthorizedAccountReferenceType,
+					1234,
+					interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
+				)
+			},
+			validateStorage: true,
+		},
+		"path_link_value": {
+			storedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.PathLinkValue{ //nolint:staticcheck
+					TargetPath: interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
+					Type:       interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
+				}
+			},
+			expectedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.PathLinkValue{ //nolint:staticcheck
+					TargetPath: interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
+					Type:       unauthorizedAccountReferenceType,
+				}
+			},
+			validateStorage: true,
+		},
+		"account_link_value": {
+			storedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.AccountLinkValue{} //nolint:staticcheck
+			},
+			expectedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return interpreter.AccountLinkValue{} //nolint:staticcheck
+			},
+			validateStorage: true,
+		},
+		"path_capability_value": {
+			storedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return &interpreter.PathCapabilityValue{ //nolint:staticcheck
+					Address:    interpreter.NewAddressValue(nil, common.Address{0x42}),
+					Path:       interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
+					BorrowType: interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
+				}
+			},
+			expectedValue: func(_ *interpreter.Interpreter) interpreter.Value {
+				return &interpreter.PathCapabilityValue{ //nolint:staticcheck
+					Address:    interpreter.NewAddressValue(nil, common.Address{0x42}),
+					Path:       interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
+					BorrowType: unauthorizedAccountReferenceType,
+				}
+			},
+			validateStorage: true,
+		},
+		"capability_dictionary": {
+			storedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewDictionaryValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeString,
+						interpreter.NewCapabilityStaticType(
+							nil,
+							interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
+						),
+					),
+					interpreter.NewUnmeteredStringValue("key"),
+					interpreter.NewCapabilityValue(
+						nil,
+						interpreter.NewUnmeteredUInt64Value(1234),
+						interpreter.NewAddressValue(nil, common.Address{}),
+						interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
+					),
+				)
+			},
+			expectedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				return interpreter.NewDictionaryValue(
+					inter,
+					interpreter.EmptyLocationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeString,
+						interpreter.NewCapabilityStaticType(
+							nil,
+							unauthorizedAccountReferenceType,
+						),
+					),
+					interpreter.NewUnmeteredStringValue("key"),
+					interpreter.NewCapabilityValue(
+						nil,
+						interpreter.NewUnmeteredUInt64Value(1234),
+						interpreter.NewAddressValue(nil, common.Address{}),
+						unauthorizedAccountReferenceType,
+					),
+				)
+			},
+			// NOTE: disabled, as storage is not expected to be always valid _during_ migration
+			validateStorage: false,
+		},
+	}
 
-	err = migration.Commit()
-	require.NoError(t, err)
+	test := func(name string, testCase testCase) {
 
-	err = storage.CheckHealth()
-	require.NoError(t, err)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	require.Empty(t, reporter.errors)
+			ledger := NewTestLedger(nil, nil)
+			storage := runtime.NewStorage(ledger, nil)
 
-	// Assert: Traverse through the storage and see if the values are updated now.
+			inter, err := interpreter.NewInterpreter(
+				nil,
+				utils.TestLocation,
+				&interpreter.Config{
+					Storage:                       storage,
+					AtreeValueValidationEnabled:   true,
+					AtreeStorageValidationEnabled: testCase.validateStorage,
+				},
+			)
+			require.NoError(t, err)
 
-	storageMap := storage.GetStorageMap(account, pathDomain.Identifier(), false)
-	require.NotNil(t, storageMap)
-	require.Greater(t, storageMap.Count(), uint64(0))
+			// Store values
 
-	iterator := storageMap.Iterator(inter)
+			transferredValue := testCase.storedValue(inter).Transfer(
+				inter,
+				interpreter.EmptyLocationRange,
+				atree.Address(account),
+				false,
+				nil,
+				nil,
+			)
 
-	for key, value := iterator.Next(); key != nil; key, value = iterator.Next() {
-		identifier := string(key.(interpreter.StringAtreeValue))
+			inter.WriteStored(
+				account,
+				pathDomain.Identifier(),
+				interpreter.StringStorageMapKey(name),
+				transferredValue,
+			)
 
-		t.Run(identifier, func(t *testing.T) {
-			testCase, ok := testCases[identifier]
-			require.True(t, ok)
+			err = storage.Commit(inter, true)
+			require.NoError(t, err)
+
+			// Migrate
+
+			migration := migrations.NewStorageMigration(inter, storage)
+
+			reporter := newTestReporter()
+
+			migration.Migrate(
+				&migrations.AddressSliceIterator{
+					Addresses: []common.Address{
+						account,
+					},
+				},
+				migration.NewValueMigrationsPathMigrator(
+					reporter,
+					NewStaticTypeMigration(),
+				),
+			)
+
+			err = migration.Commit()
+			require.NoError(t, err)
+
+			// Assert
+
+			require.Empty(t, reporter.errors)
+
+			err = storage.CheckHealth()
+			require.NoError(t, err)
+
+			storageMap := storage.GetStorageMap(account, pathDomain.Identifier(), false)
+			require.NotNil(t, storageMap)
+			require.Equal(t, uint64(1), storageMap.Count())
+
+			value := storageMap.ReadValue(nil, interpreter.StringStorageMapKey(name))
 
 			expectedStoredValue := testCase.expectedValue
 			if expectedStoredValue == nil {
 				expectedStoredValue = testCase.storedValue
 			}
 
-			utils.AssertValuesEqual(t, inter, expectedStoredValue, value)
+			utils.AssertValuesEqual(t, inter, expectedStoredValue(inter), value)
 		})
+	}
+
+	for name, testCase := range testCases {
+		test(name, testCase)
 	}
 }
 
@@ -1238,10 +1334,12 @@ func TestAccountTypeRehash(t *testing.T) {
 		err := migration.Commit()
 		require.NoError(t, err)
 
-		err = storage.CheckHealth()
-		require.NoError(t, err)
+		// Assert
 
 		require.Empty(t, reporter.errors)
+
+		err = storage.CheckHealth()
+		require.NoError(t, err)
 
 		require.Equal(t,
 			map[struct {

--- a/migrations/statictypes/account_type_migration_test.go
+++ b/migrations/statictypes/account_type_migration_test.go
@@ -236,7 +236,7 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 				[]*interpreter.InterfaceStaticType{
 					interpreter.NewInterfaceStaticType(
 						nil,
-						nil,
+						fooAddressLocation,
 						fooBarQualifiedIdentifier,
 						common.NewTypeIDFromQualifiedName(
 							nil,
@@ -251,7 +251,7 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 				[]*interpreter.InterfaceStaticType{
 					interpreter.NewInterfaceStaticType(
 						nil,
-						nil,
+						fooAddressLocation,
 						fooBarQualifiedIdentifier,
 						common.NewTypeIDFromQualifiedName(
 							nil,
@@ -267,7 +267,7 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 				Types: []*interpreter.InterfaceStaticType{},
 				LegacyType: interpreter.NewCompositeStaticType(
 					nil,
-					nil,
+					fooAddressLocation,
 					fooBarQualifiedIdentifier,
 					common.NewTypeIDFromQualifiedName(
 						nil,
@@ -278,7 +278,7 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 			},
 			expectedType: interpreter.NewCompositeStaticType(
 				nil,
-				nil,
+				fooAddressLocation,
 				fooBarQualifiedIdentifier,
 				common.NewTypeIDFromQualifiedName(
 					nil,
@@ -341,7 +341,7 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 		"non_intersection_interface": {
 			storedType: interpreter.NewInterfaceStaticType(
 				nil,
-				nil,
+				fooAddressLocation,
 				fooBarQualifiedIdentifier,
 				common.NewTypeIDFromQualifiedName(
 					nil,
@@ -354,7 +354,7 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 				[]*interpreter.InterfaceStaticType{
 					interpreter.NewInterfaceStaticType(
 						nil,
-						nil,
+						fooAddressLocation,
 						fooBarQualifiedIdentifier,
 						common.NewTypeIDFromQualifiedName(
 							nil,
@@ -371,7 +371,7 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 				[]*interpreter.InterfaceStaticType{
 					interpreter.NewInterfaceStaticType(
 						nil,
-						nil,
+						fooAddressLocation,
 						fooBarQualifiedIdentifier,
 						common.NewTypeIDFromQualifiedName(
 							nil,
@@ -386,7 +386,7 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 				[]*interpreter.InterfaceStaticType{
 					interpreter.NewInterfaceStaticType(
 						nil,
-						nil,
+						fooAddressLocation,
 						fooBarQualifiedIdentifier,
 						common.NewTypeIDFromQualifiedName(
 							nil,
@@ -400,7 +400,7 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 		"composite": {
 			storedType: interpreter.NewCompositeStaticType(
 				nil,
-				nil,
+				fooAddressLocation,
 				fooBarQualifiedIdentifier,
 				common.NewTypeIDFromQualifiedName(
 					nil,
@@ -447,7 +447,7 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 				utils.TestLocation,
 				&interpreter.Config{
 					Storage:                       storage,
-					AtreeValueValidationEnabled:   false,
+					AtreeValueValidationEnabled:   true,
 					AtreeStorageValidationEnabled: true,
 				},
 			)
@@ -1142,7 +1142,8 @@ func TestAccountTypeRehash(t *testing.T) {
 			nil,
 			utils.TestLocation,
 			&interpreter.Config{
-				Storage:                       storage,
+				Storage: storage,
+				// NOTE: atree value validation is disabled
 				AtreeValueValidationEnabled:   false,
 				AtreeStorageValidationEnabled: true,
 			},

--- a/migrations/statictypes/composite_type_migration_test.go
+++ b/migrations/statictypes/composite_type_migration_test.go
@@ -185,10 +185,12 @@ func TestCompositeAndInterfaceTypeMigration(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
-	err = storage.CheckHealth()
-	require.NoError(t, err)
+	// Assert
 
 	require.Empty(t, reporter.errors)
+
+	err = storage.CheckHealth()
+	require.NoError(t, err)
 
 	// Check reported migrated paths
 	for identifier, test := range testCases {

--- a/migrations/statictypes/composite_type_migration_test.go
+++ b/migrations/statictypes/composite_type_migration_test.go
@@ -185,6 +185,9 @@ func TestCompositeAndInterfaceTypeMigration(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
 	require.Empty(t, reporter.errors)
 
 	// Check reported migrated paths

--- a/migrations/statictypes/composite_type_migration_test.go
+++ b/migrations/statictypes/composite_type_migration_test.go
@@ -46,8 +46,8 @@ func TestCompositeAndInterfaceTypeMigration(t *testing.T) {
 	newCompositeType := func() *interpreter.CompositeStaticType {
 		return interpreter.NewCompositeStaticType(
 			nil,
-			nil,
-			"Bar",
+			fooAddressLocation,
+			fooBarQualifiedIdentifier,
 			common.NewTypeIDFromQualifiedName(
 				nil,
 				fooAddressLocation,
@@ -59,8 +59,8 @@ func TestCompositeAndInterfaceTypeMigration(t *testing.T) {
 	newInterfaceType := func() *interpreter.InterfaceStaticType {
 		return interpreter.NewInterfaceStaticType(
 			nil,
-			nil,
-			"Baz",
+			fooAddressLocation,
+			fooBazQualifiedIdentifier,
 			common.NewTypeIDFromQualifiedName(
 				nil,
 				fooAddressLocation,
@@ -124,7 +124,7 @@ func TestCompositeAndInterfaceTypeMigration(t *testing.T) {
 		utils.TestLocation,
 		&interpreter.Config{
 			Storage:                       storage,
-			AtreeValueValidationEnabled:   false,
+			AtreeValueValidationEnabled:   true,
 			AtreeStorageValidationEnabled: true,
 		},
 	)

--- a/migrations/statictypes/intersection_type_migration_test.go
+++ b/migrations/statictypes/intersection_type_migration_test.go
@@ -295,8 +295,8 @@ func TestIntersectionTypeMigration(t *testing.T) {
 		"non_intersection_interface": {
 			storedType: interpreter.NewInterfaceStaticType(
 				nil,
-				nil,
-				"Foo.Bar",
+				fooAddressLocation,
+				fooBarQualifiedIdentifier,
 				common.NewTypeIDFromQualifiedName(
 					nil,
 					fooAddressLocation,
@@ -308,8 +308,8 @@ func TestIntersectionTypeMigration(t *testing.T) {
 				[]*interpreter.InterfaceStaticType{
 					interpreter.NewInterfaceStaticType(
 						nil,
-						nil,
-						"Foo.Bar",
+						fooAddressLocation,
+						fooBarQualifiedIdentifier,
 						common.NewTypeIDFromQualifiedName(
 							nil,
 							fooAddressLocation,
@@ -325,8 +325,8 @@ func TestIntersectionTypeMigration(t *testing.T) {
 				[]*interpreter.InterfaceStaticType{
 					interpreter.NewInterfaceStaticType(
 						nil,
-						nil,
-						"Foo.Bar",
+						fooAddressLocation,
+						fooBarQualifiedIdentifier,
 						common.NewTypeIDFromQualifiedName(
 							nil,
 							fooAddressLocation,
@@ -340,8 +340,8 @@ func TestIntersectionTypeMigration(t *testing.T) {
 				[]*interpreter.InterfaceStaticType{
 					interpreter.NewInterfaceStaticType(
 						nil,
-						nil,
-						"Foo.Bar",
+						fooAddressLocation,
+						fooBarQualifiedIdentifier,
 						common.NewTypeIDFromQualifiedName(
 							nil,
 							fooAddressLocation,
@@ -355,7 +355,7 @@ func TestIntersectionTypeMigration(t *testing.T) {
 		"composite": {
 			storedType: interpreter.NewCompositeStaticType(
 				nil,
-				nil,
+				fooAddressLocation,
 				"Foo.Bar",
 				common.NewTypeIDFromQualifiedName(
 					nil,
@@ -377,7 +377,7 @@ func TestIntersectionTypeMigration(t *testing.T) {
 		utils.TestLocation,
 		&interpreter.Config{
 			Storage:                       storage,
-			AtreeValueValidationEnabled:   false,
+			AtreeValueValidationEnabled:   true,
 			AtreeStorageValidationEnabled: true,
 		},
 	)
@@ -503,7 +503,7 @@ func TestIntersectionTypeRehash(t *testing.T) {
 			utils.TestLocation,
 			&interpreter.Config{
 				Storage:                       storage,
-				AtreeValueValidationEnabled:   false,
+				AtreeValueValidationEnabled:   true,
 				AtreeStorageValidationEnabled: true,
 			},
 		)
@@ -659,7 +659,7 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 			utils.TestLocation,
 			&interpreter.Config{
 				Storage:                       storage,
-				AtreeValueValidationEnabled:   false,
+				AtreeValueValidationEnabled:   true,
 				AtreeStorageValidationEnabled: true,
 			},
 		)
@@ -1014,7 +1014,7 @@ func TestIntersectionTypeMigrationWithInterfaceTypeConverter(t *testing.T) {
 			utils.TestLocation,
 			&interpreter.Config{
 				Storage:                       storage,
-				AtreeValueValidationEnabled:   false,
+				AtreeValueValidationEnabled:   true,
 				AtreeStorageValidationEnabled: true,
 			},
 		)
@@ -1411,7 +1411,7 @@ func TestIntersectionTypeMigrationWithTypeConverters(t *testing.T) {
 			utils.TestLocation,
 			&interpreter.Config{
 				Storage:                       storage,
-				AtreeValueValidationEnabled:   false,
+				AtreeValueValidationEnabled:   true,
 				AtreeStorageValidationEnabled: true,
 			},
 		)

--- a/migrations/statictypes/intersection_type_migration_test.go
+++ b/migrations/statictypes/intersection_type_migration_test.go
@@ -417,6 +417,9 @@ func TestIntersectionTypeMigration(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
 	require.Empty(t, reporter.errors)
 
 	// Assert the migrated values.
@@ -582,6 +585,9 @@ func TestIntersectionTypeRehash(t *testing.T) {
 		)
 
 		err := migration.Commit()
+		require.NoError(t, err)
+
+		err = storage.CheckHealth()
 		require.NoError(t, err)
 
 		require.Empty(t, reporter.errors)
@@ -750,6 +756,9 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 			err := migration.Commit()
 			require.NoError(t, err)
 
+			err = storage.CheckHealth()
+			require.NoError(t, err)
+
 			require.Empty(t, reporter.errors)
 
 			require.Equal(t,
@@ -889,6 +898,9 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 			)
 
 			err := migration.Commit()
+			require.NoError(t, err)
+
+			err = storage.CheckHealth()
 			require.NoError(t, err)
 
 			require.Empty(t, reporter.errors)
@@ -1063,6 +1075,9 @@ func TestIntersectionTypeMigrationWithInterfaceTypeConverter(t *testing.T) {
 		)
 
 		err = migration.Commit()
+		require.NoError(t, err)
+
+		err = storage.CheckHealth()
 		require.NoError(t, err)
 
 		require.Empty(t, reporter.errors)
@@ -1435,6 +1450,9 @@ func TestIntersectionTypeMigrationWithTypeConverters(t *testing.T) {
 		)
 
 		err = migration.Commit()
+		require.NoError(t, err)
+
+		err = storage.CheckHealth()
 		require.NoError(t, err)
 
 		require.Empty(t, reporter.errors)

--- a/migrations/statictypes/intersection_type_migration_test.go
+++ b/migrations/statictypes/intersection_type_migration_test.go
@@ -417,10 +417,12 @@ func TestIntersectionTypeMigration(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
-	err = storage.CheckHealth()
-	require.NoError(t, err)
+	// Assert
 
 	require.Empty(t, reporter.errors)
+
+	err = storage.CheckHealth()
+	require.NoError(t, err)
 
 	// Assert the migrated values.
 	// Traverse through the storage and see if the values are updated now.
@@ -587,10 +589,12 @@ func TestIntersectionTypeRehash(t *testing.T) {
 		err := migration.Commit()
 		require.NoError(t, err)
 
-		err = storage.CheckHealth()
-		require.NoError(t, err)
+		// Assert
 
 		require.Empty(t, reporter.errors)
+
+		err = storage.CheckHealth()
+		require.NoError(t, err)
 
 		require.Equal(t,
 			map[struct {
@@ -756,10 +760,12 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 			err := migration.Commit()
 			require.NoError(t, err)
 
-			err = storage.CheckHealth()
-			require.NoError(t, err)
+			// Assert
 
 			require.Empty(t, reporter.errors)
+
+			err = storage.CheckHealth()
+			require.NoError(t, err)
 
 			require.Equal(t,
 				map[struct {
@@ -900,10 +906,12 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 			err := migration.Commit()
 			require.NoError(t, err)
 
-			err = storage.CheckHealth()
-			require.NoError(t, err)
+			// Assert
 
 			require.Empty(t, reporter.errors)
+
+			err = storage.CheckHealth()
+			require.NoError(t, err)
 
 			require.Equal(t,
 				map[struct {
@@ -1077,10 +1085,12 @@ func TestIntersectionTypeMigrationWithInterfaceTypeConverter(t *testing.T) {
 		err = migration.Commit()
 		require.NoError(t, err)
 
-		err = storage.CheckHealth()
-		require.NoError(t, err)
+		// Assert
 
 		require.Empty(t, reporter.errors)
+
+		err = storage.CheckHealth()
+		require.NoError(t, err)
 
 		// Assert the migrated value.
 
@@ -1452,10 +1462,12 @@ func TestIntersectionTypeMigrationWithTypeConverters(t *testing.T) {
 		err = migration.Commit()
 		require.NoError(t, err)
 
-		err = storage.CheckHealth()
-		require.NoError(t, err)
+		// Assert
 
 		require.Empty(t, reporter.errors)
+
+		err = storage.CheckHealth()
+		require.NoError(t, err)
 
 		key := struct {
 			interpreter.StorageKey

--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -136,16 +136,10 @@ func (m *StaticTypeMigration) Migrate(
 			return
 		}
 
-		iterator := value.Iterator(inter, interpreter.EmptyLocationRange)
-
-		return interpreter.NewArrayValueWithIterator(
+		return value.NewWithType(
 			inter,
+			interpreter.EmptyLocationRange,
 			convertedElementType.(interpreter.ArrayStaticType),
-			value.GetOwner(),
-			uint64(value.Count()),
-			func() interpreter.Value {
-				return iterator.Next(inter, interpreter.EmptyLocationRange)
-			},
 		), nil
 
 	case *interpreter.DictionaryValue:

--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -21,6 +21,8 @@ package statictypes
 import (
 	"fmt"
 
+	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/migrations"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
@@ -154,27 +156,57 @@ func (m *StaticTypeMigration) Migrate(
 			return
 		}
 
-		var keysAndValues []interpreter.Value
-
-		iterator := value.Iterator()
-
-		for {
-			keyValue, value := iterator.Next(inter)
-			if keyValue == nil {
-				break
-			}
-
-			keysAndValues = append(keysAndValues, keyValue)
-			keysAndValues = append(keysAndValues, value)
-		}
-
-		return interpreter.NewDictionaryValueWithAddress(
+		newDictionary := interpreter.NewDictionaryValueWithAddress(
 			inter,
 			interpreter.EmptyLocationRange,
 			convertedElementType.(*interpreter.DictionaryStaticType),
 			value.GetOwner(),
-			keysAndValues...,
-		), nil
+		)
+
+		var keys []atree.Value
+
+		iterator := value.Iterator()
+
+		for {
+			key := iterator.NextKeyUnconverted()
+			if key == nil {
+				break
+			}
+
+			keys = append(keys, key)
+		}
+
+		storage := inter.Storage()
+
+		for _, key := range keys {
+			existingKeyStorable, existingValueStorable := value.RemoveWithoutTransfer(
+				inter,
+				interpreter.EmptyLocationRange,
+				key,
+			)
+			if existingKeyStorable == nil || existingValueStorable == nil {
+				panic(errors.NewUnreachableError())
+			}
+
+			newKey, err := existingKeyStorable.StoredValue(storage)
+			if err != nil {
+				panic(err)
+			}
+
+			newValue, err := existingValueStorable.StoredValue(storage)
+			if err != nil {
+				panic(err)
+			}
+
+			newDictionary.InsertWithoutTransfer(
+				inter,
+				interpreter.EmptyLocationRange,
+				newKey,
+				newValue,
+			)
+		}
+
+		return newDictionary, nil
 	}
 
 	return

--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -21,8 +21,6 @@ package statictypes
 import (
 	"fmt"
 
-	"github.com/onflow/atree"
-
 	"github.com/onflow/cadence/migrations"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
@@ -156,57 +154,11 @@ func (m *StaticTypeMigration) Migrate(
 			return
 		}
 
-		newDictionary := interpreter.NewDictionaryValueWithAddress(
+		return value.NewWithType(
 			inter,
 			interpreter.EmptyLocationRange,
 			convertedElementType.(*interpreter.DictionaryStaticType),
-			value.GetOwner(),
-		)
-
-		var keys []atree.Value
-
-		iterator := value.Iterator()
-
-		for {
-			key := iterator.NextKeyUnconverted()
-			if key == nil {
-				break
-			}
-
-			keys = append(keys, key)
-		}
-
-		storage := inter.Storage()
-
-		for _, key := range keys {
-			existingKeyStorable, existingValueStorable := value.RemoveWithoutTransfer(
-				inter,
-				interpreter.EmptyLocationRange,
-				key,
-			)
-			if existingKeyStorable == nil || existingValueStorable == nil {
-				panic(errors.NewUnreachableError())
-			}
-
-			newKey, err := existingKeyStorable.StoredValue(storage)
-			if err != nil {
-				panic(err)
-			}
-
-			newValue, err := existingValueStorable.StoredValue(storage)
-			if err != nil {
-				panic(err)
-			}
-
-			newDictionary.InsertWithoutTransfer(
-				inter,
-				interpreter.EmptyLocationRange,
-				newKey,
-				newValue,
-			)
-		}
-
-		return newDictionary, nil
+		), nil
 	}
 
 	return

--- a/migrations/statictypes/statictype_migration_test.go
+++ b/migrations/statictypes/statictype_migration_test.go
@@ -41,6 +41,7 @@ func TestStaticTypeMigration(t *testing.T) {
 		t *testing.T,
 		staticTypeMigration *StaticTypeMigration,
 		value interpreter.Value,
+		atreeValueValidationEnabled bool,
 	) interpreter.Value {
 
 		// Store values
@@ -53,7 +54,7 @@ func TestStaticTypeMigration(t *testing.T) {
 			utils.TestLocation,
 			&interpreter.Config{
 				Storage:                       storage,
-				AtreeValueValidationEnabled:   false,
+				AtreeValueValidationEnabled:   atreeValueValidationEnabled,
 				AtreeStorageValidationEnabled: true,
 			},
 		)
@@ -93,10 +94,12 @@ func TestStaticTypeMigration(t *testing.T) {
 		err = migration.Commit()
 		require.NoError(t, err)
 
+		// Assert
+
+		require.Empty(t, reporter.errors)
+
 		err = storage.CheckHealth()
 		require.NoError(t, err)
-
-		assert.Empty(t, reporter.errors)
 
 		storageMap := storage.GetStorageMap(
 			testAddress,
@@ -120,6 +123,10 @@ func TestStaticTypeMigration(t *testing.T) {
 		actual := migrate(t,
 			staticTypeMigration,
 			interpreter.NewTypeValue(nil, nil),
+			// NOTE: atree value validation is disabled,
+			// because the type value has a nil type (which indicates an invalid or unknown type),
+			// and invalid unknown types are always unequal
+			false,
 		)
 		assert.Equal(t,
 			interpreter.NewTypeValue(nil, nil),
@@ -144,6 +151,7 @@ func TestStaticTypeMigration(t *testing.T) {
 				Path:       path,
 				Address:    interpreter.AddressValue(testAddress),
 			},
+			true,
 		)
 		assert.Equal(t,
 			&interpreter.PathCapabilityValue{ //nolint:staticcheck
@@ -181,6 +189,7 @@ func TestStaticTypeMigration(t *testing.T) {
 						},
 					},
 				),
+				true,
 			)
 			assert.Equal(t,
 				interpreter.NewUnmeteredTypeValue(
@@ -220,6 +229,7 @@ func TestStaticTypeMigration(t *testing.T) {
 						},
 					},
 				),
+				true,
 			)
 			assert.Equal(t,
 				interpreter.NewUnmeteredTypeValue(
@@ -268,6 +278,7 @@ func TestStaticTypeMigration(t *testing.T) {
 						LegacyType: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
 				),
+				true,
 			)
 			assert.Equal(t,
 				interpreter.NewUnmeteredTypeValue(
@@ -307,6 +318,7 @@ func TestStaticTypeMigration(t *testing.T) {
 						},
 					},
 				),
+				true,
 			)
 			assert.Equal(t,
 				interpreter.NewUnmeteredTypeValue(
@@ -347,6 +359,7 @@ func TestStaticTypeMigration(t *testing.T) {
 						LegacyType: interpreter.PrimitiveStaticTypeAnyResource,
 					},
 				),
+				true,
 			)
 			assert.Equal(t,
 				interpreter.NewUnmeteredTypeValue(
@@ -386,6 +399,7 @@ func TestStaticTypeMigration(t *testing.T) {
 						},
 					},
 				),
+				true,
 			)
 			assert.Equal(t,
 				interpreter.NewUnmeteredTypeValue(
@@ -424,6 +438,7 @@ func TestStaticTypeMigration(t *testing.T) {
 						LegacyType: interpreter.PrimitiveStaticTypeAnyStruct,
 					},
 				),
+				true,
 			)
 			assert.Equal(t,
 				interpreter.NewUnmeteredTypeValue(
@@ -449,6 +464,7 @@ func TestStaticTypeMigration(t *testing.T) {
 						},
 					},
 				),
+				true,
 			)
 			assert.Equal(t,
 				interpreter.NewUnmeteredTypeValue(
@@ -477,6 +493,7 @@ func TestStaticTypeMigration(t *testing.T) {
 						LegacyType: interpreter.PrimitiveStaticTypeAnyResource,
 					},
 				),
+				true,
 			)
 			assert.Equal(t,
 				interpreter.NewUnmeteredTypeValue(
@@ -502,6 +519,7 @@ func TestStaticTypeMigration(t *testing.T) {
 						},
 					},
 				),
+				true,
 			)
 			assert.Equal(t,
 				interpreter.NewUnmeteredTypeValue(
@@ -533,6 +551,7 @@ func TestStaticTypeMigration(t *testing.T) {
 						},
 					},
 				),
+				true,
 			)
 			assert.Equal(t,
 				interpreter.NewUnmeteredTypeValue(
@@ -565,6 +584,7 @@ func TestStaticTypeMigration(t *testing.T) {
 						},
 					},
 				),
+				true,
 			)
 			assert.Equal(t,
 				interpreter.NewUnmeteredTypeValue(
@@ -642,10 +662,12 @@ func TestMigratingNestedContainers(t *testing.T) {
 		err = migration.Commit()
 		require.NoError(t, err)
 
+		// Assert
+
+		require.Empty(t, reporter.errors)
+
 		err = storage.CheckHealth()
 		require.NoError(t, err)
-
-		assert.Empty(t, reporter.errors)
 
 		storageMap := storage.GetStorageMap(
 			testAddress,
@@ -675,8 +697,9 @@ func TestMigratingNestedContainers(t *testing.T) {
 			nil,
 			utils.TestLocation,
 			&interpreter.Config{
-				Storage:                       storage,
-				AtreeValueValidationEnabled:   false,
+				Storage:                     storage,
+				AtreeValueValidationEnabled: true,
+				// NOTE: disabled, as storage is not expected to be always valid _during_ migration
 				AtreeStorageValidationEnabled: false,
 			},
 		)

--- a/migrations/statictypes/statictype_migration_test.go
+++ b/migrations/statictypes/statictype_migration_test.go
@@ -93,7 +93,10 @@ func TestStaticTypeMigration(t *testing.T) {
 		err = migration.Commit()
 		require.NoError(t, err)
 
-		require.Empty(t, reporter.errors)
+		err = storage.CheckHealth()
+		require.NoError(t, err)
+
+		assert.Empty(t, reporter.errors)
 
 		storageMap := storage.GetStorageMap(
 			testAddress,
@@ -639,7 +642,10 @@ func TestMigratingNestedContainers(t *testing.T) {
 		err = migration.Commit()
 		require.NoError(t, err)
 
-		require.Empty(t, reporter.errors)
+		err = storage.CheckHealth()
+		require.NoError(t, err)
+
+		assert.Empty(t, reporter.errors)
 
 		storageMap := storage.GetStorageMap(
 			testAddress,

--- a/migrations/statictypes/statictype_migration_test.go
+++ b/migrations/statictypes/statictype_migration_test.go
@@ -619,7 +619,7 @@ func TestMigratingNestedContainers(t *testing.T) {
 
 		// Store values
 
-		storageMapKey := interpreter.StringStorageMapKey("test_type_value")
+		storageMapKey := interpreter.StringStorageMapKey("test_value")
 		storageDomain := common.PathDomainStorage.Identifier()
 
 		value = value.Transfer(

--- a/migrations/string_normalization/migration_test.go
+++ b/migrations/string_normalization/migration_test.go
@@ -53,9 +53,10 @@ func TestStringNormalizingMigration(t *testing.T) {
 		nil,
 		utils.TestLocation,
 		&interpreter.Config{
-			Storage:                       storage,
+			Storage: storage,
+			// NOTE: disabled, because encoded and decoded values are expected to not match
 			AtreeValueValidationEnabled:   false,
-			AtreeStorageValidationEnabled: false,
+			AtreeStorageValidationEnabled: true,
 		},
 	)
 	require.NoError(t, err)
@@ -329,7 +330,8 @@ func TestStringValueRehash(t *testing.T) {
 			nil,
 			utils.TestLocation,
 			&interpreter.Config{
-				Storage:                       storage,
+				Storage: storage,
+				// NOTE: disabled, because encoded and decoded values are expected to not match
 				AtreeValueValidationEnabled:   false,
 				AtreeStorageValidationEnabled: true,
 			},
@@ -470,7 +472,8 @@ func TestCharacterValueRehash(t *testing.T) {
 			nil,
 			utils.TestLocation,
 			&interpreter.Config{
-				Storage:                       storage,
+				Storage: storage,
+				// NOTE: disabled, because encoded and decoded values are expected to not match
 				AtreeValueValidationEnabled:   false,
 				AtreeStorageValidationEnabled: true,
 			},

--- a/migrations/string_normalization/migration_test.go
+++ b/migrations/string_normalization/migration_test.go
@@ -277,6 +277,9 @@ func TestStringNormalizingMigration(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
+	err = storage.CheckHealth()
+	require.NoError(t, err)
+
 	// Assert: Traverse through the storage and see if the values are updated now.
 
 	storageMap := storage.GetStorageMap(account, pathDomain.Identifier(), false)
@@ -414,6 +417,9 @@ func TestStringValueRehash(t *testing.T) {
 	t.Run("load", func(t *testing.T) {
 
 		storage, inter := newStorageAndInterpreter(t)
+
+		err := storage.CheckHealth()
+		require.NoError(t, err)
 
 		storageMap := storage.GetStorageMap(testAddress, common.PathDomainStorage.Identifier(), false)
 		storedValue := storageMap.ReadValue(inter, storageMapKey)
@@ -553,6 +559,9 @@ func TestCharacterValueRehash(t *testing.T) {
 	t.Run("load", func(t *testing.T) {
 
 		storage, inter := newStorageAndInterpreter(t)
+
+		err := storage.CheckHealth()
+		require.NoError(t, err)
 
 		storageMap := storage.GetStorageMap(testAddress, common.PathDomainStorage.Identifier(), false)
 		storedValue := storageMap.ReadValue(inter, storageMapKey)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -17271,7 +17271,7 @@ func (v *CompositeValue) RemoveMember(
 		)
 }
 
-func (v *CompositeValue) SetMember(
+func (v *CompositeValue) SetMemberWithoutTransfer(
 	interpreter *Interpreter,
 	locationRange LocationRange,
 	name string,
@@ -17299,19 +17299,6 @@ func (v *CompositeValue) SetMember(
 		}()
 	}
 
-	address := v.StorageAddress()
-
-	value = value.Transfer(
-		interpreter,
-		locationRange,
-		address,
-		true,
-		nil,
-		map[atree.StorageID]struct{}{
-			v.StorageID(): {},
-		},
-	)
-
 	existingStorable, err := v.dictionary.Set(
 		StringAtreeValueComparator,
 		StringAtreeValueHashInput,
@@ -17333,6 +17320,33 @@ func (v *CompositeValue) SetMember(
 	}
 
 	return false
+}
+
+func (v *CompositeValue) SetMember(
+	interpreter *Interpreter,
+	locationRange LocationRange,
+	name string,
+	value Value,
+) bool {
+	address := v.StorageAddress()
+
+	value = value.Transfer(
+		interpreter,
+		locationRange,
+		address,
+		true,
+		nil,
+		map[atree.StorageID]struct{}{
+			v.StorageID(): {},
+		},
+	)
+
+	return v.SetMemberWithoutTransfer(
+		interpreter,
+		locationRange,
+		name,
+		value,
+	)
 }
 
 func (v *CompositeValue) String() string {

--- a/runtime/interpreter/value_link.go
+++ b/runtime/interpreter/value_link.go
@@ -278,7 +278,7 @@ func (v AccountLinkValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) 
 }
 
 func (v AccountLinkValue) ChildStorables() []atree.Storable {
-	panic(errors.NewUnreachableError())
+	return nil
 }
 
 // NOTE: NEVER change, only add/increment; ensure uint64

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -4187,3 +4187,47 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 	})
 
 }
+
+func TestDictionaryValue_NewWithType(t *testing.T) {
+
+	t.Parallel()
+
+	inter := newTestInterpreter(t)
+
+	address := common.Address{0x1}
+
+	newDictionaryValue := func(dictionaryType *DictionaryStaticType) *DictionaryValue {
+		return NewDictionaryValueWithAddress(
+			inter,
+			EmptyLocationRange,
+			dictionaryType,
+			address,
+			NewUnmeteredStringValue("a"),
+			NewUnmeteredIntValueFromInt64(1),
+			NewUnmeteredStringValue("b"),
+			NewUnmeteredIntValueFromInt64(2),
+			NewUnmeteredStringValue("c"),
+			NewUnmeteredIntValueFromInt64(3),
+		)
+	}
+
+	oldType := &DictionaryStaticType{
+		KeyType:   PrimitiveStaticTypeString,
+		ValueType: PrimitiveStaticTypeAnyStruct,
+	}
+
+	newType := &DictionaryStaticType{
+		KeyType:   PrimitiveStaticTypeString,
+		ValueType: PrimitiveStaticTypeInt,
+	}
+
+	require.True(t,
+		newDictionaryValue(oldType).
+			NewWithType(inter, EmptyLocationRange, newType).
+			Equal(
+				inter,
+				EmptyLocationRange,
+				newDictionaryValue(newType),
+			),
+	)
+}

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -4231,3 +4231,42 @@ func TestDictionaryValue_NewWithType(t *testing.T) {
 			),
 	)
 }
+
+func TestArrayValue_NewWithType(t *testing.T) {
+
+	t.Parallel()
+
+	inter := newTestInterpreter(t)
+
+	address := common.Address{0x1}
+
+	newArrayValue := func(arrayType ArrayStaticType) *ArrayValue {
+		return NewArrayValue(
+			inter,
+			EmptyLocationRange,
+			arrayType,
+			address,
+			NewUnmeteredStringValue("a"),
+			NewUnmeteredStringValue("b"),
+			NewUnmeteredStringValue("c"),
+		)
+	}
+
+	oldType := &VariableSizedStaticType{
+		Type: PrimitiveStaticTypeAnyStruct,
+	}
+
+	newType := &VariableSizedStaticType{
+		Type: PrimitiveStaticTypeString,
+	}
+
+	require.True(t,
+		newArrayValue(oldType).
+			NewWithType(inter, EmptyLocationRange, newType).
+			Equal(
+				inter,
+				EmptyLocationRange,
+				newArrayValue(newType),
+			),
+	)
+}


### PR DESCRIPTION
Work towards #3096 and #3149

## Description

Great suggestion by @fxamacker: Perform a atree storage health check after each migration, to ensure individual migrations produce valid outcomes.

This currently fails for some tests:
- `statictypes.TestMigratingNestedContainers/nested_dictionary`:
  ```
  internal error: slabs not referenced from account Storage: [0x4200000000000000.4]
  ```

- `entitlements.TestMigrateSimpleContract`:

  ```
  parent and child are not owned by the same account: child.owner ��������, parent.owner B�������
  ```

### Fixes, improvements, and additions to tests

- Add atree storage health checks to tests after committing migrations - but only if there were no errors
- Enable atree value validation where possible. It is not always possible, because e.g legacy values / static types and dummy static types cause a (correct) mismatch 
- Enable atree storage health checking during tests where possible. It is not always possible, because during the migration storage might be in an invalid state, e.g. when moving a value from an old value to a new one 
- Fix: test values must be transferred to account before adding them to a storage map
- Add more tests for static type migration of nested containers: In addition to dictionaries, also test nested arrays
- Add tests for general storage migration of nested containers: Test nested dictionaries, arrays, and composites. This is similar to nested container tests in static type migration, but also tests composites, which are not migrated by the static type migration
- Fix incorrect locations and qualified identifiers of test types. They did not match the type IDs
- Refactor the static type migration tests, so each test value is independently written, migrated, and asserted. This makes pin-pointing issues easier

### Fixes for migration

The health checks identified several issues, such as missing data or unreferenced data (garbage).

Fix this in general by changing the migrations so that they properly remove old child values from old containers, without transferring them to the stack, and inserting them into the (potentially new) target container, again without transferring them.

The assumption of the container operation functions, e.g. `DictionaryValue.Insert` or `ArrayValue.Remove`, is that the input is on the stack, and the result (if any) is also returned on the stack, even if the container itself is in a non-zero address account.

During the migration, all values are always in the account that is currently migrated, and values are never on the stack.

To properly move child values between or inside containers, add new function `*WithoutTransfer` functions to `DictionaryValue`, `ArrayValue`, and `CompositeValue`, e.g. `DictionaryValue.InsertWithoutTransfer`, and use them in the migration. The existing functions for performing operations on containers, like `DictionaryValue.Insert` still perform the same: they transfer the value from the stack to the container and call into the non-transfer variant of the function (e.g. for insertion), or call into the non-transfer function and transfer the result from the account to the stack.

Finally, introduce `NewWithType` functions for dictionaries and arrays, and use them in the static type and entitlements migration. They create a new container, with the given type, and move all children to the new container. This is currently needed for these migrations, as it is not (yet) possible to change the type of containers.

Once atree exposes functions to change the type of containers directly, we can replace these calls and remove the `NewWithType` again.

Best viewed without whitespace changes.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
