### PR TITLE
Update atree register inlining 1.0 feature branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 require (
 	github.com/SaveTheRbtz/mph v0.1.1-0.20240117162131-4166ec7869bc
 	github.com/k0kubun/pp v3.0.1+incompatible
+	github.com/kodova/html-to-markdown v1.0.1
 	github.com/onflow/crypto v0.25.0
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
+github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8kdmcsrnKqMg=
 github.com/SaveTheRbtz/mph v0.1.1-0.20240117162131-4166ec7869bc h1:DCHzPQOcU/7gwDTWbFQZc5qHMPS1g0xTO56k8NXsv9M=
 github.com/SaveTheRbtz/mph v0.1.1-0.20240117162131-4166ec7869bc/go.mod h1:LJM5a3zcIJ/8TmZwlUczvROEJT8ntOdhdG9jjcR1B0I=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/bits-and-blooms/bitset v1.5.0 h1:NpE8frKRLGHIcEzkR+gZhiioW1+WbYV6fKwD6ZIpQT8=
 github.com/bits-and-blooms/bitset v1.5.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bytecodealliance/wasmtime-go/v7 v7.0.0 h1:/rBNjgFju2HCZnkPb1eL+W4GBwP8DMbaQu7i+GR9DH4=
@@ -36,6 +38,8 @@ github.com/k0kubun/pp/v3 v3.2.0/go.mod h1:ODtJQbQcIRfAD3N+theGCV1m/CBxweERz2dapd
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/klauspost/cpuid/v2 v2.2.0 h1:4ZexSFt8agMNzNisrsilL6RClWDC5YJnLHNIfTy4iuc=
 github.com/klauspost/cpuid/v2 v2.2.0/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/kodova/html-to-markdown v1.0.1 h1:MJxQAnqxtss3DaPnm72DRV65HZiMQZF3DUAfEaTg+14=
+github.com/kodova/html-to-markdown v1.0.1/go.mod h1:NhDrT7QdSrdpezFg/0EQx9zeobCHR5oAguzrKrC6mVU=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -126,9 +130,12 @@ golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPI
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191109021931-daa7c04131f5/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
@@ -172,6 +179,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 lukechampine.com/blake3 v1.2.1 h1:YuqqRuaqsGV71BV/nm9xlI0MKUv4QC54jQnBChWbGnI=

--- a/migrations/capcons/migration_test.go
+++ b/migrations/capcons/migration_test.go
@@ -159,6 +159,11 @@ func (t *testMigrationReporter) MissingTarget(
 	)
 }
 
+func (t *testMigrationReporter) DictionaryKeyConflict(addressPath interpreter.AddressPath) {
+	// For testing purposes, record the conflict as an error
+	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", addressPath))
+}
+
 const testPathIdentifier = "test"
 
 var testAddress = common.MustBytesToAddress([]byte{0x1})
@@ -454,14 +459,14 @@ func testPathCapabilityValueMigration(
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test")
-
-	capabilityMapping := &CapabilityMapping{}
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
 
 	reporter := &testMigrationReporter{}
 
-	migration.MigrateAccount(
-		testAddress,
+	capabilityMapping := &CapabilityMapping{}
+
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			&LinkValueMigration{
@@ -472,8 +477,7 @@ func testPathCapabilityValueMigration(
 		),
 	)
 
-	migration.MigrateAccount(
-		testAddress,
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			&CapabilityValueMigration{
@@ -1298,14 +1302,14 @@ func testLinkMigration(
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test")
-
-	capabilityMapping := &CapabilityMapping{}
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
 
 	reporter := &testMigrationReporter{}
 
-	migration.MigrateAccount(
-		testAddress,
+	capabilityMapping := &CapabilityMapping{}
+
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			&LinkValueMigration{
@@ -2007,14 +2011,14 @@ func TestPublishedPathCapabilityValueMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test")
-
-	capabilityMapping := &CapabilityMapping{}
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
 
 	reporter := &testMigrationReporter{}
 
-	migration.MigrateAccount(
-		testAddress,
+	capabilityMapping := &CapabilityMapping{}
+
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			&LinkValueMigration{
@@ -2025,8 +2029,7 @@ func TestPublishedPathCapabilityValueMigration(t *testing.T) {
 		),
 	)
 
-	migration.MigrateAccount(
-		testAddress,
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			&CapabilityValueMigration{
@@ -2248,14 +2251,14 @@ func TestUntypedPathCapabilityValueMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test")
-
-	capabilityMapping := &CapabilityMapping{}
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
 
 	reporter := &testMigrationReporter{}
 
-	migration.MigrateAccount(
-		testAddress,
+	capabilityMapping := &CapabilityMapping{}
+
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			&LinkValueMigration{
@@ -2266,8 +2269,7 @@ func TestUntypedPathCapabilityValueMigration(t *testing.T) {
 		),
 	)
 
-	migration.MigrateAccount(
-		testAddress,
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			&CapabilityValueMigration{

--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -122,15 +122,9 @@ func ConvertToEntitledType(
 					break
 
 				default:
-					newAuth := sema.UnauthorizedAccess
 					supportedEntitlements := entitlementSupportingType.SupportedEntitlements()
-					if supportedEntitlements.Len() > 0 {
-						newAuth = sema.EntitlementSetAccess{
-							SetKind:      sema.Conjunction,
-							Entitlements: supportedEntitlements,
-						}
-					}
-					auth = interpreter.ConvertSemaAccessToStaticAuthorization(inter, newAuth)
+					newAccess := sema.NewAccessFromEntitlementSet(supportedEntitlements, sema.Conjunction)
+					auth = interpreter.ConvertSemaAccessToStaticAuthorization(inter, newAccess)
 					returnNew = true
 				}
 			}

--- a/migrations/migration_reporter.go
+++ b/migrations/migration_reporter.go
@@ -26,5 +26,6 @@ type Reporter interface {
 		storageMapKey interpreter.StorageMapKey,
 		migration string,
 	)
+	DictionaryKeyConflict(addressPath interpreter.AddressPath)
 	Error(err error)
 }

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -82,6 +82,11 @@ func (t *testReporter) Error(err error) {
 	t.errors = append(t.errors, err)
 }
 
+func (t *testReporter) DictionaryKeyConflict(addressPath interpreter.AddressPath) {
+	// For testing purposes, record the conflict as an error
+	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", addressPath))
+}
+
 // testStringMigration
 
 type testStringMigration struct{}
@@ -510,12 +515,17 @@ func TestMultipleMigrations(t *testing.T) {
 
 	// Migrate
 
-	migration := NewStorageMigration(inter, storage, "test")
-
 	reporter := newTestReporter()
 
-	migration.MigrateAccount(
+	migration, err := NewStorageMigration(
+		inter,
+		storage,
+		"test",
 		account,
+	)
+	require.NoError(t, err)
+
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			testStringMigration{},
@@ -651,12 +661,12 @@ func TestMigrationError(t *testing.T) {
 
 	// Migrate
 
-	migration := NewStorageMigration(inter, storage, "test")
+	migration, err := NewStorageMigration(inter, storage, "test", account)
+	require.NoError(t, err)
 
 	reporter := newTestReporter()
 
-	migration.MigrateAccount(
-		account,
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			testStringMigration{},
@@ -796,12 +806,12 @@ func TestCapConMigration(t *testing.T) {
 
 	// Migrate
 
+	migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
-	migration := NewStorageMigration(inter, storage, "test")
-
-	migration.MigrateAccount(
-		testAddress,
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			testCapConMigration{},
@@ -911,12 +921,12 @@ func TestContractMigration(t *testing.T) {
 
 	// Migrate
 
+	migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
-	migration := NewStorageMigration(inter, storage, "test")
-
-	migration.MigrateAccount(
-		testAddress,
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			testStringMigration{},
@@ -1104,12 +1114,12 @@ func TestEmptyIntersectionTypeMigration(t *testing.T) {
 
 	// Migrate
 
+	migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
+
 	reporter := newTestReporter()
 
-	migration := NewStorageMigration(inter, storage, "test")
-
-	migration.MigrateAccount(
-		testAddress,
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			testCompositeValueMigration{},
@@ -1254,12 +1264,12 @@ func TestMigratingNestedContainers(t *testing.T) {
 
 		// Migrate
 
-		migration := NewStorageMigration(inter, storage, "test")
+		migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
 
 		reporter := newTestReporter()
 
-		migration.MigrateAccount(
-			testAddress,
+		migration.Migrate(
 			migration.NewValueMigrationsPathMigrator(
 				reporter,
 				valueMigration,
@@ -1684,12 +1694,12 @@ func TestMigrationPanic(t *testing.T) {
 
 	// Migrate
 
-	migration := NewStorageMigration(inter, storage, "test")
+	migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
 
 	reporter := newTestReporter()
 
-	migration.MigrateAccount(
-		testAddress,
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			testPanicMigration{},
@@ -1811,7 +1821,8 @@ func TestSkip(t *testing.T) {
 
 		// Migrate
 
-		migration := NewStorageMigration(inter, storage, "test")
+		migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
 
 		reporter := newTestReporter()
 
@@ -1819,8 +1830,7 @@ func TestSkip(t *testing.T) {
 			canSkip: canSkip,
 		}
 
-		migration.MigrateAccount(
-			testAddress,
+		migration.Migrate(
 			migration.NewValueMigrationsPathMigrator(
 				reporter,
 				valueMigration,
@@ -2167,13 +2177,12 @@ func TestPublishedValueMigration(t *testing.T) {
 	)
 
 	// Migrate
+	migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
 
 	reporter := newTestReporter()
 
-	migration := NewStorageMigration(inter, storage, "test")
-
-	migration.MigrateAccount(
-		testAddress,
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			testPublishedValueMigration{},
@@ -2278,12 +2287,12 @@ func TestDomainsMigration(t *testing.T) {
 
 		// Migrate
 
+		migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
 		reporter := newTestReporter()
 
-		migration := NewStorageMigration(inter, storage, "test")
-
-		migration.MigrateAccount(
-			testAddress,
+		migration.Migrate(
 			migration.NewValueMigrationsPathMigrator(
 				reporter,
 				testDomainsMigration{
@@ -2494,35 +2503,44 @@ func TestLegacyReferenceType(t *testing.T) {
 	})
 }
 
-// testTypeMigration
+// testDictionaryKeyConflictMigration
 
-type testTypeMigration struct{}
-
-var _ ValueMigration = testTypeMigration{}
-
-func (testTypeMigration) Name() string {
-	return "testTypeMigration"
+type testDictionaryKeyConflictMigration struct {
+	migrateValue bool
 }
 
-func (m testTypeMigration) Migrate(
+var _ ValueMigration = testDictionaryKeyConflictMigration{}
+
+func (testDictionaryKeyConflictMigration) Name() string {
+	return "testDictionaryKeyConflictMigration"
+}
+
+func (m testDictionaryKeyConflictMigration) Migrate(
 	_ interpreter.StorageKey,
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
 ) (interpreter.Value, error) {
 	typeValue, ok := value.(interpreter.TypeValue)
-	if !ok {
-		return nil, nil
+	if ok {
+		return typeValue, nil
 	}
 
-	return typeValue, nil
+	if m.migrateValue {
+		intValue, ok := value.(interpreter.IntValue)
+		if ok {
+			return interpreter.NewUnmeteredIntValueFromInt64(int64(intValue.ToInt(emptyLocationRange)) + 10), nil
+		}
+	}
+
+	return nil, nil
 }
 
-func (testTypeMigration) CanSkip(_ interpreter.StaticType) bool {
+func (testDictionaryKeyConflictMigration) CanSkip(_ interpreter.StaticType) bool {
 	return false
 }
 
-func (testTypeMigration) Domains() map[string]struct{} {
+func (testDictionaryKeyConflictMigration) Domains() map[string]struct{} {
 	return nil
 }
 
@@ -2530,38 +2548,30 @@ func TestDictionaryKeyConflict(t *testing.T) {
 
 	t.Parallel()
 
-	testAddress := common.MustBytesToAddress([]byte{0x1})
-	storagePathDomain := common.PathDomainStorage.Identifier()
-	storageMapKey := interpreter.StringStorageMapKey("test")
+	test := func(t *testing.T, migrateValue bool) {
 
-	ledger := NewTestLedger(nil, nil)
+		testAddress := common.MustBytesToAddress([]byte{0x1})
+		storagePathDomain := common.PathDomainStorage.Identifier()
+		storageMapKey := interpreter.StringStorageMapKey("test")
 
-	newStorageAndInterpreter := func(t *testing.T) (*runtime.Storage, *interpreter.Interpreter) {
-		storage := runtime.NewStorage(ledger, nil)
-		inter, err := interpreter.NewInterpreter(
-			nil,
-			utils.TestLocation,
-			&interpreter.Config{
-				Storage:                     storage,
-				AtreeValueValidationEnabled: true,
-				// NOTE: disabled, as storage is not expected to be always valid _during_ migration
-				AtreeStorageValidationEnabled: false,
-			},
-		)
-		require.NoError(t, err)
+		ledger := NewTestLedger(nil, nil)
 
-		return storage, inter
-	}
+		newStorageAndInterpreter := func(t *testing.T) (*runtime.Storage, *interpreter.Interpreter) {
+			storage := runtime.NewStorage(ledger, nil)
+			inter, err := interpreter.NewInterpreter(
+				nil,
+				utils.TestLocation,
+				&interpreter.Config{
+					Storage:                     storage,
+					AtreeValueValidationEnabled: true,
+					// NOTE: disabled, as storage is not expected to be always valid _during_ migration
+					AtreeStorageValidationEnabled: false,
+				},
+			)
+			require.NoError(t, err)
 
-	// Prepare
-	(func() {
-		storage, inter := newStorageAndInterpreter(t)
-
-		storageMap := storage.GetStorageMap(
-			testAddress,
-			storagePathDomain,
-			true,
-		)
+			return storage, inter
+		}
 
 		fooQualifiedIdentifier := "Test.Foo"
 		fooType := &interpreter.InterfaceStaticType{
@@ -2595,8 +2605,8 @@ func TestDictionaryKeyConflict(t *testing.T) {
 			},
 		)
 
-		dictionaryKey1 := interpreter.NewTypeValue(inter, intersectionType1)
-		dictionaryKey2 := interpreter.NewTypeValue(inter, intersectionType2)
+		dictionaryKey1 := interpreter.NewTypeValue(nil, intersectionType1)
+		dictionaryKey2 := interpreter.NewTypeValue(nil, intersectionType2)
 
 		// {Type: [Int]}
 		// Value is an array to ensure slabs are created
@@ -2604,152 +2614,219 @@ func TestDictionaryKeyConflict(t *testing.T) {
 			interpreter.PrimitiveStaticTypeInt,
 		)
 
-		dictionaryValue := interpreter.NewDictionaryValueWithAddress(
-			inter,
-			emptyLocationRange,
-			interpreter.NewDictionaryStaticType(
-				nil,
-				interpreter.PrimitiveStaticTypeMetaType,
-				arrayType,
-			),
-			testAddress,
-		)
+		// Prepare
+		(func() {
+			storage, inter := newStorageAndInterpreter(t)
 
-		// Write the dictionary value to storage before inserting values into dictionary,
-		// as the insertion of values into the dictionary triggers a storage health check,
-		// which fails if the dictionary value is not yet stored (unreferenced slabs)
-
-		storageMap.WriteValue(
-			inter,
-			storageMapKey,
-			dictionaryValue,
-		)
-
-		// NOTE: use legacyKey to ensure the key is encoded in old format
-
-		dictionaryValue.InsertWithoutTransfer(
-			inter,
-			emptyLocationRange,
-			legacyKey(dictionaryKey1),
-			interpreter.NewArrayValue(
-				inter,
-				emptyLocationRange,
-				arrayType,
+			storageMap := storage.GetStorageMap(
 				testAddress,
-				interpreter.NewUnmeteredIntValueFromInt64(1),
-			),
-		)
+				storagePathDomain,
+				true,
+			)
 
-		dictionaryValue.InsertWithoutTransfer(
-			inter,
-			emptyLocationRange,
-			legacyKey(dictionaryKey2),
-			interpreter.NewArrayValue(
+			dictionaryValue := interpreter.NewDictionaryValueWithAddress(
 				inter,
 				emptyLocationRange,
-				arrayType,
+				interpreter.NewDictionaryStaticType(
+					nil,
+					interpreter.PrimitiveStaticTypeMetaType,
+					arrayType,
+				),
 				testAddress,
-				interpreter.NewUnmeteredIntValueFromInt64(2),
-			),
-		)
+			)
 
-		oldValue1, ok := dictionaryValue.Get(
-			inter,
-			emptyLocationRange,
-			legacyKey(dictionaryKey1),
-		)
-		require.True(t, ok)
+			// Write the dictionary value to storage before inserting values into dictionary,
+			// as the insertion of values into the dictionary triggers a storage health check,
+			// which fails if the dictionary value is not yet stored (unreferenced slabs)
 
-		utils.AssertValuesEqual(t,
-			inter,
-			oldValue1,
-			interpreter.NewArrayValue(
+			storageMap.WriteValue(
+				inter,
+				storageMapKey,
+				dictionaryValue,
+			)
+
+			// NOTE: use legacyKey to ensure the key is encoded in old format
+
+			dictionaryValue.InsertWithoutTransfer(
 				inter,
 				emptyLocationRange,
-				arrayType,
-				common.ZeroAddress,
-				interpreter.NewUnmeteredIntValueFromInt64(1),
-			),
-		)
+				legacyKey(dictionaryKey1),
+				interpreter.NewArrayValue(
+					inter,
+					emptyLocationRange,
+					arrayType,
+					testAddress,
+					interpreter.NewUnmeteredIntValueFromInt64(1),
+				),
+			)
 
-		oldValue2, ok := dictionaryValue.Get(
-			inter,
-			emptyLocationRange,
-			legacyKey(dictionaryKey2),
-		)
-		require.True(t, ok)
-
-		utils.AssertValuesEqual(t,
-			inter,
-			oldValue2,
-			interpreter.NewArrayValue(
+			dictionaryValue.InsertWithoutTransfer(
 				inter,
 				emptyLocationRange,
-				arrayType,
-				common.ZeroAddress,
-				interpreter.NewUnmeteredIntValueFromInt64(2),
-			),
-		)
+				legacyKey(dictionaryKey2),
+				interpreter.NewArrayValue(
+					inter,
+					emptyLocationRange,
+					arrayType,
+					testAddress,
+					interpreter.NewUnmeteredIntValueFromInt64(2),
+				),
+			)
 
-		err := storage.Commit(inter, false)
-		require.NoError(t, err)
+			oldValue1, ok := dictionaryValue.Get(
+				inter,
+				emptyLocationRange,
+				legacyKey(dictionaryKey1),
+			)
+			require.True(t, ok)
 
-		err = storage.CheckHealth()
-		require.NoError(t, err)
-	})()
+			utils.AssertValuesEqual(t,
+				inter,
+				oldValue1,
+				interpreter.NewArrayValue(
+					inter,
+					emptyLocationRange,
+					arrayType,
+					common.ZeroAddress,
+					interpreter.NewUnmeteredIntValueFromInt64(1),
+				),
+			)
 
-	// Migrate
-	(func() {
+			oldValue2, ok := dictionaryValue.Get(
+				inter,
+				emptyLocationRange,
+				legacyKey(dictionaryKey2),
+			)
+			require.True(t, ok)
 
-		storage, inter := newStorageAndInterpreter(t)
+			utils.AssertValuesEqual(t,
+				inter,
+				oldValue2,
+				interpreter.NewArrayValue(
+					inter,
+					emptyLocationRange,
+					arrayType,
+					common.ZeroAddress,
+					interpreter.NewUnmeteredIntValueFromInt64(2),
+				),
+			)
 
-		reporter := newTestReporter()
+			err := storage.Commit(inter, false)
+			require.NoError(t, err)
 
-		migration := NewStorageMigration(inter, storage, "test")
+			err = storage.CheckHealth()
+			require.NoError(t, err)
+		})()
 
-		migration.MigrateAccount(
-			testAddress,
-			migration.NewValueMigrationsPathMigrator(
-				reporter,
-				testTypeMigration{},
-			),
-		)
+		// Migrate
+		(func() {
 
-		err := migration.Commit()
-		require.NoError(t, err)
+			storage, inter := newStorageAndInterpreter(t)
 
-		// Assert
+			migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+			require.NoError(t, err)
 
-		require.Len(t, reporter.errors, 1)
+			reporter := newTestReporter()
 
-		var migrationError StorageMigrationError
-		require.ErrorAs(t, reporter.errors[0], &migrationError)
+			migration.Migrate(
+				migration.NewValueMigrationsPathMigrator(
+					reporter,
+					testDictionaryKeyConflictMigration{
+						migrateValue: migrateValue,
+					},
+				),
+			)
 
-		assert.Equal(
-			t,
-			interpreter.StorageKey{
-				Address: testAddress,
-				Key:     storagePathDomain,
-			},
-			migrationError.StorageKey,
-		)
-		assert.Equal(
-			t,
-			storageMapKey,
-			migrationError.StorageMapKey,
-		)
-		assert.ErrorContains(
-			t,
-			migrationError,
-			"dictionary contains new key after removal of old key (conflict)",
-		)
-		assert.NotEmpty(t, migrationError.Stack)
+			err = migration.Commit()
+			require.NoError(t, err)
 
-		assert.Len(t, reporter.migrated, 1)
+			// Assert
 
-		// Health check is expected to fail,
-		// as one of the arrays is still stored, but no longer referenced
-		err = storage.CheckHealth()
-		require.ErrorContains(t, err, "slabs not referenced from account Storage: [0x1.3]")
-	})()
+			require.Len(t, reporter.errors, 1)
+			assert.ErrorContains(
+				t,
+				reporter.errors[0],
+				"dictionary key conflict",
+			)
+
+			assert.Len(t, reporter.migrated, 1)
+
+			err = storage.CheckHealth()
+			require.NoError(t, err)
+
+			// Check storage map
+
+			storageMap := storage.GetStorageMap(testAddress, storagePathDomain, false)
+			require.NotNil(t, storageMap)
+			require.Equal(t, uint64(2), storageMap.Count())
+
+			// Check existing migrated dictionary
+
+			migratedValue := storageMap.ReadValue(nil, storageMapKey)
+			require.NotNil(t, migratedValue)
+
+			require.IsType(t, &interpreter.DictionaryValue{}, migratedValue)
+			migratedDict := migratedValue.(*interpreter.DictionaryValue)
+
+			value, _ := migratedDict.Get(inter, emptyLocationRange, dictionaryKey2)
+			require.NotNil(t, value)
+
+			expectedInt2 := interpreter.NewUnmeteredIntValueFromInt64(2)
+			if migrateValue {
+				expectedInt2 = interpreter.NewUnmeteredIntValueFromInt64(12)
+			}
+
+			utils.RequireValuesEqual(t,
+				inter,
+				interpreter.NewArrayValue(
+					inter,
+					emptyLocationRange,
+					arrayType,
+					common.ZeroAddress,
+					expectedInt2,
+				),
+				value,
+			)
+
+			// Check newly created conflict dictionary
+
+			conflictValue := storageMap.ReadValue(nil, migration.DictionaryKeyConflictStorageMapKey(1))
+			require.NotNil(t, conflictValue)
+
+			require.IsType(t, &interpreter.DictionaryValue{}, conflictValue)
+			conflictDict := conflictValue.(*interpreter.DictionaryValue)
+
+			value, _ = conflictDict.Get(inter, emptyLocationRange, dictionaryKey1)
+			require.NotNil(t, value)
+
+			expectedInt1 := interpreter.NewUnmeteredIntValueFromInt64(1)
+			if migrateValue {
+				expectedInt1 = interpreter.NewUnmeteredIntValueFromInt64(11)
+			}
+
+			utils.RequireValuesEqual(t,
+				inter,
+				interpreter.NewArrayValue(
+					inter,
+					emptyLocationRange,
+					arrayType,
+					common.ZeroAddress,
+					expectedInt1,
+				),
+				value,
+			)
+		})()
+	}
+
+	t.Run("value migrated", func(t *testing.T) {
+		t.Parallel()
+
+		test(t, true)
+	})
+
+	t.Run("value not migrated", func(t *testing.T) {
+		t.Parallel()
+
+		test(t, false)
+	})
 }

--- a/migrations/statictypes/account_type_migration_test.go
+++ b/migrations/statictypes/account_type_migration_test.go
@@ -73,6 +73,11 @@ func (t *testReporter) Error(err error) {
 	t.errors = append(t.errors, err)
 }
 
+func (t *testReporter) DictionaryKeyConflict(addressPath interpreter.AddressPath) {
+	// For testing purposes, record the conflict as an error
+	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", addressPath))
+}
+
 func TestAccountTypeInTypeValueMigration(t *testing.T) {
 	t.Parallel()
 
@@ -461,12 +466,12 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 
 			// Migrate
 
-			migration := migrations.NewStorageMigration(inter, storage, "test")
+			migration, err := migrations.NewStorageMigration(inter, storage, "test", account)
+			require.NoError(t, err)
 
 			reporter := newTestReporter()
 
-			migration.MigrateAccount(
-				account,
+			migration.Migrate(
 				migration.NewValueMigrationsPathMigrator(
 					reporter,
 					NewStaticTypeMigration(),
@@ -855,12 +860,12 @@ func TestAccountTypeInNestedTypeValueMigration(t *testing.T) {
 
 			// Migrate
 
-			migration := migrations.NewStorageMigration(inter, storage, "test")
+			migration, err := migrations.NewStorageMigration(inter, storage, "test", account)
+			require.NoError(t, err)
 
 			reporter := newTestReporter()
 
-			migration.MigrateAccount(
-				account,
+			migration.Migrate(
 				migration.NewValueMigrationsPathMigrator(
 					reporter,
 					NewStaticTypeMigration(),
@@ -1164,12 +1169,12 @@ func TestMigratingValuesWithAccountStaticType(t *testing.T) {
 
 			// Migrate
 
-			migration := migrations.NewStorageMigration(inter, storage, "test")
+			migration, err := migrations.NewStorageMigration(inter, storage, "test", account)
+			require.NoError(t, err)
 
 			reporter := newTestReporter()
 
-			migration.MigrateAccount(
-				account,
+			migration.Migrate(
 				migration.NewValueMigrationsPathMigrator(
 					reporter,
 					NewStaticTypeMigration(),
@@ -1298,19 +1303,19 @@ func TestAccountTypeRehash(t *testing.T) {
 
 				storage, inter := newStorageAndInterpreter(t)
 
-				migration := migrations.NewStorageMigration(inter, storage, "test")
+				migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+				require.NoError(t, err)
 
 				reporter := newTestReporter()
 
-				migration.MigrateAccount(
-					testAddress,
+				migration.Migrate(
 					migration.NewValueMigrationsPathMigrator(
 						reporter,
 						NewStaticTypeMigration(),
 					),
 				)
 
-				err := migration.Commit()
+				err = migration.Commit()
 				require.NoError(t, err)
 
 				// Assert

--- a/migrations/statictypes/composite_type_migration_test.go
+++ b/migrations/statictypes/composite_type_migration_test.go
@@ -145,15 +145,15 @@ func TestCompositeAndInterfaceTypeMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test")
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
 
 	reporter := newTestReporter()
 
 	barStaticType := newCompositeType()
 	bazStaticType := newInterfaceType()
 
-	migration.MigrateAccount(
-		testAddress,
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			NewStaticTypeMigration().

--- a/migrations/statictypes/intersection_type_migration_test.go
+++ b/migrations/statictypes/intersection_type_migration_test.go
@@ -398,12 +398,12 @@ func TestIntersectionTypeMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test")
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+	require.NoError(t, err)
 
 	reporter := newTestReporter()
 
-	migration.MigrateAccount(
-		testAddress,
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			NewStaticTypeMigration(),
@@ -569,19 +569,19 @@ func TestIntersectionTypeRehash(t *testing.T) {
 
 		storage, inter := newStorageAndInterpreter(t)
 
-		migration := migrations.NewStorageMigration(inter, storage, "test")
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
 
 		reporter := newTestReporter()
 
-		migration.MigrateAccount(
-			testAddress,
+		migration.Migrate(
 			migration.NewValueMigrationsPathMigrator(
 				reporter,
 				NewStaticTypeMigration(),
 			),
 		)
 
-		err := migration.Commit()
+		err = migration.Commit()
 		require.NoError(t, err)
 
 		// Assert
@@ -740,19 +740,19 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 
 			storage, inter := newStorageAndInterpreter(t, ledger)
 
-			migration := migrations.NewStorageMigration(inter, storage, "test")
+			migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+			require.NoError(t, err)
 
 			reporter := newTestReporter()
 
-			migration.MigrateAccount(
-				testAddress,
+			migration.Migrate(
 				migration.NewValueMigrationsPathMigrator(
 					reporter,
 					NewStaticTypeMigration(),
 				),
 			)
 
-			err := migration.Commit()
+			err = migration.Commit()
 			require.NoError(t, err)
 
 			// Assert
@@ -886,19 +886,19 @@ func TestRehashNestedIntersectionType(t *testing.T) {
 
 			storage, inter := newStorageAndInterpreter(t, ledger)
 
-			migration := migrations.NewStorageMigration(inter, storage, "test")
+			migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+			require.NoError(t, err)
 
 			reporter := newTestReporter()
 
-			migration.MigrateAccount(
-				testAddress,
+			migration.Migrate(
 				migration.NewValueMigrationsPathMigrator(
 					reporter,
 					NewStaticTypeMigration(),
 				),
 			)
 
-			err := migration.Commit()
+			err = migration.Commit()
 			require.NoError(t, err)
 
 			// Assert
@@ -1039,7 +1039,8 @@ func TestIntersectionTypeMigrationWithInterfaceTypeConverter(t *testing.T) {
 
 		// Migrate
 
-		migration := migrations.NewStorageMigration(inter, storage, "test")
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
 
 		reporter := newTestReporter()
 
@@ -1065,8 +1066,7 @@ func TestIntersectionTypeMigrationWithInterfaceTypeConverter(t *testing.T) {
 			)
 		}
 
-		migration.MigrateAccount(
-			testAddress,
+		migration.Migrate(
 			migration.NewValueMigrationsPathMigrator(
 				reporter,
 				staticTypeMigration,
@@ -1434,12 +1434,12 @@ func TestIntersectionTypeMigrationWithTypeConverters(t *testing.T) {
 
 		// Migrate
 
-		migration := migrations.NewStorageMigration(inter, storage, "test")
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
 
 		reporter := newTestReporter()
 
-		migration.MigrateAccount(
-			testAddress,
+		migration.Migrate(
 			migration.NewValueMigrationsPathMigrator(
 				reporter,
 				staticTypeMigration,

--- a/migrations/statictypes/statictype_migration_test.go
+++ b/migrations/statictypes/statictype_migration_test.go
@@ -75,12 +75,12 @@ func TestStaticTypeMigration(t *testing.T) {
 
 		// Migrate
 
-		migration := migrations.NewStorageMigration(inter, storage, "test")
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
 
 		reporter := newTestReporter()
 
-		migration.MigrateAccount(
-			testAddress,
+		migration.Migrate(
 			migration.NewValueMigrationsPathMigrator(
 				reporter,
 				staticTypeMigration,
@@ -881,12 +881,12 @@ func TestMigratingNestedContainers(t *testing.T) {
 
 		// Migrate
 
-		migration := migrations.NewStorageMigration(inter, storage, "test")
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
 
 		reporter := newTestReporter()
 
-		migration.MigrateAccount(
-			testAddress,
+		migration.Migrate(
 			migration.NewValueMigrationsPathMigrator(
 				reporter,
 				staticTypeMigration,

--- a/migrations/string_normalization/migration_test.go
+++ b/migrations/string_normalization/migration_test.go
@@ -19,6 +19,7 @@
 package string_normalization
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,6 +75,11 @@ func (t *testReporter) Migrated(
 
 func (t *testReporter) Error(err error) {
 	t.errors = append(t.errors, err)
+}
+
+func (t *testReporter) DictionaryKeyConflict(addressPath interpreter.AddressPath) {
+	// For testing purposes, record the conflict as an error
+	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", addressPath))
 }
 
 func TestStringNormalizingMigration(t *testing.T) {
@@ -304,12 +310,12 @@ func TestStringNormalizingMigration(t *testing.T) {
 
 	// Migrate
 
-	migration := migrations.NewStorageMigration(inter, storage, "test")
+	migration, err := migrations.NewStorageMigration(inter, storage, "test", account)
+	require.NoError(t, err)
 
 	reporter := newTestReporter()
 
-	migration.MigrateAccount(
-		account,
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			NewStringNormalizingMigration(),
@@ -445,19 +451,19 @@ func TestStringValueRehash(t *testing.T) {
 
 		storage, inter := newStorageAndInterpreter(t)
 
-		migration := migrations.NewStorageMigration(inter, storage, "test")
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
 
 		reporter := newTestReporter()
 
-		migration.MigrateAccount(
-			testAddress,
+		migration.Migrate(
 			migration.NewValueMigrationsPathMigrator(
 				reporter,
 				NewStringNormalizingMigration(),
 			),
 		)
 
-		err := migration.Commit()
+		err = migration.Commit()
 		require.NoError(t, err)
 
 		require.Empty(t, reporter.errors)
@@ -591,19 +597,19 @@ func TestCharacterValueRehash(t *testing.T) {
 
 		storage, inter := newStorageAndInterpreter(t)
 
-		migration := migrations.NewStorageMigration(inter, storage, "test")
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
 
 		reporter := newTestReporter()
 
-		migration.MigrateAccount(
-			testAddress,
+		migration.Migrate(
 			migration.NewValueMigrationsPathMigrator(
 				reporter,
 				NewStringNormalizingMigration(),
 			),
 		)
 
-		err := migration.Commit()
+		err = migration.Commit()
 		require.NoError(t, err)
 
 		require.Empty(t, reporter.errors)

--- a/npm-packages/cadence-parser/package.json
+++ b/npm-packages/cadence-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-parser",
-  "version": "1.0.0-preview.19",
+  "version": "1.0.0-preview.20",
   "description": "The Cadence parser",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {

--- a/runtime/cmd/execute/debugger.go
+++ b/runtime/cmd/execute/debugger.go
@@ -73,7 +73,8 @@ func (d *InteractiveDebugger) Next() {
 // Show shows the values for the variables with the given names.
 // If no names are given, lists all non-base variables
 func (d *InteractiveDebugger) Show(names []string) {
-	current := d.debugger.CurrentActivation(d.stop.Interpreter)
+	inter := d.stop.Interpreter
+	current := d.debugger.CurrentActivation(inter)
 	switch len(names) {
 	case 0:
 		for name := range current.FunctionValues() { //nolint:maprange
@@ -88,7 +89,7 @@ func (d *InteractiveDebugger) Show(names []string) {
 			return
 		}
 
-		fmt.Println(colorizeValue(variable.GetValue()))
+		fmt.Println(colorizeValue(variable.GetValue(inter)))
 
 	default:
 		for _, name := range names {
@@ -100,7 +101,7 @@ func (d *InteractiveDebugger) Show(names []string) {
 			fmt.Printf(
 				"%s = %s\n",
 				name,
-				colorizeValue(variable.GetValue()),
+				colorizeValue(variable.GetValue(inter)),
 			)
 		}
 	}

--- a/runtime/debugger_test.go
+++ b/runtime/debugger_test.go
@@ -106,7 +106,7 @@ func TestRuntimeDebugger(t *testing.T) {
 	variable := activation.Find("answer")
 	require.NotNil(t, variable)
 
-	value := variable.GetValue()
+	value := variable.GetValue(stop.Interpreter)
 	require.Equal(
 		t,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
@@ -192,7 +192,7 @@ func TestRuntimeDebuggerBreakpoints(t *testing.T) {
 	variable := activation.Find("answer")
 	require.NotNil(t, variable)
 
-	value := variable.GetValue()
+	value := variable.GetValue(stop.Interpreter)
 	require.Equal(
 		t,
 		interpreter.NewUnmeteredIntValueFromInt64(42),

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -289,7 +289,7 @@ func (e *interpreterEnvironment) interpreterBaseActivationFor(
 
 	baseActivation := e.baseActivationsByLocation[location]
 	if baseActivation == nil {
-		baseActivation = activations.NewActivation[*interpreter.Variable](nil, defaultBaseActivation)
+		baseActivation = activations.NewActivation[interpreter.Variable](nil, defaultBaseActivation)
 		if e.baseActivationsByLocation == nil {
 			e.baseActivationsByLocation = map[common.Location]*interpreter.VariableActivation{}
 		}
@@ -1106,7 +1106,7 @@ func (e *interpreterEnvironment) InterpretContract(
 		)
 	}
 
-	contract = variable.GetValue().(*interpreter.CompositeValue)
+	contract = variable.GetValue(inter).(*interpreter.CompositeValue)
 
 	return
 }

--- a/runtime/interpreter/globalvariables.go
+++ b/runtime/interpreter/globalvariables.go
@@ -20,7 +20,7 @@ package interpreter
 
 // GlobalVariables represents global variables defined in a program.
 type GlobalVariables struct {
-	variables map[string]*Variable
+	variables map[string]Variable
 }
 
 func (g *GlobalVariables) Contains(name string) bool {
@@ -31,16 +31,16 @@ func (g *GlobalVariables) Contains(name string) bool {
 	return ok
 }
 
-func (g *GlobalVariables) Get(name string) *Variable {
+func (g *GlobalVariables) Get(name string) Variable {
 	if g.variables == nil {
 		return nil
 	}
 	return g.variables[name]
 }
 
-func (g *GlobalVariables) Set(name string, variable *Variable) {
+func (g *GlobalVariables) Set(name string, variable Variable) {
 	if g.variables == nil {
-		g.variables = map[string]*Variable{}
+		g.variables = map[string]Variable{}
 	}
 	g.variables[name] = variable
 }

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -70,17 +70,17 @@ func (interpreter *Interpreter) identifierExpressionGetterSetter(
 
 	return getterSetter{
 		get: func(_ bool) Value {
-			value := variable.GetValue()
+			value := variable.GetValue(interpreter)
 			interpreter.checkInvalidatedResourceUse(value, variable, identifier, identifierExpression)
 			return value
 		},
 		set: func(value Value) {
 			interpreter.startResourceTracking(value, variable, identifier, identifierExpression)
-
-			existingValue := variable.GetValue()
-			interpreter.checkResourceLoss(existingValue, locationRange)
-
-			variable.SetValue(value)
+			variable.SetValue(
+				interpreter,
+				locationRange,
+				value,
+			)
 		},
 	}
 }
@@ -404,7 +404,7 @@ func (interpreter *Interpreter) checkMemberAccess(
 func (interpreter *Interpreter) VisitIdentifierExpression(expression *ast.IdentifierExpression) Value {
 	name := expression.Identifier.Identifier
 	variable := interpreter.FindVariable(name)
-	value := variable.GetValue()
+	value := variable.GetValue(interpreter)
 
 	interpreter.checkInvalidatedResourceUse(value, variable, name, expression)
 

--- a/runtime/interpreter/interpreter_import.go
+++ b/runtime/interpreter/interpreter_import.go
@@ -56,10 +56,10 @@ func (interpreter *Interpreter) importResolvedLocation(resolvedLocation sema.Res
 	// determine which identifiers are imported /
 	// which variables need to be declared
 
-	var variables map[string]*Variable
+	var variables map[string]Variable
 	identifierLength := len(resolvedLocation.Identifiers)
 	if identifierLength > 0 {
-		variables = make(map[string]*Variable, identifierLength)
+		variables = make(map[string]Variable, identifierLength)
 		for _, identifier := range resolvedLocation.Identifiers {
 			variables[identifier.Identifier] =
 				subInterpreter.Globals.Get(identifier.Identifier)

--- a/runtime/interpreter/interpreter_invocation.go
+++ b/runtime/interpreter/interpreter_invocation.go
@@ -141,7 +141,7 @@ func (interpreter *Interpreter) invokeInterpretedFunction(
 
 	// Make `self` available, if any
 	if invocation.Self != nil {
-		interpreter.declareVariable(sema.SelfIdentifier, *invocation.Self)
+		interpreter.declareSelfVariable(*invocation.Self, invocation.LocationRange)
 	}
 	if invocation.Base != nil {
 		interpreter.declareVariable(sema.BaseIdentifier, invocation.Base)

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -65,6 +65,8 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 		nil,
 	)
 
+	self.isTransaction = true
+
 	// Construct a raw HostFunctionValue without a type,
 	// instead of using NewHostFunctionValue, which requires a type.
 	//
@@ -78,7 +80,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 
 			self := MemberAccessibleValue(self)
 			invocation.Self = &self
-			interpreter.declareVariable(sema.SelfIdentifier, self)
+			interpreter.declareSelfVariable(self, invocation.LocationRange)
 
 			if declaration.ParameterList != nil {
 				// If the transaction has a parameter list of N parameters,

--- a/runtime/interpreter/sharedstate.go
+++ b/runtime/interpreter/sharedstate.go
@@ -38,7 +38,7 @@ type SharedState struct {
 	callStack              *CallStack
 	// TODO: ideally this would be a weak map, but Go has no weak references
 	referencedResourceKindedValues              ReferencedResourceKindedValues
-	resourceVariables                           map[ResourceKindedValue]*Variable
+	resourceVariables                           map[ResourceKindedValue]Variable
 	inStorageIteration                          bool
 	storageMutatedDuringIteration               bool
 	CapabilityControllerIterations              map[AddressPath]int
@@ -60,7 +60,7 @@ func NewSharedState(config *Config) *SharedState {
 		inStorageIteration:             false,
 		storageMutatedDuringIteration:  false,
 		referencedResourceKindedValues: ReferencedResourceKindedValues{},
-		resourceVariables:              map[ResourceKindedValue]*Variable{},
+		resourceVariables:              map[ResourceKindedValue]Variable{},
 		CapabilityControllerIterations: map[AddressPath]int{},
 		containerValueIteration:        map[atree.ValueID]struct{}{},
 		destroyedResources:             map[atree.ValueID]struct{}{},

--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -39,6 +39,10 @@ type SimpleCompositeValue struct {
 	TypeID   sema.TypeID
 	// FieldNames are the names of the field members (i.e. not functions, and not computed fields), in order
 	FieldNames []string
+
+	// This is used for distinguishing between transaction values and other composite values.
+	// TODO: maybe cleanup if there is an alternative/better way.
+	isTransaction bool
 }
 
 var _ Value = &SimpleCompositeValue{}

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -234,7 +234,7 @@ type ReferenceTrackedResourceKindedValue interface {
 // Hence, during tests, the value is a HostFunctionValue.
 type ContractValue interface {
 	Value
-	SetNestedVariables(variables map[string]*Variable)
+	SetNestedVariables(variables map[string]Variable)
 }
 
 // IterableValue is a value which can be iterated over, e.g. with a for-loop
@@ -16738,7 +16738,7 @@ type CompositeValue struct {
 	Stringer        func(gauge common.MemoryGauge, value *CompositeValue, seenReferences SeenReferences) string
 	injectedFields  map[string]Value
 	computedFields  map[string]ComputedField
-	NestedVariables map[string]*Variable
+	NestedVariables map[string]Variable
 	Functions       *FunctionOrderedMap
 	dictionary      *atree.OrderedMap
 	typeID          TypeID
@@ -17154,7 +17154,7 @@ func (v *CompositeValue) GetMember(interpreter *Interpreter, locationRange Locat
 	if v.NestedVariables != nil {
 		variable, ok := v.NestedVariables[name]
 		if ok {
-			return variable.GetValue()
+			return variable.GetValue(interpreter)
 		}
 	}
 
@@ -18281,7 +18281,7 @@ func (v *CompositeValue) RemoveField(
 	interpreter.RemoveReferencedSlab(existingValueStorable)
 }
 
-func (v *CompositeValue) SetNestedVariables(variables map[string]*Variable) {
+func (v *CompositeValue) SetNestedVariables(variables map[string]Variable) {
 	v.NestedVariables = variables
 }
 

--- a/runtime/interpreter/value_function.go
+++ b/runtime/interpreter/value_function.go
@@ -174,7 +174,7 @@ type HostFunction func(invocation Invocation) Value
 
 type HostFunctionValue struct {
 	Function        HostFunction
-	NestedVariables map[string]*Variable
+	NestedVariables map[string]Variable
 	Type            *sema.FunctionType
 }
 
@@ -256,10 +256,10 @@ func (f *HostFunctionValue) invoke(invocation Invocation) Value {
 	return f.Function(invocation)
 }
 
-func (f *HostFunctionValue) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+func (f *HostFunctionValue) GetMember(inter *Interpreter, _ LocationRange, name string) Value {
 	if f.NestedVariables != nil {
 		if variable, ok := f.NestedVariables[name]; ok {
-			return variable.GetValue()
+			return variable.GetValue(inter)
 		}
 	}
 	return nil
@@ -319,7 +319,7 @@ func (*HostFunctionValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
-func (v *HostFunctionValue) SetNestedVariables(variables map[string]*Variable) {
+func (v *HostFunctionValue) SetNestedVariables(variables map[string]Variable) {
 	v.NestedVariables = variables
 }
 

--- a/runtime/interpreter/value_string.go
+++ b/runtime/interpreter/value_string.go
@@ -192,7 +192,7 @@ var stringFunction = func() Value {
 
 	addMember := func(name string, value Value) {
 		if functionValue.NestedVariables == nil {
-			functionValue.NestedVariables = map[string]*Variable{}
+			functionValue.NestedVariables = map[string]Variable{}
 		}
 		// these variables are not needed to be metered as they are only ever declared once,
 		// and can be considered base interpreter overhead

--- a/runtime/interpreter/variable.go
+++ b/runtime/interpreter/variable.go
@@ -18,14 +18,35 @@
 
 package interpreter
 
-import "github.com/onflow/cadence/runtime/common"
+import (
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
+)
 
-type Variable struct {
+type Variable interface {
+	GetValue(interpreter *Interpreter) Value
+	SetValue(interpreter *Interpreter, locationRange LocationRange, value Value)
+	InitializeWithValue(value Value)
+	InitializeWithGetter(getter func() Value)
+}
+
+type SimpleVariable struct {
 	value  Value
 	getter func() Value
 }
 
-func (v *Variable) GetValue() Value {
+var _ Variable = &SimpleVariable{}
+
+func (v *SimpleVariable) InitializeWithValue(value Value) {
+	v.getter = nil
+	v.value = value
+}
+
+func (v *SimpleVariable) InitializeWithGetter(getter func() Value) {
+	v.getter = getter
+}
+
+func (v *SimpleVariable) GetValue(*Interpreter) Value {
 	if v.getter != nil {
 		v.value = v.getter()
 		v.getter = nil
@@ -33,23 +54,70 @@ func (v *Variable) GetValue() Value {
 	return v.value
 }
 
-func (v *Variable) SetValue(value Value) {
+func (v *SimpleVariable) SetValue(interpreter *Interpreter, locationRange LocationRange, value Value) {
+	existingValue := v.GetValue(interpreter)
+	if existingValue != nil {
+		interpreter.checkResourceLoss(existingValue, locationRange)
+	}
 	v.getter = nil
 	v.value = value
 }
 
 var variableMemoryUsage = common.NewConstantMemoryUsage(common.MemoryKindVariable)
 
-func NewVariableWithValue(gauge common.MemoryGauge, value Value) *Variable {
+func NewVariableWithValue(gauge common.MemoryGauge, value Value) Variable {
 	common.UseMemory(gauge, variableMemoryUsage)
-	return &Variable{
+	return &SimpleVariable{
 		value: value,
 	}
 }
 
-func NewVariableWithGetter(gauge common.MemoryGauge, getter func() Value) *Variable {
+func NewVariableWithGetter(gauge common.MemoryGauge, getter func() Value) Variable {
 	common.UseMemory(gauge, variableMemoryUsage)
-	return &Variable{
+	return &SimpleVariable{
 		getter: getter,
 	}
+}
+
+type SelfVariable struct {
+	value   Value
+	selfRef ReferenceValue
+}
+
+var _ Variable = &SelfVariable{}
+
+func NewSelfVariableWithValue(interpreter *Interpreter, value Value, locationRange LocationRange) Variable {
+	common.UseMemory(interpreter, variableMemoryUsage)
+
+	semaType := interpreter.MustSemaTypeOfValue(value)
+
+	// Create an explicit reference to represent the implicit reference behavior of 'self' value.
+	// Authorization doesn't matter, we just need a reference to add to tracking.
+	selfRef := NewEphemeralReferenceValue(interpreter, UnauthorizedAccess, value, semaType, locationRange)
+
+	return &SelfVariable{
+		value:   value,
+		selfRef: selfRef,
+	}
+}
+
+func (v *SelfVariable) InitializeWithValue(Value) {
+	// self variable cannot re-initialized.
+	panic(errors.NewUnreachableError())
+}
+
+func (v *SelfVariable) InitializeWithGetter(func() Value) {
+	// self variable doesn't have getters.
+	panic(errors.NewUnreachableError())
+}
+
+func (v *SelfVariable) GetValue(interpreter *Interpreter) Value {
+	// TODO: pass proper location range
+	interpreter.checkInvalidatedResourceOrResourceReference(v.selfRef, EmptyLocationRange)
+	return v.value
+}
+
+func (v *SelfVariable) SetValue(*Interpreter, LocationRange, Value) {
+	// self variable cannot be updated.
+	panic(errors.NewUnreachableError())
 }

--- a/runtime/interpreter/variable_activations.go
+++ b/runtime/interpreter/variable_activations.go
@@ -20,9 +20,9 @@ package interpreter
 
 import "github.com/onflow/cadence/runtime/activations"
 
-type VariableActivations = activations.Activations[*Variable]
+type VariableActivations = activations.Activations[Variable]
 
-type VariableActivation = activations.Activation[*Variable]
+type VariableActivation = activations.Activation[Variable]
 
 func Declare(a *VariableActivation, declaration ValueDeclaration) {
 

--- a/runtime/parser/lexer/lexer.go
+++ b/runtime/parser/lexer/lexer.go
@@ -357,12 +357,24 @@ func (l *lexer) scanSpace() (containsNewline bool) {
 func (l *lexer) scanIdentifier() {
 	// lookahead is already lexed.
 	// parse more, if any
-	l.acceptWhile(func(r rune) bool {
-		return r >= 'a' && r <= 'z' ||
-			r >= 'A' && r <= 'Z' ||
-			r >= '0' && r <= '9' ||
-			r == '_'
-	})
+	l.acceptWhile(IsIdentifierRune)
+}
+
+func IsIdentifierRune(r rune) bool {
+	return r >= 'a' && r <= 'z' ||
+		r >= 'A' && r <= 'Z' ||
+		r >= '0' && r <= '9' ||
+		r == '_'
+}
+
+func IsValidIdentifier(s string) bool {
+	for _, r := range s {
+		if !IsIdentifierRune(r) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (l *lexer) scanLineComment() {

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -375,7 +375,7 @@ func (r *REPL) GetGlobal(name string) interpreter.Value {
 	if variable == nil {
 		return nil
 	}
-	return variable.GetValue()
+	return variable.GetValue(r.inter)
 }
 
 func (r *REPL) ExportValue(value interpreter.Value) (cadence.Value, error) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -10212,9 +10212,6 @@ func TestRuntimeIfLetElseBranchConfusion(t *testing.T) {
 
 func TestResourceLossViaSelfRugPull(t *testing.T) {
 
-	// TODO: Disabled temporarily
-	t.SkipNow()
-
 	t.Parallel()
 
 	runtime := NewTestInterpreterRuntime()
@@ -10361,7 +10358,7 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 	)
 	RequireError(t, err)
 
-	require.ErrorAs(t, err, &interpreter.ResourceLossError{})
+	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
 }
 
 func TestRuntimeValueTransferResourceLoss(t *testing.T) {

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -78,7 +78,7 @@ func NewAccessFromEntitlementSet(
 	set *EntitlementOrderedSet,
 	setKind EntitlementSetKind,
 ) Access {
-	if set.Len() == 0 {
+	if set == nil || set.Len() == 0 {
 		return UnauthorizedAccess
 	}
 

--- a/runtime/sema/account.go
+++ b/runtime/sema/account.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/errors"
 )
 
 //go:generate go run ./gen account.cdc account.gen.go
@@ -73,8 +72,8 @@ func init() {
 		) {
 			typeArg, ok := typeArguments.Get(Account_CapabilitiesTypeGetFunctionTypeParameterT)
 			if !ok || typeArg == nil {
-				// checker should prevent this
-				panic(errors.NewUnreachableError())
+				// Invalid, already reported by checker
+				return
 			}
 			if typeArg == NeverType {
 				report(&InvalidTypeArgumentError{

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -72,16 +72,21 @@ func (checker *Checker) checkAttachmentMemberAccess(
 	baseType Type,
 	supportedBaseEntitlements *EntitlementOrderedSet,
 ) {
-	var requestedEntitlements *EntitlementOrderedSet = &orderedmap.OrderedMap[*EntitlementType, struct{}]{}
+	var requestedEntitlements *EntitlementOrderedSet
+
 	switch memberAccess := member.Access.(type) {
 	case EntitlementSetAccess:
 		requestedEntitlements = memberAccess.Entitlements
+
 	// if the attachment field/function is declared with mapped access, the domain of the map must be a
 	// subset of the supported entitlements on the base. This is because the attachment reference
 	// will never be able to possess any entitlements other than these, so any map relations that map
 	// from other entitlements will be unreachable
 	case *EntitlementMapAccess:
 		requestedEntitlements = memberAccess.Domain().Entitlements
+
+	default:
+		requestedEntitlements = &orderedmap.OrderedMap[*EntitlementType, struct{}]{}
 	}
 
 	requestedEntitlements.Foreach(func(entitlement *EntitlementType, _ struct{}) {
@@ -99,11 +104,13 @@ func (checker *Checker) checkAttachmentMemberAccess(
 func (checker *Checker) checkAttachmentMembersAccess(attachmentType *CompositeType) {
 
 	// all the access modifiers for attachment members must be valid entitlements for the base type
-	var supportedBaseEntitlements *EntitlementOrderedSet = &orderedmap.OrderedMap[*EntitlementType, struct{}]{}
+	var supportedBaseEntitlements *EntitlementOrderedSet
 	baseType := attachmentType.GetBaseType()
-	switch base := attachmentType.GetBaseType().(type) {
-	case EntitlementSupportingType:
+	if base, ok := attachmentType.GetBaseType().(EntitlementSupportingType); ok {
 		supportedBaseEntitlements = base.SupportedEntitlements()
+	}
+	if supportedBaseEntitlements == nil {
+		supportedBaseEntitlements = &orderedmap.OrderedMap[*EntitlementType, struct{}]{}
 	}
 
 	attachmentType.EffectiveInterfaceConformanceSet().ForEach(func(intf *InterfaceType) {
@@ -2075,8 +2082,16 @@ func (checker *Checker) checkDefaultDestroyEventParam(
 	// make `self` and `base` available when checking default arguments so the fields of the composite are available
 	// as this event is emitted when the resource is destroyed, these values should be fully entitled
 	fullyEntitledAccess := NewAccessFromEntitlementSet(containerType.SupportedEntitlements(), Conjunction)
-	checker.declareSelfValue(fullyEntitledAccess, containerType, containerDeclaration.DeclarationDocString())
-	if compositeContainer, isComposite := containerType.(*CompositeType); isComposite && compositeContainer.Kind == common.CompositeKindAttachment {
+
+	checker.declareSelfValue(
+		fullyEntitledAccess,
+		containerType,
+		containerDeclaration.DeclarationDocString(),
+	)
+
+	if compositeContainer, isComposite := containerType.(*CompositeType); isComposite &&
+		compositeContainer.Kind == common.CompositeKindAttachment {
+
 		checker.declareBaseValue(
 			fullyEntitledAccess,
 			compositeContainer.baseType,
@@ -2212,6 +2227,7 @@ func (checker *Checker) checkSpecialFunction(
 	fnAccess := NewAccessFromEntitlementSet(containerType.SupportedEntitlements(), Conjunction)
 
 	checker.declareSelfValue(fnAccess, containerType, containerDocString)
+
 	if containerType.GetCompositeKind() == common.CompositeKindAttachment {
 		// attachments cannot be interfaces, so this cast must succeed
 		attachmentType, ok := containerType.(*CompositeType)

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -397,13 +397,13 @@ func (checker *Checker) visitWithPostConditions(postConditions *ast.Conditions, 
 		var resultType Type
 		if returnType.IsResourceType() {
 
-			var innerType Type = returnType
+			innerType := returnType
 			optType, isOptional := returnType.(*OptionalType)
 			if isOptional {
 				innerType = optType.Type
 			}
 
-			var auth Access = UnauthorizedAccess
+			auth := UnauthorizedAccess
 			// reference is authorized to the entire resource, since it is only accessible in a function where a resource value is owned.
 			// To create a "fully authorized" reference, we scan the resource type and produce a conjunction of all the entitlements mentioned within.
 			// So, for example,
@@ -423,12 +423,7 @@ func (checker *Checker) visitWithPostConditions(postConditions *ast.Conditions, 
 			// here the `result` value in the `post` block will have type `auth(E, X, Y) &R`
 			if entitlementSupportingType, ok := innerType.(EntitlementSupportingType); ok {
 				supportedEntitlements := entitlementSupportingType.SupportedEntitlements()
-				if supportedEntitlements.Len() > 0 {
-					auth = EntitlementSetAccess{
-						SetKind:      Conjunction,
-						Entitlements: supportedEntitlements,
-					}
-				}
+				auth = NewAccessFromEntitlementSet(supportedEntitlements, Conjunction)
 			}
 
 			resultType = &ReferenceType{

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -2844,8 +2844,8 @@ func ArrayToConstantSizedFunctionType(elementType Type) *FunctionType {
 		) {
 			typeArg, ok := typeArguments.Get(typeParameter)
 			if !ok || typeArg == nil {
-				// checker should prevent this
-				panic(errors.NewUnreachableError())
+				// Invalid, already reported by checker
+				return
 			}
 
 			constArrayType, ok := typeArg.(*ConstantSizedType)

--- a/runtime/stdlib/builtin_test.go
+++ b/runtime/stdlib/builtin_test.go
@@ -69,7 +69,7 @@ func newInterpreter(t *testing.T, code string, valueDeclarations ...StandardLibr
 
 	storage := newUnmeteredInMemoryStorage()
 
-	baseActivation := activations.NewActivation[*interpreter.Variable](nil, interpreter.BaseActivation)
+	baseActivation := activations.NewActivation[interpreter.Variable](nil, interpreter.BaseActivation)
 	for _, valueDeclaration := range valueDeclarations {
 		interpreter.Declare(baseActivation, valueDeclaration)
 	}

--- a/runtime/stdlib/crypto.go
+++ b/runtime/stdlib/crypto.go
@@ -169,7 +169,7 @@ func cryptoAlgorithmEnumValueAndCaseValues[T sema.CryptoAlgorithm](
 
 	caseCount := len(enumCases)
 	caseValues := make([]interpreter.EnumCase, caseCount)
-	constructorNestedVariables := make(map[string]*interpreter.Variable, caseCount)
+	constructorNestedVariables := make(map[string]interpreter.Variable, caseCount)
 	cases = make(map[interpreter.UInt8Value]interpreter.MemberAccessibleValue, caseCount)
 
 	for i, enumCase := range enumCases {

--- a/runtime/stdlib/random.go
+++ b/runtime/stdlib/random.go
@@ -70,8 +70,8 @@ var revertibleRandomFunctionType = func() *sema.FunctionType {
 			report func(err error)) {
 			typeArg, ok := typeArguments.Get(typeParameter)
 			if !ok || typeArg == nil {
-				// checker should prevent this
-				panic(errors.NewUnreachableError())
+				// Invalid, already reported by checker
+				return
 			}
 			if typeArg == sema.NeverType || typeArg == sema.FixedSizeUnsignedIntegerType {
 				report(&sema.InvalidTypeArgumentError{

--- a/runtime/stdlib/range.go
+++ b/runtime/stdlib/range.go
@@ -85,8 +85,8 @@ var inclusiveRangeConstructorFunctionType = func() *sema.FunctionType {
 		) {
 			memberType, ok := typeArguments.Get(typeParameter)
 			if !ok || memberType == nil {
-				// checker should prevent this
-				panic(errors.NewUnreachableError())
+				// Invalid, already reported by checker
+				return
 			}
 
 			// memberType must only be a leaf integer type.

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -19,6 +19,7 @@
 package runtime
 
 import (
+	"fmt"
 	"runtime"
 	"sort"
 
@@ -346,8 +347,22 @@ func (s *Storage) CheckHealth() error {
 			return a.Compare(b) < 0
 		})
 
-		return errors.NewUnexpectedError("slabs not referenced from account Storage: %s", unreferencedRootSlabIDs)
+		return UnreferencedRootSlabsError{
+			UnreferencedRootSlabIDs: unreferencedRootSlabIDs,
+		}
 	}
 
 	return nil
+}
+
+type UnreferencedRootSlabsError struct {
+	UnreferencedRootSlabIDs []atree.SlabID
+}
+
+var _ errors.InternalError = UnreferencedRootSlabsError{}
+
+func (UnreferencedRootSlabsError) IsInternalError() {}
+
+func (e UnreferencedRootSlabsError) Error() string {
+	return fmt.Sprintf("slabs not referenced: %s", e.UnreferencedRootSlabIDs)
 }

--- a/runtime/tests/checker/arrays_dictionaries_test.go
+++ b/runtime/tests/checker/arrays_dictionaries_test.go
@@ -2648,6 +2648,22 @@ func TestCheckResourceArrayToConstantSizedInvalid(t *testing.T) {
 	assert.IsType(t, &sema.InvalidResourceArrayMemberError{}, errs[0])
 }
 
+func TestCheckArrayToConstantSizedMissingTypeArgument(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+		fun test() {
+			let x: [Int16] = [1, 2, 3]
+			let y = x.toConstantSized()
+		}
+	`)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.TypeParameterTypeInferenceError{}, errs[0])
+}
+
 func TestCheckArrayReferenceTypeInference(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/tests/checker/builtinfunctions_test.go
+++ b/runtime/tests/checker/builtinfunctions_test.go
@@ -409,7 +409,7 @@ func TestCheckRevertibleRandom(t *testing.T) {
 
 	runInvalidCase(
 		t,
-		"invalid type arg never",
+		"invalid type argument Never",
 		`let rand = revertibleRandom<Never>(modulo: 1)`,
 		[]error{
 			&sema.TypeMismatchError{},
@@ -418,10 +418,19 @@ func TestCheckRevertibleRandom(t *testing.T) {
 	)
 	runInvalidCase(
 		t,
-		"invalid type arg FixedSizeUnsignedInteger",
+		"invalid type argument FixedSizeUnsignedInteger",
 		`let rand = revertibleRandom<FixedSizeUnsignedInteger>(modulo: 1)`,
 		[]error{
 			&sema.InvalidTypeArgumentError{},
+		},
+	)
+
+	runInvalidCase(
+		t,
+		"missing type argument",
+		`let rand = revertibleRandom()`,
+		[]error{
+			&sema.TypeParameterTypeInferenceError{},
 		},
 	)
 

--- a/runtime/tests/checker/range_value_test.go
+++ b/runtime/tests/checker/range_value_test.go
@@ -378,7 +378,10 @@ func TestCheckInclusiveRangeConstructionInvalid(t *testing.T) {
 		t,
 		"without_inner_type_annotation",
 		"let r: InclusiveRange<> = InclusiveRange(1, 10)",
-		[]error{&sema.InvalidTypeArgumentCountError{}, &sema.MissingTypeArgumentError{}},
+		[]error{
+			&sema.InvalidTypeArgumentCountError{},
+			&sema.MissingTypeArgumentError{},
+		},
 	)
 
 	runInvalidCase(

--- a/runtime/tests/interpreter/arithmetic_test.go
+++ b/runtime/tests/interpreter/arithmetic_test.go
@@ -95,7 +95,7 @@ func TestInterpretPlusOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -124,7 +124,7 @@ func TestInterpretMinusOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -153,7 +153,7 @@ func TestInterpretMulOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -182,7 +182,7 @@ func TestInterpretDivOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -211,7 +211,7 @@ func TestInterpretModOperator(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}

--- a/runtime/tests/interpreter/bitwise_test.go
+++ b/runtime/tests/interpreter/bitwise_test.go
@@ -130,7 +130,7 @@ func TestInterpretBitwiseOr(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b00010101),
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -159,7 +159,7 @@ func TestInterpretBitwiseXor(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b00000101),
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -188,7 +188,7 @@ func TestInterpretBitwiseAnd(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b00010000),
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -217,7 +217,7 @@ func TestInterpretBitwiseLeftShift(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b01100000),
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}
@@ -246,7 +246,7 @@ func TestInterpretBitwiseRightShift(t *testing.T) {
 				t,
 				inter,
 				valueFunc(0b00001100),
-				inter.Globals.Get("c").GetValue(),
+				inter.Globals.Get("c").GetValue(inter),
 			)
 		})
 	}

--- a/runtime/tests/interpreter/builtinfunctions_test.go
+++ b/runtime/tests/interpreter/builtinfunctions_test.go
@@ -54,7 +54,7 @@ func TestInterpretToString(t *testing.T) {
 				t,
 				inter,
 				interpreter.NewUnmeteredStringValue("42"),
-				inter.Globals.Get("y").GetValue(),
+				inter.Globals.Get("y").GetValue(inter),
 			)
 		})
 	}
@@ -72,7 +72,7 @@ func TestInterpretToString(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("0x0000000000000042"),
-			inter.Globals.Get("y").GetValue(),
+			inter.Globals.Get("y").GetValue(inter),
 		)
 	})
 
@@ -108,7 +108,7 @@ func TestInterpretToString(t *testing.T) {
 				t,
 				inter,
 				expected,
-				inter.Globals.Get("y").GetValue(),
+				inter.Globals.Get("y").GetValue(inter),
 			)
 		})
 	}
@@ -146,7 +146,7 @@ func TestInterpretToBytes(t *testing.T) {
 				interpreter.NewUnmeteredUInt8Value(0x34),
 				interpreter.NewUnmeteredUInt8Value(0x56),
 			),
-			inter.Globals.Get("y").GetValue(),
+			inter.Globals.Get("y").GetValue(inter),
 		)
 	})
 }
@@ -588,7 +588,7 @@ func TestInterpretToBigEndianBytes(t *testing.T) {
 					),
 				)
 
-				result := inter.Globals.Get("result").GetValue()
+				result := inter.Globals.Get("result").GetValue(inter)
 
 				AssertValuesEqual(
 					t,
@@ -930,13 +930,13 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("result").GetValue(),
+					inter.Globals.Get("result").GetValue(inter),
 				)
 				AssertValuesEqual(
 					t,
 					inter,
 					interpreter.TrueValue,
-					inter.Globals.Get("roundTripEqual").GetValue(),
+					inter.Globals.Get("roundTripEqual").GetValue(inter),
 				)
 			})
 		}
@@ -960,7 +960,7 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 					t,
 					inter,
 					interpreter.NilValue{},
-					inter.Globals.Get("result").GetValue(),
+					inter.Globals.Get("result").GetValue(inter),
 				)
 			})
 		}

--- a/runtime/tests/interpreter/composite_value_test.go
+++ b/runtime/tests/interpreter/composite_value_test.go
@@ -56,14 +56,14 @@ func TestInterpretCompositeValue(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("Apple"),
-			inter.Globals.Get("name").GetValue(),
+			inter.Globals.Get("name").GetValue(inter),
 		)
 
 		RequireValuesEqual(
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("Red"),
-			inter.Globals.Get("color").GetValue(),
+			inter.Globals.Get("color").GetValue(inter),
 		)
 	})
 }

--- a/runtime/tests/interpreter/container_mutation_test.go
+++ b/runtime/tests/interpreter/container_mutation_test.go
@@ -261,7 +261,7 @@ func TestInterpetArrayMutation(t *testing.T) {
 
 		// Check original array
 
-		namesVal := inter.Globals.Get("names").GetValue()
+		namesVal := inter.Globals.Get("names").GetValue(inter)
 		require.IsType(t, &interpreter.ArrayValue{}, namesVal)
 		namesValArray := namesVal.(*interpreter.ArrayValue)
 

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -113,14 +113,14 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 									t,
 									inter,
 									test.expected,
-									inter.Globals.Get("x").GetValue(),
+									inter.Globals.Get("x").GetValue(inter),
 								)
 
 								AssertValuesEqual(
 									t,
 									inter,
 									test.expected,
-									inter.Globals.Get("y").GetValue(),
+									inter.Globals.Get("y").GetValue(inter),
 								)
 
 								AssertValuesEqual(
@@ -129,7 +129,7 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 									interpreter.NewUnmeteredSomeValueNonCopying(
 										test.expected,
 									),
-									inter.Globals.Get("z").GetValue(),
+									inter.Globals.Get("z").GetValue(inter),
 								)
 							})
 						}
@@ -219,7 +219,7 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 							t,
 							inter,
 							interpreter.Void,
-							inter.Globals.Get("x").GetValue(),
+							inter.Globals.Get("x").GetValue(inter),
 						)
 
 						AssertValuesEqual(
@@ -228,7 +228,7 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								interpreter.Void,
 							),
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 					})
 				}
@@ -313,7 +313,7 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 							t,
 							inter,
 							interpreter.NewUnmeteredStringValue("test"),
-							inter.Globals.Get("x").GetValue(),
+							inter.Globals.Get("x").GetValue(inter),
 						)
 
 						AssertValuesEqual(
@@ -322,7 +322,7 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								interpreter.NewUnmeteredStringValue("test"),
 							),
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 					})
 				}
@@ -406,7 +406,7 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 							t,
 							inter,
 							interpreter.TrueValue,
-							inter.Globals.Get("x").GetValue(),
+							inter.Globals.Get("x").GetValue(inter),
 						)
 
 						AssertValuesEqual(
@@ -415,7 +415,7 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								interpreter.TrueValue,
 							),
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 					})
 				}
@@ -503,7 +503,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 							t,
 							inter,
 							addressValue,
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 
 						AssertValuesEqual(
@@ -512,7 +512,7 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								addressValue,
 							),
-							inter.Globals.Get("z").GetValue(),
+							inter.Globals.Get("z").GetValue(inter),
 						)
 					})
 				}
@@ -597,17 +597,17 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 
 						assert.IsType(t,
 							&interpreter.CompositeValue{},
-							inter.Globals.Get("x").GetValue(),
+							inter.Globals.Get("x").GetValue(inter),
 						)
 
 						require.IsType(t,
 							&interpreter.SomeValue{},
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 
 						require.IsType(t,
 							&interpreter.CompositeValue{},
-							inter.Globals.Get("y").GetValue().(*interpreter.SomeValue).
+							inter.Globals.Get("y").GetValue(inter).(*interpreter.SomeValue).
 								InnerValue(inter, interpreter.EmptyLocationRange),
 						)
 					})
@@ -1100,7 +1100,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 							t,
 							inter,
 							expectedValue,
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 
 						if targetType == sema.AnyStructType && !returnsOptional {
@@ -1109,7 +1109,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 								t,
 								inter,
 								expectedValue,
-								inter.Globals.Get("z").GetValue(),
+								inter.Globals.Get("z").GetValue(inter),
 							)
 
 						} else {
@@ -1119,7 +1119,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 								interpreter.NewUnmeteredSomeValueNonCopying(
 									expectedValue,
 								),
-								inter.Globals.Get("z").GetValue(),
+								inter.Globals.Get("z").GetValue(inter),
 							)
 						}
 
@@ -1206,7 +1206,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 							interpreter.NewUnmeteredIntValueFromInt64(42),
 						}
 
-						yValue := inter.Globals.Get("y").GetValue()
+						yValue := inter.Globals.Get("y").GetValue(inter)
 						require.IsType(t, yValue, &interpreter.ArrayValue{})
 						yArray := yValue.(*interpreter.ArrayValue)
 
@@ -1217,7 +1217,7 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 							ArrayElements(inter, yArray),
 						)
 
-						zValue := inter.Globals.Get("z").GetValue()
+						zValue := inter.Globals.Get("z").GetValue(inter)
 						require.IsType(t, zValue, &interpreter.SomeValue{})
 						zSome := zValue.(*interpreter.SomeValue)
 
@@ -1377,7 +1377,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 							t,
 							inter,
 							expectedDictionary,
-							inter.Globals.Get("y").GetValue(),
+							inter.Globals.Get("y").GetValue(inter),
 						)
 
 						AssertValuesEqual(
@@ -1386,7 +1386,7 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 							interpreter.NewUnmeteredSomeValueNonCopying(
 								expectedDictionary,
 							),
-							inter.Globals.Get("z").GetValue(),
+							inter.Globals.Get("z").GetValue(inter),
 						)
 					})
 				}
@@ -3485,7 +3485,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 									t,
 									inter,
 									capabilityValue,
-									inter.Globals.Get("x").GetValue(),
+									inter.Globals.Get("x").GetValue(inter),
 								)
 
 								AssertValuesEqual(
@@ -3494,7 +3494,7 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 									interpreter.NewUnmeteredSomeValueNonCopying(
 										capabilityValue,
 									),
-									inter.Globals.Get("y").GetValue(),
+									inter.Globals.Get("y").GetValue(inter),
 								)
 							})
 						}

--- a/runtime/tests/interpreter/enum_test.go
+++ b/runtime/tests/interpreter/enum_test.go
@@ -43,7 +43,7 @@ func TestInterpretEnum(t *testing.T) {
 
 	assert.IsType(t,
 		&interpreter.HostFunctionValue{},
-		inter.Globals.Get("E").GetValue(),
+		inter.Globals.Get("E").GetValue(inter),
 	)
 }
 
@@ -61,7 +61,7 @@ func TestInterpretEnumCaseUse(t *testing.T) {
       let b = E.b
     `)
 
-	a := inter.Globals.Get("a").GetValue()
+	a := inter.Globals.Get("a").GetValue(inter)
 	require.IsType(t,
 		&interpreter.CompositeValue{},
 		a,
@@ -72,7 +72,7 @@ func TestInterpretEnumCaseUse(t *testing.T) {
 		a.(*interpreter.CompositeValue).Kind,
 	)
 
-	b := inter.Globals.Get("b").GetValue()
+	b := inter.Globals.Get("b").GetValue(inter)
 	require.IsType(t,
 		&interpreter.CompositeValue{},
 		b,
@@ -102,14 +102,14 @@ func TestInterpretEnumCaseRawValue(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredInt64Value(0),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	RequireValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredInt64Value(1),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 }
 
@@ -144,7 +144,7 @@ func TestInterpretEnumCaseEquality(t *testing.T) {
 			interpreter.TrueValue,
 			interpreter.TrueValue,
 		),
-		inter.Globals.Get("res").GetValue(),
+		inter.Globals.Get("res").GetValue(inter),
 	)
 }
 
@@ -181,7 +181,7 @@ func TestInterpretEnumConstructor(t *testing.T) {
 			interpreter.TrueValue,
 			interpreter.TrueValue,
 		),
-		inter.Globals.Get("res").GetValue(),
+		inter.Globals.Get("res").GetValue(inter),
 	)
 }
 
@@ -214,7 +214,7 @@ func TestInterpretEnumInstance(t *testing.T) {
 			interpreter.TrueValue,
 			interpreter.TrueValue,
 		),
-		inter.Globals.Get("res").GetValue(),
+		inter.Globals.Get("res").GetValue(inter),
 	)
 }
 
@@ -245,7 +245,7 @@ func TestInterpretEnumInContract(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c := inter.Globals.Get("C").GetValue()
+	c := inter.Globals.Get("C").GetValue(inter)
 	require.IsType(t, &interpreter.CompositeValue{}, c)
 	contract := c.(*interpreter.CompositeValue)
 

--- a/runtime/tests/interpreter/equality_test.go
+++ b/runtime/tests/interpreter/equality_test.go
@@ -87,14 +87,14 @@ func TestInterpretEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("res1").GetValue(),
+			inter.Globals.Get("res1").GetValue(inter),
 		)
 
 		AssertValuesEqual(
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("res2").GetValue(),
+			inter.Globals.Get("res2").GetValue(inter),
 		)
 	})
 
@@ -115,14 +115,14 @@ func TestInterpretEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("res1").GetValue(),
+			inter.Globals.Get("res1").GetValue(inter),
 		)
 
 		AssertValuesEqual(
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("res2").GetValue(),
+			inter.Globals.Get("res2").GetValue(inter),
 		)
 	})
 
@@ -139,7 +139,7 @@ func TestInterpretEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("res").GetValue(),
+			inter.Globals.Get("res").GetValue(inter),
 		)
 	})
 }

--- a/runtime/tests/interpreter/fixedpoint_test.go
+++ b/runtime/tests/interpreter/fixedpoint_test.go
@@ -44,7 +44,7 @@ func TestInterpretNegativeZeroFixedPoint(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredFix64Value(-42000000),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -90,21 +90,21 @@ func TestInterpretFixedPointConversionAndAddition(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				value,
-				inter.Globals.Get("y").GetValue(),
+				inter.Globals.Get("y").GetValue(inter),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				interpreter.TrueValue,
-				inter.Globals.Get("z").GetValue(),
+				inter.Globals.Get("z").GetValue(inter),
 			)
 
 		})
@@ -159,14 +159,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					fixedPointValue,
-					inter.Globals.Get("x").GetValue(),
+					inter.Globals.Get("x").GetValue(inter),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					integerValue,
-					inter.Globals.Get("y").GetValue(),
+					inter.Globals.Get("y").GetValue(inter),
 				)
 			})
 		}
@@ -198,14 +198,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("x").GetValue(),
+					inter.Globals.Get("x").GetValue(inter),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("y").GetValue(),
+					inter.Globals.Get("y").GetValue(inter),
 				)
 			})
 		}
@@ -238,14 +238,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("x").GetValue(),
+					inter.Globals.Get("x").GetValue(inter),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("y").GetValue(),
+					inter.Globals.Get("y").GetValue(inter),
 				)
 			})
 		}
@@ -271,14 +271,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					interpreter.NewUnmeteredFix64Value(value*sema.Fix64Factor),
-					inter.Globals.Get("x").GetValue(),
+					inter.Globals.Get("x").GetValue(inter),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					interpreter.NewUnmeteredUFix64Value(uint64(value*sema.Fix64Factor)),
-					inter.Globals.Get("y").GetValue(),
+					inter.Globals.Get("y").GetValue(inter),
 				)
 			})
 		}
@@ -304,14 +304,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					interpreter.NewUnmeteredUFix64Value(uint64(value*sema.Fix64Factor)),
-					inter.Globals.Get("x").GetValue(),
+					inter.Globals.Get("x").GetValue(inter),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					interpreter.NewUnmeteredFix64Value(value*sema.Fix64Factor),
-					inter.Globals.Get("y").GetValue(),
+					inter.Globals.Get("y").GetValue(inter),
 				)
 			})
 		}
@@ -558,13 +558,13 @@ func TestInterpretFixedPointMinMax(t *testing.T) {
 			t,
 			inter,
 			test.min,
-			inter.Globals.Get("min").GetValue(),
+			inter.Globals.Get("min").GetValue(inter),
 		)
 		RequireValuesEqual(
 			t,
 			inter,
 			test.max,
-			inter.Globals.Get("max").GetValue(),
+			inter.Globals.Get("max").GetValue(inter),
 		)
 	}
 

--- a/runtime/tests/interpreter/if_test.go
+++ b/runtime/tests/interpreter/if_test.go
@@ -146,7 +146,7 @@ func TestInterpretIfStatementTestWithDeclaration(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 	})
 
@@ -163,7 +163,7 @@ func TestInterpretIfStatementTestWithDeclaration(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 	})
 }
@@ -201,7 +201,7 @@ func TestInterpretIfStatementTestWithDeclarationAndElse(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 	})
 
@@ -218,7 +218,7 @@ func TestInterpretIfStatementTestWithDeclarationAndElse(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 
 	})
@@ -260,7 +260,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 	})
 
@@ -280,7 +280,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionals(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 	})
 }
@@ -321,7 +321,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotatio
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 
 	})
@@ -341,7 +341,7 @@ func TestInterpretIfStatementTestWithDeclarationNestedOptionalsExplicitAnnotatio
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(2),
-			inter.Globals.Get("branch").GetValue(),
+			inter.Globals.Get("branch").GetValue(inter),
 		)
 	})
 }

--- a/runtime/tests/interpreter/import_test.go
+++ b/runtime/tests/interpreter/import_test.go
@@ -388,7 +388,7 @@ func TestInterpretResourceConstructionThroughIndirectImport(t *testing.T) {
 	err = inter.Interpret()
 	require.NoError(t, err)
 
-	rConstructor := subInterpreter.Globals.Get("R").GetValue()
+	rConstructor := subInterpreter.Globals.Get("R").GetValue(inter)
 
 	_, err = inter.Invoke("test", rConstructor)
 	RequireError(t, err)

--- a/runtime/tests/interpreter/integers_test.go
+++ b/runtime/tests/interpreter/integers_test.go
@@ -97,21 +97,21 @@ func TestInterpretIntegerConversions(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				value,
-				inter.Globals.Get("y").GetValue(),
+				inter.Globals.Get("y").GetValue(inter),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				interpreter.TrueValue,
-				inter.Globals.Get("z").GetValue(),
+				inter.Globals.Get("z").GetValue(inter),
 			)
 
 		})
@@ -149,7 +149,7 @@ func TestInterpretWordOverflowConversions(t *testing.T) {
 			require.Equal(
 				t,
 				"0",
-				inter.Globals.Get("y").GetValue().String(),
+				inter.Globals.Get("y").GetValue(inter).String(),
 			)
 		})
 	}
@@ -185,7 +185,7 @@ func TestInterpretWordUnderflowConversions(t *testing.T) {
 			require.Equal(
 				t,
 				value.String(),
-				inter.Globals.Get("y").GetValue().String(),
+				inter.Globals.Get("y").GetValue(inter).String(),
 			)
 		})
 	}
@@ -209,7 +209,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 			interpreter.AddressValue{
 				0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
 			},
-			inter.Globals.Get("x").GetValue(),
+			inter.Globals.Get("x").GetValue(inter),
 		)
 
 	})
@@ -228,7 +228,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 			interpreter.AddressValue{
 				0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2,
 			},
-			inter.Globals.Get("x").GetValue(),
+			inter.Globals.Get("x").GetValue(inter),
 		)
 	})
 
@@ -288,7 +288,7 @@ func TestInterpretIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 
 		})
@@ -316,7 +316,7 @@ func TestInterpretIntegerLiteralTypeConversionInVariableDeclarationOptional(t *t
 				t,
 				inter,
 				interpreter.NewUnmeteredSomeValueNonCopying(value),
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -346,7 +346,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 
 			_, err := inter.Invoke("test")
@@ -357,7 +357,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
 				t,
 				inter,
 				numberValue.Plus(inter, numberValue, interpreter.EmptyLocationRange),
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -387,7 +387,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T)
 				t,
 				inter,
 				interpreter.NewUnmeteredSomeValueNonCopying(value),
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 
 			_, err := inter.Invoke("test")
@@ -401,7 +401,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T)
 				interpreter.NewUnmeteredSomeValueNonCopying(
 					numberValue.Plus(inter, numberValue, interpreter.EmptyLocationRange),
 				),
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -431,7 +431,7 @@ func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgument(t *testing.
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -461,7 +461,7 @@ func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgumentOptional(t *
 				t,
 				inter,
 				interpreter.NewUnmeteredSomeValueNonCopying(value),
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -805,7 +805,7 @@ func TestInterpretIntegerMinMax(t *testing.T) {
 			t,
 			inter,
 			expected,
-			inter.Globals.Get("x").GetValue(),
+			inter.Globals.Get("x").GetValue(inter),
 		)
 	}
 

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -246,7 +246,7 @@ func parseCheckAndInterpretWithOptionsAndMemoryMetering(
 
 			contractVariable := inter.Globals.Get(compositeDeclaration.Identifier.Identifier)
 
-			_ = contractVariable.GetValue()
+			_ = contractVariable.GetValue(inter)
 		}
 	}
 
@@ -358,28 +358,28 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -395,14 +395,14 @@ func TestInterpretConstantAndVariableDeclarations(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredStringValue("123"),
-		inter.Globals.Get("s").GetValue(),
+		inter.Globals.Get("s").GetValue(inter),
 	)
 }
 
@@ -472,7 +472,7 @@ func TestInterpretLexicalScope(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(10),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	value, err := inter.Invoke("f")
@@ -524,7 +524,7 @@ func TestInterpretFunctionSideEffects(t *testing.T) {
 		t,
 		inter,
 		newValue,
-		inter.Globals.Get("value").GetValue(),
+		inter.Globals.Get("value").GetValue(inter),
 	)
 }
 
@@ -558,7 +558,7 @@ func TestInterpretNoHoisting(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -577,14 +577,14 @@ func TestInterpretFunctionExpressionsAndScope(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(10),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -628,7 +628,7 @@ func TestInterpretGlobalVariableAssignment(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	value, err := inter.Invoke("test")
@@ -645,7 +645,7 @@ func TestInterpretGlobalVariableAssignment(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -666,7 +666,7 @@ func TestInterpretConstantRedeclaration(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	value, err := inter.Invoke("test")
@@ -852,7 +852,7 @@ func TestInterpretArrayIndexingAssignment(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.NoError(t, err)
 
-	actualArray := inter.Globals.Get("z").GetValue()
+	actualArray := inter.Globals.Get("z").GetValue(inter)
 
 	expectedArray := interpreter.NewArrayValue(
 		inter,
@@ -927,19 +927,19 @@ func TestInterpretStringIndexing(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredCharacterValue("a"),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredCharacterValue("b"),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredCharacterValue("c"),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -1582,21 +1582,21 @@ func TestInterpretOrOperatorShortCircuitLeftSuccess(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("test").GetValue(),
+		inter.Globals.Get("test").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -1625,21 +1625,21 @@ func TestInterpretOrOperatorShortCircuitLeftFailure(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("test").GetValue(),
+		inter.Globals.Get("test").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -1710,21 +1710,21 @@ func TestInterpretAndOperatorShortCircuitLeftSuccess(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("test").GetValue(),
+		inter.Globals.Get("test").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -1753,21 +1753,21 @@ func TestInterpretAndOperatorShortCircuitLeftFailure(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("test").GetValue(),
+		inter.Globals.Get("test").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -1792,7 +1792,7 @@ func TestInterpretExpressionStatement(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	value, err := inter.Invoke("test")
@@ -1809,7 +1809,7 @@ func TestInterpretExpressionStatement(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -1934,14 +1934,14 @@ func TestInterpretUnaryIntegerNegation(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(-2),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -1960,28 +1960,28 @@ func TestInterpretUnaryBooleanNegation(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 }
 
@@ -2065,7 +2065,7 @@ func TestInterpretHostFunction(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 }
 
@@ -2533,7 +2533,7 @@ func TestInterpretStructureDeclarationWithFunction(t *testing.T) {
 
 	AssertValuesEqual(
 		t,
-		inter, newValue, inter.Globals.Get("value").GetValue())
+		inter, newValue, inter.Globals.Get("value").GetValue(inter))
 }
 
 func TestInterpretStructureFunctionCall(t *testing.T) {
@@ -2558,7 +2558,7 @@ func TestInterpretStructureFunctionCall(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals.Get("value").GetValue(),
+		inter.Globals.Get("value").GetValue(inter),
 	)
 }
 
@@ -2590,7 +2590,7 @@ func TestInterpretStructureFieldAssignment(t *testing.T) {
       }
     `)
 
-	test := inter.Globals.Get("test").GetValue().(*interpreter.CompositeValue)
+	test := inter.Globals.Get("test").GetValue(inter).(*interpreter.CompositeValue)
 
 	AssertValuesEqual(
 		t,
@@ -2633,7 +2633,7 @@ func TestInterpretStructureInitializesConstant(t *testing.T) {
       let test = Test()
     `)
 
-	actual := inter.Globals.Get("test").GetValue().(*interpreter.CompositeValue).
+	actual := inter.Globals.Get("test").GetValue(inter).(*interpreter.CompositeValue).
 		GetMember(inter, interpreter.EmptyLocationRange, "foo")
 	AssertValuesEqual(
 		t,
@@ -3081,7 +3081,7 @@ func TestInterpretUseBeforeDeclaration(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(0),
-		inter.Globals.Get("tests").GetValue(),
+		inter.Globals.Get("tests").GetValue(inter),
 	)
 
 	value, err := inter.Invoke("test")
@@ -3096,7 +3096,7 @@ func TestInterpretUseBeforeDeclaration(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals.Get("tests").GetValue(),
+		inter.Globals.Get("tests").GetValue(inter),
 	)
 
 	value, err = inter.Invoke("test")
@@ -3111,7 +3111,7 @@ func TestInterpretUseBeforeDeclaration(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("tests").GetValue(),
+		inter.Globals.Get("tests").GetValue(inter),
 	)
 }
 
@@ -3131,7 +3131,7 @@ func TestInterpretOptionalVariableDeclaration(t *testing.T) {
 				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3247,7 +3247,7 @@ func TestInterpretOptionalAssignment(t *testing.T) {
 				interpreter.NewUnmeteredIntValueFromInt64(2),
 			),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3263,7 +3263,7 @@ func TestInterpretNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3279,7 +3279,7 @@ func TestInterpretOptionalNestingNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3368,7 +3368,7 @@ func TestInterpretNilCoalescingNilIntToOptional(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3388,7 +3388,7 @@ func TestInterpretNilCoalescingNilIntToOptionals(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3407,7 +3407,7 @@ func TestInterpretNilCoalescingNilIntToOptionalNilLiteral(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3423,7 +3423,7 @@ func TestInterpretNilCoalescingRightSubtype(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3441,7 +3441,7 @@ func TestInterpretNilCoalescingNilInt(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3458,7 +3458,7 @@ func TestInterpretNilCoalescingNilLiteralInt(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3487,21 +3487,21 @@ func TestInterpretNilCoalescingShortCircuitLeftSuccess(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals.Get("test").GetValue(),
+		inter.Globals.Get("test").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3530,21 +3530,21 @@ func TestInterpretNilCoalescingShortCircuitLeftFailure(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("test").GetValue(),
+		inter.Globals.Get("test").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3561,7 +3561,7 @@ func TestInterpretNilCoalescingOptionalAnyStructNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3578,7 +3578,7 @@ func TestInterpretNilCoalescingOptionalAnyStructSome(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3598,7 +3598,7 @@ func TestInterpretNilCoalescingOptionalRightHandSide(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3618,7 +3618,7 @@ func TestInterpretNilCoalescingBothOptional(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3638,7 +3638,7 @@ func TestInterpretNilCoalescingBothOptionalLeftNil(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3654,7 +3654,7 @@ func TestInterpretNilsComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -3672,14 +3672,14 @@ func TestInterpretNonOptionalNilComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3696,7 +3696,7 @@ func TestInterpretOptionalNilComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3713,7 +3713,7 @@ func TestInterpretNestedOptionalNilComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3730,7 +3730,7 @@ func TestInterpretOptionalNilComparisonSwapped(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3747,7 +3747,7 @@ func TestInterpretNestedOptionalNilComparisonSwapped(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3765,7 +3765,7 @@ func TestInterpretNestedOptionalComparisonNils(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3783,7 +3783,7 @@ func TestInterpretNestedOptionalComparisonValues(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3801,7 +3801,7 @@ func TestInterpretNestedOptionalComparisonMixed(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -3818,7 +3818,7 @@ func TestInterpretOptionalSomeValueComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3835,7 +3835,7 @@ func TestInterpretOptionalNilValueComparison(t *testing.T) {
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -3858,7 +3858,7 @@ func TestInterpretOptionalMap(t *testing.T) {
 			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredStringValue("42"),
 			),
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -3875,7 +3875,7 @@ func TestInterpretOptionalMap(t *testing.T) {
 			t,
 			inter,
 			interpreter.Nil,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 }
@@ -3942,14 +3942,14 @@ func TestInterpretCompositeNilEquality(t *testing.T) {
 				t,
 				inter,
 				interpreter.FalseValue,
-				inter.Globals.Get("y").GetValue(),
+				inter.Globals.Get("y").GetValue(inter),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				interpreter.FalseValue,
-				inter.Globals.Get("z").GetValue(),
+				inter.Globals.Get("z").GetValue(inter),
 			)
 		})
 	}
@@ -4002,7 +4002,7 @@ func TestInterpretInterfaceConformanceNoRequirements(t *testing.T) {
 
 			assert.IsType(t,
 				&interpreter.CompositeValue{},
-				inter.Globals.Get("test").GetValue(),
+				inter.Globals.Get("test").GetValue(inter),
 			)
 		})
 	}
@@ -4082,7 +4082,7 @@ func TestInterpretInterfaceFieldUse(t *testing.T) {
 				t,
 				inter,
 				interpreter.NewUnmeteredIntValueFromInt64(1),
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -4150,7 +4150,7 @@ func TestInterpretInterfaceFunctionUse(t *testing.T) {
 				t,
 				inter,
 				interpreter.NewUnmeteredIntValueFromInt64(2),
-				inter.Globals.Get("val").GetValue(),
+				inter.Globals.Get("val").GetValue(inter),
 			)
 		})
 	}
@@ -4412,7 +4412,7 @@ func TestInterpretDictionary(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("b"), interpreter.NewUnmeteredIntValueFromInt64(2),
 	)
 
-	actualDict := inter.Globals.Get("x").GetValue()
+	actualDict := inter.Globals.Get("x").GetValue(inter)
 
 	AssertValuesEqual(
 		t,
@@ -4442,7 +4442,7 @@ func TestInterpretDictionaryInsertionOrder(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("b"), interpreter.NewUnmeteredIntValueFromInt64(2),
 	)
 
-	actualDict := inter.Globals.Get("x").GetValue()
+	actualDict := inter.Globals.Get("x").GetValue(inter)
 
 	AssertValuesEqual(
 		t,
@@ -4469,7 +4469,7 @@ func TestInterpretDictionaryIndexingString(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -4478,14 +4478,14 @@ func TestInterpretDictionaryIndexingString(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 }
 
@@ -4505,7 +4505,7 @@ func TestInterpretDictionaryIndexingBool(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -4514,7 +4514,7 @@ func TestInterpretDictionaryIndexingBool(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(2),
 		),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 }
 
@@ -4535,7 +4535,7 @@ func TestInterpretDictionaryIndexingInt(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("a"),
 		),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -4544,14 +4544,14 @@ func TestInterpretDictionaryIndexingInt(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("b"),
 		),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 }
 
@@ -4582,39 +4582,39 @@ func TestInterpretDictionaryIndexingType(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("a"),
 		),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("b"),
 		),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("c"),
 		),
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	// types need to match exactly, subtypes won't cut it
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredStringValue("f"),
 		),
-		inter.Globals.Get("f").GetValue(),
+		inter.Globals.Get("f").GetValue(inter),
 	)
 }
 
@@ -4639,7 +4639,7 @@ func TestInterpretDictionaryIndexingAssignmentExisting(t *testing.T) {
 		value,
 	)
 
-	actualValue := inter.Globals.Get("x").GetValue()
+	actualValue := inter.Globals.Get("x").GetValue(inter)
 	actualDict := actualValue.(*interpreter.DictionaryValue)
 
 	newValue := actualDict.GetKey(
@@ -4698,7 +4698,7 @@ func TestInterpretDictionaryIndexingAssignmentNew(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("abc"), interpreter.NewUnmeteredIntValueFromInt64(23),
 	)
 
-	actualDict := inter.Globals.Get("x").GetValue().(*interpreter.DictionaryValue)
+	actualDict := inter.Globals.Get("x").GetValue(inter).(*interpreter.DictionaryValue)
 
 	AssertValuesEqual(
 		t,
@@ -4764,7 +4764,7 @@ func TestInterpretDictionaryIndexingAssignmentNil(t *testing.T) {
 		interpreter.NewUnmeteredStringValue("abc"), interpreter.NewUnmeteredIntValueFromInt64(23),
 	)
 
-	actualDict := inter.Globals.Get("x").GetValue().(*interpreter.DictionaryValue)
+	actualDict := inter.Globals.Get("x").GetValue(inter).(*interpreter.DictionaryValue)
 
 	RequireValuesEqual(
 		t,
@@ -4997,7 +4997,7 @@ func TestInterpretOptionalAnyStruct(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -5016,7 +5016,7 @@ func TestInterpretOptionalAnyStructFailableCasting(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -5025,7 +5025,7 @@ func TestInterpretOptionalAnyStructFailableCasting(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -5045,14 +5045,14 @@ func TestInterpretOptionalAnyStructFailableCastingInt(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(23),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(23),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -5061,7 +5061,7 @@ func TestInterpretOptionalAnyStructFailableCastingInt(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(23),
 		),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -5079,14 +5079,14 @@ func TestInterpretOptionalAnyStructFailableCastingNil(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -5095,7 +5095,7 @@ func TestInterpretOptionalAnyStructFailableCastingNil(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 
@@ -5344,7 +5344,7 @@ func TestInterpretArrayLength(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -5361,13 +5361,13 @@ func TestInterpretStringLength(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(4),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(4),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -5461,7 +5461,7 @@ func TestInterpretArrayAppend(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.NoError(t, err)
 
-	actualArray := inter.Globals.Get("xs").GetValue()
+	actualArray := inter.Globals.Get("xs").GetValue(inter)
 
 	arrayValue := actualArray.(*interpreter.ArrayValue)
 	AssertValueSlicesEqual(
@@ -5706,7 +5706,7 @@ func TestInterpretArrayInsert(t *testing.T) {
 			_, err := inter.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(int64(testCase.index)))
 			require.NoError(t, err)
 
-			actualArray := inter.Globals.Get("x").GetValue()
+			actualArray := inter.Globals.Get("x").GetValue(inter)
 
 			require.IsType(t, &interpreter.ArrayValue{}, actualArray)
 
@@ -5769,7 +5769,7 @@ func TestInterpretArrayRemove(t *testing.T) {
       let y = x.remove(at: 1)
     `)
 
-	value := inter.Globals.Get("x").GetValue()
+	value := inter.Globals.Get("x").GetValue(inter)
 
 	arrayValue := value.(*interpreter.ArrayValue)
 	AssertValueSlicesEqual(
@@ -5786,7 +5786,7 @@ func TestInterpretArrayRemove(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(2),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -5839,7 +5839,7 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
       let y = x.removeFirst()
     `)
 
-	value := inter.Globals.Get("x").GetValue()
+	value := inter.Globals.Get("x").GetValue(inter)
 
 	arrayValue := value.(*interpreter.ArrayValue)
 	AssertValueSlicesEqual(
@@ -5856,7 +5856,7 @@ func TestInterpretArrayRemoveFirst(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(1),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -5899,7 +5899,7 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
           let y = x.removeLast()
     `)
 
-	value := inter.Globals.Get("x").GetValue()
+	value := inter.Globals.Get("x").GetValue(inter)
 
 	arrayValue := value.(*interpreter.ArrayValue)
 
@@ -5917,7 +5917,7 @@ func TestInterpretArrayRemoveLast(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(3),
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 }
 
@@ -6226,7 +6226,7 @@ func TestInterpretDictionaryRemove(t *testing.T) {
       let removed = xs.remove(key: "abc")
     `)
 
-	actualValue := inter.Globals.Get("xs").GetValue()
+	actualValue := inter.Globals.Get("xs").GetValue(inter)
 
 	require.IsType(t, actualValue, &interpreter.DictionaryValue{})
 	actualDict := actualValue.(*interpreter.DictionaryValue)
@@ -6247,7 +6247,7 @@ func TestInterpretDictionaryRemove(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("removed").GetValue(),
+		inter.Globals.Get("removed").GetValue(inter),
 	)
 }
 
@@ -6260,7 +6260,7 @@ func TestInterpretDictionaryInsert(t *testing.T) {
       let inserted = xs.insert(key: "abc", 3)
     `)
 
-	actualValue := inter.Globals.Get("xs").GetValue()
+	actualValue := inter.Globals.Get("xs").GetValue(inter)
 
 	require.IsType(t, actualValue, &interpreter.DictionaryValue{})
 	actualDict := actualValue.(*interpreter.DictionaryValue)
@@ -6283,7 +6283,7 @@ func TestInterpretDictionaryInsert(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("inserted").GetValue(),
+		inter.Globals.Get("inserted").GetValue(inter),
 	)
 }
 
@@ -6484,7 +6484,7 @@ func TestInterpretDictionaryKeyTypes(t *testing.T) {
 				interpreter.NewUnmeteredSomeValueNonCopying(
 					interpreter.NewUnmeteredStringValue("test"),
 				),
-				inter.Globals.Get("v").GetValue(),
+				inter.Globals.Get("v").GetValue(inter),
 			)
 		})
 	}
@@ -6516,7 +6516,7 @@ func TestInterpretPathToString(t *testing.T) {
 
 			assert.Equal(t,
 				interpreter.NewUnmeteredStringValue(val),
-				inter.Globals.Get("y").GetValue(),
+				inter.Globals.Get("y").GetValue(inter),
 			)
 		})
 	}
@@ -8022,7 +8022,7 @@ func TestInterpretCastingIntLiteralToInt8(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredInt8Value(42),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -8038,7 +8038,7 @@ func TestInterpretCastingIntLiteralToAnyStruct(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -8054,7 +8054,7 @@ func TestInterpretCastingIntLiteralToOptional(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredSomeValueNonCopying(interpreter.NewUnmeteredIntValueFromInt64(42)),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -8107,7 +8107,7 @@ func TestInterpretOptionalChainingFieldRead(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x1").GetValue(),
+		inter.Globals.Get("x1").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -8116,7 +8116,7 @@ func TestInterpretOptionalChainingFieldRead(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals.Get("x2").GetValue(),
+		inter.Globals.Get("x2").GetValue(inter),
 	)
 }
 
@@ -8144,17 +8144,17 @@ func TestInterpretOptionalChainingFunctionRead(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x1").GetValue(),
+		inter.Globals.Get("x1").GetValue(inter),
 	)
 
 	require.IsType(t,
 		&interpreter.SomeValue{},
-		inter.Globals.Get("x2").GetValue(),
+		inter.Globals.Get("x2").GetValue(inter),
 	)
 
 	assert.IsType(t,
 		interpreter.BoundFunctionValue{},
-		inter.Globals.Get("x2").GetValue().(*interpreter.SomeValue).
+		inter.Globals.Get("x2").GetValue(inter).(*interpreter.SomeValue).
 			InnerValue(inter, interpreter.EmptyLocationRange),
 	)
 }
@@ -8183,7 +8183,7 @@ func TestInterpretOptionalChainingFunctionCall(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("x1").GetValue(),
+		inter.Globals.Get("x1").GetValue(inter),
 	)
 
 	AssertValuesEqual(
@@ -8192,7 +8192,7 @@ func TestInterpretOptionalChainingFunctionCall(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(42),
 		),
-		inter.Globals.Get("x2").GetValue(),
+		inter.Globals.Get("x2").GetValue(inter),
 	)
 }
 
@@ -8238,7 +8238,7 @@ func TestInterpretOptionalChainingFieldReadAndNilCoalescing(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -8282,7 +8282,7 @@ func TestInterpretOptionalChainingFunctionCallAndNilCoalescing(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredIntValueFromInt64(42),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -8326,14 +8326,14 @@ func TestInterpretOptionalChainingArgumentEvaluation(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(nil, 2),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewIntValueFromInt64(nil, 1),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 }
 
@@ -8368,8 +8368,8 @@ func TestInterpretCompositeDeclarationNestedTypeScopingOuterInner(t *testing.T) 
 	)
 	require.NoError(t, err)
 
-	x1 := inter.Globals.Get("x1").GetValue()
-	x2 := inter.Globals.Get("x2").GetValue()
+	x1 := inter.Globals.Get("x1").GetValue(inter)
+	x2 := inter.Globals.Get("x2").GetValue(inter)
 
 	require.IsType(t,
 		&interpreter.CompositeValue{},
@@ -8413,7 +8413,7 @@ func TestInterpretCompositeDeclarationNestedConstructor(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	x := inter.Globals.Get("x").GetValue()
+	x := inter.Globals.Get("x").GetValue(inter)
 
 	require.IsType(t,
 		&interpreter.CompositeValue{},
@@ -8560,14 +8560,14 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 			t,
 			inter,
 			addressValue,
-			inter.Globals.Get("address1").GetValue(),
+			inter.Globals.Get("address1").GetValue(inter),
 		)
 
 		AssertValuesEqual(
 			t,
 			inter,
 			addressValue,
-			inter.Globals.Get("address2").GetValue(),
+			inter.Globals.Get("address2").GetValue(inter),
 		)
 	})
 
@@ -8710,7 +8710,7 @@ func TestInterpretContractUseInNestedDeclaration(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	i := inter.Globals.Get("C").GetValue().(interpreter.MemberAccessibleValue).
+	i := inter.Globals.Get("C").GetValue(inter).(interpreter.MemberAccessibleValue).
 		GetMember(inter, interpreter.EmptyLocationRange, "i")
 
 	require.IsType(t,
@@ -8825,21 +8825,21 @@ func TestInterpretFix64(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredUFix64Value(78_900_123_010),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredUFix64Value(123_405_600_000),
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.NewUnmeteredFix64Value(-1_234_500_678_900),
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 }
 
@@ -8857,7 +8857,7 @@ func TestInterpretFix64Mul(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredFix64Value(-121000000),
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 }
 
@@ -9018,7 +9018,7 @@ func TestInterpretOptionalChainingOptionalFieldRead(t *testing.T) {
 		interpreter.NewUnmeteredSomeValueNonCopying(
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		),
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 }
 
@@ -9267,14 +9267,14 @@ func TestInterpretForce(t *testing.T) {
 			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredIntValueFromInt64(1),
 			),
-			inter.Globals.Get("x").GetValue(),
+			inter.Globals.Get("x").GetValue(inter),
 		)
 
 		AssertValuesEqual(
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals.Get("y").GetValue(),
+			inter.Globals.Get("y").GetValue(inter),
 		)
 	})
 
@@ -9309,7 +9309,7 @@ func TestInterpretForce(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredIntValueFromInt64(1),
-			inter.Globals.Get("y").GetValue(),
+			inter.Globals.Get("y").GetValue(inter),
 		)
 	})
 }
@@ -9489,7 +9489,7 @@ func TestInterpretCountDigits256(t *testing.T) {
 
 			assert.Equal(t,
 				bigInt,
-				inter.Globals.Get("number").GetValue().(interpreter.BigNumberValue).ToBigInt(nil),
+				inter.Globals.Get("number").GetValue(inter).(interpreter.BigNumberValue).ToBigInt(nil),
 			)
 
 			expected := interpreter.NewUnmeteredUInt8Value(uint8(test.Count))
@@ -9500,7 +9500,7 @@ func TestInterpretCountDigits256(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals.Get(variableName).GetValue(),
+					inter.Globals.Get(variableName).GetValue(inter),
 				)
 			}
 		})
@@ -9535,7 +9535,7 @@ func TestInterpretFailableCastingCompositeTypeConfusion(t *testing.T) {
 		t,
 		inter,
 		interpreter.Nil,
-		inter.Globals.Get("s").GetValue(),
+		inter.Globals.Get("s").GetValue(inter),
 	)
 }
 
@@ -9829,7 +9829,7 @@ func TestInterpretMissingMember(t *testing.T) {
 	)
 
 	// Remove field `y`
-	compositeValue := inter.Globals.Get("x").GetValue().(*interpreter.CompositeValue)
+	compositeValue := inter.Globals.Get("x").GetValue(inter).(*interpreter.CompositeValue)
 	compositeValue.RemoveField(inter, interpreter.EmptyLocationRange, "y")
 
 	_, err := inter.Invoke("test")
@@ -9880,7 +9880,7 @@ func TestInterpretHostFunctionStaticType(t *testing.T) {
             let y = x.toString
         `)
 
-		value := inter.Globals.Get("y").GetValue()
+		value := inter.Globals.Get("y").GetValue(inter)
 		assert.Equal(
 			t,
 			interpreter.ConvertSemaToStaticType(nil, sema.ToStringFunctionType),
@@ -9896,7 +9896,7 @@ func TestInterpretHostFunctionStaticType(t *testing.T) {
             let y = x<Int8>()
         `)
 
-		value := inter.Globals.Get("x").GetValue()
+		value := inter.Globals.Get("x").GetValue(inter)
 		assert.Equal(
 			t,
 			interpreter.ConvertSemaToStaticType(
@@ -9909,7 +9909,7 @@ func TestInterpretHostFunctionStaticType(t *testing.T) {
 			value.StaticType(inter),
 		)
 
-		value = inter.Globals.Get("y").GetValue()
+		value = inter.Globals.Get("y").GetValue(inter)
 		assert.Equal(
 			t,
 			interpreter.PrimitiveStaticTypeMetaType,
@@ -9935,14 +9935,14 @@ func TestInterpretHostFunctionStaticType(t *testing.T) {
 		// Both `x` and `y` are two functions that returns a string.
 		// Hence, their types are equal. i.e: Receivers shouldn't matter.
 
-		xValue := inter.Globals.Get("x").GetValue()
+		xValue := inter.Globals.Get("x").GetValue(inter)
 		assert.Equal(
 			t,
 			interpreter.ConvertSemaToStaticType(nil, sema.ToStringFunctionType),
 			xValue.StaticType(inter),
 		)
 
-		yValue := inter.Globals.Get("y").GetValue()
+		yValue := inter.Globals.Get("y").GetValue(inter)
 		assert.Equal(
 			t,
 			interpreter.ConvertSemaToStaticType(nil, sema.ToStringFunctionType),
@@ -11542,7 +11542,7 @@ func TestInterpretCastingBoxing(t *testing.T) {
 					Type: interpreter.PrimitiveStaticTypeInt,
 				},
 			),
-			variable.GetValue(),
+			variable.GetValue(inter),
 		)
 	})
 
@@ -11564,7 +11564,7 @@ func TestInterpretCastingBoxing(t *testing.T) {
 					Type: interpreter.PrimitiveStaticTypeInt,
 				},
 			),
-			variable.GetValue(),
+			variable.GetValue(inter),
 		)
 	})
 
@@ -11586,7 +11586,7 @@ func TestInterpretCastingBoxing(t *testing.T) {
 					Type: interpreter.PrimitiveStaticTypeInt,
 				},
 			),
-			variable.GetValue(),
+			variable.GetValue(inter),
 		)
 	})
 }
@@ -11631,7 +11631,7 @@ func TestInterpretNilCoalesceReference(t *testing.T) {
 			BorrowedType:  sema.IntType,
 			Authorization: interpreter.UnauthorizedAccess,
 		},
-		variable.GetValue(),
+		variable.GetValue(inter),
 	)
 }
 

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -49,7 +49,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -65,7 +65,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -81,7 +81,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -97,7 +97,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -113,7 +113,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -159,7 +159,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 
@@ -219,7 +219,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(),
+			inter.Globals.Get("result").GetValue(inter),
 		)
 	})
 }
@@ -241,7 +241,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("[Int]"),
-			inter.Globals.Get("identifier").GetValue(),
+			inter.Globals.Get("identifier").GetValue(inter),
 		)
 	})
 
@@ -260,7 +260,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("S.test.S"),
-			inter.Globals.Get("identifier").GetValue(),
+			inter.Globals.Get("identifier").GetValue(inter),
 		)
 	})
 
@@ -312,7 +312,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue(""),
-			inter.Globals.Get("identifier").GetValue(),
+			inter.Globals.Get("identifier").GetValue(inter),
 		)
 	})
 
@@ -468,7 +468,7 @@ func TestInterpretIsInstance(t *testing.T) {
 				t,
 				inter,
 				interpreter.BoolValue(testCase.result),
-				inter.Globals.Get("result").GetValue(),
+				inter.Globals.Get("result").GetValue(inter),
 			)
 		})
 	}
@@ -610,7 +610,7 @@ func TestInterpretMetaTypeIsSubtype(t *testing.T) {
 
 			assert.Equal(t,
 				interpreter.BoolValue(testCase.result),
-				inter.Globals.Get("result").GetValue(),
+				inter.Globals.Get("result").GetValue(inter),
 			)
 		})
 	}

--- a/runtime/tests/interpreter/path_test.go
+++ b/runtime/tests/interpreter/path_test.go
@@ -54,7 +54,7 @@ func TestInterpretPath(t *testing.T) {
 					Domain:     domain,
 					Identifier: "random",
 				},
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}
@@ -91,7 +91,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 					Domain:     domain,
 					Identifier: "foo",
 				},
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 
@@ -112,7 +112,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 
 			assert.Equal(t,
 				interpreter.Nil,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 
@@ -133,7 +133,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 
 			assert.Equal(t,
 				interpreter.Nil,
-				inter.Globals.Get("x").GetValue(),
+				inter.Globals.Get("x").GetValue(inter),
 			)
 		})
 	}

--- a/runtime/tests/interpreter/range_value_test.go
+++ b/runtime/tests/interpreter/range_value_test.go
@@ -444,7 +444,7 @@ func TestInclusiveRange(t *testing.T) {
 				t,
 				inter,
 				expectedRangeValue,
-				inter.Globals.Get("r").GetValue(),
+				inter.Globals.Get("r").GetValue(inter),
 			)
 
 			// Check that contains returns correct information.
@@ -460,7 +460,7 @@ func TestInclusiveRange(t *testing.T) {
 					t,
 					inter,
 					expectedValue,
-					inter.Globals.Get(fmt.Sprintf("c_%d", i)).GetValue(),
+					inter.Globals.Get(fmt.Sprintf("c_%d", i)).GetValue(inter),
 				)
 			}
 		})

--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -449,7 +449,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &r as &R?
         `)
 
-		value := inter.Globals.Get("ref").GetValue()
+		value := inter.Globals.Get("ref").GetValue(inter)
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
@@ -468,7 +468,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &s as &S?
         `)
 
-		value := inter.Globals.Get("ref").GetValue()
+		value := inter.Globals.Get("ref").GetValue(inter)
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
@@ -485,7 +485,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &i as &Int?
         `)
 
-		value := inter.Globals.Get("ref").GetValue()
+		value := inter.Globals.Get("ref").GetValue(inter)
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
@@ -502,7 +502,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &i as &Int?
         `)
 
-		value := inter.Globals.Get("ref").GetValue()
+		value := inter.Globals.Get("ref").GetValue(inter)
 		require.IsType(t, &interpreter.SomeValue{}, value)
 
 		innerValue := value.(*interpreter.SomeValue).
@@ -519,7 +519,7 @@ func TestInterpretReferenceExpressionOfOptional(t *testing.T) {
           let ref = &i as &Int?
         `)
 
-		value := inter.Globals.Get("ref").GetValue()
+		value := inter.Globals.Get("ref").GetValue(inter)
 		require.IsType(t, interpreter.Nil, value)
 	})
 }
@@ -2370,7 +2370,7 @@ func TestInterpretDereference(t *testing.T) {
 					t,
 					inter,
 					expectedOriginalValue,
-					inter.Globals.Get("originalArray").GetValue(),
+					inter.Globals.Get("originalArray").GetValue(inter),
 				)
 			})
 		}
@@ -2765,7 +2765,7 @@ func TestInterpretDereference(t *testing.T) {
 					t,
 					inter,
 					expectedOriginalValue,
-					inter.Globals.Get("originalArray").GetValue(),
+					inter.Globals.Get("originalArray").GetValue(inter),
 				)
 			})
 		}

--- a/runtime/tests/interpreter/runtimetype_test.go
+++ b/runtime/tests/interpreter/runtimetype_test.go
@@ -50,7 +50,7 @@ func TestInterpretOptionalType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeString,
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -59,7 +59,7 @@ func TestInterpretOptionalType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -68,7 +68,7 @@ func TestInterpretOptionalType(t *testing.T) {
 				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -79,12 +79,12 @@ func TestInterpretOptionalType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 }
 
@@ -109,7 +109,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeString,
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -118,7 +118,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -127,7 +127,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -138,11 +138,11 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 }
 
@@ -168,7 +168,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(10),
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -178,7 +178,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(5),
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -188,7 +188,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(400),
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -201,12 +201,12 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(6),
 			},
 		},
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 }
 
@@ -234,7 +234,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 				ValueType: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -244,7 +244,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 				ValueType: interpreter.PrimitiveStaticTypeString,
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -254,7 +254,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 				KeyType:   interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -267,17 +267,17 @@ func TestInterpretDictionaryType(t *testing.T) {
 				KeyType: interpreter.PrimitiveStaticTypeBool,
 			},
 		},
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("f").GetValue(),
+		inter.Globals.Get("f").GetValue(inter),
 	)
 }
 
@@ -307,50 +307,50 @@ func TestInterpretCompositeType(t *testing.T) {
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "R"),
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "S"),
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, utils.TestLocation, "F"),
 		},
-		inter.Globals.Get("f").GetValue(),
+		inter.Globals.Get("f").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, nil, "PublicKey"),
 		},
-		inter.Globals.Get("g").GetValue(),
+		inter.Globals.Get("g").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, nil, "HashAlgorithm"),
 		},
-		inter.Globals.Get("h").GetValue(),
+		inter.Globals.Get("h").GetValue(inter),
 	)
 }
 
@@ -379,7 +379,7 @@ func TestInterpretFunctionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -394,7 +394,7 @@ func TestInterpretFunctionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -405,12 +405,12 @@ func TestInterpretFunctionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 }
 
@@ -442,7 +442,7 @@ func TestInterpretReferenceType(t *testing.T) {
 				),
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -452,7 +452,7 @@ func TestInterpretReferenceType(t *testing.T) {
 				Authorization:  interpreter.UnauthorizedAccess,
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -467,17 +467,17 @@ func TestInterpretReferenceType(t *testing.T) {
 				),
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 }
 
@@ -517,12 +517,12 @@ func TestInterpretIntersectionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -533,12 +533,12 @@ func TestInterpretIntersectionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("j").GetValue(),
+		inter.Globals.Get("j").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -550,22 +550,22 @@ func TestInterpretIntersectionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("k").GetValue(),
+		inter.Globals.Get("k").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("f").GetValue(),
+		inter.Globals.Get("f").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("h").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("h").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("b").GetValue(),
-		inter.Globals.Get("i").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
+		inter.Globals.Get("i").GetValue(inter),
 	)
 }
 
@@ -593,7 +593,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -605,7 +605,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
@@ -617,17 +617,17 @@ func TestInterpretCapabilityType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 }
 
@@ -652,26 +652,26 @@ func TestInterpretInclusiveRangeType(t *testing.T) {
 				ElementType: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("a").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("b").GetValue(),
+		inter.Globals.Get("b").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("c").GetValue(),
+		inter.Globals.Get("c").GetValue(inter),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("d").GetValue(),
+		inter.Globals.Get("d").GetValue(inter),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(),
-		inter.Globals.Get("e").GetValue(),
+		inter.Globals.Get("a").GetValue(inter),
+		inter.Globals.Get("e").GetValue(inter),
 	)
 }

--- a/runtime/tests/interpreter/string_test.go
+++ b/runtime/tests/interpreter/string_test.go
@@ -445,21 +445,21 @@ func TestInterpretCompareCharacters(t *testing.T) {
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("x").GetValue(),
+		inter.Globals.Get("x").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.TrueValue,
-		inter.Globals.Get("y").GetValue(),
+		inter.Globals.Get("y").GetValue(inter),
 	)
 
 	AssertValuesEqual(
 		t,
 		inter,
 		interpreter.FalseValue,
-		inter.Globals.Get("z").GetValue(),
+		inter.Globals.Get("z").GetValue(inter),
 	)
 }
 

--- a/runtime/tests/interpreter/transactions_test.go
+++ b/runtime/tests/interpreter/transactions_test.go
@@ -303,7 +303,7 @@ func TestInterpretTransactions(t *testing.T) {
 		err := inter.InvokeTransaction(0, arguments...)
 		require.NoError(t, err)
 
-		values := inter.Globals.Get("values").GetValue()
+		values := inter.Globals.Get("values").GetValue(inter)
 
 		require.IsType(t, &interpreter.ArrayValue{}, values)
 

--- a/tools/staged-contracts-report-printer/README.md
+++ b/tools/staged-contracts-report-printer/README.md
@@ -1,0 +1,11 @@
+# Readme
+
+A tool that takes in a JSON report produced from staged contract migration, and outputs a more
+human-readable report in Markdown format.
+
+```sh
+go run . --report /path/to/staged-contracts-migrator_report.json
+```
+
+This will produce a Markdown format report with the same name, but with the makdown extension.
+e.g: `/path/to/staged-contracts-migrator_report.md`

--- a/tools/staged-contracts-report-printer/main.go
+++ b/tools/staged-contracts-report-printer/main.go
@@ -1,0 +1,102 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/kodova/html-to-markdown/escape"
+)
+
+var reportPathFlag = flag.String("report", "", "staged contract report JSON file")
+
+func main() {
+	flag.Parse()
+
+	reportPath := *reportPathFlag
+
+	content, err := os.ReadFile(reportPath)
+	if err != nil {
+		panic(err)
+	}
+
+	var reportEntries []contractUpdateStatus
+
+	err = json.Unmarshal(content, &reportEntries)
+	if err != nil {
+		panic(err)
+	}
+
+	now := time.Now()
+
+	markdownBuilder := strings.Builder{}
+	markdownBuilder.WriteString("## Cadence 1.0 staged contracts migration results\n")
+	markdownBuilder.WriteString(fmt.Sprintf("Date: %s\n", now.Format("02 January, 2006")))
+	markdownBuilder.WriteString("|Address | Name | Status |\n")
+	markdownBuilder.WriteString("| --- | --- | --- | \n")
+
+	for _, entry := range reportEntries {
+		status := entry.Error
+		if status == "" {
+			status = "&#9989;"
+		} else {
+			status = escape.Markdown(status)
+			status = strings.ReplaceAll(status, "|", "\\|")
+			status = strings.ReplaceAll(status, "\r\n", "<br>")
+			status = strings.ReplaceAll(status, "\n", "<br>")
+			status = fmt.Sprintf("&#10060;<details><br><summary>Error:</summary><pre>%s</pre></details>", status)
+		}
+		markdownBuilder.WriteString(
+			fmt.Sprintf(
+				"| %s | %s | %s | \n",
+				entry.AccountAddress,
+				entry.ContractName,
+				status,
+			),
+		)
+	}
+
+	ext := path.Ext(reportPath)
+	mdOutput := fmt.Sprintf("%s.md", reportPath[0:len(reportPath)-len(ext)])
+
+	file, err := os.Create(mdOutput)
+	if err != nil {
+		panic(err)
+	}
+
+	mdContent := markdownBuilder.String()
+	_, err = file.Write([]byte(mdContent))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Markdown content is written to: ", mdOutput)
+}
+
+type contractUpdateStatus struct {
+	AccountAddress string `json:"address"`
+	ContractName   string `json:"name"`
+	Error          string `json:"error"`
+}

--- a/tools/storage-explorer/go.sum
+++ b/tools/storage-explorer/go.sum
@@ -958,6 +958,7 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
+github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8kdmcsrnKqMg=
 github.com/SaveTheRbtz/mph v0.1.1-0.20240117162131-4166ec7869bc h1:DCHzPQOcU/7gwDTWbFQZc5qHMPS1g0xTO56k8NXsv9M=
 github.com/SaveTheRbtz/mph v0.1.1-0.20240117162131-4166ec7869bc/go.mod h1:LJM5a3zcIJ/8TmZwlUczvROEJT8ntOdhdG9jjcR1B0I=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
@@ -983,6 +984,7 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
@@ -1620,6 +1622,7 @@ github.com/klauspost/cpuid/v2 v2.2.6 h1:ndNyv040zDGIDh8thGkXYjnFtiN02M1PVVF+JE/4
 github.com/klauspost/cpuid/v2 v2.2.6/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6/go.mod h1:+ZoRqAPRLkC4NPOvfYeR5KNOrY6TD+/sAC3HXPZgDYg=
 github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
+github.com/kodova/html-to-markdown v1.0.1/go.mod h1:NhDrT7QdSrdpezFg/0EQx9zeobCHR5oAguzrKrC6mVU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -2207,6 +2210,7 @@ golang.org/x/mod v0.11.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -2226,6 +2230,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191109021931-daa7c04131f5/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v1.0.0-preview.19"
+const Version = "v1.0.0-preview.20"


### PR DESCRIPTION
## Description

Merge `master` into `feature/atree-register-inlining-v1.0`

<details>
<summary>Conflict resolution:</summary>

```diff
commit 187eda83114cbe733e570af4e95c3bcce22560b7
Merge: 8bb9cdb06 4ada9cb43
Author: Bastian Müller <bastian@turbolent.com>
Date:   Wed Apr 17 16:08:10 2024 -0700

    Merge branch 'master' into bastian/update-atree-register-inlining-v1.0

diff --git a/go.mod b/go.mod
remerge CONFLICT (content): Merge conflict in go.mod
index 108595e14..9198e1a42 100644
--- a/go.mod
+++ b/go.mod
@@ -13,11 +13,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/leanovate/gopter v0.2.9
 	github.com/logrusorgru/aurora/v4 v4.0.0
-<<<<<<< 8bb9cdb06 (Merge pull request #3256 from onflow/bump-atree-version-for-atree-inlining-v1.0)
 	github.com/onflow/atree v0.6.1-0.20240417191405-e11f55fa33a3
-=======
-	github.com/onflow/atree v0.6.1-0.20240416233652-f4568c0c03df
->>>>>>> 4ada9cb43 (Merge pull request #3254 from onflow/fxamacker/bump-atree-version-for-stable-cadence)
 	github.com/rivo/uniseg v0.4.4
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/stretchr/testify v1.8.4
diff --git a/go.sum b/go.sum
remerge CONFLICT (content): Merge conflict in go.sum
index 3d6c68e0e..9e0381a90 100644
--- a/go.sum
+++ b/go.sum
@@ -72,13 +72,8 @@ github.com/mattn/go-tty v0.0.3/go.mod h1:ihxohKRERHTVzN+aSVRwACLCeqIoZAWpoICkkvr
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
-<<<<<<< 8bb9cdb06 (Merge pull request #3256 from onflow/bump-atree-version-for-atree-inlining-v1.0)
 github.com/onflow/atree v0.6.1-0.20240417191405-e11f55fa33a3 h1:K8LKxRn1rRdDXLCvYlDNdlQyB28b+fx2doYiIaNGnQU=
 github.com/onflow/atree v0.6.1-0.20240417191405-e11f55fa33a3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
-=======
-github.com/onflow/atree v0.6.1-0.20240416233652-f4568c0c03df h1:9dmE37nSKCV1obdPFtUgjKFH2yUHmfSkULX5h35l8yo=
-github.com/onflow/atree v0.6.1-0.20240416233652-f4568c0c03df/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
->>>>>>> 4ada9cb43 (Merge pull request #3254 from onflow/fxamacker/bump-atree-version-for-stable-cadence)
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
diff --git a/runtime/interpreter/sharedstate.go b/runtime/interpreter/sharedstate.go
remerge CONFLICT (content): Merge conflict in runtime/interpreter/sharedstate.go
index e3cc63338..61a071f9c 100644
--- a/runtime/interpreter/sharedstate.go
+++ b/runtime/interpreter/sharedstate.go
@@ -59,13 +59,8 @@ func NewSharedState(config *Config) *SharedState {
 		},
 		inStorageIteration:             false,
 		storageMutatedDuringIteration:  false,
-<<<<<<< 8bb9cdb06 (Merge pull request #3256 from onflow/bump-atree-version-for-atree-inlining-v1.0)
 		referencedResourceKindedValues: ReferencedResourceKindedValues{},
-		resourceVariables:              map[ResourceKindedValue]*Variable{},
-=======
-		referencedResourceKindedValues: map[atree.StorageID]map[*EphemeralReferenceValue]struct{}{},
 		resourceVariables:              map[ResourceKindedValue]Variable{},
->>>>>>> 4ada9cb43 (Merge pull request #3254 from onflow/fxamacker/bump-atree-version-for-stable-cadence)
 		CapabilityControllerIterations: map[AddressPath]int{},
 		containerValueIteration:        map[atree.ValueID]struct{}{},
 		destroyedResources:             map[atree.ValueID]struct{}{},
diff --git a/runtime/storage.go b/runtime/storage.go
index f24f6bf76..4c20eda49 100644
--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -356,7 +356,7 @@ func (s *Storage) CheckHealth() error {
 }
 
 type UnreferencedRootSlabsError struct {
-	UnreferencedRootSlabIDs []atree.StorageID
+	UnreferencedRootSlabIDs []atree.SlabID
 }
 
 var _ errors.InternalError = UnreferencedRootSlabsError{}
```

</details>

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
