### PR TITLE
Make migration error stacktrace configurable

### DIFF
--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -55,6 +55,7 @@ type StorageMigration struct {
 	name                   string
 	address                common.Address
 	dictionaryKeyConflicts int
+	stacktraceEnabled      bool
 }
 
 func NewStorageMigration(
@@ -77,6 +78,11 @@ func NewStorageMigration(
 		address:                address,
 		dictionaryKeyConflicts: 0,
 	}, nil
+}
+
+func (m *StorageMigration) WithErrorStacktrace(stacktraceEnabled bool) *StorageMigration {
+	m.stacktraceEnabled = stacktraceEnabled
+	return m
 }
 
 func (m *StorageMigration) Commit() error {
@@ -185,12 +191,17 @@ func (m *StorageMigration) MigrateNestedValue(
 				err = fmt.Errorf("%v", r)
 			}
 
+			var stack []byte
+			if m.stacktraceEnabled {
+				stack = debug.Stack()
+			}
+
 			err = StorageMigrationError{
 				StorageKey:    storageKey,
 				StorageMapKey: storageMapKey,
 				Migration:     m.name,
 				Err:           err,
-				Stack:         debug.Stack(),
+				Stack:         stack,
 			}
 
 			if reporter != nil {
@@ -776,12 +787,17 @@ func (m *StorageMigration) migrate(
 				err = fmt.Errorf("%v", r)
 			}
 
+			var stack []byte
+			if m.stacktraceEnabled {
+				stack = debug.Stack()
+			}
+
 			err = StorageMigrationError{
 				StorageKey:    storageKey,
 				StorageMapKey: storageMapKey,
 				Migration:     migration.Name(),
 				Err:           err,
-				Stack:         debug.Stack(),
+				Stack:         stack,
 			}
 		}
 	}()

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -1698,6 +1698,8 @@ func TestMigrationPanic(t *testing.T) {
 
 	reporter := newTestReporter()
 
+	migration = migration.WithErrorStacktrace(true)
+
 	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,


### PR DESCRIPTION
## Description

The stacktrace generation upon errors (type loading errors due un-migrated contracts, etc) is consuming a lot of CPU. This not only slows down the migration, but also shadows any actual bottlenecks in migration logic (when profiled). Therefore turn it off by default, and make it configurable so it can be enabled if needed. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
