### PR TITLE
Limited string templates: $identifier

### DIFF
--- a/runtime/ast/elementtype.go
+++ b/runtime/ast/elementtype.go
@@ -85,4 +85,5 @@ const (
 	ElementTypeForceExpression
 	ElementTypePathExpression
 	ElementTypeAttachExpression
+	ElementTypeStringTemplateExpression
 )

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -220,6 +220,63 @@ func (*StringExpression) precedence() precedence {
 	return precedenceLiteral
 }
 
+// StringTemplateExpression
+
+type StringTemplateExpression struct {
+	Values      []string
+	Expressions []Expression
+	Range
+}
+
+var _ Expression = &StringTemplateExpression{}
+
+func NewStringTemplateExpression(gauge common.MemoryGauge, values []string, exprs []Expression, exprRange Range) *StringTemplateExpression {
+	common.UseMemory(gauge, common.StringExpressionMemoryUsage)
+	return &StringTemplateExpression{
+		Values:      values,
+		Expressions: exprs,
+		Range:       exprRange,
+	}
+}
+
+var _ Element = &StringExpression{}
+var _ Expression = &StringExpression{}
+
+func (*StringTemplateExpression) ElementType() ElementType {
+	return ElementTypeStringExpression
+}
+
+func (*StringTemplateExpression) isExpression() {}
+
+func (*StringTemplateExpression) isIfStatementTest() {}
+
+func (*StringTemplateExpression) Walk(_ func(Element)) {
+	// NO-OP
+}
+
+func (e *StringTemplateExpression) String() string {
+	return Prettier(e)
+}
+
+func (e *StringTemplateExpression) Doc() prettier.Doc {
+	return prettier.Text(QuoteString("String template"))
+}
+
+func (e *StringTemplateExpression) MarshalJSON() ([]byte, error) {
+	type Alias StringTemplateExpression
+	return json.Marshal(&struct {
+		*Alias
+		Type string
+	}{
+		Type:  "StringTemplateExpression",
+		Alias: (*Alias)(e),
+	})
+}
+
+func (*StringTemplateExpression) precedence() precedence {
+	return precedenceLiteral
+}
+
 // IntegerExpression
 
 type IntegerExpression struct {

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -243,7 +243,7 @@ var _ Element = &StringExpression{}
 var _ Expression = &StringExpression{}
 
 func (*StringTemplateExpression) ElementType() ElementType {
-	return ElementTypeStringExpression
+	return ElementTypeStringTemplateExpression
 }
 
 func (*StringTemplateExpression) isExpression() {}

--- a/runtime/ast/expression.go
+++ b/runtime/ast/expression.go
@@ -231,6 +231,7 @@ type StringTemplateExpression struct {
 var _ Expression = &StringTemplateExpression{}
 
 func NewStringTemplateExpression(gauge common.MemoryGauge, values []string, exprs []Expression, exprRange Range) *StringTemplateExpression {
+	// STRINGTODO: change to be similar to array memory usage?
 	common.UseMemory(gauge, common.StringExpressionMemoryUsage)
 	return &StringTemplateExpression{
 		Values:      values,

--- a/runtime/ast/precedence.go
+++ b/runtime/ast/precedence.go
@@ -83,6 +83,7 @@ const (
 	// - BoolExpression
 	// - NilExpression
 	// - StringExpression
+	// - StringTemplateExpression
 	// - IntegerExpression
 	// - FixedPointExpression
 	// - ArrayExpression

--- a/runtime/ast/visitor.go
+++ b/runtime/ast/visitor.go
@@ -183,6 +183,7 @@ type ExpressionVisitor[T any] interface {
 	VisitNilExpression(*NilExpression) T
 	VisitBoolExpression(*BoolExpression) T
 	VisitStringExpression(*StringExpression) T
+	VisitStringTemplateExpression(*StringTemplateExpression) T
 	VisitIntegerExpression(*IntegerExpression) T
 	VisitFixedPointExpression(*FixedPointExpression) T
 	VisitDictionaryExpression(*DictionaryExpression) T
@@ -218,6 +219,9 @@ func AcceptExpression[T any](expression Expression, visitor ExpressionVisitor[T]
 
 	case ElementTypeStringExpression:
 		return visitor.VisitStringExpression(expression.(*StringExpression))
+
+	case ElementTypeStringTemplateExpression:
+		return visitor.VisitStringTemplateExpression(expression.(*StringTemplateExpression))
 
 	case ElementTypeIntegerExpression:
 		return visitor.VisitIntegerExpression(expression.(*IntegerExpression))

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -957,6 +957,34 @@ func (interpreter *Interpreter) VisitStringExpression(expression *ast.StringExpr
 	return NewUnmeteredStringValue(expression.Value)
 }
 
+func (interpreter *Interpreter) VisitStringTemplateExpression(expression *ast.StringTemplateExpression) Value {
+	values := interpreter.visitExpressionsNonCopying(expression.Expressions)
+
+	templateExpressionTypes := interpreter.Program.Elaboration.StringTemplateExpressionTypes(expression)
+	argumentTypes := templateExpressionTypes.ArgumentTypes
+
+	var copies []Value
+
+	count := len(values)
+	if count > 0 {
+		copies = make([]Value, count)
+		for i, argument := range values {
+			argumentType := argumentTypes[i]
+			argumentExpression := expression.Expressions[i]
+			locationRange := LocationRange{
+				Location:    interpreter.Location,
+				HasPosition: argumentExpression,
+			}
+			copies[i] = interpreter.transferAndConvert(argument, argumentType, sema.StringType, locationRange)
+		}
+	}
+
+	result := ""
+
+	// NOTE: already metered in lexer/parser
+	return NewUnmeteredStringValue(result)
+}
+
 func (interpreter *Interpreter) VisitArrayExpression(expression *ast.ArrayExpression) Value {
 	values := interpreter.visitExpressionsNonCopying(expression.Values)
 

--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -1167,14 +1167,15 @@ func defineStringExpression() {
 				literal = p.tokenSource(curToken)
 				length = len(literal)
 
-				if length >= 1 && literal[0] == '"' {
-					literal = literal[1:]
-					length = len(literal)
-				}
-
+				// this order of removal matters in case the token is the single quotation "
 				if length >= 1 && literal[length-1] == '"' {
 					literal = literal[:length-1]
+					length = len(literal)
 					missingEnd = false
+				}
+
+				if length >= 1 && literal[0] == '"' {
+					literal = literal[1:]
 				}
 
 				parsedString := parseStringLiteralContent(p, literal)

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -6055,7 +6055,46 @@ func TestParseStringWithUnicode(t *testing.T) {
 	utils.AssertEqualWithDiff(t, expected, actual)
 }
 
-func TestParseStringTemplates(t *testing.T) {
+func TestParseStringTemplateSimple(t *testing.T) {
+
+	t.Parallel()
+
+	actual, errs := testParseExpression(`
+      "$test"
+	`)
+
+	var err error
+	if len(errs) > 0 {
+		err = Error{
+			Errors: errs,
+		}
+	}
+
+	require.NoError(t, err)
+
+	expected := &ast.StringTemplateExpression{
+		Values: []string{
+			"",
+			"",
+		},
+		Expressions: []ast.Expression{
+			&ast.IdentifierExpression{
+				Identifier: ast.Identifier{
+					Identifier: "test",
+					Pos:        ast.Position{Offset: 9, Line: 2, Column: 8},
+				},
+			},
+		},
+		Range: ast.Range{
+			StartPos: ast.Position{Offset: 7, Line: 2, Column: 6},
+			EndPos:   ast.Position{Offset: 13, Line: 2, Column: 12},
+		},
+	}
+
+	utils.AssertEqualWithDiff(t, expected, actual)
+}
+
+func TestParseStringTemplateMulti(t *testing.T) {
 
 	t.Parallel()
 

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -6055,6 +6055,70 @@ func TestParseStringWithUnicode(t *testing.T) {
 	utils.AssertEqualWithDiff(t, expected, actual)
 }
 
+func TestParseStringTemplates(t *testing.T) {
+
+	t.Parallel()
+
+	actual, errs := testParseExpression(`
+      "this is a test $abc $def test"
+	`)
+
+	var err error
+	if len(errs) > 0 {
+		err = Error{
+			Errors: errs,
+		}
+	}
+
+	require.NoError(t, err)
+
+	expected := &ast.StringTemplateExpression{
+		Values: []string{
+			"this is a test ",
+			" ",
+			" test",
+		},
+		Expressions: []ast.Expression{
+			&ast.IdentifierExpression{
+				Identifier: ast.Identifier{
+					Identifier: "abc",
+					Pos:        ast.Position{Offset: 24, Line: 2, Column: 23},
+				},
+			},
+			&ast.IdentifierExpression{
+				Identifier: ast.Identifier{
+					Identifier: "def",
+					Pos:        ast.Position{Offset: 29, Line: 2, Column: 28},
+				},
+			},
+		},
+		Range: ast.Range{
+			StartPos: ast.Position{Offset: 7, Line: 2, Column: 6},
+			EndPos:   ast.Position{Offset: 37, Line: 2, Column: 36},
+		},
+	}
+
+	utils.AssertEqualWithDiff(t, expected, actual)
+}
+
+func TestParseStringTemplateFail(t *testing.T) {
+
+	t.Parallel()
+
+	_, errs := testParseExpression(`
+      "this is a test $FOO
+	`)
+
+	var err error
+	if len(errs) > 0 {
+		err = Error{
+			Errors: errs,
+		}
+	}
+
+	require.Error(t, err)
+}
+
 func TestParseNilCoalescing(t *testing.T) {
 
 	t.Parallel()

--- a/runtime/parser/lexer/lexer.go
+++ b/runtime/parser/lexer/lexer.go
@@ -49,6 +49,14 @@ type position struct {
 	column int
 }
 
+type LexerMode int
+
+const (
+	NORMAL = iota
+	STR_IDENTIFIER
+	STR_EXPRESSION
+)
+
 type lexer struct {
 	// memoryGauge is used for metering memory usage
 	memoryGauge common.MemoryGauge
@@ -74,6 +82,8 @@ type lexer struct {
 	prev rune
 	// canBackup indicates whether stepping back is allowed
 	canBackup bool
+	// lexer mode is used for string templates
+	mode LexerMode
 }
 
 var _ TokenStream = &lexer{}
@@ -414,6 +424,11 @@ func (l *lexer) scanString(quote rune) {
 				l.backupOne()
 				return
 			}
+		case '$':
+			// string template, stop and set mode
+			l.backupOne()
+			l.mode = STR_IDENTIFIER
+			return
 		}
 		r = l.next()
 	}

--- a/runtime/parser/lexer/lexer_test.go
+++ b/runtime/parser/lexer/lexer_test.go
@@ -1014,6 +1014,120 @@ func TestLexString(t *testing.T) {
 		)
 	})
 
+	t.Run("valid, string template", func(t *testing.T) {
+		testLex(t,
+			`"$abc.length"`,
+			[]token{
+				{
+					Token: Token{
+						Type: TokenString,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
+						},
+					},
+					Source: `"`,
+				},
+				{
+					Token: Token{
+						Type: TokenStringTemplate,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
+							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+						},
+					},
+					Source: `$`,
+				},
+				{
+					Token: Token{
+						Type: TokenIdentifier,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+						},
+					},
+					Source: `abc`,
+				},
+				{
+					Token: Token{
+						Type: TokenString,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 5, Offset: 5},
+							EndPos:   ast.Position{Line: 1, Column: 12, Offset: 12},
+						},
+					},
+					Source: `.length"`,
+				},
+				{
+					Token: Token{
+						Type: TokenEOF,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 13, Offset: 13},
+							EndPos:   ast.Position{Line: 1, Column: 13, Offset: 13},
+						},
+					},
+				},
+			},
+		)
+	})
+
+	t.Run("invalid, string template", func(t *testing.T) {
+		testLex(t,
+			`"$1"`,
+			[]token{
+				{
+					Token: Token{
+						Type: TokenString,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+							EndPos:   ast.Position{Line: 1, Column: 0, Offset: 0},
+						},
+					},
+					Source: `"`,
+				},
+				{
+					Token: Token{
+						Type: TokenStringTemplate,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 1, Offset: 1},
+							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+						},
+					},
+					Source: `$`,
+				},
+				{
+					Token: Token{
+						Type: TokenDecimalIntegerLiteral,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+							EndPos:   ast.Position{Line: 1, Column: 2, Offset: 2},
+						},
+					},
+					Source: `1`,
+				},
+				{
+					Token: Token{
+						Type: TokenString,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 3, Offset: 3},
+							EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
+						},
+					},
+					Source: `"`,
+				},
+				{
+					Token: Token{
+						Type: TokenEOF,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+						},
+					},
+				},
+			},
+		)
+	})
+
 	t.Run("invalid, empty, not terminated at line end", func(t *testing.T) {
 		testLex(t,
 			"\"\n",

--- a/runtime/parser/lexer/state.go
+++ b/runtime/parser/lexer/state.go
@@ -40,6 +40,12 @@ func rootState(l *lexer) stateFn {
 		switch r {
 		case EOF:
 			return nil
+		case '$':
+			if l.mode == STR_EXPRESSION || l.mode == STR_IDENTIFIER {
+				l.emitType(TokenStringTemplate)
+			} else {
+				return l.error(fmt.Errorf("unrecognized character: %#U", r))
+			}
 		case '+':
 			l.emitType(TokenPlus)
 		case '-':
@@ -296,6 +302,10 @@ func identifierState(l *lexer) stateFn {
 		}
 	}
 	l.emitType(TokenIdentifier)
+	if l.mode == STR_IDENTIFIER {
+		l.mode = NORMAL
+		return stringState
+	}
 	return rootState
 }
 

--- a/runtime/parser/lexer/tokentype.go
+++ b/runtime/parser/lexer/tokentype.go
@@ -82,6 +82,7 @@ const (
 	TokenAsExclamationMark
 	TokenAsQuestionMark
 	TokenPragma
+	TokenStringTemplate
 	// NOTE: not an actual token, must be last item
 	TokenMax
 )
@@ -205,6 +206,8 @@ func (t TokenType) String() string {
 		return `'as?'`
 	case TokenPragma:
 		return `'#'`
+	case TokenStringTemplate:
+		return `'$'`
 	default:
 		panic(errors.NewUnreachableError())
 	}

--- a/runtime/sema/check_string_template_expression.go
+++ b/runtime/sema/check_string_template_expression.go
@@ -1,0 +1,52 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sema
+
+import "github.com/onflow/cadence/runtime/ast"
+
+func (checker *Checker) VisitStringTemplateExpression(stringTemplateExpression *ast.StringTemplateExpression) Type {
+
+	// visit all elements
+
+	var elementType Type
+
+	elementCount := len(stringTemplateExpression.Expressions)
+
+	var argumentTypes []Type
+	if elementCount > 0 {
+		argumentTypes = make([]Type, elementCount)
+
+		for i, element := range stringTemplateExpression.Expressions {
+			valueType := checker.VisitExpression(element, stringTemplateExpression, elementType)
+
+			argumentTypes[i] = valueType
+
+			checker.checkResourceMoveOperation(element, valueType)
+		}
+	}
+
+	checker.Elaboration.SetStringTemplateExpressionTypes(
+		stringTemplateExpression,
+		StringTemplateExpressionTypes{
+			ArgumentTypes: argumentTypes,
+		},
+	)
+
+	return StringType
+}

--- a/runtime/sema/elaboration.go
+++ b/runtime/sema/elaboration.go
@@ -79,6 +79,10 @@ type ArrayExpressionTypes struct {
 	ArgumentTypes []Type
 }
 
+type StringTemplateExpressionTypes struct {
+	ArgumentTypes []Type
+}
+
 type DictionaryExpressionTypes struct {
 	DictionaryType *DictionaryType
 	EntryTypes     []DictionaryEntryType
@@ -140,6 +144,7 @@ type Elaboration struct {
 	dictionaryExpressionTypes         map[*ast.DictionaryExpression]DictionaryExpressionTypes
 	integerExpressionTypes            map[*ast.IntegerExpression]Type
 	stringExpressionTypes             map[*ast.StringExpression]Type
+	stringTemplateExpressionTypes     map[*ast.StringTemplateExpression]StringTemplateExpressionTypes
 	returnStatementTypes              map[*ast.ReturnStatement]ReturnStatementTypes
 	functionDeclarationFunctionTypes  map[*ast.FunctionDeclaration]*FunctionType
 	variableDeclarationTypes          map[*ast.VariableDeclaration]VariableDeclarationTypes
@@ -478,6 +483,21 @@ func (e *Elaboration) SetStringExpressionType(expression *ast.StringExpression, 
 		e.stringExpressionTypes = map[*ast.StringExpression]Type{}
 	}
 	e.stringExpressionTypes[expression] = ty
+}
+
+func (e *Elaboration) StringTemplateExpressionTypes(expression *ast.StringTemplateExpression) (types StringTemplateExpressionTypes) {
+	if e.stringTemplateExpressionTypes == nil {
+		return
+	}
+	// default, Elaboration.SetStringExpressionType
+	return e.stringTemplateExpressionTypes[expression]
+}
+
+func (e *Elaboration) SetStringTemplateExpressionTypes(expression *ast.StringTemplateExpression, types StringTemplateExpressionTypes) {
+	if e.stringTemplateExpressionTypes == nil {
+		e.stringTemplateExpressionTypes = map[*ast.StringTemplateExpression]StringTemplateExpressionTypes{}
+	}
+	e.stringTemplateExpressionTypes[expression] = types
 }
 
 func (e *Elaboration) ReturnStatementTypes(statement *ast.ReturnStatement) (types ReturnStatementTypes) {

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -697,3 +697,45 @@ func TestCheckStringCount(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestCheckStringTemplate(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("valid, int", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		  let a = 1
+		  let x: String = "The value of a is: $a" 
+		`)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("valid, string", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		  let a = "abc def"
+		  let x: String = "$a ghi" 
+		`)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid, missing variable", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+		  let x: String = "$a" 
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+	})
+}

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -12283,3 +12283,64 @@ func TestInterpretOptionalAddressInConditional(t *testing.T) {
 		value,
 	)
 }
+
+func TestInterpretStringTemplates(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("int", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+		let x = 123
+		let y = "x = $x"
+		`)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredIntValueFromInt64(123),
+			inter.Globals.Get("x").GetValue(inter),
+		)
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredStringValue("x = 123"),
+			inter.Globals.Get("y").GetValue(inter),
+		)
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+		let x = 123.321
+		let y = "abc"
+		let z = "$y and $x"
+		`)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredStringValue("abc and 123.32100000"),
+			inter.Globals.Get("z").GetValue(inter),
+		)
+	})
+
+	t.Run("nested template", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+		let x = "{}"
+		let y = "[$x]"
+		let z = "($y)"
+		`)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredStringValue("([{}])"),
+			inter.Globals.Get("z").GetValue(inter),
+		)
+	})
+}


### PR DESCRIPTION
Working towards #3579

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR introduces a simple string template in the form of the character `$` followed by an identifier (`"$foo"`), with plans to support the syntax of `$` followed by an expression in curly braces later.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
