### PR TITLE
Clear `inAssignment` when recursing into subexpressions

### DIFF
--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -164,7 +164,12 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression, isAssignme
 			checker.currentMemberExpression = previousMemberExpression
 		}()
 
-		accessedType = checker.VisitExpression(accessedExpression, nil)
+		// in an statement like `a.b.c = x`, the entire statement itself
+		// is an assignment, but the evaluation of the accessed exprssion itself (i.e. `a.b`)
+		// is not, so we temporarily clear the `inAssignment` status here before restoring it later.
+		accessedType = checker.withAssignment(false, func() Type {
+			return checker.VisitExpression(accessedExpression, nil)
+		})
 	}()
 
 	checker.checkUnusedExpressionResourceLoss(accessedType, accessedExpression)


### PR DESCRIPTION
This was not properly being cleared, meaning accesses nested inside assignments were able to escalate entitlements

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
