### PR TITLE
Fix error message

### DIFF
--- a/runtime/stdlib/contract_update_validation.go
+++ b/runtime/stdlib/contract_update_validation.go
@@ -841,7 +841,7 @@ func (*MissingDeclarationError) IsUserError() {}
 func (e *MissingDeclarationError) Error() string {
 	return fmt.Sprintf(
 		"missing %s declaration `%s`",
-		e.Kind,
+		e.Kind.Name(),
 		e.Name,
 	)
 }


### PR DESCRIPTION
## Description

The missing declaration error produces bad error messages like `missing DeclarationKindResourceInterface declaration`.

Use declaration kind's `Name()` instead of the `String()` function.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
