### PR TITLE
Check dictionary keys when checking the ability for dereferencing

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -7380,7 +7380,8 @@ func IsPrimitiveOrContainerOfPrimitive(referencedType Type) bool {
 		return IsPrimitiveOrContainerOfPrimitive(ty.Type)
 
 	case *DictionaryType:
-		return IsPrimitiveOrContainerOfPrimitive(ty.ValueType)
+		return IsPrimitiveOrContainerOfPrimitive(ty.KeyType) &&
+			IsPrimitiveOrContainerOfPrimitive(ty.ValueType)
 
 	default:
 		return ty.IsPrimitiveType()

--- a/runtime/tests/checker/reference_test.go
+++ b/runtime/tests/checker/reference_test.go
@@ -3512,6 +3512,23 @@ func TestCheckDereference(t *testing.T) {
               }
             `,
 		)
+
+		// Dictionaries with composite typed keys cannot be dereferenced.
+		runInvalidTestCase(
+			t,
+			"{Enum: Int}",
+			`
+                access(all) enum E:Int {
+                    access(all) case first
+                }
+
+                access(all) fun main() {
+                    var dict = {E.first: 0}
+                    var ref = &dict as &{E: Int}
+                    var deref = *ref
+                }
+            `,
+		)
 	})
 
 	runInvalidTestCase(


### PR DESCRIPTION
Port https://github.com/dapperlabs/cadence-internal/pull/229

## Description

This is currently inconsistent because enums in other places are not allowed to be dereferenced. Also makes the existing check vulnerable for future mishaps, if some new type (e.g: builtin type) is allowed to be used as a dictionary key in future, and forgets to update this logic in `IsPrimitiveOrContainerOfPrimitive`

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
