### PR TITLE
Update feature/atree-register-inlining-v0.42 to latest v0.42

### DIFF
--- a/npm-packages/cadence-parser/package.json
+++ b/npm-packages/cadence-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-parser",
-  "version": "0.42.10",
+  "version": "0.42.12",
   "description": "The Cadence parser",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {

--- a/runtime/cmd/parse/main.go
+++ b/runtime/cmd/parse/main.go
@@ -84,6 +84,7 @@ type jsonOutput struct {
 
 func newJSONOutput(file *os.File, count int) *jsonOutput {
 	return &jsonOutput{
+		file:    file,
 		results: make([]result, 0, count),
 	}
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -18324,20 +18324,24 @@ func (v *DictionaryValue) SetKey(
 		locationRange,
 	)
 
+	var existingValue Value
 	switch value := value.(type) {
 	case *SomeValue:
 		innerValue := value.InnerValue(interpreter, locationRange)
-		existingValue := v.Insert(interpreter, locationRange, keyValue, innerValue)
-		interpreter.checkResourceLoss(existingValue, locationRange)
+		existingValue = v.Insert(interpreter, locationRange, keyValue, innerValue)
 
 	case NilValue:
-		_ = v.Remove(interpreter, locationRange, keyValue)
+		existingValue = v.Remove(interpreter, locationRange, keyValue)
 
 	case placeholderValue:
 		// NO-OP
 
 	default:
 		panic(errors.NewUnreachableError())
+	}
+
+	if existingValue != nil {
+		interpreter.checkResourceLoss(existingValue, locationRange)
 	}
 }
 

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -441,13 +441,6 @@ func (checker *Checker) checkBinaryExpressionNilCoalescing(
 		return InvalidType
 	}
 
-	leftInner := leftOptional.Type
-
-	if leftInner == NeverType {
-		return rightType
-	}
-	canNarrow := false
-
 	if !rightIsInvalid {
 
 		if rightType.IsResourceType() {
@@ -458,25 +451,7 @@ func (checker *Checker) checkBinaryExpressionNilCoalescing(
 				},
 			)
 		}
-
-		if !IsSubType(rightType, leftOptional) {
-
-			checker.report(
-				&InvalidBinaryOperandError{
-					Operation:    operation,
-					Side:         common.OperandSideRight,
-					ExpectedType: leftOptional,
-					ActualType:   rightType,
-					Range:        ast.NewRangeFromPositioned(checker.memoryGauge, expression.Right),
-				},
-			)
-		} else {
-			canNarrow = IsSubType(rightType, leftInner)
-		}
 	}
 
-	if !canNarrow {
-		return leftOptional
-	}
-	return leftInner
+	return LeastCommonSuperType(leftOptional.Type, rightType)
 }

--- a/runtime/tests/checker/access_test.go
+++ b/runtime/tests/checker/access_test.go
@@ -1884,6 +1884,7 @@ func TestCheckAccessImportGlobalValueVariableDeclarationWithSecondValue(t *testi
     `)
 	require.NoError(t, err)
 
+	// these capture x and y because they are created in a different file
 	_, err = ParseAndCheckWithOptions(t,
 		`
            import x, y, createR from "imported"
@@ -1907,7 +1908,7 @@ func TestCheckAccessImportGlobalValueVariableDeclarationWithSecondValue(t *testi
 		},
 	)
 
-	errs := RequireCheckerErrors(t, err, 5)
+	errs := RequireCheckerErrors(t, err, 7)
 
 	require.IsType(t, &sema.InvalidAccessError{}, errs[0])
 	assert.Equal(t,
@@ -1917,18 +1918,22 @@ func TestCheckAccessImportGlobalValueVariableDeclarationWithSecondValue(t *testi
 
 	require.IsType(t, &sema.ResourceCapturingError{}, errs[1])
 
-	require.IsType(t, &sema.AssignmentToConstantError{}, errs[2])
+	require.IsType(t, &sema.ResourceCapturingError{}, errs[2])
+
+	require.IsType(t, &sema.AssignmentToConstantError{}, errs[3])
 	assert.Equal(t,
 		"x",
-		errs[2].(*sema.AssignmentToConstantError).Name,
+		errs[3].(*sema.AssignmentToConstantError).Name,
 	)
 
-	require.IsType(t, &sema.ResourceCapturingError{}, errs[3])
+	require.IsType(t, &sema.ResourceCapturingError{}, errs[4])
 
-	require.IsType(t, &sema.AssignmentToConstantError{}, errs[4])
+	require.IsType(t, &sema.ResourceCapturingError{}, errs[5])
+
+	require.IsType(t, &sema.AssignmentToConstantError{}, errs[6])
 	assert.Equal(t,
 		"y",
-		errs[4].(*sema.AssignmentToConstantError).Name,
+		errs[6].(*sema.AssignmentToConstantError).Name,
 	)
 }
 

--- a/runtime/tests/checker/nil_coalescing_test.go
+++ b/runtime/tests/checker/nil_coalescing_test.go
@@ -159,14 +159,29 @@ func TestCheckInvalidNilCoalescingNonMatchingTypes(t *testing.T) {
 
 	t.Parallel()
 
-	_, err := ParseAndCheck(t, `
-      let x: Int? = 1
-      let y = x ?? false
-   `)
+	t.Run("with super type", func(t *testing.T) {
+		t.Parallel()
 
-	errs := RequireCheckerErrors(t, err, 1)
+		_, err := ParseAndCheck(t, `
+          let x: Int? = 1
+          let y = x ?? false
+       `)
 
-	assert.IsType(t, &sema.InvalidBinaryOperandError{}, errs[0])
+		require.NoError(t, err)
+	})
+
+	t.Run("no super type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+          let x: Int? = 1
+          let y: Int = x ?? false
+       `)
+
+		errs := RequireCheckerErrors(t, err, 1)
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+	})
 }
 
 func TestCheckNilCoalescingAny(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v0.42.11-atree-register-inlining.2"
+const Version = "v0.42.12-atree-register-inlining.2"


### PR DESCRIPTION
Merge v0.42 into feature/atree-register-inlining-v0.42


<details><summary>Conflict Resolution</summary>

```diff
commit 8d6e12725ad096f60dbd19f8f00265622cb03beb
Merge: 945f0e65c 3660db2c9
Author: Faye Amacker <33205765+fxamacker@users.noreply.github.com>
Date:   Tue Jun 18 18:01:31 2024 -0500

    Merge branch 'v0.42' into fxamacker/update-atree-register-inlining-v0.42

diff --git a/version.go b/version.go
remerge CONFLICT (content): Merge conflict in version.go
index 7f507e5bb..3a7cfaaa7 100644
--- a/version.go
+++ b/version.go
@@ -21,8 +21,4 @@
 
 package cadence
 
-<<<<<<< 945f0e65c (Merge pull request #3394 from onflow/fxamacker/port-3300)
-const Version = "v0.42.11-atree-register-inlining.2"
-=======
-const Version = "v0.42.12"
->>>>>>> 3660db2c9 (Merge pull request #3424 from onflow/release/v0.42.12)
+const Version = "v0.42.12-atree-register-inlining.2"

```

</details>
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x]  Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
