### PR TITLE
Remove stacktrace from errors

### DIFF
--- a/runtime/errors/errors.go
+++ b/runtime/errors/errors.go
@@ -20,7 +20,6 @@ package errors
 
 import (
 	"fmt"
-	"runtime/debug"
 
 	"golang.org/x/xerrors"
 )
@@ -142,8 +141,7 @@ func (e MemoryError) Error() string {
 //
 // NOTE: This error is not used for errors occur due to bugs in a user-provided program.
 type UnexpectedError struct {
-	Err   error
-	Stack []byte
+	Err error
 }
 
 var _ InternalError = UnexpectedError{}
@@ -152,15 +150,13 @@ func (UnexpectedError) IsInternalError() {}
 
 func NewUnexpectedError(message string, arg ...any) UnexpectedError {
 	return UnexpectedError{
-		Err:   fmt.Errorf(message, arg...),
-		Stack: debug.Stack(),
+		Err: fmt.Errorf(message, arg...),
 	}
 }
 
 func NewUnexpectedErrorFromCause(err error) UnexpectedError {
 	return UnexpectedError{
-		Err:   err,
-		Stack: debug.Stack(),
+		Err: err,
 	}
 }
 
@@ -169,7 +165,7 @@ func (e UnexpectedError) Unwrap() error {
 }
 
 func (e UnexpectedError) Error() string {
-	return fmt.Sprintf("internal error: %s\n%s", e.Err.Error(), e.Stack)
+	return fmt.Sprintf("internal error: %s", e.Err.Error())
 }
 
 // DefaultUserError is the default implementation of UserError interface.


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/2679

## Description

I tried putting this behind a flag, but unfortunately there are 300+ places where this internal error is created, and many of them don't have the access to the runtime/interpreter/checker objects to get access to the "flag". Passing down the flag for all these 300+ call-sites exponentially grows and explodes in the code base. I don't really think changing that much just for a debug trace worth the effort, given this won't be useful for the smart contract developers (only we, the language developers will use it, but in such cases we would anyway be debugging the code, and won't really rely on the stack-trace).

Anyway, if we think otherwise: that the stack trace is strictly necessary, then I can start going down the rabbit hole, but trying to keep it simple here.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
