### PR TITLE
Add String.index and String.count, fix grapheme boundary functions

### DIFF
--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -4392,7 +4392,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 
 }
 
-func TestStringIsBoundaryStart(t *testing.T) {
+func TestStringIsGraphemeBoundaryStart(t *testing.T) {
 
 	t.Parallel()
 
@@ -4402,11 +4402,11 @@ func TestStringIsBoundaryStart(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			str := NewUnmeteredStringValue(s)
-			assert.Equal(t, expected, str.IsBoundaryStart(i))
+			assert.Equal(t, expected, str.IsGraphemeBoundaryStart(i))
 		})
 	}
 
-	test("", 0, true)
+	test("", 0, false)
 	test("a", 0, true)
 	test("a", 1, false)
 	test("ab", 1, true)
@@ -4433,7 +4433,7 @@ func TestStringIsBoundaryStart(t *testing.T) {
 	test(flagESflagEE, 15, false)
 }
 
-func TestStringIsBoundaryEnd(t *testing.T) {
+func TestStringIsGraphemeBoundaryEnd(t *testing.T) {
 
 	t.Parallel()
 
@@ -4443,19 +4443,19 @@ func TestStringIsBoundaryEnd(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			str := NewUnmeteredStringValue(s)
-			assert.Equal(t, expected, str.IsBoundaryEnd(i))
+			assert.Equal(t, expected, str.IsGraphemeBoundaryEnd(i))
 		})
 	}
 
-	test("", 0, true)
-	test("a", 0, true)
+	test("", 0, false)
+	test("a", 0, false)
 	test("a", 1, true)
 	test("ab", 1, true)
 
 	// 🇪🇸🇪🇪 ("ES", "EE")
 	flagESflagEE := "\U0001F1EA\U0001F1F8\U0001F1EA\U0001F1EA"
 	require.Len(t, flagESflagEE, 16)
-	test(flagESflagEE, 0, true)
+	test(flagESflagEE, 0, false)
 	test(flagESflagEE, 1, false)
 	test(flagESflagEE, 2, false)
 	test(flagESflagEE, 3, false)
@@ -4472,4 +4472,7 @@ func TestStringIsBoundaryEnd(t *testing.T) {
 	test(flagESflagEE, 13, false)
 	test(flagESflagEE, 14, false)
 	test(flagESflagEE, 15, false)
+
+	test(flagESflagEE, 16, true)
+
 }

--- a/runtime/sema/string_type.go
+++ b/runtime/sema/string_type.go
@@ -129,6 +129,18 @@ func init() {
 				StringTypeContainsFunctionType,
 				stringTypeContainsFunctionDocString,
 			),
+			NewUnmeteredPublicFunctionMember(
+				t,
+				StringTypeIndexFunctionName,
+				StringTypeIndexFunctionType,
+				stringTypeIndexFunctionDocString,
+			),
+			NewUnmeteredPublicFunctionMember(
+				t,
+				StringTypeCountFunctionName,
+				StringTypeCountFunctionType,
+				stringTypeCountFunctionDocString,
+			),
 		})
 	}
 }
@@ -192,6 +204,46 @@ const StringTypeContainsFunctionName = "contains"
 
 const stringTypeContainsFunctionDocString = `
 Returns true if this string contains the given other string as a substring.
+`
+
+var StringTypeIndexFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]Parameter{
+		{
+			Label:          "of",
+			Identifier:     "other",
+			TypeAnnotation: StringTypeAnnotation,
+		},
+	},
+	IntTypeAnnotation,
+)
+
+const StringTypeIndexFunctionName = "index"
+
+const stringTypeIndexFunctionDocString = `
+Returns the index within this string of the first occurrence of the given substring.
+
+If the substring is not found, the function returns -1.
+`
+
+var StringTypeCountFunctionType = NewSimpleFunctionType(
+	FunctionPurityView,
+	[]Parameter{
+		{
+			Label:          ArgumentLabelNotRequired,
+			Identifier:     "other",
+			TypeAnnotation: StringTypeAnnotation,
+		},
+	},
+	IntTypeAnnotation,
+)
+
+const StringTypeCountFunctionName = "count"
+
+const stringTypeCountFunctionDocString = `
+Returns the number of non-overlapping instances of the given substring in this string.
+
+If the given substring is an empty string, the function returns 1 + the number of characters in this string.
 `
 
 const StringTypeReplaceAllFunctionName = "replaceAll"

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -579,3 +579,121 @@ func TestCheckStringContains(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestCheckStringIndex(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("missing argument", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		  let a = "abcdef"
+		  let x: Int = a.index()
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.InsufficientArgumentsError{}, errs[0])
+	})
+
+	t.Run("wrong argument type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		  let a = "abcdef"
+		  let x: Int = a.index(of: 1)
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+	})
+
+	t.Run("wrong argument label", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		  let a = "abcdef"
+		  let x: Int = a.index(foo: "bc")
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.IncorrectArgumentLabelError{}, errs[0])
+	})
+
+	t.Run("missing argument label", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		  let a = "abcdef"
+		  let x: Int = a.index("bc")
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.MissingArgumentLabelError{}, errs[0])
+	})
+
+	t.Run("valid", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		  let a = "abcdef"
+		  let x: Int = a.index(of: "bc")
+		`)
+
+		require.NoError(t, err)
+	})
+}
+
+func TestCheckStringCount(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("missing argument", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		  let a = "abcdef"
+		  let x: Int = a.count()
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.InsufficientArgumentsError{}, errs[0])
+	})
+
+	t.Run("wrong argument type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		  let a = "abcdef"
+		  let x: Int = a.count(1)
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeMismatchError{}, errs[0])
+	})
+
+	t.Run("valid", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		  let a = "abcdef"
+		  let x: Int = a.count("b")
+		`)
+
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Description

Add two new functions to `String`:
- `String.index` returns the index of the first occurrence
- `String.count` returns the number of occurrences

Also:
- Fix the boundary start/end functions (need to initialize `uniseg.Graphemes` with `Next`)
- Generalize `contains` to use `index`

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
