### PR TITLE
Fix migration of built-in types

### DIFF
--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -355,6 +355,18 @@ func (m *StaticTypeMigration) maybeConvertStaticType(staticType, parentType inte
 			convertedType = compositeTypeConverter(staticType)
 		}
 
+		// Convert built-in types in composite type form to primitive type
+		if convertedType == nil && staticType.Location == nil {
+			primitiveStaticType := interpreter.PrimitiveStaticTypeFromTypeID(staticType.TypeID)
+			if primitiveStaticType != interpreter.PrimitiveStaticTypeUnknown {
+				convertedPrimitiveStaticType := m.maybeConvertStaticType(primitiveStaticType, parentType)
+				if convertedPrimitiveStaticType != nil {
+					return convertedPrimitiveStaticType
+				}
+				return primitiveStaticType
+			}
+		}
+
 		// Interface types need to be placed in intersection types.
 		// If the composite type was converted to an interface type,
 		// and if the parent type is not an intersection type,

--- a/migrations/statictypes/statictype_migration_test.go
+++ b/migrations/statictypes/statictype_migration_test.go
@@ -1124,7 +1124,7 @@ func TestMigratingNestedContainers(t *testing.T) {
 
 }
 
-func TestCanSkipprimitivestatictypeauthStaticTypeMigration(t *testing.T) {
+func TestCanSkipStaticTypeMigration(t *testing.T) {
 
 	t.Parallel()
 

--- a/migrations/statictypes/statictype_migration_test.go
+++ b/migrations/statictypes/statictype_migration_test.go
@@ -832,7 +832,7 @@ func TestStaticTypeMigration(t *testing.T) {
 			}
 
 			for ty := interpreter.PrimitiveStaticTypeUnknown + 1; ty < interpreter.PrimitiveStaticType_Count; ty++ {
-				if !ty.IsDefined() || ty.IsDeprecated() { //nolin:staticcheck
+				if !ty.IsDefined() || ty.IsDeprecated() { //nolint:staticcheck
 					continue
 				}
 

--- a/migrations/statictypes/statictype_migration_test.go
+++ b/migrations/statictypes/statictype_migration_test.go
@@ -150,6 +150,41 @@ func TestStaticTypeMigration(t *testing.T) {
 		)
 	})
 
+	t.Run("TypeValue with reference to AuthAccount", func(t *testing.T) {
+		t.Parallel()
+
+		staticTypeMigration := NewStaticTypeMigration()
+
+		actual := migrate(t,
+			staticTypeMigration,
+			interpreter.NewUnmeteredTypeValue(
+				interpreter.NewDictionaryStaticType(nil,
+					interpreter.PrimitiveStaticTypeAddress,
+					interpreter.NewCapabilityStaticType(nil,
+						interpreter.NewReferenceStaticType(
+							nil,
+							interpreter.UnauthorizedAccess,
+							interpreter.PrimitiveStaticTypeAuthAccount,
+						),
+					),
+				),
+			),
+			true,
+		)
+		assert.Equal(t,
+			interpreter.NewUnmeteredTypeValue(
+				interpreter.NewDictionaryStaticType(nil,
+					interpreter.PrimitiveStaticTypeAddress,
+					interpreter.NewCapabilityStaticType(nil,
+						// NOTE: NOT reference to reference type
+						authAccountReferenceType,
+					),
+				),
+			),
+			actual,
+		)
+	})
+
 	t.Run("PathCapabilityValue with nil borrow type", func(t *testing.T) {
 		t.Parallel()
 

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -426,6 +426,7 @@ func (t PrimitiveStaticType) MeteredString(memoryGauge common.MemoryGauge) strin
 
 func (t PrimitiveStaticType) ID() TypeID {
 
+	// Handle deprecated types specially, because they do not have a sema type equivalent anymore
 	switch t {
 	case PrimitiveStaticTypeAuthAccount: //nolint:staticcheck
 		return "AuthAccount"

--- a/runtime/interpreter/primitivestatictype.go
+++ b/runtime/interpreter/primitivestatictype.go
@@ -394,6 +394,9 @@ func (t PrimitiveStaticType) elementSize() uint {
 		PrimitiveStaticTypeAccountKey:
 		// These types are deprecated, and only exist for migration purposes
 		return UnknownElementSize
+
+	case PrimitiveStaticTypeUnknown:
+	case PrimitiveStaticType_Count:
 	}
 
 	panic(errors.NewUnexpectedError("missing case for %s", t))
@@ -422,6 +425,34 @@ func (t PrimitiveStaticType) MeteredString(memoryGauge common.MemoryGauge) strin
 }
 
 func (t PrimitiveStaticType) ID() TypeID {
+
+	switch t {
+	case PrimitiveStaticTypeAuthAccount: //nolint:staticcheck
+		return "AuthAccount"
+	case PrimitiveStaticTypePublicAccount: //nolint:staticcheck
+		return "PublicAccount"
+	case PrimitiveStaticTypeAuthAccountContracts: //nolint:staticcheck
+		return "AuthAccount.Contracts"
+	case PrimitiveStaticTypePublicAccountContracts: //nolint:staticcheck
+		return "PublicAccount.Contracts"
+	case PrimitiveStaticTypeAuthAccountKeys: //nolint:staticcheck
+		return "AuthAccount.Keys"
+	case PrimitiveStaticTypePublicAccountKeys: //nolint:staticcheck
+		return "PublicAccount.Keys"
+	case PrimitiveStaticTypeAuthAccountInbox: //nolint:staticcheck
+		return "AuthAccount.Inbox"
+	case PrimitiveStaticTypeAuthAccountStorageCapabilities: //nolint:staticcheck
+		return "AuthAccount.StorageCapabilities"
+	case PrimitiveStaticTypeAuthAccountAccountCapabilities: //nolint:staticcheck
+		return "AuthAccount.AccountCapabilities"
+	case PrimitiveStaticTypeAuthAccountCapabilities: //nolint:staticcheck
+		return "AuthAccount.Capabilities"
+	case PrimitiveStaticTypePublicAccountCapabilities: //nolint:staticcheck
+		return "PublicAccount.Capabilities"
+	case PrimitiveStaticTypeAccountKey: //nolint:staticcheck
+		return "AccountKey"
+	}
+
 	return t.SemaType().ID()
 }
 
@@ -654,6 +685,21 @@ func (t PrimitiveStaticType) SemaType() sema.Type {
 	case PrimitiveStaticTypePublicAccount: //nolint:staticcheck
 		// deprecated, but needed for migration purposes
 		return sema.AccountReferenceType
+
+	case PrimitiveStaticTypeAuthAccountContracts:
+	case PrimitiveStaticTypePublicAccountContracts:
+	case PrimitiveStaticTypeAuthAccountKeys:
+	case PrimitiveStaticTypePublicAccountKeys:
+	case PrimitiveStaticTypeAccountKey:
+	case PrimitiveStaticTypeAuthAccountInbox:
+	case PrimitiveStaticTypeAuthAccountStorageCapabilities:
+	case PrimitiveStaticTypeAuthAccountAccountCapabilities:
+	case PrimitiveStaticTypeAuthAccountCapabilities:
+	case PrimitiveStaticTypePublicAccountCapabilities:
+		panic(errors.NewUnexpectedError("cannot convert deprecated type %s", t))
+
+	case PrimitiveStaticTypeUnknown:
+	case PrimitiveStaticType_Count:
 	}
 
 	if t.IsDeprecated() {
@@ -918,4 +964,28 @@ func ConvertSemaToPrimitiveStaticType(
 	}
 
 	return NewPrimitiveStaticType(memoryGauge, typ)
+}
+
+var primitiveStaticTypesByTypeID = map[TypeID]PrimitiveStaticType{}
+
+func init() {
+	// Check all defined primitive static types,
+	// and construct a type ID to primitive static type mapping
+	for ty := PrimitiveStaticTypeUnknown + 1; ty < PrimitiveStaticType_Count; ty++ {
+		if !ty.IsDefined() {
+			continue
+		}
+
+		_ = ty.elementSize()
+
+		primitiveStaticTypesByTypeID[ty.ID()] = ty
+	}
+}
+
+func PrimitiveStaticTypeFromTypeID(typeID TypeID) PrimitiveStaticType {
+	ty, ok := primitiveStaticTypesByTypeID[typeID]
+	if !ok {
+		return PrimitiveStaticTypeUnknown
+	}
+	return ty
 }


### PR DESCRIPTION
Work towards #3192

## Description

Built-in types (location == nil) may be represented as `CompositeStaticType` instead of the simplified `PrimitiveStaticType`. This is because we're not properly normalizing the types e.g. during import, in the type construction functions, etc.

Start cleaning this up and handling this properly by extending the static type migration to convert `CompositeStaticType` to `PrimitiveStaticType`, if the composite static type refers to a built-in type that should be represented by a primitive static type.

In follow up PRs we should clean up the incorrect representation / construction (see examples above).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
