### PR TITLE
Avoid conversion from sema-type to StaticType in storage cap migration

### DIFF
--- a/migrations/capcons/capabilitymigration.go
+++ b/migrations/capcons/capabilitymigration.go
@@ -100,7 +100,7 @@ func (m *CapabilityValueMigration) migratePathCapabilityValue(
 	oldBorrowType := oldCapability.BorrowType
 
 	var capabilityID interpreter.UInt64Value
-	var controllerBorrowType sema.Type
+	var controllerBorrowType *interpreter.ReferenceStaticType
 
 	targetPath := capabilityAddressPath.Path
 	switch targetPath.Domain {
@@ -120,7 +120,7 @@ func (m *CapabilityValueMigration) migratePathCapabilityValue(
 		// Convert untyped path capability value to typed ID capability value
 		// by using capability controller's borrow type
 		if oldBorrowType == nil {
-			oldBorrowType = interpreter.ConvertSemaToStaticType(nil, controllerBorrowType)
+			oldBorrowType = controllerBorrowType
 		}
 
 	case common.PathDomainStorage:

--- a/migrations/capcons/linkmigration.go
+++ b/migrations/capcons/linkmigration.go
@@ -129,12 +129,6 @@ func (m *LinkValueMigration) Migrate(
 		panic(errors.NewUnexpectedError("unexpected value type: %T", value))
 	}
 
-	convertedBorrowStaticType := inter.MustConvertStaticToSemaType(borrowStaticType)
-	borrowType, ok := convertedBorrowStaticType.(*sema.ReferenceType)
-	if !ok {
-		panic(errors.NewUnexpectedError("unexpected non-reference borrow type: %T", borrowType))
-	}
-
 	// Get target
 
 	target, _, err := m.getPathCapabilityFinalTarget(
@@ -178,22 +172,22 @@ func (m *LinkValueMigration) Migrate(
 
 		targetPath := interpreter.PathValue(target)
 
-		capabilityID, _ = stdlib.IssueStorageCapabilityController(
+		capabilityID = stdlib.IssueStorageCapabilityController(
 			inter,
 			locationRange,
 			issueHandler,
 			accountAddress,
-			borrowType,
+			borrowStaticType,
 			targetPath,
 		)
 
 	case accountCapabilityTarget:
-		capabilityID, _ = stdlib.IssueAccountCapabilityController(
+		capabilityID = stdlib.IssueAccountCapabilityController(
 			inter,
 			locationRange,
 			issueHandler,
 			accountAddress,
-			borrowType,
+			borrowStaticType,
 		)
 
 	default:
@@ -203,7 +197,7 @@ func (m *LinkValueMigration) Migrate(
 	// Record new capability ID in source path mapping.
 	// The mapping is used later for migrating path capabilities to ID capabilities,
 	// see CapabilityMigration.
-	m.CapabilityMapping.Record(addressPath, capabilityID, borrowType)
+	m.CapabilityMapping.Record(addressPath, capabilityID, borrowStaticType)
 
 	if reporter != nil {
 		reporter.MigratedLink(addressPath, capabilityID)

--- a/migrations/capcons/mapping.go
+++ b/migrations/capcons/mapping.go
@@ -23,14 +23,13 @@ import (
 
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
-	"github.com/onflow/cadence/runtime/sema"
 )
 
 // Path capability mappings map an address and path to a capability ID and borrow type
 
 type PathCapabilityEntry struct {
 	CapabilityID interpreter.UInt64Value
-	BorrowType   *sema.ReferenceType
+	BorrowType   *interpreter.ReferenceStaticType
 }
 
 type PathCapabilityEntryMap map[interpreter.PathValue]PathCapabilityEntry
@@ -43,7 +42,7 @@ type PathCapabilityMapping struct {
 func (m *PathCapabilityMapping) Record(
 	addressPath interpreter.AddressPath,
 	capabilityID interpreter.UInt64Value,
-	borrowType *sema.ReferenceType,
+	borrowType *interpreter.ReferenceStaticType,
 ) {
 	var capMap PathCapabilityEntryMap
 	rawCapMap, ok := m.capabilityEntries.Load(addressPath.Address)
@@ -59,7 +58,7 @@ func (m *PathCapabilityMapping) Record(
 	}
 }
 
-func (m *PathCapabilityMapping) Get(addressPath interpreter.AddressPath) (interpreter.UInt64Value, sema.Type, bool) {
+func (m *PathCapabilityMapping) Get(addressPath interpreter.AddressPath) (interpreter.UInt64Value, *interpreter.ReferenceStaticType, bool) {
 	rawCapabilityEntryMap, ok := m.capabilityEntries.Load(addressPath.Address)
 	if !ok {
 		return 0, nil, false

--- a/migrations/capcons/storagecapmigration.go
+++ b/migrations/capcons/storagecapmigration.go
@@ -22,7 +22,6 @@ import (
 	"github.com/onflow/cadence/migrations"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
-	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 )
 
@@ -110,9 +109,9 @@ func IssueAccountCapabilities(
 			continue
 		}
 
-		borrowType := inter.MustConvertStaticToSemaType(borrowStaticType).(*sema.ReferenceType)
+		borrowType := borrowStaticType.(*interpreter.ReferenceStaticType)
 
-		capabilityID, _ := stdlib.IssueStorageCapabilityController(
+		capabilityID := stdlib.IssueStorageCapabilityController(
 			inter,
 			interpreter.EmptyLocationRange,
 			handler,
@@ -124,13 +123,13 @@ func IssueAccountCapabilities(
 		capabilityMapping.Record(
 			addressPath,
 			capabilityID,
-			borrowType.ID(),
+			borrowStaticType.ID(),
 		)
 
 		reporter.IssuedStorageCapabilityController(
 			address,
 			addressPath,
-			borrowStaticType.(*interpreter.ReferenceStaticType),
+			borrowType,
 			capabilityID,
 		)
 	}

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -2692,12 +2692,14 @@ func checkAndIssueStorageCapabilityControllerWithType(
 
 	// Issue capability controller
 
-	capabilityIDValue, borrowStaticType := IssueStorageCapabilityController(
+	borrowStaticType := interpreter.ConvertSemaReferenceTypeToStaticReferenceType(inter, borrowType)
+
+	capabilityIDValue := IssueStorageCapabilityController(
 		inter,
 		locationRange,
 		handler,
 		address,
-		borrowType,
+		borrowStaticType,
 		targetPathValue,
 	)
 
@@ -2720,12 +2722,9 @@ func IssueStorageCapabilityController(
 	locationRange interpreter.LocationRange,
 	handler CapabilityControllerIssueHandler,
 	address common.Address,
-	borrowType *sema.ReferenceType,
+	borrowStaticType *interpreter.ReferenceStaticType,
 	targetPathValue interpreter.PathValue,
-) (
-	interpreter.UInt64Value,
-	*interpreter.ReferenceStaticType,
-) {
+) interpreter.UInt64Value {
 	if targetPathValue.Domain != common.PathDomainStorage {
 		panic(errors.NewDefaultUserError(
 			"invalid storage capability target path domain: %s",
@@ -2734,8 +2733,6 @@ func IssueStorageCapabilityController(
 	}
 
 	// Create and write StorageCapabilityController
-
-	borrowStaticType := interpreter.ConvertSemaReferenceTypeToStaticReferenceType(inter, borrowType)
 
 	var capabilityID uint64
 	var err error
@@ -2776,7 +2773,7 @@ func IssueStorageCapabilityController(
 		},
 	)
 
-	return capabilityIDValue, borrowStaticType
+	return capabilityIDValue
 }
 
 func newAccountAccountCapabilitiesIssueFunction(
@@ -2882,13 +2879,15 @@ func checkAndIssueAccountCapabilityControllerWithType(
 
 	// Issue capability controller
 
-	capabilityIDValue, borrowStaticType :=
+	borrowStaticType := interpreter.ConvertSemaReferenceTypeToStaticReferenceType(inter, borrowType)
+
+	capabilityIDValue :=
 		IssueAccountCapabilityController(
 			inter,
 			locationRange,
 			handler,
 			address,
-			borrowType,
+			borrowStaticType,
 		)
 
 	if capabilityIDValue == interpreter.InvalidCapabilityID {
@@ -2910,14 +2909,9 @@ func IssueAccountCapabilityController(
 	locationRange interpreter.LocationRange,
 	handler CapabilityControllerIssueHandler,
 	address common.Address,
-	borrowType *sema.ReferenceType,
-) (
-	interpreter.UInt64Value,
-	*interpreter.ReferenceStaticType,
-) {
+	borrowStaticType *interpreter.ReferenceStaticType,
+) interpreter.UInt64Value {
 	// Create and write AccountCapabilityController
-
-	borrowStaticType := interpreter.ConvertSemaReferenceTypeToStaticReferenceType(inter, borrowType)
 
 	var capabilityID uint64
 	var err error
@@ -2961,7 +2955,7 @@ func IssueAccountCapabilityController(
 		},
 	)
 
-	return capabilityIDValue, borrowStaticType
+	return capabilityIDValue
 }
 
 // CapabilityControllerStorageDomain is the storage domain which stores


### PR DESCRIPTION
## Description

Corresponding flow-go changes: https://github.com/onflow/flow-go/pull/6322
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
