### PR TITLE
Adjust branches of downstream dependency checks

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'onflow/flow-go'
-          ref: ${{ github.base_ref == 'feature/stable-cadence' && 'feature/stable-cadence' || 'master' }}
+          ref: ${{ github.base_ref == 'master' && 'feature/stable-cadence' || 'master' }}
 
       - name: Setup Go
         uses: actions/setup-go@v3
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'onflow/flow-emulator'
-          ref: ${{ github.base_ref == 'feature/stable-cadence' && 'feature/stable-cadence' || 'master' }}
+          ref: ${{ github.base_ref == 'master' && 'master' || 'release/v0' }}
 
       - name: Setup Go
         uses: actions/setup-go@v3


### PR DESCRIPTION

## Description

When the Cadence 1.0 code was still on a feature branch, the CI check of the downstream dependencies used appropriate branches in the respective downstream repository.

The Cadence 1.0 code is now in master, so update the CI check, so that Cadence PRs targeting `master` will use the correct branches:
- flow-go: Cadence 1.0 code is still on a feature branch there, https://github.com/onflow/flow-go/tree/feature/stable-cadence
- flow-emulator: Cadence 1.0 code is on master

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
