### PR TITLE
add check when borrowing value that it's not a reference

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4528,6 +4528,12 @@ func (interpreter *Interpreter) authAccountBorrowFunction(
 			if value == nil {
 				return Nil
 			}
+			if reference, isReference := (*value).(ReferenceValue); isReference {
+				panic(NestedReferenceError{
+					Value:         reference,
+					LocationRange: invocation.LocationRange,
+				})
+			}
 
 			return NewSomeValueNonCopying(interpreter, reference)
 		},


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-internal/issues/235

Adds an additional check in `borrow` to make sure that the value being borrowed is not itself a reference

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
