### PR TITLE
Introduce a dedicated error for unreferenced slabs and expose the IDs

### DIFF
--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -2747,6 +2747,6 @@ func TestDictionaryKeyConflict(t *testing.T) {
 		// Health check is expected to fail,
 		// as one of the arrays is still stored, but no longer referenced
 		err = storage.CheckHealth()
-		require.ErrorContains(t, err, "slabs not referenced from account Storage: [0x1.3]")
+		require.ErrorContains(t, err, "slabs not referenced: [0x1.3]")
 	})()
 }

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -19,6 +19,7 @@
 package runtime
 
 import (
+	"fmt"
 	"runtime"
 	"sort"
 
@@ -347,8 +348,22 @@ func (s *Storage) CheckHealth() error {
 			return a.Compare(b) < 0
 		})
 
-		return errors.NewUnexpectedError("slabs not referenced from account Storage: %s", unreferencedRootSlabIDs)
+		return UnreferencedRootSlabsError{
+			UnreferencedRootSlabIDs: unreferencedRootSlabIDs,
+		}
 	}
 
 	return nil
+}
+
+type UnreferencedRootSlabsError struct {
+	UnreferencedRootSlabIDs []atree.StorageID
+}
+
+var _ errors.InternalError = UnreferencedRootSlabsError{}
+
+func (UnreferencedRootSlabsError) IsInternalError() {}
+
+func (e UnreferencedRootSlabsError) Error() string {
+	return fmt.Sprintf("slabs not referenced: %s", e.UnreferencedRootSlabIDs)
 }


### PR DESCRIPTION
Work towards https://github.com/onflow/flow-go/issues/5634

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
