### PR TITLE
Return the `TokenLimitReachedError` instead of panicking with it

### DIFF
--- a/runtime/old_parser/parser.go
+++ b/runtime/old_parser/parser.go
@@ -91,8 +91,14 @@ func Parse[T any](
 	config Config,
 ) (result T, errors []error) {
 	// create a lexer, which turns the input string into tokens
-	tokens := lexer.Lex(input, memoryGauge)
+	tokens, err := lexer.Lex(input, memoryGauge)
 	defer tokens.Reclaim()
+
+	if err != nil {
+		errors = append(errors, err)
+		return
+	}
+
 	return ParseTokenStream(
 		memoryGauge,
 		tokens,
@@ -637,8 +643,13 @@ func ParseArgumentList(
 }
 
 func ParseProgram(memoryGauge common.MemoryGauge, code []byte, config Config) (program *ast.Program, err error) {
-	tokens := lexer.Lex(code, memoryGauge)
+	tokens, err := lexer.Lex(code, memoryGauge)
 	defer tokens.Reclaim()
+
+	if err != nil {
+		return nil, err
+	}
+
 	return ParseProgramFromTokenStream(memoryGauge, tokens, config)
 }
 

--- a/runtime/parser/lexer/lexer_test.go
+++ b/runtime/parser/lexer/lexer_test.go
@@ -63,7 +63,10 @@ func testLex(t *testing.T, input string, expected []token) {
 
 	bytes := []byte(input)
 
-	withTokens(Lex(bytes, nil), func(actualTokens []Token) {
+	tokenStream, err := Lex(bytes, nil)
+	require.NoError(t, err)
+
+	withTokens(tokenStream, func(actualTokens []Token) {
 		utils.AssertEqualWithDiff(t, expectedTokens, actualTokens)
 
 		require.Len(t, actualTokens, len(expectedTokens))
@@ -2385,8 +2388,8 @@ func TestRevert(t *testing.T) {
 
 	t.Parallel()
 
-	tokenStream := Lex([]byte("1 2 3"), nil)
-
+	tokenStream, err := Lex([]byte("1 2 3"), nil)
+	require.NoError(t, err)
 	// Assert all tokens
 
 	assert.Equal(t,
@@ -2550,7 +2553,8 @@ func TestEOFsAfterError(t *testing.T) {
 
 	t.Parallel()
 
-	tokenStream := Lex([]byte(`1 ''`), nil)
+	tokenStream, err := Lex([]byte(`1 ''`), nil)
+	require.NoError(t, err)
 
 	// Assert all tokens
 
@@ -2613,7 +2617,8 @@ func TestEOFsAfterEmptyInput(t *testing.T) {
 
 	t.Parallel()
 
-	tokenStream := Lex(nil, nil)
+	tokenStream, err := Lex(nil, nil)
+	require.NoError(t, err)
 
 	// Assert EOFs keep on being returned for Next()
 	// at the end of the stream
@@ -2644,10 +2649,7 @@ func TestLimit(t *testing.T) {
 
 	code := b.String()
 
-	assert.PanicsWithValue(t,
-		TokenLimitReachedError{},
-		func() {
-			_ = Lex([]byte(code), nil)
-		},
-	)
+	_, err := Lex([]byte(code), nil)
+	require.Error(t, err)
+	require.ErrorAs(t, err, &TokenLimitReachedError{})
 }

--- a/runtime/parser/parser.go
+++ b/runtime/parser/parser.go
@@ -100,8 +100,14 @@ func Parse[T any](
 	config Config,
 ) (result T, errors []error) {
 	// create a lexer, which turns the input string into tokens
-	tokens := lexer.Lex(input, memoryGauge)
+	tokens, err := lexer.Lex(input, memoryGauge)
 	defer tokens.Reclaim()
+
+	if err != nil {
+		errors = append(errors, err)
+		return
+	}
+
 	return ParseTokenStream(
 		memoryGauge,
 		tokens,
@@ -677,8 +683,12 @@ func ParseArgumentList(
 }
 
 func ParseProgram(memoryGauge common.MemoryGauge, code []byte, config Config) (program *ast.Program, err error) {
-	tokens := lexer.Lex(code, memoryGauge)
+	tokens, err := lexer.Lex(code, memoryGauge)
 	defer tokens.Reclaim()
+	if err != nil {
+		return nil, err
+	}
+
 	return ParseProgramFromTokenStream(memoryGauge, tokens, config)
 }
 

--- a/runtime/repl.go
+++ b/runtime/repl.go
@@ -251,8 +251,12 @@ func (r *REPL) Accept(code []byte, eval bool) (inputIsComplete bool, err error) 
 		code = prefixedCode
 	}
 
-	tokens := lexer.Lex(code, nil)
+	tokens, err := lexer.Lex(code, nil)
 	defer tokens.Reclaim()
+	if err != nil {
+		r.onError(err, r.checker.Location, r.codes)
+		return
+	}
 
 	inputIsComplete = isInputComplete(tokens)
 


### PR DESCRIPTION
Work towards #3428

## Description

The follow-up PR https://github.com/onflow/cadence/pull/3578 gracefully handles all errors. Like it is mentioned in the other PR, once #3507 is merged, this PR becomes merely a code clean-up.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
