### PR TITLE
Allow removal of enum declarations from contract interfaces for C1.0 upgrade

### DIFF
--- a/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validation_test.go
+++ b/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validation_test.go
@@ -189,6 +189,13 @@ func getSingleContractUpdateErrorCause(t *testing.T, err error, contractName str
 	return updateErr.Errors[0]
 }
 
+func assertMissingDeclarationError(t *testing.T, err error, declName string) bool {
+	var missingDeclError *stdlib.MissingDeclarationError
+	require.ErrorAs(t, err, &missingDeclError)
+
+	return assert.Equal(t, declName, missingDeclError.Name)
+}
+
 func getContractUpdateError(t *testing.T, err error, contractName string) *stdlib.ContractUpdateError {
 	require.Error(t, err)
 
@@ -2065,4 +2072,52 @@ func TestInterfaceConformanceChange(t *testing.T) {
 		err := upgradeValidator.Validate()
 		require.NoError(t, err)
 	})
+}
+
+func TestContractUpgradeRemoveEnum(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("remove from contract", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract Test {
+                pub enum E: UInt {}
+            }
+        `
+
+		const newCode = `
+            access(all) contract Test {}
+        `
+
+		err := testContractUpdate(t, oldCode, newCode)
+
+		// This is not allowed because `@R{I}` is converted to `@R`, not `@{I}`
+		cause := getSingleContractUpdateErrorCause(t, err, "Test")
+		assertMissingDeclarationError(t, cause, "E")
+	})
+
+	t.Run("remove from contract interface", func(t *testing.T) {
+
+		t.Parallel()
+
+		const oldCode = `
+            pub contract interface Test {
+                pub enum E: UInt {}
+            }
+        `
+
+		const newCode = `
+            access(all) contract interface Test {
+              
+            }
+        `
+
+		err := testContractUpdate(t, oldCode, newCode)
+
+		require.NoError(t, err)
+	})
+
 }

--- a/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validation_test.go
+++ b/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validation_test.go
@@ -2094,7 +2094,6 @@ func TestContractUpgradeRemoveEnum(t *testing.T) {
 
 		err := testContractUpdate(t, oldCode, newCode)
 
-		// This is not allowed because `@R{I}` is converted to `@R`, not `@{I}`
 		cause := getSingleContractUpdateErrorCause(t, err, "Test")
 		assertMissingDeclarationError(t, cause, "E")
 	})

--- a/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validator.go
+++ b/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validator.go
@@ -533,6 +533,27 @@ func (validator *CadenceV042ToV1ContractUpdateValidator) checkDeclarationKindCha
 	return false
 }
 
+func (validator *CadenceV042ToV1ContractUpdateValidator) checkNestedDeclarationRemoval(
+	nestedDeclaration ast.Declaration,
+	oldContainingDeclaration ast.Declaration,
+	newContainingDeclaration ast.Declaration,
+) {
+
+	// enums can be removed from contract interfaces, as they have no interface equivalent and are not
+	// actually used in field type annotations in any contracts
+	if oldContainingDeclaration.DeclarationKind() == common.DeclarationKindContractInterface &&
+		newContainingDeclaration.DeclarationKind() == common.DeclarationKindContractInterface &&
+		nestedDeclaration.DeclarationKind() == common.DeclarationKindEnum {
+		return
+	}
+
+	validator.underlyingUpdateValidator.checkNestedDeclarationRemoval(
+		nestedDeclaration,
+		oldContainingDeclaration,
+		newContainingDeclaration,
+	)
+}
+
 func (validator *CadenceV042ToV1ContractUpdateValidator) checkConformanceV1(
 	oldDecl *ast.CompositeDeclaration,
 	newDecl *ast.CompositeDeclaration,


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/3182

This allows enum declarations to be removed from contract interfaces as part of the Cadence 1.0 upgrade. While in general this is not a safe operation to permit, analysis of mainnet contracts indicates that there are a small number of existing declarations of this kind, none of which are used in fields that themselves cannot be easily removed. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
