### PR TITLE
Improve dictionary migration

### DIFF
--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -730,6 +730,7 @@ func convertEntireTestValue(
 			testEntitlementsMigration{inter: inter},
 		},
 		reporter,
+		true,
 	)
 
 	err = migration.Commit()

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -259,6 +259,10 @@ func (m *StorageMigration) MigrateNestedValue(
 				continue
 			}
 
+			// We should only check if we're allowed to mutate if we actually are going to mutate,
+			// i.e. if newValue != nil. It might be the case that none of the values need to be migrated,
+			// in which case we should not panic with an error that we're not allowed to mutate
+
 			if !allowMutation {
 				panic(errors.NewUnexpectedError(
 					"mutation not allowed: attempting to migrate array element at index %d: %s",
@@ -315,6 +319,10 @@ func (m *StorageMigration) MigrateNestedValue(
 			if newValue == nil {
 				continue
 			}
+
+			// We should only check if we're allowed to mutate if we actually are going to mutate,
+			// i.e. if newValue != nil. It might be the case that none of the values need to be migrated,
+			// in which case we should not panic with an error that we're not allowed to mutate
 
 			if !allowMutation {
 				panic(errors.NewUnexpectedError(
@@ -487,6 +495,10 @@ func (m *StorageMigration) migrateDictionaryKeys(
 		if newKey == nil {
 			continue
 		}
+
+		// We should only check if we're allowed to mutate if we actually are going to mutate,
+		// i.e. if newKey != nil. It might be the case that none of the keys need to be migrated,
+		// in which case we should not panic with an error that we're not allowed to mutate
 
 		if !allowMutation {
 			panic(errors.NewUnexpectedError(
@@ -676,6 +688,10 @@ func (m *StorageMigration) migrateDictionaryValues(
 		if newValue == nil {
 			continue
 		}
+
+		// We should only check if we're allowed to mutate if we actually are going to mutate,
+		// i.e. if newValue != nil. It might be the case that none of the values need to be migrated,
+		// in which case we should not panic with an error that we're not allowed to mutate
 
 		if !allowMutation {
 			panic(errors.NewUnexpectedError(

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -303,7 +303,7 @@ func (m *StorageMigration) MigrateNestedValue(
 				fieldName,
 			)
 
-			migratedValue := m.MigrateNestedValue(
+			newValue := m.MigrateNestedValue(
 				storageKey,
 				storageMapKey,
 				existingValue,
@@ -312,7 +312,7 @@ func (m *StorageMigration) MigrateNestedValue(
 				allowMutation,
 			)
 
-			if migratedValue == nil {
+			if newValue == nil {
 				continue
 			}
 
@@ -328,7 +328,7 @@ func (m *StorageMigration) MigrateNestedValue(
 				inter,
 				emptyLocationRange,
 				fieldName,
-				migratedValue,
+				newValue,
 			)
 		}
 

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -2758,3 +2758,216 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 	err = storage.CheckHealth()
 	require.NoError(t, err)
 }
+
+// testEnumMigration
+
+type testEnumMigration struct{}
+
+var _ ValueMigration = testEnumMigration{}
+
+func (testEnumMigration) Name() string {
+	return "testEnumMigration"
+}
+
+func (testEnumMigration) Migrate(
+	_ interpreter.StorageKey,
+	_ interpreter.StorageMapKey,
+	value interpreter.Value,
+	inter *interpreter.Interpreter,
+) (interpreter.Value, error) {
+	if composite, ok := value.(*interpreter.CompositeValue); ok && composite.Kind == common.CompositeKindEnum {
+		rawValue := composite.GetField(inter, emptyLocationRange, sema.EnumRawValueFieldName)
+		raw := rawValue.(interpreter.UInt8Value)
+		return interpreter.NewCompositeValue(
+			inter,
+			emptyLocationRange,
+			composite.Location,
+			composite.QualifiedIdentifier,
+			common.CompositeKindEnum,
+			[]interpreter.CompositeField{
+				{
+					Name:  sema.EnumRawValueFieldName,
+					Value: raw + 1,
+				},
+			},
+			composite.GetOwner(),
+		), nil
+	}
+
+	return nil, nil
+}
+
+func (testEnumMigration) CanSkip(_ interpreter.StaticType) bool {
+	return false
+}
+
+func (testEnumMigration) Domains() map[string]struct{} {
+	return nil
+}
+
+func TestDictionaryWithEnumKey(t *testing.T) {
+
+	t.Parallel()
+
+	testAddress := common.MustBytesToAddress([]byte{0x1})
+	storagePathDomain := common.PathDomainStorage.Identifier()
+	storageMapKey := interpreter.StringStorageMapKey("test")
+
+	ledger := NewTestLedger(nil, nil)
+
+	newStorageAndInterpreter := func(t *testing.T) (*runtime.Storage, *interpreter.Interpreter) {
+		storage := runtime.NewStorage(ledger, nil)
+		inter, err := interpreter.NewInterpreter(
+			nil,
+			utils.TestLocation,
+			&interpreter.Config{
+				Storage:                     storage,
+				AtreeValueValidationEnabled: true,
+				// NOTE: disabled, as storage is not expected to be always valid _during_ migration
+				AtreeStorageValidationEnabled: false,
+			},
+		)
+		require.NoError(t, err)
+
+		return storage, inter
+	}
+
+	fooQualifiedIdentifier := "Test.Foo"
+	fooType := &interpreter.CompositeStaticType{
+		Location:            utils.TestLocation,
+		QualifiedIdentifier: fooQualifiedIdentifier,
+		TypeID:              utils.TestLocation.TypeID(nil, fooQualifiedIdentifier),
+	}
+
+	// Prepare
+	(func() {
+		storage, inter := newStorageAndInterpreter(t)
+
+		storageMap := storage.GetStorageMap(
+			testAddress,
+			storagePathDomain,
+			true,
+		)
+
+		// {Test.Foo: String}
+		dictionaryValue := interpreter.NewDictionaryValueWithAddress(
+			inter,
+			emptyLocationRange,
+			interpreter.NewDictionaryStaticType(
+				nil,
+				fooType,
+				interpreter.PrimitiveStaticTypeAnyStruct,
+			),
+			testAddress,
+		)
+
+		// Write the dictionary value to storage before inserting values into dictionary,
+		// as the insertion of values into the dictionary triggers a storage health check,
+		// which fails if the dictionary value is not yet stored (unreferenced slabs)
+
+		storageMap.WriteValue(
+			inter,
+			storageMapKey,
+			dictionaryValue,
+		)
+
+		dictionaryKey := interpreter.NewCompositeValue(
+			inter,
+			emptyLocationRange,
+			utils.TestLocation,
+			"Foo",
+			common.CompositeKindEnum,
+			[]interpreter.CompositeField{
+				{
+					Name:  sema.EnumRawValueFieldName,
+					Value: interpreter.UInt8Value(42),
+				},
+			},
+			testAddress,
+		)
+
+		dictionaryValue.InsertWithoutTransfer(
+			inter,
+			emptyLocationRange,
+			dictionaryKey,
+			interpreter.NewUnmeteredStringValue("test"),
+		)
+
+		err := storage.Commit(inter, false)
+		require.NoError(t, err)
+
+		err = storage.CheckHealth()
+		require.NoError(t, err)
+	})()
+
+	// Migrate
+	(func() {
+
+		storage, inter := newStorageAndInterpreter(t)
+
+		migration, err := NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
+		reporter := newTestReporter()
+
+		migration.Migrate(
+			migration.NewValueMigrationsPathMigrator(
+				reporter,
+				testStringMigration{},
+				testEnumMigration{},
+			),
+		)
+
+		err = migration.Commit()
+		require.NoError(t, err)
+
+		// Assert
+
+		require.Len(t, reporter.errors, 0)
+
+		assert.Len(t, reporter.migrated, 1)
+
+		err = storage.CheckHealth()
+		require.NoError(t, err)
+
+		// Check storage map
+
+		storageMap := storage.GetStorageMap(testAddress, storagePathDomain, false)
+		require.NotNil(t, storageMap)
+		require.Equal(t, uint64(1), storageMap.Count())
+
+		// Check existing migrated dictionary
+
+		migratedValue := storageMap.ReadValue(nil, storageMapKey)
+		require.NotNil(t, migratedValue)
+
+		require.IsType(t, &interpreter.DictionaryValue{}, migratedValue)
+		migratedDict := migratedValue.(*interpreter.DictionaryValue)
+
+		dictionaryKey2 := interpreter.NewCompositeValue(
+			inter,
+			emptyLocationRange,
+			utils.TestLocation,
+			"Foo",
+			common.CompositeKindEnum,
+			[]interpreter.CompositeField{
+				{
+					Name: sema.EnumRawValueFieldName,
+					// NOTE: updated raw value
+					Value: interpreter.UInt8Value(43),
+				},
+			},
+			common.ZeroAddress,
+		)
+
+		value, _ := migratedDict.Get(inter, emptyLocationRange, dictionaryKey2)
+		require.NotNil(t, value)
+
+		utils.RequireValuesEqual(t,
+			inter,
+			interpreter.NewUnmeteredStringValue("updated_test"),
+			value,
+		)
+	})()
+
+}


### PR DESCRIPTION
Work towards #3288 

## Info

This PR is a result of investigating and fixing #3288, the broken migration of dictionaries in the atree register inlining version, https://github.com/onflow/cadence/tree/feature/atree-register-inlining-v1.0.

Kudos to @fxamacker for investigating the issue, finding the cause, and coming up with this non-intrusive solution! 👏 
This PR mostly just ports #3316 to `master`, so that the atree register inlining feature branch only contains additional changes required for atree register inlining, and the branch does not drift too far off of master.

The PR is best reviewed by viewing each commit individually.

## Description

- 02ebd1eeca6dae80a6611f1fc12ee9fd5006abdd: Fix MigrateNestedValue() for dictionary value

  The original bug was the use of the read-only iterator when migrating dictionary keys and values. Using the read-only iterator is wrong, as the migration might mutate dictionary keys and values.

  However, simply switching from the read-only iterator to the iterator that allows mutations of children is not possible, as the iterator that allows mutations to children does not support reading old dictionary keys that will get a different hash value in Cadence 1.0. 

  @fxamacker realized that we can split the migration of dictionaries from the current "interleaved" approach of iterating over all key-value pairs, into two phases, one that migrates all keys, and then another that migrates all values. 

  - In the first phase which migrates the keys, we can use the read-only iterator, which supports loading old keys which potentially have different hash values in Cadence 1.0. Using a read-only iterator is safe, as keys are immutable anyways, and migrations should never mutate them anyways (see below for further improvements to this)
  - In the second phase which migrates the values, we keep using the mutating iterator

  This was implemented in #3316, but on top of the atree register inlining feature branch. This PR ports the commit, 02ebd1eeca6dae80a6611f1fc12ee9fd5006abdd, to `master`. Even though the change isn't strictly needed on `master`, porting it anyways keeps the approach of how dictionaries are migrated the same across the different branches.

- 412780e4b461673ba7530a1e0c9641557100cdd2: Add comments

  Explain why the migration of dictionaries is now in two phases.
  Also add a note to not attempt to refactor the conflict handling code – I caught myself attempting to "improve" it, just to realize it was working correctly, even after the changes of the previous commit.

- 274cfcee76f71356b6a2dd1a433a51446134a56e: Refactors the dictionary migration phases into separate functions

  The `MigrateNestedValue` function had become very long, so this commit refactors the dictionary case of the switch into two functions. The code got moved as-is and no changes were made to it.

- 76e337cb384c8a27dc19a24598ff0d00c510c534: Adds a test case for migrating dictionaries with enum keys

  We did not previously have a test case for it, so add one to ensure this is still supported.

- 5d2501ae0b9c598e3ead4148f1dd749b45d26655: Prevents mutation of dictionary keys

  #3288 was hard to debug and fix, because the invalid mutation of child values returned from the read-only mutation did not produce any errors. Only the defensive storage health check after the migration identified there was something wrong.

  Improve the migration of nested values by adding assertions that ensure that migrations never mutate dictionary keys. A mutation may replace a dictionary key (e.g. enum with a different enum), but it may never mutate a dictionary key in place (e.g. change the raw value of an enum).

  Add a test that has such an invalid migration, and ensure it is immediately rejected.

- c4bed076a1e3249bdf9f1da6be98818435e5b9f7: Avoid variable shadowing

  Consistently use `newValue` as the name of the variable that is the migrated version of `existingValue`, a child values that is being migrated. Avoid shadowing the final result variable of the whole function, `migratedValue`.


______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
