### PR TITLE
Unwrap optionals with dynamic cast

### DIFF
--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4025,16 +4025,6 @@ func (interpreter *Interpreter) IsSubTypeOfSemaType(staticSubType StaticType, su
 	return sema.IsSubType(semaSubType, superType)
 }
 
-func (interpreter *Interpreter) IsUnwrappable(staticSubType StaticType, superType sema.Type) bool {
-	// this is a specific check for if a subtype (which must be an optional) is unwrappable to supertype
-	// which is essentially just unwrapping the subtype first before checking
-	if staticSubType, ok := staticSubType.(*OptionalStaticType); ok {
-		return interpreter.IsUnwrappable(staticSubType.Type, superType)
-	}
-
-	return interpreter.IsSubTypeOfSemaType(staticSubType, superType)
-}
-
 func (interpreter *Interpreter) domainPaths(address common.Address, domain common.PathDomain) []Value {
 	storageMap := interpreter.Storage().GetStorageMap(address, domain.Identifier(), false)
 	if storageMap == nil {

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4028,8 +4028,7 @@ func (interpreter *Interpreter) IsSubTypeOfSemaType(staticSubType StaticType, su
 func (interpreter *Interpreter) IsUnwrappable(staticSubType StaticType, superType sema.Type) bool {
 	// this is a specific check for if a subtype (which must be an optional) is unwrappable to supertype
 	// which is essentially just unwrapping the subtype first before checking
-	switch staticSubType := staticSubType.(type) {
-	case *OptionalStaticType:
+	if staticSubType, ok := staticSubType.(*OptionalStaticType); ok {
 		return interpreter.IsUnwrappable(staticSubType.Type, superType)
 	}
 

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -4025,6 +4025,17 @@ func (interpreter *Interpreter) IsSubTypeOfSemaType(staticSubType StaticType, su
 	return sema.IsSubType(semaSubType, superType)
 }
 
+func (interpreter *Interpreter) IsUnwrappable(staticSubType StaticType, superType sema.Type) bool {
+	// this is a specific check for if a subtype (which must be an optional) is unwrappable to supertype
+	// which is essentially just unwrapping the subtype first before checking
+	switch staticSubType := staticSubType.(type) {
+	case *OptionalStaticType:
+		return interpreter.IsUnwrappable(staticSubType.Type, superType)
+	}
+
+	return interpreter.IsSubTypeOfSemaType(staticSubType, superType)
+}
+
 func (interpreter *Interpreter) domainPaths(address common.Address, domain common.PathDomain) []Value {
 	storageMap := interpreter.Storage().GetStorageMap(address, domain.Identifier(), false)
 	if storageMap == nil {

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -1367,6 +1367,12 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 		if isUnwrappable {
 			// dynamic cast now unboxes optionals
 			value = interpreter.Unbox(locationRange, value)
+
+			// we should not process nil further
+			switch value.(type) {
+			case NilValue:
+				return Nil
+			}
 		}
 
 		// The failable cast may upcast to an optional type, e.g. `1 as? Int?`, so box

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -1337,7 +1337,8 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 		// so we don't substitute them.
 
 		// if the target is anystruct or anyresource we want to preserve optionals
-		if !(expectedType == sema.AnyStructType || expectedType == sema.AnyResourceType) {
+		unboxedExpectedType := sema.UnwrapOptionalType(expectedType)
+		if !(unboxedExpectedType == sema.AnyStructType || unboxedExpectedType == sema.AnyResourceType) {
 			// otherwise dynamic cast now always unboxes optionals
 			value = interpreter.Unbox(locationRange, value)
 		}

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -1369,8 +1369,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 			value = interpreter.Unbox(locationRange, value)
 
 			// we should not process nil further
-			switch value.(type) {
-			case NilValue:
+			if _, ok := value.(NilValue); ok {
 				return Nil
 			}
 		}

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -4022,6 +4022,26 @@ func TestInterpretDynamicCastingOptionalUnwrapping(t *testing.T) {
 		)
 	})
 
+	t.Run("return optional as!", func(t *testing.T) {
+		t.Parallel()
+
+		code := `
+			let x: Int??? = 42
+			let y: Int? = x as! Int?
+		`
+
+		inter := parseCheckAndInterpret(t, code)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredSomeValueNonCopying(
+				interpreter.NewUnmeteredIntValueFromInt64(42),
+			),
+			inter.Globals.Get("y").GetValue(inter),
+		)
+	})
+
 	t.Run("return nested optional as!", func(t *testing.T) {
 		t.Parallel()
 
@@ -4038,6 +4058,30 @@ func TestInterpretDynamicCastingOptionalUnwrapping(t *testing.T) {
 			interpreter.NewUnmeteredSomeValueNonCopying(
 				interpreter.NewUnmeteredSomeValueNonCopying(
 					interpreter.NewUnmeteredIntValueFromInt64(42),
+				),
+			),
+			inter.Globals.Get("y").GetValue(inter),
+		)
+	})
+
+	t.Run("return optional as?", func(t *testing.T) {
+		t.Parallel()
+
+		code := `
+			let x: Int??? = 42
+			let y: Int??? = x as? Int??
+		`
+
+		inter := parseCheckAndInterpret(t, code)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredSomeValueNonCopying(
+				interpreter.NewUnmeteredSomeValueNonCopying(
+					interpreter.NewUnmeteredSomeValueNonCopying(
+						interpreter.NewUnmeteredIntValueFromInt64(42),
+					),
 				),
 			),
 			inter.Globals.Get("y").GetValue(inter),

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -1105,8 +1105,7 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 							inter.Globals.Get("y").GetValue(inter),
 						)
 
-						if targetType == sema.AnyStructType && !returnsOptional {
-
+						if _, ok := targetType.(*sema.OptionalType); !ok {
 							AssertValuesEqual(
 								t,
 								inter,

--- a/runtime/tests/interpreter/dynamic_casting_test.go
+++ b/runtime/tests/interpreter/dynamic_casting_test.go
@@ -3870,3 +3870,43 @@ func TestInterpretDynamicCastingReferenceCasting(t *testing.T) {
 		}
 	})
 }
+func TestInterpretDynamicCastingOptionalUnwrapping(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("as?", func(t *testing.T) {
+		inter := parseCheckAndInterpret(t,
+			fmt.Sprintf(`
+				 let x: Int? = 42
+				 let y: Int? = x %[1]s Int
+			   `,
+				"as?",
+			),
+		)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredIntValueFromInt64(42),
+			inter.Globals.Get("y").GetValue(inter),
+		)
+	})
+
+	t.Run("as!", func(t *testing.T) {
+		inter := parseCheckAndInterpret(t,
+			fmt.Sprintf(`
+				 let x: Int? = 42
+				 let y: Int = x %[1]s Int
+			   `,
+				"as!",
+			),
+		)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredIntValueFromInt64(42),
+			inter.Globals.Get("y").GetValue(inter),
+		)
+	})
+}


### PR DESCRIPTION
Closes #3183

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Dynamic casting now unwraps optionals following the behaviour of Swift.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
