### PR TITLE
Optimize storage migration: Allow skipping of values

### DIFF
--- a/migrations/capcons/capabilitymigration.go
+++ b/migrations/capcons/capabilitymigration.go
@@ -124,13 +124,8 @@ func (m *CapabilityValueMigration) Migrate(
 	return nil, nil
 }
 
-func (m *CapabilityValueMigration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	value interpreter.Value,
-	interpreter *interpreter.Interpreter,
-) bool {
-	return CanSkipCapabilityValueMigration(value.StaticType(interpreter))
+func (m *CapabilityValueMigration) CanSkip(valueType interpreter.StaticType) bool {
+	return CanSkipCapabilityValueMigration(valueType)
 }
 
 func CanSkipCapabilityValueMigration(valueType interpreter.StaticType) bool {

--- a/migrations/capcons/linkmigration.go
+++ b/migrations/capcons/linkmigration.go
@@ -51,14 +51,9 @@ func (*LinkValueMigration) Name() string {
 	return "LinkValueMigration"
 }
 
-func (m *LinkValueMigration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	value interpreter.Value,
-	interpreter *interpreter.Interpreter,
-) bool {
+func (m *LinkValueMigration) CanSkip(valueType interpreter.StaticType) bool {
 	// Link values have a capability static type
-	return CanSkipCapabilityValueMigration(value.StaticType(interpreter))
+	return CanSkipCapabilityValueMigration(valueType)
 }
 
 func (m *LinkValueMigration) Migrate(

--- a/migrations/capcons/linkmigration.go
+++ b/migrations/capcons/linkmigration.go
@@ -51,6 +51,16 @@ func (*LinkValueMigration) Name() string {
 	return "LinkValueMigration"
 }
 
+func (m *LinkValueMigration) CanSkip(
+	_ interpreter.StorageKey,
+	_ interpreter.StorageMapKey,
+	value interpreter.Value,
+	interpreter *interpreter.Interpreter,
+) bool {
+	// Link values have a capability static type
+	return CanSkipCapabilityValueMigration(value.StaticType(interpreter))
+}
+
 func (m *LinkValueMigration) Migrate(
 	storageKey interpreter.StorageKey,
 	storageMapKey interpreter.StorageMapKey,

--- a/migrations/capcons/migration_test.go
+++ b/migrations/capcons/migration_test.go
@@ -2349,3 +2349,116 @@ func TestUntypedPathCapabilityValueMigration(t *testing.T) {
 	require.NoError(t, err)
 
 }
+
+func TestCanSkipCapabilityValueMigration(t *testing.T) {
+
+	t.Parallel()
+
+	testCases := map[interpreter.StaticType]bool{
+
+		// Primitive types, like Bool and Address
+
+		interpreter.PrimitiveStaticTypeBool:    true,
+		interpreter.PrimitiveStaticTypeAddress: true,
+
+		// Number and Path types, like UInt8 and StoragePath
+
+		interpreter.PrimitiveStaticTypeUInt8:       true,
+		interpreter.PrimitiveStaticTypeStoragePath: true,
+
+		// Capability types
+
+		interpreter.PrimitiveStaticTypeCapability: false,
+		&interpreter.CapabilityStaticType{
+			BorrowType: interpreter.PrimitiveStaticTypeString,
+		}: false,
+		&interpreter.CapabilityStaticType{
+			BorrowType: interpreter.PrimitiveStaticTypeCharacter,
+		}: false,
+
+		// Existential types, like AnyStruct and AnyResource
+
+		interpreter.PrimitiveStaticTypeAnyStruct:   false,
+		interpreter.PrimitiveStaticTypeAnyResource: false,
+	}
+
+	test := func(ty interpreter.StaticType, expected bool) {
+
+		t.Run(ty.String(), func(t *testing.T) {
+
+			t.Parallel()
+
+			t.Run("base", func(t *testing.T) {
+
+				t.Parallel()
+
+				actual := CanSkipCapabilityValueMigration(ty)
+				assert.Equal(t, expected, actual)
+
+			})
+
+			t.Run("optional", func(t *testing.T) {
+
+				t.Parallel()
+
+				optionalType := interpreter.NewOptionalStaticType(nil, ty)
+
+				actual := CanSkipCapabilityValueMigration(optionalType)
+				assert.Equal(t, expected, actual)
+			})
+
+			t.Run("variable-sized", func(t *testing.T) {
+
+				t.Parallel()
+
+				arrayType := interpreter.NewVariableSizedStaticType(nil, ty)
+
+				actual := CanSkipCapabilityValueMigration(arrayType)
+				assert.Equal(t, expected, actual)
+			})
+
+			t.Run("constant-sized", func(t *testing.T) {
+
+				t.Parallel()
+
+				arrayType := interpreter.NewConstantSizedStaticType(nil, ty, 2)
+
+				actual := CanSkipCapabilityValueMigration(arrayType)
+				assert.Equal(t, expected, actual)
+			})
+
+			t.Run("dictionary key", func(t *testing.T) {
+
+				t.Parallel()
+
+				dictionaryType := interpreter.NewDictionaryStaticType(
+					nil,
+					ty,
+					interpreter.PrimitiveStaticTypeInt,
+				)
+
+				actual := CanSkipCapabilityValueMigration(dictionaryType)
+				assert.Equal(t, expected, actual)
+
+			})
+
+			t.Run("dictionary value", func(t *testing.T) {
+
+				t.Parallel()
+
+				dictionaryType := interpreter.NewDictionaryStaticType(
+					nil,
+					interpreter.PrimitiveStaticTypeInt,
+					ty,
+				)
+
+				actual := CanSkipCapabilityValueMigration(dictionaryType)
+				assert.Equal(t, expected, actual)
+			})
+		})
+	}
+
+	for ty, expected := range testCases {
+		test(ty, expected)
+	}
+}

--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -374,11 +374,6 @@ func (mig EntitlementsMigration) Migrate(
 	return ConvertValueToEntitlements(mig.Interpreter, value)
 }
 
-func (mig EntitlementsMigration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	value interpreter.Value,
-	interpreter *interpreter.Interpreter,
-) bool {
-	return statictypes.CanSkipStaticTypeMigration(value.StaticType(interpreter))
+func (mig EntitlementsMigration) CanSkip(valueType interpreter.StaticType) bool {
+	return statictypes.CanSkipStaticTypeMigration(valueType)
 }

--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -373,3 +373,12 @@ func (mig EntitlementsMigration) Migrate(
 ) {
 	return ConvertValueToEntitlements(mig.Interpreter, value)
 }
+
+func (mig EntitlementsMigration) CanSkip(
+	_ interpreter.StorageKey,
+	_ interpreter.StorageMapKey,
+	value interpreter.Value,
+	interpreter *interpreter.Interpreter,
+) bool {
+	return statictypes.CanSkipStaticTypeMigration(value.StaticType(interpreter))
+}

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -695,12 +695,7 @@ func (m testEntitlementsMigration) Migrate(
 	return ConvertValueToEntitlements(m.inter, value)
 }
 
-func (m testEntitlementsMigration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	_ interpreter.Value,
-	_ *interpreter.Interpreter,
-) bool {
+func (m testEntitlementsMigration) CanSkip(_ interpreter.StaticType) bool {
 	return false
 }
 

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -695,6 +695,15 @@ func (m testEntitlementsMigration) Migrate(
 	return ConvertValueToEntitlements(m.inter, value)
 }
 
+func (m testEntitlementsMigration) CanSkip(
+	_ interpreter.StorageKey,
+	_ interpreter.StorageMapKey,
+	_ interpreter.Value,
+	_ *interpreter.Interpreter,
+) bool {
+	return false
+}
+
 func convertEntireTestValue(
 	t *testing.T,
 	inter *interpreter.Interpreter,

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -37,12 +37,7 @@ type ValueMigration interface {
 		value interpreter.Value,
 		interpreter *interpreter.Interpreter,
 	) (newValue interpreter.Value, err error)
-	CanSkip(
-		storageKey interpreter.StorageKey,
-		storageMapKey interpreter.StorageMapKey,
-		value interpreter.Value,
-		interpreter *interpreter.Interpreter,
-	) bool
+	CanSkip(valueType interpreter.StaticType) bool
 }
 
 type DomainMigration interface {
@@ -176,12 +171,15 @@ func (m *StorageMigration) MigrateNestedValue(
 		}
 	}()
 
+	inter := m.interpreter
+
 	// skip the migration of the value,
 	// if all value migrations agree
 
 	canSkip := true
+	staticType := value.StaticType(inter)
 	for _, migration := range valueMigrations {
-		if !migration.CanSkip(storageKey, storageMapKey, value, m.interpreter) {
+		if !migration.CanSkip(staticType) {
 			canSkip = false
 			break
 		}
@@ -195,7 +193,7 @@ func (m *StorageMigration) MigrateNestedValue(
 	// i.e: depth-first traversal
 	switch typedValue := value.(type) {
 	case *interpreter.SomeValue:
-		innerValue := typedValue.InnerValue(m.interpreter, emptyLocationRange)
+		innerValue := typedValue.InnerValue(inter, emptyLocationRange)
 		newInnerValue := m.MigrateNestedValue(
 			storageKey,
 			storageMapKey,
@@ -204,7 +202,7 @@ func (m *StorageMigration) MigrateNestedValue(
 			reporter,
 		)
 		if newInnerValue != nil {
-			migratedValue = interpreter.NewSomeValueNonCopying(m.interpreter, newInnerValue)
+			migratedValue = interpreter.NewSomeValueNonCopying(inter, newInnerValue)
 
 			// chain the migrations
 			value = migratedValue
@@ -217,7 +215,7 @@ func (m *StorageMigration) MigrateNestedValue(
 		count := array.Count()
 		for index := 0; index < count; index++ {
 
-			element := array.Get(m.interpreter, emptyLocationRange, index)
+			element := array.Get(inter, emptyLocationRange, index)
 
 			newElement := m.MigrateNestedValue(
 				storageKey,
@@ -232,17 +230,17 @@ func (m *StorageMigration) MigrateNestedValue(
 			}
 
 			existingStorable := array.RemoveWithoutTransfer(
-				m.interpreter,
+				inter,
 				emptyLocationRange,
 				index,
 			)
 
-			interpreter.StoredValue(m.interpreter, existingStorable, m.storage).
-				DeepRemove(m.interpreter)
-			m.interpreter.RemoveReferencedSlab(existingStorable)
+			interpreter.StoredValue(inter, existingStorable, m.storage).
+				DeepRemove(inter)
+			inter.RemoveReferencedSlab(existingStorable)
 
 			array.InsertWithoutTransfer(
-				m.interpreter,
+				inter,
 				emptyLocationRange,
 				index,
 				newElement,
@@ -262,7 +260,7 @@ func (m *StorageMigration) MigrateNestedValue(
 
 		for _, fieldName := range fieldNames {
 			existingValue := composite.GetField(
-				m.interpreter,
+				inter,
 				emptyLocationRange,
 				fieldName,
 			)
@@ -280,7 +278,7 @@ func (m *StorageMigration) MigrateNestedValue(
 			}
 
 			composite.SetMemberWithoutTransfer(
-				m.interpreter,
+				inter,
 				emptyLocationRange,
 				fieldName,
 				migratedValue,
@@ -350,7 +348,7 @@ func (m *StorageMigration) MigrateNestedValue(
 
 			existingKey = legacyKey(existingKey)
 			existingKeyStorable, existingValueStorable := dictionary.RemoveWithoutTransfer(
-				m.interpreter,
+				inter,
 				emptyLocationRange,
 				existingKey,
 			)
@@ -368,13 +366,13 @@ func (m *StorageMigration) MigrateNestedValue(
 				// Value was migrated
 				valueToSet = newValue
 
-				interpreter.StoredValue(m.interpreter, existingValueStorable, m.storage).
-					DeepRemove(m.interpreter)
-				m.interpreter.RemoveReferencedSlab(existingValueStorable)
+				interpreter.StoredValue(inter, existingValueStorable, m.storage).
+					DeepRemove(inter)
+				inter.RemoveReferencedSlab(existingValueStorable)
 			}
 
 			dictionary.InsertWithoutTransfer(
-				m.interpreter,
+				inter,
 				emptyLocationRange,
 				keyToSet,
 				valueToSet,
@@ -393,7 +391,7 @@ func (m *StorageMigration) MigrateNestedValue(
 		if newInnerValue != nil {
 			newInnerCapability := newInnerValue.(*interpreter.IDCapabilityValue)
 			migratedValue = interpreter.NewPublishedValue(
-				m.interpreter,
+				inter,
 				publishedValue.Recipient,
 				newInnerCapability,
 			)

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -103,12 +103,7 @@ func (testStringMigration) Migrate(
 	return nil, nil
 }
 
-func (testStringMigration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	_ interpreter.Value,
-	_ *interpreter.Interpreter,
-) bool {
+func (testStringMigration) CanSkip(_ interpreter.StaticType) bool {
 	return false
 }
 
@@ -142,12 +137,7 @@ func (m testInt8Migration) Migrate(
 	return interpreter.NewUnmeteredInt8Value(int8(int8Value) + 10), nil
 }
 
-func (testInt8Migration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	_ interpreter.Value,
-	_ *interpreter.Interpreter,
-) bool {
+func (testInt8Migration) CanSkip(_ interpreter.StaticType) bool {
 	return false
 }
 
@@ -155,12 +145,7 @@ func (testInt8Migration) CanSkip(
 
 type testCapMigration struct{}
 
-func (m testCapMigration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	_ interpreter.Value,
-	_ *interpreter.Interpreter,
-) bool {
+func (m testCapMigration) CanSkip(_ interpreter.StaticType) bool {
 	return false
 }
 
@@ -225,12 +210,7 @@ func (testCapConMigration) Migrate(
 	return nil, nil
 }
 
-func (testCapConMigration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	_ interpreter.Value,
-	_ *interpreter.Interpreter,
-) bool {
+func (testCapConMigration) CanSkip(_ interpreter.StaticType) bool {
 	return false
 }
 
@@ -1010,12 +990,7 @@ func (m testCompositeValueMigration) Migrate(
 	), nil
 }
 
-func (testCompositeValueMigration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	_ interpreter.Value,
-	_ *interpreter.Interpreter,
-) bool {
+func (testCompositeValueMigration) CanSkip(_ interpreter.StaticType) bool {
 	return false
 }
 
@@ -1223,12 +1198,7 @@ func (testContainerMigration) Migrate(
 	return nil, nil
 }
 
-func (m testContainerMigration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	_ interpreter.Value,
-	_ *interpreter.Interpreter,
-) bool {
+func (m testContainerMigration) CanSkip(_ interpreter.StaticType) bool {
 	return false
 }
 
@@ -1661,12 +1631,7 @@ func (m testPanicMigration) Migrate(
 	return nil, nil
 }
 
-func (m testPanicMigration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	_ interpreter.Value,
-	_ *interpreter.Interpreter,
-) bool {
+func (m testPanicMigration) CanSkip(_ interpreter.StaticType) bool {
 	return false
 }
 
@@ -1784,13 +1749,8 @@ func (m *testSkipMigration) Migrate(
 	return nil, nil
 }
 
-func (m *testSkipMigration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	value interpreter.Value,
-	inter *interpreter.Interpreter,
-) bool {
-	return m.canSkip(value.StaticType(inter))
+func (m *testSkipMigration) CanSkip(valueType interpreter.StaticType) bool {
+	return m.canSkip(valueType)
 }
 
 func TestSkip(t *testing.T) {

--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -517,13 +517,8 @@ var unauthorizedAccountReferenceType = interpreter.NewReferenceStaticType(
 	interpreter.PrimitiveStaticTypeAccount,
 )
 
-func (m *StaticTypeMigration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	value interpreter.Value,
-	interpreter *interpreter.Interpreter,
-) bool {
-	return CanSkipStaticTypeMigration(value.StaticType(interpreter))
+func (m *StaticTypeMigration) CanSkip(valueType interpreter.StaticType) bool {
+	return CanSkipStaticTypeMigration(valueType)
 }
 
 func CanSkipStaticTypeMigration(valueType interpreter.StaticType) bool {

--- a/migrations/string_normalization/migration.go
+++ b/migrations/string_normalization/migration.go
@@ -53,13 +53,8 @@ func (StringNormalizingMigration) Migrate(
 	return nil, nil
 }
 
-func (m StringNormalizingMigration) CanSkip(
-	_ interpreter.StorageKey,
-	_ interpreter.StorageMapKey,
-	value interpreter.Value,
-	interpreter *interpreter.Interpreter,
-) bool {
-	return CanSkipStringNormalizingMigration(value.StaticType(interpreter))
+func (m StringNormalizingMigration) CanSkip(valueType interpreter.StaticType) bool {
+	return CanSkipStringNormalizingMigration(valueType)
 }
 
 func CanSkipStringNormalizingMigration(valueType interpreter.StaticType) bool {


### PR DESCRIPTION
Work towards #3096 

## Description

Optimize the Cadence 1.0 migration by allow value migrations of a storage migration to indicate that they do not need to migrate a certain value. Skip the migration of a (potentially nested) value, if all value migrations agree.

Implement skipping for all value migrations.

For example, this will heavily reduce the migration time for accounts which store lots of "binary data" in `[UInt8]`, and nested variants (e.g. `[[UInt8]]`).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
