### PR TITLE
Introduce special self-variable

### DIFF
--- a/runtime/cmd/execute/debugger.go
+++ b/runtime/cmd/execute/debugger.go
@@ -73,7 +73,8 @@ func (d *InteractiveDebugger) Next() {
 // Show shows the values for the variables with the given names.
 // If no names are given, lists all non-base variables
 func (d *InteractiveDebugger) Show(names []string) {
-	current := d.debugger.CurrentActivation(d.stop.Interpreter)
+	inter := d.stop.Interpreter
+	current := d.debugger.CurrentActivation(inter)
 	switch len(names) {
 	case 0:
 		for name := range current.FunctionValues() { //nolint:maprange
@@ -88,7 +89,7 @@ func (d *InteractiveDebugger) Show(names []string) {
 			return
 		}
 
-		fmt.Println(colorizeValue(variable.GetValue()))
+		fmt.Println(colorizeValue(variable.GetValue(inter)))
 
 	default:
 		for _, name := range names {
@@ -100,7 +101,7 @@ func (d *InteractiveDebugger) Show(names []string) {
 			fmt.Printf(
 				"%s = %s\n",
 				name,
-				colorizeValue(variable.GetValue()),
+				colorizeValue(variable.GetValue(inter)),
 			)
 		}
 	}

--- a/runtime/debugger_test.go
+++ b/runtime/debugger_test.go
@@ -106,7 +106,7 @@ func TestRuntimeDebugger(t *testing.T) {
 	variable := activation.Find("answer")
 	require.NotNil(t, variable)
 
-	value := variable.GetValue()
+	value := variable.GetValue(stop.Interpreter)
 	require.Equal(
 		t,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
@@ -192,7 +192,7 @@ func TestRuntimeDebuggerBreakpoints(t *testing.T) {
 	variable := activation.Find("answer")
 	require.NotNil(t, variable)
 
-	value := variable.GetValue()
+	value := variable.GetValue(stop.Interpreter)
 	require.Equal(
 		t,
 		interpreter.NewUnmeteredIntValueFromInt64(42),

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -289,7 +289,7 @@ func (e *interpreterEnvironment) interpreterBaseActivationFor(
 
 	baseActivation := e.baseActivationsByLocation[location]
 	if baseActivation == nil {
-		baseActivation = activations.NewActivation[*interpreter.Variable](nil, defaultBaseActivation)
+		baseActivation = activations.NewActivation[interpreter.Variable](nil, defaultBaseActivation)
 		if e.baseActivationsByLocation == nil {
 			e.baseActivationsByLocation = map[common.Location]*interpreter.VariableActivation{}
 		}
@@ -1106,7 +1106,7 @@ func (e *interpreterEnvironment) InterpretContract(
 		)
 	}
 
-	contract = variable.GetValue().(*interpreter.CompositeValue)
+	contract = variable.GetValue(inter).(*interpreter.CompositeValue)
 
 	return
 }

--- a/runtime/interpreter/globalvariables.go
+++ b/runtime/interpreter/globalvariables.go
@@ -20,7 +20,7 @@ package interpreter
 
 // GlobalVariables represents global variables defined in a program.
 type GlobalVariables struct {
-	variables map[string]*Variable
+	variables map[string]Variable
 }
 
 func (g *GlobalVariables) Contains(name string) bool {
@@ -31,16 +31,16 @@ func (g *GlobalVariables) Contains(name string) bool {
 	return ok
 }
 
-func (g *GlobalVariables) Get(name string) *Variable {
+func (g *GlobalVariables) Get(name string) Variable {
 	if g.variables == nil {
 		return nil
 	}
 	return g.variables[name]
 }
 
-func (g *GlobalVariables) Set(name string, variable *Variable) {
+func (g *GlobalVariables) Set(name string, variable Variable) {
 	if g.variables == nil {
-		g.variables = map[string]*Variable{}
+		g.variables = map[string]Variable{}
 	}
 	g.variables[name] = variable
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -245,7 +245,7 @@ var BaseActivation *VariableActivation
 
 func init() {
 	// No need to meter since this is only created once
-	BaseActivation = activations.NewActivation[*Variable](nil, nil)
+	BaseActivation = activations.NewActivation[Variable](nil, nil)
 	defineBaseFunctions(BaseActivation)
 }
 
@@ -280,7 +280,7 @@ func NewInterpreterWithSharedState(
 
 	// Initialize activations
 
-	interpreter.activations = activations.NewActivations[*Variable](interpreter)
+	interpreter.activations = activations.NewActivations[Variable](interpreter)
 
 	var baseActivation *VariableActivation
 	baseActivationHandler := sharedState.Config.BaseActivationHandler
@@ -296,11 +296,11 @@ func NewInterpreterWithSharedState(
 	return interpreter, nil
 }
 
-func (interpreter *Interpreter) FindVariable(name string) *Variable {
+func (interpreter *Interpreter) FindVariable(name string) Variable {
 	return interpreter.activations.Find(name)
 }
 
-func (interpreter *Interpreter) findOrDeclareVariable(name string) *Variable {
+func (interpreter *Interpreter) findOrDeclareVariable(name string) Variable {
 	variable := interpreter.FindVariable(name)
 	if variable == nil {
 		variable = interpreter.declareVariable(name, nil)
@@ -308,7 +308,7 @@ func (interpreter *Interpreter) findOrDeclareVariable(name string) *Variable {
 	return variable
 }
 
-func (interpreter *Interpreter) setVariable(name string, variable *Variable) {
+func (interpreter *Interpreter) setVariable(name string, variable Variable) {
 	interpreter.activations.Set(name, variable)
 }
 
@@ -367,7 +367,7 @@ func (interpreter *Interpreter) invokeVariable(
 		}
 	}
 
-	variableValue := variable.GetValue()
+	variableValue := variable.GetValue(interpreter)
 
 	// the global variable must be declared as a function
 	functionValue, ok := variableValue.(FunctionValue)
@@ -626,11 +626,11 @@ func (interpreter *Interpreter) VisitProgram(program *ast.Program) {
 	// which will evaluate the variable declaration. The resulting value
 	// is reused for subsequent reads of the variable.
 
-	var variableDeclarationVariables []*Variable
+	var variableDeclarationVariables []Variable
 
 	variableDeclarationCount := len(program.VariableDeclarations())
 	if variableDeclarationCount > 0 {
-		variableDeclarationVariables = make([]*Variable, 0, variableDeclarationCount)
+		variableDeclarationVariables = make([]Variable, 0, variableDeclarationCount)
 
 		for _, declaration := range program.VariableDeclarations() {
 
@@ -641,7 +641,7 @@ func (interpreter *Interpreter) VisitProgram(program *ast.Program) {
 
 			identifier := declaration.Identifier.Identifier
 
-			var variable *Variable
+			var variable Variable
 
 			variable = NewVariableWithGetter(interpreter, func() Value {
 				result := interpreter.visitVariableDeclaration(declaration, false)
@@ -669,7 +669,7 @@ func (interpreter *Interpreter) VisitProgram(program *ast.Program) {
 	// in the order they were declared.
 
 	for _, variable := range variableDeclarationVariables {
-		_ = variable.GetValue()
+		_ = variable.GetValue(interpreter)
 	}
 }
 
@@ -910,9 +910,37 @@ func (interpreter *Interpreter) visitCondition(condition ast.Condition, kind ast
 }
 
 // declareVariable declares a variable in the latest scope
-func (interpreter *Interpreter) declareVariable(identifier string, value Value) *Variable {
+func (interpreter *Interpreter) declareVariable(identifier string, value Value) Variable {
 	// NOTE: semantic analysis already checked possible invalid redeclaration
+
 	variable := NewVariableWithValue(interpreter, value)
+	interpreter.setVariable(identifier, variable)
+
+	// TODO: add proper location info
+	interpreter.startResourceTracking(value, variable, identifier, nil)
+
+	return variable
+}
+
+// declareSelfVariable declares a special "self" variable in the latest scope
+func (interpreter *Interpreter) declareSelfVariable(value Value) Variable {
+	identifier := sema.SelfIdentifier
+
+	// If the self variable is already a reference (e.g: in attachments),
+	// then declare it as a normal variable.
+	// No need to explicitly create a new reference for tracking.
+
+	switch value := value.(type) {
+	case ReferenceValue:
+		return interpreter.declareVariable(identifier, value)
+	case *SimpleCompositeValue:
+		if value.isTransaction {
+			return interpreter.declareVariable(identifier, value)
+		}
+	}
+
+	// NOTE: semantic analysis already checked possible invalid redeclaration
+	variable := NewSelfVariableWithValue(interpreter, value)
 	interpreter.setVariable(identifier, variable)
 
 	// TODO: add proper location info
@@ -972,7 +1000,7 @@ func (interpreter *Interpreter) declareAttachmentValue(
 	lexicalScope *VariableActivation,
 ) (
 	scope *VariableActivation,
-	variable *Variable,
+	variable Variable,
 ) {
 	return interpreter.declareCompositeValue(declaration, lexicalScope)
 }
@@ -1014,7 +1042,7 @@ func (interpreter *Interpreter) evaluateDefaultDestroyEvent(
 		base, self = attachmentBaseAndSelfValues(declarationInterpreter, access, containingResourceComposite, locationRange)
 		declarationInterpreter.declareVariable(sema.BaseIdentifier, base)
 	}
-	declarationInterpreter.declareVariable(sema.SelfIdentifier, self)
+	declarationInterpreter.declareSelfVariable(self)
 
 	for _, parameter := range parameters {
 		// "lazily" evaluate the default argument expressions.
@@ -1051,7 +1079,7 @@ func (interpreter *Interpreter) declareCompositeValue(
 	lexicalScope *VariableActivation,
 ) (
 	scope *VariableActivation,
-	variable *Variable,
+	variable Variable,
 ) {
 	if declaration.Kind() == common.CompositeKindEnum {
 		return interpreter.declareEnumConstructor(declaration.(*ast.CompositeDeclaration), lexicalScope)
@@ -1065,7 +1093,7 @@ func (declarationInterpreter *Interpreter) declareNonEnumCompositeValue(
 	lexicalScope *VariableActivation,
 ) (
 	scope *VariableActivation,
-	variable *Variable,
+	variable Variable,
 ) {
 	identifier := declaration.DeclarationIdentifier().Identifier
 	// NOTE: find *or* declare, as the function might have not been pre-declared (e.g. in the REPL)
@@ -1077,7 +1105,7 @@ func (declarationInterpreter *Interpreter) declareNonEnumCompositeValue(
 	// Evaluate nested declarations in a new scope, so values
 	// of nested declarations won't be visible after the containing declaration
 
-	nestedVariables := map[string]*Variable{}
+	nestedVariables := map[string]Variable{}
 
 	var destroyEventConstructor FunctionValue
 
@@ -1118,7 +1146,7 @@ func (declarationInterpreter *Interpreter) declareNonEnumCompositeValue(
 			// to the nested declarations so they can refer to it, and update the lexical scope
 			// so the container's functions can refer to the nested composite's value
 
-			var nestedVariable *Variable
+			var nestedVariable Variable
 			lexicalScope, nestedVariable =
 				declarationInterpreter.declareCompositeValue(
 					nestedCompositeDeclaration,
@@ -1130,7 +1158,7 @@ func (declarationInterpreter *Interpreter) declareNonEnumCompositeValue(
 
 			// statically we know there is at most one of these
 			if nestedCompositeDeclaration.IsResourceDestructionDefaultEvent() {
-				destroyEventConstructor = nestedVariable.GetValue().(FunctionValue)
+				destroyEventConstructor = nestedVariable.GetValue(declarationInterpreter).(FunctionValue)
 			}
 		}
 
@@ -1140,7 +1168,7 @@ func (declarationInterpreter *Interpreter) declareNonEnumCompositeValue(
 			// to the nested declarations so they can refer to it, and update the lexical scope
 			// so the container's functions can refer to the nested composite's value
 
-			var nestedVariable *Variable
+			var nestedVariable Variable
 			lexicalScope, nestedVariable =
 				declarationInterpreter.declareAttachmentValue(
 					nestedAttachmentDeclaration,
@@ -1388,8 +1416,7 @@ func (declarationInterpreter *Interpreter) declareNonEnumCompositeValue(
 					// NOTE: set the variable value immediately, as the contract value
 					// needs to be available for nested declarations
 
-					variable.getter = nil
-					variable.value = value
+					variable.InitializeWithValue(value)
 
 					// Also, immediately set the nested values,
 					// as the initializer of the contract may use nested declarations
@@ -1411,7 +1438,7 @@ func (declarationInterpreter *Interpreter) declareNonEnumCompositeValue(
 	// for all other composite kinds, the constructor is declared
 
 	if declaration.Kind() == common.CompositeKindContract {
-		variable.getter = func() Value {
+		variable.InitializeWithGetter(func() Value {
 			positioned := ast.NewRangeFromPositioned(declarationInterpreter, declaration.DeclarationIdentifier())
 
 			contractValue := config.ContractValueHandler(
@@ -1423,7 +1450,7 @@ func (declarationInterpreter *Interpreter) declareNonEnumCompositeValue(
 
 			contractValue.SetNestedVariables(nestedVariables)
 			return contractValue
-		}
+		})
 	} else {
 		constructor := constructorGenerator(common.ZeroAddress)
 		constructor.NestedVariables = nestedVariables
@@ -1450,7 +1477,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 	lexicalScope *VariableActivation,
 ) (
 	scope *VariableActivation,
-	variable *Variable,
+	variable Variable,
 ) {
 	identifier := declaration.Identifier.Identifier
 	// NOTE: find *or* declare, as the function might have not been pre-declared (e.g. in the REPL)
@@ -1468,7 +1495,7 @@ func (interpreter *Interpreter) declareEnumConstructor(
 	enumCases := declaration.Members.EnumCases()
 	caseValues := make([]EnumCase, len(enumCases))
 
-	constructorNestedVariables := map[string]*Variable{}
+	constructorNestedVariables := map[string]Variable{}
 
 	for i, enumCase := range enumCases {
 
@@ -1539,7 +1566,7 @@ func EnumConstructorFunction(
 	locationRange LocationRange,
 	enumType *sema.CompositeType,
 	cases []EnumCase,
-	nestedVariables map[string]*Variable,
+	nestedVariables map[string]Variable,
 ) *HostFunctionValue {
 
 	// Prepare a lookup table based on the big-endian byte representation
@@ -2317,12 +2344,12 @@ func (interpreter *Interpreter) declareInterface(
 
 	var defaultDestroyEventConstructor FunctionValue
 	if defautlDestroyEvent := interpreter.Program.Elaboration.DefaultDestroyDeclaration(declaration); defautlDestroyEvent != nil {
-		var nestedVariable *Variable
+		var nestedVariable Variable
 		lexicalScope, nestedVariable = interpreter.declareCompositeValue(
 			defautlDestroyEvent,
 			lexicalScope,
 		)
-		defaultDestroyEventConstructor = nestedVariable.GetValue().(FunctionValue)
+		defaultDestroyEventConstructor = nestedVariable.GetValue(interpreter).(FunctionValue)
 	}
 
 	functionWrappers := interpreter.functionWrappers(declaration.Members, lexicalScope)
@@ -2410,7 +2437,7 @@ func (interpreter *Interpreter) functionConditionsWrapper(
 				}
 
 				if invocation.Self != nil {
-					interpreter.declareVariable(sema.SelfIdentifier, *invocation.Self)
+					interpreter.declareSelfVariable(*invocation.Self)
 				}
 				if invocation.Base != nil {
 					interpreter.declareVariable(sema.BaseIdentifier, invocation.Base)
@@ -2445,7 +2472,7 @@ func (interpreter *Interpreter) functionConditionsWrapper(
 						// for use by the post-condition block.
 
 						type argumentVariable struct {
-							variable *Variable
+							variable Variable
 							value    ResourceKindedValue
 						}
 
@@ -3714,7 +3741,7 @@ var converterFunctionValues = func() []converterFunction {
 
 		addMember := func(name string, value Value) {
 			if converterFunctionValue.NestedVariables == nil {
-				converterFunctionValue.NestedVariables = map[string]*Variable{}
+				converterFunctionValue.NestedVariables = map[string]Variable{}
 			}
 			// these variables are not needed to be metered as they are only ever declared once,
 			// and can be considered base interpreter overhead
@@ -4094,7 +4121,7 @@ func (interpreter *Interpreter) newStorageIterationFunction(
 
 			for key, value := storageIterator.Next(); key != nil && value != nil; key, value = storageIterator.Next() {
 
-				staticType := value.StaticType(inter)
+				staticType := value.StaticType(interpreter)
 
 				// Perform a forced value de-referencing to see if the associated type is not broken.
 				// If broken, skip this value from the iteration.
@@ -4657,7 +4684,7 @@ func (interpreter *Interpreter) GetContractComposite(contractLocation common.Add
 	}
 
 	// get contract value
-	contractValue, ok := contractGlobal.GetValue().(*CompositeValue)
+	contractValue, ok := contractGlobal.GetValue(interpreter).(*CompositeValue)
 	if !ok {
 		return nil, NotDeclaredError{
 			ExpectedKind: common.DeclarationKindContract,
@@ -5303,7 +5330,7 @@ func (interpreter *Interpreter) invalidateReferencedResources(
 // A resource can only be associated with one variable at most, at a given time.
 func (interpreter *Interpreter) startResourceTracking(
 	value Value,
-	variable *Variable,
+	variable Variable,
 	identifier string,
 	hasPosition ast.HasPosition,
 ) {
@@ -5336,7 +5363,7 @@ func (interpreter *Interpreter) startResourceTracking(
 // checkInvalidatedResourceUse checks whether a resource variable is used after invalidation.
 func (interpreter *Interpreter) checkInvalidatedResourceUse(
 	value Value,
-	variable *Variable,
+	variable Variable,
 	identifier string,
 	hasPosition ast.HasPosition,
 ) {

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -70,7 +70,7 @@ func (interpreter *Interpreter) identifierExpressionGetterSetter(
 
 	return getterSetter{
 		get: func(_ bool) Value {
-			value := variable.GetValue()
+			value := variable.GetValue(interpreter)
 			interpreter.checkInvalidatedResourceUse(value, variable, identifier, identifierExpression)
 			return value
 		},
@@ -404,7 +404,7 @@ func (interpreter *Interpreter) checkMemberAccess(
 func (interpreter *Interpreter) VisitIdentifierExpression(expression *ast.IdentifierExpression) Value {
 	name := expression.Identifier.Identifier
 	variable := interpreter.FindVariable(name)
-	value := variable.GetValue()
+	value := variable.GetValue(interpreter)
 
 	interpreter.checkInvalidatedResourceUse(value, variable, name, expression)
 

--- a/runtime/interpreter/interpreter_import.go
+++ b/runtime/interpreter/interpreter_import.go
@@ -56,10 +56,10 @@ func (interpreter *Interpreter) importResolvedLocation(resolvedLocation sema.Res
 	// determine which identifiers are imported /
 	// which variables need to be declared
 
-	var variables map[string]*Variable
+	var variables map[string]Variable
 	identifierLength := len(resolvedLocation.Identifiers)
 	if identifierLength > 0 {
-		variables = make(map[string]*Variable, identifierLength)
+		variables = make(map[string]Variable, identifierLength)
 		for _, identifier := range resolvedLocation.Identifiers {
 			variables[identifier.Identifier] =
 				subInterpreter.Globals.Get(identifier.Identifier)

--- a/runtime/interpreter/interpreter_invocation.go
+++ b/runtime/interpreter/interpreter_invocation.go
@@ -140,7 +140,7 @@ func (interpreter *Interpreter) invokeInterpretedFunction(
 
 	// Make `self` available, if any
 	if invocation.Self != nil {
-		interpreter.declareVariable(sema.SelfIdentifier, *invocation.Self)
+		interpreter.declareSelfVariable(*invocation.Self)
 	}
 	if invocation.Base != nil {
 		interpreter.declareVariable(sema.BaseIdentifier, invocation.Base)

--- a/runtime/interpreter/interpreter_invocation.go
+++ b/runtime/interpreter/interpreter_invocation.go
@@ -140,7 +140,7 @@ func (interpreter *Interpreter) invokeInterpretedFunction(
 
 	// Make `self` available, if any
 	if invocation.Self != nil {
-		interpreter.declareSelfVariable(*invocation.Self)
+		interpreter.declareSelfVariable(*invocation.Self, invocation.LocationRange)
 	}
 	if invocation.Base != nil {
 		interpreter.declareVariable(sema.BaseIdentifier, invocation.Base)

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -65,6 +65,8 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 		nil,
 	)
 
+	self.isTransaction = true
+
 	// Construct a raw HostFunctionValue without a type,
 	// instead of using NewHostFunctionValue, which requires a type.
 	//
@@ -78,7 +80,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 
 			self := MemberAccessibleValue(self)
 			invocation.Self = &self
-			interpreter.declareVariable(sema.SelfIdentifier, self)
+			interpreter.declareSelfVariable(self)
 
 			if declaration.ParameterList != nil {
 				// If the transaction has a parameter list of N parameters,

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -80,7 +80,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 
 			self := MemberAccessibleValue(self)
 			invocation.Self = &self
-			interpreter.declareSelfVariable(self)
+			interpreter.declareSelfVariable(self, invocation.LocationRange)
 
 			if declaration.ParameterList != nil {
 				// If the transaction has a parameter list of N parameters,

--- a/runtime/interpreter/sharedstate.go
+++ b/runtime/interpreter/sharedstate.go
@@ -38,7 +38,7 @@ type SharedState struct {
 	callStack              *CallStack
 	// TODO: ideally this would be a weak map, but Go has no weak references
 	referencedResourceKindedValues              ReferencedResourceKindedValues
-	resourceVariables                           map[ResourceKindedValue]*Variable
+	resourceVariables                           map[ResourceKindedValue]Variable
 	inStorageIteration                          bool
 	storageMutatedDuringIteration               bool
 	CapabilityControllerIterations              map[AddressPath]int
@@ -60,7 +60,7 @@ func NewSharedState(config *Config) *SharedState {
 		inStorageIteration:             false,
 		storageMutatedDuringIteration:  false,
 		referencedResourceKindedValues: map[atree.StorageID]map[*EphemeralReferenceValue]struct{}{},
-		resourceVariables:              map[ResourceKindedValue]*Variable{},
+		resourceVariables:              map[ResourceKindedValue]Variable{},
 		CapabilityControllerIterations: map[AddressPath]int{},
 		containerValueIteration:        map[atree.StorageID]struct{}{},
 		destroyedResources:             map[atree.StorageID]struct{}{},

--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -39,6 +39,8 @@ type SimpleCompositeValue struct {
 	TypeID   sema.TypeID
 	// FieldNames are the names of the field members (i.e. not functions, and not computed fields), in order
 	FieldNames []string
+
+	isTransaction bool
 }
 
 var _ Value = &SimpleCompositeValue{}

--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -40,6 +40,8 @@ type SimpleCompositeValue struct {
 	// FieldNames are the names of the field members (i.e. not functions, and not computed fields), in order
 	FieldNames []string
 
+	// This is used for distinguishing between transaction values and other composite values.
+	// TODO: maybe cleanup if there is an alternative/better way.
 	isTransaction bool
 }
 

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -230,7 +230,7 @@ type ReferenceTrackedResourceKindedValue interface {
 // Hence, during tests, the value is a HostFunctionValue.
 type ContractValue interface {
 	Value
-	SetNestedVariables(variables map[string]*Variable)
+	SetNestedVariables(variables map[string]Variable)
 }
 
 // IterableValue is a value which can be iterated over, e.g. with a for-loop
@@ -16652,7 +16652,7 @@ type CompositeValue struct {
 	Stringer        func(gauge common.MemoryGauge, value *CompositeValue, seenReferences SeenReferences) string
 	injectedFields  map[string]Value
 	computedFields  map[string]ComputedField
-	NestedVariables map[string]*Variable
+	NestedVariables map[string]Variable
 	Functions       *FunctionOrderedMap
 	dictionary      *atree.OrderedMap
 	typeID          TypeID
@@ -17068,7 +17068,7 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, locationRange Locat
 	if v.NestedVariables != nil {
 		variable, ok := v.NestedVariables[name]
 		if ok {
-			return variable.GetValue()
+			return variable.GetValue(interpreter)
 		}
 	}
 
@@ -18139,7 +18139,7 @@ func (v *CompositeValue) RemoveField(
 	interpreter.RemoveReferencedSlab(existingValueStorable)
 }
 
-func (v *CompositeValue) SetNestedVariables(variables map[string]*Variable) {
+func (v *CompositeValue) SetNestedVariables(variables map[string]Variable) {
 	v.NestedVariables = variables
 }
 

--- a/runtime/interpreter/value_function.go
+++ b/runtime/interpreter/value_function.go
@@ -173,7 +173,7 @@ type HostFunction func(invocation Invocation) Value
 
 type HostFunctionValue struct {
 	Function        HostFunction
-	NestedVariables map[string]*Variable
+	NestedVariables map[string]Variable
 	Type            *sema.FunctionType
 }
 
@@ -255,10 +255,10 @@ func (f *HostFunctionValue) invoke(invocation Invocation) Value {
 	return f.Function(invocation)
 }
 
-func (f *HostFunctionValue) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+func (f *HostFunctionValue) GetMember(inter *Interpreter, _ LocationRange, name string) Value {
 	if f.NestedVariables != nil {
 		if variable, ok := f.NestedVariables[name]; ok {
-			return variable.GetValue()
+			return variable.GetValue(inter)
 		}
 	}
 	return nil
@@ -317,7 +317,7 @@ func (*HostFunctionValue) DeepRemove(_ *Interpreter) {
 	// NO-OP
 }
 
-func (v *HostFunctionValue) SetNestedVariables(variables map[string]*Variable) {
+func (v *HostFunctionValue) SetNestedVariables(variables map[string]Variable) {
 	v.NestedVariables = variables
 }
 

--- a/runtime/interpreter/value_string.go
+++ b/runtime/interpreter/value_string.go
@@ -192,7 +192,7 @@ var stringFunction = func() Value {
 
 	addMember := func(name string, value Value) {
 		if functionValue.NestedVariables == nil {
-			functionValue.NestedVariables = map[string]*Variable{}
+			functionValue.NestedVariables = map[string]Variable{}
 		}
 		// these variables are not needed to be metered as they are only ever declared once,
 		// and can be considered base interpreter overhead

--- a/runtime/interpreter/variable.go
+++ b/runtime/interpreter/variable.go
@@ -93,6 +93,7 @@ func NewSelfVariableWithValue(interpreter *Interpreter, value Value) Variable {
 
 	// Create an explicit reference to represent the implicit reference behavior of 'self' value.
 	// Authorization doesn't matter, we just need a reference to add to tracking.
+	// TODO: pass proper location range
 	selfRef := NewEphemeralReferenceValue(interpreter, UnauthorizedAccess, value, semaType, EmptyLocationRange)
 
 	return &SelfVariable{

--- a/runtime/interpreter/variable.go
+++ b/runtime/interpreter/variable.go
@@ -18,14 +18,35 @@
 
 package interpreter
 
-import "github.com/onflow/cadence/runtime/common"
+import (
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
+)
 
-type Variable struct {
+type Variable interface {
+	GetValue(interpreter *Interpreter) Value
+	SetValue(interpreter *Interpreter, locationRange LocationRange, value Value)
+	InitializeWithValue(value Value)
+	InitializeWithGetter(getter func() Value)
+}
+
+type SimpleVariable struct {
 	value  Value
 	getter func() Value
 }
 
-func (v *Variable) GetValue() Value {
+var _ Variable = &SimpleVariable{}
+
+func (v *SimpleVariable) InitializeWithValue(value Value) {
+	v.getter = nil
+	v.value = value
+}
+
+func (v *SimpleVariable) InitializeWithGetter(getter func() Value) {
+	v.getter = getter
+}
+
+func (v *SimpleVariable) GetValue(*Interpreter) Value {
 	if v.getter != nil {
 		v.value = v.getter()
 		v.getter = nil
@@ -33,8 +54,8 @@ func (v *Variable) GetValue() Value {
 	return v.value
 }
 
-func (v *Variable) SetValue(interpreter *Interpreter, locationRange LocationRange, value Value) {
-	existingValue := v.GetValue()
+func (v *SimpleVariable) SetValue(interpreter *Interpreter, locationRange LocationRange, value Value) {
+	existingValue := v.GetValue(interpreter)
 	if existingValue != nil {
 		interpreter.checkResourceLoss(existingValue, locationRange)
 	}
@@ -44,16 +65,59 @@ func (v *Variable) SetValue(interpreter *Interpreter, locationRange LocationRang
 
 var variableMemoryUsage = common.NewConstantMemoryUsage(common.MemoryKindVariable)
 
-func NewVariableWithValue(gauge common.MemoryGauge, value Value) *Variable {
+func NewVariableWithValue(gauge common.MemoryGauge, value Value) Variable {
 	common.UseMemory(gauge, variableMemoryUsage)
-	return &Variable{
+	return &SimpleVariable{
 		value: value,
 	}
 }
 
-func NewVariableWithGetter(gauge common.MemoryGauge, getter func() Value) *Variable {
+func NewVariableWithGetter(gauge common.MemoryGauge, getter func() Value) Variable {
 	common.UseMemory(gauge, variableMemoryUsage)
-	return &Variable{
+	return &SimpleVariable{
 		getter: getter,
 	}
+}
+
+type SelfVariable struct {
+	value   Value
+	selfRef ReferenceValue
+}
+
+var _ Variable = &SelfVariable{}
+
+func NewSelfVariableWithValue(interpreter *Interpreter, value Value) Variable {
+	common.UseMemory(interpreter, variableMemoryUsage)
+
+	semaType := interpreter.MustSemaTypeOfValue(value)
+
+	// Create an explicit reference to represent the implicit reference behavior of 'self' value.
+	// Authorization doesn't matter, we just need a reference to add to tracking.
+	selfRef := NewEphemeralReferenceValue(interpreter, UnauthorizedAccess, value, semaType, EmptyLocationRange)
+
+	return &SelfVariable{
+		value:   value,
+		selfRef: selfRef,
+	}
+}
+
+func (v *SelfVariable) InitializeWithValue(Value) {
+	// self variable cannot re-initialized.
+	panic(errors.NewUnreachableError())
+}
+
+func (v *SelfVariable) InitializeWithGetter(func() Value) {
+	// self variable doesn't have getters.
+	panic(errors.NewUnreachableError())
+}
+
+func (v *SelfVariable) GetValue(interpreter *Interpreter) Value {
+	// TODO: pass proper location range
+	interpreter.checkInvalidatedResourceOrResourceReference(v.selfRef, EmptyLocationRange)
+	return v.value
+}
+
+func (v *SelfVariable) SetValue(*Interpreter, LocationRange, Value) {
+	// self variable cannot be updated.
+	panic(errors.NewUnreachableError())
 }

--- a/runtime/interpreter/variable.go
+++ b/runtime/interpreter/variable.go
@@ -86,15 +86,14 @@ type SelfVariable struct {
 
 var _ Variable = &SelfVariable{}
 
-func NewSelfVariableWithValue(interpreter *Interpreter, value Value) Variable {
+func NewSelfVariableWithValue(interpreter *Interpreter, value Value, locationRange LocationRange) Variable {
 	common.UseMemory(interpreter, variableMemoryUsage)
 
 	semaType := interpreter.MustSemaTypeOfValue(value)
 
 	// Create an explicit reference to represent the implicit reference behavior of 'self' value.
 	// Authorization doesn't matter, we just need a reference to add to tracking.
-	// TODO: pass proper location range
-	selfRef := NewEphemeralReferenceValue(interpreter, UnauthorizedAccess, value, semaType, EmptyLocationRange)
+	selfRef := NewEphemeralReferenceValue(interpreter, UnauthorizedAccess, value, semaType, locationRange)
 
 	return &SelfVariable{
 		value:   value,

--- a/runtime/interpreter/variable_activations.go
+++ b/runtime/interpreter/variable_activations.go
@@ -20,9 +20,9 @@ package interpreter
 
 import "github.com/onflow/cadence/runtime/activations"
 
-type VariableActivations = activations.Activations[*Variable]
+type VariableActivations = activations.Activations[Variable]
 
-type VariableActivation = activations.Activation[*Variable]
+type VariableActivation = activations.Activation[Variable]
 
 func Declare(a *VariableActivation, declaration ValueDeclaration) {
 

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -375,7 +375,7 @@ func (r *REPL) GetGlobal(name string) interpreter.Value {
 	if variable == nil {
 		return nil
 	}
-	return variable.GetValue()
+	return variable.GetValue(r.inter)
 }
 
 func (r *REPL) ExportValue(value interpreter.Value) (cadence.Value, error) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -10207,9 +10207,6 @@ func TestRuntimeIfLetElseBranchConfusion(t *testing.T) {
 
 func TestResourceLossViaSelfRugPull(t *testing.T) {
 
-	// TODO: Disabled temporarily
-	t.SkipNow()
-
 	t.Parallel()
 
 	runtime := NewTestInterpreterRuntime()
@@ -10356,7 +10353,7 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 	)
 	RequireError(t, err)
 
-	require.ErrorAs(t, err, &interpreter.ResourceLossError{})
+	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
 }
 
 func TestRuntimeValueTransferResourceLoss(t *testing.T) {

--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -69,7 +69,7 @@ func newInterpreter(t *testing.T, code string, valueDeclarations ...StandardLibr
 
 	storage := newUnmeteredInMemoryStorage()
 
-	baseActivation := activations.NewActivation[*interpreter.Variable](nil, interpreter.BaseActivation)
+	baseActivation := activations.NewActivation[interpreter.Variable](nil, interpreter.BaseActivation)
 	for _, valueDeclaration := range valueDeclarations {
 		interpreter.Declare(baseActivation, valueDeclaration)
 	}

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -169,7 +169,7 @@ func cryptoAlgorithmEnumValueAndCaseValues[T sema.CryptoAlgorithm](
 
 	caseCount := len(enumCases)
 	caseValues := make([]interpreter.EnumCase, caseCount)
-	constructorNestedVariables := make(map[string]*interpreter.Variable, caseCount)
+	constructorNestedVariables := make(map[string]interpreter.Variable, caseCount)
 	cases = make(map[interpreter.UInt8Value]interpreter.MemberAccessibleValue, caseCount)
 
 	for i, enumCase := range enumCases {

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -95,7 +95,7 @@ func TestInterpretPlusOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -124,7 +124,7 @@ func TestInterpretMinusOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -153,7 +153,7 @@ func TestInterpretMulOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -182,7 +182,7 @@ func TestInterpretDivOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -211,7 +211,7 @@ func TestInterpretModOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}

--- a/runtime/tests/interpreter/bitwise_test.go
+++ b/runtime/tests/interpreter/bitwise_test.go
@@ -130,7 +130,7 @@ func TestInterpretBitwiseOr(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b00010101),
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -159,7 +159,7 @@ func TestInterpretBitwiseXor(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b00000101),
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -188,7 +188,7 @@ func TestInterpretBitwiseAnd(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b00010000),
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -217,7 +217,7 @@ func TestInterpretBitwiseLeftShift(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b01100000),
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -246,7 +246,7 @@ func TestInterpretBitwiseRightShift(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b00001100),
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -54,7 +54,7 @@ func TestInterpretToString(t *testing.T) {
 				t,
 				inter,
 				interpreter.NewUnmeteredStringValue("42"),
-				inter.Globals.Get("y").GetValue(),
+				inter.Globals.Get("y").GetValue(inter),
 			)
 		})
 	}
@@ -72,7 +72,7 @@ func TestInterpretToString(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("0x0000000000000042"),
-			inter.Globals.Get("y").GetValue(),
+			inter.Globals.Get("y").GetValue(inter),
 		)
 	})
 
@@ -108,7 +108,7 @@ func TestInterpretToString(t *testing.T) {
 				t,
 				inter,
 				expected,
-				inter.Globals.Get("y").GetValue(),
+				inter.Globals.Get("y").GetValue(inter),
 			)
 		})
 	}
@@ -146,7 +146,7 @@ func TestInterpretToBytes(t *testing.T) {
 				interpreter.NewUnmeteredUInt8Value(0x34),
 				interpreter.NewUnmeteredUInt8Value(0x56),
 			),
-			inter.Globals.Get("y").GetValue(),
+			inter.Globals.Get("y").GetValue(inter),
 		)
 	})
 }
@@ -588,7 +588,7 @@ func TestInterpretToBigEndianBytes(t *testing.T) {
 					),
 				)
 
-				result := inter.Globals.Get("result").GetValue()
+				result := inter.Globals.Get("result").GetValue(inter)
 
 				AssertValuesEqual(
 					t,
@@ -930,13 +930,13 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("result").GetValue(),
+					inter.Globals.Get("result").GetValue(inter),
 				)
 				AssertValuesEqual(
 					t,
 					inter,
 					interpreter.TrueValue,
-					inter.Globals.Get("roundTripEqual").GetValue(),
+					inter.Globals.Get("roundTripEqual").GetValue(inter),
 				)
 			})
 		}
@@ -960,7 +960,7 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 					t,
 					inter,
 					interpreter.NilValue{},
-					inter.Globals.Get("result").GetValue(),
+					inter.Globals.Get("result").GetValue(inter),
 				)
 			})
 		}

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -56,14 +56,14 @@ func TestInterpretCompositeValue(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("Apple"),
-			inter.Globals.Get("name").GetValue(),
+			inter.Globals.Get("name").GetValue(inter),
 		)
 
 		RequireValuesEqual(
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("Red"),
-			inter.Globals.Get("color").GetValue(),
+			inter.Globals.Get("color").GetValue(inter),
 		)
 	})
 }

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -261,7 +261,7 @@ func TestInterpetArrayMutation(t *testing.T) {
 
 		// Check original array
 
-		namesVal := inter.Globals.Get("names").GetValue()
+		namesVal := inter.Globals.Get("names").GetValue(inter)
 		require.IsType(t, &interpreter.ArrayValue{}, namesVal)
 		namesValArray := namesVal.(*interpreter.ArrayValue)
 

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -113,14 +113,14 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 									t,
 									inter,
 									test.expected,
-									inter.Globals.Get("x").GetValue(),
+									inter.Globals.Get("x").GetValue(inter),
 								)
 
 								AssertValuesEqual(
 									t,
 									inter,
 									test.expected,
-									inter.Globals.Get("y").GetValue(),
+									inter.Globals.Get("y").GetValue(inter),
 								)
 
 								AssertValuesEqual(
@@ -129,7 +129,7 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 									interpreter.NewUnmeteredSomeValueNonCopying(
 										test.expected,
 									),
-									inter.Globals.Get("z").GetValue(),
+									inter.Globals.Get("z").GetValue(inter),
 								)
 							})
 						}
@@ -219,7 +219,7 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 							t,
 							inter,
 							interpreter.Void,
-							inter.Globals.Get("x").GetValue(),
+							inter.Globals.Get("x").GetValue(inter),
 						)
 
 						AssertValuesEqual(
@@ -228,7 +228,7 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								interpreter.Void,
 							),
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 					})
 				}
@@ -313,7 +313,7 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 							t,
 							inter,
 							interpreter.NewUnmeteredStringValue("test"),
-							inter.Globals.Get("x").GetValue(),
+							inter.Globals.Get("x").GetValue(inter),
 						)
 
 						AssertValuesEqual(
@@ -322,7 +322,7 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								interpreter.NewUnmeteredStringValue("test"),
 							),
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 					})
 				}
@@ -406,7 +406,7 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 							t,
 							inter,
 							interpreter.TrueValue,
-							inter.Globals.Get("x").GetValue(),
+							inter.Globals.Get("x").GetValue(inter),
 						)
 
 						AssertValuesEqual(
@@ -415,7 +415,7 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								interpreter.TrueValue,
 							),
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 					})
 				}
@@ -503,7 +503,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 							t,
 							inter,
 							addressValue,
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 
 						AssertValuesEqual(
@@ -512,7 +512,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								addressValue,
 							),
-							inter.Globals.Get("z").GetValue(),
+							inter.Globals.Get("z").GetValue(inter),
 						)
 					})
 				}
@@ -597,17 +597,17 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 
 						assert.IsType(t,
 							&interpreter.CompositeValue{},
-							inter.Globals.Get("x").GetValue(),
+							inter.Globals.Get("x").GetValue(inter),
 						)
 
 						require.IsType(t,
 							&interpreter.SomeValue{},
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 
 						require.IsType(t,
 							&interpreter.CompositeValue{},
-							inter.Globals.Get("y").GetValue().(*interpreter.SomeValue).
+							inter.Globals.Get("y").GetValue(inter).(*interpreter.SomeValue).
 								InnerValue(inter, interpreter.EmptyLocationRange),
 						)
 					})
@@ -1100,7 +1100,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 							t,
 							inter,
 							expectedValue,
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 
 						if targetType == sema.AnyStructType && !returnsOptional {
@@ -1109,7 +1109,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 								t,
 								inter,
 								expectedValue,
-								inter.Globals.Get("z").GetValue(),
+								inter.Globals.Get("z").GetValue(inter),
 							)
 
 						} else {
@@ -1119,7 +1119,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 								interpreter.NewUnmeteredSomeValueNonCopying(
 									expectedValue,
 								),
-								inter.Globals.Get("z").GetValue(),
+								inter.Globals.Get("z").GetValue(inter),
 							)
 						}
 
@@ -1206,7 +1206,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 							interpreter.NewUnmeteredIntValueFromInt64(42),
 						}
 
-						yValue := inter.Globals.Get("y").GetValue()
+						yValue := inter.Globals.Get("y").GetValue(inter)
 						require.IsType(t, yValue, &interpreter.ArrayValue{})
 						yArray := yValue.(*interpreter.ArrayValue)
 
@@ -1217,7 +1217,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 							ArrayElements(inter, yArray),
 						)
 
-						zValue := inter.Globals.Get("z").GetValue()
+						zValue := inter.Globals.Get("z").GetValue(inter)
 						require.IsType(t, zValue, &interpreter.SomeValue{})
 						zSome := zValue.(*interpreter.SomeValue)
 
@@ -1377,7 +1377,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 							t,
 							inter,
 							expectedDictionary,
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 
 						AssertValuesEqual(
@@ -1386,7 +1386,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								expectedDictionary,
 							),
-							inter.Globals.Get("z").GetValue(),
+							inter.Globals.Get("z").GetValue(inter),
 						)
 					})
 				}
@@ -3485,7 +3485,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 									t,
 									inter,
 									capabilityValue,
-									inter.Globals.Get("x").GetValue(),
+									inter.Globals.Get("x").GetValue(inter),
 								)
 
 								AssertValuesEqual(
@@ -3494,7 +3494,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 									interpreter.NewUnmeteredSomeValueNonCopying(
 										capabilityValue,
 									),
-									inter.Globals.Get("y").GetValue(),
+									inter.Globals.Get("y").GetValue(inter),
 								)
 							})
 						}

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -43,7 +43,7 @@ func TestInterpretEnum(t *testing.T) {
 
 	assert.IsType(t,
 		&interpreter.HostFunctionValue{},
-		inter.Globals.Get("E").GetValue(),
+		inter.Globals.Get("E").GetValue(inter),
 	)
 }
 
@@ -61,7 +61,7 @@ func TestInterpretEnumCaseUse(t *testing.T) {
       let b = E.b
     `)
 
-	a := inter.Globals.Get("a").GetValue()
+	a := inter.Globals.Get("a").GetValue(inter)
 	require.IsType(t,
 		&interpreter.CompositeValue{},
 		a,
@@ -72,7 +72,7 @@ func TestInterpretEnumCaseUse(t *testing.T) {
 		a.(*interpreter.CompositeValue).Kind,
 	)
 
-	b := inter.Globals.Get("b").GetValue()
+	b := inter.Globals.Get("b").GetValue(inter)
 	require.IsType(t,
 		&interpreter.CompositeValue{},
 		b,
@@ -102,14 +102,14 @@ func TestInterpretEnumCaseRawValue(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredInt64Value(0),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	RequireValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredInt64Value(1),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 }
 
@@ -144,7 +144,7 @@ func TestInterpretEnumCaseEquality(t *testing.T) {
 			interpreter.TrueValue,
 			interpreter.TrueValue,
 		),
-		inter.Globals.Get("res").GetValue(),
+		inter.Globals.Get("res").GetValue(inter),
 	)
 }
 
@@ -181,7 +181,7 @@ func TestInterpretEnumConstructor(t *testing.T) {
 			interpreter.TrueValue,
 			interpreter.TrueValue,
 		),
-		inter.Globals.Get("res").GetValue(),
+		inter.Globals.Get("res").GetValue(inter),
 	)
 }
 
@@ -214,7 +214,7 @@ func TestInterpretEnumInstance(t *testing.T) {
 			interpreter.TrueValue,
 			interpreter.TrueValue,
 		),
-		inter.Globals.Get("res").GetValue(),
+		inter.Globals.Get("res").GetValue(inter),
 	)
 }
 
@@ -245,7 +245,7 @@ func TestInterpretEnumInContract(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c := inter.Globals.Get("C").GetValue()
+	c := inter.Globals.Get("C").GetValue(inter)
 	require.IsType(t, &interpreter.CompositeValue{}, c)
 	contract := c.(*interpreter.CompositeValue)
 

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -87,14 +87,14 @@ func TestInterpretEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("res1").GetValue(),
+			inter.Globals.Get("res1").GetValue(inter),
 		)
 
 		AssertValuesEqual(
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("res2").GetValue(),
+			inter.Globals.Get("res2").GetValue(inter),
 		)
 	})
 
@@ -115,14 +115,14 @@ func TestInterpretEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("res1").GetValue(),
+			inter.Globals.Get("res1").GetValue(inter),
 		)
 
 		AssertValuesEqual(
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("res2").GetValue(),
+			inter.Globals.Get("res2").GetValue(inter),
 		)
 	})
 
@@ -139,7 +139,7 @@ func TestInterpretEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("res").GetValue(),
+			inter.Globals.Get("res").GetValue(inter),
 		)
 	})
 }

--- a/runtime/tests/interpreter/fixedpoint_test.go
+++ b/runtime/tests/interpreter/fixedpoint_test.go
@@ -44,7 +44,7 @@ func TestInterpretNegativeZeroFixedPoint(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredFix64Value(-42000000),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -90,21 +90,21 @@ func TestInterpretFixedPointConversionAndAddition(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				value,
-				inter.Globals.Get("y").GetValue(),
+				inter.Globals.Get("y").GetValue(inter),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				interpreter.TrueValue,
-				inter.Globals.Get("z").GetValue(),
+				inter.Globals.Get("z").GetValue(inter),
 			)
 
 		})
@@ -159,14 +159,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					fixedPointValue,
-					inter.Globals.Get("x").GetValue(),
+					inter.Globals.Get("x").GetValue(inter),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					integerValue,
-					inter.Globals.Get("y").GetValue(),
+					inter.Globals.Get("y").GetValue(inter),
 				)
 			})
 		}
@@ -198,14 +198,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("x").GetValue(),
+					inter.Globals.Get("x").GetValue(inter),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("y").GetValue(),
+					inter.Globals.Get("y").GetValue(inter),
 				)
 			})
 		}
@@ -238,14 +238,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("x").GetValue(),
+					inter.Globals.Get("x").GetValue(inter),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("y").GetValue(),
+					inter.Globals.Get("y").GetValue(inter),
 				)
 			})
 		}
@@ -271,14 +271,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					interpreter.NewUnmeteredFix64Value(value*sema.Fix64Factor),
-					inter.Globals.Get("x").GetValue(),
+					inter.Globals.Get("x").GetValue(inter),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					interpreter.NewUnmeteredUFix64Value(uint64(value*sema.Fix64Factor)),
-					inter.Globals.Get("y").GetValue(),
+					inter.Globals.Get("y").GetValue(inter),
 				)
 			})
 		}
@@ -304,14 +304,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					interpreter.NewUnmeteredUFix64Value(uint64(value*sema.Fix64Factor)),
-					inter.Globals.Get("x").GetValue(),
+					inter.Globals.Get("x").GetValue(inter),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					interpreter.NewUnmeteredFix64Value(value*sema.Fix64Factor),
-					inter.Globals.Get("y").GetValue(),
+					inter.Globals.Get("y").GetValue(inter),
 				)
 			})
 		}
@@ -558,13 +558,13 @@ func TestInterpretFixedPointMinMax(t *testing.T) {
 			t,
 			inter,
 			test.min,
-			inter.Globals.Get("min").GetValue(),
+			inter.Globals.Get("min").GetValue(inter),
 		)
 		RequireValuesEqual(
 			t,
 			inter,
 			test.max,
-			inter.Globals.Get("max").GetValue(),
+			inter.Globals.Get("max").GetValue(inter),
 		)
 	}
 

--- a/runtime/tests/interpreter/if_test.go
+++ b/runtime/tests/interpreter/if_test.go
@@ -146,7 +146,7 @@ func TestInterpretIfStatementTestWithDeclaration(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 	})
 
@@ -163,7 +163,7 @@ func TestInterpretIfStatementTestWithDeclaration(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 	})
 }
@@ -201,7 +201,7 @@ func TestInterpretIfStatementTestWithDeclarationAndElse(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 	})
 
@@ -218,7 +218,7 @@ func TestInterpretIfStatementTestWithDeclarationAndElse(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 
 	})
@@ -260,7 +260,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 	})
 
@@ -280,7 +280,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 	})
 }
@@ -321,7 +321,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotatio
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 
 	})
@@ -341,7 +341,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotatio
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 	})
 }

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -388,7 +388,7 @@ func TestInterpretResourceConstructionThroughIndirectImport(t *testing.T) {
 	err = inter.Interpret()
 	require.NoError(t, err)
 
-	rConstructor := subInterpreter.Globals.Get("R").GetValue()
+	rConstructor := subInterpreter.Globals.Get("R").GetValue(inter)
 
 	_, err = inter.Invoke("test", rConstructor)
 	RequireError(t, err)

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -97,21 +97,21 @@ func TestInterpretIntegerConversions(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				value,
-				inter.Globals.Get("y").GetValue(),
+				inter.Globals.Get("y").GetValue(inter),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				interpreter.TrueValue,
-				inter.Globals.Get("z").GetValue(),
+				inter.Globals.Get("z").GetValue(inter),
 			)
 
 		})
@@ -149,7 +149,7 @@ func TestInterpretWordOverflowConversions(t *testing.T) {
 			require.Equal(
 				t,
 				"0",
-				inter.Globals.Get("y").GetValue().String(),
+				inter.Globals.Get("y").GetValue(inter).String(),
 			)
 		})
 	}
@@ -185,7 +185,7 @@ func TestInterpretWordUnderflowConversions(t *testing.T) {
 			require.Equal(
 				t,
 				value.String(),
-				inter.Globals.Get("y").GetValue().String(),
+				inter.Globals.Get("y").GetValue(inter).String(),
 			)
 		})
 	}
@@ -209,7 +209,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 			interpreter.AddressValue{
 				0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
 			},
-			inter.Globals.Get("x").GetValue(),
+			inter.Globals.Get("x").GetValue(inter),
 		)
 
 	})
@@ -228,7 +228,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 			interpreter.AddressValue{
 				0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2,
 			},
-			inter.Globals.Get("x").GetValue(),
+			inter.Globals.Get("x").GetValue(inter),
 		)
 	})
 
@@ -288,7 +288,7 @@ func TestInterpretIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 
 		})
@@ -316,7 +316,7 @@ func TestInterpretIntegerLiteralTypeConversionInVariableDeclarationOptional(t *t
 				t,
 				inter,
 				interpreter.NewUnmeteredSomeValueNonCopying(value),
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -346,7 +346,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 
 			_, err := inter.Invoke("test")
@@ -357,7 +357,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
 				t,
 				inter,
 				numberValue.Plus(inter, numberValue, interpreter.EmptyLocationRange),
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -387,7 +387,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T)
 				t,
 				inter,
 				interpreter.NewUnmeteredSomeValueNonCopying(value),
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 
 			_, err := inter.Invoke("test")
@@ -401,7 +401,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T)
 				interpreter.NewUnmeteredSomeValueNonCopying(
 					numberValue.Plus(inter, numberValue, interpreter.EmptyLocationRange),
 				),
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -431,7 +431,7 @@ func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgument(t *testing.
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -461,7 +461,7 @@ func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgumentOptional(t *
 				t,
 				inter,
 				interpreter.NewUnmeteredSomeValueNonCopying(value),
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -805,7 +805,7 @@ func TestInterpretIntegerMinMax(t *testing.T) {
 			t,
 			inter,
 			expected,
-			inter.Globals.Get("x").GetValue(),
+			inter.Globals.Get("x").GetValue(inter),
 		)
 	}
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -245,7 +245,7 @@ func parseCheckAndInterpretWithOptionsAndMemoryMetering(
 
 			contractVariable := inter.Globals.Get(compositeDeclaration.Identifier.Identifier)
 
-			_ = contractVariable.GetValue()
+			_ = contractVariable.GetValue(inter)
 		}
 	}
 
@@ -357,28 +357,28 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -394,14 +394,14 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredStringValue("123"),
-		inter.Globals.Get("s").GetValue(),
+		inter.Globals.Get("s").GetValue(inter),
 	)
 }
 
@@ -471,7 +471,7 @@ func TestInterpretLexicalScope(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(10),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	value, err := inter.Invoke("f")
@@ -523,7 +523,7 @@ func TestInterpretFunctionSideEffects(t *testing.T) {
 		t,
 		inter,
 		newValue,
-		inter.Globals.Get("value").GetValue(),
+		inter.Globals.Get("value").GetValue(inter),
 	)
 }
 
@@ -557,7 +557,7 @@ func TestInterpretNoHoisting(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -576,14 +576,14 @@ func TestInterpretFunctionExpressionsAndScope(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(10),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -627,7 +627,7 @@ func TestInterpretGlobalVariableAssignment(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	value, err := inter.Invoke("test")
@@ -644,7 +644,7 @@ func TestInterpretGlobalVariableAssignment(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -665,7 +665,7 @@ func TestInterpretConstantRedeclaration(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	value, err := inter.Invoke("test")
@@ -851,7 +851,7 @@ func TestInterpretArrayIndexingAssignment(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.NoError(t, err)
 
-	actualArray := inter.Globals.Get("z").GetValue()
+	actualArray := inter.Globals.Get("z").GetValue(inter)
 
 	expectedArray := interpreter.NewArrayValue(
 		inter,
@@ -926,19 +926,19 @@ func TestInterpretStringIndexing(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredCharacterValue("a"),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredCharacterValue("b"),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredCharacterValue("c"),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -1581,21 +1581,21 @@ func TestInterpretOrOperatorShortCircuitLeftSuccess(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("test").GetValue(),
+		inter.Globals.Get("test").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -1624,21 +1624,21 @@ func TestInterpretOrOperatorShortCircuitLeftFailure(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("test").GetValue(),
+		inter.Globals.Get("test").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -1709,21 +1709,21 @@ func TestInterpretAndOperatorShortCircuitLeftSuccess(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("test").GetValue(),
+		inter.Globals.Get("test").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -1752,21 +1752,21 @@ func TestInterpretAndOperatorShortCircuitLeftFailure(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("test").GetValue(),
+		inter.Globals.Get("test").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -1791,7 +1791,7 @@ func TestInterpretExpressionStatement(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	value, err := inter.Invoke("test")
@@ -1808,7 +1808,7 @@ func TestInterpretExpressionStatement(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -1933,14 +1933,14 @@ func TestInterpretUnaryIntegerNegation(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(-2),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -1959,28 +1959,28 @@ func TestInterpretUnaryBooleanNegation(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 }
 
@@ -2064,7 +2064,7 @@ func TestInterpretHostFunction(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 }
 
@@ -2532,7 +2532,7 @@ func TestInterpretStructureDeclarationWithFunction(t *testing.T) {
 
 	AssertValuesEqual(
 		t,
-		inter, newValue, inter.Globals.Get("value").GetValue())
+		inter, newValue, inter.Globals.Get("value").GetValue(inter))
 }
 
 func TestInterpretStructureFunctionCall(t *testing.T) {
@@ -2557,7 +2557,7 @@ func TestInterpretStructureFunctionCall(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals.Get("value").GetValue(),
+		inter.Globals.Get("value").GetValue(inter),
 	)
 }
 
@@ -2589,7 +2589,7 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
       }
     `)
 
-	test := inter.Globals.Get("test").GetValue().(*interpreter.CompositeValue)
+	test := inter.Globals.Get("test").GetValue(inter).(*interpreter.CompositeValue)
 
 	AssertValuesEqual(
 		t,
@@ -2632,7 +2632,7 @@ func TestInterpretStructureInitializesConstant(t *testing.T) {
       let test = Test()
     `)
 
-	actual := inter.Globals.Get("test").GetValue().(*interpreter.CompositeValue).
+	actual := inter.Globals.Get("test").GetValue(inter).(*interpreter.CompositeValue).
 		GetMember(inter, interpreter.EmptyLocationRange, "foo")
 	AssertValuesEqual(
 		t,
@@ -3080,7 +3080,7 @@ func TestInterpretUseBeforeDeclaration(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
-		inter.Globals.Get("tests").GetValue(),
+		inter.Globals.Get("tests").GetValue(inter),
 	)
 
 	value, err := inter.Invoke("test")
@@ -3095,7 +3095,7 @@ func TestInterpretUseBeforeDeclaration(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals.Get("tests").GetValue(),
+		inter.Globals.Get("tests").GetValue(inter),
 	)
 
 	value, err = inter.Invoke("test")
@@ -3110,7 +3110,7 @@ func TestInterpretUseBeforeDeclaration(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("tests").GetValue(),
+		inter.Globals.Get("tests").GetValue(inter),
 	)
 }
 
@@ -3130,7 +3130,7 @@ func TestInterpretOptionalVariableDeclaration(t *testing.T) {
 				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3246,7 +3246,7 @@ func TestInterpretOptionalAssignment(t *testing.T) {
 				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3262,7 +3262,7 @@ func TestInterpretNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3278,7 +3278,7 @@ func TestInterpretOptionalNestingNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3367,7 +3367,7 @@ func TestInterpretNilCoalescingNilIntToOptional(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3387,7 +3387,7 @@ func TestInterpretNilCoalescingNilIntToOptionals(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3406,7 +3406,7 @@ func TestInterpretNilCoalescingNilIntToOptionalNilLiteral(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3422,7 +3422,7 @@ func TestInterpretNilCoalescingRightSubtype(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3440,7 +3440,7 @@ func TestInterpretNilCoalescingNilInt(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3457,7 +3457,7 @@ func TestInterpretNilCoalescingNilLiteralInt(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3486,21 +3486,21 @@ func TestInterpretNilCoalescingShortCircuitLeftSuccess(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals.Get("test").GetValue(),
+		inter.Globals.Get("test").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3529,21 +3529,21 @@ func TestInterpretNilCoalescingShortCircuitLeftFailure(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("test").GetValue(),
+		inter.Globals.Get("test").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3560,7 +3560,7 @@ func TestInterpretNilCoalescingOptionalAnyStructNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3577,7 +3577,7 @@ func TestInterpretNilCoalescingOptionalAnyStructSome(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3597,7 +3597,7 @@ func TestInterpretNilCoalescingOptionalRightHandSide(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3617,7 +3617,7 @@ func TestInterpretNilCoalescingBothOptional(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3637,7 +3637,7 @@ func TestInterpretNilCoalescingBothOptionalLeftNil(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3653,7 +3653,7 @@ func TestInterpretNilsComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3671,14 +3671,14 @@ func TestInterpretNonOptionalNilComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3695,7 +3695,7 @@ func TestInterpretOptionalNilComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3712,7 +3712,7 @@ func TestInterpretNestedOptionalNilComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3729,7 +3729,7 @@ func TestInterpretOptionalNilComparisonSwapped(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3746,7 +3746,7 @@ func TestInterpretNestedOptionalNilComparisonSwapped(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3764,7 +3764,7 @@ func TestInterpretNestedOptionalComparisonNils(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3782,7 +3782,7 @@ func TestInterpretNestedOptionalComparisonValues(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3800,7 +3800,7 @@ func TestInterpretNestedOptionalComparisonMixed(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3817,7 +3817,7 @@ func TestInterpretOptionalSomeValueComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3834,7 +3834,7 @@ func TestInterpretOptionalNilValueComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3857,7 +3857,7 @@ func TestInterpretOptionalMap(t *testing.T) {
 			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredStringValue("42"),
 			),
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -3874,7 +3874,7 @@ func TestInterpretOptionalMap(t *testing.T) {
 			t,
 			inter,
 			interpreter.Nil,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 }
@@ -3941,14 +3941,14 @@ func TestInterpretCompositeNilEquality(t *testing.T) {
 				t,
 				inter,
 				interpreter.FalseValue,
-				inter.Globals.Get("y").GetValue(),
+				inter.Globals.Get("y").GetValue(inter),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				interpreter.FalseValue,
-				inter.Globals.Get("z").GetValue(),
+				inter.Globals.Get("z").GetValue(inter),
 			)
 		})
 	}
@@ -4001,7 +4001,7 @@ func TestInterpretInterfaceConformanceNoRequirements(t *testing.T) {
 
 			assert.IsType(t,
 				&interpreter.CompositeValue{},
-				inter.Globals.Get("test").GetValue(),
+				inter.Globals.Get("test").GetValue(inter),
 			)
 		})
 	}
@@ -4081,7 +4081,7 @@ func TestInterpretInterfaceFieldUse(t *testing.T) {
 				t,
 				inter,
 				interpreter.NewUnmeteredIntValueFromInt64(1),
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -4149,7 +4149,7 @@ func TestInterpretInterfaceFunctionUse(t *testing.T) {
 				t,
 				inter,
 				interpreter.NewUnmeteredIntValueFromInt64(2),
-				inter.Globals.Get("val").GetValue(),
+				inter.Globals.Get("val").GetValue(inter),
 			)
 		})
 	}
@@ -4411,7 +4411,7 @@ func TestInterpretDictionary(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("b"), interpreter.NewUnmeteredIntValueFromInt64(2),
 	)
 
-	actualDict := inter.Globals.Get("x").GetValue()
+	actualDict := inter.Globals.Get("x").GetValue(inter)
 
 	AssertValuesEqual(
 		t,
@@ -4441,7 +4441,7 @@ func TestInterpretDictionaryInsertionOrder(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("b"), interpreter.NewUnmeteredIntValueFromInt64(2),
 	)
 
-	actualDict := inter.Globals.Get("x").GetValue()
+	actualDict := inter.Globals.Get("x").GetValue(inter)
 
 	AssertValuesEqual(
 		t,
@@ -4468,7 +4468,7 @@ func TestInterpretDictionaryIndexingString(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -4477,14 +4477,14 @@ func TestInterpretDictionaryIndexingString(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 }
 
@@ -4504,7 +4504,7 @@ func TestInterpretDictionaryIndexingBool(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -4513,7 +4513,7 @@ func TestInterpretDictionaryIndexingBool(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 }
 
@@ -4534,7 +4534,7 @@ func TestInterpretDictionaryIndexingInt(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("a"),
 		),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -4543,14 +4543,14 @@ func TestInterpretDictionaryIndexingInt(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("b"),
 		),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 }
 
@@ -4581,39 +4581,39 @@ func TestInterpretDictionaryIndexingType(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("a"),
 		),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("b"),
 		),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("c"),
 		),
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	// types need to match exactly, subtypes won't cut it
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("f"),
 		),
-		inter.Globals.Get("f").GetValue(),
+		inter.Globals.Get("f").GetValue(inter),
 	)
 }
 
@@ -4638,7 +4638,7 @@ func TestInterpretDictionaryIndexingAssignmentExisting(t *testing.T) {
 		value,
 	)
 
-	actualValue := inter.Globals.Get("x").GetValue()
+	actualValue := inter.Globals.Get("x").GetValue(inter)
 	actualDict := actualValue.(*interpreter.DictionaryValue)
 
 	newValue := actualDict.GetKey(
@@ -4697,7 +4697,7 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("abc"), interpreter.NewUnmeteredIntValueFromInt64(23),
 	)
 
-	actualDict := inter.Globals.Get("x").GetValue().(*interpreter.DictionaryValue)
+	actualDict := inter.Globals.Get("x").GetValue(inter).(*interpreter.DictionaryValue)
 
 	AssertValuesEqual(
 		t,
@@ -4763,7 +4763,7 @@ func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("abc"), interpreter.NewUnmeteredIntValueFromInt64(23),
 	)
 
-	actualDict := inter.Globals.Get("x").GetValue().(*interpreter.DictionaryValue)
+	actualDict := inter.Globals.Get("x").GetValue(inter).(*interpreter.DictionaryValue)
 
 	RequireValuesEqual(
 		t,
@@ -4996,7 +4996,7 @@ func TestInterpretOptionalAnyStruct(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -5015,7 +5015,7 @@ func TestInterpretOptionalAnyStructFailableCasting(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -5024,7 +5024,7 @@ func TestInterpretOptionalAnyStructFailableCasting(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -5044,14 +5044,14 @@ func TestInterpretOptionalAnyStructFailableCastingInt(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(23),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(23),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -5060,7 +5060,7 @@ func TestInterpretOptionalAnyStructFailableCastingInt(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(23),
 		),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -5078,14 +5078,14 @@ func TestInterpretOptionalAnyStructFailableCastingNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -5094,7 +5094,7 @@ func TestInterpretOptionalAnyStructFailableCastingNil(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -5342,7 +5342,7 @@ func TestInterpretArrayLength(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -5359,13 +5359,13 @@ func TestInterpretStringLength(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(4),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(4),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -5459,7 +5459,7 @@ func TestInterpretArrayAppend(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.NoError(t, err)
 
-	actualArray := inter.Globals.Get("xs").GetValue()
+	actualArray := inter.Globals.Get("xs").GetValue(inter)
 
 	arrayValue := actualArray.(*interpreter.ArrayValue)
 	AssertValueSlicesEqual(
@@ -5704,7 +5704,7 @@ func TestInterpretArrayInsert(t *testing.T) {
 			_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(int64(testCase.index)))
 			require.NoError(t, err)
 
-			actualArray := inter.Globals.Get("x").GetValue()
+			actualArray := inter.Globals.Get("x").GetValue(inter)
 
 			require.IsType(t, &interpreter.ArrayValue{}, actualArray)
 
@@ -5767,7 +5767,7 @@ func TestInterpretArrayRemove(t *testing.T) {
       let y = x.remove(at: 1)
     `)
 
-	value := inter.Globals.Get("x").GetValue()
+	value := inter.Globals.Get("x").GetValue(inter)
 
 	arrayValue := value.(*interpreter.ArrayValue)
 	AssertValueSlicesEqual(
@@ -5784,7 +5784,7 @@ func TestInterpretArrayRemove(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -5837,7 +5837,7 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
       let y = x.removeFirst()
     `)
 
-	value := inter.Globals.Get("x").GetValue()
+	value := inter.Globals.Get("x").GetValue(inter)
 
 	arrayValue := value.(*interpreter.ArrayValue)
 	AssertValueSlicesEqual(
@@ -5854,7 +5854,7 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -5897,7 +5897,7 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
           let y = x.removeLast()
     `)
 
-	value := inter.Globals.Get("x").GetValue()
+	value := inter.Globals.Get("x").GetValue(inter)
 
 	arrayValue := value.(*interpreter.ArrayValue)
 
@@ -5915,7 +5915,7 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -6224,7 +6224,7 @@ func TestInterpretDictionaryRemove(t *testing.T) {
       let removed = xs.remove(key: "abc")
     `)
 
-	actualValue := inter.Globals.Get("xs").GetValue()
+	actualValue := inter.Globals.Get("xs").GetValue(inter)
 
 	require.IsType(t, actualValue, &interpreter.DictionaryValue{})
 	actualDict := actualValue.(*interpreter.DictionaryValue)
@@ -6245,7 +6245,7 @@ func TestInterpretDictionaryRemove(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("removed").GetValue(),
+		inter.Globals.Get("removed").GetValue(inter),
 	)
 }
 
@@ -6258,7 +6258,7 @@ func TestInterpretDictionaryInsert(t *testing.T) {
       let inserted = xs.insert(key: "abc", 3)
     `)
 
-	actualValue := inter.Globals.Get("xs").GetValue()
+	actualValue := inter.Globals.Get("xs").GetValue(inter)
 
 	require.IsType(t, actualValue, &interpreter.DictionaryValue{})
 	actualDict := actualValue.(*interpreter.DictionaryValue)
@@ -6281,7 +6281,7 @@ func TestInterpretDictionaryInsert(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("inserted").GetValue(),
+		inter.Globals.Get("inserted").GetValue(inter),
 	)
 }
 
@@ -6482,7 +6482,7 @@ func TestInterpretDictionaryKeyTypes(t *testing.T) {
 				interpreter.NewUnmeteredSomeValueNonCopying(
 					interpreter.NewUnmeteredStringValue("test"),
 				),
-				inter.Globals.Get("v").GetValue(),
+				inter.Globals.Get("v").GetValue(inter),
 			)
 		})
 	}
@@ -6514,7 +6514,7 @@ func TestInterpretPathToString(t *testing.T) {
 
 			assert.Equal(t,
 				interpreter.NewUnmeteredStringValue(val),
-				inter.Globals.Get("y").GetValue(),
+				inter.Globals.Get("y").GetValue(inter),
 			)
 		})
 	}
@@ -8020,7 +8020,7 @@ func TestInterpretCastingIntLiteralToInt8(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredInt8Value(42),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -8036,7 +8036,7 @@ func TestInterpretCastingIntLiteralToAnyStruct(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -8052,7 +8052,7 @@ func TestInterpretCastingIntLiteralToOptional(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(interpreter.NewUnmeteredIntValueFromInt64(42)),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -8105,7 +8105,7 @@ func TestInterpretOptionalChainingFieldRead(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x1").GetValue(),
+		inter.Globals.Get("x1").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -8114,7 +8114,7 @@ func TestInterpretOptionalChainingFieldRead(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals.Get("x2").GetValue(),
+		inter.Globals.Get("x2").GetValue(inter),
 	)
 }
 
@@ -8142,17 +8142,17 @@ func TestInterpretOptionalChainingFunctionRead(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x1").GetValue(),
+		inter.Globals.Get("x1").GetValue(inter),
 	)
 
 	require.IsType(t,
 		&interpreter.SomeValue{},
-		inter.Globals.Get("x2").GetValue(),
+		inter.Globals.Get("x2").GetValue(inter),
 	)
 
 	assert.IsType(t,
 		interpreter.BoundFunctionValue{},
-		inter.Globals.Get("x2").GetValue().(*interpreter.SomeValue).
+		inter.Globals.Get("x2").GetValue(inter).(*interpreter.SomeValue).
 			InnerValue(inter, interpreter.EmptyLocationRange),
 	)
 }
@@ -8181,7 +8181,7 @@ func TestInterpretOptionalChainingFunctionCall(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x1").GetValue(),
+		inter.Globals.Get("x1").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -8190,7 +8190,7 @@ func TestInterpretOptionalChainingFunctionCall(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals.Get("x2").GetValue(),
+		inter.Globals.Get("x2").GetValue(inter),
 	)
 }
 
@@ -8236,7 +8236,7 @@ func TestInterpretOptionalChainingFieldReadAndNilCoalescing(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -8280,7 +8280,7 @@ func TestInterpretOptionalChainingFunctionCallAndNilCoalescing(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -8324,14 +8324,14 @@ func TestInterpretOptionalChainingArgumentEvaluation(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(nil, 2),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(nil, 1),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 }
 
@@ -8366,8 +8366,8 @@ func TestInterpretCompositeDeclarationNestedTypeScopingOuterInner(t *testing.T) 
 	)
 	require.NoError(t, err)
 
-	x1 := inter.Globals.Get("x1").GetValue()
-	x2 := inter.Globals.Get("x2").GetValue()
+	x1 := inter.Globals.Get("x1").GetValue(inter)
+	x2 := inter.Globals.Get("x2").GetValue(inter)
 
 	require.IsType(t,
 		&interpreter.CompositeValue{},
@@ -8411,7 +8411,7 @@ func TestInterpretCompositeDeclarationNestedConstructor(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	x := inter.Globals.Get("x").GetValue()
+	x := inter.Globals.Get("x").GetValue(inter)
 
 	require.IsType(t,
 		&interpreter.CompositeValue{},
@@ -8558,14 +8558,14 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 			t,
 			inter,
 			addressValue,
-			inter.Globals.Get("address1").GetValue(),
+			inter.Globals.Get("address1").GetValue(inter),
 		)
 
 		AssertValuesEqual(
 			t,
 			inter,
 			addressValue,
-			inter.Globals.Get("address2").GetValue(),
+			inter.Globals.Get("address2").GetValue(inter),
 		)
 	})
 
@@ -8708,7 +8708,7 @@ func TestInterpretContractUseInNestedDeclaration(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	i := inter.Globals.Get("C").GetValue().(interpreter.MemberAccessibleValue).
+	i := inter.Globals.Get("C").GetValue(inter).(interpreter.MemberAccessibleValue).
 		GetMember(inter, interpreter.EmptyLocationRange, "i")
 
 	require.IsType(t,
@@ -8823,21 +8823,21 @@ func TestInterpretFix64(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredUFix64Value(78_900_123_010),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredUFix64Value(123_405_600_000),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredFix64Value(-1_234_500_678_900),
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 }
 
@@ -8855,7 +8855,7 @@ func TestInterpretFix64Mul(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredFix64Value(-121000000),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 }
 
@@ -9016,7 +9016,7 @@ func TestInterpretOptionalChainingOptionalFieldRead(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -9265,14 +9265,14 @@ func TestInterpretForce(t *testing.T) {
 			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredIntValueFromInt64(1),
 			),
-			inter.Globals.Get("x").GetValue(),
+			inter.Globals.Get("x").GetValue(inter),
 		)
 
 		AssertValuesEqual(
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals.Get("y").GetValue(),
+			inter.Globals.Get("y").GetValue(inter),
 		)
 	})
 
@@ -9307,7 +9307,7 @@ func TestInterpretForce(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals.Get("y").GetValue(),
+			inter.Globals.Get("y").GetValue(inter),
 		)
 	})
 }
@@ -9487,7 +9487,7 @@ func TestInterpretCountDigits256(t *testing.T) {
 
 			assert.Equal(t,
 				bigInt,
-				inter.Globals.Get("number").GetValue().(interpreter.BigNumberValue).ToBigInt(nil),
+				inter.Globals.Get("number").GetValue(inter).(interpreter.BigNumberValue).ToBigInt(nil),
 			)
 
 			expected := interpreter.NewUnmeteredUInt8Value(uint8(test.Count))
@@ -9498,7 +9498,7 @@ func TestInterpretCountDigits256(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals.Get(variableName).GetValue(),
+					inter.Globals.Get(variableName).GetValue(inter),
 				)
 			}
 		})
@@ -9533,7 +9533,7 @@ func TestInterpretFailableCastingCompositeTypeConfusion(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("s").GetValue(),
+		inter.Globals.Get("s").GetValue(inter),
 	)
 }
 
@@ -9827,7 +9827,7 @@ func TestInterpretMissingMember(t *testing.T) {
 	)
 
 	// Remove field `y`
-	compositeValue := inter.Globals.Get("x").GetValue().(*interpreter.CompositeValue)
+	compositeValue := inter.Globals.Get("x").GetValue(inter).(*interpreter.CompositeValue)
 	compositeValue.RemoveField(inter, interpreter.EmptyLocationRange, "y")
 
 	_, err := inter.Invoke("test")
@@ -9878,7 +9878,7 @@ func TestInterpretHostFunctionStaticType(t *testing.T) {
             let y = x.toString
         `)
 
-		value := inter.Globals.Get("y").GetValue()
+		value := inter.Globals.Get("y").GetValue(inter)
 		assert.Equal(
 			t,
 			interpreter.ConvertSemaToStaticType(nil, sema.ToStringFunctionType),
@@ -9894,7 +9894,7 @@ func TestInterpretHostFunctionStaticType(t *testing.T) {
             let y = x<Int8>()
         `)
 
-		value := inter.Globals.Get("x").GetValue()
+		value := inter.Globals.Get("x").GetValue(inter)
 		assert.Equal(
 			t,
 			interpreter.ConvertSemaToStaticType(
@@ -9907,7 +9907,7 @@ func TestInterpretHostFunctionStaticType(t *testing.T) {
 			value.StaticType(inter),
 		)
 
-		value = inter.Globals.Get("y").GetValue()
+		value = inter.Globals.Get("y").GetValue(inter)
 		assert.Equal(
 			t,
 			interpreter.PrimitiveStaticTypeMetaType,
@@ -9933,14 +9933,14 @@ func TestInterpretHostFunctionStaticType(t *testing.T) {
 		// Both `x` and `y` are two functions that returns a string.
 		// Hence, their types are equal. i.e: Receivers shouldn't matter.
 
-		xValue := inter.Globals.Get("x").GetValue()
+		xValue := inter.Globals.Get("x").GetValue(inter)
 		assert.Equal(
 			t,
 			interpreter.ConvertSemaToStaticType(nil, sema.ToStringFunctionType),
 			xValue.StaticType(inter),
 		)
 
-		yValue := inter.Globals.Get("y").GetValue()
+		yValue := inter.Globals.Get("y").GetValue(inter)
 		assert.Equal(
 			t,
 			interpreter.ConvertSemaToStaticType(nil, sema.ToStringFunctionType),
@@ -11540,7 +11540,7 @@ func TestInterpretCastingBoxing(t *testing.T) {
 					Type: interpreter.PrimitiveStaticTypeInt,
 				},
 			),
-			variable.GetValue(),
+			variable.GetValue(inter),
 		)
 	})
 
@@ -11562,7 +11562,7 @@ func TestInterpretCastingBoxing(t *testing.T) {
 					Type: interpreter.PrimitiveStaticTypeInt,
 				},
 			),
-			variable.GetValue(),
+			variable.GetValue(inter),
 		)
 	})
 
@@ -11584,7 +11584,7 @@ func TestInterpretCastingBoxing(t *testing.T) {
 					Type: interpreter.PrimitiveStaticTypeInt,
 				},
 			),
-			variable.GetValue(),
+			variable.GetValue(inter),
 		)
 	})
 }
@@ -11629,7 +11629,7 @@ func TestInterpretNilCoalesceReference(t *testing.T) {
 			BorrowedType:  sema.IntType,
 			Authorization: interpreter.UnauthorizedAccess,
 		},
-		variable.GetValue(),
+		variable.GetValue(inter),
 	)
 }
 

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -49,7 +49,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -65,7 +65,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -81,7 +81,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -97,7 +97,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -113,7 +113,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -159,7 +159,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -219,7 +219,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 }
@@ -241,7 +241,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("[Int]"),
-			inter.Globals.Get("identifier").GetValue(),
+			inter.Globals.Get("identifier").GetValue(inter),
 		)
 	})
 
@@ -260,7 +260,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("S.test.S"),
-			inter.Globals.Get("identifier").GetValue(),
+			inter.Globals.Get("identifier").GetValue(inter),
 		)
 	})
 
@@ -312,7 +312,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue(""),
-			inter.Globals.Get("identifier").GetValue(),
+			inter.Globals.Get("identifier").GetValue(inter),
 		)
 	})
 
@@ -468,7 +468,7 @@ func TestInterpretIsInstance(t *testing.T) {
 				t,
 				inter,
 				interpreter.BoolValue(testCase.result),
-				inter.Globals.Get("result").GetValue(),
+				inter.Globals.Get("result").GetValue(inter),
 			)
 		})
 	}
@@ -610,7 +610,7 @@ func TestInterpretMetaTypeIsSubtype(t *testing.T) {
 
 			assert.Equal(t,
 				interpreter.BoolValue(testCase.result),
-				inter.Globals.Get("result").GetValue(),
+				inter.Globals.Get("result").GetValue(inter),
 			)
 		})
 	}

--- a/runtime/tests/interpreter/path_test.go
+++ b/runtime/tests/interpreter/path_test.go
@@ -54,7 +54,7 @@ func TestInterpretPath(t *testing.T) {
 					Domain:     domain,
 					Identifier: "random",
 				},
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -91,7 +91,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 					Domain:     domain,
 					Identifier: "foo",
 				},
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 
@@ -112,7 +112,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 
 			assert.Equal(t,
 				interpreter.Nil,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 
@@ -133,7 +133,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 
 			assert.Equal(t,
 				interpreter.Nil,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}

--- a/runtime/tests/interpreter/range_value_test.go
+++ b/runtime/tests/interpreter/range_value_test.go
@@ -444,7 +444,7 @@ func TestInclusiveRange(t *testing.T) {
 				t,
 				inter,
 				expectedRangeValue,
-				inter.Globals.Get("r").GetValue(),
+				inter.Globals.Get("r").GetValue(inter),
 			)
 
 			// Check that contains returns correct information.
@@ -460,7 +460,7 @@ func TestInclusiveRange(t *testing.T) {
 					t,
 					inter,
 					expectedValue,
-					inter.Globals.Get(fmt.Sprintf("c_%d", i)).GetValue(),
+					inter.Globals.Get(fmt.Sprintf("c_%d", i)).GetValue(inter),
 				)
 			}
 		})

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -449,7 +449,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &r as &R?
         `)
 
-		value := inter.Globals.Get("ref").GetValue()
+		value := inter.Globals.Get("ref").GetValue(inter)
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
@@ -468,7 +468,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &s as &S?
         `)
 
-		value := inter.Globals.Get("ref").GetValue()
+		value := inter.Globals.Get("ref").GetValue(inter)
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
@@ -485,7 +485,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &i as &Int?
         `)
 
-		value := inter.Globals.Get("ref").GetValue()
+		value := inter.Globals.Get("ref").GetValue(inter)
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
@@ -502,7 +502,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &i as &Int?
         `)
 
-		value := inter.Globals.Get("ref").GetValue()
+		value := inter.Globals.Get("ref").GetValue(inter)
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
@@ -519,7 +519,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &i as &Int?
         `)
 
-		value := inter.Globals.Get("ref").GetValue()
+		value := inter.Globals.Get("ref").GetValue(inter)
 		require.IsType(t, interpreter.Nil, value)
 	})
 }
@@ -2370,7 +2370,7 @@ func TestInterpretDereference(t *testing.T) {
 					t,
 					inter,
 					expectedOriginalValue,
-					inter.Globals.Get("originalArray").GetValue(),
+					inter.Globals.Get("originalArray").GetValue(inter),
 				)
 			})
 		}
@@ -2765,7 +2765,7 @@ func TestInterpretDereference(t *testing.T) {
 					t,
 					inter,
 					expectedOriginalValue,
-					inter.Globals.Get("originalArray").GetValue(),
+					inter.Globals.Get("originalArray").GetValue(inter),
 				)
 			})
 		}

--- a/runtime/tests/interpreter/runtimetype_test.go
+++ b/runtime/tests/interpreter/runtimetype_test.go
@@ -50,7 +50,7 @@ func TestInterpretOptionalType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeString,
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -59,7 +59,7 @@ func TestInterpretOptionalType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -68,7 +68,7 @@ func TestInterpretOptionalType(t *testing.T) {
 				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -79,12 +79,12 @@ func TestInterpretOptionalType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 }
 
@@ -109,7 +109,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeString,
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -118,7 +118,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -127,7 +127,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -138,11 +138,11 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 }
 
@@ -168,7 +168,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(10),
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -178,7 +178,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(5),
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -188,7 +188,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(400),
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -201,12 +201,12 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(6),
 			},
 		},
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 }
 
@@ -234,7 +234,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 				ValueType: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -244,7 +244,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 				ValueType: interpreter.PrimitiveStaticTypeString,
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -254,7 +254,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 				KeyType:   interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -267,17 +267,17 @@ func TestInterpretDictionaryType(t *testing.T) {
 				KeyType: interpreter.PrimitiveStaticTypeBool,
 			},
 		},
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("f").GetValue(),
+		inter.Globals.Get("f").GetValue(inter),
 	)
 }
 
@@ -307,50 +307,50 @@ func TestInterpretCompositeType(t *testing.T) {
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "S"),
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "F"),
 		},
-		inter.Globals.Get("f").GetValue(),
+		inter.Globals.Get("f").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, nil, "PublicKey"),
 		},
-		inter.Globals.Get("g").GetValue(),
+		inter.Globals.Get("g").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, nil, "HashAlgorithm"),
 		},
-		inter.Globals.Get("h").GetValue(),
+		inter.Globals.Get("h").GetValue(inter),
 	)
 }
 
@@ -379,7 +379,7 @@ func TestInterpretFunctionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -394,7 +394,7 @@ func TestInterpretFunctionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -405,12 +405,12 @@ func TestInterpretFunctionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 }
 
@@ -442,7 +442,7 @@ func TestInterpretReferenceType(t *testing.T) {
 				),
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -452,7 +452,7 @@ func TestInterpretReferenceType(t *testing.T) {
 				Authorization:  interpreter.UnauthorizedAccess,
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -467,17 +467,17 @@ func TestInterpretReferenceType(t *testing.T) {
 				),
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 }
 
@@ -517,12 +517,12 @@ func TestInterpretIntersectionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -533,12 +533,12 @@ func TestInterpretIntersectionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("j").GetValue(),
+		inter.Globals.Get("j").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -550,22 +550,22 @@ func TestInterpretIntersectionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("k").GetValue(),
+		inter.Globals.Get("k").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("f").GetValue(),
+		inter.Globals.Get("f").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("h").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("h").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("b").GetValue(),
-		inter.Globals.Get("i").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
+		inter.Globals.Get("i").GetValue(inter),
 	)
 }
 
@@ -593,7 +593,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -605,7 +605,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -617,17 +617,17 @@ func TestInterpretCapabilityType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 }
 
@@ -652,26 +652,26 @@ func TestInterpretInclusiveRangeType(t *testing.T) {
 				ElementType: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 }

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -445,21 +445,21 @@ func TestInterpretCompareCharacters(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -303,7 +303,7 @@ func TestInterpretTransactions(t *testing.T) {
 		err := inter.InvokeTransaction(0, arguments...)
 		require.NoError(t, err)
 
-		values := inter.Globals.Get("values").GetValue()
+		values := inter.Globals.Get("values").GetValue(inter)
 
 		require.IsType(t, &interpreter.ArrayValue{}, values)
 


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-internal/issues/192

## Description

Core idea:
- Introduce a special variable for `self`, which not only holds the value, but also an explicitly created reference to the value.
- This explicitly created reference represents the implicit reference behaviour of self-values. It is used for reference tracking.
- When the value is accessed, always check the reference for any invalidations. This is similar to what is done in bound functions.

Implementation details:
- Introduced an interface for `Variable`. Rename the existing implementation to `SimpleVariable`.
- Add `interpreter` as a parameter for `Variable.GetValue()` method. Majority of the changes in the PR are related to this change (updating tests, etc.).
- Transactions can also become a `self` value. However, creating a reference to them is not possible (transactions don't have a type associated with them) / not useful (they cannot be moved around). So had to special case to not to create the explicit references for transaction values.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
