### PR TITLE
Implement FLIP 262

### DIFF
--- a/runtime/ast/access.go
+++ b/runtime/ast/access.go
@@ -129,18 +129,18 @@ func (e EntitlementAccess) entitlementsString(prefix *strings.Builder) {
 }
 
 func (e EntitlementAccess) String() string {
-	str := &strings.Builder{}
-	str.WriteString("EntitlementAccess ")
-	e.entitlementsString(str)
-	return str.String()
+	var sb strings.Builder
+	sb.WriteString("EntitlementAccess ")
+	e.entitlementsString(&sb)
+	return sb.String()
 }
 
 func (e EntitlementAccess) Keyword() string {
-	str := &strings.Builder{}
-	str.WriteString("access(")
-	e.entitlementsString(str)
-	str.WriteString(")")
-	return str.String()
+	var sb strings.Builder
+	sb.WriteString("access(")
+	e.entitlementsString(&sb)
+	sb.WriteString(")")
+	return sb.String()
 }
 
 func (e EntitlementAccess) MarshalJSON() ([]byte, error) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -495,7 +495,8 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 			check: func(t *testing.T, err error) {
 				RequireError(t, err)
 
-				assert.IsType(t, &InvalidEntryPointArgumentError{}, errors.Unwrap(err))
+				var invalidEntryPointArgumentErr *InvalidEntryPointArgumentError
+				assert.ErrorAs(t, err, &invalidEntryPointArgumentErr)
 			},
 		},
 		{
@@ -513,8 +514,11 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 			check: func(t *testing.T, err error) {
 				RequireError(t, err)
 
-				assert.IsType(t, &InvalidEntryPointArgumentError{}, errors.Unwrap(err))
-				assert.IsType(t, &InvalidValueTypeError{}, errors.Unwrap(errors.Unwrap(err)))
+				var invalidEntryPointArgumentErr *InvalidEntryPointArgumentError
+				assert.ErrorAs(t, err, &invalidEntryPointArgumentErr)
+
+				var invalidValueTypeErr *InvalidValueTypeError
+				assert.ErrorAs(t, err, &invalidValueTypeErr)
 			},
 		},
 		{
@@ -10562,19 +10566,6 @@ func TestRuntimeNonPublicAccessModifierInInterface(t *testing.T) {
 		}
 	`)
 
-	tx := []byte(`
-        import C1 from 0x1
-        import C2 from 0x2
-
-        transaction {
-            prepare(acct: &Account) {
-               C1.test(C2.S1())
-               C1.test(C2.S2())
-               C2.test()
-            }
-        }
-    `)
-
 	deploy1 := DeploymentTransaction("C1", contract1)
 	deploy2 := DeploymentTransaction("C2", contract2)
 
@@ -10635,17 +10626,10 @@ func TestRuntimeNonPublicAccessModifierInInterface(t *testing.T) {
 			Location:  nextTransactionLocation(),
 		},
 	)
-	require.NoError(t, err)
+	RequireError(t, err)
 
-	// Run test transaction
+	var conformanceErr *sema.ConformanceError
+	require.ErrorAs(t, err, &conformanceErr)
 
-	err = runtime.ExecuteTransaction(
-		Script{
-			Source: tx,
-		},
-		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-		})
-	require.NoError(t, err)
+	require.Len(t, conformanceErr.MemberMismatches, 2)
 }

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -37,8 +37,6 @@ type Access interface {
 	String() string
 	QualifiedString() string
 	Equal(other Access) bool
-	// IsLessPermissiveThan returns whether receiver access is less permissive than argument access
-	IsLessPermissiveThan(Access) bool
 	// PermitsAccess returns whether receiver access permits argument access
 	PermitsAccess(Access) bool
 }
@@ -252,18 +250,6 @@ func (e EntitlementSetAccess) PermitsAccess(other Access) bool {
 	}
 }
 
-func (e EntitlementSetAccess) IsLessPermissiveThan(other Access) bool {
-	switch otherAccess := other.(type) {
-	case PrimitiveAccess:
-		return ast.PrimitiveAccess(otherAccess) != ast.AccessSelf
-	case EntitlementSetAccess:
-		// subset check returns true on equality, and we want this function to be false on equality, so invert the >= check
-		return !e.PermitsAccess(otherAccess)
-	default:
-		return true
-	}
-}
-
 // EntitlementMapAccess
 
 type EntitlementMapAccess struct {
@@ -344,18 +330,6 @@ func (e *EntitlementMapAccess) PermitsAccess(other Access) bool {
 		return e.Codomain().PermitsAccess(otherAccess)
 	default:
 		return false
-	}
-}
-
-func (e *EntitlementMapAccess) IsLessPermissiveThan(other Access) bool {
-	switch otherAccess := other.(type) {
-	case PrimitiveAccess:
-		return ast.PrimitiveAccess(otherAccess) != ast.AccessSelf
-	case *EntitlementMapAccess:
-		// this should be false on equality
-		return !e.Type.Equal(otherAccess.Type)
-	default:
-		return true
 	}
 }
 
@@ -481,14 +455,6 @@ func (a PrimitiveAccess) Equal(other Access) bool {
 		return ast.PrimitiveAccess(a) == ast.PrimitiveAccess(otherAccess)
 	}
 	return false
-}
-
-func (a PrimitiveAccess) IsLessPermissiveThan(otherAccess Access) bool {
-	if otherPrimitive, ok := otherAccess.(PrimitiveAccess); ok {
-		return ast.PrimitiveAccess(a) < ast.PrimitiveAccess(otherPrimitive)
-	}
-	// primitive and entitlement access should never mix in interface conformance checks
-	return true
 }
 
 func (a PrimitiveAccess) PermitsAccess(otherAccess Access) bool {

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -1592,7 +1592,7 @@ func (checker *Checker) memberSatisfied(
 	effectiveInterfaceMemberAccess := checker.effectiveInterfaceMemberAccess(interfaceMember.Access)
 	effectiveCompositeMemberAccess := checker.EffectiveCompositeMemberAccess(compositeMember.Access)
 
-	return !effectiveCompositeMemberAccess.IsLessPermissiveThan(effectiveInterfaceMemberAccess)
+	return effectiveCompositeMemberAccess.Equal(effectiveInterfaceMemberAccess)
 }
 
 func CompositeLikeConstructorType(

--- a/runtime/tests/checker/conformance_test.go
+++ b/runtime/tests/checker/conformance_test.go
@@ -19,11 +19,13 @@
 package checker
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/sema"
 )
 
@@ -281,4 +283,131 @@ func TestCheckInitializerConformanceErrorMessages(t *testing.T) {
 			conformanceErr.SecondaryError(),
 		)
 	})
+}
+
+func TestCheckConformanceAccessModifierMatches(t *testing.T) {
+	t.Parallel()
+
+	e1 := &sema.EntitlementType{
+		Identifier: "E1",
+	}
+	e2 := &sema.EntitlementType{
+		Identifier: "E2",
+	}
+
+	accessModifiers := []sema.Access{
+		sema.PrimitiveAccess(ast.AccessSelf),
+		sema.PrimitiveAccess(ast.AccessAccount),
+		sema.PrimitiveAccess(ast.AccessContract),
+		sema.NewEntitlementSetAccess(
+			[]*sema.EntitlementType{e1, e2},
+			sema.Conjunction,
+		),
+		sema.NewEntitlementSetAccess(
+			[]*sema.EntitlementType{e1, e2},
+			sema.Disjunction,
+		),
+		sema.NewEntitlementSetAccess(
+			[]*sema.EntitlementType{e1},
+			sema.Conjunction,
+		),
+		sema.PrimitiveAccess(ast.AccessAll),
+	}
+
+	asASTAccess := func(access sema.Access) ast.Access {
+		switch access := access.(type) {
+		case sema.PrimitiveAccess:
+			return ast.PrimitiveAccess(access)
+
+		case sema.EntitlementSetAccess:
+
+			entitlementTypes := make([]*ast.NominalType, 0, access.Entitlements.Len())
+
+			access.Entitlements.Foreach(func(entitlementType *sema.EntitlementType, _ struct{}) {
+				entitlementTypes = append(
+					entitlementTypes,
+					&ast.NominalType{
+						Identifier: ast.Identifier{
+							Identifier: entitlementType.QualifiedIdentifier(),
+						},
+					},
+				)
+			})
+
+			var entitlementSet ast.EntitlementSet
+			switch access.SetKind {
+			case sema.Conjunction:
+				entitlementSet = ast.NewConjunctiveEntitlementSet(entitlementTypes)
+
+			case sema.Disjunction:
+				entitlementSet = ast.NewDisjunctiveEntitlementSet(entitlementTypes)
+
+			default:
+				panic(errors.NewUnreachableError())
+			}
+
+			return ast.EntitlementAccess{
+				EntitlementSet: entitlementSet,
+			}
+
+		default:
+			panic(errors.NewUnreachableError())
+		}
+	}
+
+	test := func(t *testing.T, interfaceAccess, implementationAccess sema.Access) {
+		name := fmt.Sprintf("%s %s", interfaceAccess, implementationAccess)
+		t.Run(name, func(t *testing.T) {
+
+			t.Parallel()
+
+			_, err := ParseAndCheck(t,
+				fmt.Sprintf(
+					`
+                      entitlement E1
+                      entitlement E2
+
+                      struct interface SI {
+                          %s fun foo()
+                      }
+
+                      struct S: SI {
+                          %s fun foo() {}
+                      }
+                    `,
+					asASTAccess(interfaceAccess).Keyword(),
+					asASTAccess(implementationAccess).Keyword(),
+				),
+			)
+
+			if interfaceAccess == sema.PrimitiveAccess(ast.AccessSelf) {
+				if implementationAccess == sema.PrimitiveAccess(ast.AccessSelf) {
+					errs := RequireCheckerErrors(t, err, 1)
+
+					require.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+				} else {
+					errs := RequireCheckerErrors(t, err, 2)
+
+					require.IsType(t, &sema.InvalidAccessModifierError{}, errs[0])
+					require.IsType(t, &sema.ConformanceError{}, errs[1])
+				}
+			} else if !implementationAccess.Equal(interfaceAccess) {
+				errs := RequireCheckerErrors(t, err, 1)
+
+				var conformanceErr *sema.ConformanceError
+				require.ErrorAs(t, errs[0], &conformanceErr)
+
+				require.Len(t, conformanceErr.MemberMismatches, 1)
+
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	for _, access1 := range accessModifiers {
+		for _, access2 := range accessModifiers {
+			test(t, access1, access2)
+		}
+	}
 }

--- a/runtime/tests/checker/conformance_test.go
+++ b/runtime/tests/checker/conformance_test.go
@@ -218,9 +218,9 @@ func TestCheckInitializerConformanceErrorMessages(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		require.IsType(t, &sema.ConformanceError{}, errs[0])
+		var conformanceErr *sema.ConformanceError
+		require.ErrorAs(t, errs[0], &conformanceErr)
 
-		conformanceErr := errs[0].(*sema.ConformanceError)
 		require.NotNil(t, conformanceErr.InitializerMismatch)
 		notes := conformanceErr.ErrorNotes()
 		require.Len(t, notes, 1)
@@ -238,19 +238,23 @@ func TestCheckInitializerConformanceErrorMessages(t *testing.T) {
 		t.Parallel()
 
 		_, err := ParseAndCheck(t, `
-        access(all) resource interface I {
-            fun foo(): Int
-        }
+          access(all) resource interface I {
+              fun foo(): Int
+          }
 
-        access(all) resource R: I {
-        }
+          access(all) resource R: I {
+          }
         `)
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		require.IsType(t, &sema.ConformanceError{}, errs[0])
-		conformanceErr := errs[0].(*sema.ConformanceError)
-		require.Equal(t, "`R` is missing definitions for members: `foo`", conformanceErr.SecondaryError())
+		var conformanceErr *sema.ConformanceError
+		require.ErrorAs(t, errs[0], &conformanceErr)
+
+		require.Equal(t,
+			"`R` is missing definitions for members: `foo`",
+			conformanceErr.SecondaryError(),
+		)
 	})
 
 	t.Run("2 missing member", func(t *testing.T) {
@@ -258,19 +262,23 @@ func TestCheckInitializerConformanceErrorMessages(t *testing.T) {
 		t.Parallel()
 
 		_, err := ParseAndCheck(t, `
-        access(all) resource interface I {
-            fun foo(): Int
-            fun bar(): Int
-        }
+          access(all) resource interface I {
+              fun foo(): Int
+              fun bar(): Int
+          }
 
-        access(all) resource R: I {
-        }
+          access(all) resource R: I {
+          }
         `)
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		require.IsType(t, &sema.ConformanceError{}, errs[0])
-		conformanceErr := errs[0].(*sema.ConformanceError)
-		require.Equal(t, "`R` is missing definitions for members: `foo`, `bar`", conformanceErr.SecondaryError())
+		var conformanceErr *sema.ConformanceError
+		require.ErrorAs(t, errs[0], &conformanceErr)
+
+		require.Equal(t,
+			"`R` is missing definitions for members: `foo`, `bar`",
+			conformanceErr.SecondaryError(),
+		)
 	})
 }

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -2702,7 +2702,10 @@ func TestCheckEntitlementInheritance(t *testing.T) {
             }
         `)
 
-		assert.NoError(t, err)
+		errs := RequireCheckerErrors(t, err, 2)
+
+		require.IsType(t, &sema.ConformanceError{}, errs[0])
+		require.IsType(t, &sema.ConformanceError{}, errs[1])
 	})
 
 	t.Run("more expanded entitlements valid in disjunction", func(t *testing.T) {
@@ -2720,7 +2723,9 @@ func TestCheckEntitlementInheritance(t *testing.T) {
             }
         `)
 
-		assert.NoError(t, err)
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.ConformanceError{}, errs[0])
 	})
 
 	t.Run("reduced entitlements valid with conjunction", func(t *testing.T) {
@@ -2741,7 +2746,10 @@ func TestCheckEntitlementInheritance(t *testing.T) {
             }
         `)
 
-		assert.NoError(t, err)
+		errs := RequireCheckerErrors(t, err, 2)
+
+		require.IsType(t, &sema.ConformanceError{}, errs[0])
+		require.IsType(t, &sema.ConformanceError{}, errs[1])
 	})
 
 	t.Run("more reduced entitlements valid with conjunction", func(t *testing.T) {
@@ -2759,7 +2767,9 @@ func TestCheckEntitlementInheritance(t *testing.T) {
             }
         `)
 
-		assert.NoError(t, err)
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.ConformanceError{}, errs[0])
 	})
 
 	t.Run("expanded entitlements invalid in conjunction", func(t *testing.T) {
@@ -2924,7 +2934,9 @@ func TestCheckEntitlementInheritance(t *testing.T) {
             }
         `)
 
-		assert.NoError(t, err)
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.ConformanceError{}, errs[0])
 	})
 
 	t.Run("overlapped entitlements valid with conjunction/disjunction subtype", func(t *testing.T) {
@@ -2942,8 +2954,9 @@ func TestCheckEntitlementInheritance(t *testing.T) {
             }
         `)
 
-		// implementation is less specific because it only requires one, but interface guarantees both
-		assert.NoError(t, err)
+		errs := RequireCheckerErrors(t, err, 1)
+
+		require.IsType(t, &sema.ConformanceError{}, errs[0])
 	})
 
 	t.Run("different entitlements invalid", func(t *testing.T) {
@@ -2964,9 +2977,10 @@ func TestCheckEntitlementInheritance(t *testing.T) {
             }
         `)
 
-		errs := RequireCheckerErrors(t, err, 1)
+		errs := RequireCheckerErrors(t, err, 2)
 
 		require.IsType(t, &sema.ConformanceError{}, errs[0])
+		require.IsType(t, &sema.ConformanceError{}, errs[1])
 	})
 
 	t.Run("default function entitlements", func(t *testing.T) {
@@ -5656,7 +5670,7 @@ func TestCheckEntitlementConditions(t *testing.T) {
 			access(X, Y) view fun foo(): Bool
 		}
 		resource interface J: I {
-			access(Y) view fun foo(): Bool
+			access(X, Y) view fun foo(): Bool
 		}
 		fun bar(r: @{J}): @{J} {
 			post {

--- a/runtime/tests/interpreter/entitlements_test.go
+++ b/runtime/tests/interpreter/entitlements_test.go
@@ -2487,7 +2487,7 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 			entitlement E
 			entitlement G
 			struct S: I {
-				access(X, E) fun foo() {}
+				access(X, E, G) fun foo() {}
 			}
 			struct interface I {
 				access(X, E, G) fun foo()


### PR DESCRIPTION
Closes #3245 

## Description

Require implementation member to have same access modifier as interface member

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
