### PR TITLE
Cache results of static types migration and entitlements migration

### DIFF
--- a/migrations/cache.go
+++ b/migrations/cache.go
@@ -1,0 +1,79 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package migrations
+
+import (
+	"sync"
+
+	"github.com/onflow/cadence/runtime/interpreter"
+)
+
+type CachedStaticType struct {
+	StaticType interpreter.StaticType
+	Error      error
+}
+
+type StaticTypeKey string
+
+func NewStaticTypeKey(staticType interpreter.StaticType) (StaticTypeKey, error) {
+	raw, err := interpreter.StaticTypeToBytes(staticType)
+	if err != nil {
+		return "", err
+	}
+	return StaticTypeKey(raw), nil
+}
+
+type StaticTypeCache interface {
+	Get(key StaticTypeKey) (CachedStaticType, bool)
+	Set(
+		key StaticTypeKey,
+		staticType interpreter.StaticType,
+		err error,
+	)
+}
+
+type DefaultStaticTypeCache struct {
+	entries sync.Map
+}
+
+func NewDefaultStaticTypeCache() *DefaultStaticTypeCache {
+	return &DefaultStaticTypeCache{}
+}
+
+func (c *DefaultStaticTypeCache) Get(key StaticTypeKey) (CachedStaticType, bool) {
+	v, ok := c.entries.Load(key)
+	if !ok {
+		return CachedStaticType{}, false
+	}
+	return v.(CachedStaticType), true
+}
+
+func (c *DefaultStaticTypeCache) Set(
+	key StaticTypeKey,
+	staticType interpreter.StaticType,
+	err error,
+) {
+	c.entries.Store(
+		key,
+		CachedStaticType{
+			StaticType: staticType,
+			Error:      err,
+		},
+	)
+}

--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -35,8 +35,7 @@ type EntitlementsMigration struct {
 var _ migrations.ValueMigration = EntitlementsMigration{}
 
 func NewEntitlementsMigration(inter *interpreter.Interpreter) EntitlementsMigration {
-	staticTypeCache := migrations.NewDefaultStaticTypeCache()
-	return NewEntitlementsMigrationWithCache(inter, staticTypeCache)
+	return NewEntitlementsMigrationWithCache(inter, nil)
 }
 
 func NewEntitlementsMigrationWithCache(

--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -40,8 +40,7 @@ type InterfaceTypeConverterFunc func(*interpreter.InterfaceStaticType) interpret
 var _ migrations.ValueMigration = &StaticTypeMigration{}
 
 func NewStaticTypeMigration() *StaticTypeMigration {
-	staticTypeCache := migrations.NewDefaultStaticTypeCache()
-	return NewStaticTypeMigrationWithCache(staticTypeCache)
+	return NewStaticTypeMigrationWithCache(nil)
 }
 
 func NewStaticTypeMigrationWithCache(migratedTypeCache migrations.StaticTypeCache) *StaticTypeMigration {

--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -180,19 +180,19 @@ func (m *StaticTypeMigration) maybeConvertStaticType(
 
 	if parentType == nil {
 		migratedTypeCache := m.migratedTypeCache
+		if migratedTypeCache != nil {
+			// Only cache if cache key generation succeeds.
+			// Some static types, like function types, are not encodable.
+			if key, keyErr := migrations.NewStaticTypeKey(staticType); keyErr == nil {
+				if cachedType, exists := migratedTypeCache.Get(key); exists {
+					return cachedType.StaticType
+				}
 
-		key, err := migrations.NewStaticTypeKey(staticType)
-		if err != nil {
-			panic(errors.NewUnexpectedErrorFromCause(err))
+				defer func() {
+					migratedTypeCache.Set(key, resultType, nil)
+				}()
+			}
 		}
-
-		if cachedType, exists := migratedTypeCache.Get(key); exists {
-			return cachedType.StaticType
-		}
-
-		defer func() {
-			migratedTypeCache.Set(key, resultType, nil)
-		}()
 	}
 
 	switch staticType := staticType.(type) {


### PR DESCRIPTION
Work towards #3297

## Description

In #3375 we removed the broken caching of results of the static types migration and entitlements migration.

Bring back the caching, but use the encoding of the static type instead of the type ID. The encoding of a static type isn't ambiguous or lacking any details compared to the type ID. I double checked that legacy /  pre-1.0 information in static types, like the legacy restricted type in an intersection type (previously restriction type), is not only decoded properly for the migration, but also encoded again with the legacy information (which isn't the case for type IDs).

Disable the caching by default, so the default behaviour is always correct. In flow-go, this feature will be enabled through a flag (again, off by default).

I tested this approach in flow-go, and a run with caching always produces the same new state commitment as a non-caching run.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
