### PR TITLE
Add/improve caching in static type and entitlements migration

### DIFF
--- a/migrations/cache.go
+++ b/migrations/cache.go
@@ -42,7 +42,8 @@ func (c *DefaultStaticTypeCache) Get(typeID interpreter.TypeID) (interpreter.Sta
 	if !ok {
 		return nil, false
 	}
-	return v.(interpreter.StaticType), true
+	staticType, _ := v.(interpreter.StaticType)
+	return staticType, true
 }
 
 func (c *DefaultStaticTypeCache) Set(typeID interpreter.TypeID, ty interpreter.StaticType) {

--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -89,13 +89,11 @@ func (m EntitlementsMigration) ConvertToEntitledType(
 	staticTypeID := staticType.ID()
 
 	if migratedType, exists := migratedTypeCache.Get(staticTypeID); exists {
-		return migratedType, nil
+		return migratedType.StaticType, migratedType.Error
 	}
 
 	defer func() {
-		if err != nil {
-			migratedTypeCache.Set(staticTypeID, resultType)
-		}
+		migratedTypeCache.Set(staticTypeID, resultType, err)
 	}()
 
 	switch t := staticType.(type) {

--- a/migrations/statictypes/account_type_migration_test.go
+++ b/migrations/statictypes/account_type_migration_test.go
@@ -506,14 +506,15 @@ func TestAccountTypeInTypeValueMigration(t *testing.T) {
 							StorageMapKey: storageMapKey,
 						}: {},
 					},
-					reporter.migrated)
+					reporter.migrated,
+				)
 			}
 
 			// Assert the migrated values.
 
 			storageMap := storage.GetStorageMap(account, pathDomain.Identifier(), false)
 			require.NotNil(t, storageMap)
-			require.Equal(t, storageMap.Count(), uint64(1))
+			require.Equal(t, uint64(1), storageMap.Count())
 
 			value := storageMap.ReadValue(nil, storageMapKey)
 

--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -177,19 +177,16 @@ func (m *StaticTypeMigration) maybeConvertStaticType(
 	// Parse of the migration, e.g. the intersection type migration depends on the parent type.
 	// For example, `{Ts}` in `&{Ts}` is migrated differently from `{Ts}`.
 
-	if parentType == nil {
+	migratedTypeCache := m.migratedTypeCache
+	staticTypeID := staticType.ID()
 
-		migratedTypeCache := m.migratedTypeCache
-		staticTypeID := staticType.ID()
-
-		if migratedType, exists := migratedTypeCache.Get(staticTypeID); exists {
-			return migratedType
-		}
-
-		defer func() {
-			migratedTypeCache.Set(staticTypeID, resultType)
-		}()
+	if cachedType, exists := migratedTypeCache.Get(staticTypeID); exists {
+		return cachedType.StaticType
 	}
+
+	defer func() {
+		migratedTypeCache.Set(staticTypeID, resultType, nil)
+	}()
 
 	switch staticType := staticType.(type) {
 	case *interpreter.ConstantSizedStaticType:

--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -171,9 +171,11 @@ func (m *StaticTypeMigration) maybeConvertStaticType(
 ) (
 	resultType interpreter.StaticType,
 ) {
-	// Consult the cache and cache the result
-	// at the root of the migration,
+	// Consult the cache and cache the result at the root of the migration,
 	// i.e. when the parent type is nil.
+	//
+	// Parse of the migration, e.g. the intersection type migration depends on the parent type.
+	// For example, `{Ts}` in `&{Ts}` is migrated differently from `{Ts}`.
 
 	if parentType == nil {
 

--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -177,16 +177,18 @@ func (m *StaticTypeMigration) maybeConvertStaticType(
 	// Parse of the migration, e.g. the intersection type migration depends on the parent type.
 	// For example, `{Ts}` in `&{Ts}` is migrated differently from `{Ts}`.
 
-	migratedTypeCache := m.migratedTypeCache
-	staticTypeID := staticType.ID()
+	if parentType == nil {
+		migratedTypeCache := m.migratedTypeCache
+		staticTypeID := staticType.ID()
 
-	if cachedType, exists := migratedTypeCache.Get(staticTypeID); exists {
-		return cachedType.StaticType
+		if cachedType, exists := migratedTypeCache.Get(staticTypeID); exists {
+			return cachedType.StaticType
+		}
+
+		defer func() {
+			migratedTypeCache.Set(staticTypeID, resultType, nil)
+		}()
 	}
-
-	defer func() {
-		migratedTypeCache.Set(staticTypeID, resultType, nil)
-	}()
 
 	switch staticType := staticType.(type) {
 	case *interpreter.ConstantSizedStaticType:


### PR DESCRIPTION
Closes #3326

## Description

- Improve caching in the entitlements migration: Always cache the result, even if the outcome is that no migration of the type is necessary, i.e. the result is `nil`
- Add caching to the static type migration
- Refactor the tests so that individual test cases are run independently.

  There might be "conflicts" between the test cases, in the sense that one test case defines a type `X` as something (e.g. an interface), while another test case defines it as something else (e.g. a composite type).

  When test cases are combined and all run using a single migration, the added caching will result in incorrect results.

Best viewed with whitespace disabled in the diff.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
