### PR TITLE
Add access top type to model inaccessible access for identity maps

### DIFF
--- a/runtime/ast/access.go
+++ b/runtime/ast/access.go
@@ -211,6 +211,7 @@ type PrimitiveAccess uint8
 
 const (
 	AccessNotSpecified PrimitiveAccess = iota
+	AccessNone                         // "top" access, only used for mapping operations, not actually expressible in the language
 	AccessSelf
 	AccessContract
 	AccessAccount
@@ -256,6 +257,8 @@ func (a PrimitiveAccess) Keyword() string {
 		return "access(contract)"
 	case AccessPubSettableLegacy:
 		return "pub(set)"
+	case AccessNone:
+		return "inaccessible"
 	}
 
 	panic(errors.NewUnreachableError())
@@ -275,6 +278,8 @@ func (a PrimitiveAccess) Description() string {
 		return "contract"
 	case AccessPubSettableLegacy:
 		return "legacy public settable"
+	case AccessNone:
+		return "inaccessible"
 	}
 
 	panic(errors.NewUnreachableError())

--- a/runtime/ast/primitiveaccess_string.go
+++ b/runtime/ast/primitiveaccess_string.go
@@ -9,16 +9,17 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[AccessNotSpecified-0]
-	_ = x[AccessSelf-1]
-	_ = x[AccessContract-2]
-	_ = x[AccessAccount-3]
-	_ = x[AccessAll-4]
-	_ = x[AccessPubSettableLegacy-5]
+	_ = x[AccessNone-1]
+	_ = x[AccessSelf-2]
+	_ = x[AccessContract-3]
+	_ = x[AccessAccount-4]
+	_ = x[AccessAll-5]
+	_ = x[AccessPubSettableLegacy-6]
 }
 
-const _PrimitiveAccess_name = "AccessNotSpecifiedAccessSelfAccessContractAccessAccountAccessAllAccessPubSettableLegacy"
+const _PrimitiveAccess_name = "AccessNotSpecifiedAccessNoneAccessSelfAccessContractAccessAccountAccessAllAccessPubSettableLegacy"
 
-var _PrimitiveAccess_index = [...]uint8{0, 18, 28, 42, 55, 64, 87}
+var _PrimitiveAccess_index = [...]uint8{0, 18, 28, 38, 52, 65, 74, 97}
 
 func (i PrimitiveAccess) String() string {
 	if i >= PrimitiveAccess(len(_PrimitiveAccess_index)-1) {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1658,6 +1658,12 @@ func (d TypeDecoder) decodeStaticAuthorization() (Authorization, error) {
 			return nil, err
 		}
 		return UnauthorizedAccess, nil
+	case CBORTagInaccessibleStaticAuthorization:
+		err := d.decoder.DecodeNil()
+		if err != nil {
+			return nil, err
+		}
+		return InaccessibleAccess, nil
 	case CBORTagEntitlementMapStaticAuthorization:
 		typeID, err := d.decoder.DecodeString()
 		if err != nil {

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -224,8 +224,14 @@ const (
 	CBORTagUnauthorizedStaticAuthorization
 	CBORTagEntitlementMapStaticAuthorization
 	CBORTagEntitlementSetStaticAuthorization
-	CBORTagInclusiveRangeStaticType
 	CBORTagInaccessibleStaticAuthorization
+
+	_
+	_
+	_
+	_
+
+	CBORTagInclusiveRangeStaticType
 
 	// !!! *WARNING* !!!
 	// ADD NEW TYPES *BEFORE* THIS WARNING.

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -225,6 +225,7 @@ const (
 	CBORTagEntitlementMapStaticAuthorization
 	CBORTagEntitlementSetStaticAuthorization
 	CBORTagInclusiveRangeStaticType
+	CBORTagInaccessibleStaticAuthorization
 
 	// !!! *WARNING* !!!
 	// ADD NEW TYPES *BEFORE* THIS WARNING.
@@ -1310,6 +1311,17 @@ func (t Unauthorized) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, CBORTagUnauthorizedStaticAuthorization,
+	})
+	if err != nil {
+		return err
+	}
+	return e.EncodeNil()
+}
+
+func (t Inaccessible) Encode(e *cbor.StreamEncoder) error {
+	err := e.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, CBORTagInaccessibleStaticAuthorization,
 	})
 	if err != nil {
 		return err

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -3587,7 +3587,7 @@ func TestCBORTagValue(t *testing.T) {
 	t.Parallel()
 
 	t.Run("No new types added in between", func(t *testing.T) {
-		require.Equal(t, byte(227), byte(CBORTag_Count))
+		require.Equal(t, byte(231), byte(CBORTag_Count))
 	})
 }
 

--- a/runtime/interpreter/encoding_test.go
+++ b/runtime/interpreter/encoding_test.go
@@ -3587,7 +3587,7 @@ func TestCBORTagValue(t *testing.T) {
 	t.Parallel()
 
 	t.Run("No new types added in between", func(t *testing.T) {
-		require.Equal(t, byte(226), byte(CBORTag_Count))
+		require.Equal(t, byte(227), byte(CBORTag_Count))
 	})
 }
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4991,7 +4991,7 @@ func (interpreter *Interpreter) mapMemberValueAuthorization(
 
 		default:
 			var access sema.Access
-			if mappedAccess.Type == sema.IdentityType {
+			if mappedAccess.Type.IncludesIdentity {
 				access = sema.AllSupportedEntitlements(resultingType)
 			}
 

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -643,11 +643,11 @@ var FullyEntitledAccountAccess = ConvertSemaAccessToStaticAuthorization(nil, sem
 func (Unauthorized) isAuthorization() {}
 
 func (Unauthorized) String() string {
-	return ""
+	return "Unauthorized"
 }
 
-func (Unauthorized) MeteredString(_ common.MemoryGauge) string {
-	return ""
+func (a Unauthorized) MeteredString(_ common.MemoryGauge) string {
+	return "Unauthorized"
 }
 
 func (Unauthorized) ID() TypeID {
@@ -666,11 +666,11 @@ var InaccessibleAccess Authorization = Inaccessible{}
 func (Inaccessible) isAuthorization() {}
 
 func (Inaccessible) String() string {
-	return ""
+	return "Inaccessible"
 }
 
 func (Inaccessible) MeteredString(_ common.MemoryGauge) string {
-	return ""
+	return "Inaccessible"
 }
 
 func (Inaccessible) ID() TypeID {
@@ -854,7 +854,10 @@ func (t *ReferenceStaticType) String() string {
 
 func (t *ReferenceStaticType) MeteredString(memoryGauge common.MemoryGauge) string {
 	typeStr := t.ReferencedType.MeteredString(memoryGauge)
-	authString := t.Authorization.MeteredString(memoryGauge)
+	authString := ""
+	if !t.Authorization.Equal(InaccessibleAccess) && !t.Authorization.Equal(UnauthorizedAccess) {
+		authString = t.Authorization.MeteredString(memoryGauge)
+	}
 
 	common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(len(typeStr)+1+len(authString)))
 	return fmt.Sprintf("%s&%s", authString, typeStr)

--- a/runtime/interpreter/statictype.go
+++ b/runtime/interpreter/statictype.go
@@ -25,7 +25,6 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/onflow/atree"
 
-	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/common/orderedmap"
 	"github.com/onflow/cadence/runtime/errors"
@@ -1073,7 +1072,7 @@ func ConvertSemaAccessToStaticAuthorization(
 		if access.Equal(sema.UnauthorizedAccess) {
 			return UnauthorizedAccess
 		}
-		if access.Equal(sema.PrimitiveAccess(ast.AccessNone)) {
+		if access.Equal(sema.InaccessibleAccess) {
 			return InaccessibleAccess
 		}
 
@@ -1152,7 +1151,7 @@ func ConvertStaticAuthorizationToSemaAccess(
 		return sema.UnauthorizedAccess, nil
 
 	case Inaccessible:
-		return sema.PrimitiveAccess(ast.AccessNone), nil
+		return sema.InaccessibleAccess, nil
 
 	case EntitlementMapAuthorization:
 		entitlement, err := handler.GetEntitlementMapType(auth.TypeID)

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -464,8 +464,8 @@ func (a PrimitiveAccess) Equal(other Access) bool {
 }
 
 func (a PrimitiveAccess) PermitsAccess(otherAccess Access) bool {
-	if ast.PrimitiveAccess(a) == ast.AccessNone {
-		return PrimitiveAccess(ast.AccessNone) == otherAccess
+	if a == InaccessibleAccess {
+		return otherAccess == InaccessibleAccess
 	}
 	if otherPrimitive, ok := otherAccess.(PrimitiveAccess); ok {
 		return ast.PrimitiveAccess(a) >= ast.PrimitiveAccess(otherPrimitive)

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -326,7 +326,13 @@ func (e *EntitlementMapAccess) PermitsAccess(other Access) bool {
 	// the input entitlement. It is only safe for `R` to give out these entitlements if it actually
 	// possesses them, so we require the initializing value to have every possible entitlement that may
 	// be produced by the map
+	//
+	// However, if the map is or includes the `Identity`, there is no possible set that is permitted by
+	// this map, since the theoretical codomain of the Identity map is infinite
 	case EntitlementSetAccess:
+		if e.Type.IncludesIdentity {
+			return false
+		}
 		return e.Codomain().PermitsAccess(otherAccess)
 	default:
 		return false

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -465,7 +465,7 @@ func (a PrimitiveAccess) Equal(other Access) bool {
 
 func (a PrimitiveAccess) PermitsAccess(otherAccess Access) bool {
 	if ast.PrimitiveAccess(a) == ast.AccessNone {
-		return false
+		return PrimitiveAccess(ast.AccessNone) == otherAccess
 	}
 	if otherPrimitive, ok := otherAccess.(PrimitiveAccess); ok {
 		return ast.PrimitiveAccess(a) >= ast.PrimitiveAccess(otherPrimitive)

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -256,7 +256,7 @@ type EntitlementMapAccess struct {
 	Type         *EntitlementMapType
 	domain       EntitlementSetAccess
 	domainOnce   sync.Once
-	codomain     Access
+	codomain     EntitlementSetAccess
 	codomainOnce sync.Once
 	images       sync.Map
 }

--- a/runtime/sema/access.go
+++ b/runtime/sema/access.go
@@ -256,7 +256,7 @@ type EntitlementMapAccess struct {
 	Type         *EntitlementMapType
 	domain       EntitlementSetAccess
 	domainOnce   sync.Once
-	codomain     EntitlementSetAccess
+	codomain     Access
 	codomainOnce sync.Once
 	images       sync.Map
 }
@@ -352,7 +352,7 @@ func (e *EntitlementMapAccess) Domain() EntitlementSetAccess {
 	return e.domain
 }
 
-func (e *EntitlementMapAccess) Codomain() EntitlementSetAccess {
+func (e *EntitlementMapAccess) Codomain() Access {
 	e.codomainOnce.Do(func() {
 		codomain := common.MappedSliceWithNoDuplicates(
 			e.Type.Relations,
@@ -464,6 +464,9 @@ func (a PrimitiveAccess) Equal(other Access) bool {
 }
 
 func (a PrimitiveAccess) PermitsAccess(otherAccess Access) bool {
+	if ast.PrimitiveAccess(a) == ast.AccessNone {
+		return false
+	}
 	if otherPrimitive, ok := otherAccess.(PrimitiveAccess); ok {
 		return ast.PrimitiveAccess(a) >= ast.PrimitiveAccess(otherPrimitive)
 	}

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -487,7 +487,7 @@ func (checker *Checker) mapAccess(
 		//  possibly be authorized enough to write to it
 		if checker.inAssignment {
 			if mappedAccess.Type.IncludesIdentity {
-				return true, PrimitiveAccess(ast.AccessNone)
+				return true, InaccessibleAccess
 			}
 			return true, mappedAccess.Codomain()
 		}
@@ -499,7 +499,7 @@ func (checker *Checker) mapAccess(
 	default:
 		if mappedAccess.Type.IncludesIdentity {
 			if checker.inAssignment {
-				return true, PrimitiveAccess(ast.AccessNone)
+				return true, InaccessibleAccess
 			}
 			access := AllSupportedEntitlements(resultingType)
 			if access != nil {

--- a/runtime/sema/check_member_expression.go
+++ b/runtime/sema/check_member_expression.go
@@ -492,7 +492,7 @@ func (checker *Checker) mapAccess(
 		return checker.mapAccess(mappedAccess, ty.Type, resultingType, accessRange)
 
 	default:
-		if mappedAccess.Type == IdentityType {
+		if mappedAccess.Type.IncludesIdentity {
 			access := AllSupportedEntitlements(resultingType)
 			if access != nil {
 				return true, access

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -9264,10 +9264,14 @@ func NewEntitlementRelation(
 }
 
 type EntitlementMapType struct {
-	Location          common.Location
-	containerType     Type
-	Identifier        string
-	Relations         []EntitlementRelation
+	Location      common.Location
+	containerType Type
+	Identifier    string
+	Relations     []EntitlementRelation
+
+	// Whether this map type includes the special identity relation,
+	// which maps every input to itself. The `Identity` mapping itself
+	// is defined as the empty map type that includes the identity relation
 	IncludesIdentity  bool
 	resolveInclusions sync.Once
 }

--- a/runtime/sema/type.go
+++ b/runtime/sema/type.go
@@ -6946,6 +6946,7 @@ var _ ValueIndexableType = &ReferenceType{}
 var _ TypeIndexableType = &ReferenceType{}
 
 var UnauthorizedAccess Access = PrimitiveAccess(ast.AccessAll)
+var InaccessibleAccess Access = PrimitiveAccess(ast.AccessNone)
 
 func NewReferenceType(
 	memoryGauge common.MemoryGauge,

--- a/runtime/tests/interpreter/entitlements_test.go
+++ b/runtime/tests/interpreter/entitlements_test.go
@@ -3024,7 +3024,7 @@ func TestInterpretIdentityMapping(t *testing.T) {
 
                 init() {
                     let x = X()
-                    self.x1 = &x as auth(A, B, C) &X
+                    self.x1 = &x
                     self.x2 = nil
                 }
             }


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-internal/issues/236

The `Identity` entitlement mapping has a codomain (output space) that is theoretically infinite, as any number of possible entitlements can be produced from it. This means that in order to be safe when initializing a field that is mapped with the `Identity`, or a mapping that includes it, the reference used to initialize this field must be authorized to an impossible access, an infinite set of entitlements. Otherwise, the `Identity` mapping could be used to escalate entitlements, as seen in one of the tests added in this PR.

This PR introduces a new `None` access to represent this impossible set, and ensures that this permits no other access besides itself (functionally the top type of the access lattice, the same way that `all` is the bottom). Initializing a reference with the `Identity` map type requires this top access value, which can only be obtained via immediately creating a reference to an owned value. This way we ensure that `Identity`-mapped fields can never be initialized with a reference that has a limited entitlement set. 

______

<!-- Complete: -->

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
