### PR TITLE
Relax interface conformance changes in contract update validator

### DIFF
--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -1625,7 +1625,7 @@ func changeAccountContracts(
 				contractName,
 				handler,
 				oldProgram,
-				program.Program,
+				program,
 				inter.AllElaborations(),
 			)
 		} else {

--- a/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validation_test.go
+++ b/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validation_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/old_parser"
 	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/sema"
@@ -55,12 +56,14 @@ func testContractUpdate(t *testing.T, oldCode string, newCode string) error {
 	err = checker.Check()
 	require.NoError(t, err)
 
+	program := interpreter.ProgramFromChecker(checker)
+
 	upgradeValidator := stdlib.NewCadenceV042ToV1ContractUpdateValidator(
 		utils.TestLocation,
 		"Test",
 		&runtime_utils.TestRuntimeInterface{},
 		oldProgram,
-		newProgram,
+		program,
 		map[common.Location]*sema.Elaboration{
 			utils.TestLocation: checker.Elaboration,
 		})
@@ -104,7 +107,7 @@ func parseAndCheckPrograms(
 	newImports map[common.Location]string,
 ) (
 	oldProgram *ast.Program,
-	newProgram *ast.Program,
+	newProgram *interpreter.Program,
 	elaborations map[common.Location]*sema.Elaboration,
 ) {
 
@@ -112,7 +115,7 @@ func parseAndCheckPrograms(
 	oldProgram, err = old_parser.ParseProgram(nil, []byte(oldCode), old_parser.Config{})
 	require.NoError(t, err)
 
-	newProgram, err = parser.ParseProgram(nil, []byte(newCode), parser.Config{})
+	program, err := parser.ParseProgram(nil, []byte(newCode), parser.Config{})
 	require.NoError(t, err)
 
 	elaborations = map[common.Location]*sema.Elaboration{}
@@ -139,7 +142,7 @@ func parseAndCheckPrograms(
 	}
 
 	checker, err := sema.NewChecker(
-		newProgram,
+		program,
 		location,
 		nil,
 		&sema.Config{
@@ -174,7 +177,7 @@ func parseAndCheckPrograms(
 	err = checker.Check()
 	require.NoError(t, err)
 
-	elaborations[location] = checker.Elaboration
+	newProgram = interpreter.ProgramFromChecker(checker)
 
 	return
 }
@@ -1968,6 +1971,91 @@ func TestInterfaceConformanceChange(t *testing.T) {
 				switch oldTypeID {
 				case inftTypeID:
 					return true, newTypeID == nftTypeID
+				}
+
+				return false, false
+			},
+		)
+
+		err := upgradeValidator.Validate()
+		require.NoError(t, err)
+	})
+
+	t.Run("with custom rules and changed import", func(t *testing.T) {
+		t.Parallel()
+
+		const oldCode = `
+            import MetadataViews from 0x02
+
+            pub contract Test {
+                pub resource R: MetadataViews.Resolver {}
+            }
+        `
+
+		const newImport = `
+            access(all) contract ViewResolver {
+                access(all) resource interface Resolver {}
+            }
+        `
+
+		const newCode = `
+            import ViewResolver from 0x02
+
+            access(all) contract Test {
+                access(all) resource R: ViewResolver.Resolver {}
+            }
+        `
+
+		viewResolverLocation := common.AddressLocation{
+			Name:    "ViewResolver",
+			Address: common.MustBytesToAddress([]byte{0x2}),
+		}
+
+		metadatViewsLocation := common.AddressLocation{
+			Name:    "MetadataViews",
+			Address: common.MustBytesToAddress([]byte{0x2}),
+		}
+
+		imports := map[common.Location]string{
+			viewResolverLocation: newImport,
+		}
+
+		const contractName = "Test"
+		location := common.AddressLocation{
+			Name:    contractName,
+			Address: common.MustBytesToAddress([]byte{0x1}),
+		}
+
+		oldProgram, newProgram, elaborations := parseAndCheckPrograms(t, location, oldCode, newCode, imports)
+
+		metadataViewsResolverTypeID := common.NewTypeIDFromQualifiedName(
+			nil,
+			metadatViewsLocation,
+			"MetadataViews.Resolver",
+		)
+
+		viewResolverResolverTypeID := common.NewTypeIDFromQualifiedName(
+			nil,
+			viewResolverLocation,
+			"ViewResolver.Resolver",
+		)
+
+		upgradeValidator := stdlib.NewCadenceV042ToV1ContractUpdateValidator(
+			location,
+			contractName,
+			&runtime_utils.TestRuntimeInterface{
+				OnGetAccountContractNames: func(address runtime.Address) ([]string, error) {
+					return []string{"TestImport"}, nil
+				},
+			},
+			oldProgram,
+			newProgram,
+			elaborations,
+		).WithUserDefinedTypeChangeChecker(
+			func(oldTypeID common.TypeID, newTypeID common.TypeID) (checked, valid bool) {
+				switch oldTypeID {
+				case metadataViewsResolverTypeID:
+					return true, newTypeID == viewResolverResolverTypeID
 				}
 
 				return false, false


### PR DESCRIPTION
Working towards https://github.com/onflow/cadence/issues/3098#issuecomment-2007977094

## Description

Includes:
- [Consider inherited interfaces when checking for conformances](https://github.com/onflow/cadence/commit/6d56a062dd9ee14e1cb84fa57544f4860415208c)
  - It is OK to remove the explicit conformance to an interface, as long as it is implicitly available via inheritance.
- [Consider custom composite/interface type change rules](https://github.com/onflow/cadence/commit/a78ac56a86e2c074ea51041b60bce7ffb76bde32)
  - We already allow defining custom rules for static type changes. Some of these are also applicable for the conformance changes. 
  - e.g: `MetadataViews.Resolver` is changed to `ViewResolver.Resolver`.
  - So consider these custom rules as well, when checking for conformance changes.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
