### PR TITLE
Improve errors in state migration

### DIFF
--- a/migrations/capcons/migration_test.go
+++ b/migrations/capcons/migration_test.go
@@ -70,16 +70,9 @@ type testMigration struct {
 	migration     string
 }
 
-type testMigrationError struct {
-	storageKey    interpreter.StorageKey
-	storageMapKey interpreter.StorageMapKey
-	migration     string
-	err           error
-}
-
 type testMigrationReporter struct {
 	migrations               []testMigration
-	errors                   []testMigrationError
+	errors                   []error
 	linkMigrations           []testCapConsLinkMigration
 	pathCapabilityMigrations []testCapConsPathCapabilityMigration
 	missingCapabilityIDs     []testCapConsMissingCapabilityID
@@ -106,21 +99,8 @@ func (t *testMigrationReporter) Migrated(
 	)
 }
 
-func (t *testMigrationReporter) Error(
-	storageKey interpreter.StorageKey,
-	storageMapKey interpreter.StorageMapKey,
-	migration string,
-	err error,
-) {
-	t.errors = append(
-		t.errors,
-		testMigrationError{
-			storageKey:    storageKey,
-			storageMapKey: storageMapKey,
-			migration:     migration,
-			err:           err,
-		},
-	)
+func (t *testMigrationReporter) Error(err error) {
+	t.errors = append(t.errors, err)
 }
 func (t *testMigrationReporter) MigratedLink(
 	accountAddressPath interpreter.AddressPath,
@@ -252,7 +232,7 @@ func testPathCapabilityValueMigration(
 	pathLinks []testLink,
 	accountLinks []interpreter.PathValue,
 	expectedMigrations []testMigration,
-	expectedErrors []testMigrationError,
+	expectedErrors []error,
 	expectedPathMigrations []testCapConsPathCapabilityMigration,
 	expectedMissingCapabilityIDs []testCapConsMissingCapabilityID,
 	setupFunction, checkFunction string,
@@ -583,7 +563,7 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		pathLinks                    []testLink
 		accountLinks                 []interpreter.PathValue
 		expectedMigrations           []testMigration
-		expectedErrors               []testMigrationError
+		expectedErrors               []error
 		expectedPathMigrations       []testCapConsPathCapabilityMigration
 		expectedMissingCapabilityIDs []testCapConsMissingCapabilityID
 		borrowShouldFail             bool
@@ -1240,7 +1220,7 @@ func testLinkMigration(
 	pathLinks []testLink,
 	accountLinks []interpreter.PathValue,
 	expectedMigrations []testMigration,
-	expectedErrors []testMigrationError,
+	expectedErrors []error,
 	expectedLinkMigrations []testCapConsLinkMigration,
 	expectedCyclicLinkErrors []CyclicLinkError,
 	expectedMissingTargets []interpreter.AddressPath,
@@ -1387,7 +1367,7 @@ func TestLinkMigration(t *testing.T) {
 		pathLinks                []testLink
 		accountLinks             []interpreter.PathValue
 		expectedMigrations       []testMigration
-		expectedErrors           []testMigrationError
+		expectedErrors           []error
 		expectedLinkMigrations   []testCapConsLinkMigration
 		expectedCyclicLinkErrors []CyclicLinkError
 		expectedMissingTargets   []interpreter.AddressPath

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -3029,10 +3029,7 @@ type testReporter struct {
 		interpreter.StorageKey
 		interpreter.StorageMapKey
 	}]struct{}
-	errors map[struct {
-		interpreter.StorageKey
-		interpreter.StorageMapKey
-	}][]error
+	errors []error
 }
 
 func newTestReporter() *testReporter {
@@ -3041,10 +3038,6 @@ func newTestReporter() *testReporter {
 			interpreter.StorageKey
 			interpreter.StorageMapKey
 		}]struct{}{},
-		errors: map[struct {
-			interpreter.StorageKey
-			interpreter.StorageMapKey
-		}][]error{},
 	}
 }
 
@@ -3062,24 +3055,8 @@ func (t *testReporter) Migrated(
 	}] = struct{}{}
 }
 
-func (t *testReporter) Error(
-	storageKey interpreter.StorageKey,
-	storageMapKey interpreter.StorageMapKey,
-	_ string,
-	err error,
-) {
-	key := struct {
-		interpreter.StorageKey
-		interpreter.StorageMapKey
-	}{
-		StorageKey:    storageKey,
-		StorageMapKey: storageMapKey,
-	}
-
-	t.errors[key] = append(
-		t.errors[key],
-		err,
-	)
+func (t *testReporter) Error(err error) {
+	t.errors = append(t.errors, err)
 }
 
 func TestRehash(t *testing.T) {

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -19,6 +19,8 @@
 package migrations
 
 import (
+	goRuntime "runtime"
+
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
@@ -149,6 +151,9 @@ func (m *StorageMigration) MigrateNestedValue(
 
 		if r := recover(); r != nil {
 			switch r := r.(type) {
+			case goRuntime.Error:
+				panic(r)
+
 			case error:
 				if reporter != nil {
 					reporter.Error(
@@ -451,8 +456,12 @@ func (m *StorageMigration) migrate(
 	defer func() {
 		if r := recover(); r != nil {
 			switch r := r.(type) {
+			case goRuntime.Error:
+				panic(r)
+
 			case error:
 				err = r
+
 			default:
 				panic(r)
 			}

--- a/migrations/migration_reporter.go
+++ b/migrations/migration_reporter.go
@@ -26,10 +26,5 @@ type Reporter interface {
 		storageMapKey interpreter.StorageMapKey,
 		migration string,
 	)
-	Error(
-		storageKey interpreter.StorageKey,
-		storageMapKey interpreter.StorageMapKey,
-		migration string,
-		err error,
-	)
+	Error(err error)
 }

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -643,19 +643,16 @@ func TestMigrationError(t *testing.T) {
 	err = migration.Commit()
 	require.NoError(t, err)
 
-	assert.Equal(t,
-		map[struct {
-			interpreter.StorageKey
-			interpreter.StorageMapKey
-		}][]error{
-			{
+	require.Equal(t,
+		[]error{
+			StorageMigrationError{
 				StorageKey: interpreter.StorageKey{
 					Address: account,
 					Key:     pathDomain.Identifier(),
 				},
 				StorageMapKey: interpreter.StringStorageMapKey("int8_value"),
-			}: {
-				errors.New("error occurred while migrating int8"),
+				Migration:     "testInt8Migration",
+				Err:           errors.New("error occurred while migrating int8"),
 			},
 		},
 		reporter.errors,
@@ -700,21 +697,6 @@ func TestMigrationError(t *testing.T) {
 			},
 		},
 		reporter.migrated,
-	)
-
-	require.Equal(t,
-		[]error{
-			StorageMigrationError{
-				StorageKey: interpreter.StorageKey{
-					Address: account,
-					Key:     pathDomain.Identifier(),
-				},
-				StorageMapKey: interpreter.StringStorageMapKey("int8_value"),
-				Migration:     "testInt8Migration",
-				Err:           errors.New("error occurred while migrating int8"),
-			},
-		},
-		reporter.errors,
 	)
 }
 

--- a/migrations/statictypes/account_type_migration_test.go
+++ b/migrations/statictypes/account_type_migration_test.go
@@ -69,12 +69,7 @@ func (t *testReporter) Migrated(
 	t.migrated[key] = struct{}{}
 }
 
-func (t *testReporter) Error(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	_ string,
-	err error,
-) {
+func (t *testReporter) Error(err error) {
 	t.errors = append(t.errors, err)
 }
 


### PR DESCRIPTION

Work towards #3096 

## Description

Introduce a new error type, `MigrationError`, which captures migration location information.

Include a stack trace when reporting it for recovered errors

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
