### PR TITLE
Fix CI: Flow CLI is 1.0 now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: make ci
 
       - name: Cadence Testing Framework
-        run: cd runtime/stdlib/contracts && flow-c1 test --cover --covercode="contracts" crypto_test.cdc
+        run: cd runtime/stdlib/contracts && flow test --cover --covercode="contracts" crypto_test.cdc
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v2


### PR DESCRIPTION

## Description

`flow-c1` is gone, `flow` is now 1.0

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
