### PR TITLE
Improve handling of releases in update tool

### DIFF
--- a/tools/update/main.ts
+++ b/tools/update/main.ts
@@ -253,12 +253,15 @@ class Updater {
             const [owner, repoName] = fullRepoName.split('/')
             // Heuristic: Fetch as many releases on the first page as possible,
             // and find the latest release by sorting the releases by semver
-            const releases = await this.octokit.rest.repos.listReleases({
+            const response = await this.octokit.rest.repos.listReleases({
                 owner,
                 repo: repoName,
                 per_page: 100
             })
-            const release = releases.data.sort((a, b) => {
+
+            const releases = response.data.filter(release => !release.draft)
+
+            const release = releases.sort((a, b) => {
                 return a.created_at.localeCompare(b.created_at)
             }).pop()
             if (release === undefined) {


### PR DESCRIPTION

## Description

Only consider published releases / ignore draft release. For example, https://github.com/onflow/flow-cli uses a release auto-drafting bot.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
