### PR TITLE
Smoke test update of enum key in dictionary

### DIFF
--- a/runtime/tests/interpreter/values_test.go
+++ b/runtime/tests/interpreter/values_test.go
@@ -375,17 +375,18 @@ func TestInterpretRandomMapOperations(t *testing.T) {
 
 		newEntries := newValueMap(numberOfValues)
 
-		value := interpreter.NewUnmeteredIntValueFromInt64(1)
+		value1 := interpreter.NewUnmeteredIntValueFromInt64(1)
+		value2 := interpreter.NewUnmeteredIntValueFromInt64(2)
 
 		keyValues := make([][2]interpreter.Value, numberOfValues)
 		for i := 0; i < numberOfValues; i++ {
 			// Create a random enum as key
 			key := r.generateRandomHashableValue(inter, randomValueKindEnum)
 
-			newEntries.put(inter, key, value)
+			newEntries.put(inter, key, value1)
 
 			keyValues[i][0] = key
-			keyValues[i][1] = value
+			keyValues[i][1] = value1
 		}
 
 		// Insert
@@ -393,11 +394,15 @@ func TestInterpretRandomMapOperations(t *testing.T) {
 			dictionary.Insert(inter, interpreter.EmptyLocationRange, keyValue[0], keyValue[1])
 		}
 
-		value = interpreter.NewUnmeteredIntValueFromInt64(2)
-
 		// Update
 		newEntries.foreach(func(orgKey, orgValue interpreter.Value) (exit bool) {
-			oldValue := dictionary.Insert(inter, interpreter.EmptyLocationRange, orgKey.Clone(inter), value)
+			oldValue := dictionary.Insert(
+				inter,
+				interpreter.EmptyLocationRange,
+				orgKey.Clone(inter),
+				// change value1 to value2
+				value2,
+			)
 
 			require.IsType(t, &interpreter.SomeValue{}, oldValue)
 			someValue := oldValue.(*interpreter.SomeValue)


### PR DESCRIPTION
## Description

See https://www.notion.so/Cadence-Implementation-Sync-Notes-Agenda-cf6890eb8a9f4692a8c08611856a5af5?d=f9a77e431f9843ceb7e4246ddc7467b1&pvs=4#fff1aee1232480b4b050e6e628ab7ad4

@fxamacker Is this the kind of update you were referring to, i.e. replacing the value for an existing enum key, or is it mutating the value of the enum key?

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
