### PR TITLE
Improve borrow type inferrence for storage path capabilities

### DIFF
--- a/migrations/capcons/storagecapmigration.go
+++ b/migrations/capcons/storagecapmigration.go
@@ -98,6 +98,7 @@ func IssueAccountCapabilities(
 	handler stdlib.CapabilityControllerIssueHandler,
 	typedCapabilityMapping *PathTypeCapabilityMapping,
 	untypedCapabilityMapping *PathCapabilityMapping,
+	inferAuth func(valueType interpreter.StaticType) interpreter.Authorization,
 ) {
 
 	storageMap := storage.GetStorageMap(
@@ -141,12 +142,12 @@ func IssueAccountCapabilities(
 				continue
 			}
 
-			staticType := value.StaticType(inter)
+			valueType := value.StaticType(inter)
 
 			borrowType = interpreter.NewReferenceStaticType(
 				nil,
-				interpreter.UnauthorizedAccess,
-				staticType,
+				inferAuth(valueType),
+				valueType,
 			)
 
 			reporter.InferredMissingBorrowType(address, addressPath, borrowType)


### PR DESCRIPTION

## Description

Use a function to infer the authorization of the inferred borrow type

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
