### PR TITLE
Add additional fields to account key added event

### DIFF
--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -539,17 +539,17 @@ func TestRuntimeAuthAccountKeysAdd(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.EqualValues(t, key0Weight, key0AddedEvent.Fields[2])
-	assert.EqualValues(t, sema.UFix64Type.ID(), key0AddedEvent.Fields[2].Type().ID())
+	assert.EqualValues(t, sema.UFix64TypeName, key0AddedEvent.Fields[2].Type().ID())
 	assert.EqualValues(t, key1Weight, key1AddedEvent.Fields[2])
 
 	// key hash algorithm
 	assert.EqualValues(t, sema.HashAlgorithmSHA3_256, key0AddedEvent.Fields[3].(cadence.Enum).Fields[0])
-	assert.EqualValues(t, sema.HashAlgorithmType.ID(), key0AddedEvent.Fields[3].Type().ID())
+	assert.EqualValues(t, sema.HashAlgorithmTypeName, key0AddedEvent.Fields[3].Type().ID())
 	assert.EqualValues(t, sema.HashAlgorithmSHA2_256, key1AddedEvent.Fields[3].(cadence.Enum).Fields[0])
 
 	// key index
 	assert.EqualValues(t, cadence.NewInt(0), key0AddedEvent.Fields[4])
-	assert.EqualValues(t, sema.IntType.ID(), key0AddedEvent.Fields[4].Type().ID())
+	assert.EqualValues(t, sema.IntTypeName, key0AddedEvent.Fields[4].Type().ID())
 	assert.EqualValues(t, cadence.NewInt(1), key1AddedEvent.Fields[4])
 }
 

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -532,13 +532,24 @@ func TestRuntimeAuthAccountKeysAdd(t *testing.T) {
 		key0AddedEvent.Type().ID(),
 	)
 
-	assert.EqualValues(t, cadence.NewInt(100), key0AddedEvent.Fields[2])
-	assert.EqualValues(t, cadence.NewInt(0), key1AddedEvent.Fields[2])
+	// key weight
+	key0Weight, err := cadence.NewUFix64("100.0")
+	require.NoError(t, err)
+	key1Weight, err := cadence.NewUFix64("0.0")
+	require.NoError(t, err)
 
+	assert.EqualValues(t, key0Weight, key0AddedEvent.Fields[2])
+	assert.EqualValues(t, sema.UFix64Type.ID(), key0AddedEvent.Fields[2].Type().ID())
+	assert.EqualValues(t, key1Weight, key1AddedEvent.Fields[2])
+
+	// key hash algorithm
 	assert.EqualValues(t, sema.HashAlgorithmSHA3_256, key0AddedEvent.Fields[3].(cadence.Enum).Fields[0])
+	assert.EqualValues(t, sema.HashAlgorithmType.ID(), key0AddedEvent.Fields[3].Type().ID())
 	assert.EqualValues(t, sema.HashAlgorithmSHA2_256, key1AddedEvent.Fields[3].(cadence.Enum).Fields[0])
 
+	// key index
 	assert.EqualValues(t, cadence.NewInt(0), key0AddedEvent.Fields[4])
+	assert.EqualValues(t, sema.IntType.ID(), key0AddedEvent.Fields[4].Type().ID())
 	assert.EqualValues(t, cadence.NewInt(1), key1AddedEvent.Fields[4])
 }
 

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -519,17 +519,21 @@ func TestRuntimeAuthAccountKeysAdd(t *testing.T) {
 
 	require.Len(t, storage.events, 3)
 
-	assert.EqualValues(t,
-		stdlib.AccountCreatedEventType.ID(),
+	assert.Equal(t,
+		string(stdlib.AccountCreatedEventType.ID()),
 		storage.events[0].Type().ID(),
 	)
 
 	key0AddedEvent := storage.events[1]
 	key1AddedEvent := storage.events[2]
 
-	assert.EqualValues(t,
-		stdlib.AccountKeyAddedFromPublicKeyEventType.ID(),
+	assert.Equal(t,
+		string(stdlib.AccountKeyAddedFromPublicKeyEventType.ID()),
 		key0AddedEvent.Type().ID(),
+	)
+	assert.Equal(t,
+		string(stdlib.AccountKeyAddedFromPublicKeyEventType.ID()),
+		key1AddedEvent.Type().ID(),
 	)
 
 	// key weight
@@ -538,19 +542,48 @@ func TestRuntimeAuthAccountKeysAdd(t *testing.T) {
 	key1Weight, err := cadence.NewUFix64("0.0")
 	require.NoError(t, err)
 
-	assert.EqualValues(t, key0Weight, key0AddedEvent.Fields[2])
-	assert.EqualValues(t, sema.UFix64TypeName, key0AddedEvent.Fields[2].Type().ID())
-	assert.EqualValues(t, key1Weight, key1AddedEvent.Fields[2])
+	assert.Equal(t,
+		key0Weight,
+		key0AddedEvent.Fields[2],
+	)
+	assert.Equal(t,
+		sema.UFix64TypeName,
+		key0AddedEvent.Fields[2].Type().ID(),
+	)
+
+	assert.Equal(t,
+		key1Weight,
+		key1AddedEvent.Fields[2],
+	)
+	assert.Equal(t,
+		sema.UFix64TypeName,
+		key1AddedEvent.Fields[2].Type().ID(),
+	)
 
 	// key hash algorithm
-	assert.EqualValues(t, sema.HashAlgorithmSHA3_256, key0AddedEvent.Fields[3].(cadence.Enum).Fields[0])
-	assert.EqualValues(t, sema.HashAlgorithmTypeName, key0AddedEvent.Fields[3].Type().ID())
-	assert.EqualValues(t, sema.HashAlgorithmSHA2_256, key1AddedEvent.Fields[3].(cadence.Enum).Fields[0])
+	assert.Equal(t,
+		cadence.UInt8(sema.HashAlgorithmSHA3_256),
+		key0AddedEvent.Fields[3].(cadence.Enum).Fields[0],
+	)
+	assert.Equal(t,
+		sema.HashAlgorithmTypeName,
+		key0AddedEvent.Fields[3].Type().ID(),
+	)
+
+	assert.Equal(t,
+		cadence.UInt8(sema.HashAlgorithmSHA2_256),
+		key1AddedEvent.Fields[3].(cadence.Enum).Fields[0],
+	)
+	assert.Equal(t,
+		sema.HashAlgorithmTypeName,
+		key1AddedEvent.Fields[3].Type().ID(),
+	)
 
 	// key index
-	assert.EqualValues(t, cadence.NewInt(0), key0AddedEvent.Fields[4])
-	assert.EqualValues(t, sema.IntTypeName, key0AddedEvent.Fields[4].Type().ID())
-	assert.EqualValues(t, cadence.NewInt(1), key1AddedEvent.Fields[4])
+	assert.Equal(t, cadence.NewInt(0), key0AddedEvent.Fields[4])
+	assert.Equal(t, sema.IntTypeName, key0AddedEvent.Fields[4].Type().ID())
+	assert.Equal(t, cadence.NewInt(1), key1AddedEvent.Fields[4])
+	assert.Equal(t, sema.IntTypeName, key1AddedEvent.Fields[4].Type().ID())
 }
 
 func TestRuntimePublicAccountKeys(t *testing.T) {

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -612,10 +612,12 @@ func newAccountKeysAddFunction(
 
 			hashAlgoValue := invocation.Arguments[1]
 			hashAlgo := NewHashAlgorithmFromValue(inter, locationRange, hashAlgoValue)
+
 			weightValue, ok := invocation.Arguments[2].(interpreter.UFix64Value)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}
+
 			weight := weightValue.ToInt(locationRange)
 
 			var accountKey *AccountKey
@@ -632,7 +634,7 @@ func newAccountKeysAddFunction(
 				[]interpreter.Value{
 					addressValue,
 					publicKeyValue,
-					interpreter.NewIntValueFromInt64(gauge, int64(accountKey.Weight)),
+					weightValue,
 					hashAlgoValue,
 					interpreter.NewIntValueFromInt64(gauge, int64(accountKey.KeyIndex)),
 				},

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -610,7 +610,8 @@ func newAccountKeysAddFunction(
 				panic(err)
 			}
 
-			hashAlgo := NewHashAlgorithmFromValue(inter, locationRange, invocation.Arguments[1])
+			hashAlgoValue := invocation.Arguments[1]
+			hashAlgo := NewHashAlgorithmFromValue(inter, locationRange, hashAlgoValue)
 			weightValue, ok := invocation.Arguments[2].(interpreter.UFix64Value)
 			if !ok {
 				panic(errors.NewUnreachableError())
@@ -631,6 +632,9 @@ func newAccountKeysAddFunction(
 				[]interpreter.Value{
 					addressValue,
 					publicKeyValue,
+					interpreter.NewIntValueFromInt64(gauge, int64(accountKey.Weight)),
+					hashAlgoValue,
+					interpreter.NewIntValueFromInt64(gauge, int64(accountKey.KeyIndex)),
 				},
 				locationRange,
 			)

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -209,14 +209,14 @@ var AccountEventContractParameter = sema.Parameter{
 	TypeAnnotation: sema.StringTypeAnnotation,
 }
 
-var AccountEventHashAlgorithmParameter = sema.Parameter{
-	Identifier:     "hashAlgorithm",
-	TypeAnnotation: sema.HashAlgorithmTypeAnnotation,
-}
-
 var AccountEventKeyWeightParameter = sema.Parameter{
 	Identifier:     "weight",
 	TypeAnnotation: sema.UFix64TypeAnnotation,
+}
+
+var AccountEventHashAlgorithmParameter = sema.Parameter{
+	Identifier:     "hashAlgorithm",
+	TypeAnnotation: sema.HashAlgorithmTypeAnnotation,
 }
 
 var AccountEventKeyIndexParameter = sema.Parameter{

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -209,6 +209,21 @@ var AccountEventContractParameter = sema.Parameter{
 	TypeAnnotation: sema.StringTypeAnnotation,
 }
 
+var AccountEventHashAlgorithmParameter = sema.Parameter{
+	Identifier:     "hashAlgorithm",
+	TypeAnnotation: sema.UInt8TypeAnnotation,
+}
+
+var AccountEventKeyWeightParameter = sema.Parameter{
+	Identifier:     "weight",
+	TypeAnnotation: sema.UInt8TypeAnnotation,
+}
+
+var AccountEventKeyIndexParameter = sema.Parameter{
+	Identifier:     "keyIndex",
+	TypeAnnotation: sema.IntTypeAnnotation,
+}
+
 var AccountCreatedEventType = newFlowEventType(
 	"AccountCreated",
 	AccountEventAddressParameter,
@@ -218,6 +233,9 @@ var AccountKeyAddedFromPublicKeyEventType = newFlowEventType(
 	"AccountKeyAdded",
 	AccountEventAddressParameter,
 	AccountEventPublicKeyParameterAsCompositeType,
+	AccountEventKeyWeightParameter,
+	AccountEventHashAlgorithmParameter,
+	AccountEventKeyIndexParameter,
 )
 
 var AccountKeyRemovedFromPublicKeyIndexEventType = newFlowEventType(

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -216,7 +216,7 @@ var AccountEventHashAlgorithmParameter = sema.Parameter{
 
 var AccountEventKeyWeightParameter = sema.Parameter{
 	Identifier:     "weight",
-	TypeAnnotation: sema.UInt8TypeAnnotation,
+	TypeAnnotation: sema.IntTypeAnnotation,
 }
 
 var AccountEventKeyIndexParameter = sema.Parameter{

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -211,12 +211,12 @@ var AccountEventContractParameter = sema.Parameter{
 
 var AccountEventHashAlgorithmParameter = sema.Parameter{
 	Identifier:     "hashAlgorithm",
-	TypeAnnotation: sema.UInt8TypeAnnotation,
+	TypeAnnotation: sema.HashAlgorithmTypeAnnotation,
 }
 
 var AccountEventKeyWeightParameter = sema.Parameter{
 	Identifier:     "weight",
-	TypeAnnotation: sema.IntTypeAnnotation,
+	TypeAnnotation: sema.UFix64TypeAnnotation,
 }
 
 var AccountEventKeyIndexParameter = sema.Parameter{


### PR DESCRIPTION
Closes #3146

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
adding the following information to `flow.AccountKeyAdded` event:
- hash algorithm
- weight
- key index


______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
