### PR TITLE
Fix String.split

### DIFF
--- a/runtime/tests/interpreter/metering_test.go
+++ b/runtime/tests/interpreter/metering_test.go
@@ -657,6 +657,6 @@ func TestInterpretStdlibComputationMetering(t *testing.T) {
 		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint(10), computationMeteredValues[common.ComputationKindLoop])
+		assert.Equal(t, uint(58), computationMeteredValues[common.ComputationKindLoop])
 	})
 }


### PR DESCRIPTION
## Description

Split into characters (grapheme clusters). Go's `strings.Split` is not grapheme cluster aware.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
