### PR TITLE
Don't short circuit references on member access when entitlements are involved

### DIFF
--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -10731,3 +10731,114 @@ func TestRuntimeContractWithInvalidCapability(t *testing.T) {
 		logs,
 	)
 }
+
+func TestRuntimeAccountEntitlementEscalation(t *testing.T) {
+
+	t.Parallel()
+
+	addressValue := Address{
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
+	}
+
+	runtime := NewTestInterpreterRuntime()
+
+	contract := []byte(`
+		access(all) contract Test{
+
+			access(all) struct S{
+				access(mapping Identity) var s: AnyStruct
+		
+				init(_ a: AnyStruct){
+				self.s = a
+				}
+			}
+		}
+	`)
+
+	deploy := DeploymentTransaction("Test", contract)
+
+	initialTx := []byte(`
+		transaction {
+
+			prepare(acct: auth(Storage) &Account) {
+				acct.storage.save(42, to: /storage/foo)
+			}
+		}
+	`)
+
+	exploitTx := []byte(`
+		import Test from 0x01
+		
+		transaction {
+			prepare(acct: auth(Storage) &Account) {}
+			execute {
+				var a = getAccount(0x1)
+				var r = &Test.S(a) as auth(Storage) &Test.S
+				var rr = r.s as! auth(Storage) &Account
+
+				rr.storage.load<Int>(from: /storage/foo)
+			}
+		}
+	`)
+
+	accountCodes := map[Location][]byte{}
+	var events []cadence.Event
+
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
+			return accountCodes[location], nil
+		},
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
+			return []Address{addressValue}, nil
+		},
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			return accountCodes[location], nil
+		},
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			accountCodes[location] = code
+			return nil
+		},
+		OnCreateAccount: func(payer Address) (address Address, err error) {
+			return addressValue, nil
+		},
+		OnEmitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
+		},
+	}
+
+	nextTransactionLocation := NewTransactionLocationGenerator()
+
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: deploy,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
+	)
+	require.NoError(t, err)
+
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: initialTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		})
+	require.NoError(t, err)
+
+	err = runtime.ExecuteTransaction(
+		Script{
+			Source: exploitTx,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		})
+	require.ErrorAs(t, err, &interpreter.InvalidMemberReferenceError{})
+}


### PR DESCRIPTION
When a struct-typed field is accessed on a reference to a composite, we return a reference to that struct instead of the actual struct itself. However, when the struct-typed field has type `AnyStruct` and the underlying value of that field is itself a reference, we don't create a doubly nested reference, instead just returning the underlying value directly. This is normally fine, but when the type being created has entitlements (usually as the result of a mapping) this can cause entitlements to be granted to the resulting reference that it shouldn't have. This disables this short circuiting when if the reference type being created should be entitled. 

Thanks to @bluesign for the report

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
