### PR TITLE
Simplify AuthorizationMismatchError

### DIFF
--- a/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validator.go
+++ b/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validator.go
@@ -684,24 +684,19 @@ type AuthorizationMismatchError struct {
 }
 
 var _ errors.UserError = &AuthorizationMismatchError{}
-var _ errors.SecondaryError = &AuthorizationMismatchError{}
 
 func (*AuthorizationMismatchError) IsUserError() {}
 
 func (e *AuthorizationMismatchError) Error() string {
-	return "mismatching authorization"
-}
-
-func (e *AuthorizationMismatchError) SecondaryError() string {
 	if e.ExpectedAuthorization == sema.PrimitiveAccess(ast.AccessAll) {
 		return fmt.Sprintf(
-			"The entitlements migration would not grant this value any entitlements, but the annotation present is `%s`",
+			"mismatching authorization: the entitlements migration would not grant this value any entitlements, but the annotation present is `%s`",
 			e.FoundAuthorization.QualifiedString(),
 		)
 	}
 
 	return fmt.Sprintf(
-		"The entitlements migration would only grant this value `%s`, but the annotation present is `%s`",
+		"mismatching authorization: the entitlements migration would only grant this value `%s`, but the annotation present is `%s`",
 		e.ExpectedAuthorization.QualifiedString(),
 		e.FoundAuthorization.QualifiedString(),
 	)


### PR DESCRIPTION
Required for https://github.com/onflow/flow-go/pull/5596

## Description

Given the `AuthorizationMismatchError` is already  a secondary error of `FieldMismatchError`, the `SecondaryError()` method of `AuthorizationMismatchError` would not get called during pretty printing. So simply include all error details in the `Error()` method.

A better fix is to make `FieldMismatchError` a `ParentError`, and return it's children, so the pretty-printer would print recursively. However, when there are multiple levels of child errors, pretty-printer doesn't print the errors at the top, but rather only print the ones at the bottom of the tree (the ones without any more child errors). There is also bit of mixed/confused usages of `ChildErrors()` and `SecondaryError()`. We may need to fix both of these separately.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
