### PR TITLE
Improve Cadence composite to Go struct decoding

### DIFF
--- a/types_test.go
+++ b/types_test.go
@@ -2284,6 +2284,19 @@ func TestDecodeFields(t *testing.T) {
 			NewDictionary([]KeyValuePair{
 				{Key: UInt8(42), Value: UInt8(24)},
 			}),
+			NewStruct([]Value{
+				NewInt(42),
+			}).WithType(NewStructType(
+				utils.TestLocation,
+				"NestedStruct",
+				[]Field{
+					{
+						Identifier: "intField",
+						Type:       IntType,
+					},
+				},
+				nil,
+			)),
 		},
 	).WithType(NewEventType(
 		utils.TestLocation,
@@ -2408,9 +2421,17 @@ func TestDecodeFields(t *testing.T) {
 					ElementType: UInt8Type,
 				},
 			},
+			{
+				Identifier: "goUint8Struct",
+				Type:       AnyStructType,
+			},
 		},
 		nil,
 	))
+
+	type nestedStruct struct {
+		Int Int `cadence:"intField"`
+	}
 
 	type eventStruct struct {
 		Int                            Int                     `cadence:"intField"`
@@ -2433,6 +2454,7 @@ func TestDecodeFields(t *testing.T) {
 		GoUint8PtrSome                 *uint8                  `cadence:"goUint8PtrSome"`
 		GoUint8Slice                   []uint8                 `cadence:"goUint8Slice"`
 		GoUint8Map                     map[uint8]uint8         `cadence:"goUint8Map"`
+		GoUint8Struct                  nestedStruct            `cadence:"goUint8Struct"`
 		NonCadenceField                Int
 	}
 
@@ -2491,6 +2513,7 @@ func TestDecodeFields(t *testing.T) {
 	assert.Equal(t, &expectedUint8, evt.GoUint8PtrSome)
 	assert.Equal(t, []uint8{4, 2}, evt.GoUint8Slice)
 	assert.Equal(t, map[uint8]uint8{42: 24}, evt.GoUint8Map)
+	assert.Equal(t, NewInt(42), evt.GoUint8Struct.Int)
 
 	type ErrCases struct {
 		Value       interface{}


### PR DESCRIPTION
## Description

Currently, decoding is not recursive. A Cadence `UInt8` value can be decoded into a `uint8` field, but an `[UInt8]` value cannot be decoded into a `[]uint8`.

Add support for nested types, which at the same time also simplifies the code.

Also improve errors along the way.

This is for example useful in flow-go when decoding EVM event types, e.g. https://github.com/onflow/flow-go/blob/a9a235c7a31b3b33d3d3cd1c0cac82e91008d658/fvm/evm/types/events.go#L189

cc @rrrkren Could you maybe try this in your codebase and check this does not break any existing functionality that you have that uses this function? Thanks!

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
