### PR TITLE
Fix program recovery

### DIFF
--- a/runtime/empty.go
+++ b/runtime/empty.go
@@ -235,6 +235,6 @@ func (EmptyRuntimeInterface) GenerateAccountID(_ common.Address) (uint64, error)
 	panic("unexpected call to GenerateAccountID")
 }
 
-func (EmptyRuntimeInterface) RecoverProgram(_ *ast.Program, _ common.Location) (*ast.Program, error) {
+func (EmptyRuntimeInterface) RecoverProgram(_ *ast.Program, _ common.Location) ([]byte, error) {
 	panic("unexpected call to RecoverProgram")
 }

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -556,7 +556,7 @@ func (e *interpreterEnvironment) parseAndCheckProgram(
 // recoverProgram parses and checks the given program with the old parser,
 // and recovers the elaboration from the old program.
 func (e *interpreterEnvironment) recoverProgram(
-	code []byte,
+	oldCode []byte,
 	location common.Location,
 	checkedImports importResolutionResults,
 ) (
@@ -568,7 +568,7 @@ func (e *interpreterEnvironment) recoverProgram(
 	var err error
 	reportMetric(
 		func() {
-			program, err = old_parser.ParseProgram(e, code, old_parser.Config{})
+			program, err = old_parser.ParseProgram(e, oldCode, old_parser.Config{})
 		},
 		e.runtimeInterface,
 		func(metrics Metrics, duration time.Duration) {
@@ -581,10 +581,18 @@ func (e *interpreterEnvironment) recoverProgram(
 
 	// Recover elaboration from the old program
 
+	var newCode []byte
 	errors.WrapPanic(func() {
-		program, err = e.runtimeInterface.RecoverProgram(program, location)
+		newCode, err = e.runtimeInterface.RecoverProgram(program, location)
 	})
-	if err != nil || program == nil {
+	if err != nil || newCode == nil {
+		return nil, nil
+	}
+
+	// Parse and check the recovered program
+
+	program, err = parser.ParseProgram(e, newCode, parser.Config{})
+	if err != nil {
 		return nil, nil
 	}
 
@@ -592,6 +600,8 @@ func (e *interpreterEnvironment) recoverProgram(
 	if err != nil || elaboration == nil {
 		return nil, nil
 	}
+
+	e.codesAndPrograms.setCode(location, newCode)
 
 	return program, elaboration
 }

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -144,7 +144,7 @@ type Interface interface {
 	)
 	// GenerateAccountID generates a new, *non-zero*, unique ID for the given account.
 	GenerateAccountID(address common.Address) (uint64, error)
-	RecoverProgram(program *ast.Program, location common.Location) (*ast.Program, error)
+	RecoverProgram(program *ast.Program, location common.Location) ([]byte, error)
 }
 
 type MeterInterface interface {

--- a/runtime/tests/runtime_utils/testinterface.go
+++ b/runtime/tests/runtime_utils/testinterface.go
@@ -121,7 +121,7 @@ type TestRuntimeInterface struct {
 	OnMemoryUsed        func() (uint64, error)
 	OnInteractionUsed   func() (uint64, error)
 	OnGenerateAccountID func(address common.Address) (uint64, error)
-	OnRecoverProgram    func(program *ast.Program, location common.Location) (*ast.Program, error)
+	OnRecoverProgram    func(program *ast.Program, location common.Location) ([]byte, error)
 
 	lastUUID            uint64
 	accountIDs          map[common.Address]uint64
@@ -608,7 +608,7 @@ func (i *TestRuntimeInterface) InvalidateUpdatedPrograms() {
 	}
 }
 
-func (i *TestRuntimeInterface) RecoverProgram(program *ast.Program, location common.Location) (*ast.Program, error) {
+func (i *TestRuntimeInterface) RecoverProgram(program *ast.Program, location common.Location) ([]byte, error) {
 	if i.OnRecoverProgram == nil {
 		return nil, nil
 	}


### PR DESCRIPTION

## Description

Discovered while working on https://github.com/onflow/flow-go/pull/6388

Program recovery must return the replacement program in source code form, so that the new code is used for error pretty printing. Otherwise errors are reported for the original, old code, leading to potential runtime errors (e.g. line out-of-bounds indexing).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
