### PR TITLE
Add contract-update test for removing a field from nested resource

### DIFF
--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -395,6 +395,54 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 		assertExtraneousFieldError(t, cause, "TestResource", "c")
 	})
 
+	testWithValidators(t, "remove field from nested decl", func(t *testing.T, config Config) {
+
+		const oldCode = `
+            access(all) contract Test {
+
+                access(all) var a: @TestResource
+
+                init() {
+                    self.a <- create Test.TestResource()
+                }
+
+                access(all) resource TestResource {
+
+                    access(all) var b: String
+                    access(all) var c: Int
+
+                    init() {
+                        self.b = "hello"
+                        self.c = 0
+                    }
+                }
+            }
+        `
+
+		const newCode = `
+            access(all) contract Test {
+
+                access(all) var a: @Test.TestResource
+
+                init() {
+                    self.a <- create Test.TestResource()
+                }
+
+                access(all) resource TestResource {
+
+                    access(all) var b: String
+
+                    init() {
+                        self.b = "hello"
+                    }
+                }
+            }
+        `
+
+		err := testDeployAndUpdate(t, "Test", oldCode, newCode, config)
+		require.NoError(t, err)
+	})
+
 	testWithValidators(t, "change indirect field type", func(t *testing.T, config Config) {
 
 		const oldCode = `


### PR DESCRIPTION
## Description

There are already tests for adding and updating fields of a nested declaration (e.g: a resource). Also add a similar test for removing a field from a nested declaration.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
