### PR TITLE
Fix data races caused by empty string singleton

### DIFF
--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -943,6 +943,12 @@ func (interpreter *Interpreter) VisitStringExpression(expression *ast.StringExpr
 		return NewUnmeteredCharacterValue(expression.Value)
 	}
 
+	// Optimization: If the string is empty, return the empty string singleton
+	// to avoid allocating a new string value.
+	if len(expression.Value) == 0 {
+		return EmptyString
+	}
+
 	// NOTE: already metered in lexer/parser
 	return NewUnmeteredStringValue(expression.Value)
 }

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -1095,6 +1095,14 @@ var _ IterableValue = &StringValue{}
 var VarSizedArrayOfStringType = NewVariableSizedStaticType(nil, PrimitiveStaticTypeString)
 
 func (v *StringValue) prepareGraphemes() {
+	// If the string is empty, methods of StringValue should never call prepareGraphemes,
+	// as it is not only unnecessary, but also means that the value is the empty string singleton EmptyString,
+	// which should not be mutated because it may be used from different goroutines,
+	// so should not get mutated by preparing the graphemes iterator.
+	if len(v.Str) == 0 {
+		panic(errors.NewUnreachableError())
+	}
+
 	if v.graphemes == nil {
 		v.graphemes = uniseg.NewGraphemes(v.Str)
 	} else {
@@ -1270,7 +1278,14 @@ func (v *StringValue) slice(fromIndex int, toIndex int, locationRange LocationRa
 		})
 	}
 
-	if fromIndex == toIndex {
+	// If the string is empty or the result is empty,
+	// return the empty string singleton EmptyString,
+	// as an optimization to avoid allocating a new value.
+	//
+	// It also ensures that if the sliced value is the empty string singleton EmptyString,
+	// which should not be mutated because it may be used from different goroutines,
+	// it does not get mutated by preparing the graphemes iterator.
+	if len(v.Str) == 0 || fromIndex == toIndex {
 		return EmptyString
 	}
 
@@ -1513,6 +1528,14 @@ func (*StringValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value
 
 // Length returns the number of characters (grapheme clusters)
 func (v *StringValue) Length() int {
+	// If the string is empty, the length is 0, and there are no graphemes.
+	//
+	// Do NOT store the length, as the value is the empty string singleton EmptyString,
+	// which should not be mutated because it may be used from different goroutines.
+	if len(v.Str) == 0 {
+		return 0
+	}
+
 	if v.length < 0 {
 		var length int
 		v.prepareGraphemes()
@@ -1843,6 +1866,16 @@ func (v *StringValue) ForEach(
 }
 
 func (v *StringValue) IsGraphemeBoundaryStart(startOffset int) bool {
+
+	// Empty strings have no grapheme clusters, and therefore no boundaries.
+	//
+	// Exiting early also ensures that if the checked value is the empty string singleton EmptyString,
+	// which should not be mutated because it may be used from different goroutines,
+	// it does not get mutated by preparing the graphemes iterator.
+	if len(v.Str) == 0 {
+		return false
+	}
+
 	v.prepareGraphemes()
 
 	var characterIndex int
@@ -1873,6 +1906,16 @@ func (v *StringValue) seekGraphemeBoundaryStartPrepared(startOffset int, charact
 }
 
 func (v *StringValue) IsGraphemeBoundaryEnd(end int) bool {
+
+	// Empty strings have no grapheme clusters, and therefore no boundaries.
+	//
+	// Exiting early also ensures that if the checked value is the empty string singleton EmptyString,
+	// which should not be mutated because it may be used from different goroutines,
+	// it does not get mutated by preparing the graphemes iterator.
+	if len(v.Str) == 0 {
+		return false
+	}
+
 	v.prepareGraphemes()
 	v.graphemes.Next()
 
@@ -1880,10 +1923,6 @@ func (v *StringValue) IsGraphemeBoundaryEnd(end int) bool {
 }
 
 func (v *StringValue) isGraphemeBoundaryEndPrepared(end int) bool {
-	// Empty strings have no grapheme clusters, and therefore no boundaries
-	if len(v.Str) == 0 {
-		return false
-	}
 
 	for {
 		boundaryStart, boundaryEnd := v.graphemes.Positions()
@@ -1916,6 +1955,15 @@ func (v *StringValue) indexOf(inter *Interpreter, other *StringValue) (character
 
 	if len(other.Str) == 0 {
 		return 0, 0
+	}
+
+	// If the string is empty, exit early.
+	//
+	// That ensures that if the checked value is the empty string singleton EmptyString,
+	// which should not be mutated because it may be used from different goroutines,
+	// it does not get mutated by preparing the graphemes iterator.
+	if len(v.Str) == 0 {
+		return -1, -1
 	}
 
 	// Meter computation as if the string was iterated.


### PR DESCRIPTION
Fixes #3477 

## Description

Prevent mutation of empty string singleton by handling zero-length cases in string functions.

Checked this by running `go test -parallel 8 -count 20 -v -race` in `runtime/tests/interpreter`.
Previously, even `go test -parallel 8 -count 3 -v -race -run=TestInterpretStringCount` instantly reported a data race.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
