### PR TITLE
Add test for untyped optional nested-reference creation

### DIFF
--- a/runtime/tests/interpreter/reference_test.go
+++ b/runtime/tests/interpreter/reference_test.go
@@ -1840,6 +1840,25 @@ func TestInterpretReferenceToReference(t *testing.T) {
 		RequireError(t, err)
 		require.ErrorAs(t, err, &interpreter.NestedReferenceError{})
 	})
+
+	t.Run("nested optional reference as AnyStruct", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+            fun main() {
+                var array: [Foo] = []
+                var optionalArrayRef: (&[Foo])? = &array as &[Foo]
+                var anyStructValue = optionalArrayRef as AnyStruct
+                var ref = &anyStructValue as &AnyStruct
+            }
+
+            struct Foo {}
+        `)
+
+		_, err := inter.Invoke("main")
+		RequireError(t, err)
+		require.ErrorAs(t, err, &interpreter.NestedReferenceError{})
+	})
 }
 
 func TestInterpretDereference(t *testing.T) {


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-internal/issues/228#issuecomment-2097063877

## Description

The nested-reference prevention check only check whether the referenced-value is also a `ReferenceValue`: https://github.com/onflow/cadence/blob/dc8a27d79e5e6deaba16c01c66fd3c363739d891/runtime/interpreter/value.go#L20913-L20918

Added a test to ensure that it also catches optional-`ReferenceValue`s. (Good news is) All possible combinations are handled in `createReference` method: https://github.com/onflow/cadence/blob/dc8a27d79e5e6deaba16c01c66fd3c363739d891/runtime/interpreter/interpreter_expression.go#L1452

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
