### PR TITLE
Improve parsing of commit from Go's pseudo-version in update tool

### DIFF
--- a/tools/update/main.ts
+++ b/tools/update/main.ts
@@ -30,11 +30,13 @@ function semVerAtLeast(actualVersion: string, expectedVersion: string): boolean 
 }
 
 function extractVersionCommit(version: string): string | null {
-    const parts = version.split('-')
-    if (parts.length <= 1) {
-        return null
-    }
-    return parts[parts.length-1]
+    // Parse commit from Go's generated pseudo-version.
+    // They end with '<timestamp>-<commit>'.
+    // See https://go.dev/ref/mod#glos-pseudo-version
+    const match = version.match(/\d{14}-([0-9a-f]{12})$/)
+    if (!match)
+        return null;
+    return match[1]
 }
 
 function capitalizeFirstLetter(string: string): string {


### PR DESCRIPTION
## Description

The current parsing function for Go's pseudo-versions gets confused by semantic versions by build metadata and pre-releases.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
