### PR TITLE
Add `TypeArgumentsCheck`s to certain builtin functions

### DIFF
--- a/runtime/capabilities_test.go
+++ b/runtime/capabilities_test.go
@@ -236,13 +236,6 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
               }
 
               access(all)
-              fun testNever() {
-                  let path = /public/r
-                  assert(self.account.capabilities.get<Never>(path) == nil)
-                  assert(self.account.capabilities.exists(path))
-              }
-
-              access(all)
               fun testSwap(): Int {
                  let ref = self.account.capabilities.get<&R>(/public/r)!.borrow()!
 
@@ -309,11 +302,6 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
 		t.Run("testNonExistent", func(t *testing.T) {
 			_, err := invoke("testNonExistent")
-			require.NoError(t, err)
-		})
-
-		t.Run("testNever", func(t *testing.T) {
-			_, err := invoke("testNever")
 			require.NoError(t, err)
 		})
 

--- a/runtime/sema/account.go
+++ b/runtime/sema/account.go
@@ -18,6 +18,14 @@
 
 package sema
 
+import (
+	"fmt"
+
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
+)
+
 //go:generate go run ./gen account.cdc account.gen.go
 
 var AccountTypeAnnotation = NewTypeAnnotation(AccountType)
@@ -55,6 +63,33 @@ var FullyEntitledAccountReferenceTypeAnnotation = NewTypeAnnotation(FullyEntitle
 
 func init() {
 	Account_ContractsTypeAddFunctionType.Arity = &Arity{Min: 2}
+
+	Account_CapabilitiesTypeGetFunctionType.TypeArgumentsCheck =
+		func(memoryGauge common.MemoryGauge,
+			typeArguments *TypeParameterTypeOrderedMap,
+			_ []*ast.TypeAnnotation,
+			invocationRange ast.HasPosition,
+			report func(err error),
+		) {
+			typeArg, ok := typeArguments.Get(Account_CapabilitiesTypeGetFunctionTypeParameterT)
+			if !ok || typeArg == nil {
+				// checker should prevent this
+				panic(errors.NewUnreachableError())
+			}
+			if typeArg == NeverType {
+				errorRange := invocationRange
+
+				report(&InvalidTypeArgumentError{
+					TypeArgumentName: Account_CapabilitiesTypeGetFunctionTypeParameterT.Name,
+					Range:            ast.NewRangeFromPositioned(memoryGauge, errorRange),
+					Details: fmt.Sprintf(
+						"Type argument for `%s` cannot be `%s`",
+						Account_CapabilitiesTypeGetFunctionName,
+						NeverType,
+					),
+				})
+			}
+		}
 
 	addToBaseActivation(AccountMappingType)
 	addToBaseActivation(CapabilitiesMappingType)

--- a/runtime/sema/account.go
+++ b/runtime/sema/account.go
@@ -77,11 +77,9 @@ func init() {
 				panic(errors.NewUnreachableError())
 			}
 			if typeArg == NeverType {
-				errorRange := invocationRange
-
 				report(&InvalidTypeArgumentError{
 					TypeArgumentName: Account_CapabilitiesTypeGetFunctionTypeParameterT.Name,
-					Range:            ast.NewRangeFromPositioned(memoryGauge, errorRange),
+					Range:            ast.NewRangeFromPositioned(memoryGauge, invocationRange),
 					Details: fmt.Sprintf(
 						"Type argument for `%s` cannot be `%s`",
 						Account_CapabilitiesTypeGetFunctionName,

--- a/runtime/stdlib/random.go
+++ b/runtime/stdlib/random.go
@@ -20,8 +20,10 @@ package stdlib
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math/big"
 
+	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
@@ -35,6 +37,8 @@ NOTE: The use of this function is unsafe if not used correctly.
 
 Follow best practices to prevent security issues when using this function
 `
+
+const revertibleRandomFunctionName = "revertibleRandom"
 
 var revertibleRandomFunctionType = func() *sema.FunctionType {
 	typeParameter := &sema.TypeParameter{
@@ -57,6 +61,29 @@ var revertibleRandomFunctionType = func() *sema.FunctionType {
 				Identifier:     "modulo",
 				TypeAnnotation: typeAnnotation,
 			},
+		},
+		TypeArgumentsCheck: func(
+			memoryGauge common.MemoryGauge,
+			typeArguments *sema.TypeParameterTypeOrderedMap,
+			_ []*ast.TypeAnnotation,
+			invocationRange ast.HasPosition,
+			report func(err error)) {
+			typeArg, ok := typeArguments.Get(typeParameter)
+			if !ok || typeArg == nil {
+				// checker should prevent this
+				panic(errors.NewUnreachableError())
+			}
+			if typeArg == sema.NeverType || typeArg == sema.FixedSizeUnsignedIntegerType {
+				report(&sema.InvalidTypeArgumentError{
+					TypeArgumentName: typeParameter.Name,
+					Range:            ast.NewRangeFromPositioned(memoryGauge, invocationRange),
+					Details: fmt.Sprintf(
+						"Type argument for `%s` cannot be `%s`",
+						revertibleRandomFunctionName,
+						typeArg,
+					),
+				})
+			}
 		},
 		ReturnTypeAnnotation: typeAnnotation,
 		// `modulo` parameter is optional
@@ -84,7 +111,7 @@ var ZeroModuloError = errors.NewDefaultUserError("modulo argument cannot be zero
 
 func NewRevertibleRandomFunction(generator RandomGenerator) StandardLibraryValue {
 	return NewStandardLibraryFunction(
-		"revertibleRandom",
+		revertibleRandomFunctionName,
 		revertibleRandomFunctionType,
 		revertibleRandomFunctionDocString,
 		func(invocation interpreter.Invocation) interpreter.Value {

--- a/runtime/tests/checker/account_test.go
+++ b/runtime/tests/checker/account_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/tests/utils"
 )
@@ -1725,6 +1726,21 @@ func TestCheckAccountCapabilities(t *testing.T) {
 
 		require.IsType(t, &sema.InvalidAccessError{}, errors[0])
 		require.IsType(t, &sema.InvalidAccessError{}, errors[1])
+	})
+
+	t.Run("never type arg", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          fun test(capabilities: &Account.Capabilities) {
+              capabilities.get<Never>(/public/foo)!
+          }
+        `)
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.InvalidTypeArgumentError{}, errs[0])
+		require.Equal(t, errs[0].(errors.SecondaryError).SecondaryError(), "Type argument for `get` cannot be `Never`")
 	})
 }
 

--- a/runtime/tests/checker/builtinfunctions_test.go
+++ b/runtime/tests/checker/builtinfunctions_test.go
@@ -407,6 +407,24 @@ func TestCheckRevertibleRandom(t *testing.T) {
 		},
 	)
 
+	runInvalidCase(
+		t,
+		"invalid type arg never",
+		`let rand = revertibleRandom<Never>(modulo: 1)`,
+		[]error{
+			&sema.TypeMismatchError{},
+			&sema.InvalidTypeArgumentError{},
+		},
+	)
+	runInvalidCase(
+		t,
+		"invalid type arg FixedSizeUnsignedInteger",
+		`let rand = revertibleRandom<FixedSizeUnsignedInteger>(modulo: 1)`,
+		[]error{
+			&sema.InvalidTypeArgumentError{},
+		},
+	)
+
 	t.Run("type parameter used for argument", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-internal/issues/188

Uses the `TypeArgumentCheck` functionality to prevent certain builtin functions from being used with invalid typeargs. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
