### PR TITLE
Fix dereferencing non-reference type

### DIFF
--- a/runtime/sema/check_unary_expression.go
+++ b/runtime/sema/check_unary_expression.go
@@ -83,8 +83,8 @@ func (checker *Checker) VisitUnaryExpression(expression *ast.UnaryExpression) Ty
 						),
 					},
 				)
-				return InvalidType
 			}
+			return InvalidType
 		}
 
 		innerType := referenceType.Type

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -3546,6 +3546,27 @@ func TestCheckDereference(t *testing.T) {
             `,
 		)
 	})
+
+	runInvalidTestCase(
+		t,
+		"non-reference",
+		`
+          fun test(foo: Int): AnyStruct {
+              return *foo
+          }
+        `,
+	)
+
+	t.Run("invalid type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          let x = *y
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+	})
 }
 
 func TestCheckReferenceRequiredTypeAnnotation(t *testing.T) {


### PR DESCRIPTION
Closes #3214

## Description

Fix Go nil pointer dereference caused by using reference type even when dereferenced type is not a reference.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
