### PR TITLE
Handle missing interfaces in Cadence 1.0 contract update validator

### DIFF
--- a/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validator.go
+++ b/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validator.go
@@ -241,8 +241,12 @@ func (validator *CadenceV042ToV1ContractUpdateValidator) getInterfaceType(intf *
 func (validator *CadenceV042ToV1ContractUpdateValidator) getIntersectedInterfaces(
 	intersection []*ast.NominalType,
 ) (interfaceTypes []*sema.InterfaceType) {
-	for _, interfaceType := range intersection {
-		interfaceTypes = append(interfaceTypes, validator.getInterfaceType(interfaceType))
+	for _, astInterfaceType := range intersection {
+		interfaceType := validator.getInterfaceType(astInterfaceType)
+		if interfaceType == nil {
+			continue
+		}
+		interfaceTypes = append(interfaceTypes, interfaceType)
 	}
 	return
 }
@@ -288,6 +292,10 @@ func (validator *CadenceV042ToV1ContractUpdateValidator) expectedAuthorizationOf
 	// ignoring the legacy restricted type, as an intersection type appearing in the new contract means it must have originally
 	// been a restricted type with no legacy type
 	interfaces := validator.getIntersectedInterfaces(intersectionTypes)
+
+	if len(interfaces) == 0 {
+		return sema.UnauthorizedAccess
+	}
 
 	intersectionType := sema.NewIntersectionType(nil, nil, interfaces)
 


### PR DESCRIPTION
Closes #3336 

## Description


Fix a nil-dereference crasher, which occurred when the upgradability of a field is checked, in particular when the old type had a restricted type with a non-existing interface.

The patch fixes the crasher, but I'm not 100% sure if this is sufficient in terms of validity – should the validator also report an error that the interface cannot be found?

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
