### PR TITLE
Handle unparameterized Capability static types

### DIFF
--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -182,9 +182,12 @@ func (m *StaticTypeMigration) maybeConvertStaticType(staticType, parentType inte
 		}
 
 	case *interpreter.CapabilityStaticType:
-		convertedBorrowType := m.maybeConvertStaticType(staticType.BorrowType, staticType)
-		if convertedBorrowType != nil {
-			return interpreter.NewCapabilityStaticType(nil, convertedBorrowType)
+		borrowType := staticType.BorrowType
+		if borrowType != nil {
+			convertedBorrowType := m.maybeConvertStaticType(borrowType, staticType)
+			if convertedBorrowType != nil {
+				return interpreter.NewCapabilityStaticType(nil, convertedBorrowType)
+			}
 		}
 
 	case *interpreter.IntersectionStaticType:

--- a/migrations/statictypes/statictype_migration_test.go
+++ b/migrations/statictypes/statictype_migration_test.go
@@ -118,14 +118,34 @@ func TestStaticTypeMigration(t *testing.T) {
 
 		actual := migrate(t,
 			staticTypeMigration,
-			interpreter.NewTypeValue(nil, nil),
+			interpreter.NewUnmeteredTypeValue(nil),
 			// NOTE: atree value validation is disabled,
 			// because the type value has a nil type (which indicates an invalid or unknown type),
 			// and invalid unknown types are always unequal
 			false,
 		)
 		assert.Equal(t,
-			interpreter.NewTypeValue(nil, nil),
+			interpreter.NewUnmeteredTypeValue(nil),
+			actual,
+		)
+	})
+
+	t.Run("TypeValue with unparameterized Capability type", func(t *testing.T) {
+		t.Parallel()
+
+		staticTypeMigration := NewStaticTypeMigration()
+
+		actual := migrate(t,
+			staticTypeMigration,
+			interpreter.NewUnmeteredTypeValue(
+				interpreter.NewCapabilityStaticType(nil, nil),
+			),
+			true,
+		)
+		assert.Equal(t,
+			interpreter.NewUnmeteredTypeValue(
+				interpreter.NewCapabilityStaticType(nil, nil),
+			),
 			actual,
 		)
 	})


### PR DESCRIPTION
Work towards #3192

## Description

`Capability`'s type parameter is optional, but the static type migration assumes it is always set / never nil.

Only migrate the borrow type if it is given.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
