### PR TITLE
Make static type cache an interface

### DIFF
--- a/migrations/cache.go
+++ b/migrations/cache.go
@@ -24,11 +24,20 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 )
 
-type StaticTypeCache struct {
+type StaticTypeCache interface {
+	Get(typeID interpreter.TypeID) (interpreter.StaticType, bool)
+	Set(typeID interpreter.TypeID, ty interpreter.StaticType)
+}
+
+type DefaultStaticTypeCache struct {
 	entries sync.Map
 }
 
-func (c *StaticTypeCache) Get(typeID interpreter.TypeID) (interpreter.StaticType, bool) {
+func NewDefaultStaticTypeCache() *DefaultStaticTypeCache {
+	return &DefaultStaticTypeCache{}
+}
+
+func (c *DefaultStaticTypeCache) Get(typeID interpreter.TypeID) (interpreter.StaticType, bool) {
 	v, ok := c.entries.Load(typeID)
 	if !ok {
 		return nil, false
@@ -36,6 +45,6 @@ func (c *StaticTypeCache) Get(typeID interpreter.TypeID) (interpreter.StaticType
 	return v.(interpreter.StaticType), true
 }
 
-func (c *StaticTypeCache) Set(typeID interpreter.TypeID, ty interpreter.StaticType) {
+func (c *DefaultStaticTypeCache) Set(typeID interpreter.TypeID, ty interpreter.StaticType) {
 	c.entries.Store(typeID, ty)
 }

--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -29,18 +29,19 @@ import (
 
 type EntitlementsMigration struct {
 	Interpreter       *interpreter.Interpreter
-	migratedTypeCache *migrations.StaticTypeCache
+	migratedTypeCache migrations.StaticTypeCache
 }
 
 var _ migrations.ValueMigration = EntitlementsMigration{}
 
 func NewEntitlementsMigration(inter *interpreter.Interpreter) EntitlementsMigration {
-	return NewEntitlementsMigrationWithCache(inter, &migrations.StaticTypeCache{})
+	staticTypeCache := migrations.NewDefaultStaticTypeCache()
+	return NewEntitlementsMigrationWithCache(inter, staticTypeCache)
 }
 
 func NewEntitlementsMigrationWithCache(
 	inter *interpreter.Interpreter,
-	migratedTypeCache *migrations.StaticTypeCache,
+	migratedTypeCache migrations.StaticTypeCache,
 ) EntitlementsMigration {
 	return EntitlementsMigration{
 		Interpreter:       inter,


### PR DESCRIPTION
Work towards #3297 

## Description

Make the static type cache an interface, so we can try different cache implementations.

For example, we might want to give https://github.com/alphadose/haxmap a try

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
