### PR TITLE
Handle unmigrated path capabilities and path links in Account.capabilities functions

### DIFF
--- a/migrations/capcons/capabilitymigration.go
+++ b/migrations/capcons/capabilitymigration.go
@@ -164,7 +164,7 @@ func (m *CapabilityValueMigration) migratePathCapabilityValue(
 
 	newCapability := interpreter.NewUnmeteredCapabilityValue(
 		capabilityID,
-		oldCapability.Address,
+		oldCapability.Address(),
 		newBorrowType,
 	)
 

--- a/migrations/capcons/linkmigration.go
+++ b/migrations/capcons/linkmigration.go
@@ -339,7 +339,7 @@ func (m *LinkValueMigration) getPathCapabilityFinalTarget(
 				reference := stdlib.GetCheckedCapabilityControllerReference(
 					inter,
 					locationRange,
-					value.Address,
+					value.Address(),
 					value.ID,
 					wantedBorrowType,
 					capabilityBorrowType,

--- a/migrations/capcons/migration_test.go
+++ b/migrations/capcons/migration_test.go
@@ -731,14 +731,14 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		{
 			name: "Path links, working chain (public -> private -> storage)",
 			// Equivalent to: getCapability<&Test.R>(/public/test)
-			capabilityValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: testRReferenceStaticType,
-				Path: interpreter.PathValue{
+			capabilityValue: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				testRReferenceStaticType,
+				interpreter.AddressValue(testAddress),
+				interpreter.PathValue{
 					Domain:     common.PathDomainPublic,
 					Identifier: testPathIdentifier,
 				},
-				Address: interpreter.AddressValue(testAddress),
-			},
+			),
 			pathLinks: []testLink{
 				// Equivalent to:
 				//   link<&Test.R>(/public/test, target: /private/test)
@@ -808,14 +808,14 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		{
 			name: "Path links, working chain (public -> storage)",
 			// Equivalent to: getCapability<&Test.R>(/public/test)
-			capabilityValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: testRReferenceStaticType,
-				Path: interpreter.PathValue{
+			capabilityValue: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				testRReferenceStaticType,
+				interpreter.AddressValue(testAddress),
+				interpreter.PathValue{
 					Domain:     common.PathDomainPublic,
 					Identifier: testPathIdentifier,
 				},
-				Address: interpreter.AddressValue(testAddress),
-			},
+			),
 			pathLinks: []testLink{
 				// Equivalent to:
 				//   link<&Test.R>(/public/test, target: /storage/test)
@@ -863,14 +863,14 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		{
 			name: "Path links, working chain (private -> storage)",
 			// Equivalent to: getCapability<&Test.R>(/private/test)
-			capabilityValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: testRReferenceStaticType,
-				Path: interpreter.PathValue{
+			capabilityValue: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				testRReferenceStaticType,
+				interpreter.AddressValue(testAddress),
+				interpreter.PathValue{
 					Domain:     common.PathDomainPrivate,
 					Identifier: testPathIdentifier,
 				},
-				Address: interpreter.AddressValue(testAddress),
-			},
+			),
 			pathLinks: []testLink{
 				// Equivalent to:
 				//   link<&Test.R>(/private/test, target: /storage/test)
@@ -923,14 +923,14 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		{
 			name: "Path links, working chain (private -> private -> storage)",
 			// Equivalent to: getCapability<&Test.R>(/private/test)
-			capabilityValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: testRReferenceStaticType,
-				Path: interpreter.PathValue{
+			capabilityValue: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				testRReferenceStaticType,
+				interpreter.AddressValue(testAddress),
+				interpreter.PathValue{
 					Domain:     common.PathDomainPrivate,
 					Identifier: testPathIdentifier,
 				},
-				Address: interpreter.AddressValue(testAddress),
-			},
+			),
 			pathLinks: []testLink{
 				// Equivalent to:
 				//   link<&Test.R>(/private/test, target: /private/test2)
@@ -1001,14 +1001,14 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		{
 			name: "Path links, valid chain (public -> storage), different borrow type",
 			// Equivalent to: getCapability<&Test.R>(/public/test)
-			capabilityValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: testRReferenceStaticType,
-				Path: interpreter.PathValue{
+			capabilityValue: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				testRReferenceStaticType,
+				interpreter.AddressValue(testAddress),
+				interpreter.PathValue{
 					Domain:     common.PathDomainPublic,
 					Identifier: testPathIdentifier,
 				},
-				Address: interpreter.AddressValue(testAddress),
-			},
+			),
 			pathLinks: []testLink{
 				// Equivalent to:
 				//   link<&Test.S>(/public/test, target: /storage/test)
@@ -1058,14 +1058,14 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		{
 			name: "Path links, cyclic chain (public -> private -> public)",
 			// Equivalent to: getCapability<&Test.R>(/public/test)
-			capabilityValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: testRReferenceStaticType,
-				Path: interpreter.PathValue{
+			capabilityValue: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				testRReferenceStaticType,
+				interpreter.AddressValue(testAddress),
+				interpreter.PathValue{
 					Domain:     common.PathDomainPublic,
 					Identifier: testPathIdentifier,
 				},
-				Address: interpreter.AddressValue(testAddress),
-			},
+			),
 			pathLinks: []testLink{
 				// Equivalent to:
 				//   link<&Test.R>(/public/test, target: /private/test)
@@ -1112,14 +1112,14 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		{
 			name: "Path links, missing source (public -> private)",
 			// Equivalent to: getCapability<&Test.R>(/public/test)
-			capabilityValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: testRReferenceStaticType,
-				Path: interpreter.PathValue{
+			capabilityValue: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				testRReferenceStaticType,
+				interpreter.AddressValue(testAddress),
+				interpreter.PathValue{
 					Domain:     common.PathDomainPublic,
 					Identifier: testPathIdentifier,
 				},
-				Address: interpreter.AddressValue(testAddress),
-			},
+			),
 			pathLinks:              nil,
 			expectedPathMigrations: nil,
 			expectedMissingCapabilityIDs: []testCapConsMissingCapabilityID{
@@ -1139,14 +1139,14 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		{
 			name: "Path links, missing target (public -> private)",
 			// Equivalent to: getCapability<&Test.R>(/public/test)
-			capabilityValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: testRReferenceStaticType,
-				Path: interpreter.PathValue{
+			capabilityValue: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				testRReferenceStaticType,
+				interpreter.AddressValue(testAddress),
+				interpreter.PathValue{
 					Domain:     common.PathDomainPublic,
 					Identifier: testPathIdentifier,
 				},
-				Address: interpreter.AddressValue(testAddress),
-			},
+			),
 			pathLinks: []testLink{
 				// Equivalent to:
 				//   link<&Test.R>(/public/test, target: /private/test)
@@ -1180,14 +1180,14 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		{
 			name: "Path link, storage path",
 			// Equivalent to: getCapability<&Test.R>(/storage/test)
-			capabilityValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: testRReferenceStaticType,
-				Path: interpreter.PathValue{
+			capabilityValue: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				testRReferenceStaticType,
+				interpreter.AddressValue(testAddress),
+				interpreter.PathValue{
 					Domain:     common.PathDomainStorage,
 					Identifier: testPathIdentifier,
 				},
-				Address: interpreter.AddressValue(testAddress),
-			},
+			),
 			pathLinks: nil,
 			expectedMigrations: []testMigration{
 				expectedWrappedCapabilityValueMigration,
@@ -1213,14 +1213,14 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		{
 			name: "Account link, working chain (public), unauthorized",
 			// Equivalent to: getCapability<&Account>(/public/test)
-			capabilityValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: unauthorizedAccountReferenceStaticType,
-				Path: interpreter.PathValue{
+			capabilityValue: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				unauthorizedAccountReferenceStaticType,
+				interpreter.AddressValue(testAddress),
+				interpreter.PathValue{
 					Domain:     common.PathDomainPublic,
 					Identifier: testPathIdentifier,
 				},
-				Address: interpreter.AddressValue(testAddress),
-			},
+			),
 			accountLinks: []interpreter.PathValue{
 				// Equivalent to:
 				//   linkAccount(/public/test)
@@ -1261,18 +1261,18 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		{
 			name: "Account link, working chain (public), authorized",
 			// Equivalent to: getCapability<auth(Capabilities, Contracts, Inbox, Keys, Storage) &Account>(/public/test)
-			capabilityValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: interpreter.NewReferenceStaticType(
+			capabilityValue: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				interpreter.NewReferenceStaticType(
 					nil,
 					interpreter.FullyEntitledAccountAccess,
 					interpreter.PrimitiveStaticTypeAccount,
 				),
-				Path: interpreter.PathValue{
+				interpreter.AddressValue(testAddress),
+				interpreter.PathValue{
 					Domain:     common.PathDomainPublic,
 					Identifier: testPathIdentifier,
 				},
-				Address: interpreter.AddressValue(testAddress),
-			},
+			),
 			accountLinks: []interpreter.PathValue{
 				// Equivalent to:
 				//   linkAccount(/public/test)
@@ -1313,14 +1313,14 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		{
 			name: "Account link, working chain (private), unauthorized",
 			// Equivalent to: getCapability<&Account>(/public/test)
-			capabilityValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: unauthorizedAccountReferenceStaticType,
-				Path: interpreter.PathValue{
+			capabilityValue: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				unauthorizedAccountReferenceStaticType,
+				interpreter.AddressValue(testAddress),
+				interpreter.PathValue{
 					Domain:     common.PathDomainPrivate,
 					Identifier: testPathIdentifier,
 				},
-				Address: interpreter.AddressValue(testAddress),
-			},
+			),
 			accountLinks: []interpreter.PathValue{
 				// Equivalent to:
 				//   linkAccount(/private/test)
@@ -1361,14 +1361,14 @@ func TestPathCapabilityValueMigration(t *testing.T) {
 		{
 			name: "Account link, working chain (private), authorized",
 			// Equivalent to: getCapability<auth(Capabilities, Contracts, Inbox, Keys, Storage) &Account>(/public/test)
-			capabilityValue: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: fullyEntitledAccountReferenceStaticType,
-				Path: interpreter.PathValue{
+			capabilityValue: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				fullyEntitledAccountReferenceStaticType,
+				interpreter.AddressValue(testAddress),
+				interpreter.PathValue{
 					Domain:     common.PathDomainPrivate,
 					Identifier: testPathIdentifier,
 				},
-				Address: interpreter.AddressValue(testAddress),
-			},
+			),
 			accountLinks: []interpreter.PathValue{
 				// Equivalent to:
 				//   linkAccount(/private/test)
@@ -2290,14 +2290,14 @@ func TestPublishedPathCapabilityValueMigration(t *testing.T) {
 	)
 
 	// Equivalent to: getCapability<&Int>(/public/test)
-	capabilityValue := &interpreter.PathCapabilityValue{ //nolint:staticcheck
-		BorrowType: borrowType,
-		Path: interpreter.PathValue{
+	capabilityValue := interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+		borrowType,
+		interpreter.AddressValue(testAddress),
+		interpreter.PathValue{
 			Domain:     common.PathDomainPublic,
 			Identifier: testPathIdentifier,
 		},
-		Address: interpreter.AddressValue(testAddress),
-	}
+	)
 
 	pathLinks := []testLink{
 		// Equivalent to:
@@ -2541,15 +2541,15 @@ func TestUntypedPathCapabilityValueMigration(t *testing.T) {
 	)
 
 	// Equivalent to: getCapability(/public/test)
-	capabilityValue := &interpreter.PathCapabilityValue{ //nolint:staticcheck
+	capabilityValue := interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
 		// NOTE: no borrow type
-		BorrowType: nil,
-		Path: interpreter.PathValue{
+		nil,
+		interpreter.AddressValue(testAddress),
+		interpreter.PathValue{
 			Domain:     common.PathDomainPublic,
 			Identifier: testPathIdentifier,
 		},
-		Address: interpreter.AddressValue(testAddress),
-	}
+	)
 
 	pathLinks := []testLink{
 		// Equivalent to:
@@ -2932,25 +2932,25 @@ func TestStorageCapMigration(t *testing.T) {
 	// - the last two have the same borrow type
 
 	// Equivalent to: getCapability<&String>(/storage/test)
-	capabilityValue1 := &interpreter.PathCapabilityValue{ //nolint:staticcheck
-		BorrowType: testBorrowType1,
-		Path:       testPath,
-		Address:    interpreter.AddressValue(testAddress),
-	}
+	capabilityValue1 := interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+		testBorrowType1,
+		interpreter.AddressValue(testAddress),
+		testPath,
+	)
 
 	// Equivalent to: getCapability<&Int>(/storage/test)
-	capabilityValue2 := &interpreter.PathCapabilityValue{ //nolint:staticcheck
-		BorrowType: testBorrowType2,
-		Path:       testPath,
-		Address:    interpreter.AddressValue(testAddress),
-	}
+	capabilityValue2 := interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+		testBorrowType2,
+		interpreter.AddressValue(testAddress),
+		testPath,
+	)
 
 	// Equivalent to: getCapability<&Int>(/storage/test)
-	capabilityValue3 := &interpreter.PathCapabilityValue{ //nolint:staticcheck
-		BorrowType: testBorrowType2,
-		Path:       testPath,
-		Address:    interpreter.AddressValue(testAddress),
-	}
+	capabilityValue3 := interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+		testBorrowType2,
+		interpreter.AddressValue(testAddress),
+		testPath,
+	)
 
 	rt := NewTestInterpreterRuntime()
 
@@ -3227,13 +3227,12 @@ func TestUntypedStorageCapMigration(t *testing.T) {
 		Path:    testPath,
 	}
 
-	capabilityValue := &interpreter.PathCapabilityValue{ //nolint:staticcheck
+	capabilityValue := interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
 		// Borrow type must be nil.
-		BorrowType: nil,
-
-		Path:    testPath,
-		Address: interpreter.AddressValue(testAddress),
-	}
+		nil,
+		interpreter.AddressValue(testAddress),
+		testPath,
+	)
 
 	rt := NewTestInterpreterRuntime()
 
@@ -3502,13 +3501,12 @@ func TestUntypedStorageCapWithMissingTargetMigration(t *testing.T) {
 	// Capability targets `addressB`.
 	// Capability itself is stored in `addressA`
 
-	capabilityValue := &interpreter.PathCapabilityValue{ //nolint:staticcheck
+	capabilityValue := interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
 		// Borrow type must be nil.
-		BorrowType: nil,
-
-		Path:    targetPath,
-		Address: interpreter.AddressValue(addressB),
-	}
+		nil,
+		interpreter.AddressValue(addressB),
+		targetPath,
+	)
 
 	rt := NewTestInterpreterRuntime()
 

--- a/migrations/entitlements/migration.go
+++ b/migrations/entitlements/migration.go
@@ -305,7 +305,7 @@ func (m EntitlementsMigration) ConvertValueToEntitlements(v interpreter.Value) (
 			return interpreter.NewCapabilityValue(
 				inter,
 				v.ID,
-				v.Address,
+				v.Address(),
 				entitledBorrowType,
 			), nil
 		}
@@ -319,11 +319,11 @@ func (m EntitlementsMigration) ConvertValueToEntitlements(v interpreter.Value) (
 		}
 
 		if entitledBorrowType != nil {
-			return &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				Path:       v.Path,
-				Address:    v.Address,
-				BorrowType: entitledBorrowType,
-			}, nil
+			return interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				entitledBorrowType,
+				v.Address(),
+				v.Path,
+			), nil
 		}
 
 	case interpreter.TypeValue:

--- a/migrations/entitlements/migration_test.go
+++ b/migrations/entitlements/migration_test.go
@@ -1232,11 +1232,11 @@ func TestConvertToEntitledValue(t *testing.T) {
 		{
 			name: "path capability value",
 			wrap: func(staticType interpreter.StaticType) interpreter.Value {
-				return &interpreter.PathCapabilityValue{ //nolint:staticcheck
-					BorrowType: staticType,
-					Address:    interpreter.AddressValue{},
-					Path:       interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "test"),
-				}
+				return interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+					staticType,
+					interpreter.AddressValue{},
+					interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "test"),
+				)
 			},
 		},
 		{
@@ -1595,11 +1595,11 @@ func TestNilPathCapabilityValue(t *testing.T) {
 
 	migration := NewEntitlementsMigration(NewTestInterpreter(t))
 	result, err := migration.ConvertValueToEntitlements(
-		&interpreter.PathCapabilityValue{ //nolint:staticcheck
-			Address:    interpreter.NewAddressValue(nil, common.MustBytesToAddress([]byte{0x1})),
-			Path:       interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "test"),
-			BorrowType: nil,
-		},
+		interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+			nil,
+			interpreter.NewAddressValue(nil, common.MustBytesToAddress([]byte{0x1})),
+			interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "test"),
+		),
 	)
 	require.NoError(t, err)
 	require.Nil(t, result)

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -192,7 +192,7 @@ func (testCapMigration) Migrate(
 		return interpreter.NewCapabilityValue(
 			nil,
 			value.ID+10,
-			value.Address,
+			value.Address(),
 			value.BorrowType,
 		), nil
 	}
@@ -2308,14 +2308,14 @@ func TestPublishedValueMigration(t *testing.T) {
 		interpreter.NewPublishedValue(
 			nil,
 			interpreter.AddressValue(testAddress),
-			&interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: nil,
-				Path: interpreter.PathValue{
+			interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				nil,
+				interpreter.AddressValue{0x2},
+				interpreter.PathValue{
 					Domain:     common.PathDomainStorage,
 					Identifier: "foo",
 				},
-				Address: interpreter.AddressValue{0x2},
-			},
+			),
 		),
 	)
 

--- a/migrations/statictypes/account_type_migration_test.go
+++ b/migrations/statictypes/account_type_migration_test.go
@@ -1064,18 +1064,18 @@ func TestMigratingValuesWithAccountStaticType(t *testing.T) {
 		},
 		"path_capability_value": {
 			storedValue: func(_ *interpreter.Interpreter) interpreter.Value {
-				return &interpreter.PathCapabilityValue{ //nolint:staticcheck
-					Address:    interpreter.NewAddressValue(nil, common.Address{0x42}),
-					Path:       interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
-					BorrowType: interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
-				}
+				return interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+					interpreter.PrimitiveStaticTypePublicAccount, //nolint:staticcheck
+					interpreter.NewAddressValue(nil, common.Address{0x42}),
+					interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
+				)
 			},
 			expectedValue: func(_ *interpreter.Interpreter) interpreter.Value {
-				return &interpreter.PathCapabilityValue{ //nolint:staticcheck
-					Address:    interpreter.NewAddressValue(nil, common.Address{0x42}),
-					Path:       interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
-					BorrowType: unauthorizedAccountReferenceType,
-				}
+				return interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+					unauthorizedAccountReferenceType,
+					interpreter.NewAddressValue(nil, common.Address{0x42}),
+					interpreter.NewUnmeteredPathValue(common.PathDomainStorage, "v1"),
+				)
 			},
 			validateStorage: true,
 		},

--- a/migrations/statictypes/statictype_migration.go
+++ b/migrations/statictypes/statictype_migration.go
@@ -93,7 +93,11 @@ func (m *StaticTypeMigration) Migrate(
 		if convertedBorrowType == nil {
 			return nil, nil
 		}
-		return interpreter.NewUnmeteredCapabilityValue(value.ID, value.Address, convertedBorrowType), nil
+		return interpreter.NewUnmeteredCapabilityValue(
+			value.ID,
+			value.Address(),
+			convertedBorrowType,
+		), nil
 
 	case *interpreter.PathCapabilityValue: //nolint:staticcheck
 		// Type is optional
@@ -105,11 +109,11 @@ func (m *StaticTypeMigration) Migrate(
 		if convertedBorrowType == nil {
 			return nil, nil
 		}
-		return &interpreter.PathCapabilityValue{ //nolint:staticcheck
-			BorrowType: convertedBorrowType,
-			Path:       value.Path,
-			Address:    value.Address,
-		}, nil
+		return interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+			convertedBorrowType,
+			value.Address(),
+			value.Path,
+		), nil
 
 	case interpreter.PathLinkValue: //nolint:staticcheck
 		convertedBorrowType := m.maybeConvertStaticType(value.Type, nil)

--- a/migrations/statictypes/statictype_migration_test.go
+++ b/migrations/statictypes/statictype_migration_test.go
@@ -240,19 +240,19 @@ func TestStaticTypeMigration(t *testing.T) {
 
 		actual := migrate(t,
 			staticTypeMigration,
-			&interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: nil,
-				Path:       path,
-				Address:    interpreter.AddressValue(testAddress),
-			},
+			interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				nil,
+				interpreter.AddressValue(testAddress),
+				path,
+			),
 			true,
 		)
 		assert.Equal(t,
-			&interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: nil,
-				Path:       path,
-				Address:    interpreter.AddressValue(testAddress),
-			},
+			interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				nil,
+				interpreter.AddressValue(testAddress),
+				path,
+			),
 			actual,
 		)
 	})

--- a/runtime/capabilitycontrollers_test.go
+++ b/runtime/capabilitycontrollers_test.go
@@ -3799,7 +3799,7 @@ func TestRuntimeCapabilitiesGetBackwardCompatibility(t *testing.T) {
 	t.Run("path capability, typed", func(t *testing.T) {
 		t.Parallel()
 
-		test(t, interpreter.NewUnmeteredPathCapabilityValue(
+		test(t, interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
 			&interpreter.ReferenceStaticType{
 				Authorization:  interpreter.UnauthorizedAccess,
 				ReferencedType: interpreter.PrimitiveStaticTypeInt,
@@ -3815,7 +3815,7 @@ func TestRuntimeCapabilitiesGetBackwardCompatibility(t *testing.T) {
 	t.Run("path capability, untyped", func(t *testing.T) {
 		t.Parallel()
 
-		test(t, interpreter.NewUnmeteredPathCapabilityValue(
+		test(t, interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
 			// NOTE: no borrow type
 			nil,
 			interpreter.AddressValue(testAddress),
@@ -3829,7 +3829,7 @@ func TestRuntimeCapabilitiesGetBackwardCompatibility(t *testing.T) {
 	t.Run("path link", func(t *testing.T) {
 		t.Parallel()
 
-		test(t, interpreter.PathLinkValue{
+		test(t, interpreter.PathLinkValue{ //nolint:staticcheck
 			Type: &interpreter.ReferenceStaticType{
 				Authorization:  interpreter.UnauthorizedAccess,
 				ReferencedType: interpreter.PrimitiveStaticTypeInt,
@@ -3904,7 +3904,7 @@ func TestRuntimeCapabilitiesPublishBackwardCompatibility(t *testing.T) {
 	t.Run("path capability, untyped", func(t *testing.T) {
 		t.Parallel()
 
-		test(t, interpreter.NewUnmeteredPathCapabilityValue(
+		test(t, interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
 			// NOTE: no borrow type
 			nil,
 			interpreter.AddressValue(testAddress),
@@ -3918,7 +3918,7 @@ func TestRuntimeCapabilitiesPublishBackwardCompatibility(t *testing.T) {
 	t.Run("path capability, typed", func(t *testing.T) {
 		t.Parallel()
 
-		test(t, interpreter.NewUnmeteredPathCapabilityValue(
+		test(t, interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
 			&interpreter.ReferenceStaticType{
 				Authorization:  interpreter.UnauthorizedAccess,
 				ReferencedType: interpreter.PrimitiveStaticTypeInt,
@@ -3995,7 +3995,7 @@ func TestRuntimeCapabilitiesUnpublishBackwardCompatibility(t *testing.T) {
 	t.Run("path capability, untyped", func(t *testing.T) {
 		t.Parallel()
 
-		test(t, interpreter.NewUnmeteredPathCapabilityValue(
+		test(t, interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
 			// NOTE: no borrow type
 			nil,
 			interpreter.AddressValue(testAddress),
@@ -4009,7 +4009,7 @@ func TestRuntimeCapabilitiesUnpublishBackwardCompatibility(t *testing.T) {
 	t.Run("path capability, typed", func(t *testing.T) {
 		t.Parallel()
 
-		test(t, interpreter.NewUnmeteredPathCapabilityValue(
+		test(t, interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
 			&interpreter.ReferenceStaticType{
 				Authorization:  interpreter.UnauthorizedAccess,
 				ReferencedType: interpreter.PrimitiveStaticTypeInt,
@@ -4025,7 +4025,7 @@ func TestRuntimeCapabilitiesUnpublishBackwardCompatibility(t *testing.T) {
 	t.Run("path link", func(t *testing.T) {
 		t.Parallel()
 
-		test(t, interpreter.PathLinkValue{
+		test(t, interpreter.PathLinkValue{ //nolint:staticcheck
 			Type: &interpreter.ReferenceStaticType{
 				Authorization:  interpreter.UnauthorizedAccess,
 				ReferencedType: interpreter.PrimitiveStaticTypeInt,

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -713,8 +713,12 @@ func exportPathCapabilityValue(
 	v *interpreter.PathCapabilityValue, //nolint:staticcheck
 	inter *interpreter.Interpreter,
 ) (cadence.Capability, error) {
-	borrowType := inter.MustConvertStaticToSemaType(v.BorrowType)
-	exportedBorrowType := ExportMeteredType(inter, borrowType, map[sema.TypeID]cadence.Type{})
+	var exportedBorrowType cadence.Type
+
+	if v.BorrowType != nil {
+		borrowType := inter.MustConvertStaticToSemaType(v.BorrowType)
+		exportedBorrowType = ExportMeteredType(inter, borrowType, map[sema.TypeID]cadence.Type{})
+	}
 
 	capability := cadence.NewMeteredCapability(
 		inter,

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -704,7 +704,7 @@ func exportCapabilityValue(
 	return cadence.NewMeteredCapability(
 		inter,
 		cadence.NewMeteredUInt64(inter, uint64(v.ID)),
-		cadence.NewMeteredAddress(inter, v.Address),
+		cadence.NewMeteredAddress(inter, v.Address()),
 		exportedBorrowType,
 	), nil
 }
@@ -719,7 +719,7 @@ func exportPathCapabilityValue(
 	capability := cadence.NewMeteredCapability(
 		inter,
 		cadence.NewMeteredUInt64(inter, uint64(interpreter.InvalidCapabilityID)),
-		cadence.NewMeteredAddress(inter, v.Address),
+		cadence.NewMeteredAddress(inter, v.Address()),
 		exportedBorrowType,
 	)
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -568,14 +568,14 @@ func TestRuntimeExportValue(t *testing.T) {
 		},
 		{
 			label: "path capability",
-			value: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: interpreter.PrimitiveStaticTypeAnyResource,
-				Path: interpreter.PathValue{
+			value: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				interpreter.PrimitiveStaticTypeAnyResource,
+				interpreter.AddressValue{0x1},
+				interpreter.PathValue{
 					Domain:     common.PathDomainStorage,
 					Identifier: "foo",
 				},
-				Address: interpreter.AddressValue{0x1},
-			},
+			),
 			expected: cadence.NewDeprecatedPathCapability( //nolint:staticcheck
 				cadence.Address{0x1},
 				cadence.MustNewPath(common.PathDomainStorage, "foo"),

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -567,7 +567,7 @@ func TestRuntimeExportValue(t *testing.T) {
 			invalid: true,
 		},
 		{
-			label: "path capability",
+			label: "path capability, typed",
 			value: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
 				interpreter.PrimitiveStaticTypeAnyResource,
 				interpreter.AddressValue{0x1},
@@ -580,6 +580,23 @@ func TestRuntimeExportValue(t *testing.T) {
 				cadence.Address{0x1},
 				cadence.MustNewPath(common.PathDomainStorage, "foo"),
 				cadence.AnyResourceType,
+			),
+		},
+		{
+			label: "path capability, untyped",
+			value: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				// NOTE: no borrow type
+				nil,
+				interpreter.AddressValue{0x1},
+				interpreter.PathValue{
+					Domain:     common.PathDomainStorage,
+					Identifier: "foo",
+				},
+			),
+			expected: cadence.NewDeprecatedPathCapability( //nolint:staticcheck
+				cadence.Address{0x1},
+				cadence.MustNewPath(common.PathDomainStorage, "foo"),
+				nil,
 			),
 		},
 	} {

--- a/runtime/interpreter/decode.go
+++ b/runtime/interpreter/decode.go
@@ -1409,7 +1409,7 @@ func (d StorableDecoder) decodePathCapability() (*PathCapabilityValue, error) {
 	}
 
 	return &PathCapabilityValue{
-		Address:    address,
+		address:    address,
 		Path:       pathValue,
 		BorrowType: borrowType,
 	}, nil

--- a/runtime/interpreter/encode.go
+++ b/runtime/interpreter/encode.go
@@ -889,7 +889,7 @@ func (v *IDCapabilityValue) Encode(e *atree.Encoder) error {
 	}
 
 	// Encode address at array index encodedCapabilityValueAddressFieldKey
-	err = v.Address.Encode(e)
+	err = v.address.Encode(e)
 	if err != nil {
 		return err
 	}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -2194,12 +2194,12 @@ func (interpreter *Interpreter) convert(value Value, valueType, targetType sema.
 				valueBorrowType := capability.BorrowType.(*ReferenceStaticType)
 				borrowType := interpreter.convertStaticType(valueBorrowType, targetBorrowType)
 				if capability.isInvalid() {
-					return NewInvalidCapabilityValue(interpreter, capability.Address, borrowType)
+					return NewInvalidCapabilityValue(interpreter, capability.address, borrowType)
 				}
 				return NewCapabilityValue(
 					interpreter,
 					capability.ID,
-					capability.Address,
+					capability.address,
 					borrowType,
 				)
 			default:
@@ -4244,7 +4244,7 @@ func (interpreter *Interpreter) checkValue(
 		_ = interpreter.SharedState.Config.CapabilityCheckHandler(
 			interpreter,
 			locationRange,
-			capability.Address,
+			capability.address,
 			capability.ID,
 			referenceType,
 			referenceType,

--- a/runtime/interpreter/value_pathcapability.go
+++ b/runtime/interpreter/value_pathcapability.go
@@ -43,6 +43,7 @@ var _ EquatableValue = &PathCapabilityValue{}
 var _ MemberAccessibleValue = &PathCapabilityValue{}
 var _ CapabilityValue = &PathCapabilityValue{}
 
+// Deprecated: NewUnmeteredPathCapabilityValue
 func NewUnmeteredPathCapabilityValue(
 	borrowType StaticType,
 	address AddressValue,

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -1182,29 +1182,30 @@ func TestStringer(t *testing.T) {
 		},
 		"Path capability with borrow type": {
 			value: func(_ *Interpreter) Value {
-				return &PathCapabilityValue{ //nolint:staticcheck
-					BorrowType: &ReferenceStaticType{
+				return NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+					&ReferenceStaticType{
 						Authorization:  UnauthorizedAccess,
 						ReferencedType: PrimitiveStaticTypeInt,
 					},
-					Path: NewUnmeteredPathValue(
+					NewUnmeteredAddressValueFromBytes([]byte{1, 2, 3, 4, 5}),
+					NewUnmeteredPathValue(
 						common.PathDomainStorage,
 						"foo",
 					),
-					Address: NewUnmeteredAddressValueFromBytes([]byte{1, 2, 3, 4, 5}),
-				}
+				)
 			},
 			expected: "Capability<&Int>(address: 0x0000000102030405, path: /storage/foo)",
 		},
 		"Path capability without borrow type": {
 			value: func(_ *Interpreter) Value {
-				return &PathCapabilityValue{ //nolint:staticcheck
-					Path: NewUnmeteredPathValue(
+				return NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+					nil,
+					NewUnmeteredAddressValueFromBytes([]byte{1, 2, 3, 4, 5}),
+					NewUnmeteredPathValue(
 						common.PathDomainStorage,
 						"foo",
 					),
-					Address: NewUnmeteredAddressValueFromBytes([]byte{1, 2, 3, 4, 5}),
-				}
+				)
 			},
 			expected: "Capability(address: 0x0000000102030405, path: /storage/foo)",
 		},

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -3951,7 +3951,7 @@ func newAccountCapabilitiesGetFunction(
 					capabilityAddress = readValue.Address()
 					capabilityStaticBorrowType = readValue.BorrowType
 
-				case *interpreter.PathCapabilityValue:
+				case *interpreter.PathCapabilityValue: //nolint:staticcheck
 					capabilityID = interpreter.InvalidCapabilityID
 					capabilityAddress = readValue.Address()
 					capabilityStaticBorrowType = readValue.BorrowType

--- a/runtime/stdlib/account.go
+++ b/runtime/stdlib/account.go
@@ -3529,7 +3529,7 @@ func newAccountCapabilitiesPublishFunction(
 					panic(errors.NewUnreachableError())
 				}
 
-				capabilityAddressValue := capabilityValue.Address
+				capabilityAddressValue := capabilityValue.Address()
 				if capabilityAddressValue != accountAddressValue {
 					panic(interpreter.CapabilityAddressPublishingError{
 						LocationRange:     locationRange,
@@ -3952,7 +3952,7 @@ func newAccountCapabilitiesGetFunction(
 				}
 
 				capabilityID := readCapabilityValue.ID
-				capabilityAddress := readCapabilityValue.Address
+				capabilityAddress := readCapabilityValue.Address()
 
 				var resultValue interpreter.Value
 				if borrow {

--- a/runtime/tests/interpreter/pathcapability_test.go
+++ b/runtime/tests/interpreter/pathcapability_test.go
@@ -46,14 +46,14 @@ func TestInterpretPathCapability(t *testing.T) {
 			Type: &sema.CapabilityType{
 				BorrowType: borrowType,
 			},
-			Value: &interpreter.PathCapabilityValue{ //nolint:staticcheck
-				BorrowType: borrowStaticType,
-				Path: interpreter.PathValue{
+			Value: interpreter.NewUnmeteredPathCapabilityValue( //nolint:staticcheck
+				borrowStaticType,
+				interpreter.AddressValue{0x42},
+				interpreter.PathValue{
 					Domain:     common.PathDomainStorage,
 					Identifier: "foo",
 				},
-				Address: interpreter.AddressValue{0x42},
-			},
+			),
 			Name: "cap",
 			Kind: common.DeclarationKindConstant,
 		}


### PR DESCRIPTION
## Description

Path links which cannot be migrated stay as-is (see `LinkValueMigration.Migrate`, when `getPathCapabilityFinalTarget` returns failure). Path capabilities which cannot be migrated stay as-is (see `CapabilityValueMigration.migratePathCapabilityValue`, when controller ID is missing from mapping).

As result, we cannot assume capability values in general and values stored in public paths are always ID capability values (`IDCapabilityValue`), they might be path capability values (`PathCapabilityValue`) and path link values (`PathLinkValue`).

- Add a `CapabilityValue.Address()` function to easily get the address of `IDCapabilityValue` and `PathCapabilityValue`.

  I didn't do this for the `Type` and `ID` fields, because I realized it would require a lot more code to change. It still would be nice to also add getter functions for those fields, in a follow up PR, later

- Fix the export of path capability values. They don't always have a borrow type.
  
  I noticed this when writing the tests, as publishing a capability emits an event which includes the capability, which leads to an export of the event and the capability it contains.

- Handle path capability values and path link values in `Account.capabilities.get`, `publish`, and `unpublish` 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
