### PR TITLE
Forbid interface removals

### DIFF
--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -3246,19 +3246,57 @@ func TestPragmaUpdates(t *testing.T) {
 		const oldCode = `
 				access(all) contract Test {
 					access(all) resource R {}
-					access(all) struct interface I {}
+					access(all) struct S {}
 				}
 			`
 
 		const newCode = `
 				access(all) contract Test {
 					#removedType(R)
-					#removedType(I)
+					#removedType(S)
 				}
 			`
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode, withC1Upgrade)
 		require.NoError(t, err)
+	})
+
+	testWithValidators(t, "#removedType does not allow resource interface type removal", func(t *testing.T, withC1Upgrade bool) {
+
+		const oldCode = `
+				access(all) contract Test {
+					access(all) resource interface R {}
+				}
+			`
+
+		const newCode = `
+				access(all) contract Test {
+					#removedType(R)
+				}
+			`
+
+		err := testDeployAndUpdate(t, "Test", oldCode, newCode, withC1Upgrade)
+		var expectedErr *stdlib.MissingDeclarationError
+		require.ErrorAs(t, err, &expectedErr)
+	})
+
+	testWithValidators(t, "#removedType does not allow struct interface type removal", func(t *testing.T, withC1Upgrade bool) {
+
+		const oldCode = `
+				access(all) contract Test {
+					access(all) struct interface S {}
+				}
+			`
+
+		const newCode = `
+				access(all) contract Test {
+					#removedType(S)
+				}
+			`
+
+		err := testDeployAndUpdate(t, "Test", oldCode, newCode, withC1Upgrade)
+		var expectedErr *stdlib.MissingDeclarationError
+		require.ErrorAs(t, err, &expectedErr)
 	})
 
 	testWithValidators(t, "#removedType can be added", func(t *testing.T, withC1Upgrade bool) {

--- a/runtime/stdlib/contract_update_validation.go
+++ b/runtime/stdlib/contract_update_validation.go
@@ -347,19 +347,23 @@ func (validator *ContractUpdateValidator) checkNestedDeclarationRemoval(
 	newContainingDeclaration ast.Declaration,
 	removedTypes *orderedmap.OrderedMap[string, struct{}],
 ) {
+	declarationKind := nestedDeclaration.DeclarationKind()
+
 	// OK to remove events - they are not stored
-	if nestedDeclaration.DeclarationKind() == common.DeclarationKindEvent {
+	if declarationKind == common.DeclarationKindEvent {
 		return
 	}
 
-	// OK to remove a type if it is included in a #removedType pragma
-	if removedTypes.Contains(nestedDeclaration.DeclarationIdentifier().Identifier) {
+	// OK to remove a type if it is included in a #removedType pragma, and it is not an interface
+	if removedTypes.Contains(nestedDeclaration.DeclarationIdentifier().Identifier) &&
+		declarationKind != common.DeclarationKindResourceInterface &&
+		declarationKind != common.DeclarationKindStructureInterface {
 		return
 	}
 
 	validator.report(&MissingDeclarationError{
 		Name: nestedDeclaration.DeclarationIdentifier().Identifier,
-		Kind: nestedDeclaration.DeclarationKind(),
+		Kind: declarationKind,
 		Range: ast.NewUnmeteredRangeFromPositioned(
 			newContainingDeclaration.DeclarationIdentifier(),
 		),

--- a/runtime/stdlib/contract_update_validation.go
+++ b/runtime/stdlib/contract_update_validation.go
@@ -356,8 +356,7 @@ func (validator *ContractUpdateValidator) checkNestedDeclarationRemoval(
 
 	// OK to remove a type if it is included in a #removedType pragma, and it is not an interface
 	if removedTypes.Contains(nestedDeclaration.DeclarationIdentifier().Identifier) &&
-		declarationKind != common.DeclarationKindResourceInterface &&
-		declarationKind != common.DeclarationKindStructureInterface {
+		!declarationKind.IsInterfaceDeclaration() {
 		return
 	}
 


### PR DESCRIPTION
Prevent the `#removedType` pragma from removing interfaces

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
