### PR TITLE
Fix address conversion

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -21200,6 +21200,10 @@ func NewAddressValueFromConstructor(
 }
 
 func ConvertAddress(memoryGauge common.MemoryGauge, value Value, locationRange LocationRange) AddressValue {
+	if address, ok := value.(AddressValue); ok {
+		return address
+	}
+
 	converter := func() (result common.Address) {
 		uint64Value := ConvertUInt64(memoryGauge, value, locationRange)
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -12156,7 +12156,7 @@ func TestInterpretOptionalAddressInConditional(t *testing.T) {
 
 	inter := parseCheckAndInterpret(t, `
       fun test(ok: Bool): Address? {
-         return ok ? Address(0x1) : nil
+         return ok ? 0x1 : nil
       }
     `)
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -12149,3 +12149,26 @@ func TestInterpretSwapDictionaryKeysWithSideEffects(t *testing.T) {
 		require.Equal(t, interpreter.NewIntValueFromInt64(nil, 3), events[2].event.GetField(inter, interpreter.EmptyLocationRange, "value"))
 	})
 }
+
+func TestInterpretOptionalAddressInConditional(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndInterpret(t, `
+      fun test(ok: Bool): Address? {
+         return ok ? Address(0x1) : nil
+      }
+    `)
+
+	value, err := inter.Invoke("test", interpreter.TrueValue)
+	require.NoError(t, err)
+
+	AssertValuesEqual(
+		t,
+		inter,
+		interpreter.NewSomeValueNonCopying(nil,
+			interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
+		),
+		value,
+	)
+}


### PR DESCRIPTION
Closes #3194 

## Description

When converting a value to an address, do not assume it is a number value, it may already be an address value.

In that case, return the address as-is.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
