### PR TITLE
Update atree register inlining feature branch to v1.0.0-preview.30

### DIFF
--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -3518,3 +3518,218 @@ func TestIntersectionTypeWithIntersectionLegacyType(t *testing.T) {
 		require.Equal(t, expectedType, typeValue.Type)
 	})()
 }
+
+func TestUseAfterMigrationFailure(t *testing.T) {
+
+	t.Parallel()
+
+	locationRange := interpreter.EmptyLocationRange
+
+	ledger := NewTestLedger(nil, nil)
+
+	storageMapKey := interpreter.StringStorageMapKey("dict")
+	newTestValue := func() interpreter.Value {
+		return interpreter.NewUnmeteredStringValue("test")
+	}
+
+	const fooBarQualifiedIdentifier = "Foo.Bar"
+	testAddress := common.Address{0x42}
+	fooAddressLocation := common.NewAddressLocation(nil, testAddress, "Foo")
+
+	newStorageAndInterpreter := func(t *testing.T) (*runtime.Storage, *interpreter.Interpreter) {
+		storage := runtime.NewStorage(ledger, nil)
+		inter, err := interpreter.NewInterpreter(
+			nil,
+			utils.TestLocation,
+			&interpreter.Config{
+				Storage: storage,
+				// NOTE: disabled, because encoded and decoded values are expected to not match
+				AtreeValueValidationEnabled:   false,
+				AtreeStorageValidationEnabled: true,
+			},
+		)
+		require.NoError(t, err)
+
+		return storage, inter
+	}
+
+	newCompositeType := func() *interpreter.CompositeStaticType {
+		return interpreter.NewCompositeStaticType(
+			nil,
+			fooAddressLocation,
+			fooBarQualifiedIdentifier,
+			common.NewTypeIDFromQualifiedName(
+				nil,
+				fooAddressLocation,
+				fooBarQualifiedIdentifier,
+			),
+		)
+	}
+
+	// Prepare
+	(func() {
+
+		storage, inter := newStorageAndInterpreter(t)
+
+		dictionaryStaticType := interpreter.NewDictionaryStaticType(
+			nil,
+			interpreter.PrimitiveStaticTypeMetaType,
+			interpreter.PrimitiveStaticTypeString,
+		)
+		dictValue := interpreter.NewDictionaryValue(inter, locationRange, dictionaryStaticType)
+
+		refType := interpreter.NewReferenceStaticType(
+			nil,
+			interpreter.UnauthorizedAccess,
+			newCompositeType(),
+		)
+		refType.HasLegacyIsAuthorized = true
+		refType.LegacyIsAuthorized = true
+
+		legacyRefType := &migrations.LegacyReferenceType{
+			ReferenceStaticType: refType,
+		}
+
+		optType := interpreter.NewOptionalStaticType(
+			nil,
+			legacyRefType,
+		)
+
+		legacyOptType := &migrations.LegacyOptionalType{
+			OptionalStaticType: optType,
+		}
+
+		typeValue := interpreter.NewUnmeteredTypeValue(legacyOptType)
+
+		dictValue.Insert(
+			inter,
+			locationRange,
+			typeValue,
+			newTestValue(),
+		)
+
+		// Note: ID is in the old format
+		assert.Equal(t,
+			common.TypeID("auth&A.4200000000000000.Foo.Bar?"),
+			legacyOptType.ID(),
+		)
+
+		storageMap := storage.GetStorageMap(
+			testAddress,
+			common.PathDomainStorage.Identifier(),
+			true,
+		)
+
+		storageMap.SetValue(inter,
+			storageMapKey,
+			dictValue.Transfer(
+				inter,
+				locationRange,
+				atree.Address(testAddress),
+				false,
+				nil,
+				nil,
+				true, // dictValue is standalone
+			),
+		)
+
+		err := storage.Commit(inter, false)
+		require.NoError(t, err)
+
+		err = storage.CheckHealth()
+		require.NoError(t, err)
+	})()
+
+	// Migrate
+	(func() {
+
+		storage, inter := newStorageAndInterpreter(t)
+
+		const importErrorMessage = "cannot import"
+
+		inter.SharedState.Config.ImportLocationHandler =
+			func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
+				panic(importErrorMessage)
+			}
+
+		migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
+		require.NoError(t, err)
+
+		reporter := newTestReporter()
+
+		migration.Migrate(
+			migration.NewValueMigrationsPathMigrator(
+				reporter,
+				NewEntitlementsMigration(inter),
+			),
+		)
+
+		err = migration.Commit()
+		require.NoError(t, err)
+
+		// Assert
+
+		err = storage.CheckHealth()
+		require.NoError(t, err)
+
+		require.Len(t, reporter.errors, 1)
+
+		assert.ErrorContains(t, reporter.errors[0], importErrorMessage)
+
+		require.Empty(t, reporter.migrated)
+	})()
+
+	// Load
+	(func() {
+
+		storage, inter := newStorageAndInterpreter(t)
+
+		err := storage.CheckHealth()
+		require.NoError(t, err)
+
+		storageMap := storage.GetStorageMap(
+			testAddress,
+			common.PathDomainStorage.Identifier(),
+			false,
+		)
+		storedValue := storageMap.ReadValue(inter, storageMapKey)
+
+		require.IsType(t, &interpreter.DictionaryValue{}, storedValue)
+
+		dictValue := storedValue.(*interpreter.DictionaryValue)
+
+		refType := interpreter.NewReferenceStaticType(
+			nil,
+			interpreter.UnauthorizedAccess,
+			newCompositeType(),
+		)
+		refType.HasLegacyIsAuthorized = true
+		refType.LegacyIsAuthorized = true
+
+		optType := interpreter.NewOptionalStaticType(
+			nil,
+			refType,
+		)
+
+		typeValue := interpreter.NewUnmeteredTypeValue(optType)
+
+		// Note: ID is in the new format
+		assert.Equal(t,
+			common.TypeID("(&A.4200000000000000.Foo.Bar)?"),
+			optType.ID(),
+		)
+
+		assert.Equal(t, 1, dictValue.Count())
+
+		// Key did not get migrated, so is inaccessible using the "new" type value
+		_, ok := dictValue.Get(inter, locationRange, typeValue)
+		require.False(t, ok)
+
+		// But the key is still accessible using the "old" type value
+		legacyKey := migrations.LegacyKey(typeValue)
+
+		value, ok := dictValue.Get(inter, locationRange, legacyKey)
+		require.True(t, ok)
+		require.Equal(t, newTestValue(), value)
+	})()
+}

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -2485,12 +2485,12 @@ func TestDictionaryKeyConflict(t *testing.T) {
 				dictionaryValue,
 			)
 
-			// NOTE: use legacyKey to ensure the key is encoded in old format
+			// NOTE: use LegacyKey to ensure the key is encoded in old format
 
 			dictionaryValue.InsertWithoutTransfer(
 				inter,
 				emptyLocationRange,
-				legacyKey(dictionaryKey1),
+				LegacyKey(dictionaryKey1),
 				interpreter.NewArrayValue(
 					inter,
 					emptyLocationRange,
@@ -2503,7 +2503,7 @@ func TestDictionaryKeyConflict(t *testing.T) {
 			dictionaryValue.InsertWithoutTransfer(
 				inter,
 				emptyLocationRange,
-				legacyKey(dictionaryKey2),
+				LegacyKey(dictionaryKey2),
 				interpreter.NewArrayValue(
 					inter,
 					emptyLocationRange,
@@ -2516,7 +2516,7 @@ func TestDictionaryKeyConflict(t *testing.T) {
 			oldValue1, ok := dictionaryValue.Get(
 				inter,
 				emptyLocationRange,
-				legacyKey(dictionaryKey1),
+				LegacyKey(dictionaryKey1),
 			)
 			require.True(t, ok)
 
@@ -2535,7 +2535,7 @@ func TestDictionaryKeyConflict(t *testing.T) {
 			oldValue2, ok := dictionaryValue.Get(
 				inter,
 				emptyLocationRange,
-				legacyKey(dictionaryKey2),
+				LegacyKey(dictionaryKey2),
 			)
 			require.True(t, ok)
 

--- a/npm-packages/cadence-parser/package.json
+++ b/npm-packages/cadence-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-parser",
-  "version": "1.0.0-preview.29",
+  "version": "1.0.0-preview.31",
   "description": "The Cadence parser",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -3246,19 +3246,57 @@ func TestPragmaUpdates(t *testing.T) {
 		const oldCode = `
 				access(all) contract Test {
 					access(all) resource R {}
-					access(all) struct interface I {}
+					access(all) struct S {}
 				}
 			`
 
 		const newCode = `
 				access(all) contract Test {
 					#removedType(R)
-					#removedType(I)
+					#removedType(S)
 				}
 			`
 
 		err := testDeployAndUpdate(t, "Test", oldCode, newCode, withC1Upgrade)
 		require.NoError(t, err)
+	})
+
+	testWithValidators(t, "#removedType does not allow resource interface type removal", func(t *testing.T, withC1Upgrade bool) {
+
+		const oldCode = `
+				access(all) contract Test {
+					access(all) resource interface R {}
+				}
+			`
+
+		const newCode = `
+				access(all) contract Test {
+					#removedType(R)
+				}
+			`
+
+		err := testDeployAndUpdate(t, "Test", oldCode, newCode, withC1Upgrade)
+		var expectedErr *stdlib.MissingDeclarationError
+		require.ErrorAs(t, err, &expectedErr)
+	})
+
+	testWithValidators(t, "#removedType does not allow struct interface type removal", func(t *testing.T, withC1Upgrade bool) {
+
+		const oldCode = `
+				access(all) contract Test {
+					access(all) struct interface S {}
+				}
+			`
+
+		const newCode = `
+				access(all) contract Test {
+					#removedType(S)
+				}
+			`
+
+		err := testDeployAndUpdate(t, "Test", oldCode, newCode, withC1Upgrade)
+		var expectedErr *stdlib.MissingDeclarationError
+		require.ErrorAs(t, err, &expectedErr)
 	})
 
 	testWithValidators(t, "#removedType can be added", func(t *testing.T, withC1Upgrade bool) {


### PR DESCRIPTION
## Description

Merge `master` / `v1.0.0-preview.30` into `feature/atree-register-inlining-v1.0`.

<details>
<summary>Conflict resolution:</summary>

```diff
commit 8b6f7205badee2fc9da53f307d656d8616c6357d
Merge: a187365fe b0d291e00
Author: Bastian Müller <bastian@turbolent.com>
Date:   Wed May 29 16:20:09 2024 -0700

    Merge tag 'v1.0.0-preview.31' into bastian/update-atree-register-inlining-v1.0-5

diff --git a/migrations/entitlements/migration_test.go b/migrations/entitlements/migration_test.go
index 65eabf85c..3faad2222 100644
--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -3629,6 +3629,7 @@ func TestUseAfterMigrationFailure(t *testing.T) {
 				false,
 				nil,
 				nil,
+				true, // dictValue is standalone
 			),
 		)
 
diff --git a/migrations/migration.go b/migrations/migration.go
remerge CONFLICT (content): Merge conflict in migrations/migration.go
index 804729783..1cde187b6 100644
--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -685,34 +685,10 @@ func (m *StorageMigration) migrateDictionaryValues(
 			existingKey = LegacyKey(existingKey)
 		}
 
-<<<<<<< a187365fe (Merge pull request #3378 from onflow/bastian/update-atree-register-inlining-v1.0-4)
-	dictionary.Iterate(
-		inter,
-		emptyLocationRange,
-		func(key, value interpreter.Value) (resume bool) {
-
-			existingKeysAndValues = append(
-				existingKeysAndValues,
-				keyValuePair{
-					key:   key,
-					value: value,
-				},
-			)
-
-			// Continue iteration
-			return true
-		},
-	)
-
-	for _, existingKeyAndValue := range existingKeysAndValues {
-		existingKey := existingKeyAndValue.key
-		existingValue := existingKeyAndValue.value
-=======
 		existingValue, ok := dictionary.Get(inter, emptyLocationRange, existingKey)
 		if !ok {
 			panic(errors.NewUnexpectedError("failed to get existing value for key: %s", existingKey))
 		}
->>>>>>> b0d291e00 (v1.0.0-preview.31)
 
 		newValue := m.MigrateNestedValue(
 			storageKey,
diff --git a/version.go b/version.go
remerge CONFLICT (content): Merge conflict in version.go
index 48ff59fdc..63f1734e7 100644
--- a/version.go
+++ b/version.go
@@ -21,8 +21,4 @@
 
 package cadence
 
-<<<<<<< a187365fe (Merge pull request #3378 from onflow/bastian/update-atree-register-inlining-v1.0-4)
 const Version = "v1.0.0-preview-atree-register-inlining.29"
-=======
-const Version = "v1.0.0-preview.31"
->>>>>>> b0d291e00 (v1.0.0-preview.31)

```


</details>

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
