### PR TITLE
Fix resource-loss check in dictionary set-key

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -19049,20 +19049,24 @@ func (v *DictionaryValue) SetKey(
 		locationRange,
 	)
 
+	var existingValue Value
 	switch value := value.(type) {
 	case *SomeValue:
 		innerValue := value.InnerValue(interpreter, locationRange)
-		existingValue := v.Insert(interpreter, locationRange, keyValue, innerValue)
-		interpreter.checkResourceLoss(existingValue, locationRange)
+		existingValue = v.Insert(interpreter, locationRange, keyValue, innerValue)
 
 	case NilValue:
-		_ = v.Remove(interpreter, locationRange, keyValue)
+		existingValue = v.Remove(interpreter, locationRange, keyValue)
 
 	case placeholderValue:
 		// NO-OP
 
 	default:
 		panic(errors.NewUnreachableError())
+	}
+
+	if existingValue != nil {
+		interpreter.checkResourceLoss(existingValue, locationRange)
 	}
 }
 

--- a/runtime/tests/interpreter/resources_test.go
+++ b/runtime/tests/interpreter/resources_test.go
@@ -2927,7 +2927,11 @@ func TestInterpretResourceLoss(t *testing.T) {
 
 	t.Parallel()
 
-	inter, _, err := parseCheckAndInterpretWithLogs(t, `
+	t.Run("in callback", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
         access(all) resource R {
             access(all) let id: String
 
@@ -2970,11 +2974,36 @@ func TestInterpretResourceLoss(t *testing.T) {
            destroy rl
         }
     `)
-	require.NoError(t, err)
 
-	_, err = inter.Invoke("main")
-	RequireError(t, err)
-	require.ErrorAs(t, err, &interpreter.ResourceLossError{})
+		_, err := inter.Invoke("main")
+		RequireError(t, err)
+		require.ErrorAs(t, err, &interpreter.ResourceLossError{})
+	})
+
+	t.Run("force nil assignment", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            access(all) resource R {
+                access(all) event ResourceDestroyed()
+            }
+
+            access(all) fun loseResource(_ victim: @R) {
+                var dict <- { 0: <- victim}
+                dict[0] <-! nil
+                destroy dict
+            }
+
+            access(all) fun main() {
+                loseResource(<- create R())
+            }
+        `)
+
+		_, err := inter.Invoke("main")
+		RequireError(t, err)
+		require.ErrorAs(t, err, &interpreter.ResourceLossError{})
+	})
 }
 
 func TestInterpretPreConditionResourceMove(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-internal/issues/218

## Description

Checked in other places where `checkResourceLoss` is called, and they don't have this problem.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
