### PR TITLE
Add Storage.NondeterministicCommit for faster migrations

### DIFF
--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -86,7 +86,7 @@ func (m *StorageMigration) WithErrorStacktrace(stacktraceEnabled bool) *StorageM
 }
 
 func (m *StorageMigration) Commit() error {
-	return m.storage.Commit(m.interpreter, false)
+	return m.storage.NondeterministicCommit(m.interpreter, false)
 }
 
 func (m *StorageMigration) Migrate(migrator StorageMapKeyMigrator) {


### PR DESCRIPTION
This PR adds `Storage.NondeterministicCommit` as a faster and nondeterministic alternative to `Storage.Commit`.

It can be used by migration programs to commit deltas more quickly by using nondeterministic order.  

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
