### PR TITLE
Improve dictionary key migration

### DIFF
--- a/migrations/capcons/capabilitymigration.go
+++ b/migrations/capcons/capabilitymigration.go
@@ -68,7 +68,12 @@ func (m *CapabilityValueMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
-) (interpreter.Value, error) {
+	_ migrations.ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
+
 	reporter := m.Reporter
 
 	switch value := value.(type) {

--- a/migrations/capcons/linkmigration.go
+++ b/migrations/capcons/linkmigration.go
@@ -70,7 +70,11 @@ func (m *LinkValueMigration) Migrate(
 	storageMapKey interpreter.StorageMapKey,
 	value interpreter.Value,
 	inter *interpreter.Interpreter,
-) (interpreter.Value, error) {
+	_ migrations.ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
 
 	pathValue, ok := storageKeyToPathValue(storageKey, storageMapKey)
 	if !ok {

--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -371,6 +371,7 @@ func (m EntitlementsMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
+	_ migrations.ValueMigrationPosition,
 ) (
 	interpreter.Value,
 	error,

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/migrations"
 	"github.com/onflow/cadence/migrations/statictypes"
+	"github.com/onflow/cadence/migrations/type_keys"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
@@ -690,6 +691,7 @@ func (m testEntitlementsMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
+	_ migrations.ValueMigrationPosition,
 ) (
 	interpreter.Value,
 	error,
@@ -731,6 +733,7 @@ func convertEntireTestValue(
 		},
 		reporter,
 		true,
+		migrations.ValueMigrationPositionOther,
 	)
 
 	err = migration.Commit()
@@ -2863,6 +2866,7 @@ func TestConvertMigratedAccountTypes(t *testing.T) {
 					nil,
 					value,
 					inter,
+					migrations.ValueMigrationPositionOther,
 				)
 			require.NoError(t, err)
 			require.NotNil(t, newValue)
@@ -3658,6 +3662,7 @@ func TestUseAfterMigrationFailure(t *testing.T) {
 			migration.NewValueMigrationsPathMigrator(
 				reporter,
 				NewEntitlementsMigration(inter),
+				type_keys.NewTypeKeyMigration(),
 			),
 		)
 
@@ -3673,7 +3678,21 @@ func TestUseAfterMigrationFailure(t *testing.T) {
 
 		assert.ErrorContains(t, reporter.errors[0], importErrorMessage)
 
-		require.Empty(t, reporter.migrated)
+		assert.Equal(t,
+			map[struct {
+				interpreter.StorageKey
+				interpreter.StorageMapKey
+			}]struct{}{
+				{
+					StorageKey: interpreter.StorageKey{
+						Address: testAddress,
+						Key:     common.PathDomainStorage.Identifier(),
+					},
+					StorageMapKey: interpreter.StringStorageMapKey("dict"),
+				}: {},
+			},
+			reporter.migrated,
+		)
 	})()
 
 	// Load
@@ -3718,15 +3737,9 @@ func TestUseAfterMigrationFailure(t *testing.T) {
 
 		assert.Equal(t, 1, dictValue.Count())
 
-		// Key did not get migrated, so is inaccessible using the "new" type value
+		// Key did not get migrated, but got still re-stored in new format,
+		// so it can be loaded and used after the migration failure
 		_, ok := dictValue.Get(inter, locationRange, typeValue)
-		require.False(t, ok)
-
-		// But the key is still accessible using the "old" type value
-		legacyKey := migrations.LegacyKey(typeValue)
-
-		value, ok := dictValue.Get(inter, locationRange, legacyKey)
 		require.True(t, ok)
-		require.Equal(t, newTestValue(), value)
 	})()
 }

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"runtime/debug"
 
+	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/errors"
@@ -37,10 +39,18 @@ type ValueMigration interface {
 		storageMapKey interpreter.StorageMapKey,
 		value interpreter.Value,
 		interpreter *interpreter.Interpreter,
+		position ValueMigrationPosition,
 	) (newValue interpreter.Value, err error)
 	CanSkip(valueType interpreter.StaticType) bool
 	Domains() map[string]struct{}
 }
+
+type ValueMigrationPosition uint8
+
+const (
+	ValueMigrationPositionOther ValueMigrationPosition = iota
+	ValueMigrationPositionDictionaryKey
+)
 
 type DomainMigration interface {
 	Name() string
@@ -162,6 +172,7 @@ func (m *StorageMigration) NewValueMigrationsPathMigrator(
 				valueMigrations,
 				reporter,
 				true,
+				ValueMigrationPositionOther,
 			)
 		},
 	)
@@ -176,6 +187,7 @@ func (m *StorageMigration) MigrateNestedValue(
 	valueMigrations []ValueMigration,
 	reporter Reporter,
 	allowMutation bool,
+	position ValueMigrationPosition,
 ) (migratedValue interpreter.Value) {
 
 	defer func() {
@@ -240,6 +252,7 @@ func (m *StorageMigration) MigrateNestedValue(
 			valueMigrations,
 			reporter,
 			allowMutation,
+			ValueMigrationPositionOther,
 		)
 		if newInnerValue != nil {
 			migratedValue = interpreter.NewSomeValueNonCopying(inter, newInnerValue)
@@ -264,6 +277,7 @@ func (m *StorageMigration) MigrateNestedValue(
 				valueMigrations,
 				reporter,
 				allowMutation,
+				ValueMigrationPositionOther,
 			)
 
 			if newElement == nil {
@@ -325,6 +339,7 @@ func (m *StorageMigration) MigrateNestedValue(
 				valueMigrations,
 				reporter,
 				allowMutation,
+				ValueMigrationPositionOther,
 			)
 
 			if newValue == nil {
@@ -390,6 +405,7 @@ func (m *StorageMigration) MigrateNestedValue(
 			valueMigrations,
 			reporter,
 			allowMutation,
+			ValueMigrationPositionOther,
 		)
 		if newInnerValue != nil {
 			newInnerCapability := newInnerValue.(interpreter.CapabilityValue)
@@ -414,6 +430,7 @@ func (m *StorageMigration) MigrateNestedValue(
 			storageKey,
 			storageMapKey,
 			value,
+			position,
 		)
 
 		if err != nil {
@@ -501,6 +518,7 @@ func (m *StorageMigration) migrateDictionaryKeys(
 			reporter,
 			// NOTE: Mutation of keys is not allowed.
 			false,
+			ValueMigrationPositionDictionaryKey,
 		)
 
 		if newKey == nil {
@@ -520,14 +538,25 @@ func (m *StorageMigration) migrateDictionaryKeys(
 
 		// We only reach here because key needs to be migrated.
 
-		// Remove the old key-value pair
+		// Remove the old key-value pair.
 
-		existingKey = legacyKey(existingKey)
-		existingKeyStorable, existingValueStorable := dictionary.RemoveWithoutTransfer(
-			inter,
-			emptyLocationRange,
-			existingKey,
-		)
+		var existingKeyStorable, existingValueStorable atree.Storable
+
+		legacyKey := LegacyKey(existingKey)
+		if legacyKey != nil {
+			existingKeyStorable, existingValueStorable = dictionary.RemoveWithoutTransfer(
+				inter,
+				emptyLocationRange,
+				legacyKey,
+			)
+		}
+		if existingKeyStorable == nil {
+			existingKeyStorable, existingValueStorable = dictionary.RemoveWithoutTransfer(
+				inter,
+				emptyLocationRange,
+				existingKey,
+			)
+		}
 		if existingKeyStorable == nil {
 			panic(errors.NewUnexpectedError(
 				"failed to remove old value for migrated key: %s",
@@ -578,6 +607,7 @@ func (m *StorageMigration) migrateDictionaryKeys(
 				valueMigrations,
 				reporter,
 				allowMutation,
+				ValueMigrationPositionOther,
 			)
 
 			var valueToSet interpreter.Value
@@ -694,6 +724,7 @@ func (m *StorageMigration) migrateDictionaryValues(
 			valueMigrations,
 			reporter,
 			allowMutation,
+			ValueMigrationPositionOther,
 		)
 
 		if newValue == nil {
@@ -769,6 +800,7 @@ func (m *StorageMigration) migrate(
 	storageKey interpreter.StorageKey,
 	storageMapKey interpreter.StorageMapKey,
 	value interpreter.Value,
+	position ValueMigrationPosition,
 ) (
 	converted interpreter.Value,
 	err error,
@@ -807,11 +839,12 @@ func (m *StorageMigration) migrate(
 		storageMapKey,
 		value,
 		m.interpreter,
+		position,
 	)
 }
 
-// legacyKey return the same type with the "old" hash/ID generation function.
-func legacyKey(key interpreter.Value) interpreter.Value {
+// LegacyKey return the same type with the "old" hash/ID generation function.
+func LegacyKey(key interpreter.Value) interpreter.Value {
 	switch key := key.(type) {
 	case interpreter.TypeValue:
 		legacyType := legacyType(key.Type)
@@ -830,7 +863,7 @@ func legacyKey(key interpreter.Value) interpreter.Value {
 		}
 	}
 
-	return key
+	return nil
 }
 
 func legacyType(staticType interpreter.StaticType) interpreter.StaticType {

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -104,7 +104,11 @@ func (testStringMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
-) (interpreter.Value, error) {
+	_ ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
 	if value, ok := value.(*interpreter.StringValue); ok {
 		return interpreter.NewUnmeteredStringValue(fmt.Sprintf("updated_%s", value.Str)), nil
 	}
@@ -137,7 +141,11 @@ func (m testInt8Migration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
-) (interpreter.Value, error) {
+	_ ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
 	int8Value, ok := value.(interpreter.Int8Value)
 	if !ok {
 		return nil, nil
@@ -173,7 +181,11 @@ func (testCapMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
-) (interpreter.Value, error) {
+	_ ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
 	if value, ok := value.(*interpreter.IDCapabilityValue); ok {
 		return interpreter.NewCapabilityValue(
 			nil,
@@ -209,7 +221,11 @@ func (testCapConMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
-) (interpreter.Value, error) {
+	_ ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
 
 	switch value := value.(type) {
 	case *interpreter.StorageCapabilityControllerValue:
@@ -984,6 +1000,7 @@ func (m testCompositeValueMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	inter *interpreter.Interpreter,
+	_ ValueMigrationPosition,
 ) (
 	interpreter.Value,
 	error,
@@ -1178,7 +1195,11 @@ func (testContainerMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	inter *interpreter.Interpreter,
-) (interpreter.Value, error) {
+	_ ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
 
 	switch value := value.(type) {
 	case *interpreter.DictionaryValue:
@@ -1640,7 +1661,11 @@ func (m testPanicMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	_ interpreter.Value,
 	_ *interpreter.Interpreter,
-) (interpreter.Value, error) {
+	_ ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
 
 	// NOTE: out-of-bounds access, panic
 	_ = []int{}[0]
@@ -1759,7 +1784,11 @@ func (m *testSkipMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
-) (interpreter.Value, error) {
+	_ ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
 
 	m.migrationCalls = append(m.migrationCalls, value)
 
@@ -2114,7 +2143,11 @@ func (testPublishedValueMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
-) (interpreter.Value, error) {
+	_ ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
 
 	if pathCap, ok := value.(*interpreter.PathCapabilityValue); ok { //nolint:staticcheck
 		return pathCap, nil
@@ -2219,7 +2252,11 @@ func (m testDomainsMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	_ interpreter.Value,
 	_ *interpreter.Interpreter,
-) (interpreter.Value, error) {
+	_ ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
 
 	if m.domains != nil {
 		_, ok := m.domains[storageKey.Key]
@@ -2355,7 +2392,11 @@ func (m testDictionaryKeyConflictMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
-) (interpreter.Value, error) {
+	_ ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
 	typeValue, ok := value.(interpreter.TypeValue)
 	if ok {
 		return typeValue, nil
@@ -2480,12 +2521,12 @@ func TestDictionaryKeyConflict(t *testing.T) {
 				dictionaryValue,
 			)
 
-			// NOTE: use legacyKey to ensure the key is encoded in old format
+			// NOTE: use LegacyKey to ensure the key is encoded in old format
 
 			dictionaryValue.InsertWithoutTransfer(
 				inter,
 				emptyLocationRange,
-				legacyKey(dictionaryKey1),
+				LegacyKey(dictionaryKey1),
 				interpreter.NewArrayValue(
 					inter,
 					emptyLocationRange,
@@ -2498,7 +2539,7 @@ func TestDictionaryKeyConflict(t *testing.T) {
 			dictionaryValue.InsertWithoutTransfer(
 				inter,
 				emptyLocationRange,
-				legacyKey(dictionaryKey2),
+				LegacyKey(dictionaryKey2),
 				interpreter.NewArrayValue(
 					inter,
 					emptyLocationRange,
@@ -2511,7 +2552,7 @@ func TestDictionaryKeyConflict(t *testing.T) {
 			oldValue1, ok := dictionaryValue.Get(
 				inter,
 				emptyLocationRange,
-				legacyKey(dictionaryKey1),
+				LegacyKey(dictionaryKey1),
 			)
 			require.True(t, ok)
 
@@ -2530,7 +2571,7 @@ func TestDictionaryKeyConflict(t *testing.T) {
 			oldValue2, ok := dictionaryValue.Get(
 				inter,
 				emptyLocationRange,
-				legacyKey(dictionaryKey2),
+				LegacyKey(dictionaryKey2),
 			)
 			require.True(t, ok)
 
@@ -2776,7 +2817,11 @@ func (testEnumMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	inter *interpreter.Interpreter,
-) (interpreter.Value, error) {
+	_ ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
 	if composite, ok := value.(*interpreter.CompositeValue); ok && composite.Kind == common.CompositeKindEnum {
 		rawValue := composite.GetField(inter, emptyLocationRange, sema.EnumRawValueFieldName)
 		raw := rawValue.(interpreter.UInt8Value)

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -2480,12 +2480,12 @@ func TestDictionaryKeyConflict(t *testing.T) {
 				dictionaryValue,
 			)
 
-			// NOTE: use LegacyKey to ensure the key is encoded in old format
+			// NOTE: use legacyKey to ensure the key is encoded in old format
 
 			dictionaryValue.InsertWithoutTransfer(
 				inter,
 				emptyLocationRange,
-				LegacyKey(dictionaryKey1),
+				legacyKey(dictionaryKey1),
 				interpreter.NewArrayValue(
 					inter,
 					emptyLocationRange,
@@ -2498,7 +2498,7 @@ func TestDictionaryKeyConflict(t *testing.T) {
 			dictionaryValue.InsertWithoutTransfer(
 				inter,
 				emptyLocationRange,
-				LegacyKey(dictionaryKey2),
+				legacyKey(dictionaryKey2),
 				interpreter.NewArrayValue(
 					inter,
 					emptyLocationRange,
@@ -2511,7 +2511,7 @@ func TestDictionaryKeyConflict(t *testing.T) {
 			oldValue1, ok := dictionaryValue.Get(
 				inter,
 				emptyLocationRange,
-				LegacyKey(dictionaryKey1),
+				legacyKey(dictionaryKey1),
 			)
 			require.True(t, ok)
 
@@ -2530,7 +2530,7 @@ func TestDictionaryKeyConflict(t *testing.T) {
 			oldValue2, ok := dictionaryValue.Get(
 				inter,
 				emptyLocationRange,
-				LegacyKey(dictionaryKey2),
+				legacyKey(dictionaryKey2),
 			)
 			require.True(t, ok)
 

--- a/migrations/string_normalization/migration.go
+++ b/migrations/string_normalization/migration.go
@@ -43,6 +43,7 @@ func (StringNormalizingMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
+	_ migrations.ValueMigrationPosition,
 ) (
 	interpreter.Value,
 	error,

--- a/migrations/type_keys/migration.go
+++ b/migrations/type_keys/migration.go
@@ -1,0 +1,118 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package type_keys
+
+import (
+	"github.com/onflow/cadence/migrations"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+type TypeKeyMigration struct{}
+
+var _ migrations.ValueMigration = TypeKeyMigration{}
+
+func NewTypeKeyMigration() TypeKeyMigration {
+	return TypeKeyMigration{}
+}
+
+func (TypeKeyMigration) Name() string {
+	return "TypeKeyMigration"
+}
+
+func (TypeKeyMigration) Migrate(
+	_ interpreter.StorageKey,
+	_ interpreter.StorageMapKey,
+	value interpreter.Value,
+	_ *interpreter.Interpreter,
+	position migrations.ValueMigrationPosition,
+) (
+	interpreter.Value,
+	error,
+) {
+	// Re-store Type values used as dictionary keys,
+	// to ensure that even when such values failed to get migrated
+	// by the static types and entitlements migration,
+	// they are still stored using their new hash.
+
+	if position == migrations.ValueMigrationPositionDictionaryKey {
+		if typeValue, ok := value.(interpreter.TypeValue); ok {
+			return typeValue, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (TypeKeyMigration) Domains() map[string]struct{} {
+	return nil
+}
+
+func (m TypeKeyMigration) CanSkip(valueType interpreter.StaticType) bool {
+	return CanSkipTypeKeyMigration(valueType)
+}
+
+func CanSkipTypeKeyMigration(valueType interpreter.StaticType) bool {
+
+	switch valueType := valueType.(type) {
+	case *interpreter.DictionaryStaticType:
+		return CanSkipTypeKeyMigration(valueType.KeyType) &&
+			CanSkipTypeKeyMigration(valueType.ValueType)
+
+	case interpreter.ArrayStaticType:
+		return CanSkipTypeKeyMigration(valueType.ElementType())
+
+	case *interpreter.OptionalStaticType:
+		return CanSkipTypeKeyMigration(valueType.Type)
+
+	case *interpreter.CapabilityStaticType:
+		// Typed capability, can skip
+		return true
+
+	case interpreter.PrimitiveStaticType:
+
+		switch valueType {
+		case interpreter.PrimitiveStaticTypeMetaType:
+			return false
+
+		case interpreter.PrimitiveStaticTypeBool,
+			interpreter.PrimitiveStaticTypeVoid,
+			interpreter.PrimitiveStaticTypeAddress,
+			interpreter.PrimitiveStaticTypeBlock,
+			interpreter.PrimitiveStaticTypeString,
+			interpreter.PrimitiveStaticTypeCharacter,
+			// Untyped capability, can skip
+			interpreter.PrimitiveStaticTypeCapability:
+
+			return true
+		}
+
+		if !valueType.IsDeprecated() { //nolint:staticcheck
+			semaType := valueType.SemaType()
+
+			if sema.IsSubType(semaType, sema.NumberType) ||
+				sema.IsSubType(semaType, sema.PathType) {
+
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/migrations/type_keys/migration_test.go
+++ b/migrations/type_keys/migration_test.go
@@ -1,0 +1,269 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package type_keys
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/atree"
+
+	"github.com/onflow/cadence/migrations"
+	"github.com/onflow/cadence/runtime"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	. "github.com/onflow/cadence/runtime/tests/runtime_utils"
+	"github.com/onflow/cadence/runtime/tests/utils"
+)
+
+type testReporter struct {
+	migrated map[struct {
+		interpreter.StorageKey
+		interpreter.StorageMapKey
+	}][]string
+	errors []error
+}
+
+var _ migrations.Reporter = &testReporter{}
+
+func newTestReporter() *testReporter {
+	return &testReporter{
+		migrated: map[struct {
+			interpreter.StorageKey
+			interpreter.StorageMapKey
+		}][]string{},
+	}
+}
+
+func (t *testReporter) Migrated(
+	storageKey interpreter.StorageKey,
+	storageMapKey interpreter.StorageMapKey,
+	migration string,
+) {
+	key := struct {
+		interpreter.StorageKey
+		interpreter.StorageMapKey
+	}{
+		StorageKey:    storageKey,
+		StorageMapKey: storageMapKey,
+	}
+
+	t.migrated[key] = append(
+		t.migrated[key],
+		migration,
+	)
+}
+
+func (t *testReporter) Error(err error) {
+	t.errors = append(t.errors, err)
+}
+
+func (t *testReporter) DictionaryKeyConflict(addressPath interpreter.AddressPath) {
+	// For testing purposes, record the conflict as an error
+	t.errors = append(t.errors, fmt.Errorf("dictionary key conflict: %s", addressPath))
+}
+
+func TestTypeKeyMigration(t *testing.T) {
+	t.Parallel()
+
+	account := common.Address{0x42}
+	pathDomain := common.PathDomainPublic
+	locationRange := interpreter.EmptyLocationRange
+
+	type testCase struct {
+		name          string
+		storedValue   func(inter *interpreter.Interpreter) interpreter.Value
+		expectedValue func(inter *interpreter.Interpreter) interpreter.Value
+	}
+
+	test := func(t *testing.T, testCase testCase) {
+
+		t.Run(testCase.name, func(t *testing.T) {
+
+			t.Parallel()
+
+			ledger := NewTestLedger(nil, nil)
+
+			storageMapKey := interpreter.StringStorageMapKey("test")
+
+			newStorageAndInterpreter := func(t *testing.T) (*runtime.Storage, *interpreter.Interpreter) {
+				storage := runtime.NewStorage(ledger, nil)
+				inter, err := interpreter.NewInterpreter(
+					nil,
+					utils.TestLocation,
+					&interpreter.Config{
+						Storage: storage,
+						// NOTE: disabled, because encoded and decoded values are expected to not match
+						AtreeValueValidationEnabled:   false,
+						AtreeStorageValidationEnabled: true,
+					},
+				)
+				require.NoError(t, err)
+
+				return storage, inter
+			}
+
+			// Store value
+			(func() {
+
+				storage, inter := newStorageAndInterpreter(t)
+
+				transferredValue := testCase.storedValue(inter).Transfer(
+					inter,
+					locationRange,
+					atree.Address(account),
+					false,
+					nil,
+					nil,
+				)
+
+				inter.WriteStored(
+					account,
+					pathDomain.Identifier(),
+					storageMapKey,
+					transferredValue,
+				)
+
+				err := storage.Commit(inter, true)
+				require.NoError(t, err)
+			})()
+
+			// Migrate
+			(func() {
+
+				storage, inter := newStorageAndInterpreter(t)
+
+				migration, err := migrations.NewStorageMigration(inter, storage, "test", account)
+				require.NoError(t, err)
+
+				reporter := newTestReporter()
+
+				migration.Migrate(
+					migration.NewValueMigrationsPathMigrator(
+						reporter,
+						NewTypeKeyMigration(),
+					),
+				)
+
+				err = migration.Commit()
+				require.NoError(t, err)
+
+				require.Empty(t, reporter.errors)
+
+			})()
+
+			// Load
+			(func() {
+
+				storage, inter := newStorageAndInterpreter(t)
+
+				err := storage.CheckHealth()
+				require.NoError(t, err)
+
+				storageMap := storage.GetStorageMap(account, pathDomain.Identifier(), false)
+				require.NotNil(t, storageMap)
+				require.Equal(t, uint64(1), storageMap.Count())
+
+				actualValue := storageMap.ReadValue(nil, storageMapKey)
+
+				expectedValue := testCase.expectedValue(inter)
+
+				utils.AssertValuesEqual(t, inter, expectedValue, actualValue)
+			})()
+		})
+	}
+
+	testCases := []testCase{
+		{
+			name: "optional reference",
+			storedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+
+				dictValue := interpreter.NewDictionaryValue(
+					inter,
+					locationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeMetaType,
+						interpreter.PrimitiveStaticTypeInt,
+					),
+				)
+
+				dictValue.Insert(
+					inter,
+					locationRange,
+					// NOTE: storing with legacy key
+					migrations.LegacyKey(
+						interpreter.NewTypeValue(
+							nil,
+							interpreter.NewOptionalStaticType(
+								nil,
+								interpreter.NewReferenceStaticType(
+									nil,
+									interpreter.UnauthorizedAccess,
+									interpreter.PrimitiveStaticTypeInt,
+								),
+							),
+						),
+					),
+					interpreter.NewUnmeteredIntValueFromInt64(42),
+				)
+
+				return dictValue
+			},
+			expectedValue: func(inter *interpreter.Interpreter) interpreter.Value {
+				dictValue := interpreter.NewDictionaryValue(
+					inter,
+					locationRange,
+					interpreter.NewDictionaryStaticType(
+						nil,
+						interpreter.PrimitiveStaticTypeMetaType,
+						interpreter.PrimitiveStaticTypeInt,
+					),
+				)
+
+				dictValue.Insert(
+					inter,
+					locationRange,
+					// NOTE: expecting to load with new key
+					interpreter.NewTypeValue(
+						nil,
+						interpreter.NewOptionalStaticType(
+							nil,
+							interpreter.NewReferenceStaticType(
+								nil,
+								interpreter.UnauthorizedAccess,
+								interpreter.PrimitiveStaticTypeInt,
+							),
+						),
+					),
+					interpreter.NewUnmeteredIntValueFromInt64(42),
+				)
+
+				return dictValue
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		test(t, testCase)
+	}
+
+}


### PR DESCRIPTION
## Description

Context: https://discord.com/channels/613813861610684416/1108479699732152503/1245434532572958791

Revert part of #3381. This approach does not work: When a new migration runs that does not migrate, after a previous migration that did migrate, then we can't just use the legacy key as a lookup – the key has not been migrated in the current migration, but it is in migrated form.

Improve the migration of dictionary keys that have a legacy representation: Introduce a new migration, `TypeKeyMigration`, that re-stores `Type` values as-is, if they appear as dictionary keys. This migration is meant to be run after the existing migrations that update `Type` values, i.e. the static type migration and entitlements migration. The migration ensures that type values used as dictionary keys are stored under their new hash, even if a prior migration failed to do so. That way the key-value pair stays accessible, and the mutating iterator of the inlining-version of atree does not fail when iterating over the migrated dictionary.

I tested this will also work on `feature/atree-register-inlining-v1.0` and in flow-go `master.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
