### PR TITLE
Emit events when capability controllers are issued

### DIFF
--- a/migrations/capcons/linkmigration.go
+++ b/migrations/capcons/linkmigration.go
@@ -40,9 +40,9 @@ type LinkMigrationReporter interface {
 
 // LinkValueMigration migrates all links to capability controllers.
 type LinkValueMigration struct {
-	CapabilityMapping  *CapabilityMapping
-	AccountIDGenerator stdlib.AccountIDGenerator
-	Reporter           LinkMigrationReporter
+	CapabilityMapping *CapabilityMapping
+	Handler           stdlib.CapabilityControllerIssueHandler
+	Reporter          LinkMigrationReporter
 }
 
 var _ migrations.ValueMigration = &LinkValueMigration{}
@@ -98,7 +98,7 @@ func (m *LinkValueMigration) Migrate(
 	}
 
 	reporter := m.Reporter
-	accountIDGenerator := m.AccountIDGenerator
+	handler := m.Handler
 
 	locationRange := interpreter.EmptyLocationRange
 
@@ -180,7 +180,7 @@ func (m *LinkValueMigration) Migrate(
 		capabilityID, _ = stdlib.IssueStorageCapabilityController(
 			inter,
 			locationRange,
-			accountIDGenerator,
+			handler,
 			accountAddress,
 			borrowType,
 			targetPath,
@@ -190,7 +190,7 @@ func (m *LinkValueMigration) Migrate(
 		capabilityID, _ = stdlib.IssueAccountCapabilityController(
 			inter,
 			locationRange,
-			accountIDGenerator,
+			handler,
 			accountAddress,
 			borrowType,
 		)

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -768,10 +768,16 @@ func TestCapConMigration(t *testing.T) {
 
 	rt := NewTestInterpreterRuntime()
 
+	var events []cadence.Event
+
 	runtimeInterface := &TestRuntimeInterface{
 		Storage: NewTestLedger(nil, nil),
 		OnGetSigningAccounts: func() ([]runtime.Address, error) {
 			return []runtime.Address{testAddress}, nil
+		},
+		OnEmitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -949,6 +955,22 @@ func TestCapConMigration(t *testing.T) {
 
 	accountCapEntry = accountCapStorageMap.ReadValue(nil, interpreter.Uint64StorageMapKey(2))
 	assert.NotNil(t, accountCapEntry)
+
+	require.Equal(t,
+		[]string{
+			`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&AnyStruct>(), path: /storage/foo)`,
+			`flow.AccountCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&Account>())`,
+		},
+		eventStrings(events),
+	)
+}
+
+func eventStrings(events []cadence.Event) []string {
+	strings := make([]string, 0, len(events))
+	for _, event := range events {
+		strings = append(strings, event.String())
+	}
+	return strings
 }
 
 func TestContractMigration(t *testing.T) {

--- a/runtime/capabilitycontrollers_test.go
+++ b/runtime/capabilitycontrollers_test.go
@@ -42,6 +42,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 	testWithSignerCount := func(t *testing.T, tx string, signerCount int) (
 		err error,
 		storage *Storage,
+		events []cadence.Event,
 	) {
 
 		rt := NewTestInterpreterRuntime()
@@ -144,7 +145,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 				// NO-OP
 			},
 			OnEmitEvent: func(event cadence.Event) error {
-				// NO-OP
+				events = append(events, event)
 				return nil
 			},
 			OnGetSigningAccounts: func() ([]Address, error) {
@@ -200,6 +201,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 	test := func(t *testing.T, tx string) (
 		err error,
 		storage *Storage,
+		events []cadence.Event,
 	) {
 		return testWithSignerCount(t, tx, 1)
 	}
@@ -222,7 +224,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					fmt.Sprintf(
 						// language=cadence
@@ -248,6 +250,11 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 					),
 				)
 				require.NoError(t, err)
+
+				require.Equal(t,
+					[]string{},
+					nonDeploymentEventStrings(events),
+				)
 			})
 
 			t.Run("get and check existing, with valid type", func(t *testing.T) {
@@ -255,7 +262,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 				t.Parallel()
 
 				t.Run("storage capability", func(t *testing.T) {
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -291,10 +298,17 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 
 				t.Run("account capability", func(t *testing.T) {
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -325,6 +339,12 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+						},
+						nonDeploymentEventStrings(events))
 				})
 			})
 
@@ -334,7 +354,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 				t.Run("storage capability", func(t *testing.T) {
 
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -372,11 +392,17 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+						},
+						nonDeploymentEventStrings(events))
 				})
 
 				t.Run("account capability", func(t *testing.T) {
 
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -409,6 +435,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 			})
 
@@ -418,7 +451,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 				t.Run("storage capability", func(t *testing.T) {
 
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -456,11 +489,18 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 
 				t.Run("account capability", func(t *testing.T) {
 
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -495,6 +535,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 			})
 
@@ -504,7 +551,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 				t.Run("storage capability", func(t *testing.T) {
 
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -542,11 +589,18 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 
 				t.Run("account capability", func(t *testing.T) {
 
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -579,6 +633,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 			})
 
@@ -587,7 +648,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 				t.Parallel()
 
 				t.Run("storage capability", func(t *testing.T) {
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -627,10 +688,17 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 
 				t.Run("account capability", func(t *testing.T) {
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -665,6 +733,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 
 			})
@@ -673,7 +748,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					fmt.Sprintf(
 						// language=cadence
@@ -693,6 +768,11 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 					),
 				)
 				require.NoError(t, err)
+
+				require.Equal(t,
+					[]string{},
+					nonDeploymentEventStrings(events),
+				)
 			})
 
 			t.Run("borrow existing, with valid type", func(t *testing.T) {
@@ -700,7 +780,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 				t.Parallel()
 
 				t.Run("storage capability", func(t *testing.T) {
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -734,10 +814,17 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 
 				t.Run("account capability", func(t *testing.T) {
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -766,6 +853,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 			})
 
@@ -775,7 +869,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 				t.Run("storage capability", func(t *testing.T) {
 
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -809,11 +903,18 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 
 				t.Run("account capability", func(t *testing.T) {
 
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -844,6 +945,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 			})
 
@@ -853,7 +961,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 				t.Run("storage capability", func(t *testing.T) {
 
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -887,11 +995,18 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 
 				t.Run("account capability", func(t *testing.T) {
 
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -920,6 +1035,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 			})
 
@@ -928,7 +1050,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 				t.Parallel()
 
 				t.Run("storage capability", func(t *testing.T) {
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -964,10 +1086,17 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 
 				t.Run("account capability", func(t *testing.T) {
-					err, _ := test(
+					err, _, events := test(
 						t,
 						fmt.Sprintf(
 							// language=cadence
@@ -998,6 +1127,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						),
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{
+							`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+						},
+						nonDeploymentEventStrings(events),
+					)
 				})
 			})
 
@@ -1008,7 +1144,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 					t.Parallel()
 
 					t.Run("storage capability", func(t *testing.T) {
-						err, _ := test(
+						err, _, events := test(
 							t,
 							// language=cadence
 							`
@@ -1035,10 +1171,17 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 						var overwriteErr interpreter.OverwriteError
 						require.ErrorAs(t, err, &overwriteErr)
+
+						require.Equal(t,
+							[]string{
+								`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+							},
+							nonDeploymentEventStrings(events),
+						)
 					})
 
-					t.Run("storage capability", func(t *testing.T) {
-						err, _ := test(
+					t.Run("account capability", func(t *testing.T) {
+						err, _, events := test(
 							t,
 							// language=cadence
 							`
@@ -1062,6 +1205,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 						var overwriteErr interpreter.OverwriteError
 						require.ErrorAs(t, err, &overwriteErr)
+
+						require.Equal(t,
+							[]string{
+								`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+							},
+							nonDeploymentEventStrings(events),
+						)
 					})
 				})
 
@@ -1071,7 +1221,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 					t.Run("storage capability", func(t *testing.T) {
 
-						err, _ := testWithSignerCount(
+						err, _, events := testWithSignerCount(
 							t,
 							// language=cadence
 							`
@@ -1106,11 +1256,19 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 							interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
 							publishingError.CapabilityAddress,
 						)
+
+						require.Equal(
+							t,
+							[]string{
+								`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&AnyStruct>(), path: /storage/r)`,
+							},
+							nonDeploymentEventStrings(events),
+						)
 					})
 
 					t.Run("account capability", func(t *testing.T) {
 
-						err, _ := testWithSignerCount(
+						err, _, events := testWithSignerCount(
 							t,
 							// language=cadence
 							`
@@ -1144,6 +1302,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 							interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
 							publishingError.CapabilityAddress,
 						)
+
+						require.Equal(t,
+							[]string{
+								`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+							},
+							nonDeploymentEventStrings(events),
+						)
 					})
 				})
 
@@ -1151,7 +1316,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 					t.Parallel()
 
-					err, _ := test(
+					err, _, events := test(
 						t,
 						// language=cadence
 						`
@@ -1169,6 +1334,11 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                         `,
 					)
 					require.NoError(t, err)
+
+					require.Equal(t,
+						[]string{},
+						nonDeploymentEventStrings(events),
+					)
 				})
 			}
 		})
@@ -1189,7 +1359,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1220,13 +1390,24 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(
+				t,
+				[]string{
+					`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 3, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 4, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r2)`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("issue, multiple controllers to various paths, with same or different type, type value", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1257,13 +1438,23 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 3, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 4, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r2)`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("issue with type value, invalid type", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1277,13 +1468,18 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 			RequireError(t, err)
 
 			require.ErrorAs(t, err, &interpreter.InvalidCapabilityIssueTypeError{})
+
+			require.Equal(t,
+				[]string{},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("getController, non-existing", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1303,13 +1499,18 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("getController, account capability controller", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1330,13 +1531,20 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("getController, multiple controllers to various paths, with same or different type", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1388,13 +1596,23 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 3, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 4, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r2)`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("getControllers", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1444,13 +1662,23 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 3, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 4, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r2)`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, no controllers", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1475,13 +1703,18 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, all", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1544,13 +1777,23 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 3, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 4, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r2)`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, stop immediately", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1584,13 +1827,21 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, mutation (issue), stop", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1618,13 +1869,21 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, mutation (issue), continue", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1655,13 +1914,21 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 			var mutationErr stdlib.CapabilityControllersMutatedDuringIterationError
 			require.ErrorAs(t, err, &mutationErr)
+
+			require.Equal(t,
+				[]string{
+					`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					`flow.StorageCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, mutation (delete), stop", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1689,13 +1956,20 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, mutation (delete), continue", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1726,6 +2000,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 			var mutationErr stdlib.CapabilityControllersMutatedDuringIterationError
 			require.ErrorAs(t, err, &mutationErr)
+
+			require.Equal(t,
+				[]string{
+					`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 	})
 
@@ -1737,7 +2018,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1760,13 +2041,22 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+					`flow.AccountCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&Account>())`,
+					`flow.AccountCapabilityControllerIssued(id: 3, address: 0x0000000000000001, type: Type<&Account>())`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("issue, multiple controllers, with same or different type, type value", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1789,13 +2079,22 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+					`flow.AccountCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&Account>())`,
+					`flow.AccountCapabilityControllerIssued(id: 3, address: 0x0000000000000001, type: Type<&Account>())`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("issue with type value, invalid type", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1809,13 +2108,18 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 			RequireError(t, err)
 
 			require.ErrorAs(t, err, &interpreter.InvalidCapabilityIssueTypeError{})
+
+			require.Equal(t,
+				[]string{},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("getController, non-existing", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1835,13 +2139,18 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("getController, storage capability controller", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1862,13 +2171,20 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&AnyStruct>(), path: /storage/x)`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("getController, multiple controllers to various paths, with same or different type", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1904,13 +2220,22 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+					`flow.AccountCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&Account>())`,
+					`flow.AccountCapabilityControllerIssued(id: 3, address: 0x0000000000000001, type: Type<&Account>())`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("getControllers", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1951,13 +2276,23 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(
+				t,
+				[]string{
+					`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+					`flow.AccountCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&Account>())`,
+					`flow.AccountCapabilityControllerIssued(id: 3, address: 0x0000000000000001, type: Type<&Account>())`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, no controllers", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -1980,13 +2315,18 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, all", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -2031,13 +2371,22 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+					`flow.AccountCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&Account>())`,
+					`flow.AccountCapabilityControllerIssued(id: 3, address: 0x0000000000000001, type: Type<&Account>())`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, stop immediately", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -2066,13 +2415,21 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+					`flow.AccountCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&Account>())`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, mutation (issue), continue", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -2098,13 +2455,21 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 			var mutationErr stdlib.CapabilityControllersMutatedDuringIterationError
 			require.ErrorAs(t, err, &mutationErr)
+
+			require.Equal(t,
+				[]string{
+					`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+					`flow.AccountCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&Account>())`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, mutation (issue), stop", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -2127,13 +2492,21 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+					`flow.AccountCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&Account>())`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, mutation (delete), continue", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -2159,13 +2532,20 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 
 			var mutationErr stdlib.CapabilityControllersMutatedDuringIterationError
 			require.ErrorAs(t, err, &mutationErr)
+
+			require.Equal(t,
+				[]string{
+					`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("forEachController, mutation (delete), stop", func(t *testing.T) {
 
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -2188,6 +2568,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					"flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())",
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 	})
 
@@ -2198,7 +2585,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 		t.Run("capability", func(t *testing.T) {
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -2231,12 +2618,19 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("tag", func(t *testing.T) {
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -2272,6 +2666,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("retarget", func(t *testing.T) {
@@ -2281,7 +2682,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 			t.Run("target, getControllers", func(t *testing.T) {
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					// language=cadence
 					`
@@ -2381,12 +2782,22 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                     `,
 				)
 				require.NoError(t, err)
+
+				require.Equal(t,
+					[]string{
+						`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+						`flow.StorageCapabilityControllerIssued(id: 2, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+						`flow.StorageCapabilityControllerIssued(id: 3, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+						`flow.StorageCapabilityControllerIssued(id: 4, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r2)`,
+					},
+					nonDeploymentEventStrings(events),
+				)
 			})
 
 			t.Run("retarget empty, borrow", func(t *testing.T) {
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					// language=cadence
 					`
@@ -2421,12 +2832,19 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                     `,
 				)
 				require.NoError(t, err)
+
+				require.Equal(t,
+					[]string{
+						"flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)",
+					},
+					nonDeploymentEventStrings(events),
+				)
 			})
 
 			t.Run("retarget to value with same type, borrow", func(t *testing.T) {
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					// language=cadence
 					`
@@ -2464,12 +2882,19 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                     `,
 				)
 				require.NoError(t, err)
+
+				require.Equal(t,
+					[]string{
+						`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					},
+					nonDeploymentEventStrings(events),
+				)
 			})
 
 			t.Run("retarget to value with different type, borrow", func(t *testing.T) {
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					// language=cadence
 					`
@@ -2505,6 +2930,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                     `,
 				)
 				require.NoError(t, err)
+
+				require.Equal(t,
+					[]string{
+						`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					},
+					nonDeploymentEventStrings(events),
+				)
 			})
 		})
 
@@ -2515,7 +2947,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 			t.Run("getController, getControllers", func(t *testing.T) {
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					// language=cadence
 					`
@@ -2550,12 +2982,19 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                     `,
 				)
 				require.NoError(t, err)
+
+				require.Equal(t,
+					[]string{
+						`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					},
+					nonDeploymentEventStrings(events),
+				)
 			})
 
 			t.Run("target", func(t *testing.T) {
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					// language=cadence
 					`
@@ -2581,12 +3020,19 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                     `,
 				)
 				require.ErrorContains(t, err, "controller is deleted")
+
+				require.Equal(t,
+					[]string{
+						`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					},
+					nonDeploymentEventStrings(events),
+				)
 			})
 
 			t.Run("retarget", func(t *testing.T) {
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					// language=cadence
 					`
@@ -2612,12 +3058,19 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                     `,
 				)
 				require.ErrorContains(t, err, "controller is deleted")
+
+				require.Equal(t,
+					[]string{
+						`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					},
+					nonDeploymentEventStrings(events),
+				)
 			})
 
 			t.Run("delete", func(t *testing.T) {
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					// language=cadence
 					`
@@ -2643,12 +3096,19 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                     `,
 				)
 				require.ErrorContains(t, err, "controller is deleted")
+
+				require.Equal(t,
+					[]string{
+						`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					},
+					nonDeploymentEventStrings(events),
+				)
 			})
 
 			t.Run("capability set cleared from storage", func(t *testing.T) {
 				t.Parallel()
 
-				err, storage := test(
+				err, storage, events := test(
 					t,
 					// language=cadence
 					`
@@ -2679,12 +3139,19 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 				)
 				require.Zero(t, storageMap.Count())
 
+				require.Equal(t,
+					[]string{
+						`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					},
+					nonDeploymentEventStrings(events),
+				)
+
 			})
 
 			t.Run("check, borrow", func(t *testing.T) {
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					// language=cadence
 					`
@@ -2716,6 +3183,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                     `,
 				)
 				require.NoError(t, err)
+
+				require.Equal(t,
+					[]string{
+						`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&A.0000000000000001.Test.R>(), path: /storage/r)`,
+					},
+					nonDeploymentEventStrings(events),
+				)
 			})
 
 		})
@@ -2728,7 +3202,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 		t.Run("capability", func(t *testing.T) {
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -2757,12 +3231,19 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("tag", func(t *testing.T) {
 			t.Parallel()
 
-			err, _ := test(
+			err, _, events := test(
 				t,
 				// language=cadence
 				`
@@ -2794,6 +3275,13 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                 `,
 			)
 			require.NoError(t, err)
+
+			require.Equal(t,
+				[]string{
+					`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+				},
+				nonDeploymentEventStrings(events),
+			)
 		})
 
 		t.Run("delete", func(t *testing.T) {
@@ -2803,7 +3291,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 			t.Run("getController, getControllers", func(t *testing.T) {
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					// language=cadence
 					`
@@ -2834,12 +3322,19 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                     `,
 				)
 				require.NoError(t, err)
+
+				require.Equal(t,
+					[]string{
+						`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+					},
+					nonDeploymentEventStrings(events),
+				)
 			})
 
 			t.Run("delete", func(t *testing.T) {
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					// language=cadence
 					`
@@ -2861,12 +3356,19 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                     `,
 				)
 				require.ErrorContains(t, err, "controller is deleted")
+
+				require.Equal(t,
+					[]string{
+						`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+					},
+					nonDeploymentEventStrings(events),
+				)
 			})
 
 			t.Run("check, borrow", func(t *testing.T) {
 				t.Parallel()
 
-				err, _ := test(
+				err, _, events := test(
 					t,
 					// language=cadence
 					`
@@ -2892,10 +3394,31 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
                     `,
 				)
 				require.NoError(t, err)
+
+				require.Equal(t,
+					[]string{
+						`flow.AccountCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&Account>())`,
+					},
+					nonDeploymentEventStrings(events),
+				)
 			})
 		})
 	})
 
+}
+
+func nonDeploymentEventStrings(events []cadence.Event) []string {
+	accountContractAddedEventTypeID := stdlib.AccountContractAddedEventType.ID()
+
+	strings := make([]string, 0, len(events))
+	for _, event := range events {
+		// Skip deployment events, i.e. contract added to account
+		if common.TypeID(event.Type().ID()) == accountContractAddedEventTypeID {
+			continue
+		}
+		strings = append(strings, event.String())
+	}
+	return strings
 }
 
 func TestRuntimeCapabilityBorrowAsInheritedInterface(t *testing.T) {

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1884,12 +1884,18 @@ func TestRuntimeExportReferenceValue(t *testing.T) {
 		address, err := common.HexToAddress("0x1")
 		require.NoError(t, err)
 
+		var events []cadence.Event
+
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: NewTestLedger(nil, nil),
 			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{
 					address,
 				}, nil
+			},
+			OnEmitEvent: func(event cadence.Event) error {
+				events = append(events, event)
+				return nil
 			},
 		}
 

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -377,11 +377,11 @@ func (e *interpreterEnvironment) EmitEvent(
 	values []interpreter.Value,
 	locationRange interpreter.LocationRange,
 ) {
-	emitEventFields(
+	EmitEventFields(
 		inter,
 		locationRange,
 		eventType,
-		newExportableValues(inter, values),
+		values,
 		e.runtimeInterface.EmitEvent,
 	)
 }

--- a/runtime/inbox_test.go
+++ b/runtime/inbox_test.go
@@ -19,6 +19,7 @@
 package runtime_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -114,6 +115,7 @@ func TestRuntimeAccountInboxPublishUnpublish(t *testing.T) {
 
 	require.Equal(t,
 		[]string{
+			`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&[Int]>(), path: /storage/foo)`,
 			`flow.InboxValuePublished(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: "foo", type: Type<Capability<&[Int]>>())`,
 			`flow.InboxValueUnpublished(provider: 0x0000000000000001, name: "foo")`,
 		},
@@ -194,6 +196,7 @@ func TestRuntimeAccountInboxUnpublishWrongType(t *testing.T) {
 
 	require.Equal(t,
 		[]string{
+			`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&[Int]>(), path: /storage/foo)`,
 			`flow.InboxValuePublished(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: "foo", type: Type<Capability<&[Int]>>())`,
 		},
 		events,
@@ -283,6 +286,7 @@ func TestRuntimeAccountInboxUnpublishAbsent(t *testing.T) {
 
 	require.Equal(t,
 		[]string{
+			`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&[Int]>(), path: /storage/foo)`,
 			`flow.InboxValuePublished(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: "foo", type: Type<Capability<&[Int]>>())`,
 		},
 		events,
@@ -388,12 +392,15 @@ func TestRuntimeAccountInboxUnpublishRemove(t *testing.T) {
 
 	require.Equal(t,
 		[]string{
-			`flow.InboxValuePublished(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: ` +
-				nameArgument.String() +
-				`, type: Type<Capability<&[Int]>>())`,
-			`flow.InboxValueUnpublished(provider: 0x0000000000000001, name: ` +
-				nameArgument.String() +
-				`)`,
+			`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&[Int]>(), path: /storage/foo)`,
+			fmt.Sprintf(
+				`flow.InboxValuePublished(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: %s, type: Type<Capability<&[Int]>>())`,
+				nameArgument.String(),
+			),
+			fmt.Sprintf(
+				`flow.InboxValueUnpublished(provider: 0x0000000000000001, name: %s)`,
+				nameArgument.String(),
+			),
 		},
 		events,
 	)
@@ -523,6 +530,7 @@ func TestRuntimeAccountInboxUnpublishWrongAccount(t *testing.T) {
 
 	require.Equal(t,
 		[]string{
+			`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&[Int]>(), path: /storage/foo)`,
 			`flow.InboxValuePublished(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: "foo", type: Type<Capability<&[Int]>>())`,
 			`flow.InboxValueUnpublished(provider: 0x0000000000000001, name: "foo")`,
 		},
@@ -632,6 +640,7 @@ func TestRuntimeAccountInboxPublishClaim(t *testing.T) {
 
 	require.Equal(t,
 		[]string{
+			`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&[Int]>(), path: /storage/foo)`,
 			`flow.InboxValuePublished(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: "foo", type: Type<Capability<&[Int]>>())`,
 			`flow.InboxValueClaimed(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: "foo")`,
 		},
@@ -734,6 +743,7 @@ func TestRuntimeAccountInboxPublishClaimWrongType(t *testing.T) {
 
 	require.Equal(t,
 		[]string{
+			`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&[Int]>(), path: /storage/foo)`,
 			`flow.InboxValuePublished(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: "foo", type: Type<Capability<&[Int]>>())`,
 		},
 		events,
@@ -836,6 +846,7 @@ func TestRuntimeAccountInboxPublishClaimWrongName(t *testing.T) {
 
 	require.Equal(t,
 		[]string{
+			`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&[Int]>(), path: /storage/foo)`,
 			`flow.InboxValuePublished(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: "foo", type: Type<Capability<&[Int]>>())`,
 		},
 		events,
@@ -962,6 +973,7 @@ func TestRuntimeAccountInboxPublishClaimRemove(t *testing.T) {
 
 	require.Equal(t,
 		[]string{
+			`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&[Int]>(), path: /storage/foo)`,
 			`flow.InboxValuePublished(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: "foo", type: Type<Capability<&[Int]>>())`,
 			`flow.InboxValueClaimed(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: "foo")`,
 		},
@@ -1103,6 +1115,7 @@ func TestRuntimeAccountInboxPublishClaimWrongAccount(t *testing.T) {
 
 	require.Equal(t,
 		[]string{
+			`flow.StorageCapabilityControllerIssued(id: 1, address: 0x0000000000000001, type: Type<&[Int]>(), path: /storage/foo)`,
 			`flow.InboxValuePublished(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: "foo", type: Type<Capability<&[Int]>>())`,
 			`flow.InboxValueClaimed(provider: 0x0000000000000001, recipient: 0x0000000000000002, name: "foo")`,
 		},

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1388,6 +1388,7 @@ func TestRuntimeStorageMultipleTransactionsResourceWithArray(t *testing.T) {
     `)
 
 	var loggedMessages []string
+	var events []cadence.Event
 
 	runtimeInterface := &TestRuntimeInterface{
 		OnGetCode: func(location Location) (bytes []byte, err error) {
@@ -1404,6 +1405,10 @@ func TestRuntimeStorageMultipleTransactionsResourceWithArray(t *testing.T) {
 		},
 		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
+		},
+		OnEmitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -1908,6 +1913,7 @@ func TestRuntimeResourceContractUseThroughLink(t *testing.T) {
     `)
 
 	var loggedMessages []string
+	var events []cadence.Event
 
 	runtimeInterface := &TestRuntimeInterface{
 		OnGetCode: func(location Location) (bytes []byte, err error) {
@@ -1924,6 +1930,10 @@ func TestRuntimeResourceContractUseThroughLink(t *testing.T) {
 		},
 		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
+		},
+		OnEmitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -2010,6 +2020,7 @@ func TestRuntimeResourceContractWithInterface(t *testing.T) {
     `)
 
 	var loggedMessages []string
+	var events []cadence.Event
 
 	runtimeInterface := &TestRuntimeInterface{
 		OnGetCode: func(location Location) (bytes []byte, err error) {
@@ -2028,6 +2039,10 @@ func TestRuntimeResourceContractWithInterface(t *testing.T) {
 		},
 		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
+		},
+		OnEmitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -2587,6 +2602,7 @@ func TestRuntimeAccountPublishAndAccess(t *testing.T) {
 	)
 
 	var loggedMessages []string
+	var events []cadence.Event
 
 	runtimeInterface := &TestRuntimeInterface{
 		OnGetCode: func(location Location) ([]byte, error) {
@@ -2603,6 +2619,10 @@ func TestRuntimeAccountPublishAndAccess(t *testing.T) {
 		},
 		OnProgramLog: func(message string) {
 			loggedMessages = append(loggedMessages, message)
+		},
+		OnEmitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
 		},
 	}
 

--- a/runtime/stdlib/flow.go
+++ b/runtime/stdlib/flow.go
@@ -305,3 +305,36 @@ var AccountInboxClaimedEventType = newFlowEventType(
 	AccountEventRecipientParameter,
 	AccountEventNameParameter,
 )
+
+var CapabilityControllerEventIDParameter = sema.Parameter{
+	Identifier:     "id",
+	TypeAnnotation: sema.UInt64TypeAnnotation,
+}
+
+var CapabilityControllerEventAddressParameter = sema.Parameter{
+	Identifier:     "address",
+	TypeAnnotation: sema.AddressTypeAnnotation,
+}
+
+var CapabilityControllerEventTypeParameter = sema.Parameter{
+	Identifier:     "type",
+	TypeAnnotation: sema.MetaTypeAnnotation,
+}
+
+var StorageCapabilityControllerIssuedEventType = newFlowEventType(
+	"StorageCapabilityControllerIssued",
+	CapabilityControllerEventIDParameter,
+	CapabilityControllerEventAddressParameter,
+	CapabilityControllerEventTypeParameter,
+	sema.Parameter{
+		Identifier:     "path",
+		TypeAnnotation: sema.StoragePathTypeAnnotation,
+	},
+)
+
+var AccountCapabilityControllerIssuedEventType = newFlowEventType(
+	"AccountCapabilityControllerIssued",
+	CapabilityControllerEventIDParameter,
+	CapabilityControllerEventAddressParameter,
+	CapabilityControllerEventTypeParameter,
+)

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -401,10 +401,16 @@ func TestRuntimeStorageReadAndBorrow(t *testing.T) {
 
 	signer := common.MustBytesToAddress([]byte{0x42})
 
+	var events []cadence.Event
+
 	runtimeInterface := &TestRuntimeInterface{
 		Storage: storage,
 		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signer}, nil
+		},
+		OnEmitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -1048,10 +1054,16 @@ func TestRuntimeStoragePublishAndUnpublish(t *testing.T) {
 
 	signer := common.MustBytesToAddress([]byte{0x42})
 
+	var events []cadence.Event
+
 	runtimeInterface := &TestRuntimeInterface{
 		Storage: storage,
 		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signer}, nil
+		},
+		OnEmitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
 		},
 	}
 
@@ -1132,10 +1144,16 @@ func TestRuntimeStorageSaveCapability(t *testing.T) {
 
 	signer := common.MustBytesToAddress([]byte{0x42})
 
+	var events []cadence.Event
+
 	runtimeInterface := &TestRuntimeInterface{
 		Storage: storage,
 		OnGetSigningAccounts: func() ([]Address, error) {
 			return []Address{signer}, nil
+		},
+		OnEmitEvent: func(event cadence.Event) error {
+			events = append(events, event)
+			return nil
 		},
 	}
 

--- a/runtime/value.go
+++ b/runtime/value.go
@@ -40,16 +40,6 @@ func newExportableValue(v interpreter.Value, inter *interpreter.Interpreter) exp
 	}
 }
 
-func newExportableValues(inter *interpreter.Interpreter, values []interpreter.Value) []exportableValue {
-	exportableValues := make([]exportableValue, 0, len(values))
-
-	for _, value := range values {
-		exportableValues = append(exportableValues, newExportableValue(value, inter))
-	}
-
-	return exportableValues
-}
-
 func (v exportableValue) Interpreter() *interpreter.Interpreter {
 	return v.inter
 }


### PR DESCRIPTION
Work towards #3459

## Description

For the following functions, emit the new event:

- `StorageCapabilityControllers.issue`:
   `flow.StorageCapabilityControllerIssued(id: UInt64, address: Address, type: Type, path: StoragePath)`
- `AccountCapabilityControllers.issue`:
   `flow.AccountCapabilityControllerIssued(id: UInt64, address: Address, type: Type)`


______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
