### PR TITLE
Improve atree register inlining v1.0

### DIFF
--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -312,22 +312,23 @@ func (m *StorageMigration) MigrateNestedValue(
 		// by the modification of the nested values.
 		var existingKeysAndValues []keyValuePair
 
-		iterator := dictionary.Iterator()
+		dictionary.IterateReadOnly(
+			inter,
+			emptyLocationRange,
+			func(key, value interpreter.Value) (resume bool) {
 
-		for {
-			key, value := iterator.Next(nil)
-			if key == nil {
-				break
-			}
+				existingKeysAndValues = append(
+					existingKeysAndValues,
+					keyValuePair{
+						key:   key,
+						value: value,
+					},
+				)
 
-			existingKeysAndValues = append(
-				existingKeysAndValues,
-				keyValuePair{
-					key:   key,
-					value: value,
-				},
-			)
-		}
+				// Continue iteration
+				return true
+			},
+		)
 
 		for _, existingKeyAndValue := range existingKeysAndValues {
 			existingKey := existingKeyAndValue.key

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -5244,7 +5244,7 @@ func (interpreter *Interpreter) invalidateReferencedResources(
 
 	switch value := value.(type) {
 	case *CompositeValue:
-		value.ForEachLoadedField(
+		value.ForEachReadOnlyLoadedField(
 			interpreter,
 			func(_ string, fieldValue Value) (resume bool) {
 				interpreter.invalidateReferencedResources(fieldValue, locationRange)
@@ -5256,7 +5256,7 @@ func (interpreter *Interpreter) invalidateReferencedResources(
 		valueID = value.ValueID()
 
 	case *DictionaryValue:
-		value.IterateLoaded(
+		value.IterateReadOnlyLoaded(
 			interpreter,
 			locationRange,
 			func(_, value Value) (resume bool) {
@@ -5267,7 +5267,7 @@ func (interpreter *Interpreter) invalidateReferencedResources(
 		valueID = value.ValueID()
 
 	case *ArrayValue:
-		value.IterateLoaded(
+		value.IterateReadOnlyLoaded(
 			interpreter,
 			func(element Value) (resume bool) {
 				interpreter.invalidateReferencedResources(element, locationRange)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1924,7 +1924,9 @@ func (v *ArrayValue) Iterate(
 	)
 }
 
-func (v *ArrayValue) IterateLoaded(
+// IterateReadOnlyLoaded iterates over all LOADED elements of the array.
+// DO NOT perform storage mutations in the callback!
+func (v *ArrayValue) IterateReadOnlyLoaded(
 	interpreter *Interpreter,
 	f func(element Value) (resume bool),
 	locationRange LocationRange,
@@ -18194,9 +18196,10 @@ func (v *CompositeValue) ForEachField(
 	)
 }
 
-// ForEachLoadedField iterates over all LOADED field-name field-value pairs of the composite value.
+// ForEachReadOnlyLoadedField iterates over all LOADED field-name field-value pairs of the composite value.
 // It does NOT iterate over computed fields and functions!
-func (v *CompositeValue) ForEachLoadedField(
+// DO NOT perform storage mutations in the callback!
+func (v *CompositeValue) ForEachReadOnlyLoadedField(
 	interpreter *Interpreter,
 	f func(fieldName string, fieldValue Value) (resume bool),
 	locationRange LocationRange,
@@ -18959,7 +18962,9 @@ func (v *DictionaryValue) Iterate(
 	v.iterate(interpreter, iterate, f, locationRange)
 }
 
-func (v *DictionaryValue) IterateLoaded(
+// IterateReadOnlyLoaded iterates over all LOADED key-valye pairs of the array.
+// DO NOT perform storage mutations in the callback!
+func (v *DictionaryValue) IterateReadOnlyLoaded(
 	interpreter *Interpreter,
 	locationRange LocationRange,
 	f func(key, value Value) (resume bool),


### PR DESCRIPTION
Depends on #3229

## Description

Follow-up to #3229:

- [Improve `StorageMigration.MigrateNestedValue` for `DictionaryValue`: use read-only iterator](https://github.com/onflow/cadence/commit/0a3b9d3576b52f4ea9fc70a9d7be9fce1e85b15f)
- [Improve naming and documentation of "loaded" iteration functions: they are read-only](https://github.com/onflow/cadence/commit/2f646ef8ed3de94cd0f86e15157ce58334717cfe)

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
