### PR TITLE
Add an empty implementation of `runtime.Interface`

### DIFF
--- a/runtime/empty.go
+++ b/runtime/empty.go
@@ -29,6 +29,8 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 )
 
+// EmptyRuntimeInterface is an empty implementation of runtime.Interface.
+// It can be embedded in other types implementing runtime.Interface to avoid having to implement all methods.
 type EmptyRuntimeInterface struct{}
 
 var _ Interface = EmptyRuntimeInterface{}

--- a/runtime/empty.go
+++ b/runtime/empty.go
@@ -1,0 +1,233 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"time"
+
+	"github.com/onflow/atree"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+)
+
+type EmptyRuntimeInterface struct{}
+
+var _ Interface = EmptyRuntimeInterface{}
+
+func (EmptyRuntimeInterface) MeterMemory(_ common.MemoryUsage) error {
+	// NO-OP
+	return nil
+}
+
+func (EmptyRuntimeInterface) ResolveLocation(_ []Identifier, _ Location) ([]ResolvedLocation, error) {
+	panic("unexpected call to ResolveLocation")
+}
+
+func (EmptyRuntimeInterface) GetOrLoadProgram(_ Location, _ func() (*interpreter.Program, error)) (*interpreter.Program, error) {
+	panic("unexpected call to GetOrLoadProgram")
+}
+
+func (EmptyRuntimeInterface) GetAccountContractCode(_ common.AddressLocation) (code []byte, err error) {
+	panic("unexpected call to GetAccountContractCode")
+}
+
+func (EmptyRuntimeInterface) MeterComputation(_ common.ComputationKind, _ uint) error {
+	// NO-OP
+	return nil
+}
+
+func (EmptyRuntimeInterface) ComputationUsed() (uint64, error) {
+	panic("unexpected call to ComputationUsed")
+}
+
+func (EmptyRuntimeInterface) MemoryUsed() (uint64, error) {
+	panic("unexpected call to MemoryUsed")
+}
+
+func (EmptyRuntimeInterface) InteractionUsed() (uint64, error) {
+	panic("unexpected call to InteractionUsed")
+}
+
+func (EmptyRuntimeInterface) GetCode(_ Location) ([]byte, error) {
+	panic("unexpected call to GetCode")
+}
+
+func (EmptyRuntimeInterface) SetInterpreterSharedState(_ *interpreter.SharedState) {
+	panic("unexpected call to SetInterpreterSharedState")
+}
+
+func (EmptyRuntimeInterface) GetInterpreterSharedState() *interpreter.SharedState {
+	panic("unexpected call to GetInterpreterSharedState")
+}
+
+func (EmptyRuntimeInterface) GetValue(_, _ []byte) (value []byte, err error) {
+	panic("unexpected call to GetValue")
+}
+
+func (EmptyRuntimeInterface) SetValue(_, _, _ []byte) (err error) {
+	panic("unexpected call to SetValue")
+}
+
+func (EmptyRuntimeInterface) ValueExists(_, _ []byte) (exists bool, err error) {
+	panic("unexpected call to ValueExists")
+}
+
+func (EmptyRuntimeInterface) AllocateStorageIndex(_ []byte) (atree.StorageIndex, error) {
+	panic("unexpected call to AllocateStorageIndex")
+}
+
+func (EmptyRuntimeInterface) CreateAccount(_ Address) (address Address, err error) {
+	panic("unexpected call to CreateAccount")
+}
+
+func (EmptyRuntimeInterface) AddAccountKey(
+	_ Address,
+	_ *PublicKey,
+	_ HashAlgorithm,
+	_ int,
+) (*AccountKey, error) {
+	panic("unexpected call to AddAccountKey")
+}
+
+func (EmptyRuntimeInterface) GetAccountKey(_ Address, _ uint32) (*AccountKey, error) {
+	panic("unexpected call to GetAccountKey")
+}
+
+func (EmptyRuntimeInterface) AccountKeysCount(_ Address) (uint32, error) {
+	panic("unexpected call to AccountKeysCount")
+}
+
+func (EmptyRuntimeInterface) RevokeAccountKey(_ Address, _ uint32) (*AccountKey, error) {
+	panic("unexpected call to RevokeAccountKey")
+}
+
+func (EmptyRuntimeInterface) UpdateAccountContractCode(_ common.AddressLocation, _ []byte) (err error) {
+	panic("unexpected call to UpdateAccountContractCode")
+}
+
+func (EmptyRuntimeInterface) RemoveAccountContractCode(_ common.AddressLocation) (err error) {
+	panic("unexpected call to RemoveAccountContractCode")
+}
+
+func (EmptyRuntimeInterface) GetSigningAccounts() ([]Address, error) {
+	panic("unexpected call to GetSigningAccounts")
+}
+
+func (EmptyRuntimeInterface) ProgramLog(_ string) error {
+	panic("unexpected call to ProgramLog")
+}
+
+func (EmptyRuntimeInterface) EmitEvent(_ cadence.Event) error {
+	panic("unexpected call to EmitEvent")
+}
+
+func (EmptyRuntimeInterface) GenerateUUID() (uint64, error) {
+	panic("unexpected call to GenerateUUID")
+}
+
+func (EmptyRuntimeInterface) DecodeArgument(_ []byte, _ cadence.Type) (cadence.Value, error) {
+	panic("unexpected call to DecodeArgument")
+}
+
+func (EmptyRuntimeInterface) GetCurrentBlockHeight() (uint64, error) {
+	panic("unexpected call to GetCurrentBlockHeight")
+}
+
+func (EmptyRuntimeInterface) GetBlockAtHeight(_ uint64) (block Block, exists bool, err error) {
+	panic("unexpected call to GetBlockAtHeight")
+}
+
+func (EmptyRuntimeInterface) ReadRandom(_ []byte) error {
+	panic("unexpected call to ReadRandom")
+}
+
+func (EmptyRuntimeInterface) VerifySignature(
+	_ []byte,
+	_ string,
+	_ []byte,
+	_ []byte,
+	_ SignatureAlgorithm,
+	_ HashAlgorithm,
+) (bool, error) {
+	panic("unexpected call to VerifySignature")
+}
+
+func (EmptyRuntimeInterface) Hash(_ []byte, _ string, _ HashAlgorithm) ([]byte, error) {
+	panic("unexpected call to Hash")
+}
+
+func (EmptyRuntimeInterface) GetAccountBalance(_ common.Address) (value uint64, err error) {
+	panic("unexpected call to GetAccountBalance")
+}
+
+func (EmptyRuntimeInterface) GetAccountAvailableBalance(_ common.Address) (value uint64, err error) {
+	panic("unexpected call to GetAccountAvailableBalance")
+}
+
+func (EmptyRuntimeInterface) GetStorageUsed(_ Address) (value uint64, err error) {
+	panic("unexpected call to GetStorageUsed")
+}
+
+func (EmptyRuntimeInterface) GetStorageCapacity(_ Address) (value uint64, err error) {
+	panic("unexpected call to GetStorageCapacity")
+}
+
+func (EmptyRuntimeInterface) ImplementationDebugLog(_ string) error {
+	panic("unexpected call to ImplementationDebugLog")
+}
+
+func (EmptyRuntimeInterface) ValidatePublicKey(_ *PublicKey) error {
+	panic("unexpected call to ValidatePublicKey")
+}
+
+func (EmptyRuntimeInterface) GetAccountContractNames(_ Address) ([]string, error) {
+	panic("unexpected call to GetAccountContractNames")
+}
+
+func (EmptyRuntimeInterface) RecordTrace(_ string, _ Location, _ time.Duration, _ []attribute.KeyValue) {
+	panic("unexpected call to RecordTrace")
+}
+
+func (EmptyRuntimeInterface) BLSVerifyPOP(_ *PublicKey, _ []byte) (bool, error) {
+	panic("unexpected call to BLSVerifyPOP")
+}
+
+func (EmptyRuntimeInterface) BLSAggregateSignatures(_ [][]byte) ([]byte, error) {
+	panic("unexpected call to BLSAggregateSignatures")
+}
+
+func (EmptyRuntimeInterface) BLSAggregatePublicKeys(_ []*PublicKey) (*PublicKey, error) {
+	panic("unexpected call to BLSAggregatePublicKeys")
+}
+
+func (EmptyRuntimeInterface) ResourceOwnerChanged(
+	_ *interpreter.Interpreter,
+	_ *interpreter.CompositeValue,
+	_ common.Address,
+	_ common.Address,
+) {
+	panic("unexpected call to ResourceOwnerChanged")
+}
+
+func (EmptyRuntimeInterface) GenerateAccountID(_ common.Address) (uint64, error) {
+	panic("unexpected call to GenerateAccountID")
+}


### PR DESCRIPTION
## Description

As suggested by @janezpodhostnik in https://github.com/onflow/flow-go/pull/6224#discussion_r1684316002:
Provide an empty implementation of `runtime.Interface`, which can be embedded in another implementation.

This avoids having implementations of the interface to implement all functions of this very large interface, even though most functions won't be implemented / won't be used.

This will allow us to clean up the several implementations of the interface in several downstream dependencies (flow-go, language server, etc.)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
