### PR TITLE
Produce a validator error when contracts would produce unrepresentable entitlements sets in the migration

### DIFF
--- a/runtime/common/orderedmap/orderedmap.go
+++ b/runtime/common/orderedmap/orderedmap.go
@@ -150,6 +150,9 @@ func (om *OrderedMap[K, V]) Delete(key K) (oldValue V, present bool) {
 
 // Len returns the length of the ordered map.
 func (om *OrderedMap[K, V]) Len() int {
+	if om == nil {
+		return 0
+	}
 	return len(om.pairs)
 }
 

--- a/runtime/sema/entitlementset.go
+++ b/runtime/sema/entitlementset.go
@@ -132,7 +132,7 @@ func (s *EntitlementSet) Merge(other *EntitlementSet) {
 // It removes disjunctions that contain entitlements
 // which are also in the entitlement set
 func (s *EntitlementSet) Minimize() {
-	s.minimized = true
+	defer func() { s.minimized = true }()
 
 	// If there are no entitlements or no disjunctions,
 	// there is nothing to minimize

--- a/runtime/sema/entitlementset_test.go
+++ b/runtime/sema/entitlementset_test.go
@@ -40,6 +40,7 @@ func TestEntitlementSet_Add(t *testing.T) {
 		}
 		set.Add(e1)
 
+		assert.False(t, set.minimized)
 		assert.Equal(t, 1, set.Entitlements.Len())
 		assert.Nil(t, set.Disjunctions)
 
@@ -48,6 +49,7 @@ func TestEntitlementSet_Add(t *testing.T) {
 		}
 		set.Add(e2)
 
+		assert.False(t, set.minimized)
 		assert.Equal(t, 2, set.Entitlements.Len())
 		assert.Nil(t, set.Disjunctions)
 	})
@@ -70,6 +72,7 @@ func TestEntitlementSet_Add(t *testing.T) {
 
 		set.AddDisjunction(e1e2)
 
+		assert.False(t, set.minimized)
 		assert.Nil(t, set.Entitlements)
 		assert.Equal(t, 1, set.Disjunctions.Len())
 
@@ -77,6 +80,7 @@ func TestEntitlementSet_Add(t *testing.T) {
 
 		set.Add(e2)
 
+		assert.False(t, set.minimized)
 		assert.Equal(t, 1, set.Entitlements.Len())
 		// NOTE: the set is not minimal,
 		// the disjunction is not discarded
@@ -108,6 +112,7 @@ func TestEntitlementSet_AddDisjunction(t *testing.T) {
 
 		set.AddDisjunction(e1e2)
 
+		assert.False(t, set.minimized)
 		assert.Nil(t, set.Entitlements)
 		assert.Equal(t, 1, set.Disjunctions.Len())
 
@@ -115,6 +120,7 @@ func TestEntitlementSet_AddDisjunction(t *testing.T) {
 
 		set.AddDisjunction(e1e2)
 
+		assert.False(t, set.minimized)
 		assert.Nil(t, set.Entitlements)
 		assert.Equal(t, 1, set.Disjunctions.Len())
 
@@ -126,6 +132,7 @@ func TestEntitlementSet_AddDisjunction(t *testing.T) {
 
 		set.AddDisjunction(e2e1)
 
+		assert.False(t, set.minimized)
 		assert.Nil(t, set.Entitlements)
 		assert.Equal(t, 1, set.Disjunctions.Len())
 
@@ -141,6 +148,7 @@ func TestEntitlementSet_AddDisjunction(t *testing.T) {
 
 		set.AddDisjunction(e2e3)
 
+		assert.False(t, set.minimized)
 		assert.Nil(t, set.Entitlements)
 		assert.Equal(t, 2, set.Disjunctions.Len())
 	})
@@ -156,6 +164,7 @@ func TestEntitlementSet_AddDisjunction(t *testing.T) {
 
 		set.Add(e1)
 
+		assert.False(t, set.minimized)
 		assert.Equal(t, 1, set.Entitlements.Len())
 		assert.Nil(t, set.Disjunctions)
 
@@ -171,6 +180,7 @@ func TestEntitlementSet_AddDisjunction(t *testing.T) {
 
 		set.AddDisjunction(e1e2)
 
+		assert.False(t, set.minimized)
 		assert.Equal(t, 1, set.Entitlements.Len())
 		assert.Nil(t, set.Disjunctions)
 	})
@@ -206,6 +216,7 @@ func TestEntitlementSet_Merge(t *testing.T) {
 	set1.Add(e1)
 	set1.AddDisjunction(e2e3)
 
+	assert.False(t, set1.minimized)
 	assert.Equal(t, 1, set1.Entitlements.Len())
 	assert.Equal(t, 1, set1.Disjunctions.Len())
 
@@ -215,6 +226,7 @@ func TestEntitlementSet_Merge(t *testing.T) {
 	set2.Add(e2)
 	set2.AddDisjunction(e3e4)
 
+	assert.False(t, set2.minimized)
 	assert.Equal(t, 1, set2.Entitlements.Len())
 	assert.Equal(t, 1, set2.Disjunctions.Len())
 
@@ -222,6 +234,7 @@ func TestEntitlementSet_Merge(t *testing.T) {
 
 	set1.Merge(set2)
 
+	assert.False(t, set1.minimized)
 	assert.Equal(t, 2, set1.Entitlements.Len())
 	assert.True(t, set1.Entitlements.Contains(e1))
 	assert.True(t, set1.Entitlements.Contains(e2))
@@ -257,6 +270,7 @@ func TestEntitlementSet_Minimize(t *testing.T) {
 	set.Add(e1)
 
 	// NOTE: the set is not minimal
+	assert.False(t, set.minimized)
 	assert.Equal(t, 1, set.Entitlements.Len())
 	assert.Equal(t, 1, set.Disjunctions.Len())
 
@@ -264,8 +278,174 @@ func TestEntitlementSet_Minimize(t *testing.T) {
 
 	set.Minimize()
 
+	assert.True(t, set.minimized)
 	assert.Equal(t, 1, set.Entitlements.Len())
 	assert.Equal(t, 0, set.Disjunctions.Len())
+}
+
+func TestEntitlementSet_MinimallyRepresentable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no entitlements, no disjunctions", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+		assert.True(t, set.IsMinimallyRepresentable())
+	})
+
+	t.Run("one entitlement, no disjunctions", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+		set.Add(e1)
+
+		assert.True(t, set.IsMinimallyRepresentable())
+	})
+
+	t.Run("two entitlements, no disjunctions", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+		set.Add(e1)
+
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+		set.Add(e2)
+
+		assert.True(t, set.IsMinimallyRepresentable())
+	})
+
+	t.Run("one entitlement, redundant disjunction", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+
+		set.Add(e1)
+
+		e1e2 := orderedmap.New[EntitlementOrderedSet](2)
+		e1e2.Set(e1, struct{}{})
+		e1e2.Set(e2, struct{}{})
+
+		set.AddDisjunction(e1e2)
+
+		assert.True(t, set.IsMinimallyRepresentable())
+	})
+
+	t.Run("two entitlements, two redundant disjunctions", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+
+		e3 := &EntitlementType{
+			Identifier: "E1",
+		}
+
+		e4 := &EntitlementType{
+			Identifier: "E2",
+		}
+
+		set.Add(e1)
+		set.Add(e3)
+
+		e1e2 := orderedmap.New[EntitlementOrderedSet](2)
+		e1e2.Set(e1, struct{}{})
+		e1e2.Set(e2, struct{}{})
+
+		set.AddDisjunction(e1e2)
+
+		e3e4 := orderedmap.New[EntitlementOrderedSet](2)
+		e3e4.Set(e3, struct{}{})
+		e3e4.Set(e4, struct{}{})
+
+		set.AddDisjunction(e3e4)
+
+		assert.True(t, set.IsMinimallyRepresentable())
+	})
+
+	t.Run("one entitlement, non-redundant disjunction", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+
+		e3 := &EntitlementType{
+			Identifier: "E3",
+		}
+
+		set.Add(e1)
+
+		e3e2 := orderedmap.New[EntitlementOrderedSet](2)
+		e3e2.Set(e3, struct{}{})
+		e3e2.Set(e2, struct{}{})
+
+		set.AddDisjunction(e3e2)
+
+		assert.False(t, set.IsMinimallyRepresentable())
+	})
+
+	t.Run("two disjunctions", func(t *testing.T) {
+		t.Parallel()
+
+		set := &EntitlementSet{}
+
+		e1 := &EntitlementType{
+			Identifier: "E1",
+		}
+
+		e2 := &EntitlementType{
+			Identifier: "E2",
+		}
+
+		e3 := &EntitlementType{
+			Identifier: "E3",
+		}
+
+		e1e2 := orderedmap.New[EntitlementOrderedSet](2)
+		e1e2.Set(e1, struct{}{})
+		e1e2.Set(e2, struct{}{})
+
+		set.AddDisjunction(e1e2)
+
+		e3e2 := orderedmap.New[EntitlementOrderedSet](2)
+		e3e2.Set(e3, struct{}{})
+		e3e2.Set(e2, struct{}{})
+
+		set.AddDisjunction(e3e2)
+
+		assert.False(t, set.IsMinimallyRepresentable())
+	})
 }
 
 func TestEntitlementSet_Access(t *testing.T) {
@@ -278,6 +458,7 @@ func TestEntitlementSet_Access(t *testing.T) {
 
 		access := set.Access()
 
+		assert.True(t, set.minimized)
 		assert.Equal(t, UnauthorizedAccess, access)
 	})
 
@@ -296,7 +477,9 @@ func TestEntitlementSet_Access(t *testing.T) {
 		}
 		set.Add(e2)
 
+		assert.False(t, set.minimized)
 		access := set.Access()
+		assert.True(t, set.minimized)
 
 		expectedEntitlements := orderedmap.New[EntitlementOrderedSet](2)
 		expectedEntitlements.Set(e1, struct{}{})
@@ -329,7 +512,9 @@ func TestEntitlementSet_Access(t *testing.T) {
 
 		set.AddDisjunction(e1e2)
 
+		assert.False(t, set.minimized)
 		access := set.Access()
+		assert.True(t, set.minimized)
 
 		assert.Equal(t,
 			EntitlementSetAccess{
@@ -364,12 +549,20 @@ func TestEntitlementSet_Access(t *testing.T) {
 		e2e3.Set(e3, struct{}{})
 
 		set.AddDisjunction(e1e2)
+
+		assert.False(t, set.minimized)
+		set.Minimize()
+		assert.True(t, set.minimized)
+
 		set.AddDisjunction(e2e3)
+		assert.False(t, set.minimized)
 
 		access := set.Access()
+		assert.True(t, set.minimized)
 
 		// Cannot express (E1 | E2), (E2 | E3) in an access/auth,
 		// so the result is the conjunction of all entitlements
+		assert.False(t, set.IsMinimallyRepresentable())
 
 		expectedEntitlements := orderedmap.New[EntitlementOrderedSet](3)
 		expectedEntitlements.Set(e1, struct{}{})
@@ -407,11 +600,14 @@ func TestEntitlementSet_Access(t *testing.T) {
 		e2e3.Set(e3, struct{}{})
 
 		set.AddDisjunction(e2e3)
+		assert.False(t, set.minimized)
 
 		access := set.Access()
+		assert.True(t, set.minimized)
 
 		// Cannot express E1, (E2 | E3) in an access/auth,
 		// so the result is the conjunction of all entitlements
+		assert.False(t, set.IsMinimallyRepresentable())
 
 		expectedEntitlements := orderedmap.New[EntitlementOrderedSet](3)
 		expectedEntitlements.Set(e1, struct{}{})
@@ -444,12 +640,19 @@ func TestEntitlementSet_Access(t *testing.T) {
 		e1e2.Set(e2, struct{}{})
 
 		set.AddDisjunction(e1e2)
+		assert.False(t, set.minimized)
+
+		set.Minimize()
+		assert.True(t, set.minimized)
 
 		set.Add(e1)
+		assert.False(t, set.minimized)
 
 		access := set.Access()
+		assert.True(t, set.minimized)
 
 		// NOTE: disjunction got removed during minimization
+		assert.True(t, set.IsMinimallyRepresentable())
 
 		expectedEntitlements := orderedmap.New[EntitlementOrderedSet](1)
 		expectedEntitlements.Set(e1, struct{}{})

--- a/runtime/sema/entitlementset_test.go
+++ b/runtime/sema/entitlementset_test.go
@@ -451,7 +451,7 @@ func TestEntitlementSet_MinimallyRepresentable(t *testing.T) {
 func TestEntitlementSet_Access(t *testing.T) {
 	t.Parallel()
 
-	t.Run("no entitlements, no disjunctions", func(t *testing.T) {
+	t.Run("no entitlements, no disjunctions: {} = unauthorized", func(t *testing.T) {
 		t.Parallel()
 
 		set := &EntitlementSet{}
@@ -462,7 +462,7 @@ func TestEntitlementSet_Access(t *testing.T) {
 		assert.Equal(t, UnauthorizedAccess, access)
 	})
 
-	t.Run("entitlements, no disjunctions", func(t *testing.T) {
+	t.Run("entitlements, no disjunctions: {E1, E2} = auth(E1, E2)", func(t *testing.T) {
 		t.Parallel()
 
 		set := &EntitlementSet{}
@@ -494,7 +494,7 @@ func TestEntitlementSet_Access(t *testing.T) {
 		)
 	})
 
-	t.Run("no entitlements, one disjunction", func(t *testing.T) {
+	t.Run("no entitlements, one disjunction: {(E1 | E2)} = auth(E1 | E2)", func(t *testing.T) {
 		t.Parallel()
 
 		set := &EntitlementSet{}
@@ -525,7 +525,7 @@ func TestEntitlementSet_Access(t *testing.T) {
 		)
 	})
 
-	t.Run("no entitlements, two disjunctions", func(t *testing.T) {
+	t.Run("no entitlements, two disjunctions: {(E1 | E2), (E2 | E3)} = auth(E1, E2, E3)", func(t *testing.T) {
 		t.Parallel()
 
 		set := &EntitlementSet{}
@@ -578,7 +578,7 @@ func TestEntitlementSet_Access(t *testing.T) {
 		)
 	})
 
-	t.Run("entitlement, one disjunction, minimal", func(t *testing.T) {
+	t.Run("entitlement, one disjunction, not minimal: {E1, (E2 | E3)} = auth(E1, E2, E3)", func(t *testing.T) {
 		t.Parallel()
 
 		set := &EntitlementSet{}
@@ -623,7 +623,7 @@ func TestEntitlementSet_Access(t *testing.T) {
 		)
 	})
 
-	t.Run("entitlement, one disjunction, not minimal", func(t *testing.T) {
+	t.Run("entitlement, one disjunction, minimal: {(E1 | E2), E1} = auth(E1)", func(t *testing.T) {
 		t.Parallel()
 
 		set := &EntitlementSet{}

--- a/runtime/sema/entitlementset_test.go
+++ b/runtime/sema/entitlementset_test.go
@@ -286,14 +286,14 @@ func TestEntitlementSet_Minimize(t *testing.T) {
 func TestEntitlementSet_MinimallyRepresentable(t *testing.T) {
 	t.Parallel()
 
-	t.Run("no entitlements, no disjunctions", func(t *testing.T) {
+	t.Run("no entitlements, no disjunctions: {} = true", func(t *testing.T) {
 		t.Parallel()
 
 		set := &EntitlementSet{}
 		assert.True(t, set.IsMinimallyRepresentable())
 	})
 
-	t.Run("one entitlement, no disjunctions", func(t *testing.T) {
+	t.Run("one entitlement, no disjunctions: {E1} = true", func(t *testing.T) {
 		t.Parallel()
 
 		set := &EntitlementSet{}
@@ -306,7 +306,7 @@ func TestEntitlementSet_MinimallyRepresentable(t *testing.T) {
 		assert.True(t, set.IsMinimallyRepresentable())
 	})
 
-	t.Run("two entitlements, no disjunctions", func(t *testing.T) {
+	t.Run("two entitlements, no disjunctions: {E1, E2} = true", func(t *testing.T) {
 		t.Parallel()
 
 		set := &EntitlementSet{}
@@ -324,7 +324,7 @@ func TestEntitlementSet_MinimallyRepresentable(t *testing.T) {
 		assert.True(t, set.IsMinimallyRepresentable())
 	})
 
-	t.Run("one entitlement, redundant disjunction", func(t *testing.T) {
+	t.Run("one entitlement, redundant disjunction: {E1, (E1 | E2)} = true", func(t *testing.T) {
 		t.Parallel()
 
 		set := &EntitlementSet{}
@@ -348,7 +348,7 @@ func TestEntitlementSet_MinimallyRepresentable(t *testing.T) {
 		assert.True(t, set.IsMinimallyRepresentable())
 	})
 
-	t.Run("two entitlements, two redundant disjunctions", func(t *testing.T) {
+	t.Run("two entitlements, two redundant disjunctions: {E1, E3, (E1 | E2), (E3 | E4)} = true", func(t *testing.T) {
 		t.Parallel()
 
 		set := &EntitlementSet{}
@@ -387,7 +387,7 @@ func TestEntitlementSet_MinimallyRepresentable(t *testing.T) {
 		assert.True(t, set.IsMinimallyRepresentable())
 	})
 
-	t.Run("one entitlement, non-redundant disjunction", func(t *testing.T) {
+	t.Run("one entitlement, non-redundant disjunction: {E1, (E3 | E2)} = false", func(t *testing.T) {
 		t.Parallel()
 
 		set := &EntitlementSet{}
@@ -415,7 +415,7 @@ func TestEntitlementSet_MinimallyRepresentable(t *testing.T) {
 		assert.False(t, set.IsMinimallyRepresentable())
 	})
 
-	t.Run("two disjunctions", func(t *testing.T) {
+	t.Run("two disjunctions: {(E1 | E2), (E2 | E3)} = false", func(t *testing.T) {
 		t.Parallel()
 
 		set := &EntitlementSet{}


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3296

When a contract upgrade would cause the entitlements migration to overapproximate an entitlements set (as a result of not being able to represent a conjunction of disjunctions), reject that staged contract instead of silently allowing the potentially unsafe migration. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
