### PR TITLE
Use parent to determine whether an expression is target of an invocation

### DIFF
--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -301,7 +301,7 @@ func (r *REPL) Accept(code []byte, eval bool) (inputIsComplete bool, err error) 
 			var expressionType sema.Type
 			expressionStatement, isExpression := statement.(*ast.ExpressionStatement)
 			if isExpression {
-				expressionType = r.checker.VisitExpression(expressionStatement.Expression, nil)
+				expressionType = r.checker.VisitExpression(expressionStatement.Expression, expressionStatement, nil)
 				if !eval && expressionType != sema.InvalidType {
 					r.onExpressionType(expressionType)
 				}

--- a/runtime/sema/check_array_expression.go
+++ b/runtime/sema/check_array_expression.go
@@ -69,7 +69,7 @@ func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) Ty
 		argumentTypes = make([]Type, elementCount)
 
 		for i, value := range expression.Values {
-			valueType := checker.VisitExpression(value, elementType)
+			valueType := checker.VisitExpression(value, expression, elementType)
 
 			argumentTypes[i] = valueType
 

--- a/runtime/sema/check_array_expression.go
+++ b/runtime/sema/check_array_expression.go
@@ -20,7 +20,7 @@ package sema
 
 import "github.com/onflow/cadence/runtime/ast"
 
-func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) Type {
+func (checker *Checker) VisitArrayExpression(arrayExpression *ast.ArrayExpression) Type {
 
 	// visit all elements, ensure they are all the same type
 
@@ -29,7 +29,7 @@ func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) Ty
 	var elementType Type
 	var resultType ArrayType
 
-	elementCount := len(expression.Values)
+	elementCount := len(arrayExpression.Values)
 
 	switch typ := expectedType.(type) {
 
@@ -43,7 +43,7 @@ func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) Ty
 				&ConstantSizedArrayLiteralSizeError{
 					ExpectedSize: typ.Size,
 					ActualSize:   literalCount,
-					Range:        expression.Range,
+					Range:        arrayExpression.Range,
 				},
 			)
 		}
@@ -68,13 +68,13 @@ func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) Ty
 	if elementCount > 0 {
 		argumentTypes = make([]Type, elementCount)
 
-		for i, value := range expression.Values {
-			valueType := checker.VisitExpression(value, expression, elementType)
+		for i, element := range arrayExpression.Values {
+			valueType := checker.VisitExpression(element, arrayExpression, elementType)
 
 			argumentTypes[i] = valueType
 
-			checker.checkVariableMove(value)
-			checker.checkResourceMoveOperation(value, valueType)
+			checker.checkVariableMove(element)
+			checker.checkResourceMoveOperation(element, valueType)
 		}
 	}
 
@@ -87,7 +87,7 @@ func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) Ty
 			checker.report(
 				&TypeAnnotationRequiredError{
 					Cause: "cannot infer type from array literal:",
-					Pos:   expression.StartPos,
+					Pos:   arrayExpression.StartPos,
 				},
 			)
 
@@ -100,7 +100,7 @@ func (checker *Checker) VisitArrayExpression(expression *ast.ArrayExpression) Ty
 	}
 
 	checker.Elaboration.SetArrayExpressionTypes(
-		expression,
+		arrayExpression,
 		ArrayExpressionTypes{
 			ArgumentTypes: argumentTypes,
 			ArrayType:     resultType,

--- a/runtime/sema/check_assignment.go
+++ b/runtime/sema/check_assignment.go
@@ -59,7 +59,7 @@ func (checker *Checker) checkAssignment(
 	if checker.accessedSelfMember(target) == nil {
 		checkValue = checker.VisitExpressionWithReferenceCheck
 	}
-	valueType = checkValue(value, targetType)
+	valueType = checkValue(value, assignment, targetType)
 
 	// NOTE: Visiting the `value` checks the compatibility between value and target types.
 	// Check for the *target* type, so that assignment using non-resource typed value (e.g. `nil`)

--- a/runtime/sema/check_attach_expression.go
+++ b/runtime/sema/check_attach_expression.go
@@ -34,7 +34,7 @@ func (checker *Checker) VisitAttachExpression(expression *ast.AttachExpression) 
 	attachment := expression.Attachment
 	baseExpression := expression.Base
 
-	baseType := checker.VisitExpression(baseExpression, checker.expectedType)
+	baseType := checker.VisitExpression(baseExpression, expression, checker.expectedType)
 	attachmentType := checker.checkInvocationExpression(attachment)
 
 	if attachmentType.IsInvalidType() || baseType.IsInvalidType() {

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -67,7 +67,12 @@ func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) 
 	// Visit the expression, with contextually expected type. Use the expected type
 	// only for inferring wherever possible, but do not check for compatibility.
 	// Compatibility is checked separately for each operand kind.
-	leftType = checker.VisitExpressionWithForceType(expression.Left, expectedType, false)
+	leftType = checker.VisitExpressionWithForceType(
+		expression.Left,
+		expression,
+		expectedType,
+		false,
+	)
 
 	leftIsInvalid := leftType.IsInvalidType()
 
@@ -123,7 +128,12 @@ func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) 
 			expectedType = leftType
 		}
 
-		rightType = checker.VisitExpressionWithForceType(expression.Right, expectedType, false)
+		rightType = checker.VisitExpressionWithForceType(
+			expression.Right,
+			expression,
+			expectedType,
+			false,
+		)
 
 		rightIsInvalid := rightType.IsInvalidType()
 
@@ -174,7 +184,12 @@ func (checker *Checker) VisitBinaryExpression(expression *ast.BinaryExpression) 
 					expectedType = optionalLeftType.Type
 				}
 			}
-			return checker.VisitExpressionWithForceType(expression.Right, expectedType, false)
+			return checker.VisitExpressionWithForceType(
+				expression.Right,
+				expression,
+				expectedType,
+				false,
+			)
 		})
 
 		rightIsInvalid := rightType.IsInvalidType()

--- a/runtime/sema/check_casting_expression.go
+++ b/runtime/sema/check_casting_expression.go
@@ -44,7 +44,7 @@ func (checker *Checker) VisitCastingExpression(expression *ast.CastingExpression
 
 	beforeErrors := len(checker.errors)
 
-	leftHandType, exprActualType := checker.visitExpression(leftHandExpression, expectedType)
+	leftHandType, exprActualType := checker.visitExpression(leftHandExpression, expression, expectedType)
 
 	hasErrors := len(checker.errors) > beforeErrors
 

--- a/runtime/sema/check_composite_declaration.go
+++ b/runtime/sema/check_composite_declaration.go
@@ -2087,6 +2087,7 @@ func (checker *Checker) checkDefaultDestroyParamExpressionKind(
 
 func (checker *Checker) checkDefaultDestroyEventParam(
 	param Parameter,
+	eventDeclaration ast.CompositeLikeDeclaration,
 	astParam *ast.Parameter,
 	containerType EntitlementSupportingType,
 	containerDeclaration ast.Declaration,
@@ -2113,7 +2114,8 @@ func (checker *Checker) checkDefaultDestroyEventParam(
 			compositeContainer,
 			compositeContainer.baseTypeDocString)
 	}
-	param.DefaultArgument = checker.VisitExpression(paramDefaultArgument, paramType)
+
+	param.DefaultArgument = checker.VisitExpression(paramDefaultArgument, eventDeclaration, paramType)
 
 	// default events must have default arguments for all their parameters; this is enforced in the parser
 	// we want to check that these arguments are all either literals or field accesses, and have primitive types
@@ -2143,7 +2145,13 @@ func (checker *Checker) checkDefaultDestroyEvent(
 	defer checker.leaveValueScope(eventDeclaration.EndPosition, true)
 
 	for index, param := range eventType.ConstructorParameters {
-		checker.checkDefaultDestroyEventParam(param, constructorFunctionParameters[index], containerType, containerDeclaration)
+		checker.checkDefaultDestroyEventParam(
+			param,
+			eventDeclaration,
+			constructorFunctionParameters[index],
+			containerType,
+			containerDeclaration,
+		)
 	}
 }
 

--- a/runtime/sema/check_conditional.go
+++ b/runtime/sema/check_conditional.go
@@ -30,7 +30,7 @@ func (checker *Checker) VisitIfStatement(statement *ast.IfStatement) (_ struct{}
 
 	switch test := statement.Test.(type) {
 	case ast.Expression:
-		checker.VisitExpression(test, BoolType)
+		checker.VisitExpression(test, statement, BoolType)
 
 		checker.checkConditionalBranches(
 			func() Type {
@@ -90,14 +90,14 @@ func (checker *Checker) VisitConditionalExpression(expression *ast.ConditionalEx
 
 	expectedType := checker.expectedType
 
-	checker.VisitExpression(expression.Test, BoolType)
+	checker.VisitExpression(expression.Test, expression, BoolType)
 
 	thenType, elseType := checker.checkConditionalBranches(
 		func() Type {
-			return checker.VisitExpression(expression.Then, expectedType)
+			return checker.VisitExpression(expression.Then, expression, expectedType)
 		},
 		func() Type {
-			return checker.VisitExpression(expression.Else, expectedType)
+			return checker.VisitExpression(expression.Else, expression, expectedType)
 		},
 	)
 

--- a/runtime/sema/check_conditions.go
+++ b/runtime/sema/check_conditions.go
@@ -51,11 +51,11 @@ func (checker *Checker) checkCondition(condition ast.Condition) {
 	case *ast.TestCondition:
 
 		// check test expression is boolean
-		checker.VisitExpression(condition.Test, BoolType)
+		checker.VisitExpression(condition.Test, condition, BoolType)
 
 		// check message expression results in a string
 		if condition.Message != nil {
-			checker.VisitExpression(condition.Message, StringType)
+			checker.VisitExpression(condition.Message, condition, StringType)
 		}
 
 	case *ast.EmitCondition:

--- a/runtime/sema/check_create_expression.go
+++ b/runtime/sema/check_create_expression.go
@@ -34,7 +34,7 @@ func (checker *Checker) VisitCreateExpression(expression *ast.CreateExpression) 
 
 	invocation := expression.InvocationExpression
 
-	ty := checker.VisitExpression(invocation, nil)
+	ty := checker.VisitExpression(invocation, expression, nil)
 
 	if ty.IsInvalidType() {
 		return ty

--- a/runtime/sema/check_destroy_expression.go
+++ b/runtime/sema/check_destroy_expression.go
@@ -25,7 +25,7 @@ import (
 func (checker *Checker) VisitDestroyExpression(expression *ast.DestroyExpression) (resultType Type) {
 	resultType = VoidType
 
-	valueType := checker.VisitExpression(expression.Expression, nil)
+	valueType := checker.VisitExpression(expression.Expression, expression, nil)
 
 	checker.ObserveImpureOperation(expression)
 	checker.recordResourceInvalidation(

--- a/runtime/sema/check_dictionary_expression.go
+++ b/runtime/sema/check_dictionary_expression.go
@@ -50,11 +50,11 @@ func (checker *Checker) VisitDictionaryExpression(expression *ast.DictionaryExpr
 			// NOTE: important to check move after each type check,
 			// not combined after both type checks!
 
-			entryKeyType := checker.VisitExpression(entry.Key, keyType)
+			entryKeyType := checker.VisitExpression(entry.Key, expression, keyType)
 			checker.checkVariableMove(entry.Key)
 			checker.checkResourceMoveOperation(entry.Key, entryKeyType)
 
-			entryValueType := checker.VisitExpression(entry.Value, valueType)
+			entryValueType := checker.VisitExpression(entry.Value, expression, valueType)
 			checker.checkVariableMove(entry.Value)
 			checker.checkResourceMoveOperation(entry.Value, entryValueType)
 

--- a/runtime/sema/check_expression.go
+++ b/runtime/sema/check_expression.go
@@ -161,7 +161,7 @@ func (checker *Checker) checkResourceVariableCapturingInFunction(variable *Varia
 func (checker *Checker) VisitExpressionStatement(statement *ast.ExpressionStatement) (_ struct{}) {
 	expression := statement.Expression
 
-	ty := checker.VisitExpression(expression, nil)
+	ty := checker.VisitExpression(expression, statement, nil)
 
 	if ty.IsResourceType() {
 		checker.report(
@@ -270,7 +270,7 @@ func (checker *Checker) visitIndexExpression(
 ) Type {
 
 	targetExpression := indexExpression.TargetExpression
-	targetType := checker.VisitExpression(targetExpression, nil)
+	targetType := checker.VisitExpression(targetExpression, indexExpression, nil)
 
 	// NOTE: check indexed type first for UX reasons
 
@@ -309,6 +309,7 @@ func (checker *Checker) visitIndexExpression(
 		}
 		indexingType := checker.VisitExpression(
 			indexExpression.IndexingExpression,
+			indexExpression,
 			valueIndexedType.IndexingType(),
 		)
 

--- a/runtime/sema/check_for.go
+++ b/runtime/sema/check_for.go
@@ -41,7 +41,7 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) (_ struct
 		}
 	}
 
-	valueType := checker.VisitExpression(valueExpression, expectedType)
+	valueType := checker.VisitExpression(valueExpression, statement, expectedType)
 
 	// Only get the element type if the array is not a resource array.
 	// Otherwise, in addition to the `UnsupportedResourceForLoopError`,

--- a/runtime/sema/check_force_expression.go
+++ b/runtime/sema/check_force_expression.go
@@ -28,7 +28,7 @@ func (checker *Checker) VisitForceExpression(expression *ast.ForceExpression) Ty
 	// i.e: if `x!` is `String`, then `x` is expected to be `String?`.
 	expectedType := wrapWithOptionalIfNotNil(checker.expectedType)
 
-	valueType := checker.VisitExpression(expression.Expression, expectedType)
+	valueType := checker.VisitExpression(expression.Expression, expression, expectedType)
 
 	if valueType.IsInvalidType() {
 		return valueType

--- a/runtime/sema/check_invocation_expression.go
+++ b/runtime/sema/check_invocation_expression.go
@@ -89,7 +89,7 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 	// check the invoked expression can be invoked
 
 	invokedExpression := invocationExpression.InvokedExpression
-	expressionType := checker.VisitExpression(invokedExpression, nil)
+	expressionType := checker.VisitExpression(invokedExpression, invocationExpression, nil)
 
 	// `inInvocation` should be reset before visiting arguments
 	checker.inInvocation = false
@@ -131,7 +131,7 @@ func (checker *Checker) checkInvocationExpression(invocationExpression *ast.Invo
 			argumentTypes = make([]Type, 0, argumentCount)
 
 			for _, argument := range invocationExpression.Arguments {
-				argumentType := checker.VisitExpression(argument.Expression, nil)
+				argumentType := checker.VisitExpression(argument.Expression, invocationExpression, nil)
 				argumentTypes = append(argumentTypes, argumentType)
 			}
 
@@ -469,7 +469,7 @@ func (checker *Checker) checkInvocation(
 
 			parameterTypes[argumentIndex] =
 				checker.checkInvocationRequiredArgument(
-					invocationExpression.Arguments,
+					invocationExpression,
 					argumentIndex,
 					functionType,
 					argumentTypes,
@@ -482,7 +482,7 @@ func (checker *Checker) checkInvocation(
 		for i := minCount; i < argumentCount; i++ {
 			argument := invocationExpression.Arguments[i]
 			// TODO: pass the expected type to support type inferring for parameters
-			argumentTypes[i] = checker.VisitExpression(argument.Expression, nil)
+			argumentTypes[i] = checker.VisitExpression(argument.Expression, invocationExpression, nil)
 		}
 	}
 
@@ -571,7 +571,7 @@ func (checker *Checker) checkTypeParameterInference(
 }
 
 func (checker *Checker) checkInvocationRequiredArgument(
-	arguments ast.Arguments,
+	invocationExpression *ast.InvocationExpression,
 	argumentIndex int,
 	functionType *FunctionType,
 	argumentTypes []Type,
@@ -579,7 +579,7 @@ func (checker *Checker) checkInvocationRequiredArgument(
 ) (
 	parameterType Type,
 ) {
-	argument := arguments[argumentIndex]
+	argument := invocationExpression.Arguments[argumentIndex]
 
 	parameter := functionType.Parameters[argumentIndex]
 	parameterType = parameter.TypeAnnotation.Type
@@ -637,7 +637,7 @@ func (checker *Checker) checkInvocationRequiredArgument(
 			expectedType = nil
 		}
 
-		argumentType = checker.VisitExpression(argument.Expression, expectedType)
+		argumentType = checker.VisitExpression(argument.Expression, invocationExpression, expectedType)
 
 		// If we did not pass an expected type,
 		// we must manually check that the argument type and the parameter type are compatible.
@@ -659,7 +659,7 @@ func (checker *Checker) checkInvocationRequiredArgument(
 		// We will then have to manually check that the argument type is compatible
 		// with the parameter type (see below).
 
-		argumentType = checker.VisitExpression(argument.Expression, nil)
+		argumentType = checker.VisitExpression(argument.Expression, invocationExpression, nil)
 
 		// Try to unify the parameter type with the argument type.
 		// If unification fails, fall back to the parameter type for now.

--- a/runtime/sema/check_reference_expression.go
+++ b/runtime/sema/check_reference_expression.go
@@ -59,7 +59,7 @@ func (checker *Checker) VisitReferenceExpression(referenceExpression *ast.Refere
 
 	beforeErrors := len(checker.errors)
 
-	referencedType, actualType := checker.visitExpression(referencedExpression, expectedLeftType)
+	referencedType, actualType := checker.visitExpression(referencedExpression, referenceExpression, expectedLeftType)
 
 	// check that the type of the referenced value is not itself a reference
 	var requireNoReferenceNesting func(actualType Type)

--- a/runtime/sema/check_remove_statement.go
+++ b/runtime/sema/check_remove_statement.go
@@ -32,7 +32,7 @@ func (checker *Checker) VisitRemoveStatement(statement *ast.RemoveStatement) (_ 
 	}
 
 	nominalType := checker.convertNominalType(statement.Attachment)
-	base := checker.VisitExpression(statement.Value, nil)
+	base := checker.VisitExpression(statement.Value, statement, nil)
 	checker.checkUnusedExpressionResourceLoss(base, statement.Value)
 
 	if nominalType == InvalidType {

--- a/runtime/sema/check_return_statement.go
+++ b/runtime/sema/check_return_statement.go
@@ -60,7 +60,7 @@ func (checker *Checker) VisitReturnStatement(statement *ast.ReturnStatement) (_ 
 	// If the return statement has a return value,
 	// check that the value's type matches the enclosing function's return type
 
-	valueType := checker.VisitExpression(statement.Expression, returnType)
+	valueType := checker.VisitExpression(statement.Expression, statement, returnType)
 
 	checker.Elaboration.SetReturnStatementTypes(
 		statement,

--- a/runtime/sema/check_swap.go
+++ b/runtime/sema/check_swap.go
@@ -31,8 +31,8 @@ func (checker *Checker) VisitSwapStatement(swap *ast.SwapStatement) (_ struct{})
 
 	// Then re-visit the same expressions, this time treat them as the value-expr of the assignment.
 	// The 'expected type' of the two expression would be the types obtained from the previous visit, swapped.
-	leftValueType := checker.VisitExpression(swap.Left, rightTargetType)
-	rightValueType := checker.VisitExpression(swap.Right, leftTargetType)
+	leftValueType := checker.VisitExpression(swap.Left, swap, rightTargetType)
+	rightValueType := checker.VisitExpression(swap.Right, swap, leftTargetType)
 
 	checker.Elaboration.SetSwapStatementTypes(
 		swap,

--- a/runtime/sema/check_switch.go
+++ b/runtime/sema/check_switch.go
@@ -24,7 +24,7 @@ import (
 
 func (checker *Checker) VisitSwitchStatement(statement *ast.SwitchStatement) (_ struct{}) {
 
-	testType := checker.VisitExpression(statement.Expression, nil)
+	testType := checker.VisitExpression(statement.Expression, statement, nil)
 
 	testTypeIsValid := !testType.IsInvalidType()
 
@@ -43,6 +43,7 @@ func (checker *Checker) VisitSwitchStatement(statement *ast.SwitchStatement) (_ 
 
 	checker.functionActivations.Current().WithSwitch(func() {
 		checker.checkSwitchCasesStatements(
+			statement,
 			statement.Cases,
 			testType,
 			testTypeIsValid,
@@ -53,6 +54,7 @@ func (checker *Checker) VisitSwitchStatement(statement *ast.SwitchStatement) (_ 
 }
 
 func (checker *Checker) checkSwitchCaseExpression(
+	statement *ast.SwitchStatement,
 	caseExpression ast.Expression,
 	testType Type,
 	testTypeIsValid bool,
@@ -63,7 +65,7 @@ func (checker *Checker) checkSwitchCaseExpression(
 		caseExprExpectedType = testType
 	}
 
-	caseType := checker.VisitExpression(caseExpression, caseExprExpectedType)
+	caseType := checker.VisitExpression(caseExpression, statement, caseExprExpectedType)
 
 	if caseType.IsInvalidType() {
 		return
@@ -88,6 +90,7 @@ func (checker *Checker) checkSwitchCaseExpression(
 }
 
 func (checker *Checker) checkSwitchCasesStatements(
+	statement *ast.SwitchStatement,
 	remainingCases []*ast.SwitchCase,
 	testType Type,
 	testTypeIsValid bool,
@@ -128,6 +131,7 @@ func (checker *Checker) checkSwitchCasesStatements(
 	}
 
 	checker.checkSwitchCaseExpression(
+		statement,
 		caseExpression,
 		testType,
 		testTypeIsValid,
@@ -145,6 +149,7 @@ func (checker *Checker) checkSwitchCasesStatements(
 		},
 		func() Type {
 			checker.checkSwitchCasesStatements(
+				statement,
 				remainingCases[1:],
 				testType,
 				testTypeIsValid,

--- a/runtime/sema/check_unary_expression.go
+++ b/runtime/sema/check_unary_expression.go
@@ -30,7 +30,12 @@ func (checker *Checker) VisitUnaryExpression(expression *ast.UnaryExpression) Ty
 		expectedType = checker.expectedType
 	}
 
-	valueType := checker.VisitExpressionWithForceType(expression.Expression, expectedType, false)
+	valueType := checker.VisitExpressionWithForceType(
+		expression.Expression,
+		expression,
+		expectedType,
+		false,
+	)
 
 	reportInvalidUnaryOperator := func(expectedType Type) {
 		checker.report(

--- a/runtime/sema/check_variable_declaration.go
+++ b/runtime/sema/check_variable_declaration.go
@@ -54,7 +54,7 @@ func (checker *Checker) visitVariableDeclarationValues(declaration *ast.Variable
 		}
 	}
 
-	valueType := checker.VisitExpression(declaration.Value, expectedValueType)
+	valueType := checker.VisitExpression(declaration.Value, declaration, expectedValueType)
 
 	if isOptionalBinding {
 		optionalType, isOptional := valueType.(*OptionalType)
@@ -203,7 +203,7 @@ func (checker *Checker) visitVariableDeclarationValues(declaration *ast.Variable
 			if recordedResourceInvalidation != nil {
 				checker.resources.RemoveTemporaryMoveInvalidation(recordedResourceInvalidation.resource, recordedResourceInvalidation.invalidation)
 			}
-			checker.VisitExpression(declaration.Value, expectedValueType)
+			checker.VisitExpression(declaration.Value, declaration, expectedValueType)
 		}
 	}
 

--- a/runtime/sema/check_while.go
+++ b/runtime/sema/check_while.go
@@ -25,7 +25,7 @@ import (
 
 func (checker *Checker) VisitWhileStatement(statement *ast.WhileStatement) (_ struct{}) {
 
-	checker.VisitExpression(statement.Test, BoolType)
+	checker.VisitExpression(statement.Test, statement, BoolType)
 
 	// The body of the loop will maybe be evaluated.
 	// That means that resource invalidations and


### PR DESCRIPTION
Port https://github.com/dapperlabs/cadence-internal/pull/220

Closes https://github.com/dapperlabs/cadence-internal/issues/213

Also lays the foundation for https://github.com/onflow/cadence/pull/3341

## Description

Concept is same as https://github.com/dapperlabs/cadence-internal/pull/146, where parent is tracked to determine whether the current expression is an invoked-expression.

However, unlike in https://github.com/dapperlabs/cadence-internal/pull/146, only record the parent temporarily as the checker visit the expression, and then reset it. Doesn't store the parent-child mapping in the elaboration. This way, there is no performance impact:
```
                                                 │   before    │               after               │
                                                 │   sec/op    │   sec/op     vs base              │
CheckContractInterfaceFungibleTokenConformance-8   65.28µ ± 0%   65.58µ ± 0%  +0.46% (p=0.009 n=6)

                                                 │    before    │               after                │
                                                 │     B/op     │     B/op      vs base              │
CheckContractInterfaceFungibleTokenConformance-8   57.77Ki ± 0%   57.78Ki ± 0%  +0.03% (p=0.002 n=6)

                                                 │   before    │             after              │
                                                 │  allocs/op  │  allocs/op   vs base           │
CheckContractInterfaceFungibleTokenConformance-8   1.022k ± 0%   1.022k ± 0%  ~ (p=1.000 n=6) ¹
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
