### PR TITLE
Fix contract update validation: Check updated contract name

### DIFF
--- a/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validation_test.go
+++ b/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validation_test.go
@@ -3031,3 +3031,29 @@ func TestContractUpgrade(t *testing.T) {
 	cause := getSingleContractUpdateErrorCause(t, err, "Test")
 	assertFieldAuthorizationMismatchError(t, cause, "A", "cap", "all", "E")
 }
+
+func TestContractUpgradeWrongName(t *testing.T) {
+
+	t.Parallel()
+
+	const oldCode = `
+        access(all)
+        contract Test {}
+    `
+
+	const newCode = `
+        access(all)
+        contract Bad {}
+    `
+
+	err := testContractUpdate(t, oldCode, newCode)
+	require.Error(t, err)
+
+	err = getSingleContractUpdateErrorCause(t, err, "Test")
+
+	var nameMismatchError *stdlib.NameMismatchError
+	require.ErrorAs(t, err, &nameMismatchError)
+
+	assert.Equal(t, "Test", nameMismatchError.OldName)
+	assert.Equal(t, "Bad", nameMismatchError.NewName)
+}

--- a/runtime/stdlib/contract_update_validation.go
+++ b/runtime/stdlib/contract_update_validation.go
@@ -280,6 +280,17 @@ func checkDeclarationUpdatability(
 		validator.setCurrentDeclaration(parentDecl)
 	}()
 
+	oldIdentifier := oldDeclaration.DeclarationIdentifier()
+	newIdentifier := newDeclaration.DeclarationIdentifier()
+	if oldIdentifier.Identifier != newIdentifier.Identifier {
+
+		validator.report(&NameMismatchError{
+			OldName: oldIdentifier.Identifier,
+			NewName: newIdentifier.Identifier,
+			Range:   ast.NewUnmeteredRangeFromPositioned(newIdentifier),
+		})
+	}
+
 	checkFields(validator, oldDeclaration, newDeclaration)
 
 	checkNestedDeclarations(validator, oldDeclaration, newDeclaration, checkConformance)
@@ -921,5 +932,24 @@ func (e *TypeRemovalPragmaRemovalError) Error() string {
 	return fmt.Sprintf(
 		"missing #removedType pragma for %s",
 		e.RemovedType,
+	)
+}
+
+// NameMismatchError is reported during a contract update, when an a composite
+// declaration has a different name than the existing declaration.
+type NameMismatchError struct {
+	OldName string
+	NewName string
+	ast.Range
+}
+
+var _ errors.UserError = &NameMismatchError{}
+
+func (*NameMismatchError) IsUserError() {}
+
+func (e *NameMismatchError) Error() string {
+	return fmt.Sprintf("name mismatch: got `%s`, expected `%s`",
+		e.NewName,
+		e.OldName,
 	)
 }


### PR DESCRIPTION
## Description

Ensure the update's contract name matches the original contract name.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
