### PR TITLE
Add Type.address and Type.contractName

### DIFF
--- a/runtime/interpreter/value_type.go
+++ b/runtime/interpreter/value_type.go
@@ -172,6 +172,31 @@ func (v TypeValue) GetMember(interpreter *Interpreter, _ LocationRange, name str
 		}
 
 		return AsBoolValue(elaboration.IsRecovered)
+
+	case sema.MetaTypeAddressFieldName:
+		staticType := v.Type
+		if staticType == nil {
+			return Nil
+		}
+
+		location, _, err := common.DecodeTypeID(interpreter, string(staticType.ID()))
+		if err != nil || location == nil {
+			return Nil
+		}
+
+		addressLocation, ok := location.(common.AddressLocation)
+		if !ok {
+			return Nil
+		}
+
+		addressValue := NewAddressValue(
+			interpreter,
+			addressLocation.Address,
+		)
+		return NewSomeValueNonCopying(
+			interpreter,
+			addressValue,
+		)
 	}
 
 	return nil

--- a/runtime/interpreter/value_type.go
+++ b/runtime/interpreter/value_type.go
@@ -181,8 +181,16 @@ func (v TypeValue) GetMember(interpreter *Interpreter, _ LocationRange, name str
 			return Nil
 		}
 
-		location, _, err := common.DecodeTypeID(interpreter, string(staticType.ID()))
-		if err != nil || location == nil {
+		var location common.Location
+
+		switch staticType := staticType.(type) {
+		case *CompositeStaticType:
+			location = staticType.Location
+
+		case *InterfaceStaticType:
+			location = staticType.Location
+
+		default:
 			return Nil
 		}
 
@@ -206,8 +214,19 @@ func (v TypeValue) GetMember(interpreter *Interpreter, _ LocationRange, name str
 			return Nil
 		}
 
-		location, qualifiedIdentifier, err := common.DecodeTypeID(interpreter, string(staticType.ID()))
-		if err != nil || location == nil {
+		var location common.Location
+		var qualifiedIdentifier string
+
+		switch staticType := staticType.(type) {
+		case *CompositeStaticType:
+			location = staticType.Location
+			qualifiedIdentifier = staticType.QualifiedIdentifier
+
+		case *InterfaceStaticType:
+			location = staticType.Location
+			qualifiedIdentifier = staticType.QualifiedIdentifier
+
+		default:
 			return Nil
 		}
 

--- a/runtime/sema/meta_type.go
+++ b/runtime/sema/meta_type.go
@@ -69,6 +69,16 @@ const metaTypeIsRecoveredFieldDocString = `
 The type was defined through a recovered program
 `
 
+const MetaTypeAddressFieldName = "address"
+
+var MetaTypeAddressFieldType = &OptionalType{
+	Type: TheAddressType,
+}
+
+const metaTypeAddressFieldDocString = `
+The address of the type, if it was declared in a contract deployed to an account
+`
+
 func init() {
 	MetaType.Members = func(t *SimpleType) map[string]MemberResolver {
 		return MembersAsResolvers([]*Member{
@@ -89,6 +99,12 @@ func init() {
 				MetaTypeIsRecoveredFieldName,
 				MetaTypeIsRecoveredFieldType,
 				metaTypeIsRecoveredFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				MetaTypeAddressFieldName,
+				MetaTypeAddressFieldType,
+				metaTypeAddressFieldDocString,
 			),
 		})
 	}

--- a/runtime/sema/meta_type.go
+++ b/runtime/sema/meta_type.go
@@ -79,6 +79,16 @@ const metaTypeAddressFieldDocString = `
 The address of the type, if it was declared in a contract deployed to an account
 `
 
+const MetaTypeContractNameFieldName = "contractName"
+
+var MetaTypeContractNameFieldType = &OptionalType{
+	Type: StringType,
+}
+
+const metaTypeContractNameFieldDocString = `
+The contract name of the type, if it was declared in a contract
+`
+
 func init() {
 	MetaType.Members = func(t *SimpleType) map[string]MemberResolver {
 		return MembersAsResolvers([]*Member{
@@ -105,6 +115,12 @@ func init() {
 				MetaTypeAddressFieldName,
 				MetaTypeAddressFieldType,
 				metaTypeAddressFieldDocString,
+			),
+			NewUnmeteredPublicConstantFieldMember(
+				t,
+				MetaTypeContractNameFieldName,
+				MetaTypeContractNameFieldType,
+				metaTypeContractNameFieldDocString,
 			),
 		})
 	}

--- a/runtime/tests/checker/metatype_test.go
+++ b/runtime/tests/checker/metatype_test.go
@@ -317,6 +317,16 @@ func TestCheckMetaTypeIsRecovered(t *testing.T) {
       let type: Type = Type<Int>()
       let isRecovered: Bool = type.isRecovered
     `)
+	require.NoError(t, err)
+}
 
+func TestCheckMetaTypeAddress(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      let type: Type = Type<Int>()
+      let address: Address = type.address!
+    `)
 	require.NoError(t, err)
 }

--- a/runtime/tests/checker/metatype_test.go
+++ b/runtime/tests/checker/metatype_test.go
@@ -330,3 +330,14 @@ func TestCheckMetaTypeAddress(t *testing.T) {
     `)
 	require.NoError(t, err)
 }
+
+func TestCheckMetaTypeContractName(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+      let type: Type = Type<Int>()
+      let contractName: String = type.contractName!
+    `)
+	require.NoError(t, err)
+}

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -1224,3 +1224,190 @@ func TestInterpretMetaTypeAddress(t *testing.T) {
 		)
 	})
 }
+
+func TestInterpretMetaTypeContractName(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("built-in", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          let type = Type<Int>()
+          let contractName = type.contractName
+        `)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.Nil,
+			inter.Globals.Get("contractName").GetValue(inter),
+		)
+	})
+
+	t.Run("address location", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          fun test(): String? {
+              let type = CompositeType("A.0000000000000001.X.Y")!
+              return type.contractName
+          }
+        `)
+
+		addressLocation := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "X",
+		}
+
+		yType := &sema.CompositeType{
+			Location:   addressLocation,
+			Kind:       common.CompositeKindStructure,
+			Identifier: "Y",
+		}
+		xType := &sema.CompositeType{
+			Location:   addressLocation,
+			Kind:       common.CompositeKindContract,
+			Identifier: "X",
+		}
+		xType.SetNestedType("Y", yType)
+		yType.SetContainerType(xType)
+
+		inter.SharedState.Config.ImportLocationHandler =
+			func(_ *interpreter.Interpreter, _ common.Location) interpreter.Import {
+				elaboration := sema.NewElaboration(nil)
+				elaboration.SetCompositeType(
+					addressLocation.TypeID(nil, "X"),
+					xType,
+				)
+				elaboration.SetCompositeType(
+					addressLocation.TypeID(nil, "X.Y"),
+					yType,
+				)
+				return interpreter.VirtualImport{
+					Elaboration: elaboration,
+				}
+			}
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredSomeValueNonCopying(
+				interpreter.NewUnmeteredStringValue("X"),
+			),
+			result,
+		)
+	})
+
+	t.Run("string location", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          fun test(): String? {
+		      let type = CompositeType("S.test2.X.Y")!
+              return type.contractName
+          }
+        `)
+
+		stringLocation := common.StringLocation("test2")
+
+		yType := &sema.CompositeType{
+			Location:   stringLocation,
+			Kind:       common.CompositeKindStructure,
+			Identifier: "Y",
+		}
+		xType := &sema.CompositeType{
+			Location:   stringLocation,
+			Kind:       common.CompositeKindContract,
+			Identifier: "X",
+		}
+		xType.SetNestedType("Y", yType)
+		yType.SetContainerType(xType)
+
+		inter.SharedState.Config.ImportLocationHandler =
+			func(_ *interpreter.Interpreter, _ common.Location) interpreter.Import {
+				elaboration := sema.NewElaboration(nil)
+				elaboration.SetCompositeType(
+					stringLocation.TypeID(nil, "X"),
+					xType,
+				)
+				elaboration.SetCompositeType(
+					stringLocation.TypeID(nil, "X.Y"),
+					yType,
+				)
+				return interpreter.VirtualImport{
+					Elaboration: elaboration,
+				}
+			}
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredSomeValueNonCopying(
+				interpreter.NewUnmeteredStringValue("X"),
+			),
+			result,
+		)
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+
+		t.Parallel()
+
+		valueDeclarations := []stdlib.StandardLibraryValue{
+			{
+				Name: "unknownType",
+				Type: sema.MetaType,
+				Value: interpreter.TypeValue{
+					Type: nil,
+				},
+				Kind: common.DeclarationKindConstant,
+			},
+		}
+
+		baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+		for _, valueDeclaration := range valueDeclarations {
+			baseValueActivation.DeclareValue(valueDeclaration)
+		}
+
+		baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
+		for _, valueDeclaration := range valueDeclarations {
+			interpreter.Declare(baseActivation, valueDeclaration)
+		}
+
+		inter, err := parseCheckAndInterpretWithOptions(t,
+			`
+	         let contractName = unknownType.contractName
+	       `,
+			ParseCheckAndInterpretOptions{
+				CheckerConfig: &sema.Config{
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
+				},
+				Config: &interpreter.Config{
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.Nil,
+			inter.Globals.Get("contractName").GetValue(inter),
+		)
+	})
+}

--- a/runtime/tests/interpreter/metatype_test.go
+++ b/runtime/tests/interpreter/metatype_test.go
@@ -1067,3 +1067,160 @@ func TestInterpretMetaTypeIsRecovered(t *testing.T) {
 		require.ErrorIs(t, err, importErr)
 	})
 }
+
+func TestInterpretMetaTypeAddress(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("built-in", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          let type = Type<Int>()
+          let address = type.address
+        `)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.Nil,
+			inter.Globals.Get("address").GetValue(inter),
+		)
+	})
+
+	t.Run("address location", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          fun test(): Address? {
+              let type = CompositeType("A.0000000000000001.X.Y")!
+              return type.address
+          }
+        `)
+
+		addressLocation := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "X",
+		}
+
+		inter.SharedState.Config.ImportLocationHandler =
+			func(_ *interpreter.Interpreter, _ common.Location) interpreter.Import {
+				elaboration := sema.NewElaboration(nil)
+				elaboration.SetCompositeType(
+					addressLocation.TypeID(nil, "X.Y"),
+					&sema.CompositeType{
+						Location: addressLocation,
+						Kind:     common.CompositeKindStructure,
+					},
+				)
+				return interpreter.VirtualImport{
+					Elaboration: elaboration,
+				}
+			}
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredSomeValueNonCopying(
+				interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
+			),
+			result,
+		)
+	})
+
+	t.Run("string location", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+          fun test(): Address? {
+		      let type = CompositeType("S.test2.X.Y")!
+              return type.address
+          }
+        `)
+
+		stringLocation := common.StringLocation("test2")
+
+		inter.SharedState.Config.ImportLocationHandler =
+			func(_ *interpreter.Interpreter, _ common.Location) interpreter.Import {
+				elaboration := sema.NewElaboration(nil)
+				elaboration.SetCompositeType(
+					stringLocation.TypeID(nil, "X.Y"),
+					&sema.CompositeType{
+						Location: stringLocation,
+						Kind:     common.CompositeKindStructure,
+					},
+				)
+				return interpreter.VirtualImport{
+					Elaboration: elaboration,
+				}
+			}
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.Nil,
+			result,
+		)
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+
+		t.Parallel()
+
+		valueDeclarations := []stdlib.StandardLibraryValue{
+			{
+				Name: "unknownType",
+				Type: sema.MetaType,
+				Value: interpreter.TypeValue{
+					Type: nil,
+				},
+				Kind: common.DeclarationKindConstant,
+			},
+		}
+
+		baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+		for _, valueDeclaration := range valueDeclarations {
+			baseValueActivation.DeclareValue(valueDeclaration)
+		}
+
+		baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
+		for _, valueDeclaration := range valueDeclarations {
+			interpreter.Declare(baseActivation, valueDeclaration)
+		}
+
+		inter, err := parseCheckAndInterpretWithOptions(t,
+			`
+	         let address = unknownType.address
+	       `,
+			ParseCheckAndInterpretOptions{
+				CheckerConfig: &sema.Config{
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
+				},
+				Config: &interpreter.Config{
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.Nil,
+			inter.Globals.Get("address").GetValue(inter),
+		)
+	})
+}


### PR DESCRIPTION
## Description

Extend `Type` by adding two new fields:

- ```cadence
  /// The address of the type, if it was declared in a contract deployed to an account
  let address: Address?
  ```

- ```cadence
  /// The contract name of the type, if it was declared in a contract
  let contractName: String?
  ```

Currently, getting this information requires manually extracting the information from the type identifier, e.g. https://github.com/onflow/flow-evm-bridge/blob/ca95d452aa89ba17ca79776592ff9fd7a9d7f804/cadence/contracts/bridge/FlowEVMBridgeUtils.cdc#L947-L960

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
