### PR TITLE
Ensure contracts cannot be borrowed with an authorization

### DIFF
--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -1338,6 +1338,10 @@ func newAccountContractsBorrowFunction(
 					panic(errors.NewUnreachableError())
 				}
 
+				if referenceType.Authorization != sema.UnauthorizedAccess {
+					panic(errors.NewDefaultUserError("cannot borrow a reference with an authorization"))
+				}
+
 				// Check if the contract exists
 
 				var code []byte


### PR DESCRIPTION
## Description

The Cadence function `Account.Contracts.borrow()` allows borrowing a contract.

Ensure that the borrowed type does not have an authorization, by adding an explicit check and descriptive error message.

This PR only improves the UX, borrowing an entitled contract reference is already forbidding today, through the defensive value transfer check. For example, without the explicit check and descriptive error, the test already fails with 

```
invalid transfer of value: expected `auth(Hello.E) &Hello?`, got `&Hello?`
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
