### PR TITLE
Also migrate path-capability storage maps

### DIFF
--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -127,6 +127,12 @@ func (m *StorageMigration) Migrate(migrator StorageMapKeyMigrator) {
 		stdlib.CapabilityControllerStorageDomain,
 		migrator,
 	)
+
+	accountStorage.MigrateStringKeys(
+		m.interpreter,
+		stdlib.PathCapabilityStorageDomain,
+		migrator,
+	)
 }
 
 func (m *StorageMigration) NewValueMigrationsPathMigrator(


### PR DESCRIPTION
Related to https://github.com/onflow/flow-go/issues/6069

## Description

For completeness, also migrate the storage maps which contain the path-to-capability sets. Those storage maps have strings as keys (the identifier of the storage path, e.g. `foo` in `/storage/foo`), and the values are Cadence dictionaries, which are rather sets, where the keys are the capability IDs (`UInt64`) and the values are always Cadence `nil` values.

AFAIK we currently do not have migrations required for Cadence 1.0 that migrate such values (dictionaries and `UInt64` values), but still migrate these storage maps for completeness / correctness – the assumption we do not have migrations for such values might not hold in the future.

Kudos to @fxamacker for noticing this omission. In the Cadence 1.0 migrations it is not important, but in the atree inlining migrations *all* values need to be migrated, so it is important there. See related issue.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
