### PR TITLE
Improve the commit-based version handling in the update tool

### DIFF
--- a/tools/update/main.ts
+++ b/tools/update/main.ts
@@ -107,9 +107,12 @@ class Updater {
             repo: repoName,
             ref: `heads/${defaultBranch}`
         })
-        const defaultRef = defaultRefResponse.data.object.sha
 
-        if (await this.repoModsUpdated(defaultRef, repo)) {
+        // Go uses the first 12 digits of the commit hash
+        // See https://go.dev/ref/mod#glos-pseudo-version
+        const defaultVersion = defaultRefResponse.data.object.sha.slice(0, 12)
+
+        if (await this.repoModsUpdated(defaultVersion, repo)) {
             console.log(`> Default branch (${defaultBranch}) of repo ${fullRepoName} is updated`)
 
             if (repo.needsRelease) {


### PR DESCRIPTION

## Description

Go does not use the full commit hash in the version, but only the first 12 digits.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
