### PR TITLE
Fix borrowing of contract interface

### DIFF
--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -19,6 +19,7 @@
 package stdlib
 
 import (
+	goerrors "errors"
 	"fmt"
 
 	"golang.org/x/crypto/sha3"
@@ -1325,12 +1326,19 @@ func newAccountContractsBorrowFunction(
 				return interpreter.Nil
 			}
 
-			// Load the contract
+			// Load the contract and get the contract composite value.
+			// The requested contract may be a contract interface,
+			// in which case there will be no contract composite value.
 
 			contractLocation := common.NewAddressLocation(gauge, address, name)
 			inter = inter.EnsureLoaded(contractLocation)
 			contractValue, err := inter.GetContractComposite(contractLocation)
 			if err != nil {
+				var notDeclaredErr interpreter.NotDeclaredError
+				if goerrors.As(err, &notDeclaredErr) {
+					return interpreter.Nil
+				}
+
 				panic(err)
 			}
 


### PR DESCRIPTION
Closes #3241 

## Description

When borrowing a contract interface (not to be confused with borrowing _as_ an interface), return `nil` instead of panicing.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
