### PR TITLE
Only encode reference static type in legacy format if it was decoded as such

### DIFF
--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -3124,6 +3124,7 @@ func TestRehash(t *testing.T) {
 			interpreter.UnauthorizedAccess,
 			newCompositeType(),
 		)
+		refType.HasLegacyIsAuthorized = true
 		refType.LegacyIsAuthorized = true
 
 		legacyRefType := &migrations.LegacyReferenceType{

--- a/migrations/legacy_reference_type.go
+++ b/migrations/legacy_reference_type.go
@@ -35,6 +35,11 @@ type LegacyReferenceType struct {
 var _ interpreter.StaticType = &LegacyReferenceType{}
 
 func (t *LegacyReferenceType) ID() common.TypeID {
+	if !t.HasLegacyIsAuthorized {
+		// Encode as a regular reference type
+		return t.ReferenceStaticType.ID()
+	}
+
 	borrowedType := t.ReferencedType
 	return common.TypeID(
 		formatReferenceType(
@@ -58,6 +63,14 @@ func formatReferenceType(
 }
 
 func (t *LegacyReferenceType) Encode(e *cbor.StreamEncoder) error {
+	if !t.HasLegacyIsAuthorized {
+		// Encode as a regular reference type
+		return t.ReferenceStaticType.Encode(e)
+	}
+
+	// Has legacy isAuthorized flag,
+	// encode as a legacy reference type
+
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
 		// tag number

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -19,10 +19,12 @@
 package migrations
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -2295,5 +2297,171 @@ func TestDomainsMigration(t *testing.T) {
 			common.PathDomainStorage.Identifier(): {},
 			stdlib.InboxStorageDomain:             {},
 		})
+	})
+}
+
+func TestLegacyReferenceType(t *testing.T) {
+
+	t.Parallel()
+
+	test := func(
+		t *testing.T,
+		refType *interpreter.ReferenceStaticType,
+		expectedTypeID common.TypeID,
+		expectedEncoding []byte,
+	) {
+
+		legacyRefType := &LegacyReferenceType{
+			ReferenceStaticType: refType,
+		}
+
+		assert.Equal(t,
+			expectedTypeID,
+			legacyRefType.ID(),
+		)
+
+		var buf bytes.Buffer
+
+		encoder := cbor.NewStreamEncoder(&buf)
+		err := legacyRefType.Encode(encoder)
+		require.NoError(t, err)
+
+		err = encoder.Flush()
+		require.NoError(t, err)
+
+		assert.Equal(t, expectedEncoding, buf.Bytes())
+	}
+
+	t.Run("has legacy authorized, unauthorized", func(t *testing.T) {
+
+		t.Parallel()
+
+		refType := interpreter.NewReferenceStaticType(
+			nil,
+			interpreter.UnauthorizedAccess,
+			interpreter.PrimitiveStaticTypeAnyStruct,
+		)
+		refType.HasLegacyIsAuthorized = true
+		refType.LegacyIsAuthorized = false
+
+		test(t,
+			refType,
+			"&AnyStruct",
+			[]byte{
+				// tag
+				0xd8, interpreter.CBORTagReferenceStaticType,
+				// array, 2 items follow
+				0x82,
+				// authorized = false
+				0xf4,
+				// tag
+				0xd8, interpreter.CBORTagPrimitiveStaticType,
+				// AnyStruct,
+				byte(interpreter.PrimitiveStaticTypeAnyStruct),
+			},
+		)
+	})
+
+	t.Run("has legacy authorized, authorized", func(t *testing.T) {
+
+		t.Parallel()
+
+		refType := interpreter.NewReferenceStaticType(
+			nil,
+			interpreter.UnauthorizedAccess,
+			interpreter.PrimitiveStaticTypeAnyStruct,
+		)
+		refType.HasLegacyIsAuthorized = true
+		refType.LegacyIsAuthorized = true
+
+		test(t,
+			refType,
+			"auth&AnyStruct",
+			[]byte{
+				// tag
+				0xd8, interpreter.CBORTagReferenceStaticType,
+				// array, 2 items follow
+				0x82,
+				// authorized = true
+				0xf5,
+				// tag
+				0xd8, interpreter.CBORTagPrimitiveStaticType,
+				// AnyStruct,
+				byte(interpreter.PrimitiveStaticTypeAnyStruct),
+			},
+		)
+	})
+
+	t.Run("new authorization, unauthorized", func(t *testing.T) {
+		t.Parallel()
+
+		refType := interpreter.NewReferenceStaticType(
+			nil,
+			interpreter.UnauthorizedAccess,
+			interpreter.PrimitiveStaticTypeAnyStruct,
+		)
+
+		test(t,
+			refType,
+			"&AnyStruct",
+			[]byte{
+				// tag
+				0xd8, interpreter.CBORTagReferenceStaticType,
+				// array, 2 items follow
+				0x82,
+				// tag
+				0xd8, interpreter.CBORTagUnauthorizedStaticAuthorization,
+				// nil
+				0xf6,
+				// tag
+				0xd8, interpreter.CBORTagPrimitiveStaticType,
+				// AnyStruct,
+				byte(interpreter.PrimitiveStaticTypeAnyStruct),
+			},
+		)
+
+	})
+
+	t.Run("new authorization, authorized", func(t *testing.T) {
+		t.Parallel()
+
+		refType := interpreter.NewReferenceStaticType(
+			nil,
+			interpreter.NewEntitlementSetAuthorization(
+				nil,
+				func() []common.TypeID {
+					return []common.TypeID{"Foo"}
+				},
+				1,
+				sema.Conjunction,
+			),
+			interpreter.PrimitiveStaticTypeAnyStruct,
+		)
+
+		test(t,
+			refType,
+			"auth(Foo)&AnyStruct",
+			[]byte{
+				// tag
+				0xd8, interpreter.CBORTagReferenceStaticType,
+				// array, 2 items follow
+				0x82,
+				// tag
+				0xd8, interpreter.CBORTagEntitlementSetStaticAuthorization,
+				// array, 2 items follow
+				0x82,
+				0x0,
+				// array, 1 items follow
+				0x81,
+				// UTF-8 string, 3 bytes follow
+				0x63,
+				// F, o, o
+				0x46, 0x6f, 0x6f,
+				// tag
+				0xd8, interpreter.CBORTagPrimitiveStaticType,
+				// AnyStruct,
+				byte(interpreter.PrimitiveStaticTypeAnyStruct),
+			},
+		)
 	})
 }

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1772,16 +1772,18 @@ func (d TypeDecoder) decodeReferenceStaticType() (StaticType, error) {
 		return nil, err
 	}
 
-	var isAuthorized bool
+	var hasLegacyIsAuthorized bool
+	var legacyIsAuthorized bool
 
 	if t == cbor.BoolType {
 		// if we saw a bool here, this is a reference encoded in the old format
-		isAuthorized, err = d.decoder.DecodeBool()
+		hasLegacyIsAuthorized = true
+
+		legacyIsAuthorized, err = d.decoder.DecodeBool()
 		if err != nil {
 			return nil, err
 		}
 
-		// TODO: better decoding for old values to compute new, sensible authorizations for them.
 		authorization = UnauthorizedAccess
 	} else {
 		// Decode authorized at array index encodedReferenceStaticTypeAuthorizationFieldKey
@@ -1812,7 +1814,8 @@ func (d TypeDecoder) decodeReferenceStaticType() (StaticType, error) {
 		staticType,
 	)
 
-	referenceType.LegacyIsAuthorized = isAuthorized
+	referenceType.HasLegacyIsAuthorized = hasLegacyIsAuthorized
+	referenceType.LegacyIsAuthorized = legacyIsAuthorized
 
 	return referenceType, nil
 }

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -799,8 +799,9 @@ func (a EntitlementMapAuthorization) Equal(other Authorization) bool {
 type ReferenceStaticType struct {
 	Authorization Authorization
 	// ReferencedType is type of the referenced value (the type of the target)
-	ReferencedType     StaticType
-	LegacyIsAuthorized bool
+	ReferencedType        StaticType
+	HasLegacyIsAuthorized bool
+	LegacyIsAuthorized    bool
 }
 
 var _ StaticType = &ReferenceStaticType{}


### PR DESCRIPTION
Work towards #3192 

## Description

When removing an existing key from a dictionary, a "legacy key" is used, which encodes the key in its original form.

However, only do so if the key was actually decoded in legacy form.

In particular, reference static types may have been already migrated, e.g. the entitlements migration adds authorization with an entitlement set, which then should not be encoded in legacy form, i.e. with an authorization flag.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
