### PR TITLE
Prevent storage reference to another reference

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -20601,6 +20601,13 @@ func (v *StorageReferenceValue) dereference(interpreter *Interpreter, locationRa
 		return nil, nil
 	}
 
+	if reference, isReference := referenced.(ReferenceValue); isReference {
+		panic(NestedReferenceError{
+			Value:         reference,
+			LocationRange: locationRange,
+		})
+	}
+
 	if v.BorrowedType != nil {
 		staticType := referenced.StaticType(interpreter)
 


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-internal/issues/235

## Description

Based on #3398. Thanks for @dsainati1 for the initial investigation.

Nested references are not allowed. 

The creation of an ephemeral reference, e.g. through a reference expression, already prevents this (`NewUnmeteredEphemeralReferenceValue` aborts with `NestedReferenceError`).

Also prevent storage references to references. Given that the target of a storage reference is a path and the value stored in the path may change, check the referenced value is not a reference value on each dereference, not just when the storage reference is created.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
