### PR TITLE
Speed up update tool

### DIFF
--- a/tools/update/main.ts
+++ b/tools/update/main.ts
@@ -707,7 +707,7 @@ async function gitClone(protocol: Protocol, fullRepoName: string, dir: string, b
             console.error(`unsupported protocol: ${protocol}`)
             return
     }
-    await exec(`git clone ${branch ? `-b ${branch} ` : ""}${prefix}${fullRepoName} ${dir}`)
+    await exec(`git clone --depth 1 ${branch ? `-b ${branch} ` : ""}${prefix}${fullRepoName} ${dir}`)
 }
 
 async function runWithConsoleGroup(func: () => Promise<boolean>): Promise<boolean> {


### PR DESCRIPTION
## Description

Speed up `git clone` by not fetching whole commit history. Especially for large repos, like `flow-go` this reduces the time for a clone significantly.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
