### PR TITLE
Update atree register inlining v0.42 feature branch

### DIFF
--- a/npm-packages/cadence-parser/package.json
+++ b/npm-packages/cadence-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-parser",
-  "version": "0.42.9",
+  "version": "0.42.10",
   "description": "The Cadence parser",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -356,7 +356,7 @@ func (s *Storage) CheckHealth() error {
 }
 
 type UnreferencedRootSlabsError struct {
-	UnreferencedRootSlabIDs []atree.StorageID
+	UnreferencedRootSlabIDs []atree.SlabID
 }
 
 var _ errors.InternalError = UnreferencedRootSlabsError{}

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -19,6 +19,7 @@
 package runtime
 
 import (
+	"fmt"
 	"runtime"
 	"sort"
 
@@ -346,8 +347,22 @@ func (s *Storage) CheckHealth() error {
 			return a.Compare(b) < 0
 		})
 
-		return errors.NewUnexpectedError("slabs not referenced from account storage: %s", unreferencedRootSlabIDs)
+		return UnreferencedRootSlabsError{
+			UnreferencedRootSlabIDs: unreferencedRootSlabIDs,
+		}
 	}
 
 	return nil
+}
+
+type UnreferencedRootSlabsError struct {
+	UnreferencedRootSlabIDs []atree.StorageID
+}
+
+var _ errors.InternalError = UnreferencedRootSlabsError{}
+
+func (UnreferencedRootSlabsError) IsInternalError() {}
+
+func (e UnreferencedRootSlabsError) Error() string {
+	return fmt.Sprintf("slabs not referenced: %s", e.UnreferencedRootSlabIDs)
 }

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v0.42.9"
+const Version = "v0.42.10"


### PR DESCRIPTION
## Description

Merge `v0.42` into `feature/atree-register-inlining-v0.42`

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
