### PR TITLE
Always report errors against the new program during contract update validation

### DIFF
--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -3666,3 +3666,101 @@ func TestTypeRemovalPragmaUpdates(t *testing.T) {
 		},
 	)
 }
+
+func TestRuntimeContractUpdateErrorsInOldProgram(t *testing.T) {
+
+	t.Parallel()
+
+	testWithValidatorsAndTypeRemovalEnabled(t,
+		"invalid #removedType pragma in old code",
+		func(t *testing.T, config Config) {
+
+			const oldCode = `
+                access(all) contract Test {
+                    // invalid type removal pragma in old code
+                    #removedType(R, R2)
+                    access(all) resource R {}
+                }
+            `
+
+			const newCode = `
+                access(all) contract Test {
+                    access(all) resource R {}
+                }
+            `
+
+			err := testDeployAndUpdate(t, "Test", oldCode, newCode, config)
+
+			// Should not report any errors for the type invalid removal pragma in the old code.
+			require.NoError(t, err)
+		},
+	)
+
+	testWithValidators(t, "invalid old program", func(t *testing.T, config Config) {
+
+		runtime := NewTestInterpreterRuntime()
+
+		var events []cadence.Event
+
+		address := common.MustBytesToAddress([]byte{0x2})
+
+		location := common.AddressLocation{
+			Name:    "Test",
+			Address: address,
+		}
+
+		const oldCode = `
+		    access(all) fun main() {
+                // some lines to increase program length
+            }
+		`
+
+		accountCodes := map[Location][]byte{
+			location: []byte(oldCode),
+		}
+
+		runtimeInterface := &TestRuntimeInterface{
+			OnGetCode: func(location Location) (bytes []byte, err error) {
+				return accountCodes[location], nil
+			},
+			Storage: NewTestLedger(nil, nil),
+			OnGetSigningAccounts: func() ([]Address, error) {
+				return []Address{address}, nil
+			},
+			OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+				return accountCodes[location], nil
+			},
+			OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+				accountCodes[location] = code
+				return nil
+			},
+			OnEmitEvent: func(event cadence.Event) error {
+				events = append(events, event)
+				return nil
+			},
+		}
+
+		nextTransactionLocation := NewTransactionLocationGenerator()
+
+		const newCode = `
+			access(all) contract Test {}
+		`
+
+		updateTransaction := []byte(newContractUpdateTransaction("Test", newCode))
+
+		err := runtime.ExecuteTransaction(
+			Script{
+				Source: updateTransaction,
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+			},
+		)
+
+		RequireError(t, err)
+		oldProgramError := &stdlib.OldProgramError{}
+		require.ErrorAs(t, err, &oldProgramError)
+	})
+}

--- a/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validator.go
+++ b/runtime/stdlib/cadence_v0.42_to_v1_contract_upgrade_validator.go
@@ -71,6 +71,10 @@ func NewCadenceV042ToV1ContractUpdateValidator(
 
 var _ UpdateValidator = &CadenceV042ToV1ContractUpdateValidator{}
 
+func (validator *CadenceV042ToV1ContractUpdateValidator) Location() common.Location {
+	return validator.underlyingUpdateValidator.location
+}
+
 func (validator *CadenceV042ToV1ContractUpdateValidator) isTypeRemovalEnabled() bool {
 	return validator.underlyingUpdateValidator.isTypeRemovalEnabled()
 }
@@ -105,7 +109,7 @@ func (validator *CadenceV042ToV1ContractUpdateValidator) getAccountContractNames
 func (validator *CadenceV042ToV1ContractUpdateValidator) Validate() error {
 	underlyingValidator := validator.underlyingUpdateValidator
 
-	oldRootDecl := getRootDeclaration(validator, underlyingValidator.oldProgram)
+	oldRootDecl := getRootDeclarationOfOldProgram(validator, underlyingValidator.oldProgram, underlyingValidator.newProgram)
 	if underlyingValidator.hasErrors() {
 		return underlyingValidator.getContractUpdateError()
 	}
@@ -314,8 +318,8 @@ func (validator *CadenceV042ToV1ContractUpdateValidator) expectedAuthorizationOf
 	return intersectionType.SupportedEntitlements().Access()
 }
 
-func (validator *CadenceV042ToV1ContractUpdateValidator) validateEntitlementsRepresentableComposite(decl *ast.CompositeDeclaration) {
-	dummyNominalType := ast.NewNominalType(nil, decl.Identifier, nil)
+func (validator *CadenceV042ToV1ContractUpdateValidator) validateEntitlementsRepresentableComposite(newDecl *ast.CompositeDeclaration) {
+	dummyNominalType := ast.NewNominalType(nil, newDecl.Identifier, nil)
 	compositeType := validator.getCompositeType(dummyNominalType)
 	supportedEntitlements := compositeType.SupportedEntitlements()
 
@@ -323,13 +327,13 @@ func (validator *CadenceV042ToV1ContractUpdateValidator) validateEntitlementsRep
 		validator.report(&UnrepresentableEntitlementsUpgrade{
 			Type:                 compositeType,
 			InvalidAuthorization: supportedEntitlements.Access(),
-			Range:                decl.Range,
+			Range:                newDecl.Range,
 		})
 	}
 }
 
-func (validator *CadenceV042ToV1ContractUpdateValidator) validateEntitlementsRepresentableInterface(decl *ast.InterfaceDeclaration) {
-	dummyNominalType := ast.NewNominalType(nil, decl.Identifier, nil)
+func (validator *CadenceV042ToV1ContractUpdateValidator) validateEntitlementsRepresentableInterface(newDecl *ast.InterfaceDeclaration) {
+	dummyNominalType := ast.NewNominalType(nil, newDecl.Identifier, nil)
 	interfaceType := validator.getInterfaceType(dummyNominalType)
 	supportedEntitlements := interfaceType.SupportedEntitlements()
 
@@ -337,7 +341,7 @@ func (validator *CadenceV042ToV1ContractUpdateValidator) validateEntitlementsRep
 		validator.report(&UnrepresentableEntitlementsUpgrade{
 			Type:                 interfaceType,
 			InvalidAuthorization: supportedEntitlements.Access(),
-			Range:                decl.Range,
+			Range:                newDecl.Range,
 		})
 	}
 }


### PR DESCRIPTION
Closes #3574

## Description

Having a mix of errors from both old and new programs could result in incorrect positions being reported.
So always report errors only against new program's positions. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
