### PR TITLE
Add runtime check for transaction value moves

### DIFF
--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -271,6 +271,13 @@ func (v *SimpleCompositeValue) Transfer(
 	if remove {
 		interpreter.RemoveReferencedSlab(storable)
 	}
+
+	if v.isTransaction {
+		panic(NonTransferableValueError{
+			Value: v,
+		})
+	}
+
 	return v
 }
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -10633,3 +10633,120 @@ func TestRuntimeNonPublicAccessModifierInInterface(t *testing.T) {
 
 	require.Len(t, conformanceErr.MemberMismatches, 2)
 }
+
+func TestRuntimeMoveSelfVariable(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("contract", func(t *testing.T) {
+		t.Parallel()
+
+		contract := []byte(`
+            access(all) contract Foo {
+
+                access(all) fun moveSelf() {
+                    var x = self!
+                }
+            }
+        `)
+
+		runtime := NewTestInterpreterRuntimeWithConfig(Config{
+			AtreeValidationEnabled: false,
+		})
+
+		address := common.MustBytesToAddress([]byte{0x1})
+
+		var contractCode []byte
+
+		runtimeInterface := &TestRuntimeInterface{
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
+				return []Address{address}, nil
+			},
+			OnGetAccountContractCode: func(location common.AddressLocation) ([]byte, error) {
+				return contractCode, nil
+			},
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnUpdateAccountContractCode: func(_ common.AddressLocation, code []byte) error {
+				contractCode = code
+				return nil
+			},
+			OnEmitEvent: func(event cadence.Event) error {
+				return nil
+			},
+		}
+
+		nextTransactionLocation := NewTransactionLocationGenerator()
+
+		// Deploy
+
+		deploymentTx := DeploymentTransaction("Foo", contract)
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: deploymentTx,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+		require.NoError(t, err)
+
+		// Execute script
+
+		nextScriptLocation := NewScriptLocationGenerator()
+
+		script := []byte(fmt.Sprintf(`
+            import Foo from %[1]s
+
+            access(all) fun main(): Void {
+                Foo.moveSelf()
+            }`,
+			address.HexWithPrefix(),
+		))
+
+		_, err = runtime.ExecuteScript(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextScriptLocation(),
+			},
+		)
+
+		RequireError(t, err)
+		require.ErrorAs(t, err, &interpreter.NonTransferableValueError{})
+	})
+
+	t.Run("transaction", func(t *testing.T) {
+		t.Parallel()
+
+		script := []byte(`
+            transaction {
+                prepare() {
+                    var x = true ? self : self
+                }
+                execute {}
+            }
+        `)
+
+		runtime := NewTestInterpreterRuntime()
+		runtimeInterface := &TestRuntimeInterface{}
+
+		nextTransactionLocation := NewTransactionLocationGenerator()
+
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: script,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+
+		RequireError(t, err)
+		require.ErrorAs(t, err, &interpreter.NonTransferableValueError{})
+	})
+}


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-internal/issues/217

## Description

Currently this panics with a type loading error. This PR adds a dedicated error for trying to move transaction values.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
