### PR TITLE
Properly handle `Never` type argument to `Capabilities.get`

### DIFF
--- a/runtime/capabilities_test.go
+++ b/runtime/capabilities_test.go
@@ -236,6 +236,13 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
               }
 
               access(all)
+              fun testNever() {
+                  let path = /public/r
+                  assert(self.account.capabilities.get<Never>(path) == nil)
+                  assert(self.account.capabilities.exists(path))
+              }
+
+              access(all)
               fun testSwap(): Int {
                  let ref = self.account.capabilities.get<&R>(/public/r)!.borrow()!
 
@@ -302,6 +309,11 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
 		t.Run("testNonExistent", func(t *testing.T) {
 			_, err := invoke("testNonExistent")
+			require.NoError(t, err)
+		})
+
+		t.Run("testNever", func(t *testing.T) {
+			_, err := invoke("testNever")
 			require.NoError(t, err)
 		})
 

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -3592,8 +3592,13 @@ func newAccountCapabilitiesGetFunction(
 
 			// Get borrow type type argument
 
-			typeParameterPair := invocation.TypeParameterTypes.Oldest()
-			wantedBorrowType, ok := typeParameterPair.Value.(*sema.ReferenceType)
+			typeParameterPairValue := invocation.TypeParameterTypes.Oldest().Value
+			// `Never` is never a supertype of any stored value
+			if typeParameterPairValue.Equal(sema.NeverType) {
+				return interpreter.Nil
+			}
+
+			wantedBorrowType, ok := typeParameterPairValue.(*sema.ReferenceType)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-internal/issues/176

Properly return a `nil` value in this case rather than panicking. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
