### PR TITLE
Implicitly track composite reference in attachment iteration

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -18148,6 +18148,7 @@ func (v *CompositeValue) GetAttachments(interpreter *Interpreter, locationRange 
 }
 
 func (v *CompositeValue) forEachAttachmentFunction(interpreter *Interpreter, locationRange LocationRange) Value {
+
 	return NewHostFunctionValue(
 		interpreter,
 		sema.CompositeForEachAttachmentFunctionType(interpreter.MustSemaTypeOfValue(v).(*sema.CompositeType).GetCompositeKind()),
@@ -18208,19 +18209,45 @@ func attachmentBaseAndSelfValues(
 	return
 }
 
-func (v *CompositeValue) forEachAttachment(interpreter *Interpreter, locationRange LocationRange, f func(*CompositeValue)) {
-	iterator, err := v.dictionary.Iterator()
+func (v *CompositeValue) forEachAttachment(
+	interpreter *Interpreter,
+	locationRange LocationRange,
+	f func(*CompositeValue),
+) {
+	// The attachment iteration creates an implicit reference to the composite, and holds onto that referenced-value.
+	// But the reference could get invalidated during the iteration, making that referenced-value invalid.
+	// We create a reference here for the purposes of tracking it during iteration.
+	vType := interpreter.MustSemaTypeOfValue(v)
+	compositeReference := NewEphemeralReferenceValue(interpreter, UnauthorizedAccess, v, vType, locationRange)
+	interpreter.maybeTrackReferencedResourceKindedValue(compositeReference)
+	forEachAttachment(interpreter, compositeReference, locationRange, f)
+}
+
+func forEachAttachment(
+	interpreter *Interpreter,
+	compositeReference *EphemeralReferenceValue,
+	locationRange LocationRange,
+	f func(*CompositeValue),
+) {
+	composite, ok := compositeReference.Value.(*CompositeValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+
+	iterator, err := composite.dictionary.Iterator()
 	if err != nil {
 		panic(errors.NewExternalError(err))
 	}
 
-	oldSharedState := interpreter.SharedState.inAttachmentIteration(v)
-	interpreter.SharedState.setAttachmentIteration(v, true)
+	oldSharedState := interpreter.SharedState.inAttachmentIteration(composite)
+	interpreter.SharedState.setAttachmentIteration(composite, true)
 	defer func() {
-		interpreter.SharedState.setAttachmentIteration(v, oldSharedState)
+		interpreter.SharedState.setAttachmentIteration(composite, oldSharedState)
 	}()
 
 	for {
+		// Check that the implicit composite reference was not invalidated during iteration
+		interpreter.checkInvalidatedResourceOrResourceReference(compositeReference, locationRange)
 		key, value, err := iterator.Next()
 		if err != nil {
 			panic(errors.NewExternalError(err))
@@ -18237,7 +18264,7 @@ func (v *CompositeValue) forEachAttachment(interpreter *Interpreter, locationRan
 			// attachments is added that takes a `fun (&Attachment): Void` callback, the `f` provided here
 			// should convert the provided attachment value into a reference before passing it to the user
 			// callback
-			attachment.setBaseValue(interpreter, v)
+			attachment.setBaseValue(interpreter, composite)
 			f(attachment)
 		}
 	}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -18148,7 +18148,6 @@ func (v *CompositeValue) GetAttachments(interpreter *Interpreter, locationRange 
 }
 
 func (v *CompositeValue) forEachAttachmentFunction(interpreter *Interpreter, locationRange LocationRange) Value {
-
 	return NewHostFunctionValue(
 		interpreter,
 		sema.CompositeForEachAttachmentFunctionType(interpreter.MustSemaTypeOfValue(v).(*sema.CompositeType).GetCompositeKind()),


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-internal/issues/209
______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
