### PR TITLE
Check resource loss in all variable assignments

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1388,11 +1388,8 @@ func (declarationInterpreter *Interpreter) declareNonEnumCompositeValue(
 					// NOTE: set the variable value immediately, as the contract value
 					// needs to be available for nested declarations
 
-					variable.SetValue(
-						interpreter,
-						locationRange,
-						value,
-					)
+					variable.getter = nil
+					variable.value = value
 
 					// Also, immediately set the nested values,
 					// as the initializer of the contract may use nested declarations
@@ -1433,7 +1430,7 @@ func (declarationInterpreter *Interpreter) declareNonEnumCompositeValue(
 		variable.SetValue(
 			declarationInterpreter,
 			LocationRange{
-				Location: location,
+				Location:    location,
 				HasPosition: declaration,
 			},
 			constructor,

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -692,12 +692,19 @@ func (interpreter *Interpreter) VisitFunctionDeclaration(declaration *ast.Functi
 	// make the function itself available inside the function
 	lexicalScope.Set(identifier, variable)
 
+	value := interpreter.functionDeclarationValue(
+		declaration,
+		functionType,
+		lexicalScope,
+	)
+
 	variable.SetValue(
-		interpreter.functionDeclarationValue(
-			declaration,
-			functionType,
-			lexicalScope,
-		),
+		interpreter,
+		LocationRange{
+			Location:    interpreter.Location,
+			HasPosition: declaration,
+		},
+		value,
 	)
 
 	return nil
@@ -1381,7 +1388,11 @@ func (declarationInterpreter *Interpreter) declareNonEnumCompositeValue(
 					// NOTE: set the variable value immediately, as the contract value
 					// needs to be available for nested declarations
 
-					variable.SetValue(value)
+					variable.SetValue(
+						interpreter,
+						locationRange,
+						value,
+					)
 
 					// Also, immediately set the nested values,
 					// as the initializer of the contract may use nested declarations
@@ -1419,7 +1430,14 @@ func (declarationInterpreter *Interpreter) declareNonEnumCompositeValue(
 	} else {
 		constructor := constructorGenerator(common.ZeroAddress)
 		constructor.NestedVariables = nestedVariables
-		variable.SetValue(constructor)
+		variable.SetValue(
+			declarationInterpreter,
+			LocationRange{
+				Location: location,
+				HasPosition: declaration,
+			},
+			constructor,
+		)
 	}
 
 	return lexicalScope, variable
@@ -1510,7 +1528,11 @@ func (interpreter *Interpreter) declareEnumConstructor(
 		caseValues,
 		constructorNestedVariables,
 	)
-	variable.SetValue(value)
+	variable.SetValue(
+		interpreter,
+		locationRange,
+		value,
+	)
 
 	return lexicalScope, variable
 }

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -76,11 +76,11 @@ func (interpreter *Interpreter) identifierExpressionGetterSetter(
 		},
 		set: func(value Value) {
 			interpreter.startResourceTracking(value, variable, identifier, identifierExpression)
-
-			existingValue := variable.GetValue()
-			interpreter.checkResourceLoss(existingValue, locationRange)
-
-			variable.SetValue(value)
+			variable.SetValue(
+				interpreter,
+				locationRange,
+				value,
+			)
 		},
 	}
 }

--- a/runtime/interpreter/variable.go
+++ b/runtime/interpreter/variable.go
@@ -34,7 +34,7 @@ func (v *Variable) GetValue() Value {
 }
 
 func (v *Variable) SetValue(interpreter *Interpreter, locationRange LocationRange, value Value) {
-	existingValue := v.value
+	existingValue := v.GetValue()
 	if existingValue != nil {
 		interpreter.checkResourceLoss(existingValue, locationRange)
 	}

--- a/runtime/interpreter/variable.go
+++ b/runtime/interpreter/variable.go
@@ -33,7 +33,11 @@ func (v *Variable) GetValue() Value {
 	return v.value
 }
 
-func (v *Variable) SetValue(value Value) {
+func (v *Variable) SetValue(interpreter *Interpreter, locationRange LocationRange, value Value) {
+	existingValue := v.value
+	if existingValue != nil {
+		interpreter.checkResourceLoss(existingValue, locationRange)
+	}
 	v.getter = nil
 	v.value = value
 }


### PR DESCRIPTION

## Description

Instead of only checking for resource loss in `identifierExpressionGetterSetter`, check in all cases where the value of a variable is updated, and an existing value is dropped.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
