### PR TITLE
Simplify subtyping

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -3997,39 +3997,31 @@ func (interpreter *Interpreter) IsSubType(subType StaticType, superType StaticTy
 	return interpreter.IsSubTypeOfSemaType(subType, semaType)
 }
 
-func (interpreter *Interpreter) IsSubTypeOfSemaType(subType StaticType, superType sema.Type) bool {
+func (interpreter *Interpreter) IsSubTypeOfSemaType(staticSubType StaticType, superType sema.Type) bool {
 	if superType == sema.AnyType {
 		return true
 	}
 
-	switch subType := subType.(type) {
+	// Optimization: Implement subtyping for common cases directly,
+	// without converting the subtype to a sema type.
+
+	switch staticSubType := staticSubType.(type) {
 	case *OptionalStaticType:
 		if superType, ok := superType.(*sema.OptionalType); ok {
-			return interpreter.IsSubTypeOfSemaType(subType.Type, superType.Type)
+			return interpreter.IsSubTypeOfSemaType(staticSubType.Type, superType.Type)
 		}
 
 		switch superType {
 		case sema.AnyStructType, sema.AnyResourceType:
-			return interpreter.IsSubTypeOfSemaType(subType.Type, superType)
-		}
-
-	case *ReferenceStaticType:
-		if superType, ok := superType.(*sema.ReferenceType); ok {
-
-			// First, check that the static type of the referenced value
-			// is a subtype of the super type
-
-			return subType.ReferencedType != nil &&
-				interpreter.IsSubTypeOfSemaType(subType.ReferencedType, superType.Type) &&
-				superType.Authorization.PermitsAccess(interpreter.MustConvertStaticAuthorizationToSemaAccess(subType.Authorization))
+			return interpreter.IsSubTypeOfSemaType(staticSubType.Type, superType)
 		}
 
 		return superType == sema.AnyStructType
 	}
 
-	semaType := interpreter.MustConvertStaticToSemaType(subType)
+	semaSubType := interpreter.MustConvertStaticToSemaType(staticSubType)
 
-	return sema.IsSubType(semaType, superType)
+	return sema.IsSubType(semaSubType, superType)
 }
 
 func (interpreter *Interpreter) domainPaths(address common.Address, domain common.PathDomain) []Value {


### PR DESCRIPTION
## Description

Simplify `IsSubTypeOfSemaType` a bit, and prevent it from getting out-of-sync with subtyping rules for references in the checker. A single source-of-truth is better than this optimization (?).

Also add a comment explaining the purpose of the switch-case.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
