### PR TITLE
[v0.42] Simplify nil-coalescing checking

### DIFF
--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -441,13 +441,6 @@ func (checker *Checker) checkBinaryExpressionNilCoalescing(
 		return InvalidType
 	}
 
-	leftInner := leftOptional.Type
-
-	if leftInner == NeverType {
-		return rightType
-	}
-	canNarrow := false
-
 	if !rightIsInvalid {
 
 		if rightType.IsResourceType() {
@@ -458,25 +451,7 @@ func (checker *Checker) checkBinaryExpressionNilCoalescing(
 				},
 			)
 		}
-
-		if !IsSubType(rightType, leftOptional) {
-
-			checker.report(
-				&InvalidBinaryOperandError{
-					Operation:    operation,
-					Side:         common.OperandSideRight,
-					ExpectedType: leftOptional,
-					ActualType:   rightType,
-					Range:        ast.NewRangeFromPositioned(checker.memoryGauge, expression.Right),
-				},
-			)
-		} else {
-			canNarrow = IsSubType(rightType, leftInner)
-		}
 	}
 
-	if !canNarrow {
-		return leftOptional
-	}
-	return leftInner
+	return LeastCommonSuperType(leftOptional.Type, rightType)
 }

--- a/runtime/tests/checker/nil_coalescing_test.go
+++ b/runtime/tests/checker/nil_coalescing_test.go
@@ -159,14 +159,29 @@ func TestCheckInvalidNilCoalescingNonMatchingTypes(t *testing.T) {
 
 	t.Parallel()
 
-	_, err := ParseAndCheck(t, `
-      let x: Int? = 1
-      let y = x ?? false
-   `)
+	t.Run("with super type", func(t *testing.T) {
+		t.Parallel()
 
-	errs := RequireCheckerErrors(t, err, 1)
+		_, err := ParseAndCheck(t, `
+          let x: Int? = 1
+          let y = x ?? false
+       `)
 
-	assert.IsType(t, &sema.InvalidBinaryOperandError{}, errs[0])
+		require.NoError(t, err)
+	})
+
+	t.Run("no super type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          let x: Int? = 1
+          let y: Int = x ?? false
+       `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+	})
 }
 
 func TestCheckNilCoalescingAny(t *testing.T) {

--- a/runtime/tests/checker/resources_test.go
+++ b/runtime/tests/checker/resources_test.go
@@ -9936,3 +9936,21 @@ func TestCheckInvalidNestedResourceCapture(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestCheckInvalidOptionalResourceCoalescingRightSideNilLeftSide(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+       resource R {}
+       fun test() {
+           let rs: @[R?] <- [nil, nil]
+           rs[0] <-! create R()
+           rs[1] <-! nil ?? rs[0]
+           destroy rs
+       }
+    `)
+
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.InvalidNilCoalescingRightResourceOperandError{}, errs[0])
+}


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-internal/issues/237

Port of https://github.com/dapperlabs/cadence-internal/pull/239

## Description

The expression type of a nil-coalescing expression `(T?) ?? R` should be the super type of `(T, R)`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
