### PR TITLE
Merge v1.0.0-preview.34 into feature/atree-register-inlining-v1.0

### DIFF
--- a/npm-packages/cadence-parser/package.json
+++ b/npm-packages/cadence-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-parser",
-  "version": "1.0.0-preview.33",
+  "version": "1.0.0-preview.34",
   "description": "The Cadence parser",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {


### PR DESCRIPTION
No actual changes due to the recent sync before the tag, but did it anyways for consistency
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
