### PR TITLE
Allow borrowing of capability with subtype

### DIFF
--- a/runtime/capabilities_test.go
+++ b/runtime/capabilities_test.go
@@ -278,12 +278,38 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
               access(all)
               fun testRI() {
-                  let unentitledRI1 = self.account.capabilities.get<&{RI}>(/public/unentitledRI).borrow()!
-                  let entitledRI1 = self.account.capabilities.get<auth(X) &{RI}>(/public/unentitledRI).borrow()
-                  assert(entitledRI1 == nil)
+                  // Borrow /public/unentitledRI.
+                  // - All unentitled borrows should succeed (as &{RI} / as &R)
+                  // - All entitled borrows should fail (as &{RI} / as &R)
 
-                  let unentitledRI2 = self.account.capabilities.get<&{RI}>(/public/entitledRI).borrow()!
-                  let entitledRI2 = self.account.capabilities.get<auth(X) &{RI}>(/public/entitledRI).borrow()!
+                  let unentitledRI1 = self.account.capabilities.get<&{RI}>(/public/unentitledRI).borrow()
+                  assert(unentitledRI1 != nil, message: "unentitledRI1 should not be nil")
+
+                  let entitledRI1 = self.account.capabilities.get<auth(X) &{RI}>(/public/unentitledRI).borrow()
+                  assert(entitledRI1 == nil, message: "entitledRI1 should be nil")
+
+                  let unentitledR1 = self.account.capabilities.get<&R>(/public/unentitledRI).borrow()
+                  assert(unentitledR1 != nil, message: "unentitledR1 should not be nil")
+
+                  let entitledR1 = self.account.capabilities.get<auth(X) &R>(/public/unentitledRI).borrow()
+                  assert(entitledR1 == nil, message: "entitledR1 should be nil")
+
+                  // Borrow /public/entitledRI.
+                  // All borrows should succeed:
+                  // - As &{RI} / as &R
+                  // - Unentitled / entitled
+
+                  let unentitledRI2 = self.account.capabilities.get<&{RI}>(/public/entitledRI).borrow()
+                  assert(unentitledRI2 != nil, message: "unentitledRI2 should not be nil")
+
+                  let entitledRI2 = self.account.capabilities.get<auth(X) &{RI}>(/public/entitledRI).borrow()
+                  assert(entitledRI2 != nil, message: "entitledRI2 should not be nil")
+
+                  let unentitledR2 = self.account.capabilities.get<&R>(/public/entitledRI).borrow()
+                  assert(unentitledR2 != nil, message: "unentitledR2 should not be nil")
+
+                  let entitledR2 = self.account.capabilities.get<auth(X) &R>(/public/entitledRI).borrow()
+                  assert(entitledR2 != nil, message: "entitledR2 should not be nil")
               }
           }
         `
@@ -573,12 +599,39 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
               access(all)
               fun testSI() {
-                  let unentitledSI1 = self.account.capabilities.get<&{SI}>(/public/unentitledSI).borrow()!
-                  let entitledSI1 = self.account.capabilities.get<auth(X) &{SI}>(/public/unentitledSI).borrow()
-                  assert(entitledSI1 == nil)
 
-                  let unentitledSI2 = self.account.capabilities.get<&{SI}>(/public/entitledSI).borrow()!
-                  let entitledSI2 = self.account.capabilities.get<auth(X) &{SI}>(/public/entitledSI).borrow()!
+                  // Borrow /public/unentitledSI.
+                  // - All unentitled borrows should succeed (as &{SI} / as &S)
+                  // - All entitled borrows should fail (as &{SI} / as &S)
+
+                  let unentitledSI1 = self.account.capabilities.get<&{SI}>(/public/unentitledSI).borrow()
+                  assert(unentitledSI1 != nil, message: "unentitledSI1 should not be nil")
+
+                  let entitledSI1 = self.account.capabilities.get<auth(X) &{SI}>(/public/unentitledSI).borrow()
+                  assert(entitledSI1 == nil, message: "entitledSI1 should be nil")
+
+                  let unentitledS1 = self.account.capabilities.get<&S>(/public/unentitledSI).borrow()
+                  assert(unentitledS1 != nil, message: "unentitledS1 should not be nil")
+
+                  let entitledS1 = self.account.capabilities.get<auth(X) &S>(/public/unentitledSI).borrow()
+                  assert(entitledS1 == nil, message: "entitledS1 should be nil")
+
+                  // Borrow /public/entitledSI.
+                  // All borrows should succeed:
+                  // - As &{SI} / as &S
+                  // - Unentitled / entitled
+
+                  let unentitledSI2 = self.account.capabilities.get<&{SI}>(/public/entitledSI).borrow()
+                  assert(unentitledSI2 != nil, message: "unentitledSI2 should not be nil")
+
+                  let entitledSI2 = self.account.capabilities.get<auth(X) &{SI}>(/public/entitledSI).borrow()
+                  assert(entitledSI2 != nil, message: "entitledSI2 should not be nil")
+
+                  let unentitledS2 = self.account.capabilities.get<&S>(/public/entitledSI).borrow()
+                  assert(unentitledS2 != nil, message: "unentitledS2 should not be nil")
+
+                  let entitledS2 = self.account.capabilities.get<auth(X) &S>(/public/entitledSI).borrow()
+                  assert(entitledS2 != nil, message: "entitledS2 should not be nil")
               }
           }
         `

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -1792,7 +1792,7 @@ func (interpreter *Interpreter) VisitEnumCaseDeclaration(_ *ast.EnumCaseDeclarat
 	panic(errors.NewUnreachableError())
 }
 
-func (interpreter *Interpreter) substituteMappedEntitlements(ty sema.Type) sema.Type {
+func (interpreter *Interpreter) SubstituteMappedEntitlements(ty sema.Type) sema.Type {
 	if interpreter.SharedState.currentEntitlementMappedValue == nil {
 		return ty
 	}
@@ -1830,7 +1830,7 @@ func (interpreter *Interpreter) transferAndConvert(
 		nil,
 	)
 
-	targetType = interpreter.substituteMappedEntitlements(targetType)
+	targetType = interpreter.SubstituteMappedEntitlements(targetType)
 
 	result := interpreter.ConvertAndBox(
 		locationRange,

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -1312,7 +1312,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 	}
 
 	castingExpressionTypes := interpreter.Program.Elaboration.CastingExpressionTypes(expression)
-	expectedType := interpreter.substituteMappedEntitlements(castingExpressionTypes.TargetType)
+	expectedType := interpreter.SubstituteMappedEntitlements(castingExpressionTypes.TargetType)
 
 	switch expression.Operation {
 	case ast.OperationFailableCast, ast.OperationForceCast:
@@ -1325,7 +1325,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 		// thus this is the only place where it becomes necessary to "instantiate" the result of a map to its
 		// concrete outputs. In other places (e.g. interface conformance checks) we want to leave maps generic,
 		// so we don't substitute them.
-		valueSemaType := interpreter.substituteMappedEntitlements(interpreter.MustSemaTypeOfValue(value))
+		valueSemaType := interpreter.SubstituteMappedEntitlements(interpreter.MustSemaTypeOfValue(value))
 		valueStaticType := ConvertSemaToStaticType(interpreter, valueSemaType)
 		isSubType := interpreter.IsSubTypeOfSemaType(valueStaticType, expectedType)
 

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -3522,7 +3522,7 @@ func canBorrow(
 		return false
 	}
 
-	// Ensure the wanted borrow type must be a subtype or supertype of the capability borrow type
+	// Ensure the wanted borrow type is a subtype or supertype of the capability borrow type
 
 	return sema.IsSubType(wantedBorrowType.Type, capabilityBorrowType.Type) ||
 		sema.IsSubType(capabilityBorrowType.Type, wantedBorrowType.Type)

--- a/runtime/stdlib/account_test.go
+++ b/runtime/stdlib/account_test.go
@@ -19,11 +19,13 @@
 package stdlib
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/tests/utils"
 )
 
 func TestSemaCheckPathLiteralForInternalStorageDomains(t *testing.T) {
@@ -52,4 +54,279 @@ func TestSemaCheckPathLiteralForInternalStorageDomains(t *testing.T) {
 	for _, domain := range internalStorageDomains {
 		test(domain)
 	}
+}
+
+func TestCanBorrow(t *testing.T) {
+
+	t.Parallel()
+
+	inter := newInterpreter(t, `
+        access(all)
+        entitlement E
+
+        access(all)
+        entitlement F
+
+        access(all)
+        resource interface RI {}
+
+        access(all)
+        resource R: RI {}
+    `)
+
+	typeID := func(qualifiedIdentifier string) sema.TypeID {
+		return utils.TestLocation.TypeID(nil, qualifiedIdentifier)
+	}
+
+	entitlementE := inter.Program.Elaboration.EntitlementType(typeID("E"))
+	require.NotNil(t, entitlementE)
+
+	entitlementF := inter.Program.Elaboration.EntitlementType(typeID("F"))
+	require.NotNil(t, entitlementF)
+
+	test := func(
+		t *testing.T,
+		instantiate func(a, b sema.Type) (a2, b2 *sema.ReferenceType),
+		expected bool,
+	) {
+		rType := inter.Program.Elaboration.CompositeType(typeID("R"))
+		require.NotNil(t, rType)
+
+		riType := inter.Program.Elaboration.InterfaceType(typeID("RI"))
+		require.NotNil(t, riType)
+
+		riIntersectionType := sema.NewIntersectionType(
+			nil,
+			nil,
+			[]*sema.InterfaceType{
+				riType,
+			},
+		)
+
+		types := []sema.Type{
+			rType,
+			riIntersectionType,
+			sema.AnyResourceType,
+		}
+
+		for _, a := range types {
+			for _, b := range types {
+				a2, b2 := instantiate(a, b)
+
+				t.Run(fmt.Sprintf("%s / %s", a2, b2), func(t *testing.T) {
+					t.Parallel()
+
+					require.Equal(t, expected, canBorrow(a2, b2))
+				})
+			}
+		}
+	}
+
+	t.Run("&T / &T", func(t *testing.T) {
+
+		t.Parallel()
+
+		// Borrowing with the same type and no entitlements is allowed
+
+		test(t,
+			func(a, b sema.Type) (a2, b2 *sema.ReferenceType) {
+				return sema.NewReferenceType(nil, sema.UnauthorizedAccess, a),
+					sema.NewReferenceType(nil, sema.UnauthorizedAccess, b)
+			},
+			true,
+		)
+	})
+
+	t.Run("auth(E) &T / &T", func(t *testing.T) {
+
+		t.Parallel()
+
+		// Borrowing with more permissions is NOT allowed
+
+		test(t,
+			func(a, b sema.Type) (a2, b2 *sema.ReferenceType) {
+				return sema.NewReferenceType(
+						nil,
+						sema.NewEntitlementSetAccess(
+							[]*sema.EntitlementType{
+								entitlementE,
+							},
+							sema.Conjunction,
+						),
+						a,
+					),
+					sema.NewReferenceType(nil, sema.UnauthorizedAccess, b)
+			},
+			false,
+		)
+	})
+
+	t.Run("auth(E) &T / auth(E) &T", func(t *testing.T) {
+
+		t.Parallel()
+
+		// Borrowing with same permissions is allowed
+
+		test(t,
+			func(a, b sema.Type) (a2, b2 *sema.ReferenceType) {
+				return sema.NewReferenceType(
+						nil,
+						sema.NewEntitlementSetAccess(
+							[]*sema.EntitlementType{
+								entitlementE,
+							},
+							sema.Conjunction,
+						),
+						a,
+					),
+					sema.NewReferenceType(
+						nil,
+						sema.NewEntitlementSetAccess(
+							[]*sema.EntitlementType{
+								entitlementE,
+							},
+							sema.Conjunction,
+						),
+						b,
+					)
+			},
+			true,
+		)
+	})
+
+	t.Run("auth(E, F) &T / auth(E) &T", func(t *testing.T) {
+
+		t.Parallel()
+
+		// Borrowing with more permissions is NOT allowed
+
+		test(t,
+			func(a, b sema.Type) (a2, b2 *sema.ReferenceType) {
+				return sema.NewReferenceType(
+						nil,
+						sema.NewEntitlementSetAccess(
+							[]*sema.EntitlementType{
+								entitlementE,
+								entitlementF,
+							},
+							sema.Conjunction,
+						),
+						a,
+					),
+					sema.NewReferenceType(
+						nil,
+						sema.NewEntitlementSetAccess(
+							[]*sema.EntitlementType{
+								entitlementE,
+							},
+							sema.Conjunction,
+						),
+						b,
+					)
+			},
+			false,
+		)
+	})
+
+	t.Run("auth(E) &T / auth(E, F) &T", func(t *testing.T) {
+
+		t.Parallel()
+
+		// Borrowing with fewer permissions is allowed
+
+		test(t,
+			func(a, b sema.Type) (a2, b2 *sema.ReferenceType) {
+
+				return sema.NewReferenceType(
+						nil,
+						sema.NewEntitlementSetAccess(
+							[]*sema.EntitlementType{
+								entitlementE,
+							},
+							sema.Conjunction,
+						),
+						a,
+					),
+					sema.NewReferenceType(
+						nil,
+						sema.NewEntitlementSetAccess(
+							[]*sema.EntitlementType{
+								entitlementE,
+								entitlementF,
+							},
+							sema.Conjunction,
+						),
+						b,
+					)
+			},
+			true,
+		)
+	})
+
+	t.Run("auth(E | F) &T / auth(E) &T", func(t *testing.T) {
+
+		t.Parallel()
+
+		// Borrowing with fewer permissions is allowed
+
+		test(t,
+			func(a, b sema.Type) (a2, b2 *sema.ReferenceType) {
+				return sema.NewReferenceType(
+						nil,
+						sema.NewEntitlementSetAccess(
+							[]*sema.EntitlementType{
+								entitlementE,
+								entitlementF,
+							},
+							sema.Disjunction,
+						),
+						a,
+					),
+					sema.NewReferenceType(
+						nil,
+						sema.NewEntitlementSetAccess(
+							[]*sema.EntitlementType{
+								entitlementE,
+							},
+							sema.Conjunction,
+						),
+						b,
+					)
+			},
+			true,
+		)
+	})
+
+	t.Run("auth(F) &T / auth(E) &T", func(t *testing.T) {
+
+		t.Parallel()
+
+		// Borrowing with unrelated permission is NOT allowed
+
+		test(t,
+			func(a, b sema.Type) (a2, b2 *sema.ReferenceType) {
+				return sema.NewReferenceType(
+						nil,
+						sema.NewEntitlementSetAccess(
+							[]*sema.EntitlementType{
+								entitlementF,
+							},
+							sema.Conjunction,
+						),
+						a,
+					),
+					sema.NewReferenceType(
+						nil,
+						sema.NewEntitlementSetAccess(
+							[]*sema.EntitlementType{
+								entitlementE,
+							},
+							sema.Conjunction,
+						),
+						b,
+					)
+			},
+			false,
+		)
+	})
 }


### PR DESCRIPTION
Closes #3080

## Description

Extend borrowing functions (`borrow`, `check`) to allow borrowing a capability also with a subtype, not just a supertype.

This is valid, because a reference borrowed with the issued type may also be downcasted, since https://github.com/onflow/flips/blob/main/cadence/20221214-auth-remodel.md.

Ensure though that the requested type's auth/access is not more permissive than the capability's.

cc @dsainati1 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
