### PR TITLE
Improve dictionary key conflict handling

### DIFF
--- a/migrations/capcons/migration_test.go
+++ b/migrations/capcons/migration_test.go
@@ -159,9 +159,9 @@ func (t *testMigrationReporter) MissingTarget(
 	)
 }
 
-func (t *testMigrationReporter) DictionaryKeyConflict(key interpreter.StringStorageMapKey) {
+func (t *testMigrationReporter) DictionaryKeyConflict(addressPath interpreter.AddressPath) {
 	// For testing purposes, record the conflict as an error
-	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", key))
+	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", addressPath))
 }
 
 const testPathIdentifier = "test"
@@ -459,7 +459,9 @@ func testPathCapabilityValueMigration(
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := &testMigrationReporter{}
 
 	capabilityMapping := &CapabilityMapping{}
@@ -1300,7 +1302,9 @@ func testLinkMigration(
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := &testMigrationReporter{}
 
 	capabilityMapping := &CapabilityMapping{}
@@ -2007,7 +2011,9 @@ func TestPublishedPathCapabilityValueMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := &testMigrationReporter{}
 
 	capabilityMapping := &CapabilityMapping{}
@@ -2245,7 +2251,9 @@ func TestUntypedPathCapabilityValueMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := &testMigrationReporter{}
 
 	capabilityMapping := &CapabilityMapping{}

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -714,7 +714,8 @@ func convertEntireTestValue(
 
 	reporter := newTestReporter()
 
-	migration := migrations.NewStorageMigration(inter, storage, "test", address)
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", address)
+	require.NoError(t, err)
 
 	migratedValue := migration.MigrateNestedValue(
 		interpreter.StorageKey{
@@ -729,7 +730,7 @@ func convertEntireTestValue(
 		reporter,
 	)
 
-	err := migration.Commit()
+	err = migration.Commit()
 	require.NoError(t, err)
 
 	// Assert
@@ -1529,7 +1530,9 @@ func TestMigrateSimpleContract(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test", account)
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", account)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
 	migration.Migrate(
@@ -1711,7 +1714,9 @@ func TestMigratePublishedValue(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
 	migration.Migrate(
@@ -1970,7 +1975,9 @@ func TestMigratePublishedValueAcrossTwoAccounts(t *testing.T) {
 		testAddress2,
 	} {
 
-		migration := migrations.NewStorageMigration(inter, storage, "test", address)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", address)
+		require.NoError(t, err)
+
 		migrator := migration.NewValueMigrationsPathMigrator(
 			reporter,
 			NewEntitlementsMigration(inter),
@@ -2216,7 +2223,9 @@ func TestMigrateAcrossContracts(t *testing.T) {
 		testAddress1,
 		testAddress2,
 	} {
-		migration := migrations.NewStorageMigration(inter, storage, "test", address)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", address)
+		require.NoError(t, err)
+
 		migrator := migration.NewValueMigrationsPathMigrator(
 			reporter,
 			NewEntitlementsMigration(inter),
@@ -2422,7 +2431,9 @@ func TestMigrateArrayOfValues(t *testing.T) {
 		testAddress1,
 		testAddress2,
 	} {
-		migration := migrations.NewStorageMigration(inter, storage, "test", address)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", address)
+		require.NoError(t, err)
+
 		migrator := migration.NewValueMigrationsPathMigrator(
 			reporter,
 			NewEntitlementsMigration(inter),
@@ -2671,7 +2682,9 @@ func TestMigrateDictOfValues(t *testing.T) {
 		testAddress1,
 		testAddress2,
 	} {
-		migration := migrations.NewStorageMigration(inter, storage, "test", address)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", address)
+		require.NoError(t, err)
+
 		migrator := migration.NewValueMigrationsPathMigrator(
 			reporter,
 			NewEntitlementsMigration(inter),
@@ -2993,7 +3006,9 @@ func TestMigrateCapConsAcrossTwoAccounts(t *testing.T) {
 		testAddress1,
 		testAddress2,
 	} {
-		migration := migrations.NewStorageMigration(inter, storage, "test", address)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", address)
+		require.NoError(t, err)
+
 		migrator := migration.NewValueMigrationsPathMigrator(
 			reporter,
 			NewEntitlementsMigration(inter),
@@ -3054,9 +3069,9 @@ func (t *testReporter) Error(err error) {
 	t.errors = append(t.errors, err)
 }
 
-func (t *testReporter) DictionaryKeyConflict(key interpreter.StringStorageMapKey) {
+func (t *testReporter) DictionaryKeyConflict(addressPath interpreter.AddressPath) {
 	// For testing purposes, record the conflict as an error
-	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", key))
+	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", addressPath))
 }
 
 func TestRehash(t *testing.T) {
@@ -3210,7 +3225,9 @@ func TestRehash(t *testing.T) {
 			return compositeType
 		}
 
-		migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
 		reporter := newTestReporter()
 
 		migration.Migrate(
@@ -3220,7 +3237,7 @@ func TestRehash(t *testing.T) {
 			),
 		)
 
-		err := migration.Commit()
+		err = migration.Commit()
 		require.NoError(t, err)
 
 		// Assert
@@ -3401,7 +3418,9 @@ func TestIntersectionTypeWithIntersectionLegacyType(t *testing.T) {
 			}
 		}
 
-		migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
 		reporter := newTestReporter()
 
 		migration.Migrate(
@@ -3411,7 +3430,7 @@ func TestIntersectionTypeWithIntersectionLegacyType(t *testing.T) {
 			),
 		)
 
-		err := migration.Commit()
+		err = migration.Commit()
 		require.NoError(t, err)
 
 		// Assert

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -26,6 +26,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/parser/lexer"
 	"github.com/onflow/cadence/runtime/stdlib"
 )
 
@@ -61,14 +62,21 @@ func NewStorageMigration(
 	storage *runtime.Storage,
 	name string,
 	address common.Address,
-) *StorageMigration {
+) (
+	*StorageMigration,
+	error,
+) {
+	if !lexer.IsValidIdentifier(name) {
+		return nil, fmt.Errorf("invalid migration name: %s", name)
+	}
+
 	return &StorageMigration{
 		storage:                storage,
 		interpreter:            interpreter,
 		name:                   name,
 		address:                address,
 		dictionaryKeyConflicts: 0,
-	}
+	}, nil
 }
 
 func (m *StorageMigration) Commit() error {
@@ -412,7 +420,9 @@ func (m *StorageMigration) MigrateNestedValue(
 			) {
 				owner := dictionary.GetOwner()
 
-				storageMap := m.storage.GetStorageMap(owner, common.PathDomainStorage.Identifier(), true)
+				pathDomain := common.PathDomainStorage
+
+				storageMap := m.storage.GetStorageMap(owner, pathDomain.Identifier(), true)
 				conflictDictionary := interpreter.NewDictionaryValueWithAddress(
 					inter,
 					emptyLocationRange,
@@ -434,7 +444,15 @@ func (m *StorageMigration) MigrateNestedValue(
 					conflictDictionary,
 				)
 
-				reporter.DictionaryKeyConflict(conflictStorageMapKey)
+				reporter.DictionaryKeyConflict(
+					interpreter.AddressPath{
+						Address: owner,
+						Path: interpreter.PathValue{
+							Domain:     pathDomain,
+							Identifier: string(conflictStorageMapKey),
+						},
+					},
+				)
 
 			} else {
 
@@ -537,12 +555,13 @@ func (m *StorageMigration) MigrateNestedValue(
 
 func (m *StorageMigration) nextDictionaryKeyConflictStorageMapKey() interpreter.StringStorageMapKey {
 	m.dictionaryKeyConflicts++
-	return DictionaryKeyConflictStorageMapKey(m.dictionaryKeyConflicts)
+	return m.DictionaryKeyConflictStorageMapKey(m.dictionaryKeyConflicts)
 }
 
-func DictionaryKeyConflictStorageMapKey(index int) interpreter.StringStorageMapKey {
+func (m *StorageMigration) DictionaryKeyConflictStorageMapKey(index int) interpreter.StringStorageMapKey {
 	return interpreter.StringStorageMapKey(fmt.Sprintf(
-		"cadence_1_migration_dictionary_key_conflict_%d",
+		"cadence1_%s_dictionaryKeyConflict_%d",
+		m.name,
 		index,
 	))
 }

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -438,21 +438,27 @@ func (m *StorageMigration) MigrateNestedValue(
 
 				conflictStorageMapKey := m.nextDictionaryKeyConflictStorageMapKey()
 
+				addressPath := interpreter.AddressPath{
+					Address: owner,
+					Path: interpreter.PathValue{
+						Domain:     pathDomain,
+						Identifier: string(conflictStorageMapKey),
+					},
+				}
+
+				if storageMap.ValueExists(conflictStorageMapKey) {
+					panic(errors.NewUnexpectedError(
+						"conflict storage map key already exists: %s", addressPath,
+					))
+				}
+
 				storageMap.SetValue(
 					inter,
 					conflictStorageMapKey,
 					conflictDictionary,
 				)
 
-				reporter.DictionaryKeyConflict(
-					interpreter.AddressPath{
-						Address: owner,
-						Path: interpreter.PathValue{
-							Domain:     pathDomain,
-							Identifier: string(conflictStorageMapKey),
-						},
-					},
-				)
+				reporter.DictionaryKeyConflict(addressPath)
 
 			} else {
 

--- a/migrations/migration_reporter.go
+++ b/migrations/migration_reporter.go
@@ -26,6 +26,6 @@ type Reporter interface {
 		storageMapKey interpreter.StorageMapKey,
 		migration string,
 	)
-	DictionaryKeyConflict(key interpreter.StringStorageMapKey)
+	DictionaryKeyConflict(addressPath interpreter.AddressPath)
 	Error(err error)
 }

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -82,9 +82,9 @@ func (t *testReporter) Error(err error) {
 	t.errors = append(t.errors, err)
 }
 
-func (t *testReporter) DictionaryKeyConflict(key interpreter.StringStorageMapKey) {
+func (t *testReporter) DictionaryKeyConflict(addressPath interpreter.AddressPath) {
 	// For testing purposes, record the conflict as an error
-	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", key))
+	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", addressPath))
 }
 
 // testStringMigration
@@ -516,12 +516,13 @@ func TestMultipleMigrations(t *testing.T) {
 
 	reporter := newTestReporter()
 
-	migration := NewStorageMigration(
+	migration, err := NewStorageMigration(
 		inter,
 		storage,
 		"test",
 		account,
 	)
+	require.NoError(t, err)
 
 	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
@@ -658,7 +659,9 @@ func TestMigrationError(t *testing.T) {
 
 	// Migrate
 
-	migration := NewStorageMigration(inter, storage, "test", account)
+	migration, err := NewStorageMigration(inter, storage, "test", account)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
 	migration.Migrate(
@@ -801,7 +804,9 @@ func TestCapConMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := NewStorageMigration(inter, storage, "test", testAddress)
+	migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
 	migration.Migrate(
@@ -914,7 +919,9 @@ func TestContractMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := NewStorageMigration(inter, storage, "test", testAddress)
+	migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
 	migration.Migrate(
@@ -1105,7 +1112,9 @@ func TestEmptyIntersectionTypeMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := NewStorageMigration(inter, storage, "test", testAddress)
+	migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
 	migration.Migrate(
@@ -1252,7 +1261,9 @@ func TestMigratingNestedContainers(t *testing.T) {
 
 		// Migrate
 
-		migration := NewStorageMigration(inter, storage, "test", testAddress)
+		migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
 		reporter := newTestReporter()
 
 		migration.Migrate(
@@ -1680,7 +1691,9 @@ func TestMigrationPanic(t *testing.T) {
 
 	// Migrate
 
-	migration := NewStorageMigration(inter, storage, "test", testAddress)
+	migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
 	migration.Migrate(
@@ -1805,7 +1818,9 @@ func TestSkip(t *testing.T) {
 
 		// Migrate
 
-		migration := NewStorageMigration(inter, storage, "test", testAddress)
+		migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
 		reporter := newTestReporter()
 
 		valueMigration := &testSkipMigration{
@@ -2159,7 +2174,9 @@ func TestPublishedValueMigration(t *testing.T) {
 	)
 
 	// Migrate
-	migration := NewStorageMigration(inter, storage, "test", testAddress)
+	migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
 	migration.Migrate(
@@ -2267,7 +2284,9 @@ func TestDomainsMigration(t *testing.T) {
 
 		// Migrate
 
-		migration := NewStorageMigration(inter, storage, "test", testAddress)
+		migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
 		reporter := newTestReporter()
 
 		migration.Migrate(
@@ -2701,7 +2720,9 @@ func TestDictionaryKeyConflict(t *testing.T) {
 
 			storage, inter := newStorageAndInterpreter(t)
 
-			migration := NewStorageMigration(inter, storage, "test", testAddress)
+			migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+			require.NoError(t, err)
+
 			reporter := newTestReporter()
 
 			migration.Migrate(
@@ -2713,7 +2734,7 @@ func TestDictionaryKeyConflict(t *testing.T) {
 				),
 			)
 
-			err := migration.Commit()
+			err = migration.Commit()
 			require.NoError(t, err)
 
 			// Assert
@@ -2766,7 +2787,7 @@ func TestDictionaryKeyConflict(t *testing.T) {
 
 			// Check newly created conflict dictionary
 
-			conflictValue := storageMap.ReadValue(nil, DictionaryKeyConflictStorageMapKey(1))
+			conflictValue := storageMap.ReadValue(nil, migration.DictionaryKeyConflictStorageMapKey(1))
 			require.NotNil(t, conflictValue)
 
 			require.IsType(t, &interpreter.DictionaryValue{}, conflictValue)

--- a/migrations/statictypes/account_type_migration_test.go
+++ b/migrations/statictypes/account_type_migration_test.go
@@ -73,9 +73,9 @@ func (t *testReporter) Error(err error) {
 	t.errors = append(t.errors, err)
 }
 
-func (t *testReporter) DictionaryKeyConflict(key interpreter.StringStorageMapKey) {
+func (t *testReporter) DictionaryKeyConflict(addressPath interpreter.AddressPath) {
 	// For testing purposes, record the conflict as an error
-	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", key))
+	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", addressPath))
 }
 
 func TestAccountTypeInTypeValueMigration(t *testing.T) {
@@ -466,7 +466,9 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 
 			// Migrate
 
-			migration := migrations.NewStorageMigration(inter, storage, "test", account)
+			migration, err := migrations.NewStorageMigration(inter, storage, "test", account)
+			require.NoError(t, err)
+
 			reporter := newTestReporter()
 
 			migration.Migrate(
@@ -855,7 +857,9 @@ func TestAccountTypeInNestedTypeValueMigration(t *testing.T) {
 
 			// Migrate
 
-			migration := migrations.NewStorageMigration(inter, storage, "test", account)
+			migration, err := migrations.NewStorageMigration(inter, storage, "test", account)
+			require.NoError(t, err)
+
 			reporter := newTestReporter()
 
 			migration.Migrate(
@@ -1159,7 +1163,9 @@ func TestMigratingValuesWithAccountStaticType(t *testing.T) {
 
 			// Migrate
 
-			migration := migrations.NewStorageMigration(inter, storage, "test", account)
+			migration, err := migrations.NewStorageMigration(inter, storage, "test", account)
+			require.NoError(t, err)
+
 			reporter := newTestReporter()
 
 			migration.Migrate(
@@ -1290,7 +1296,9 @@ func TestAccountTypeRehash(t *testing.T) {
 
 				storage, inter := newStorageAndInterpreter(t)
 
-				migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+				migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+				require.NoError(t, err)
+
 				reporter := newTestReporter()
 
 				migration.Migrate(
@@ -1300,7 +1308,7 @@ func TestAccountTypeRehash(t *testing.T) {
 					),
 				)
 
-				err := migration.Commit()
+				err = migration.Commit()
 				require.NoError(t, err)
 
 				// Assert

--- a/migrations/statictypes/composite_type_migration_test.go
+++ b/migrations/statictypes/composite_type_migration_test.go
@@ -145,7 +145,9 @@ func TestCompositeAndInterfaceTypeMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
 	barStaticType := newCompositeType()

--- a/migrations/statictypes/intersection_type_migration_test.go
+++ b/migrations/statictypes/intersection_type_migration_test.go
@@ -398,7 +398,9 @@ func TestIntersectionTypeMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
 	migration.Migrate(
@@ -566,7 +568,9 @@ func TestIntersectionTypeRehash(t *testing.T) {
 
 		storage, inter := newStorageAndInterpreter(t)
 
-		migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
 		reporter := newTestReporter()
 
 		migration.Migrate(
@@ -576,7 +580,7 @@ func TestIntersectionTypeRehash(t *testing.T) {
 			),
 		)
 
-		err := migration.Commit()
+		err = migration.Commit()
 		require.NoError(t, err)
 
 		// Assert
@@ -734,7 +738,9 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 
 			storage, inter := newStorageAndInterpreter(t, ledger)
 
-			migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+			migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+			require.NoError(t, err)
+
 			reporter := newTestReporter()
 
 			migration.Migrate(
@@ -744,7 +750,7 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 				),
 			)
 
-			err := migration.Commit()
+			err = migration.Commit()
 			require.NoError(t, err)
 
 			// Assert
@@ -877,7 +883,9 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 
 			storage, inter := newStorageAndInterpreter(t, ledger)
 
-			migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+			migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+			require.NoError(t, err)
+
 			reporter := newTestReporter()
 
 			migration.Migrate(
@@ -887,7 +895,7 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 				),
 			)
 
-			err := migration.Commit()
+			err = migration.Commit()
 			require.NoError(t, err)
 
 			// Assert
@@ -1028,7 +1036,9 @@ func TestIntersectionTypeMigrationWithInterfaceTypeConverter(t *testing.T) {
 
 		// Migrate
 
-		migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
 		reporter := newTestReporter()
 
 		staticTypeMigration := NewStaticTypeMigration()
@@ -1421,7 +1431,9 @@ func TestIntersectionTypeMigrationWithTypeConverters(t *testing.T) {
 
 		// Migrate
 
-		migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
 		reporter := newTestReporter()
 
 		migration.Migrate(

--- a/migrations/statictypes/statictype_migration_test.go
+++ b/migrations/statictypes/statictype_migration_test.go
@@ -75,7 +75,9 @@ func TestStaticTypeMigration(t *testing.T) {
 
 		// Migrate
 
-		migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
 		reporter := newTestReporter()
 
 		migration.Migrate(
@@ -878,7 +880,9 @@ func TestMigratingNestedContainers(t *testing.T) {
 
 		// Migrate
 
-		migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
 		reporter := newTestReporter()
 
 		migration.Migrate(

--- a/migrations/string_normalization/migration_test.go
+++ b/migrations/string_normalization/migration_test.go
@@ -77,9 +77,9 @@ func (t *testReporter) Error(err error) {
 	t.errors = append(t.errors, err)
 }
 
-func (t *testReporter) DictionaryKeyConflict(key interpreter.StringStorageMapKey) {
+func (t *testReporter) DictionaryKeyConflict(addressPath interpreter.AddressPath) {
 	// For testing purposes, record the conflict as an error
-	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", key))
+	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", addressPath))
 }
 
 func TestStringNormalizingMigration(t *testing.T) {
@@ -309,7 +309,9 @@ func TestStringNormalizingMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test", account)
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", account)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
 	migration.Migrate(
@@ -446,7 +448,8 @@ func TestStringValueRehash(t *testing.T) {
 
 		storage, inter := newStorageAndInterpreter(t)
 
-		migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
 
 		reporter := newTestReporter()
 
@@ -457,7 +460,7 @@ func TestStringValueRehash(t *testing.T) {
 			),
 		)
 
-		err := migration.Commit()
+		err = migration.Commit()
 		require.NoError(t, err)
 
 		require.Empty(t, reporter.errors)
@@ -590,7 +593,9 @@ func TestCharacterValueRehash(t *testing.T) {
 
 		storage, inter := newStorageAndInterpreter(t)
 
-		migration := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
 		reporter := newTestReporter()
 
 		migration.Migrate(
@@ -600,7 +605,7 @@ func TestCharacterValueRehash(t *testing.T) {
 			),
 		)
 
-		err := migration.Commit()
+		err = migration.Commit()
 		require.NoError(t, err)
 
 		require.Empty(t, reporter.errors)

--- a/runtime/parser/lexer/lexer.go
+++ b/runtime/parser/lexer/lexer.go
@@ -357,12 +357,24 @@ func (l *lexer) scanSpace() (containsNewline bool) {
 func (l *lexer) scanIdentifier() {
 	// lookahead is already lexed.
 	// parse more, if any
-	l.acceptWhile(func(r rune) bool {
-		return r >= 'a' && r <= 'z' ||
-			r >= 'A' && r <= 'Z' ||
-			r >= '0' && r <= '9' ||
-			r == '_'
-	})
+	l.acceptWhile(IsIdentifierRune)
+}
+
+func IsIdentifierRune(r rune) bool {
+	return r >= 'a' && r <= 'z' ||
+		r >= 'A' && r <= 'Z' ||
+		r >= '0' && r <= '9' ||
+		r == '_'
+}
+
+func IsValidIdentifier(s string) bool {
+	for _, r := range s {
+		if !IsIdentifierRune(r) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (l *lexer) scanLineComment() {


### PR DESCRIPTION
## Description

While updating flow-go in https://github.com/onflow/flow-go/pull/5667, I noticed that the reported information for a dictionary key conflict is currently useless.

Include the account address, report the full address path.

While implementing this I also realized that there is a potential for multiple different migrations to run into a dictionary key conflict, but the generation of storage paths for the key conflicts was producing potentially conflicting keys itself. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
