### PR TITLE
Fix supertype inference

### DIFF
--- a/runtime/sema/check_array_expression.go
+++ b/runtime/sema/check_array_expression.go
@@ -80,16 +80,8 @@ func (checker *Checker) VisitArrayExpression(arrayExpression *ast.ArrayExpressio
 	if elementType == nil {
 		// Contextually expected type is not available.
 		// Therefore, find the least common supertype of the elements.
-		elementType = LeastCommonSuperType(argumentTypes...)
-
+		elementType = checker.leastCommonSuperType(arrayExpression, argumentTypes...)
 		if elementType == InvalidType {
-			checker.report(
-				&TypeAnnotationRequiredError{
-					Cause: "cannot infer type from array literal:",
-					Pos:   arrayExpression.StartPos,
-				},
-			)
-
 			return InvalidType
 		}
 

--- a/runtime/sema/check_binary_expression.go
+++ b/runtime/sema/check_binary_expression.go
@@ -468,5 +468,5 @@ func (checker *Checker) checkBinaryExpressionNilCoalescing(
 		}
 	}
 
-	return LeastCommonSuperType(leftOptional.Type, rightType)
+	return checker.leastCommonSuperType(expression, leftOptional.Type, rightType)
 }

--- a/runtime/sema/check_conditional.go
+++ b/runtime/sema/check_conditional.go
@@ -128,7 +128,7 @@ func (checker *Checker) VisitConditionalExpression(expression *ast.ConditionalEx
 		return thenType
 	}
 
-	return LeastCommonSuperType(thenType, elseType)
+	return checker.leastCommonSuperType(expression, thenType, elseType)
 }
 
 // checkConditionalBranches checks two conditional branches.

--- a/runtime/sema/check_dictionary_expression.go
+++ b/runtime/sema/check_dictionary_expression.go
@@ -69,18 +69,13 @@ func (checker *Checker) VisitDictionaryExpression(expression *ast.DictionaryExpr
 	if keyType == nil && valueType == nil {
 		// Contextually expected type is not available.
 		// Therefore, find the least common supertype of the keys and values.
-		keyType = LeastCommonSuperType(keyTypes...)
-		valueType = LeastCommonSuperType(valueTypes...)
+		keyType = checker.leastCommonSuperType(expression, keyTypes...)
+		if keyType == InvalidType {
+			return InvalidType
+		}
 
-		if keyType == InvalidType ||
-			valueType == InvalidType {
-			checker.report(
-				&TypeAnnotationRequiredError{
-					Cause: "cannot infer type from dictionary literal:",
-					Pos:   expression.StartPos,
-				},
-			)
-
+		valueType = checker.leastCommonSuperType(expression, valueTypes...)
+		if valueType == InvalidType {
 			return InvalidType
 		}
 	}

--- a/runtime/sema/checker.go
+++ b/runtime/sema/checker.go
@@ -2766,3 +2766,18 @@ func (checker *Checker) checkNativeModifier(isNative bool, position ast.HasPosit
 		)
 	}
 }
+
+func (checker *Checker) leastCommonSuperType(pos ast.HasPosition, types ...Type) Type {
+	elementType := LeastCommonSuperType(types...)
+
+	if elementType == InvalidType {
+		checker.report(
+			&TypeAnnotationRequiredError{
+				Cause: "cannot infer type:",
+				Pos:   pos.StartPosition(),
+			},
+		)
+	}
+
+	return elementType
+}

--- a/runtime/sema/type_tags.go
+++ b/runtime/sema/type_tags.go
@@ -997,6 +997,11 @@ func commonSuperTypeOfHeterogeneousTypes(types []Type) Type {
 	var hasStructs, hasResources, allHashableStructs bool
 	allHashableStructs = true
 	for _, typ := range types {
+		// Ignore 'Never' type as it doesn't affect the supertype.
+		if typ == NeverType {
+			continue
+		}
+
 		isResource := typ.IsResourceType()
 		hasResources = hasResources || isResource
 		hasStructs = hasStructs || !isResource

--- a/runtime/tests/checker/conditional_test.go
+++ b/runtime/tests/checker/conditional_test.go
@@ -66,9 +66,10 @@ func TestCheckInvalidConditionalExpressionElse(t *testing.T) {
             let x = true ? 2 : y
 	    `)
 
-		errs := RequireCheckerErrors(t, err, 1)
+		errs := RequireCheckerErrors(t, err, 2)
 
 		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+		assert.IsType(t, &sema.TypeAnnotationRequiredError{}, errs[1])
 
 		xType := RequireGlobalValue(t, checker.Elaboration, "x")
 		assert.Equal(t, sema.InvalidType, xType)

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -11684,6 +11684,42 @@ func TestInterpretNilCoalesceReference(t *testing.T) {
 	)
 }
 
+func TestInterpretNilCoalesceAnyResourceAndPanic(t *testing.T) {
+
+	t.Parallel()
+
+	baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+	baseValueActivation.DeclareValue(stdlib.PanicFunction)
+
+	baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
+	interpreter.Declare(baseActivation, stdlib.PanicFunction)
+
+	_, err := parseCheckAndInterpretWithOptions(t,
+		`
+          resource R {}
+
+          fun f(): @AnyResource? {
+              return <-create R()
+          }
+
+          let y <- f() ?? panic("no R")
+        `,
+		ParseCheckAndInterpretOptions{
+			CheckerConfig: &sema.Config{
+				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
+			},
+			Config: &interpreter.Config{
+				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+					return baseActivation
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+}
+
 func TestInterpretDictionaryDuplicateKey(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
Closes #3491

## Description

Thanks @turbolent for the reproducer!

When inferring the super-type for heterogeneous types, the `NeverType` needs to be ignored. This is already done  when inferring LCS for other types, like  arrays, dictionaries, references, etc.

Also fixes the missing error reporting for inferred `InvalidType`. Moved it to a common method, so it won't be missed out in future.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
