### PR TITLE
Improve type inference for authorized references

### DIFF
--- a/runtime/common/orderedmap/orderedmap.go
+++ b/runtime/common/orderedmap/orderedmap.go
@@ -254,6 +254,27 @@ func (om *OrderedMap[K, V]) KeySetIsDisjointFrom(other *OrderedMap[K, V]) bool {
 	return isDisjoint
 }
 
+// KeySetIntersection returns a map containing the intersection of the keys in the two maps
+// this is only well defined for sets (i.e. maps without meaningful values)
+func KeySetIntersection[K comparable, V any](om *OrderedMap[K, V], other *OrderedMap[K, V]) *OrderedMap[K, V] {
+	intersection := New[OrderedMap[K, V]](len(om.pairs))
+	om.Foreach(func(key K, value V) {
+		if other.Contains(key) {
+			intersection.Set(key, value)
+		}
+	})
+	return intersection
+}
+
+// KeySetUnion returns a map containing the union of the keys in the two maps
+// this is only well defined for sets (i.e. maps without meaningful values)
+func KeySetUnion[K comparable, V any](om *OrderedMap[K, V], other *OrderedMap[K, V]) *OrderedMap[K, V] {
+	union := New[OrderedMap[K, V]](len(om.pairs))
+	union.SetAll(om)
+	union.SetAll(other)
+	return union
+}
+
 // Pair is an entry in an OrderedMap
 type Pair[K any, V any] struct {
 	Key   K

--- a/runtime/sema/type_test.go
+++ b/runtime/sema/type_test.go
@@ -1240,6 +1240,18 @@ func TestCommonSuperType(t *testing.T) {
 	t.Run("References types", func(t *testing.T) {
 		t.Parallel()
 
+		testLocation := common.StringLocation("test")
+
+		entitlementE := NewEntitlementType(nil, testLocation, "E")
+		entitlementF := NewEntitlementType(nil, testLocation, "F")
+		entitlementG := NewEntitlementType(nil, testLocation, "G")
+
+		entitlementsEOnly := NewEntitlementSetAccess([]*EntitlementType{entitlementE}, Conjunction)
+		entitlementsEAndF := NewEntitlementSetAccess([]*EntitlementType{entitlementE, entitlementF}, Conjunction)
+		entitlementsEAndFAndG := NewEntitlementSetAccess([]*EntitlementType{entitlementE, entitlementG, entitlementF}, Conjunction)
+		entitlementsEOrFOrG := NewEntitlementSetAccess([]*EntitlementType{entitlementE, entitlementF, entitlementG}, Disjunction)
+		entitlementsEOrG := NewEntitlementSetAccess([]*EntitlementType{entitlementE, entitlementG}, Disjunction)
+
 		tests := []testCase{
 			{
 				name: "homogenous references",
@@ -1313,8 +1325,95 @@ func TestCommonSuperType(t *testing.T) {
 						Authorization: EntitlementSetAccess{},
 					},
 				},
-				// maybe have this be unauthorized instead of anystruct?
-				expectedSuperType: AnyStructType,
+				expectedSuperType: &ReferenceType{
+					Type:          Int8Type,
+					Authorization: UnauthorizedAccess,
+				},
+			},
+			{
+				name: "E and (E, F)",
+				types: []Type{
+					&ReferenceType{
+						Type:          Int8Type,
+						Authorization: entitlementsEOnly,
+					},
+					&ReferenceType{
+						Type:          Int8Type,
+						Authorization: entitlementsEAndF,
+					},
+				},
+				expectedSuperType: &ReferenceType{
+					Type:          Int8Type,
+					Authorization: entitlementsEOnly,
+				},
+			},
+			{
+				name: "E and (E | G)",
+				types: []Type{
+					&ReferenceType{
+						Type:          Int8Type,
+						Authorization: entitlementsEOnly,
+					},
+					&ReferenceType{
+						Type:          Int8Type,
+						Authorization: entitlementsEOrG,
+					},
+				},
+				expectedSuperType: &ReferenceType{
+					Type:          Int8Type,
+					Authorization: entitlementsEOrG,
+				},
+			},
+			{
+				name: "(E, F) and (E | G)",
+				types: []Type{
+					&ReferenceType{
+						Type:          Int8Type,
+						Authorization: entitlementsEAndF,
+					},
+					&ReferenceType{
+						Type:          Int8Type,
+						Authorization: entitlementsEOrG,
+					},
+				},
+				expectedSuperType: &ReferenceType{
+					Type:          Int8Type,
+					Authorization: entitlementsEOrG,
+				},
+			},
+			{
+				name: "(E, F) and (E, F, G)",
+				types: []Type{
+					&ReferenceType{
+						Type:          Int8Type,
+						Authorization: entitlementsEAndF,
+					},
+					&ReferenceType{
+						Type:          Int8Type,
+						Authorization: entitlementsEAndFAndG,
+					},
+				},
+				expectedSuperType: &ReferenceType{
+					Type:          Int8Type,
+					Authorization: entitlementsEAndF,
+				},
+			},
+			{
+				name: "(E | G) and (E | F | G)",
+				types: []Type{
+					&ReferenceType{
+						Type:          Int8Type,
+						Authorization: entitlementsEOrG,
+					},
+					&ReferenceType{
+						Type:          Int8Type,
+						Authorization: entitlementsEOrFOrG,
+					},
+				},
+				expectedSuperType: &ReferenceType{
+					Type:          Int8Type,
+					Authorization: entitlementsEOrFOrG,
+				},
 			},
 		}
 


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/2826

Adds better computing of the least common supertype of authorized reference types

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
