### PR TITLE
Optimize string migration: only return new value if needed

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -817,10 +817,21 @@ type CharacterValue struct {
 	UnnormalizedStr string
 }
 
-func NewUnmeteredCharacterValue(r string) CharacterValue {
+func NewUnmeteredCharacterValue(str string) CharacterValue {
 	return CharacterValue{
-		Str:             norm.NFC.String(r),
-		UnnormalizedStr: r,
+		Str:             norm.NFC.String(str),
+		UnnormalizedStr: str,
+	}
+}
+
+// Deprecated: NewStringValue_UnsafeNewCharacterValue_Unsafe creates a new character value
+// from the given normalized and unnormalized string.
+// NOTE: this function is unsafe, as it does not normalize the string.
+// It should only be used for e.g. migration purposes.
+func NewCharacterValue_Unsafe(normalizedStr, unnormalizedStr string) CharacterValue {
+	return CharacterValue{
+		Str:             normalizedStr,
+		UnnormalizedStr: unnormalizedStr,
 	}
 }
 
@@ -1040,6 +1051,19 @@ func NewUnmeteredStringValue(str string) *StringValue {
 	return &StringValue{
 		Str:             norm.NFC.String(str),
 		UnnormalizedStr: str,
+		// a negative value indicates the length has not been initialized, see Length()
+		length: -1,
+	}
+}
+
+// Deprecated: NewStringValue_Unsafe creates a new string value
+// from the given normalized and unnormalized string.
+// NOTE: this function is unsafe, as it does not normalize the string.
+// It should only be used for e.g. migration purposes.
+func NewStringValue_Unsafe(normalizedStr, unnormalizedStr string) *StringValue {
+	return &StringValue{
+		Str:             normalizedStr,
+		UnnormalizedStr: unnormalizedStr,
 		// a negative value indicates the length has not been initialized, see Length()
 		length: -1,
 	}


### PR DESCRIPTION
Work towards #3096 

## Description

Great suggestion from @bluesign: Currently, the string migration always returns a new string/character value, even if the value was already normalized. 

Only return a new value if the old value was not normalized. 
Only compute the normalized form once, and use it both for comparison and actual use in the value.

Given the majority of the strings are likely do not need any normalization, this should reduce a lot of unnecessary overhead.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
