### PR TITLE
Check if CBOR tag number is reserved by atree before using it to encode Cadence values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/leanovate/gopter v0.2.9
 	github.com/logrusorgru/aurora/v4 v4.0.0
-	github.com/onflow/atree v0.8.0-rc.5
+	github.com/onflow/atree v0.8.0-rc.5.0.20240815140907-141ec5ca3ce2
 	github.com/rivo/uniseg v0.4.4
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/stretchr/testify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/leanovate/gopter v0.2.9
 	github.com/logrusorgru/aurora/v4 v4.0.0
-	github.com/onflow/atree v0.8.0-rc.5.0.20240815140907-141ec5ca3ce2
+	github.com/onflow/atree v0.8.0-rc.6
 	github.com/rivo/uniseg v0.4.4
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2Em
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/onflow/atree v0.8.0-rc.5 h1:1sU+c6UfDzq/EjM8nTw4EI8GvEMarcxkWkJKy6piFSY=
-github.com/onflow/atree v0.8.0-rc.5/go.mod h1:yccR+LR7xc1Jdic0mrjocbHvUD7lnVvg8/Ct1AA5zBo=
+github.com/onflow/atree v0.8.0-rc.5.0.20240815140907-141ec5ca3ce2 h1:Lz6qqVn855ifWXh+JIMy/bz8O7efNL0jb/SMQiidoIc=
+github.com/onflow/atree v0.8.0-rc.5.0.20240815140907-141ec5ca3ce2/go.mod h1:yccR+LR7xc1Jdic0mrjocbHvUD7lnVvg8/Ct1AA5zBo=
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2Em
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/onflow/atree v0.8.0-rc.5.0.20240815140907-141ec5ca3ce2 h1:Lz6qqVn855ifWXh+JIMy/bz8O7efNL0jb/SMQiidoIc=
-github.com/onflow/atree v0.8.0-rc.5.0.20240815140907-141ec5ca3ce2/go.mod h1:yccR+LR7xc1Jdic0mrjocbHvUD7lnVvg8/Ct1AA5zBo=
+github.com/onflow/atree v0.8.0-rc.6 h1:GWgaylK24b5ta2Hq+TvyOF7X5tZLiLzMMn7lEt59fsA=
+github.com/onflow/atree v0.8.0-rc.6/go.mod h1:yccR+LR7xc1Jdic0mrjocbHvUD7lnVvg8/Ct1AA5zBo=
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/runtime/cmd/decode-state-values/main.go
+++ b/runtime/cmd/decode-state-values/main.go
@@ -115,23 +115,13 @@ func decodeSlab(id atree.SlabID, data []byte) (atree.Slab, error) {
 }
 
 func slabIDToStorageKey(id atree.SlabID) storageKey {
-	const (
-		addressSize = len(atree.Address{})
-		indexSize   = len(atree.SlabIndex{})
-		slabIDSize  = addressSize + indexSize
-		indexPos    = addressSize
-	)
-
-	var b [slabIDSize]byte
-	_, err := id.ToRawBytes(b[:])
-	if err != nil {
-		panic(err)
-	}
+	address := id.Address()
+	index := id.Index()
 
 	return storageKey{
-		string(b[:addressSize]),
+		string(address[:]),
 		"",
-		"$" + string(b[indexPos:]),
+		"$" + string(index[:]),
 	}
 }
 

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -20,6 +20,7 @@ package interpreter
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"math/big"
 
@@ -252,6 +253,40 @@ var CBOREncMode = func() cbor.EncMode {
 	}
 	return encMode
 }()
+
+func init() {
+	// Here, init is only used for sanity checks (coding errors) and does not perform any initialization.
+
+	// Check if the CBOR tag number range is not reserved for internal use by atree.
+	// Cadence must only use available (unreserved by atree) CBOR tag numbers to encode elements in atree managed containers.
+
+	// As of Aug 15, 2024:
+	// - Atree reserves CBOR tag numbers from 240 to 255 for atree internal use.
+	// - Cadence uses CBOR tag numbers from 128 to 230 to encode internal Cadence values.
+
+	// When a new tag number is needed, Atree will use higher tag number first from its reserved range.
+	// In contrast, Cadence will use lower tag numbers first from its own (different) reserved range.
+	// This allows Atree and Cadence more flexibility in case we need to revisit the
+	// allocation of adjacent unused ranges for Atree and Cadence.
+
+	minCBORTagNum := uint64(CBORTagBase)
+	maxCBORTagNum := uint64(CBORTag_Count) - 1
+
+	tagNumOK, err := atree.IsCBORTagNumberRangeAvailable(minCBORTagNum, maxCBORTagNum)
+	if err != nil {
+		panic(err)
+	}
+
+	if !tagNumOK {
+		atreeMinCBORTagNum, atreeMaxCBORTagNum := atree.ReservedCBORTagNumberRange()
+		panic(fmt.Errorf(
+			"cadence internal tag numbers [%d, %d] overlaps with atree internal tag numbers [%d, %d]",
+			minCBORTagNum,
+			maxCBORTagNum,
+			atreeMinCBORTagNum,
+			atreeMaxCBORTagNum))
+	}
+}
 
 // Encode encodes the value as a CBOR nil
 func (v NilValue) Encode(e *atree.Encoder) error {


### PR DESCRIPTION
Using tag numbers reserved for atree internal use can result in data in storage that cannot be decoded.

To reduce risks, this PR checks if CBOR tag number is reserved by atree for internal use before using it to encode Cadence values as elements in atree containers.

As of Aug 15, 2024:
- Atree reserves CBOR tag numbers [240, 255] for internal use.
- Cadence uses CBOR tag numbers [128, 230] for encoding Cadence values as elements in atree containers.

When new tag numbers are needed in Atree, we will use higher tag numbers first from Atree's reserved range.  In Cadence, we will use lower tag numbers first from its own (different) reserved range. This allows Atree and Cadence more flexibility in case we need to revisit allocation of adjacent unused ranges for Atree and Cadence.

While at it, also used new function `SlabID.Address()` to simply related code.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
