### PR TITLE
Fix intersection type's legacy type getting converted to intersection type

### DIFF
--- a/migrations/statictypes/statictype_migration_test.go
+++ b/migrations/statictypes/statictype_migration_test.go
@@ -605,7 +605,7 @@ func TestStaticTypeMigration(t *testing.T) {
 
 	})
 
-	t.Run("merge converted legacy type when intersection", func(t *testing.T) {
+	t.Run("legacy type gets converted intersection", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -674,18 +674,29 @@ func TestStaticTypeMigration(t *testing.T) {
 			true,
 		)
 
+		// NOTE: the expected type {S2}{S1} is expected to be ("temporarily") invalid.
+		// The entitlements migrations will handle such cases, i.e. rewrite the type to a valid type ({S2}).
+		// This is important to ensure that the entitlement migration does not infer entitlements for {S1, S2}.
+
+		expectedIntersection := interpreter.NewIntersectionStaticType(
+			nil,
+			[]*interpreter.InterfaceStaticType{
+				interfaceType1,
+			},
+		)
+		expectedIntersection.LegacyType = interpreter.NewIntersectionStaticType(
+			nil,
+			[]*interpreter.InterfaceStaticType{
+				interfaceType2,
+			},
+		)
+
 		expected := interpreter.NewTypeValue(
 			nil,
 			interpreter.NewReferenceStaticType(
 				nil,
 				interpreter.UnauthorizedAccess,
-				interpreter.NewIntersectionStaticType(
-					nil,
-					[]*interpreter.InterfaceStaticType{
-						interfaceType1,
-						interfaceType2,
-					},
-				),
+				expectedIntersection,
 			),
 		)
 

--- a/runtime/interpreter/config.go
+++ b/runtime/interpreter/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	UUIDHandler UUIDHandlerFunc
 	// CompositeTypeHandler is used to load composite types
 	CompositeTypeHandler CompositeTypeHandlerFunc
+	// InterfaceTypeHandler is used to load interface types
+	InterfaceTypeHandler InterfaceTypeHandlerFunc
 	// CompositeValueFunctionsHandler is used to load composite value functions
 	CompositeValueFunctionsHandler CompositeValueFunctionsHandlerFunc
 	BaseActivationHandler          func(location common.Location) *VariableActivation


### PR DESCRIPTION
Work towards #3162 

## Description

Discovered while adding test cases in flow-go.

"Revert" previous fix of handling intersection type's legacy type getting converted to intersection type, by merging the intersections, #3164.

Merging the intersections is not valid, as the entitlements migration will then incorrectly infer additional entitlements.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
