### PR TITLE
Add check for storage of nonstorable values

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2662,6 +2662,12 @@ func (interpreter *Interpreter) WriteStored(
 	key StorageMapKey,
 	value Value,
 ) (existed bool) {
+	if value != nil && !value.IsStorable() {
+		panic(&NonStorableValueError{
+			Value: value,
+		})
+	}
+
 	accountStorage := interpreter.Storage().GetStorageMap(storageAddress, domain, true)
 	return accountStorage.WriteValue(interpreter, key, value)
 }

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2663,7 +2663,7 @@ func (interpreter *Interpreter) WriteStored(
 	value Value,
 ) (existed bool) {
 	if value != nil && !value.IsStorable() {
-		panic(&NonStorableValueError{
+		panic(NonStorableValueError{
 			Value: value,
 		})
 	}

--- a/runtime/interpreter/simplecompositevalue.go
+++ b/runtime/interpreter/simplecompositevalue.go
@@ -251,6 +251,10 @@ func (v *SimpleCompositeValue) Storable(_ atree.SlabStorage, _ atree.Address, _ 
 	return NonStorable{Value: v}, nil
 }
 
+func (*SimpleCompositeValue) IsStorable() bool {
+	return false
+}
+
 func (*SimpleCompositeValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -142,6 +142,7 @@ type Value interface {
 	// NOTE: memory metering is unnecessary for Clone methods
 	Clone(interpreter *Interpreter) Value
 	IsImportable(interpreter *Interpreter, locationRange LocationRange) bool
+	IsStorable() bool
 }
 
 // ValueIndexableValue
@@ -511,6 +512,10 @@ func (v TypeValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
 	return v, nil
 }
 
+func (_ TypeValue) IsStorable() bool {
+	return true
+}
+
 func (TypeValue) ChildStorables() []atree.Storable {
 	return nil
 }
@@ -591,6 +596,10 @@ func (v VoidValue) Equal(_ *Interpreter, _ LocationRange, other Value) bool {
 
 func (v VoidValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
 	return v, nil
+}
+
+func (_ VoidValue) IsStorable() bool {
+	return true
 }
 
 func (VoidValue) NeedsStoreTo(_ atree.Address) bool {
@@ -764,6 +773,10 @@ func (v BoolValue) ConformsToStaticType(
 
 func (v BoolValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
 	return v, nil
+}
+
+func (_ BoolValue) IsStorable() bool {
+	return true
 }
 
 func (BoolValue) NeedsStoreTo(_ atree.Address) bool {
@@ -952,6 +965,10 @@ func (v CharacterValue) ConformsToStaticType(
 
 func (v CharacterValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
 	return v, nil
+}
+
+func (_ CharacterValue) IsStorable() bool {
+	return true
 }
 
 func (CharacterValue) NeedsStoreTo(_ atree.Address) bool {
@@ -1550,6 +1567,10 @@ func (v *StringValue) ReplaceAll(inter *Interpreter, _ LocationRange, of string,
 
 func (v *StringValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
 	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
+}
+
+func (*StringValue) IsStorable() bool {
+	return true
 }
 
 func (*StringValue) NeedsStoreTo(_ atree.Address) bool {
@@ -2952,6 +2973,10 @@ func (v *ArrayValue) Storable(
 	return v.array.Storable(storage, address, maxInlineSize)
 }
 
+func (*ArrayValue) IsStorable() bool {
+	return true
+}
+
 func (v *ArrayValue) IsReferenceTrackedResourceKindedValue() {}
 
 func (v *ArrayValue) Transfer(
@@ -4304,6 +4329,10 @@ func (v IntValue) Storable(storage atree.SlabStorage, address atree.Address, max
 	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
+func (IntValue) IsStorable() bool {
+	return true
+}
+
 func (IntValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
@@ -4942,6 +4971,10 @@ func (v Int8Value) ConformsToStaticType(
 
 func (v Int8Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
 	return v, nil
+}
+
+func (Int8Value) IsStorable() bool {
+	return true
 }
 
 func (Int8Value) NeedsStoreTo(_ atree.Address) bool {
@@ -5586,6 +5619,10 @@ func (v Int16Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (at
 	return v, nil
 }
 
+func (Int16Value) IsStorable() bool {
+	return true
+}
+
 func (Int16Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
@@ -6228,6 +6265,10 @@ func (v Int32Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (at
 	return v, nil
 }
 
+func (Int32Value) IsStorable() bool {
+	return true
+}
+
 func (Int32Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
@@ -6860,6 +6901,10 @@ func (v Int64Value) ConformsToStaticType(
 
 func (v Int64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
 	return v, nil
+}
+
+func (Int64Value) IsStorable() bool {
+	return true
 }
 
 func (Int64Value) NeedsStoreTo(_ atree.Address) bool {
@@ -7606,6 +7651,10 @@ func (v Int128Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (a
 	return v, nil
 }
 
+func (Int128Value) IsStorable() bool {
+	return true
+}
+
 func (Int128Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
@@ -8347,6 +8396,10 @@ func (v Int256Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (a
 	return v, nil
 }
 
+func (Int256Value) IsStorable() bool {
+	return true
+}
+
 func (Int256Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
@@ -8976,6 +9029,10 @@ func (v UIntValue) Storable(storage atree.SlabStorage, address atree.Address, ma
 	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
+func (UIntValue) IsStorable() bool {
+	return true
+}
+
 func (UIntValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
@@ -9560,6 +9617,10 @@ func (v UInt8Value) ConformsToStaticType(
 
 func (v UInt8Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
 	return v, nil
+}
+
+func (UInt8Value) IsStorable() bool {
+	return true
 }
 
 func (UInt8Value) NeedsStoreTo(_ atree.Address) bool {
@@ -19682,6 +19743,10 @@ func (v *DictionaryValue) Storable(
 	return v.dictionary.Storable(storage, address, maxInlineSize)
 }
 
+func (*DictionaryValue) IsStorable() bool {
+	return true
+}
+
 func (v *DictionaryValue) IsReferenceTrackedResourceKindedValue() {}
 
 func (v *DictionaryValue) Transfer(
@@ -20343,6 +20408,10 @@ func (v *SomeValue) Storable(
 		address,
 		maxInlineSize,
 	)
+}
+
+func (v *SomeValue) IsStorable() bool {
+	return v.value.IsStorable()
 }
 
 func (v *SomeValue) NeedsStoreTo(address atree.Address) bool {

--- a/runtime/interpreter/value_function.go
+++ b/runtime/interpreter/value_function.go
@@ -137,6 +137,10 @@ func (f *InterpretedFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address
 	return NonStorable{Value: f}, nil
 }
 
+func (_ InterpretedFunctionValue) IsStorable() bool {
+	return false
+}
+
 func (*InterpretedFunctionValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
@@ -287,6 +291,10 @@ func (f *HostFunctionValue) ConformsToStaticType(
 
 func (f *HostFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
 	return NonStorable{Value: f}, nil
+}
+
+func (_ HostFunctionValue) IsStorable() bool {
+	return false
 }
 
 func (*HostFunctionValue) NeedsStoreTo(_ atree.Address) bool {
@@ -463,6 +471,10 @@ func (f BoundFunctionValue) ConformsToStaticType(
 
 func (f BoundFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
 	return NonStorable{Value: f}, nil
+}
+
+func (_ BoundFunctionValue) IsStorable() bool {
+	return false
 }
 
 func (BoundFunctionValue) NeedsStoreTo(_ atree.Address) bool {

--- a/runtime/interpreter/value_link.go
+++ b/runtime/interpreter/value_link.go
@@ -109,7 +109,7 @@ func (v PathLinkValue) Equal(interpreter *Interpreter, locationRange LocationRan
 }
 
 func (PathLinkValue) IsStorable() bool {
-	panic(errors.NewUnreachableError())
+	return true
 }
 
 func (v PathLinkValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
@@ -231,7 +231,7 @@ func (v AccountLinkValue) Equal(_ *Interpreter, _ LocationRange, other Value) bo
 }
 
 func (AccountLinkValue) IsStorable() bool {
-	panic(errors.NewUnreachableError())
+	return true
 }
 
 func (v AccountLinkValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {

--- a/runtime/interpreter/value_pathcapability.go
+++ b/runtime/interpreter/value_pathcapability.go
@@ -151,7 +151,7 @@ func (v *PathCapabilityValue) Equal(interpreter *Interpreter, locationRange Loca
 }
 
 func (*PathCapabilityValue) IsStorable() bool {
-	panic(errors.NewUnreachableError())
+	return true
 }
 
 func (v *PathCapabilityValue) Storable(

--- a/runtime/interpreter/value_placeholder.go
+++ b/runtime/interpreter/value_placeholder.go
@@ -71,6 +71,10 @@ func (f placeholderValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint6
 	return NonStorable{Value: f}, nil
 }
 
+func (placeholderValue) IsStorable() bool {
+	return false
+}
+
 func (placeholderValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -10910,8 +10910,7 @@ func TestRuntimeAccountAnyStructReference(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		var nonStorableValueError *interpreter.NonStorableValueError
-		require.ErrorAs(t, err, &nonStorableValueError)
+		require.ErrorAs(t, err, &interpreter.NonStorableValueError{})
 	})
 
 	t.Run("function", func(t *testing.T) {
@@ -10974,8 +10973,7 @@ func TestRuntimeAccountAnyStructReference(t *testing.T) {
 				Location:  nextTransactionLocation(),
 			},
 		)
-		var nonStorableValueError *interpreter.NonStorableValueError
-		require.ErrorAs(t, err, &nonStorableValueError)
+		require.ErrorAs(t, err, &interpreter.NonStorableValueError{})
 	})
 
 	t.Run("reference array", func(t *testing.T) {


### PR DESCRIPTION
Part of https://github.com/dapperlabs/cadence-internal/issues/235

Prevents sticking nonstorable things in storage by casting them through `AnyStruct`

Thanks @bluesign for the report
______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
