### PR TITLE
Change index expression's start position

### DIFF
--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -2676,49 +2676,6 @@ func TestRuntimeGetAuthAccount(t *testing.T) {
 
 		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
 	})
-
-	t.Run("update names index expression start position", func(t *testing.T) {
-		t.Parallel()
-
-		rt := NewTestInterpreterRuntime()
-
-		script := []byte(`
-            transaction {
-                prepare(signer: auth(Mutate) &Account) {
-                    signer.contracts.names[0] = "baz"
-                }
-            }
-        `)
-
-		runtimeInterface := &TestRuntimeInterface{
-			OnGetSigningAccounts: func() ([]Address, error) {
-				return []Address{{42}}, nil
-			},
-			OnGetAccountContractNames: func(_ Address) ([]string, error) {
-				return []string{"foo", "bar"}, nil
-			},
-		}
-
-		nextTransactionLocation := NewTransactionLocationGenerator()
-
-		err := rt.ExecuteTransaction(
-			Script{
-				Source: script,
-			},
-			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-			},
-		)
-
-		errs := checker.RequireCheckerErrors(t, err, 1)
-
-		assert.IsType(t, &sema.UnauthorizedReferenceAssignmentError{}, errs[0])
-
-		unauthorizedReferenceAssignmentError := errs[0].(*sema.UnauthorizedReferenceAssignmentError)
-		assert.Equal(t, 20, unauthorizedReferenceAssignmentError.StartPos.Column)
-		assert.Equal(t, 44, unauthorizedReferenceAssignmentError.EndPos.Column)
-	})
 }
 
 type fakeError struct{}

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -1262,7 +1262,7 @@ func defineIndexExpression() {
 				firstIndexExpr,
 				ast.NewRange(
 					p.memoryGauge,
-					token.StartPos,
+					left.StartPosition(),
 					endToken.EndPos,
 				),
 			), nil

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -1245,7 +1245,7 @@ func defineIndexExpression() {
 	setExprLeftBindingPower(lexer.TokenBracketOpen, exprLeftBindingPowerAccess)
 	setExprLeftDenotation(
 		lexer.TokenBracketOpen,
-		func(p *parser, token lexer.Token, left ast.Expression) (ast.Expression, error) {
+		func(p *parser, _ lexer.Token, left ast.Expression) (ast.Expression, error) {
 			firstIndexExpr, err := parseExpression(p, lowestBindingPower)
 			if err != nil {
 				return nil, err

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -952,7 +952,7 @@ func TestParseIndexExpression(t *testing.T) {
 					},
 				},
 				Range: ast.Range{
-					StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 					EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
 				},
 			},
@@ -984,7 +984,7 @@ func TestParseIndexExpression(t *testing.T) {
 					},
 				},
 				Range: ast.Range{
-					StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 					EndPos:   ast.Position{Line: 1, Column: 6, Offset: 6},
 				},
 			},
@@ -1013,7 +1013,7 @@ func TestParseIndexExpression(t *testing.T) {
 					},
 				},
 				Range: ast.Range{
-					StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
 					EndPos:   ast.Position{Line: 1, Column: 6, Offset: 6},
 				},
 			},
@@ -2425,7 +2425,7 @@ func TestParseReference(t *testing.T) {
 						},
 					},
 					Range: ast.Range{
-						StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+						StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
 						EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
 					},
 				},
@@ -2500,9 +2500,9 @@ func TestParseNilCoelesceReference(t *testing.T) {
 						},
 						Range: ast.Range{
 							StartPos: ast.Position{
-								Offset: 14,
+								Offset: 12,
 								Line:   2,
-								Column: 13,
+								Column: 11,
 							},
 							EndPos: ast.Position{
 								Offset: 18,
@@ -5076,7 +5076,7 @@ func TestParseIndexExpressionInVariableDeclaration(t *testing.T) {
 						},
 					},
 					Range: ast.Range{
-						StartPos: ast.Position{Offset: 15, Line: 2, Column: 14},
+						StartPos: ast.Position{Offset: 14, Line: 2, Column: 13},
 						EndPos:   ast.Position{Offset: 17, Line: 2, Column: 16},
 					},
 				},
@@ -6558,7 +6558,7 @@ func TestParseReferenceInVariableDeclaration(t *testing.T) {
 						},
 					},
 					Range: ast.Range{
-						StartPos: ast.Position{Offset: 32, Line: 2, Column: 31},
+						StartPos: ast.Position{Offset: 17, Line: 2, Column: 16},
 						EndPos:   ast.Position{Offset: 34, Line: 2, Column: 33},
 					},
 				},

--- a/runtime/parser/statement_test.go
+++ b/runtime/parser/statement_test.go
@@ -2106,7 +2106,7 @@ func TestParseAccessAssignment(t *testing.T) {
 												},
 											},
 											Range: ast.Range{
-												StartPos: ast.Position{Offset: 40, Line: 3, Column: 21},
+												StartPos: ast.Position{Offset: 31, Line: 3, Column: 12},
 												EndPos:   ast.Position{Offset: 42, Line: 3, Column: 23},
 											},
 										},
@@ -2120,7 +2120,7 @@ func TestParseAccessAssignment(t *testing.T) {
 											},
 										},
 										Range: ast.Range{
-											StartPos: ast.Position{Offset: 43, Line: 3, Column: 24},
+											StartPos: ast.Position{Offset: 31, Line: 3, Column: 12},
 											EndPos:   ast.Position{Offset: 45, Line: 3, Column: 26},
 										},
 									},
@@ -2219,7 +2219,7 @@ func TestParseExpressionStatementWithAccess(t *testing.T) {
 												},
 											},
 											Range: ast.Range{
-												StartPos: ast.Position{Offset: 28, Line: 2, Column: 27},
+												StartPos: ast.Position{Offset: 19, Line: 2, Column: 18},
 												EndPos:   ast.Position{Offset: 30, Line: 2, Column: 29},
 											},
 										},
@@ -2233,7 +2233,7 @@ func TestParseExpressionStatementWithAccess(t *testing.T) {
 											},
 										},
 										Range: ast.Range{
-											StartPos: ast.Position{Offset: 31, Line: 2, Column: 30},
+											StartPos: ast.Position{Offset: 19, Line: 2, Column: 18},
 											EndPos:   ast.Position{Offset: 33, Line: 2, Column: 32},
 										},
 									},
@@ -2531,7 +2531,7 @@ func TestParseSwapStatementInFunctionDeclaration(t *testing.T) {
 										},
 									},
 									Range: ast.Range{
-										StartPos: ast.Position{Offset: 33, Line: 3, Column: 13},
+										StartPos: ast.Position{Offset: 30, Line: 3, Column: 10},
 										EndPos:   ast.Position{Offset: 35, Line: 3, Column: 15},
 									},
 								},

--- a/runtime/tests/checker/purity_test.go
+++ b/runtime/tests/checker/purity_test.go
@@ -397,7 +397,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 		assert.Equal(
 			t,
 			ast.Range{
-				StartPos: ast.Position{Offset: 66, Line: 5, Column: 15},
+				StartPos: ast.Position{Offset: 65, Line: 5, Column: 14},
 				EndPos:   ast.Position{Offset: 72, Line: 5, Column: 21},
 			},
 			errs[0].(*sema.PurityError).Range,
@@ -552,7 +552,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 		assert.Equal(
 			t,
 			ast.Range{
-				StartPos: ast.Position{Offset: 133, Line: 7, Column: 15},
+				StartPos: ast.Position{Offset: 132, Line: 7, Column: 14},
 				EndPos:   ast.Position{Offset: 145, Line: 7, Column: 27},
 			},
 			errs[0].(*sema.PurityError).Range,
@@ -666,7 +666,7 @@ func TestCheckPurityEnforcement(t *testing.T) {
 		assert.Equal(
 			t,
 			ast.Range{
-				StartPos: ast.Position{Offset: 183, Line: 9, Column: 19},
+				StartPos: ast.Position{Offset: 182, Line: 9, Column: 18},
 				EndPos:   ast.Position{Offset: 191, Line: 9, Column: 27},
 			},
 			errs[0].(*sema.PurityError).Range,
@@ -929,7 +929,7 @@ func TestCheckResourceWritePurity(t *testing.T) {
 		assert.Equal(
 			t,
 			ast.Range{
-				StartPos: ast.Position{Offset: 202, Line: 10, Column: 19},
+				StartPos: ast.Position{Offset: 201, Line: 10, Column: 18},
 				EndPos:   ast.Position{Offset: 210, Line: 10, Column: 27},
 			},
 			errs[0].(*sema.PurityError).Range,
@@ -960,7 +960,7 @@ func TestCheckResourceWritePurity(t *testing.T) {
 		assert.Equal(
 			t,
 			ast.Range{
-				StartPos: ast.Position{Offset: 209, Line: 10, Column: 22},
+				StartPos: ast.Position{Offset: 205, Line: 10, Column: 18},
 				EndPos:   ast.Position{Offset: 217, Line: 10, Column: 30},
 			},
 			errs[0].(*sema.PurityError).Range,
@@ -1104,7 +1104,7 @@ func TestCheckCompositeWritePurity(t *testing.T) {
 		assert.Equal(
 			t,
 			ast.Range{
-				StartPos: ast.Position{Offset: 124, Line: 8, Column: 19},
+				StartPos: ast.Position{Offset: 123, Line: 8, Column: 18},
 				EndPos:   ast.Position{Offset: 130, Line: 8, Column: 25},
 			},
 			errs[0].(*sema.PurityError).Range,
@@ -1136,7 +1136,7 @@ func TestCheckCompositeWritePurity(t *testing.T) {
 		require.IsType(t, &sema.PurityError{}, errs[0])
 		assert.Equal(t,
 			ast.Range{
-				StartPos: ast.Position{Offset: 126, Line: 8, Column: 19},
+				StartPos: ast.Position{Offset: 125, Line: 8, Column: 18},
 				EndPos:   ast.Position{Offset: 132, Line: 8, Column: 25},
 			},
 			errs[0].(*sema.PurityError).Range)

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -826,7 +826,7 @@ func TestInterpretInvalidArrayIndexing(t *testing.T) {
 			assert.Equal(t, index, indexErr.Index)
 			assert.Equal(t, 2, indexErr.Size)
 			assert.Equal(t,
-				ast.Position{Offset: 107, Line: 4, Column: 27},
+				ast.Position{Offset: 106, Line: 4, Column: 26},
 				indexErr.HasPosition.StartPosition(),
 			)
 			assert.Equal(t,
@@ -901,7 +901,7 @@ func TestInterpretInvalidArrayIndexingAssignment(t *testing.T) {
 			assert.Equal(t, index, indexErr.Index)
 			assert.Equal(t, 2, indexErr.Size)
 			assert.Equal(t,
-				ast.Position{Offset: 95, Line: 4, Column: 20},
+				ast.Position{Offset: 94, Line: 4, Column: 19},
 				indexErr.HasPosition.StartPosition(),
 			)
 			assert.Equal(t,
@@ -971,7 +971,7 @@ func TestInterpretInvalidStringIndexing(t *testing.T) {
 			assert.Equal(t, index, indexErr.Index)
 			assert.Equal(t, 2, indexErr.Length)
 			assert.Equal(t,
-				ast.Position{Offset: 93, Line: 4, Column: 20},
+				ast.Position{Offset: 92, Line: 4, Column: 19},
 				indexErr.HasPosition.StartPosition(),
 			)
 			assert.Equal(t,


### PR DESCRIPTION
Closes #718

## Description

This PR adds a test which throws an error involving index expression different from the type mismatch error addressed in #719. Index expression's start position was changed from opening square bracket to indexed expression's start position.
<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
