### PR TITLE
Improve supported entitlements and entitlements inferrence in migration

### DIFF
--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -123,7 +123,7 @@ func ConvertToEntitledType(
 
 				default:
 					supportedEntitlements := entitlementSupportingType.SupportedEntitlements()
-					newAccess := sema.NewAccessFromEntitlementSet(supportedEntitlements, sema.Conjunction)
+					newAccess := supportedEntitlements.Access()
 					auth = interpreter.ConvertSemaAccessToStaticAuthorization(inter, newAccess)
 					returnNew = true
 				}

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -474,7 +474,7 @@ func TestConvertToEntitledType(t *testing.T) {
 		},
 		{
 			Input:  sema.NewReferenceType(nil, sema.UnauthorizedAccess, compositeResourceWithEOrF),
-			Output: sema.NewReferenceType(nil, eAndFAccess, compositeResourceWithEOrF),
+			Output: sema.NewReferenceType(nil, eOrFAccess, compositeResourceWithEOrF),
 			Name:   "composite E or F",
 		},
 		{

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -1562,7 +1562,7 @@ func (interpreter *Interpreter) VisitAttachExpression(attachExpression *ast.Atta
 	// within the constructor, the attachment's base and self references should be fully entitled,
 	// as the constructor of the attachment is only callable by the owner of the base
 	baseType := interpreter.MustSemaTypeOfValue(base).(sema.EntitlementSupportingType)
-	baseAccess := sema.NewAccessFromEntitlementSet(baseType.SupportedEntitlements(), sema.Conjunction)
+	baseAccess := baseType.SupportedEntitlements().Access()
 	auth := ConvertSemaAccessToStaticAuthorization(interpreter, baseAccess)
 
 	attachmentType := interpreter.Program.Elaboration.AttachTypes(attachExpression)

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -18370,10 +18370,10 @@ func (v *CompositeValue) GetTypeKey(
 	locationRange LocationRange,
 	ty sema.Type,
 ) Value {
-	var access sema.Access = sema.UnauthorizedAccess
+	access := sema.UnauthorizedAccess
 	attachmentTyp, isAttachmentType := ty.(*sema.CompositeType)
 	if isAttachmentType {
-		access = sema.NewAccessFromEntitlementSet(attachmentTyp.SupportedEntitlements(), sema.Conjunction)
+		access = attachmentTyp.SupportedEntitlements().Access()
 	}
 	return v.getTypeKey(interpreter, locationRange, ty, access)
 }

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -74,7 +74,7 @@ func NewEntitlementSetAccess(
 	}
 }
 
-func NewAccessFromEntitlementSet(
+func NewAccessFromEntitlementOrderedSet(
 	set *EntitlementOrderedSet,
 	setKind EntitlementSetKind,
 ) Access {

--- a/runtime/sema/check_function.go
+++ b/runtime/sema/check_function.go
@@ -423,7 +423,7 @@ func (checker *Checker) visitWithPostConditions(postConditions *ast.Conditions, 
 			// here the `result` value in the `post` block will have type `auth(E, X, Y) &R`
 			if entitlementSupportingType, ok := innerType.(EntitlementSupportingType); ok {
 				supportedEntitlements := entitlementSupportingType.SupportedEntitlements()
-				auth = NewAccessFromEntitlementSet(supportedEntitlements, Conjunction)
+				auth = supportedEntitlements.Access()
 			}
 
 			resultType = &ReferenceType{

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -521,12 +521,9 @@ func allSupportedEntitlements(typ Type, isInnerType bool) Access {
 			return allSupportedEntitlements(typ.ReturnTypeAnnotation.Type, true)
 		}
 	case EntitlementSupportingType:
-		supportedEntitlements := typ.SupportedEntitlements()
-		if supportedEntitlements != nil && supportedEntitlements.Len() > 0 {
-			return EntitlementSetAccess{
-				SetKind:      Conjunction,
-				Entitlements: supportedEntitlements,
-			}
+		access := typ.SupportedEntitlements().Access()
+		if access != UnauthorizedAccess {
+			return access
 		}
 	}
 

--- a/runtime/sema/entitlementset.go
+++ b/runtime/sema/entitlementset.go
@@ -1,0 +1,191 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/onflow/cadence/runtime/common/orderedmap"
+)
+
+func disjunctionKey(disjunction *EntitlementOrderedSet) string {
+	// Gather type IDs, sorted
+	var typeIDs []string
+	disjunction.Foreach(func(entitlementType *EntitlementType, _ struct{}) {
+		typeIDs = append(typeIDs, string(entitlementType.ID()))
+	})
+	sort.Strings(typeIDs)
+
+	// Join type IDs
+	var sb strings.Builder
+	for index, typeID := range typeIDs {
+		if index > 0 {
+			sb.WriteByte('|')
+		}
+		sb.WriteString(typeID)
+	}
+	return sb.String()
+}
+
+// DisjunctionOrderedSet is a set of entitlement disjunctions, keyed by disjunctionKey
+type DisjunctionOrderedSet = orderedmap.OrderedMap[string, *EntitlementOrderedSet]
+
+// EntitlementSet is a set (conjunction) of entitlements and entitlement disjunctions.
+// e.g. {entitlements: A, B; disjunctions: (C | D), (E | F)}
+type EntitlementSet struct {
+	// Entitlements is a set of entitlements
+	Entitlements *EntitlementOrderedSet
+	// Disjunctions is a set of entitlement disjunctions, keyed by disjunctionKey
+	Disjunctions *DisjunctionOrderedSet
+}
+
+// Add adds an entitlement to the set.
+//
+// NOTE: The resulting set is potentially not minimal:
+// If the set contains a disjunction that contains the entitlement,
+// then the disjunction is NOT discarded.
+// Call Minimize to obtain a minimal set.
+func (s *EntitlementSet) Add(entitlementType *EntitlementType) {
+	if s.Entitlements == nil {
+		s.Entitlements = orderedmap.New[EntitlementOrderedSet](1)
+	}
+	s.Entitlements.Set(entitlementType, struct{}{})
+}
+
+// AddDisjunction adds an entitlement disjunction to the set.
+// If the set already contains an entitlement of the given disjunction,
+// then the disjunction is discarded.
+func (s *EntitlementSet) AddDisjunction(disjunction *EntitlementOrderedSet) {
+	// If this set already contains an entitlement of the given disjunction,
+	// there is no need to add the disjunction.
+	if s.Entitlements != nil &&
+		disjunction.ForAnyKey(s.Entitlements.Contains) {
+
+		return
+	}
+
+	// If the disjunction already exists in the set,
+	// there is no need to add the disjunction.
+	key := disjunctionKey(disjunction)
+	if s.Disjunctions != nil && s.Disjunctions.Contains(key) {
+		return
+	}
+
+	if s.Disjunctions == nil {
+		s.Disjunctions = orderedmap.New[DisjunctionOrderedSet](1)
+	}
+	s.Disjunctions.Set(key, disjunction)
+}
+
+// Merge merges the other entitlement set into this set.
+// The result is the union of the entitlements and disjunctions of both sets.
+//
+// The result is not necessarily minimal:
+// For example, if s contains a disjunction d,
+// and other contains an entitlement e that is part of d,
+// then the result will still contain d.
+// See Add.
+// Call Minimize to obtain a minimal set.
+func (s *EntitlementSet) Merge(other *EntitlementSet) {
+	if other.Entitlements != nil {
+		other.Entitlements.Foreach(func(key *EntitlementType, _ struct{}) {
+			s.Add(key)
+		})
+	}
+
+	if other.Disjunctions != nil {
+		other.Disjunctions.
+			Foreach(func(_ string, disjunction *EntitlementOrderedSet) {
+				s.AddDisjunction(disjunction)
+			})
+	}
+}
+
+// Minimize minimizes the entitlement set.
+// It removes disjunctions that contain entitlements
+// which are also in the entitlement set
+func (s *EntitlementSet) Minimize() {
+	// If there are no entitlements or no disjunctions,
+	// there is nothing to minimize
+	if s.Entitlements == nil || s.Disjunctions == nil {
+		return
+	}
+
+	// Remove disjunctions that contain entitlements that are also in the entitlement set
+	var keysToRemove []string
+	s.Disjunctions.Foreach(func(key string, disjunction *EntitlementOrderedSet) {
+		if disjunction.ForAnyKey(s.Entitlements.Contains) {
+			keysToRemove = append(keysToRemove, key)
+		}
+	})
+
+	for _, key := range keysToRemove {
+		s.Disjunctions.Delete(key)
+	}
+}
+
+// Access returns the access represented by the entitlement set.
+// The set is minimized before the access is computed.
+func (s *EntitlementSet) Access() Access {
+	if s == nil {
+		return UnauthorizedAccess
+	}
+
+	s.Minimize()
+
+	var entitlements *EntitlementOrderedSet
+	if s.Entitlements != nil && s.Entitlements.Len() > 0 {
+		entitlements = orderedmap.New[EntitlementOrderedSet](s.Entitlements.Len())
+		entitlements.SetAll(s.Entitlements)
+	}
+
+	if s.Disjunctions != nil && s.Disjunctions.Len() > 0 {
+		if entitlements == nil {
+			// If there are no entitlements, and there is only one disjunction,
+			// then the access is the disjunction.
+			if s.Disjunctions.Len() == 1 {
+				onlyDisjunction := s.Disjunctions.Oldest().Value
+				return EntitlementSetAccess{
+					Entitlements: onlyDisjunction,
+					SetKind:      Disjunction,
+				}
+			}
+
+			// There are no entitlements, but disjunctions.
+			// Allocate a new ordered map for all entitlements in the disjunctions
+			// (at minimum there are two entitlements in each disjunction).
+			entitlements = orderedmap.New[EntitlementOrderedSet](s.Disjunctions.Len() * 2)
+		}
+
+		// Add all entitlements in the disjunctions to the entitlements
+		s.Disjunctions.Foreach(func(_ string, disjunction *EntitlementOrderedSet) {
+			entitlements.SetAll(disjunction)
+		})
+	}
+
+	if entitlements == nil {
+		return UnauthorizedAccess
+	}
+
+	return EntitlementSetAccess{
+		Entitlements: entitlements,
+		SetKind:      Conjunction,
+	}
+}

--- a/runtime/sema/entitlementset_test.go
+++ b/runtime/sema/entitlementset_test.go
@@ -1,0 +1,465 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/cadence/runtime/common/orderedmap"
+)
+
+func TestEntitlementSet_Add(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no existing disjunctions", func(t *testing.T) {
+
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+		set.Add(e1)
+
+		assert.Equal(t, 1, set.Entitlements.Len())
+		assert.Nil(t, set.Disjunctions)
+
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+		set.Add(e2)
+
+		assert.Equal(t, 2, set.Entitlements.Len())
+		assert.Nil(t, set.Disjunctions)
+	})
+
+	t.Run("with existing disjunctions", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+
+		e1e2 := orderedmap.New[EntitlementOrderedSet](2)
+		e1e2.Set(e1, struct{}{})
+		e1e2.Set(e2, struct{}{})
+
+		set.AddDisjunction(e1e2)
+
+		assert.Nil(t, set.Entitlements)
+		assert.Equal(t, 1, set.Disjunctions.Len())
+
+		// Add
+
+		set.Add(e2)
+
+		assert.Equal(t, 1, set.Entitlements.Len())
+		// NOTE: the set is not minimal,
+		// the disjunction is not discarded
+		assert.Equal(t, 1, set.Disjunctions.Len())
+
+	})
+}
+
+func TestEntitlementSet_AddDisjunction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no existing entitlements", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+
+		e1e2 := orderedmap.New[EntitlementOrderedSet](2)
+		e1e2.Set(e1, struct{}{})
+		e1e2.Set(e2, struct{}{})
+
+		// Add
+
+		set.AddDisjunction(e1e2)
+
+		assert.Nil(t, set.Entitlements)
+		assert.Equal(t, 1, set.Disjunctions.Len())
+
+		// Re-add same
+
+		set.AddDisjunction(e1e2)
+
+		assert.Nil(t, set.Entitlements)
+		assert.Equal(t, 1, set.Disjunctions.Len())
+
+		// Re-add equal with different order
+
+		e2e1 := orderedmap.New[EntitlementOrderedSet](2)
+		e2e1.Set(e2, struct{}{})
+		e2e1.Set(e1, struct{}{})
+
+		set.AddDisjunction(e2e1)
+
+		assert.Nil(t, set.Entitlements)
+		assert.Equal(t, 1, set.Disjunctions.Len())
+
+		// Re-add different, with partial overlap
+
+		e3 := &EntitlementType{
+			Identifier: "E3",
+		}
+
+		e2e3 := orderedmap.New[EntitlementOrderedSet](2)
+		e2e3.Set(e2, struct{}{})
+		e2e3.Set(e3, struct{}{})
+
+		set.AddDisjunction(e2e3)
+
+		assert.Nil(t, set.Entitlements)
+		assert.Equal(t, 2, set.Disjunctions.Len())
+	})
+
+	t.Run("with existing entitlements", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+
+		set.Add(e1)
+
+		assert.Equal(t, 1, set.Entitlements.Len())
+		assert.Nil(t, set.Disjunctions)
+
+		// Add disjunction with overlap
+
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+
+		e1e2 := orderedmap.New[EntitlementOrderedSet](2)
+		e1e2.Set(e1, struct{}{})
+		e1e2.Set(e2, struct{}{})
+
+		set.AddDisjunction(e1e2)
+
+		assert.Equal(t, 1, set.Entitlements.Len())
+		assert.Nil(t, set.Disjunctions)
+	})
+}
+
+func TestEntitlementSet_Merge(t *testing.T) {
+	t.Parallel()
+
+	e1 := &EntitlementType{
+		Identifier: "E1",
+	}
+	e2 := &EntitlementType{
+		Identifier: "E2",
+	}
+	e3 := &EntitlementType{
+		Identifier: "E3",
+	}
+	e4 := &EntitlementType{
+		Identifier: "E4",
+	}
+
+	e2e3 := orderedmap.New[EntitlementOrderedSet](2)
+	e2e3.Set(e2, struct{}{})
+	e2e3.Set(e3, struct{}{})
+
+	e3e4 := orderedmap.New[EntitlementOrderedSet](2)
+	e3e4.Set(e3, struct{}{})
+	e3e4.Set(e4, struct{}{})
+
+	// Prepare set 1
+
+	set1 := &EntitlementSet{}
+	set1.Add(e1)
+	set1.AddDisjunction(e2e3)
+
+	assert.Equal(t, 1, set1.Entitlements.Len())
+	assert.Equal(t, 1, set1.Disjunctions.Len())
+
+	// Prepare set 2
+
+	set2 := &EntitlementSet{}
+	set2.Add(e2)
+	set2.AddDisjunction(e3e4)
+
+	assert.Equal(t, 1, set2.Entitlements.Len())
+	assert.Equal(t, 1, set2.Disjunctions.Len())
+
+	// Merge
+
+	set1.Merge(set2)
+
+	assert.Equal(t, 2, set1.Entitlements.Len())
+	assert.True(t, set1.Entitlements.Contains(e1))
+	assert.True(t, set1.Entitlements.Contains(e2))
+
+	// NOTE: the result is not minimal
+	assert.Equal(t, 2, set1.Disjunctions.Len())
+	assert.True(t, set1.Disjunctions.Contains(disjunctionKey(e2e3)))
+	assert.True(t, set1.Disjunctions.Contains(disjunctionKey(e3e4)))
+}
+
+func TestEntitlementSet_Minimize(t *testing.T) {
+	t.Parallel()
+
+	e1 := &EntitlementType{
+		Identifier: "E1",
+	}
+	e2 := &EntitlementType{
+		Identifier: "E2",
+	}
+
+	e1e2 := orderedmap.New[EntitlementOrderedSet](2)
+	e1e2.Set(e1, struct{}{})
+	e1e2.Set(e2, struct{}{})
+
+	set := &EntitlementSet{}
+	set.AddDisjunction(e1e2)
+
+	assert.Nil(t, set.Entitlements)
+	assert.Equal(t, 1, set.Disjunctions.Len())
+
+	// Add entitlement
+
+	set.Add(e1)
+
+	// NOTE: the set is not minimal
+	assert.Equal(t, 1, set.Entitlements.Len())
+	assert.Equal(t, 1, set.Disjunctions.Len())
+
+	// Minimize
+
+	set.Minimize()
+
+	assert.Equal(t, 1, set.Entitlements.Len())
+	assert.Equal(t, 0, set.Disjunctions.Len())
+}
+
+func TestEntitlementSet_Access(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no entitlements, no disjunctions", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		access := set.Access()
+
+		assert.Equal(t, UnauthorizedAccess, access)
+	})
+
+	t.Run("entitlements, no disjunctions", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+		set.Add(e1)
+
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+		set.Add(e2)
+
+		access := set.Access()
+
+		expectedEntitlements := orderedmap.New[EntitlementOrderedSet](2)
+		expectedEntitlements.Set(e1, struct{}{})
+		expectedEntitlements.Set(e2, struct{}{})
+
+		assert.Equal(t,
+			EntitlementSetAccess{
+				Entitlements: expectedEntitlements,
+				SetKind:      Conjunction,
+			},
+			access,
+		)
+	})
+
+	t.Run("no entitlements, one disjunction", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+
+		e1e2 := orderedmap.New[EntitlementOrderedSet](2)
+		e1e2.Set(e1, struct{}{})
+		e1e2.Set(e2, struct{}{})
+
+		set.AddDisjunction(e1e2)
+
+		access := set.Access()
+
+		assert.Equal(t,
+			EntitlementSetAccess{
+				Entitlements: e1e2,
+				SetKind:      Disjunction,
+			},
+			access,
+		)
+	})
+
+	t.Run("no entitlements, two disjunctions", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+		e3 := &EntitlementType{
+			Identifier: "E3",
+		}
+
+		e1e2 := orderedmap.New[EntitlementOrderedSet](2)
+		e1e2.Set(e1, struct{}{})
+		e1e2.Set(e2, struct{}{})
+
+		e2e3 := orderedmap.New[EntitlementOrderedSet](2)
+		e2e3.Set(e2, struct{}{})
+		e2e3.Set(e3, struct{}{})
+
+		set.AddDisjunction(e1e2)
+		set.AddDisjunction(e2e3)
+
+		access := set.Access()
+
+		// Cannot express (E1 | E2), (E2 | E3) in an access/auth,
+		// so the result is the conjunction of all entitlements
+
+		expectedEntitlements := orderedmap.New[EntitlementOrderedSet](3)
+		expectedEntitlements.Set(e1, struct{}{})
+		expectedEntitlements.Set(e2, struct{}{})
+		expectedEntitlements.Set(e3, struct{}{})
+
+		assert.Equal(t,
+			EntitlementSetAccess{
+				Entitlements: expectedEntitlements,
+				SetKind:      Conjunction,
+			},
+			access,
+		)
+	})
+
+	t.Run("entitlement, one disjunction, minimal", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+		e3 := &EntitlementType{
+			Identifier: "E3",
+		}
+
+		set.Add(e1)
+
+		e2e3 := orderedmap.New[EntitlementOrderedSet](2)
+		e2e3.Set(e2, struct{}{})
+		e2e3.Set(e3, struct{}{})
+
+		set.AddDisjunction(e2e3)
+
+		access := set.Access()
+
+		// Cannot express E1, (E2 | E3) in an access/auth,
+		// so the result is the conjunction of all entitlements
+
+		expectedEntitlements := orderedmap.New[EntitlementOrderedSet](3)
+		expectedEntitlements.Set(e1, struct{}{})
+		expectedEntitlements.Set(e2, struct{}{})
+		expectedEntitlements.Set(e3, struct{}{})
+
+		assert.Equal(t,
+			EntitlementSetAccess{
+				Entitlements: expectedEntitlements,
+				SetKind:      Conjunction,
+			},
+			access,
+		)
+	})
+
+	t.Run("entitlement, one disjunction, not minimal", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+
+		e1e2 := orderedmap.New[EntitlementOrderedSet](2)
+		e1e2.Set(e1, struct{}{})
+		e1e2.Set(e2, struct{}{})
+
+		set.AddDisjunction(e1e2)
+
+		set.Add(e1)
+
+		access := set.Access()
+
+		// NOTE: disjunction got removed during minimization
+
+		expectedEntitlements := orderedmap.New[EntitlementOrderedSet](1)
+		expectedEntitlements.Set(e1, struct{}{})
+
+		assert.Equal(t,
+			EntitlementSetAccess{
+				Entitlements: expectedEntitlements,
+				SetKind:      Conjunction,
+			},
+			access,
+		)
+	})
+}

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -3071,6 +3071,7 @@ func (e *InvalidAccessError) SecondaryError() string {
 			fmt.Fprint(&sb, "reference needs all of entitlements ")
 			missingEntitlements.ForeachWithIndex(enumerateEntitlements(missingLen, "and"))
 		}
+
 	case Disjunction:
 		// when both `required` is a disjunction, we know `possessed` has none of the entitlements in it:
 		// suggest adding one of those entitlements
@@ -3079,6 +3080,9 @@ func (e *InvalidAccessError) SecondaryError() string {
 		requiredLen := requiredEntitlementsSet.Len()
 		// singleton-1 sets are always conjunctions
 		requiredEntitlementsSet.ForeachWithIndex(enumerateEntitlements(requiredLen, "or"))
+
+	default:
+		panic(errors.NewUnreachableError())
 	}
 
 	return sb.String()

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -30,7 +30,6 @@ import (
 	"github.com/onflow/cadence/fixedpoint"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/common/orderedmap"
 	"github.com/onflow/cadence/runtime/errors"
 )
 
@@ -253,7 +252,7 @@ type NominalType interface {
 // entitlement supporting types
 type EntitlementSupportingType interface {
 	Type
-	SupportedEntitlements() *EntitlementOrderedSet
+	SupportedEntitlements() *EntitlementSet
 }
 
 // ContainedType is a type which might have a container type
@@ -797,7 +796,7 @@ func (t *OptionalType) Resolve(typeArguments *TypeParameterTypeOrderedMap) Type 
 	}
 }
 
-func (t *OptionalType) SupportedEntitlements() *EntitlementOrderedSet {
+func (t *OptionalType) SupportedEntitlements() *EntitlementSet {
 	if entitlementSupportingType, ok := t.Type.(EntitlementSupportingType); ok {
 		return entitlementSupportingType.SupportedEntitlements()
 	}
@@ -3125,15 +3124,15 @@ func (t *VariableSizedType) Resolve(typeArguments *TypeParameterTypeOrderedMap) 
 	}
 }
 
-func (t *VariableSizedType) SupportedEntitlements() *EntitlementOrderedSet {
+func (t *VariableSizedType) SupportedEntitlements() *EntitlementSet {
 	return arrayDictionaryEntitlements
 }
 
-var arrayDictionaryEntitlements = func() *EntitlementOrderedSet {
-	set := orderedmap.New[EntitlementOrderedSet](3)
-	set.Set(MutateType, struct{}{})
-	set.Set(InsertType, struct{}{})
-	set.Set(RemoveType, struct{}{})
+var arrayDictionaryEntitlements = func() *EntitlementSet {
+	set := &EntitlementSet{}
+	set.Add(MutateType)
+	set.Add(InsertType)
+	set.Add(RemoveType)
 	return set
 }()
 
@@ -3321,7 +3320,7 @@ func (t *ConstantSizedType) Resolve(typeArguments *TypeParameterTypeOrderedMap) 
 	}
 }
 
-func (t *ConstantSizedType) SupportedEntitlements() *EntitlementOrderedSet {
+func (t *ConstantSizedType) SupportedEntitlements() *EntitlementSet {
 	return arrayDictionaryEntitlements
 }
 
@@ -4770,7 +4769,7 @@ type CompositeType struct {
 	// Only applicable for native composite types
 	ImportableBuiltin         bool
 	supportedEntitlementsOnce sync.Once
-	supportedEntitlements     *EntitlementOrderedSet
+	supportedEntitlements     *EntitlementSet
 }
 
 var _ Type = &CompositeType{}
@@ -4957,27 +4956,69 @@ func (t *CompositeType) MemberMap() *StringMemberOrderedMap {
 	return t.Members
 }
 
-func (t *CompositeType) SupportedEntitlements() *EntitlementOrderedSet {
-	t.supportedEntitlementsOnce.Do(func() {
-		set := orderedmap.New[EntitlementOrderedSet](t.Members.Len())
-		t.Members.Foreach(func(_ string, member *Member) {
-			switch access := member.Access.(type) {
-			case *EntitlementMapAccess:
-				set.SetAll(access.Domain().Entitlements)
-			case EntitlementSetAccess:
-				set.SetAll(access.Entitlements)
+// TODO: improve naming
+func newCompositeOrInterfaceSupportedEntitlementSet(
+	members *StringMemberOrderedMap,
+	effectiveInterfaceConformanceSet *InterfaceSet,
+) *EntitlementSet {
+	set := &EntitlementSet{}
+
+	// First pass: Handle maps and conjunctions
+	members.Foreach(func(_ string, member *Member) {
+		switch access := member.Access.(type) {
+		case *EntitlementMapAccess:
+			// Domain is a conjunction, add all entitlements
+			domain := access.Domain()
+			if domain.SetKind != Conjunction {
+				panic(errors.NewUnreachableError())
 			}
-		})
-		t.EffectiveInterfaceConformanceSet().ForEach(func(it *InterfaceType) {
-			set.SetAll(it.SupportedEntitlements())
-		})
+			domain.Entitlements.
+				Foreach(func(entitlementType *EntitlementType, _ struct{}) {
+					set.Add(entitlementType)
+				})
+
+		case EntitlementSetAccess:
+			// Disjunctions are handled in a second pass
+			if access.SetKind == Conjunction {
+				access.Entitlements.Foreach(func(entitlementType *EntitlementType, _ struct{}) {
+					set.Add(entitlementType)
+				})
+			}
+		}
+	})
+
+	// Second pass: Handle disjunctions
+	for pair := members.Oldest(); pair != nil; pair = pair.Next() {
+		member := pair.Value
+
+		if access, ok := member.Access.(EntitlementSetAccess); ok &&
+			access.SetKind == Disjunction {
+
+			set.AddDisjunction(access.Entitlements)
+		}
+	}
+
+	effectiveInterfaceConformanceSet.ForEach(func(it *InterfaceType) {
+		set.Merge(it.SupportedEntitlements())
+	})
+
+	return set
+}
+
+func (t *CompositeType) SupportedEntitlements() *EntitlementSet {
+	t.supportedEntitlementsOnce.Do(func() {
+
+		set := newCompositeOrInterfaceSupportedEntitlementSet(
+			t.Members,
+			t.EffectiveInterfaceConformanceSet(),
+		)
 
 		// attachments support at least the entitlements supported by their base,
 		// and we must ensure there is no recursive case
 		if entitlementSupportingBase, isEntitlementSupportingBase :=
 			t.GetBaseType().(EntitlementSupportingType); isEntitlementSupportingBase && entitlementSupportingBase != t {
 
-			set.SetAll(entitlementSupportingBase.SupportedEntitlements())
+			set.Merge(entitlementSupportingBase.SupportedEntitlements())
 		}
 
 		t.supportedEntitlements = set
@@ -5155,7 +5196,7 @@ func (t *CompositeType) TypeIndexingElementType(indexingType Type, _ func() ast.
 	case *CompositeType:
 		// when accessed on an owned value, the produced attachment reference is entitled to all the
 		// entitlements it supports
-		access = NewAccessFromEntitlementSet(attachment.SupportedEntitlements(), Conjunction)
+		access = attachment.SupportedEntitlements().Access()
 	}
 
 	return &OptionalType{
@@ -5658,7 +5699,7 @@ type InterfaceType struct {
 	effectiveInterfaceConformances   []Conformance
 	effectiveInterfaceConformanceSet *InterfaceSet
 	supportedEntitlementsOnce        sync.Once
-	supportedEntitlements            *EntitlementOrderedSet
+	supportedEntitlements            *EntitlementSet
 
 	DefaultDestroyEvent *CompositeType
 }
@@ -5767,27 +5808,12 @@ func (t *InterfaceType) MemberMap() *StringMemberOrderedMap {
 	return t.Members
 }
 
-func (t *InterfaceType) SupportedEntitlements() *EntitlementOrderedSet {
+func (t *InterfaceType) SupportedEntitlements() *EntitlementSet {
 	t.supportedEntitlementsOnce.Do(func() {
-		set := orderedmap.New[EntitlementOrderedSet](t.Members.Len())
-		t.Members.Foreach(func(_ string, member *Member) {
-			switch access := member.Access.(type) {
-			case *EntitlementMapAccess:
-				access.Domain().Entitlements.Foreach(func(entitlement *EntitlementType, _ struct{}) {
-					set.Set(entitlement, struct{}{})
-				})
-			case EntitlementSetAccess:
-				access.Entitlements.Foreach(func(entitlement *EntitlementType, _ struct{}) {
-					set.Set(entitlement, struct{}{})
-				})
-			}
-		})
-
-		t.EffectiveInterfaceConformanceSet().ForEach(func(it *InterfaceType) {
-			set.SetAll(it.SupportedEntitlements())
-		})
-
-		t.supportedEntitlements = set
+		t.supportedEntitlements = newCompositeOrInterfaceSupportedEntitlementSet(
+			t.Members,
+			t.EffectiveInterfaceConformanceSet(),
+		)
 	})
 	return t.supportedEntitlements
 }
@@ -6535,7 +6561,7 @@ func (t *DictionaryType) Resolve(typeArguments *TypeParameterTypeOrderedMap) Typ
 	}
 }
 
-func (t *DictionaryType) SupportedEntitlements() *EntitlementOrderedSet {
+func (t *DictionaryType) SupportedEntitlements() *EntitlementSet {
 	return arrayDictionaryEntitlements
 }
 
@@ -8146,7 +8172,7 @@ type IntersectionType struct {
 	memberResolvers              map[string]MemberResolver
 	memberResolversOnce          sync.Once
 	supportedEntitlementsOnce    sync.Once
-	supportedEntitlements        *EntitlementOrderedSet
+	supportedEntitlements        *EntitlementSet
 	// Deprecated
 	LegacyType Type
 }
@@ -8401,13 +8427,14 @@ func (t *IntersectionType) initializeMemberResolvers() {
 	})
 }
 
-func (t *IntersectionType) SupportedEntitlements() *EntitlementOrderedSet {
+func (t *IntersectionType) SupportedEntitlements() *EntitlementSet {
 	t.supportedEntitlementsOnce.Do(func() {
 		// an intersection type supports all the entitlements of its interfaces
-		set := orderedmap.New[EntitlementOrderedSet](t.EffectiveIntersectionSet().Len())
-		t.EffectiveIntersectionSet().ForEach(func(it *InterfaceType) {
-			set.SetAll(it.SupportedEntitlements())
-		})
+		set := &EntitlementSet{}
+		t.EffectiveIntersectionSet().
+			ForEach(func(interfaceType *InterfaceType) {
+				set.Merge(interfaceType.SupportedEntitlements())
+			})
 		t.supportedEntitlements = set
 	})
 
@@ -8450,7 +8477,7 @@ func (t *IntersectionType) TypeIndexingElementType(indexingType Type, _ func() a
 	case *CompositeType:
 		// when accessed on an owned value, the produced attachment reference is entitled to all the
 		// entitlements it supports
-		access = NewAccessFromEntitlementSet(attachment.SupportedEntitlements(), Conjunction)
+		access = attachment.SupportedEntitlements().Access()
 	}
 
 	return &OptionalType{

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -4956,12 +4956,15 @@ func (t *CompositeType) MemberMap() *StringMemberOrderedMap {
 	return t.Members
 }
 
-// TODO: improve naming
 func newCompositeOrInterfaceSupportedEntitlementSet(
 	members *StringMemberOrderedMap,
 	effectiveInterfaceConformanceSet *InterfaceSet,
 ) *EntitlementSet {
 	set := &EntitlementSet{}
+
+	// We need to handle conjunctions and disjunctions separately, in two passes,
+	// as adding entitlements after disjunctions does not remove disjunctions from the set,
+	// whereas adding disjunctions after entitlements does.
 
 	// First pass: Handle maps and conjunctions
 	members.Foreach(func(_ string, member *Member) {

--- a/runtime/sema/type_tags.go
+++ b/runtime/sema/type_tags.go
@@ -736,7 +736,7 @@ func leastCommonAccess(accessA, accessB Access) Access {
 			// e.g. the least common supertype of (E, F) and (E, G)  is just E
 			intersection := orderedmap.KeySetIntersection(setAccessA.Entitlements, setAccessB.Entitlements)
 			if intersection.Len() != 0 {
-				return NewAccessFromEntitlementSet(intersection, Conjunction)
+				return NewAccessFromEntitlementOrderedSet(intersection, Conjunction)
 			}
 			// if the intersection is completely empty (i.e. the two sets are totally disjoint)
 			// the least common supertype is the union of one element arbitrarily chosen from each conjunction.
@@ -749,7 +749,7 @@ func leastCommonAccess(accessA, accessB Access) Access {
 			// e.g. the least common supertype of E and F is `(E | F)`
 			// and the least common supertype of `(A, B)` and `(C, D)` is `(A | B | C | D)`
 			union := orderedmap.KeySetUnion(setAccessA.Entitlements, setAccessB.Entitlements)
-			return NewAccessFromEntitlementSet(union, Disjunction)
+			return NewAccessFromEntitlementOrderedSet(union, Disjunction)
 
 		case Disjunction:
 			// least common supertype of a non-disjoint conjunction and a disjunction is
@@ -769,7 +769,7 @@ func leastCommonAccess(accessA, accessB Access) Access {
 			// which luckily here is just the union of the elements of the disjunction and the conjunction.
 			// E.g. our computed supertype of `(E, F)` and `(G | H)` is `(E | F | G | H)`
 			union := orderedmap.KeySetUnion(setAccessA.Entitlements, setAccessB.Entitlements)
-			return NewAccessFromEntitlementSet(union, Disjunction)
+			return NewAccessFromEntitlementOrderedSet(union, Disjunction)
 		}
 
 	case Disjunction:
@@ -781,7 +781,7 @@ func leastCommonAccess(accessA, accessB Access) Access {
 			// least common access of two disjunctions is their union
 			// e.g. the least common supertype of (E | F) and (E | G) is (E | F | G)
 			union := orderedmap.KeySetUnion(setAccessA.Entitlements, setAccessB.Entitlements)
-			return NewAccessFromEntitlementSet(union, Disjunction)
+			return NewAccessFromEntitlementOrderedSet(union, Disjunction)
 		}
 	}
 

--- a/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validator.go
+++ b/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validator.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/common/orderedmap"
 	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -267,7 +266,7 @@ func (validator *CadenceV042ToV1ContractUpdateValidator) expectedAuthorizationOf
 	}
 
 	supportedEntitlements := compositeType.SupportedEntitlements()
-	return sema.NewAccessFromEntitlementSet(supportedEntitlements, sema.Conjunction)
+	return supportedEntitlements.Access()
 }
 
 func (validator *CadenceV042ToV1ContractUpdateValidator) expectedAuthorizationOfIntersection(
@@ -279,13 +278,9 @@ func (validator *CadenceV042ToV1ContractUpdateValidator) expectedAuthorizationOf
 	// been a restricted type with no legacy type
 	interfaces := validator.getIntersectedInterfaces(intersectionTypes)
 
-	supportedEntitlements := orderedmap.New[sema.EntitlementOrderedSet](0)
+	intersectionType := sema.NewIntersectionType(nil, nil, interfaces)
 
-	for _, interfaceType := range interfaces {
-		supportedEntitlements.SetAll(interfaceType.SupportedEntitlements())
-	}
-
-	return sema.NewAccessFromEntitlementSet(supportedEntitlements, sema.Conjunction)
+	return intersectionType.SupportedEntitlements().Access()
 }
 
 func (validator *CadenceV042ToV1ContractUpdateValidator) checkEntitlementsUpgrade(


### PR DESCRIPTION
Closes #3253

## Description

- Introduce a new Go type `EntitlementSet` (maybe needs a more descriptive name, suggestions very welcome), which is a conjunction of entitlement types, and disjunctions of entitlements. For example, it can represent `{A, B, (C | D)}`. This allows representing more complex entitlement sets than access/auth entitlement sets can (only conjunction or disjunction of entitlements, e.g. `{A, B}` OR `{A | B}`)
- Switch `EntitlementSupportingType.SupportedEntitlements` to return `EntitlementSet`. 

  Implementations of the function combine sub-sets – for example, composite type's implementation merges the entitlement sets of all members, and intersection type's implementation merges the entitlement sets of all interface types' supported entitlements. Switching the return type to a set type which is able to represent more complex sets results in less "information loss" in recursive calls. 

  As a result, when translating the resulting entitlement set to an access, it is possible to get a disjunction now, which was not previously possible.

Given `EntitlementSupportingType.SupportedEntitlements` is used in the entitlements migration and the contract update checker to infer the entitlements/auth, these changes should hopefully result in authorizations that are  less permissive than before.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
