### PR TITLE
Changed data type of account key index to uin32

### DIFF
--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -269,6 +269,7 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		testEnv := initTestEnvironment(t, nextTransactionLocation())
 
 		test := accountKeyTestCase{
+			//language=Cadence
 			code: `
                 transaction {
                     prepare(signer: &Account) {
@@ -276,8 +277,8 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
                         log(key)
                         assert(!key.isRevoked)
                     }
-                }`,
-			args: []cadence.Value{},
+                }
+            `,
 		}
 
 		err := test.executeTransaction(
@@ -306,14 +307,15 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		testEnv := initTestEnvironment(t, nextTransactionLocation())
 
 		test := accountKeyTestCase{
+			//language=Cadence
 			code: `
                 transaction {
                     prepare(signer: &Account) {
                         let key: AccountKey? = signer.keys.get(keyIndex: 5)
                         assert(key == nil)
                     }
-                }`,
-			args: []cadence.Value{},
+                }
+            `,
 		}
 
 		err := test.executeTransaction(
@@ -325,6 +327,62 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		assert.Nil(t, testEnv.storage.returnedKey)
 	})
 
+	t.Run("get negative index", func(t *testing.T) {
+
+		t.Parallel()
+
+		nextTransactionLocation := NewTransactionLocationGenerator()
+		testEnv := initTestEnvironment(t, nextTransactionLocation())
+
+		test := accountKeyTestCase{
+			//language=Cadence
+			code: `
+                transaction {
+                    prepare(signer: &Account) {
+                        signer.keys.get(keyIndex: -1)
+                    }
+                }
+            `,
+		}
+
+		err := test.executeTransaction(
+			testEnv.runtime,
+			testEnv.runtimeInterface,
+			nextTransactionLocation(),
+		)
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.OverflowError{})
+	})
+
+	t.Run("get index overflow", func(t *testing.T) {
+
+		t.Parallel()
+
+		nextTransactionLocation := NewTransactionLocationGenerator()
+		testEnv := initTestEnvironment(t, nextTransactionLocation())
+
+		test := accountKeyTestCase{
+			//language=Cadence
+			code: `
+                transaction {
+                    prepare(signer: &Account) {
+                        signer.keys.get(keyIndex: Int(UInt32.max) + 100)
+                    }
+                }
+            `,
+		}
+
+		err := test.executeTransaction(
+			testEnv.runtime,
+			testEnv.runtimeInterface,
+			nextTransactionLocation(),
+		)
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.OverflowError{})
+	})
+
 	t.Run("revoke existing key", func(t *testing.T) {
 
 		t.Parallel()
@@ -333,14 +391,15 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		testEnv := initTestEnvironment(t, nextTransactionLocation())
 
 		test := accountKeyTestCase{
+			//language=Cadence
 			code: `
                 transaction {
                     prepare(signer: auth(RevokeKey) &Account) {
                         let key = signer.keys.revoke(keyIndex: 0) ?? panic("unexpectedly nil")
                         assert(key.isRevoked)
                     }
-                }`,
-			args: []cadence.Value{},
+                }
+            `,
 		}
 
 		err := test.executeTransaction(
@@ -362,6 +421,7 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		testEnv := initTestEnvironment(t, nextTransactionLocation())
 
 		test := accountKeyTestCase{
+			//language=Cadence
 			code: `
                 transaction {
                     prepare(signer: auth(RevokeKey) &Account) {
@@ -369,7 +429,6 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
                         assert(key == nil)
                     }
                 }`,
-			args: []cadence.Value{},
 		}
 
 		err := test.executeTransaction(
@@ -388,6 +447,7 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		testEnv := initTestEnvironment(t, nextTransactionLocation())
 
 		test := accountKeyTestCase{
+			//language=Cadence
 			code: `
                 transaction {
                     prepare(signer: auth(RevokeKey) &Account) {
@@ -400,7 +460,6 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
                     }
                 }
             `,
-			args: []cadence.Value{},
 		}
 
 		err := test.executeTransaction(
@@ -420,6 +479,7 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		testEnv := initTestEnvironment(t, nextTransactionLocation())
 
 		test := accountKeyTestCase{
+			//language=Cadence
 			code: `
                 transaction {
                     prepare(signer: auth(Keys) &Account) {
@@ -441,7 +501,6 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
                     }
                 }
             `,
-			args: []cadence.Value{},
 		}
 
 		err := test.executeTransaction(
@@ -467,6 +526,63 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 			keys[keyIdx] = nil
 		}
 	})
+
+	t.Run("revoke negative index", func(t *testing.T) {
+
+		t.Parallel()
+
+		nextTransactionLocation := NewTransactionLocationGenerator()
+		testEnv := initTestEnvironment(t, nextTransactionLocation())
+
+		test := accountKeyTestCase{
+			//language=Cadence
+			code: `
+                transaction {
+                    prepare(signer: auth(Keys) &Account) {
+                        signer.keys.revoke(keyIndex: -1)
+                    }
+                }
+            `,
+		}
+
+		err := test.executeTransaction(
+			testEnv.runtime,
+			testEnv.runtimeInterface,
+			nextTransactionLocation(),
+		)
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.OverflowError{})
+	})
+
+	t.Run("revoke index overflow", func(t *testing.T) {
+
+		t.Parallel()
+
+		nextTransactionLocation := NewTransactionLocationGenerator()
+		testEnv := initTestEnvironment(t, nextTransactionLocation())
+
+		test := accountKeyTestCase{
+			//language=Cadence
+			code: `
+                transaction {
+                    prepare(signer: auth(Keys) &Account) {
+                        signer.keys.revoke(keyIndex: Int(UInt32.max) + 100)
+                    }
+                }
+            `,
+		}
+
+		err := test.executeTransaction(
+			testEnv.runtime,
+			testEnv.runtimeInterface,
+			nextTransactionLocation(),
+		)
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.OverflowError{})
+	})
+
 }
 
 func TestRuntimeAuthAccountKeysAdd(t *testing.T) {
@@ -669,13 +785,13 @@ func TestRuntimePublicAccountKeys(t *testing.T) {
 
 		testEnv := initTestEnv(accountKeyA, accountKeyB)
 		test := accountKeyTestCase{
+			//language=Cadence
 			code: `
               access(all) fun main(): AccountKey? {
                   let acc = getAccount(0x02)
                   return acc.keys.get(keyIndex: 0)
               }
             `,
-			args: []cadence.Value{},
 		}
 
 		value, err := test.executeScript(testEnv.runtime, testEnv.runtimeInterface)
@@ -706,13 +822,13 @@ func TestRuntimePublicAccountKeys(t *testing.T) {
 		testEnv := initTestEnv(accountKeyA, accountKeyB)
 
 		test := accountKeyTestCase{
+			//language=Cadence
 			code: `
               access(all) fun main(): AccountKey? {
                   let acc = getAccount(0x02)
                   return acc.keys.get(keyIndex: 1)
               }
             `,
-			args: []cadence.Value{},
 		}
 
 		value, err := test.executeScript(testEnv.runtime, testEnv.runtimeInterface)
@@ -742,13 +858,13 @@ func TestRuntimePublicAccountKeys(t *testing.T) {
 		testEnv := initTestEnv(accountKeyA, accountKeyB)
 
 		test := accountKeyTestCase{
+			//language=Cadence
 			code: `
                 access(all) fun main(): AccountKey? {
                     let acc = getAccount(0x02)
                     return acc.keys.get(keyIndex: 4)
                 }
             `,
-			args: []cadence.Value{},
 		}
 
 		value, err := test.executeScript(testEnv.runtime, testEnv.runtimeInterface)
@@ -761,6 +877,50 @@ func TestRuntimePublicAccountKeys(t *testing.T) {
 		assert.Nil(t, optionalValue.Value)
 	})
 
+	t.Run("get negative index", func(t *testing.T) {
+
+		t.Parallel()
+
+		testEnv := initTestEnv(accountKeyA, accountKeyB)
+
+		test := accountKeyTestCase{
+			//language=Cadence
+			code: `
+                access(all) fun main(): AccountKey? {
+                    let acc = getAccount(0x02)
+                    return acc.keys.get(keyIndex: -1)
+                }
+            `,
+		}
+
+		_, err := test.executeScript(testEnv.runtime, testEnv.runtimeInterface)
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.OverflowError{})
+	})
+
+	t.Run("get index overflow", func(t *testing.T) {
+
+		t.Parallel()
+
+		testEnv := initTestEnv(accountKeyA, accountKeyB)
+
+		test := accountKeyTestCase{
+			//language=Cadence
+			code: `
+                access(all) fun main(): AccountKey? {
+                    let acc = getAccount(0x02)
+                    return acc.keys.get(keyIndex: Int(UInt32.max) + 100)
+                }
+            `,
+		}
+
+		_, err := test.executeScript(testEnv.runtime, testEnv.runtimeInterface)
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.OverflowError{})
+	})
+
 	t.Run("get revoked key", func(t *testing.T) {
 
 		t.Parallel()
@@ -768,6 +928,7 @@ func TestRuntimePublicAccountKeys(t *testing.T) {
 		testEnv := initTestEnv(revokedAccountKeyA, accountKeyB)
 
 		test := accountKeyTestCase{
+			//language=Cadence
 			code: `
               access(all) fun main(): AccountKey? {
                   let acc = getAccount(0x02)
@@ -775,7 +936,6 @@ func TestRuntimePublicAccountKeys(t *testing.T) {
                   return keys.get(keyIndex: 0)
               }
             `,
-			args: []cadence.Value{},
 		}
 
 		value, err := test.executeScript(testEnv.runtime, testEnv.runtimeInterface)
@@ -804,6 +964,7 @@ func TestRuntimePublicAccountKeys(t *testing.T) {
 		testEnv := initTestEnv(revokedAccountKeyA, accountKeyB)
 
 		test := accountKeyTestCase{
+			//language=Cadence
 			code: `
             access(all) fun main(): UInt64 {
                 return getAccount(0x02).keys.count
@@ -824,15 +985,15 @@ func TestRuntimePublicAccountKeys(t *testing.T) {
 
 		testEnv := initTestEnv(revokedAccountKeyA, accountKeyB)
 		test := accountKeyTestCase{
+			//language=Cadence
 			code: `
                 access(all) fun main() {
-                        getAccount(0x02).keys.forEach(fun(key: AccountKey): Bool {
-                            log(key.keyIndex)
-                            return true
-                        })
-                    }
+                    getAccount(0x02).keys.forEach(fun(key: AccountKey): Bool {
+                        log(key.keyIndex)
+                        return true
+                    })
+                }
             `,
-			args: []cadence.Value{},
 		}
 
 		value, err := test.executeScript(testEnv.runtime, testEnv.runtimeInterface)
@@ -1148,22 +1309,23 @@ func newAccountKeyTestRuntimeInterface(storage *testAccountKeyStorage) *TestRunt
 func addAuthAccountKey(t *testing.T, runtime Runtime, runtimeInterface *TestRuntimeInterface, location Location) {
 	test := accountKeyTestCase{
 		name: "Add key",
+		//language=Cadence
 		code: `
-                transaction {
-                    prepare(signer: auth(AddKey) &Account) {
-                        let key = PublicKey(
-                            publicKey: "010203".decodeHex(),
-                            signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
-                        )
+            transaction {
+                prepare(signer: auth(AddKey) &Account) {
+                    let key = PublicKey(
+                        publicKey: "010203".decodeHex(),
+                        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+                    )
 
-                        var addedKey: AccountKey = signer.keys.add(
-                            publicKey: key,
-                            hashAlgorithm: HashAlgorithm.SHA3_256,
-                            weight: 100.0
-                        )
-                    }
-                }`,
-		args: []cadence.Value{},
+                    var addedKey: AccountKey = signer.keys.add(
+                        publicKey: key,
+                        hashAlgorithm: HashAlgorithm.SHA3_256,
+                        weight: 100.0
+                    )
+                }
+            }
+        `,
 	}
 
 	err := test.executeTransaction(runtime, runtimeInterface, location)

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -82,6 +82,10 @@ func noopRuntimeUInt64Getter(_ common.Address) (uint64, error) {
 	return 0, nil
 }
 
+func noopRuntimeUInt32Getter(_ common.Address) (uint32, error) {
+	return 0, nil
+}
+
 func TestRuntimeReturnPublicAccount(t *testing.T) {
 
 	t.Parallel()
@@ -99,7 +103,7 @@ func TestRuntimeReturnPublicAccount(t *testing.T) {
 		OnGetAccountAvailableBalance: noopRuntimeUInt64Getter,
 		OnGetStorageUsed:             noopRuntimeUInt64Getter,
 		OnGetStorageCapacity:         noopRuntimeUInt64Getter,
-		OnAccountKeysCount:           noopRuntimeUInt64Getter,
+		OnAccountKeysCount:           noopRuntimeUInt32Getter,
 		Storage:                      NewTestLedger(nil, nil),
 	}
 
@@ -132,7 +136,7 @@ func TestRuntimeReturnAuthAccount(t *testing.T) {
 		OnGetAccountAvailableBalance: noopRuntimeUInt64Getter,
 		OnGetStorageUsed:             noopRuntimeUInt64Getter,
 		OnGetStorageCapacity:         noopRuntimeUInt64Getter,
-		OnAccountKeysCount:           noopRuntimeUInt64Getter,
+		OnAccountKeysCount:           noopRuntimeUInt32Getter,
 		Storage:                      NewTestLedger(nil, nil),
 	}
 
@@ -449,7 +453,7 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 
 		keys := make(map[int]*AccountKey, len(testEnv.storage.keys))
 		for _, key := range testEnv.storage.keys {
-			keys[key.KeyIndex] = key
+			keys[int(key.KeyIndex)] = key
 		}
 		for _, loggedIndex := range testEnv.storage.logs {
 			keyIdx, err := strconv.Atoi(loggedIndex)
@@ -837,7 +841,7 @@ func TestRuntimePublicAccountKeys(t *testing.T) {
 
 		keys := make(map[int]*AccountKey, len(testEnv.storage.keys))
 		for _, key := range testEnv.storage.keys {
-			keys[key.KeyIndex] = key
+			keys[int(key.KeyIndex)] = key
 		}
 		for _, loggedIndex := range testEnv.storage.logs {
 			keyIdx, err := strconv.Atoi(loggedIndex)
@@ -1082,7 +1086,7 @@ func newAccountKeyTestRuntimeInterface(storage *testAccountKeyStorage) *TestRunt
 			return accountKeyTestAddress, nil
 		},
 		OnAddAccountKey: func(address Address, publicKey *stdlib.PublicKey, hashAlgo HashAlgorithm, weight int) (*stdlib.AccountKey, error) {
-			index := len(storage.keys)
+			index := uint32(len(storage.keys))
 			accountKey := &stdlib.AccountKey{
 				KeyIndex:  index,
 				PublicKey: publicKey,
@@ -1096,8 +1100,8 @@ func newAccountKeyTestRuntimeInterface(storage *testAccountKeyStorage) *TestRunt
 			storage.returnedKey = accountKey
 			return accountKey, nil
 		},
-		OnGetAccountKey: func(address Address, index int) (*stdlib.AccountKey, error) {
-			if index >= len(storage.keys) {
+		OnGetAccountKey: func(address Address, index uint32) (*stdlib.AccountKey, error) {
+			if index >= uint32(len(storage.keys)) {
 				storage.returnedKey = nil
 				return nil, nil
 			}
@@ -1106,8 +1110,8 @@ func newAccountKeyTestRuntimeInterface(storage *testAccountKeyStorage) *TestRunt
 			storage.returnedKey = accountKey
 			return accountKey, nil
 		},
-		OnRemoveAccountKey: func(address Address, index int) (*stdlib.AccountKey, error) {
-			if index >= len(storage.keys) {
+		OnRemoveAccountKey: func(address Address, index uint32) (*stdlib.AccountKey, error) {
+			if index >= uint32(len(storage.keys)) {
 				storage.returnedKey = nil
 				return nil, nil
 			}
@@ -1125,8 +1129,8 @@ func newAccountKeyTestRuntimeInterface(storage *testAccountKeyStorage) *TestRunt
 
 			return accountKey, nil
 		},
-		OnAccountKeysCount: func(address Address) (uint64, error) {
-			return uint64(storage.unrevokedKeyCount), nil
+		OnAccountKeysCount: func(address Address) (uint32, error) {
+			return uint32(storage.unrevokedKeyCount), nil
 		},
 		OnProgramLog: func(message string) {
 			storage.logs = append(storage.logs, message)

--- a/runtime/cmd/cmd.go
+++ b/runtime/cmd/cmd.go
@@ -308,11 +308,11 @@ func (*StandardLibraryHandler) Hash(_ []byte, _ string, _ sema.HashAlgorithm) ([
 	return nil, goerrors.New("crypto functionality is not available in this environment")
 }
 
-func (*StandardLibraryHandler) GetAccountKey(_ common.Address, _ int) (*stdlib.AccountKey, error) {
+func (*StandardLibraryHandler) GetAccountKey(_ common.Address, _ uint32) (*stdlib.AccountKey, error) {
 	return nil, goerrors.New("accounts are not supported in this environment")
 }
 
-func (*StandardLibraryHandler) AccountKeysCount(_ common.Address) (uint64, error) {
+func (*StandardLibraryHandler) AccountKeysCount(_ common.Address) (uint32, error) {
 	return 0, goerrors.New("accounts are not supported in this environment")
 }
 
@@ -354,7 +354,7 @@ func (*StandardLibraryHandler) AddAccountKey(
 	return nil, goerrors.New("accounts are not available in this environment")
 }
 
-func (*StandardLibraryHandler) RevokeAccountKey(_ common.Address, _ int) (*stdlib.AccountKey, error) {
+func (*StandardLibraryHandler) RevokeAccountKey(_ common.Address, _ uint32) (*stdlib.AccountKey, error) {
 	return nil, goerrors.New("accounts are not available in this environment")
 }
 

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -347,11 +347,11 @@ func (e *interpreterEnvironment) GetStorageCapacity(address common.Address) (uin
 	return e.runtimeInterface.GetStorageCapacity(address)
 }
 
-func (e *interpreterEnvironment) GetAccountKey(address common.Address, index int) (*stdlib.AccountKey, error) {
+func (e *interpreterEnvironment) GetAccountKey(address common.Address, index uint32) (*stdlib.AccountKey, error) {
 	return e.runtimeInterface.GetAccountKey(address, index)
 }
 
-func (e *interpreterEnvironment) AccountKeysCount(address common.Address) (uint64, error) {
+func (e *interpreterEnvironment) AccountKeysCount(address common.Address) (uint32, error) {
 	return e.runtimeInterface.AccountKeysCount(address)
 }
 
@@ -395,7 +395,7 @@ func (e *interpreterEnvironment) AddAccountKey(
 	return e.runtimeInterface.AddAccountKey(address, key, algo, weight)
 }
 
-func (e *interpreterEnvironment) RevokeAccountKey(address common.Address, index int) (*stdlib.AccountKey, error) {
+func (e *interpreterEnvironment) RevokeAccountKey(address common.Address, index uint32) (*stdlib.AccountKey, error) {
 	return e.runtimeInterface.RevokeAccountKey(address, index)
 }
 

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -74,10 +74,10 @@ type Interface interface {
 	// AddAccountKey appends a key to an account.
 	AddAccountKey(address Address, publicKey *PublicKey, hashAlgo HashAlgorithm, weight int) (*AccountKey, error)
 	// GetAccountKey retrieves a key from an account by index.
-	GetAccountKey(address Address, index int) (*AccountKey, error)
-	AccountKeysCount(address Address) (uint64, error)
+	GetAccountKey(address Address, index uint32) (*AccountKey, error)
+	AccountKeysCount(address Address) (uint32, error)
 	// RevokeAccountKey removes a key from an account by index.
-	RevokeAccountKey(address Address, index int) (*AccountKey, error)
+	RevokeAccountKey(address Address, index uint32) (*AccountKey, error)
 	// UpdateAccountContractCode updates the code associated with an account contract.
 	UpdateAccountContractCode(location common.AddressLocation, code []byte) (err error)
 	// GetAccountContractCode returns the code associated with an account contract.

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -4177,6 +4177,24 @@ func (v IntValue) ToInt(locationRange LocationRange) int {
 	return int(v.BigInt.Int64())
 }
 
+func (v IntValue) ToUint32(locationRange LocationRange) uint32 {
+	if !v.BigInt.IsUint64() {
+		panic(OverflowError{
+			LocationRange: locationRange,
+		})
+	}
+
+	result := v.BigInt.Uint64()
+
+	if result > math.MaxUint32 {
+		panic(OverflowError{
+			LocationRange: locationRange,
+		})
+	}
+
+	return uint32(result)
+}
+
 func (v IntValue) ByteLength() int {
 	return common.BigIntByteLength(v.BigInt)
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -7918,7 +7918,7 @@ func TestRuntimeErrorExcerpts(t *testing.T) {
 		OnGetAccountAvailableBalance: noopRuntimeUInt64Getter,
 		OnGetStorageUsed:             noopRuntimeUInt64Getter,
 		OnGetStorageCapacity:         noopRuntimeUInt64Getter,
-		OnAccountKeysCount:           noopRuntimeUInt64Getter,
+		OnAccountKeysCount:           noopRuntimeUInt32Getter,
 		Storage:                      NewTestLedger(nil, nil),
 	}
 
@@ -7970,7 +7970,7 @@ func TestRuntimeErrorExcerptsMultiline(t *testing.T) {
 		OnGetAccountAvailableBalance: noopRuntimeUInt64Getter,
 		OnGetStorageUsed:             noopRuntimeUInt64Getter,
 		OnGetStorageCapacity:         noopRuntimeUInt64Getter,
-		OnAccountKeysCount:           noopRuntimeUInt64Getter,
+		OnAccountKeysCount:           noopRuntimeUInt32Getter,
 		Storage:                      NewTestLedger(nil, nil),
 	}
 

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -657,7 +657,7 @@ func newAccountKeysAddFunction(
 
 type AccountKey struct {
 	PublicKey *PublicKey
-	KeyIndex  int
+	KeyIndex  uint32
 	Weight    int
 	HashAlgo  sema.HashAlgorithm
 	IsRevoked bool
@@ -669,8 +669,8 @@ type AccountKeyProvider interface {
 	BLSPoPVerifier
 	Hasher
 	// GetAccountKey retrieves a key from an account by index.
-	GetAccountKey(address common.Address, index int) (*AccountKey, error)
-	AccountKeysCount(address common.Address) (uint64, error)
+	GetAccountKey(address common.Address, index uint32) (*AccountKey, error)
+	AccountKeysCount(address common.Address) (uint32, error)
 }
 
 func newAccountKeysGetFunction(
@@ -699,7 +699,7 @@ func newAccountKeysGetFunction(
 				var err error
 				var accountKey *AccountKey
 				errors.WrapPanic(func() {
-					accountKey, err = provider.GetAccountKey(address, index)
+					accountKey, err = provider.GetAccountKey(address, uint32(index))
 				})
 
 				if err != nil {
@@ -778,7 +778,7 @@ func newAccountKeysForEachFunction(
 					)
 				}
 
-				var count uint64
+				var count uint32
 				var err error
 
 				errors.WrapPanic(func() {
@@ -791,9 +791,9 @@ func newAccountKeysForEachFunction(
 
 				var accountKey *AccountKey
 
-				for index := uint64(0); index < count; index++ {
+				for index := uint32(0); index < count; index++ {
 					errors.WrapPanic(func() {
-						accountKey, err = provider.GetAccountKey(address, int(index))
+						accountKey, err = provider.GetAccountKey(address, index)
 					})
 					if err != nil {
 						panic(interpreter.WrappedExternalError(err))
@@ -842,7 +842,7 @@ func newAccountKeysCountGetter(
 
 	return func() interpreter.UInt64Value {
 		return interpreter.NewUInt64Value(gauge, func() uint64 {
-			var count uint64
+			var count uint32
 			var err error
 
 			errors.WrapPanic(func() {
@@ -854,7 +854,7 @@ func newAccountKeysCountGetter(
 				panic(interpreter.WrappedExternalError(err))
 			}
 
-			return count
+			return uint64(count)
 		})
 	}
 }
@@ -866,7 +866,7 @@ type AccountKeyRevocationHandler interface {
 	PublicKeySignatureVerifier
 	BLSPoPVerifier
 	// RevokeAccountKey removes a key from an account by index.
-	RevokeAccountKey(address common.Address, index int) (*AccountKey, error)
+	RevokeAccountKey(address common.Address, index uint32) (*AccountKey, error)
 }
 
 func newAccountKeysRevokeFunction(
@@ -894,7 +894,7 @@ func newAccountKeysRevokeFunction(
 				var err error
 				var accountKey *AccountKey
 				errors.WrapPanic(func() {
-					accountKey, err = handler.RevokeAccountKey(address, index)
+					accountKey, err = handler.RevokeAccountKey(address, uint32(index))
 				})
 				if err != nil {
 					panic(interpreter.WrappedExternalError(err))

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -704,12 +704,12 @@ func newAccountKeysGetFunction(
 					panic(errors.NewUnreachableError())
 				}
 				locationRange := invocation.LocationRange
-				index := indexValue.ToInt(locationRange)
+				index := indexValue.ToUint32(locationRange)
 
 				var err error
 				var accountKey *AccountKey
 				errors.WrapPanic(func() {
-					accountKey, err = provider.GetAccountKey(address, uint32(index))
+					accountKey, err = provider.GetAccountKey(address, index)
 				})
 
 				if err != nil {
@@ -899,12 +899,12 @@ func newAccountKeysRevokeFunction(
 					panic(errors.NewUnreachableError())
 				}
 				locationRange := invocation.LocationRange
-				index := indexValue.ToInt(locationRange)
+				index := indexValue.ToUint32(locationRange)
 
 				var err error
 				var accountKey *AccountKey
 				errors.WrapPanic(func() {
-					accountKey, err = handler.RevokeAccountKey(address, uint32(index))
+					accountKey, err = handler.RevokeAccountKey(address, index)
 				})
 				if err != nil {
 					panic(interpreter.WrappedExternalError(err))

--- a/runtime/tests/interpreter/account_test.go
+++ b/runtime/tests/interpreter/account_test.go
@@ -87,8 +87,8 @@ type testAccountHandler struct {
 	)
 	blsVerifyPOP     func(publicKey *stdlib.PublicKey, signature []byte) (bool, error)
 	hash             func(data []byte, tag string, algorithm sema.HashAlgorithm) ([]byte, error)
-	getAccountKey    func(address common.Address, index int) (*stdlib.AccountKey, error)
-	accountKeysCount func(address common.Address) (uint64, error)
+	getAccountKey    func(address common.Address, index uint32) (*stdlib.AccountKey, error)
+	accountKeysCount func(address common.Address) (uint32, error)
 	emitEvent        func(
 		inter *interpreter.Interpreter,
 		eventType *sema.CompositeType,
@@ -104,7 +104,7 @@ type testAccountHandler struct {
 		*stdlib.AccountKey,
 		error,
 	)
-	revokeAccountKey       func(address common.Address, index int) (*stdlib.AccountKey, error)
+	revokeAccountKey       func(address common.Address, index uint32) (*stdlib.AccountKey, error)
 	getAccountContractCode func(location common.AddressLocation) ([]byte, error)
 	parseAndCheckProgram   func(
 		code []byte,
@@ -225,14 +225,14 @@ func (t *testAccountHandler) Hash(data []byte, tag string, algorithm sema.HashAl
 	return t.hash(data, tag, algorithm)
 }
 
-func (t *testAccountHandler) GetAccountKey(address common.Address, index int) (*stdlib.AccountKey, error) {
+func (t *testAccountHandler) GetAccountKey(address common.Address, index uint32) (*stdlib.AccountKey, error) {
 	if t.getAccountKey == nil {
 		panic(errors.NewUnexpectedError("unexpected call to GetAccountKey"))
 	}
 	return t.getAccountKey(address, index)
 }
 
-func (t *testAccountHandler) AccountKeysCount(address common.Address) (uint64, error) {
+func (t *testAccountHandler) AccountKeysCount(address common.Address) (uint32, error) {
 	if t.accountKeysCount == nil {
 		panic(errors.NewUnexpectedError("unexpected call to AccountKeysCount"))
 	}
@@ -276,7 +276,7 @@ func (t *testAccountHandler) AddAccountKey(
 	)
 }
 
-func (t *testAccountHandler) RevokeAccountKey(address common.Address, index int) (*stdlib.AccountKey, error) {
+func (t *testAccountHandler) RevokeAccountKey(address common.Address, index uint32) (*stdlib.AccountKey, error) {
 	if t.revokeAccountKey == nil {
 		panic(errors.NewUnexpectedError("unexpected call to RevokeAccountKey"))
 	}

--- a/runtime/tests/runtime_utils/testinterface.go
+++ b/runtime/tests/runtime_utils/testinterface.go
@@ -62,9 +62,9 @@ type TestRuntimeInterface struct {
 		hashAlgo runtime.HashAlgorithm,
 		weight int,
 	) (*stdlib.AccountKey, error)
-	OnGetAccountKey             func(address runtime.Address, index int) (*stdlib.AccountKey, error)
-	OnRemoveAccountKey          func(address runtime.Address, index int) (*stdlib.AccountKey, error)
-	OnAccountKeysCount          func(address runtime.Address) (uint64, error)
+	OnGetAccountKey             func(address runtime.Address, index uint32) (*stdlib.AccountKey, error)
+	OnRemoveAccountKey          func(address runtime.Address, index uint32) (*stdlib.AccountKey, error)
+	OnAccountKeysCount          func(address runtime.Address) (uint32, error)
 	OnUpdateAccountContractCode func(location common.AddressLocation, code []byte) error
 	OnGetAccountContractCode    func(location common.AddressLocation) (code []byte, err error)
 	OnRemoveAccountContractCode func(location common.AddressLocation) (err error)
@@ -259,21 +259,21 @@ func (i *TestRuntimeInterface) AddAccountKey(
 	return i.OnAddAccountKey(address, publicKey, hashAlgo, weight)
 }
 
-func (i *TestRuntimeInterface) GetAccountKey(address runtime.Address, index int) (*stdlib.AccountKey, error) {
+func (i *TestRuntimeInterface) GetAccountKey(address runtime.Address, index uint32) (*stdlib.AccountKey, error) {
 	if i.OnGetAccountKey == nil {
 		panic("must specify TestRuntimeInterface.OnGetAccountKey")
 	}
 	return i.OnGetAccountKey(address, index)
 }
 
-func (i *TestRuntimeInterface) AccountKeysCount(address runtime.Address) (uint64, error) {
+func (i *TestRuntimeInterface) AccountKeysCount(address runtime.Address) (uint32, error) {
 	if i.OnAccountKeysCount == nil {
 		panic("must specify TestRuntimeInterface.OnAccountKeysCount")
 	}
 	return i.OnAccountKeysCount(address)
 }
 
-func (i *TestRuntimeInterface) RevokeAccountKey(address runtime.Address, index int) (*stdlib.AccountKey, error) {
+func (i *TestRuntimeInterface) RevokeAccountKey(address runtime.Address, index uint32) (*stdlib.AccountKey, error) {
 	if i.OnRemoveAccountKey == nil {
 		panic("must specify TestRuntimeInterface.OnRemoveAccountKey")
 	}


### PR DESCRIPTION
Work towards onflow/flow-go#6204

## Description

Changed data type of account key index to uin32.

There are still a few casts in the code, that I did not know how to get rid of.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
