### PR TITLE
Name storage migration, include in error

### DIFF
--- a/migrations/capcons/migration_test.go
+++ b/migrations/capcons/migration_test.go
@@ -454,7 +454,7 @@ func testPathCapabilityValueMigration(
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 
 	capabilityMapping := &CapabilityMapping{}
 
@@ -1298,7 +1298,7 @@ func testLinkMigration(
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 
 	capabilityMapping := &CapabilityMapping{}
 
@@ -2007,7 +2007,7 @@ func TestPublishedPathCapabilityValueMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 
 	capabilityMapping := &CapabilityMapping{}
 
@@ -2248,7 +2248,7 @@ func TestUntypedPathCapabilityValueMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 
 	capabilityMapping := &CapabilityMapping{}
 

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -713,7 +713,7 @@ func convertEntireTestValue(
 
 	reporter := newTestReporter()
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 
 	migratedValue := migration.MigrateNestedValue(
 		interpreter.StorageKey{
@@ -1530,7 +1530,7 @@ func TestMigrateSimpleContract(t *testing.T) {
 
 	reporter := newTestReporter()
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 	migration.MigrateAccount(
 		account,
 		migration.NewValueMigrationsPathMigrator(
@@ -1713,7 +1713,7 @@ func TestMigratePublishedValue(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 	migration.MigrateAccount(
 		testAddress,
 		migration.NewValueMigrationsPathMigrator(
@@ -1966,7 +1966,7 @@ func TestMigratePublishedValueAcrossTwoAccounts(t *testing.T) {
 
 	reporter := newTestReporter()
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 	migrator := migration.NewValueMigrationsPathMigrator(
 		reporter,
 		NewEntitlementsMigration(inter),
@@ -2213,7 +2213,7 @@ func TestMigrateAcrossContracts(t *testing.T) {
 
 	reporter := newTestReporter()
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 	migrator := migration.NewValueMigrationsPathMigrator(
 		reporter,
 		NewEntitlementsMigration(inter),
@@ -2416,7 +2416,7 @@ func TestMigrateArrayOfValues(t *testing.T) {
 
 	reporter := newTestReporter()
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 	migrator := migration.NewValueMigrationsPathMigrator(
 		reporter,
 		NewEntitlementsMigration(inter),
@@ -2665,7 +2665,7 @@ func TestMigrateDictOfValues(t *testing.T) {
 
 	reporter := newTestReporter()
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 	migrator := migration.NewValueMigrationsPathMigrator(
 		reporter,
 		NewEntitlementsMigration(inter),
@@ -2986,7 +2986,7 @@ func TestMigrateCapConsAcrossTwoAccounts(t *testing.T) {
 
 	reporter := newTestReporter()
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 	migrator := migration.NewValueMigrationsPathMigrator(
 		reporter,
 		NewEntitlementsMigration(inter),
@@ -3198,7 +3198,7 @@ func TestRehash(t *testing.T) {
 			return compositeType
 		}
 
-		migration := migrations.NewStorageMigration(inter, storage)
+		migration := migrations.NewStorageMigration(inter, storage, "test")
 
 		reporter := newTestReporter()
 
@@ -3388,7 +3388,7 @@ func TestIntersectionTypeWithIntersectionLegacyType(t *testing.T) {
 			}
 		}
 
-		migration := migrations.NewStorageMigration(inter, storage)
+		migration := migrations.NewStorageMigration(inter, storage, "test")
 
 		reporter := newTestReporter()
 

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -51,15 +51,18 @@ type DomainMigration interface {
 type StorageMigration struct {
 	storage     *runtime.Storage
 	interpreter *interpreter.Interpreter
+	name        string
 }
 
 func NewStorageMigration(
 	interpreter *interpreter.Interpreter,
 	storage *runtime.Storage,
+	name string,
 ) *StorageMigration {
 	return &StorageMigration{
 		storage:     storage,
 		interpreter: interpreter,
+		name:        name,
 	}
 }
 
@@ -173,7 +176,7 @@ func (m *StorageMigration) MigrateNestedValue(
 			err = StorageMigrationError{
 				StorageKey:    storageKey,
 				StorageMapKey: storageMapKey,
-				Migration:     "StorageMigration",
+				Migration:     m.name,
 				Err:           err,
 				Stack:         debug.Stack(),
 			}

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -507,7 +507,7 @@ func TestMultipleMigrations(t *testing.T) {
 
 	// Migrate
 
-	migration := NewStorageMigration(inter, storage)
+	migration := NewStorageMigration(inter, storage, "test")
 
 	reporter := newTestReporter()
 
@@ -647,7 +647,7 @@ func TestMigrationError(t *testing.T) {
 
 	// Migrate
 
-	migration := NewStorageMigration(inter, storage)
+	migration := NewStorageMigration(inter, storage, "test")
 
 	reporter := newTestReporter()
 
@@ -794,7 +794,7 @@ func TestCapConMigration(t *testing.T) {
 
 	reporter := newTestReporter()
 
-	migration := NewStorageMigration(inter, storage)
+	migration := NewStorageMigration(inter, storage, "test")
 
 	migration.MigrateAccount(
 		testAddress,
@@ -909,7 +909,7 @@ func TestContractMigration(t *testing.T) {
 
 	reporter := newTestReporter()
 
-	migration := NewStorageMigration(inter, storage)
+	migration := NewStorageMigration(inter, storage, "test")
 
 	migration.MigrateAccount(
 		testAddress,
@@ -1102,7 +1102,7 @@ func TestEmptyIntersectionTypeMigration(t *testing.T) {
 
 	reporter := newTestReporter()
 
-	migration := NewStorageMigration(inter, storage)
+	migration := NewStorageMigration(inter, storage, "test")
 
 	migration.MigrateAccount(
 		testAddress,
@@ -1246,7 +1246,7 @@ func TestMigratingNestedContainers(t *testing.T) {
 
 		// Migrate
 
-		migration := NewStorageMigration(inter, storage)
+		migration := NewStorageMigration(inter, storage, "test")
 
 		reporter := newTestReporter()
 
@@ -1676,7 +1676,7 @@ func TestMigrationPanic(t *testing.T) {
 
 	// Migrate
 
-	migration := NewStorageMigration(inter, storage)
+	migration := NewStorageMigration(inter, storage, "test")
 
 	reporter := newTestReporter()
 
@@ -1803,7 +1803,7 @@ func TestSkip(t *testing.T) {
 
 		// Migrate
 
-		migration := NewStorageMigration(inter, storage)
+		migration := NewStorageMigration(inter, storage, "test")
 
 		reporter := newTestReporter()
 
@@ -2143,7 +2143,7 @@ func TestPublishedValueMigration(t *testing.T) {
 
 	reporter := newTestReporter()
 
-	migration := NewStorageMigration(inter, storage)
+	migration := NewStorageMigration(inter, storage, "test")
 
 	migration.MigrateAccount(
 		testAddress,
@@ -2250,7 +2250,7 @@ func TestDomainsMigration(t *testing.T) {
 
 		reporter := newTestReporter()
 
-		migration := NewStorageMigration(inter, storage)
+		migration := NewStorageMigration(inter, storage, "test")
 
 		migration.MigrateAccount(
 			testAddress,

--- a/migrations/statictypes/account_type_migration_test.go
+++ b/migrations/statictypes/account_type_migration_test.go
@@ -461,7 +461,7 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 
 			// Migrate
 
-			migration := migrations.NewStorageMigration(inter, storage)
+			migration := migrations.NewStorageMigration(inter, storage, "test")
 
 			reporter := newTestReporter()
 
@@ -852,7 +852,7 @@ func TestAccountTypeInNestedTypeValueMigration(t *testing.T) {
 
 			// Migrate
 
-			migration := migrations.NewStorageMigration(inter, storage)
+			migration := migrations.NewStorageMigration(inter, storage, "test")
 
 			reporter := newTestReporter()
 
@@ -1158,7 +1158,7 @@ func TestMigratingValuesWithAccountStaticType(t *testing.T) {
 
 			// Migrate
 
-			migration := migrations.NewStorageMigration(inter, storage)
+			migration := migrations.NewStorageMigration(inter, storage, "test")
 
 			reporter := newTestReporter()
 
@@ -1298,7 +1298,7 @@ func TestAccountTypeRehash(t *testing.T) {
 
 		storage, inter := newStorageAndInterpreter(t)
 
-		migration := migrations.NewStorageMigration(inter, storage)
+		migration := migrations.NewStorageMigration(inter, storage, "test")
 
 		reporter := newTestReporter()
 

--- a/migrations/statictypes/composite_type_migration_test.go
+++ b/migrations/statictypes/composite_type_migration_test.go
@@ -145,7 +145,7 @@ func TestCompositeAndInterfaceTypeMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 
 	reporter := newTestReporter()
 

--- a/migrations/statictypes/intersection_type_migration_test.go
+++ b/migrations/statictypes/intersection_type_migration_test.go
@@ -398,7 +398,7 @@ func TestIntersectionTypeMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 
 	reporter := newTestReporter()
 
@@ -566,7 +566,7 @@ func TestIntersectionTypeRehash(t *testing.T) {
 
 		storage, inter := newStorageAndInterpreter(t)
 
-		migration := migrations.NewStorageMigration(inter, storage)
+		migration := migrations.NewStorageMigration(inter, storage, "test")
 
 		reporter := newTestReporter()
 
@@ -733,7 +733,7 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 
 			storage, inter := newStorageAndInterpreter(t, ledger)
 
-			migration := migrations.NewStorageMigration(inter, storage)
+			migration := migrations.NewStorageMigration(inter, storage, "test")
 
 			reporter := newTestReporter()
 
@@ -875,7 +875,7 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 
 			storage, inter := newStorageAndInterpreter(t, ledger)
 
-			migration := migrations.NewStorageMigration(inter, storage)
+			migration := migrations.NewStorageMigration(inter, storage, "test")
 
 			reporter := newTestReporter()
 
@@ -1028,7 +1028,7 @@ func TestIntersectionTypeMigrationWithInterfaceTypeConverter(t *testing.T) {
 
 		// Migrate
 
-		migration := migrations.NewStorageMigration(inter, storage)
+		migration := migrations.NewStorageMigration(inter, storage, "test")
 
 		reporter := newTestReporter()
 
@@ -1423,7 +1423,7 @@ func TestIntersectionTypeMigrationWithTypeConverters(t *testing.T) {
 
 		// Migrate
 
-		migration := migrations.NewStorageMigration(inter, storage)
+		migration := migrations.NewStorageMigration(inter, storage, "test")
 
 		reporter := newTestReporter()
 

--- a/migrations/statictypes/statictype_migration_test.go
+++ b/migrations/statictypes/statictype_migration_test.go
@@ -75,7 +75,7 @@ func TestStaticTypeMigration(t *testing.T) {
 
 		// Migrate
 
-		migration := migrations.NewStorageMigration(inter, storage)
+		migration := migrations.NewStorageMigration(inter, storage, "test")
 
 		reporter := newTestReporter()
 
@@ -757,7 +757,7 @@ func TestMigratingNestedContainers(t *testing.T) {
 
 		// Migrate
 
-		migration := migrations.NewStorageMigration(inter, storage)
+		migration := migrations.NewStorageMigration(inter, storage, "test")
 
 		reporter := newTestReporter()
 

--- a/migrations/string_normalization/migration_test.go
+++ b/migrations/string_normalization/migration_test.go
@@ -303,7 +303,7 @@ func TestStringNormalizingMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage)
+	migration := migrations.NewStorageMigration(inter, storage, "test")
 
 	reporter := newTestReporter()
 
@@ -440,7 +440,7 @@ func TestStringValueRehash(t *testing.T) {
 
 		storage, inter := newStorageAndInterpreter(t)
 
-		migration := migrations.NewStorageMigration(inter, storage)
+		migration := migrations.NewStorageMigration(inter, storage, "test")
 
 		reporter := newTestReporter()
 
@@ -583,7 +583,7 @@ func TestCharacterValueRehash(t *testing.T) {
 
 		storage, inter := newStorageAndInterpreter(t)
 
-		migration := migrations.NewStorageMigration(inter, storage)
+		migration := migrations.NewStorageMigration(inter, storage, "test")
 
 		reporter := newTestReporter()
 


### PR DESCRIPTION
Work towards #3192 

## Description

Currently, the storage migration errors that occur at the "framework" level, i.e. not during an "inner" value migration, but in the "outer" storage migration itself, have the generic name "StorageMigration". 

This makes it hard to identify which migration pass in the full migration pipeline caused the error.

Add a name to the storage migration, and include it in the error.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
