### PR TITLE
Check resource loss in `CompositeValue.RemoveField`

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -2217,11 +2217,8 @@ func (v *ArrayValue) Set(interpreter *Interpreter, locationRange LocationRange, 
 	interpreter.maybeValidateAtreeValue(v.array)
 
 	existingValue := StoredValue(interpreter, existingStorable, interpreter.Storage())
-
 	interpreter.checkResourceLoss(existingValue, locationRange)
-
 	existingValue.DeepRemove(interpreter)
-
 	interpreter.RemoveReferencedSlab(existingStorable)
 }
 
@@ -18111,7 +18108,7 @@ func (v *CompositeValue) StorageAddress() atree.Address {
 
 func (v *CompositeValue) RemoveField(
 	interpreter *Interpreter,
-	_ LocationRange,
+	locationRange LocationRange,
 	name string,
 ) {
 
@@ -18137,6 +18134,7 @@ func (v *CompositeValue) RemoveField(
 
 	// Value
 	existingValue := StoredValue(interpreter, existingValueStorable, interpreter.Storage())
+	interpreter.checkResourceLoss(existingValue, locationRange)
 	existingValue.DeepRemove(interpreter)
 	interpreter.RemoveReferencedSlab(existingValueStorable)
 }


### PR DESCRIPTION
## Description

For consistency, also check for resource loss when removing a composite field.

The function is currently only used in tests, but might be used in the future.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
