### PR TITLE
Return a copy for enum-typed members, during member-access via references

### DIFF
--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -5150,8 +5150,8 @@ func (*CompositeType) IsComparable() bool {
 	return false
 }
 
-func (*CompositeType) ContainFieldsOrElements() bool {
-	return true
+func (t *CompositeType) ContainFieldsOrElements() bool {
+	return t.Kind != common.CompositeKindEnum
 }
 
 func (t *CompositeType) TypeAnnotationState() TypeAnnotationState {

--- a/runtime/tests/checker/entitlements_test.go
+++ b/runtime/tests/checker/entitlements_test.go
@@ -1615,6 +1615,29 @@ func TestCheckBasicEntitlementMappingAccess(t *testing.T) {
 
 		assert.NoError(t, err)
 	})
+
+	t.Run("enum field", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            enum Status: Int {
+                case On
+                case Off
+            }
+
+            entitlement mapping M {}
+
+            struct interface S {
+                // enum cases are public.
+                // Hence, using entitlement mappings for enum-typed variables are pointless.
+                // So reject this statically.
+                access(mapping M) let status: Status
+            }
+        `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+		require.IsType(t, &sema.InvalidMappedEntitlementMemberError{}, errs[0])
+	})
 }
 
 func TestCheckInvalidEntitlementAccess(t *testing.T) {

--- a/runtime/tests/checker/for_test.go
+++ b/runtime/tests/checker/for_test.go
@@ -507,4 +507,26 @@ func TestCheckReferencesInForLoop(t *testing.T) {
 
 		require.NoError(t, err)
 	})
+
+	t.Run("Enum array", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            enum Status: Int {
+                case On
+                case Off
+            }
+
+            fun main() {
+                var array = [Status.On, Status.Off]
+                var arrayRef = &array as &[Status]
+
+                for element in arrayRef {
+                    let e: Status = element
+                }
+            }
+        `)
+
+		require.NoError(t, err)
+	})
 }

--- a/runtime/tests/checker/member_test.go
+++ b/runtime/tests/checker/member_test.go
@@ -961,4 +961,30 @@ func TestCheckMemberAccess(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("composite reference, enum field", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+            struct Test {
+                var status: Status
+                init() {
+                    self.status = Status.Off
+                }
+            }
+
+            enum Status: Int {
+                case On
+                case Off
+            }
+
+            fun test() {
+                let test = Test()
+                let testRef = &test as &Test
+                var x: Status = testRef.status
+            }
+        `)
+
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/3355

## Description

Enums are immutable, so returning a copy during member access via references is safe.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
