### PR TITLE
Improve `result` variable

### DIFF
--- a/runtime/ast/block.go
+++ b/runtime/ast/block.go
@@ -355,10 +355,13 @@ func (c *EmitCondition) Walk(walkChild func(Element)) {
 
 // Conditions
 
-type Conditions []Condition
+type Conditions struct {
+	Conditions []Condition
+	Range
+}
 
 func (c *Conditions) IsEmpty() bool {
-	return c == nil || len(*c) == 0
+	return c == nil || len(c.Conditions) == 0
 }
 
 func (c *Conditions) Doc(keywordDoc prettier.Doc) prettier.Doc {
@@ -368,7 +371,7 @@ func (c *Conditions) Doc(keywordDoc prettier.Doc) prettier.Doc {
 
 	var doc prettier.Concat
 
-	for _, condition := range *c {
+	for _, condition := range c.Conditions {
 		doc = append(
 			doc,
 			prettier.HardLine{},
@@ -395,7 +398,7 @@ func (c *Conditions) Walk(walkChild func(Element)) {
 		return
 	}
 
-	for _, condition := range *c {
+	for _, condition := range c.Conditions {
 		walkChild(condition)
 	}
 }

--- a/runtime/ast/block_test.go
+++ b/runtime/ast/block_test.go
@@ -220,45 +220,57 @@ func TestFunctionBlock_MarshalJSON(t *testing.T) {
 				},
 			},
 			PreConditions: &Conditions{
-				&TestCondition{
-					Test: &BoolExpression{
-						Value: false,
-						Range: Range{
-							StartPos: Position{Offset: 7, Line: 8, Column: 9},
-							EndPos:   Position{Offset: 10, Line: 11, Column: 12},
-						},
-					},
-					Message: &StringExpression{
-						Value: "Pre failed",
-						Range: Range{
-							StartPos: Position{Offset: 13, Line: 14, Column: 15},
-							EndPos:   Position{Offset: 16, Line: 17, Column: 18},
-						},
-					},
+				Range: Range{
+					StartPos: Position{Offset: 44, Line: 45, Column: 46},
+					EndPos:   Position{Offset: 47, Line: 48, Column: 49},
 				},
-				&EmitCondition{
-					InvocationExpression: &InvocationExpression{
-						InvokedExpression: &IdentifierExpression{
-							Identifier: Identifier{
-								Identifier: "foobar",
-								Pos:        Position{Offset: 31, Line: 32, Column: 33},
+				Conditions: []Condition{
+					&TestCondition{
+						Test: &BoolExpression{
+							Value: false,
+							Range: Range{
+								StartPos: Position{Offset: 7, Line: 8, Column: 9},
+								EndPos:   Position{Offset: 10, Line: 11, Column: 12},
 							},
 						},
-						TypeArguments:     []*TypeAnnotation{},
-						Arguments:         []*Argument{},
-						ArgumentsStartPos: Position{Offset: 34, Line: 35, Column: 36},
-						EndPos:            Position{Offset: 37, Line: 38, Column: 39},
+						Message: &StringExpression{
+							Value: "Pre failed",
+							Range: Range{
+								StartPos: Position{Offset: 13, Line: 14, Column: 15},
+								EndPos:   Position{Offset: 16, Line: 17, Column: 18},
+							},
+						},
 					},
-					StartPos: Position{Offset: 40, Line: 41, Column: 42},
+					&EmitCondition{
+						InvocationExpression: &InvocationExpression{
+							InvokedExpression: &IdentifierExpression{
+								Identifier: Identifier{
+									Identifier: "foobar",
+									Pos:        Position{Offset: 31, Line: 32, Column: 33},
+								},
+							},
+							TypeArguments:     []*TypeAnnotation{},
+							Arguments:         []*Argument{},
+							ArgumentsStartPos: Position{Offset: 34, Line: 35, Column: 36},
+							EndPos:            Position{Offset: 37, Line: 38, Column: 39},
+						},
+						StartPos: Position{Offset: 40, Line: 41, Column: 42},
+					},
 				},
 			},
 			PostConditions: &Conditions{
-				&TestCondition{
-					Test: &BoolExpression{
-						Value: true,
-						Range: Range{
-							StartPos: Position{Offset: 19, Line: 20, Column: 21},
-							EndPos:   Position{Offset: 22, Line: 23, Column: 24},
+				Range: Range{
+					StartPos: Position{Offset: 50, Line: 51, Column: 52},
+					EndPos:   Position{Offset: 53, Line: 54, Column: 55},
+				},
+				Conditions: []Condition{
+					&TestCondition{
+						Test: &BoolExpression{
+							Value: true,
+							Range: Range{
+								StartPos: Position{Offset: 19, Line: 20, Column: 21},
+								EndPos:   Position{Offset: 22, Line: 23, Column: 24},
+							},
 						},
 					},
 				},
@@ -279,62 +291,70 @@ func TestFunctionBlock_MarshalJSON(t *testing.T) {
 								"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
 								"EndPos": {"Offset": 4, "Line": 5, "Column": 6}
 							},
-							"PreConditions": [
-								{
-									"Type": "TestCondition",
-									"Test": {
-										"Type": "BoolExpression",
-										"Value": false,
+							"PreConditions": {
+							    "StartPos": {"Offset": 44, "Line": 45, "Column": 46},
+							    "EndPos": {"Offset": 47, "Line": 48, "Column": 49},
+							    "Conditions": [
+									{
+										"Type": "TestCondition",
+										"Test": {
+											"Type": "BoolExpression",
+											"Value": false,
+											"StartPos": {"Offset": 7, "Line": 8, "Column": 9},
+											"EndPos": {"Offset": 10, "Line": 11, "Column": 12}
+										},
+										"Message": {
+											"Type": "StringExpression",
+											"Value": "Pre failed",
+											"StartPos": {"Offset": 13, "Line": 14, "Column": 15},
+											"EndPos": {"Offset": 16, "Line": 17, "Column": 18}
+										},
 										"StartPos": {"Offset": 7, "Line": 8, "Column": 9},
-										"EndPos": {"Offset": 10, "Line": 11, "Column": 12}
-									},
-									"Message": {
-										"Type": "StringExpression",
-										"Value": "Pre failed",
-										"StartPos": {"Offset": 13, "Line": 14, "Column": 15},
 										"EndPos": {"Offset": 16, "Line": 17, "Column": 18}
 									},
-									"StartPos": {"Offset": 7, "Line": 8, "Column": 9},
-									"EndPos": {"Offset": 16, "Line": 17, "Column": 18}
-								},
-								{
-									"Type": "EmitCondition",
-									"InvocationExpression": {
-										"Type": "InvocationExpression",
-										"InvokedExpression": {
-										   "Type": "IdentifierExpression",
-										   "Identifier": {
-											   "Identifier": "foobar",
+									{
+										"Type": "EmitCondition",
+										"InvocationExpression": {
+											"Type": "InvocationExpression",
+											"InvokedExpression": {
+											   "Type": "IdentifierExpression",
+											   "Identifier": {
+												   "Identifier": "foobar",
+												   "StartPos": {"Offset": 31, "Line": 32, "Column": 33},
+												   "EndPos": {"Offset": 36, "Line": 32, "Column": 38}
+											   },
 											   "StartPos": {"Offset": 31, "Line": 32, "Column": 33},
 											   "EndPos": {"Offset": 36, "Line": 32, "Column": 38}
-										   },
-										   "StartPos": {"Offset": 31, "Line": 32, "Column": 33},
-										   "EndPos": {"Offset": 36, "Line": 32, "Column": 38}
+											},
+											"TypeArguments": [],
+											"Arguments": [],
+											"ArgumentsStartPos": {"Offset": 34, "Line": 35, "Column": 36},
+											"StartPos": {"Offset": 31, "Line": 32, "Column": 33},
+											"EndPos": {"Offset": 37, "Line": 38, "Column": 39}
 										},
-										"TypeArguments": [],
-										"Arguments": [],
-										"ArgumentsStartPos": {"Offset": 34, "Line": 35, "Column": 36},
-										"StartPos": {"Offset": 31, "Line": 32, "Column": 33},
+										"StartPos": {"Offset": 40, "Line": 41, "Column": 42},
 										"EndPos": {"Offset": 37, "Line": 38, "Column": 39}
-									},
-									"StartPos": {"Offset": 40, "Line": 41, "Column": 42},
-									"EndPos": {"Offset": 37, "Line": 38, "Column": 39}
-								}
-							],
-							"PostConditions": [
-								{
-									"Type": "TestCondition",
-									"Test": {
-										"Type": "BoolExpression",
-										"Value": true,
+									}
+								]
+							},
+							"PostConditions": {
+							    "StartPos": {"Offset": 50, "Line": 51, "Column": 52},
+							    "EndPos": {"Offset": 53, "Line": 54, "Column": 55},
+							    "Conditions": [
+									{
+										"Type": "TestCondition",
+										"Test": {
+											"Type": "BoolExpression",
+											"Value": true,
+											"StartPos": {"Offset": 19, "Line": 20, "Column": 21},
+											"EndPos": {"Offset": 22, "Line": 23, "Column": 24}
+										},
+										"Message": null,
 										"StartPos": {"Offset": 19, "Line": 20, "Column": 21},
 										"EndPos": {"Offset": 22, "Line": 23, "Column": 24}
-									},
-									"Message": null,
-									"StartPos": {"Offset": 19, "Line": 20, "Column": 21},
-									"EndPos": {"Offset": 22, "Line": 23, "Column": 24}
-								}
-							],
+									}
+								]
+							},
 							"StartPos": {"Offset": 1, "Line": 2, "Column": 3},
 							"EndPos": {"Offset": 4, "Line": 5, "Column": 6}
 						}
@@ -407,28 +427,32 @@ func TestFunctionBlock_Doc(t *testing.T) {
 				},
 			},
 			PreConditions: &Conditions{
-				&TestCondition{
-					Test: &BoolExpression{
-						Value: false,
+				Conditions: []Condition{
+					&TestCondition{
+						Test: &BoolExpression{
+							Value: false,
+						},
+						Message: &StringExpression{
+							Value: "Pre failed",
+						},
 					},
-					Message: &StringExpression{
-						Value: "Pre failed",
-					},
-				},
-				&EmitCondition{
-					InvocationExpression: &InvocationExpression{
-						InvokedExpression: &IdentifierExpression{
-							Identifier: Identifier{
-								Identifier: "Foo",
+					&EmitCondition{
+						InvocationExpression: &InvocationExpression{
+							InvokedExpression: &IdentifierExpression{
+								Identifier: Identifier{
+									Identifier: "Foo",
+								},
 							},
 						},
 					},
 				},
 			},
 			PostConditions: &Conditions{
-				&TestCondition{
-					Test: &BoolExpression{
-						Value: true,
+				Conditions: []Condition{
+					&TestCondition{
+						Test: &BoolExpression{
+							Value: true,
+						},
 					},
 				},
 			},
@@ -561,22 +585,26 @@ func TestFunctionBlock_String(t *testing.T) {
 				},
 			},
 			PreConditions: &Conditions{
-				&TestCondition{
-					Test: &BoolExpression{
-						Value: false,
-					},
-					Message: &StringExpression{
-						Value: "Pre failed",
+				Conditions: []Condition{
+					&TestCondition{
+						Test: &BoolExpression{
+							Value: false,
+						},
+						Message: &StringExpression{
+							Value: "Pre failed",
+						},
 					},
 				},
 			},
 			PostConditions: &Conditions{
-				&TestCondition{
-					Test: &BoolExpression{
-						Value: true,
-					},
-					Message: &StringExpression{
-						Value: "Post failed",
+				Conditions: []Condition{
+					&TestCondition{
+						Test: &BoolExpression{
+							Value: true,
+						},
+						Message: &StringExpression{
+							Value: "Post failed",
+						},
 					},
 				},
 			},

--- a/runtime/ast/expression_test.go
+++ b/runtime/ast/expression_test.go
@@ -4623,22 +4623,26 @@ func TestFunctionExpression_Doc(t *testing.T) {
 			},
 			FunctionBlock: &FunctionBlock{
 				PreConditions: &Conditions{
-					&TestCondition{
-						Test: &BoolExpression{
-							Value: true,
-						},
-						Message: &StringExpression{
-							Value: "pre",
+					Conditions: []Condition{
+						&TestCondition{
+							Test: &BoolExpression{
+								Value: true,
+							},
+							Message: &StringExpression{
+								Value: "pre",
+							},
 						},
 					},
 				},
 				PostConditions: &Conditions{
-					&TestCondition{
-						Test: &BoolExpression{
-							Value: false,
-						},
-						Message: &StringExpression{
-							Value: "post",
+					Conditions: []Condition{
+						&TestCondition{
+							Test: &BoolExpression{
+								Value: false,
+							},
+							Message: &StringExpression{
+								Value: "post",
+							},
 						},
 					},
 				},
@@ -4877,22 +4881,26 @@ func TestFunctionExpression_String(t *testing.T) {
 			},
 			FunctionBlock: &FunctionBlock{
 				PreConditions: &Conditions{
-					&TestCondition{
-						Test: &BoolExpression{
-							Value: true,
-						},
-						Message: &StringExpression{
-							Value: "pre",
+					Conditions: []Condition{
+						&TestCondition{
+							Test: &BoolExpression{
+								Value: true,
+							},
+							Message: &StringExpression{
+								Value: "pre",
+							},
 						},
 					},
 				},
 				PostConditions: &Conditions{
-					&TestCondition{
-						Test: &BoolExpression{
-							Value: false,
-						},
-						Message: &StringExpression{
-							Value: "post",
+					Conditions: []Condition{
+						&TestCondition{
+							Test: &BoolExpression{
+								Value: false,
+							},
+							Message: &StringExpression{
+								Value: "post",
+							},
 						},
 					},
 				},

--- a/runtime/ast/transaction_declaration_test.go
+++ b/runtime/ast/transaction_declaration_test.go
@@ -41,12 +41,22 @@ func TestTransactionDeclaration_MarshalJSON(t *testing.T) {
 				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
 			},
 		},
-		Fields:         []*FieldDeclaration{},
-		Prepare:        nil,
-		PreConditions:  &Conditions{},
-		PostConditions: &Conditions{},
-		DocString:      "test",
-		Execute:        nil,
+		Fields:  []*FieldDeclaration{},
+		Prepare: nil,
+		PreConditions: &Conditions{
+			Range: Range{
+				StartPos: Position{Offset: 13, Line: 14, Column: 15},
+				EndPos:   Position{Offset: 16, Line: 17, Column: 18},
+			},
+		},
+		PostConditions: &Conditions{
+			Range: Range{
+				StartPos: Position{Offset: 19, Line: 20, Column: 21},
+				EndPos:   Position{Offset: 22, Line: 23, Column: 24},
+			},
+		},
+		DocString: "test",
+		Execute:   nil,
 		Range: Range{
 			StartPos: Position{Offset: 7, Line: 8, Column: 9},
 			EndPos:   Position{Offset: 10, Line: 11, Column: 12},
@@ -68,8 +78,16 @@ func TestTransactionDeclaration_MarshalJSON(t *testing.T) {
             },
 		    "Fields":         [],
 		    "Prepare":        null,
-		    "PreConditions":  [],
-		    "PostConditions": [],
+		    "PreConditions":  {
+                "Conditions": null,
+                "StartPos": {"Offset": 13, "Line": 14, "Column": 15},
+                "EndPos":  {"Offset": 16, "Line": 17, "Column": 18}
+		    },
+		    "PostConditions": {
+                "Conditions": null,
+                "StartPos": {"Offset": 19, "Line": 20, "Column": 21},
+                "EndPos": {"Offset": 22, "Line": 23, "Column": 24}
+		    },
 		    "Execute":        null,
             "DocString":      "test",
             "StartPos": {"Offset": 7, "Line": 8, "Column": 9},
@@ -146,12 +164,14 @@ func TestTransactionDeclaration_Doc(t *testing.T) {
 			},
 		},
 		PreConditions: &Conditions{
-			&TestCondition{
-				Test: &BoolExpression{
-					Value: true,
-				},
-				Message: &StringExpression{
-					Value: "pre",
+			Conditions: []Condition{
+				&TestCondition{
+					Test: &BoolExpression{
+						Value: true,
+					},
+					Message: &StringExpression{
+						Value: "pre",
+					},
 				},
 			},
 		},
@@ -173,12 +193,14 @@ func TestTransactionDeclaration_Doc(t *testing.T) {
 			},
 		},
 		PostConditions: &Conditions{
-			&TestCondition{
-				Test: &BoolExpression{
-					Value: false,
-				},
-				Message: &StringExpression{
-					Value: "post",
+			Conditions: []Condition{
+				&TestCondition{
+					Test: &BoolExpression{
+						Value: false,
+					},
+					Message: &StringExpression{
+						Value: "post",
+					},
 				},
 			},
 		},
@@ -418,12 +440,14 @@ func TestTransactionDeclaration_String(t *testing.T) {
 			},
 		},
 		PreConditions: &Conditions{
-			&TestCondition{
-				Test: &BoolExpression{
-					Value: true,
-				},
-				Message: &StringExpression{
-					Value: "pre",
+			Conditions: []Condition{
+				&TestCondition{
+					Test: &BoolExpression{
+						Value: true,
+					},
+					Message: &StringExpression{
+						Value: "pre",
+					},
 				},
 			},
 		},
@@ -445,12 +469,14 @@ func TestTransactionDeclaration_String(t *testing.T) {
 			},
 		},
 		PostConditions: &Conditions{
-			&TestCondition{
-				Test: &BoolExpression{
-					Value: false,
-				},
-				Message: &StringExpression{
-					Value: "post",
+			Conditions: []Condition{
+				&TestCondition{
+					Test: &BoolExpression{
+						Value: false,
+					},
+					Message: &StringExpression{
+						Value: "post",
+					},
 				},
 			},
 		},

--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -216,12 +216,12 @@ func (r *CoverageReport) InspectProgram(location Location, program *ast.Program)
 				// Track also pre/post conditions defined inside functions.
 				if isFunctionBlock {
 					if functionBlock.PreConditions != nil {
-						for _, condition := range *functionBlock.PreConditions {
+						for _, condition := range functionBlock.PreConditions.Conditions {
 							recordLine(condition.CodeElement())
 						}
 					}
 					if functionBlock.PostConditions != nil {
-						for _, condition := range *functionBlock.PostConditions {
+						for _, condition := range functionBlock.PostConditions.Conditions {
 							recordLine(condition.CodeElement())
 						}
 					}

--- a/runtime/interpreter/interpreter.go
+++ b/runtime/interpreter/interpreter.go
@@ -740,13 +740,13 @@ func (interpreter *Interpreter) functionDeclarationValue(
 	lexicalScope *VariableActivation,
 ) *InterpretedFunctionValue {
 
-	var preConditions ast.Conditions
+	var preConditions []ast.Condition
 	if declaration.FunctionBlock.PreConditions != nil {
-		preConditions = *declaration.FunctionBlock.PreConditions
+		preConditions = declaration.FunctionBlock.PreConditions.Conditions
 	}
 
 	var beforeStatements []ast.Statement
-	var rewrittenPostConditions ast.Conditions
+	var rewrittenPostConditions []ast.Condition
 
 	if declaration.FunctionBlock.PostConditions != nil {
 		postConditionsRewrite :=
@@ -778,9 +778,9 @@ func (interpreter *Interpreter) visitBlock(block *ast.Block) StatementResult {
 
 func (interpreter *Interpreter) visitFunctionBody(
 	beforeStatements []ast.Statement,
-	preConditions ast.Conditions,
+	preConditions []ast.Condition,
 	body func() StatementResult,
-	postConditions ast.Conditions,
+	postConditions []ast.Condition,
 	returnType sema.Type,
 	declarationLocationRange LocationRange,
 ) Value {
@@ -875,7 +875,7 @@ func (interpreter *Interpreter) resultValue(returnValue Value, returnType sema.T
 	)
 }
 
-func (interpreter *Interpreter) visitConditions(conditions ast.Conditions, kind ast.ConditionKind) {
+func (interpreter *Interpreter) visitConditions(conditions []ast.Condition, kind ast.ConditionKind) {
 	for _, condition := range conditions {
 		interpreter.visitCondition(condition, kind)
 	}
@@ -1674,15 +1674,15 @@ func (interpreter *Interpreter) compositeInitializerFunction(
 
 	parameterList := initializer.FunctionDeclaration.ParameterList
 
-	var preConditions ast.Conditions
+	var preConditions []ast.Condition
 	if initializer.FunctionDeclaration.FunctionBlock.PreConditions != nil {
-		preConditions = *initializer.FunctionDeclaration.FunctionBlock.PreConditions
+		preConditions = initializer.FunctionDeclaration.FunctionBlock.PreConditions.Conditions
 	}
 
 	statements := initializer.FunctionDeclaration.FunctionBlock.Block.Statements
 
 	var beforeStatements []ast.Statement
-	var rewrittenPostConditions ast.Conditions
+	var rewrittenPostConditions []ast.Condition
 
 	postConditions := initializer.FunctionDeclaration.FunctionBlock.PostConditions
 	if postConditions != nil {
@@ -1791,14 +1791,14 @@ func (interpreter *Interpreter) compositeFunction(
 
 	functionType := interpreter.Program.Elaboration.FunctionDeclarationFunctionType(functionDeclaration)
 
-	var preConditions ast.Conditions
+	var preConditions []ast.Condition
 
 	if functionDeclaration.FunctionBlock.PreConditions != nil {
-		preConditions = *functionDeclaration.FunctionBlock.PreConditions
+		preConditions = functionDeclaration.FunctionBlock.PreConditions.Conditions
 	}
 
 	var beforeStatements []ast.Statement
-	var rewrittenPostConditions ast.Conditions
+	var rewrittenPostConditions []ast.Condition
 
 	if functionDeclaration.FunctionBlock.PostConditions != nil {
 
@@ -2456,13 +2456,13 @@ func (interpreter *Interpreter) functionConditionsWrapper(
 		return nil
 	}
 
-	var preConditions ast.Conditions
+	var preConditions []ast.Condition
 	if declaration.FunctionBlock.PreConditions != nil {
-		preConditions = *declaration.FunctionBlock.PreConditions
+		preConditions = declaration.FunctionBlock.PreConditions.Conditions
 	}
 
 	var beforeStatements []ast.Statement
-	var rewrittenPostConditions ast.Conditions
+	var rewrittenPostConditions []ast.Condition
 
 	if declaration.FunctionBlock.PostConditions != nil {
 

--- a/runtime/interpreter/interpreter_expression.go
+++ b/runtime/interpreter/interpreter_expression.go
@@ -1297,13 +1297,13 @@ func (interpreter *Interpreter) VisitFunctionExpression(expression *ast.Function
 
 	functionType := interpreter.Program.Elaboration.FunctionExpressionFunctionType(expression)
 
-	var preConditions ast.Conditions
+	var preConditions []ast.Condition
 	if expression.FunctionBlock.PreConditions != nil {
-		preConditions = *expression.FunctionBlock.PreConditions
+		preConditions = expression.FunctionBlock.PreConditions.Conditions
 	}
 
 	var beforeStatements []ast.Statement
-	var rewrittenPostConditions ast.Conditions
+	var rewrittenPostConditions []ast.Condition
 
 	if expression.FunctionBlock.PostConditions != nil {
 		postConditionsRewrite :=

--- a/runtime/interpreter/interpreter_transaction.go
+++ b/runtime/interpreter/interpreter_transaction.go
@@ -129,9 +129,9 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 				}
 			}
 
-			var preConditions ast.Conditions
+			var preConditions []ast.Condition
 			if declaration.PreConditions != nil {
-				preConditions = *declaration.PreConditions
+				preConditions = declaration.PreConditions.Conditions
 			}
 
 			declarationLocationRange := LocationRange{

--- a/runtime/interpreter/value_function.go
+++ b/runtime/interpreter/value_function.go
@@ -45,9 +45,9 @@ type InterpretedFunctionValue struct {
 	Type             *sema.FunctionType
 	Activation       *VariableActivation
 	BeforeStatements []ast.Statement
-	PreConditions    ast.Conditions
+	PreConditions    []ast.Condition
 	Statements       []ast.Statement
-	PostConditions   ast.Conditions
+	PostConditions   []ast.Condition
 }
 
 func NewInterpretedFunctionValue(
@@ -56,9 +56,9 @@ func NewInterpretedFunctionValue(
 	functionType *sema.FunctionType,
 	lexicalScope *VariableActivation,
 	beforeStatements []ast.Statement,
-	preConditions ast.Conditions,
+	preConditions []ast.Condition,
 	statements []ast.Statement,
-	postConditions ast.Conditions,
+	postConditions []ast.Condition,
 ) *InterpretedFunctionValue {
 
 	common.UseMemory(interpreter, common.InterpretedFunctionValueMemoryUsage)

--- a/runtime/old_parser/declaration_test.go
+++ b/runtime/old_parser/declaration_test.go
@@ -699,63 +699,67 @@ func TestParseFunctionDeclaration(t *testing.T) {
 					},
 					FunctionBlock: &ast.FunctionBlock{
 						PreConditions: &ast.Conditions{
-							&ast.TestCondition{
-								Test: &ast.BoolExpression{
-									Value: true,
-									Range: ast.Range{
-										StartPos: ast.Position{Line: 4, Column: 17, Offset: 61},
-										EndPos:   ast.Position{Line: 4, Column: 20, Offset: 64},
-									},
-								},
-								Message: &ast.StringExpression{
-									Value: "test",
-									Range: ast.Range{
-										StartPos: ast.Position{Line: 4, Column: 24, Offset: 68},
-										EndPos:   ast.Position{Line: 4, Column: 29, Offset: 73},
-									},
-								},
-							},
-							&ast.TestCondition{
-								Test: &ast.BinaryExpression{
-									Operation: ast.OperationGreater,
-									Left: &ast.IntegerExpression{
-										PositiveLiteral: []byte("2"),
-										Value:           big.NewInt(2),
-										Base:            10,
+							Conditions: []ast.Condition{
+								&ast.TestCondition{
+									Test: &ast.BoolExpression{
+										Value: true,
 										Range: ast.Range{
-											StartPos: ast.Position{Line: 5, Column: 17, Offset: 92},
-											EndPos:   ast.Position{Line: 5, Column: 17, Offset: 92},
+											StartPos: ast.Position{Line: 4, Column: 17, Offset: 61},
+											EndPos:   ast.Position{Line: 4, Column: 20, Offset: 64},
 										},
 									},
-									Right: &ast.IntegerExpression{
-										PositiveLiteral: []byte("1"),
-										Value:           big.NewInt(1),
-										Base:            10,
+									Message: &ast.StringExpression{
+										Value: "test",
 										Range: ast.Range{
-											StartPos: ast.Position{Line: 5, Column: 21, Offset: 96},
-											EndPos:   ast.Position{Line: 5, Column: 21, Offset: 96},
+											StartPos: ast.Position{Line: 4, Column: 24, Offset: 68},
+											EndPos:   ast.Position{Line: 4, Column: 29, Offset: 73},
 										},
 									},
 								},
-								Message: &ast.StringExpression{
-									Value: "foo",
-									Range: ast.Range{
-										StartPos: ast.Position{Line: 5, Column: 25, Offset: 100},
-										EndPos:   ast.Position{Line: 5, Column: 29, Offset: 104},
+								&ast.TestCondition{
+									Test: &ast.BinaryExpression{
+										Operation: ast.OperationGreater,
+										Left: &ast.IntegerExpression{
+											PositiveLiteral: []byte("2"),
+											Value:           big.NewInt(2),
+											Base:            10,
+											Range: ast.Range{
+												StartPos: ast.Position{Line: 5, Column: 17, Offset: 92},
+												EndPos:   ast.Position{Line: 5, Column: 17, Offset: 92},
+											},
+										},
+										Right: &ast.IntegerExpression{
+											PositiveLiteral: []byte("1"),
+											Value:           big.NewInt(1),
+											Base:            10,
+											Range: ast.Range{
+												StartPos: ast.Position{Line: 5, Column: 21, Offset: 96},
+												EndPos:   ast.Position{Line: 5, Column: 21, Offset: 96},
+											},
+										},
+									},
+									Message: &ast.StringExpression{
+										Value: "foo",
+										Range: ast.Range{
+											StartPos: ast.Position{Line: 5, Column: 25, Offset: 100},
+											EndPos:   ast.Position{Line: 5, Column: 29, Offset: 104},
+										},
 									},
 								},
 							},
 						},
 						PostConditions: &ast.Conditions{
-							&ast.TestCondition{
-								Test: &ast.BoolExpression{
-									Value: false,
-									Range: ast.Range{
-										StartPos: ast.Position{Line: 9, Column: 17, Offset: 161},
-										EndPos:   ast.Position{Line: 9, Column: 21, Offset: 165},
+							Conditions: []ast.Condition{
+								&ast.TestCondition{
+									Test: &ast.BoolExpression{
+										Value: false,
+										Range: ast.Range{
+											StartPos: ast.Position{Line: 9, Column: 17, Offset: 161},
+											EndPos:   ast.Position{Line: 9, Column: 21, Offset: 165},
+										},
 									},
+									Message: nil,
 								},
-								Message: nil,
 							},
 						},
 						Block: &ast.Block{
@@ -3883,44 +3887,48 @@ func TestParseTransactionDeclaration(t *testing.T) {
 						},
 					},
 					PreConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "x",
-										Pos:        ast.Position{Offset: 117, Line: 11, Column: 10},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "x",
+											Pos:        ast.Position{Offset: 117, Line: 11, Column: 10},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 122, Line: 11, Column: 15},
-										EndPos:   ast.Position{Offset: 122, Line: 11, Column: 15},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 122, Line: 11, Column: 15},
+											EndPos:   ast.Position{Offset: 122, Line: 11, Column: 15},
+										},
 									},
 								},
 							},
 						},
 					},
 					PostConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "x",
-										Pos:        ast.Position{Offset: 197, Line: 19, Column: 11},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "x",
+											Pos:        ast.Position{Offset: 197, Line: 19, Column: 11},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("2"),
-									Value:           big.NewInt(2),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 202, Line: 19, Column: 16},
-										EndPos:   ast.Position{Offset: 202, Line: 19, Column: 16},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("2"),
+										Value:           big.NewInt(2),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 202, Line: 19, Column: 16},
+											EndPos:   ast.Position{Offset: 202, Line: 19, Column: 16},
+										},
 									},
 								},
 							},
@@ -4118,44 +4126,48 @@ func TestParseTransactionDeclaration(t *testing.T) {
 						},
 					},
 					PreConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "x",
-										Pos:        ast.Position{Offset: 117, Line: 11, Column: 10},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "x",
+											Pos:        ast.Position{Offset: 117, Line: 11, Column: 10},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 122, Line: 11, Column: 15},
-										EndPos:   ast.Position{Offset: 122, Line: 11, Column: 15},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 122, Line: 11, Column: 15},
+											EndPos:   ast.Position{Offset: 122, Line: 11, Column: 15},
+										},
 									},
 								},
 							},
 						},
 					},
 					PostConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "x",
-										Pos:        ast.Position{Offset: 154, Line: 15, Column: 11},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "x",
+											Pos:        ast.Position{Offset: 154, Line: 15, Column: 11},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("2"),
-									Value:           big.NewInt(2),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 159, Line: 15, Column: 16},
-										EndPos:   ast.Position{Offset: 159, Line: 15, Column: 16},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("2"),
+										Value:           big.NewInt(2),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 159, Line: 15, Column: 16},
+											EndPos:   ast.Position{Offset: 159, Line: 15, Column: 16},
+										},
 									},
 								},
 							},
@@ -4721,64 +4733,69 @@ func TestParsePreAndPostConditions(t *testing.T) {
 						},
 					},
 					PreConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationNotEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "n",
-										Pos:        ast.Position{Offset: 62, Line: 4, Column: 16},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationNotEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "n",
+											Pos:        ast.Position{Offset: 62, Line: 4, Column: 16},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 67, Line: 4, Column: 21},
-										EndPos:   ast.Position{Offset: 67, Line: 4, Column: 21},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 67, Line: 4, Column: 21},
+											EndPos:   ast.Position{Offset: 67, Line: 4, Column: 21},
+										},
 									},
 								},
 							},
-						},
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationGreater,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "n",
-										Pos:        ast.Position{Offset: 85, Line: 5, Column: 16},
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationGreater,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "n",
+											Pos:        ast.Position{Offset: 85, Line: 5, Column: 16},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 89, Line: 5, Column: 20},
-										EndPos:   ast.Position{Offset: 89, Line: 5, Column: 20},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 89, Line: 5, Column: 20},
+											EndPos:   ast.Position{Offset: 89, Line: 5, Column: 20},
+										},
 									},
 								},
 							},
 						},
 					},
 					PostConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "result",
-										Pos:        ast.Position{Offset: 140, Line: 8, Column: 16},
+						Conditions: []ast.Condition{
+
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "result",
+											Pos:        ast.Position{Offset: 140, Line: 8, Column: 16},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 150, Line: 8, Column: 26},
-										EndPos:   ast.Position{Offset: 150, Line: 8, Column: 26},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 150, Line: 8, Column: 26},
+											EndPos:   ast.Position{Offset: 150, Line: 8, Column: 26},
+										},
 									},
 								},
 							},
@@ -4862,30 +4879,32 @@ func TestParseConditionMessage(t *testing.T) {
 						},
 					},
 					PreConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationGreaterEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "n",
-										Pos:        ast.Position{Offset: 62, Line: 4, Column: 16},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationGreaterEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "n",
+											Pos:        ast.Position{Offset: 62, Line: 4, Column: 16},
+										},
+									},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 67, Line: 4, Column: 21},
+											EndPos:   ast.Position{Offset: 67, Line: 4, Column: 21},
+										},
 									},
 								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
+								Message: &ast.StringExpression{
+									Value: "n must be positive",
 									Range: ast.Range{
-										StartPos: ast.Position{Offset: 67, Line: 4, Column: 21},
-										EndPos:   ast.Position{Offset: 67, Line: 4, Column: 21},
+										StartPos: ast.Position{Offset: 70, Line: 4, Column: 24},
+										EndPos:   ast.Position{Offset: 89, Line: 4, Column: 43},
 									},
-								},
-							},
-							Message: &ast.StringExpression{
-								Value: "n must be positive",
-								Range: ast.Range{
-									StartPos: ast.Position{Offset: 70, Line: 4, Column: 24},
-									EndPos:   ast.Position{Offset: 89, Line: 4, Column: 43},
 								},
 							},
 						},
@@ -6139,39 +6158,42 @@ func TestParsePreconditionWithUnaryNegation(t *testing.T) {
 						},
 					},
 					PreConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BoolExpression{
-								Value: true,
-								Range: ast.Range{
-									StartPos: ast.Position{Offset: 47, Line: 4, Column: 14},
-									EndPos:   ast.Position{Offset: 50, Line: 4, Column: 17},
-								},
-							},
-							Message: &ast.StringExpression{
-								Value: "one",
-								Range: ast.Range{
-									StartPos: ast.Position{Offset: 53, Line: 4, Column: 20},
-									EndPos:   ast.Position{Offset: 57, Line: 4, Column: 24},
-								},
-							},
-						},
-						&ast.TestCondition{
-							Test: &ast.UnaryExpression{
-								Operation: ast.OperationNegate,
-								Expression: &ast.BoolExpression{
-									Value: false,
+						Conditions: []ast.Condition{
+
+							&ast.TestCondition{
+								Test: &ast.BoolExpression{
+									Value: true,
 									Range: ast.Range{
-										StartPos: ast.Position{Offset: 74, Line: 5, Column: 15},
-										EndPos:   ast.Position{Offset: 78, Line: 5, Column: 19},
+										StartPos: ast.Position{Offset: 47, Line: 4, Column: 14},
+										EndPos:   ast.Position{Offset: 50, Line: 4, Column: 17},
 									},
 								},
-								StartPos: ast.Position{Offset: 73, Line: 5, Column: 14},
+								Message: &ast.StringExpression{
+									Value: "one",
+									Range: ast.Range{
+										StartPos: ast.Position{Offset: 53, Line: 4, Column: 20},
+										EndPos:   ast.Position{Offset: 57, Line: 4, Column: 24},
+									},
+								},
 							},
-							Message: &ast.StringExpression{
-								Value: "two",
-								Range: ast.Range{
-									StartPos: ast.Position{Offset: 81, Line: 5, Column: 22},
-									EndPos:   ast.Position{Offset: 85, Line: 5, Column: 26},
+							&ast.TestCondition{
+								Test: &ast.UnaryExpression{
+									Operation: ast.OperationNegate,
+									Expression: &ast.BoolExpression{
+										Value: false,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 74, Line: 5, Column: 15},
+											EndPos:   ast.Position{Offset: 78, Line: 5, Column: 19},
+										},
+									},
+									StartPos: ast.Position{Offset: 73, Line: 5, Column: 14},
+								},
+								Message: &ast.StringExpression{
+									Value: "two",
+									Range: ast.Range{
+										StartPos: ast.Position{Offset: 81, Line: 5, Column: 22},
+										EndPos:   ast.Position{Offset: 85, Line: 5, Column: 26},
+									},
 								},
 							},
 						},

--- a/runtime/old_parser/statement.go
+++ b/runtime/old_parser/statement.go
@@ -492,12 +492,10 @@ func parseFunctionBlock(p *parser) (*ast.FunctionBlock, error) {
 	var preConditions *ast.Conditions
 	if p.isToken(p.current, lexer.TokenIdentifier, keywordPre) {
 		p.next()
-		conditions, err := parseConditions(p, ast.ConditionKindPre)
+		preConditions, err = parseConditions(p, ast.ConditionKindPre)
 		if err != nil {
 			return nil, err
 		}
-
-		preConditions = &conditions
 	}
 
 	p.skipSpaceAndComments()
@@ -505,12 +503,10 @@ func parseFunctionBlock(p *parser) (*ast.FunctionBlock, error) {
 	var postConditions *ast.Conditions
 	if p.isToken(p.current, lexer.TokenIdentifier, keywordPost) {
 		p.next()
-		conditions, err := parseConditions(p, ast.ConditionKindPost)
+		postConditions, err = parseConditions(p, ast.ConditionKindPost)
 		if err != nil {
 			return nil, err
 		}
-
-		postConditions = &conditions
 	}
 
 	statements, err := parseStatements(p, func(token lexer.Token) bool {
@@ -542,13 +538,15 @@ func parseFunctionBlock(p *parser) (*ast.FunctionBlock, error) {
 }
 
 // parseConditions parses conditions (pre/post)
-func parseConditions(p *parser, kind ast.ConditionKind) (conditions ast.Conditions, err error) {
+func parseConditions(p *parser, kind ast.ConditionKind) (conditions *ast.Conditions, err error) {
 
 	p.skipSpaceAndComments()
 	_, err = p.mustOne(lexer.TokenBraceOpen)
 	if err != nil {
 		return nil, err
 	}
+
+	conditions = &ast.Conditions{}
 
 	defer func() {
 		p.skipSpaceAndComments()
@@ -572,7 +570,7 @@ func parseConditions(p *parser, kind ast.ConditionKind) (conditions ast.Conditio
 				return
 			}
 
-			conditions = append(conditions, condition)
+			conditions.Conditions = append(conditions.Conditions, condition)
 		}
 	}
 }

--- a/runtime/old_parser/transaction.go
+++ b/runtime/old_parser/transaction.go
@@ -125,12 +125,10 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 		if p.isToken(p.current, lexer.TokenIdentifier, keywordPre) {
 			// Skip the `pre` keyword
 			p.next()
-			conditions, err := parseConditions(p, ast.ConditionKindPre)
+			preConditions, err = parseConditions(p, ast.ConditionKindPre)
 			if err != nil {
 				return nil, err
 			}
-
-			preConditions = &conditions
 		}
 	}
 
@@ -166,12 +164,10 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 				}
 				// Skip the `post` keyword
 				p.next()
-				conditions, err := parseConditions(p, ast.ConditionKindPost)
+				postConditions, err = parseConditions(p, ast.ConditionKindPost)
 				if err != nil {
 					return nil, err
 				}
-
-				postConditions = &conditions
 				sawPost = true
 
 			default:

--- a/runtime/parser/declaration_test.go
+++ b/runtime/parser/declaration_test.go
@@ -764,63 +764,75 @@ func TestParseFunctionDeclaration(t *testing.T) {
 					},
 					FunctionBlock: &ast.FunctionBlock{
 						PreConditions: &ast.Conditions{
-							&ast.TestCondition{
-								Test: &ast.BoolExpression{
-									Value: true,
-									Range: ast.Range{
-										StartPos: ast.Position{Line: 4, Column: 17, Offset: 61},
-										EndPos:   ast.Position{Line: 4, Column: 20, Offset: 64},
-									},
-								},
-								Message: &ast.StringExpression{
-									Value: "test",
-									Range: ast.Range{
-										StartPos: ast.Position{Line: 4, Column: 24, Offset: 68},
-										EndPos:   ast.Position{Line: 4, Column: 29, Offset: 73},
-									},
-								},
+							Range: ast.Range{
+								StartPos: ast.Position{Offset: 38, Line: 3, Column: 14},
+								EndPos:   ast.Position{Offset: 120, Line: 6, Column: 14},
 							},
-							&ast.TestCondition{
-								Test: &ast.BinaryExpression{
-									Operation: ast.OperationGreater,
-									Left: &ast.IntegerExpression{
-										PositiveLiteral: []byte("2"),
-										Value:           big.NewInt(2),
-										Base:            10,
+							Conditions: []ast.Condition{
+								&ast.TestCondition{
+									Test: &ast.BoolExpression{
+										Value: true,
 										Range: ast.Range{
-											StartPos: ast.Position{Line: 5, Column: 17, Offset: 92},
-											EndPos:   ast.Position{Line: 5, Column: 17, Offset: 92},
+											StartPos: ast.Position{Line: 4, Column: 17, Offset: 61},
+											EndPos:   ast.Position{Line: 4, Column: 20, Offset: 64},
 										},
 									},
-									Right: &ast.IntegerExpression{
-										PositiveLiteral: []byte("1"),
-										Value:           big.NewInt(1),
-										Base:            10,
+									Message: &ast.StringExpression{
+										Value: "test",
 										Range: ast.Range{
-											StartPos: ast.Position{Line: 5, Column: 21, Offset: 96},
-											EndPos:   ast.Position{Line: 5, Column: 21, Offset: 96},
+											StartPos: ast.Position{Line: 4, Column: 24, Offset: 68},
+											EndPos:   ast.Position{Line: 4, Column: 29, Offset: 73},
 										},
 									},
 								},
-								Message: &ast.StringExpression{
-									Value: "foo",
-									Range: ast.Range{
-										StartPos: ast.Position{Line: 5, Column: 25, Offset: 100},
-										EndPos:   ast.Position{Line: 5, Column: 29, Offset: 104},
+								&ast.TestCondition{
+									Test: &ast.BinaryExpression{
+										Operation: ast.OperationGreater,
+										Left: &ast.IntegerExpression{
+											PositiveLiteral: []byte("2"),
+											Value:           big.NewInt(2),
+											Base:            10,
+											Range: ast.Range{
+												StartPos: ast.Position{Line: 5, Column: 17, Offset: 92},
+												EndPos:   ast.Position{Line: 5, Column: 17, Offset: 92},
+											},
+										},
+										Right: &ast.IntegerExpression{
+											PositiveLiteral: []byte("1"),
+											Value:           big.NewInt(1),
+											Base:            10,
+											Range: ast.Range{
+												StartPos: ast.Position{Line: 5, Column: 21, Offset: 96},
+												EndPos:   ast.Position{Line: 5, Column: 21, Offset: 96},
+											},
+										},
+									},
+									Message: &ast.StringExpression{
+										Value: "foo",
+										Range: ast.Range{
+											StartPos: ast.Position{Line: 5, Column: 25, Offset: 100},
+											EndPos:   ast.Position{Line: 5, Column: 29, Offset: 104},
+										},
 									},
 								},
 							},
 						},
 						PostConditions: &ast.Conditions{
-							&ast.TestCondition{
-								Test: &ast.BoolExpression{
-									Value: false,
-									Range: ast.Range{
-										StartPos: ast.Position{Line: 9, Column: 17, Offset: 161},
-										EndPos:   ast.Position{Line: 9, Column: 21, Offset: 165},
+							Range: ast.Range{
+								StartPos: ast.Position{Offset: 137, Line: 8, Column: 14},
+								EndPos:   ast.Position{Offset: 181, Line: 10, Column: 14},
+							},
+							Conditions: []ast.Condition{
+								&ast.TestCondition{
+									Test: &ast.BoolExpression{
+										Value: false,
+										Range: ast.Range{
+											StartPos: ast.Position{Line: 9, Column: 17, Offset: 161},
+											EndPos:   ast.Position{Line: 9, Column: 21, Offset: 165},
+										},
 									},
+									Message: nil,
 								},
-								Message: nil,
 							},
 						},
 						Block: &ast.Block{
@@ -5228,44 +5240,56 @@ func TestParseTransactionDeclaration(t *testing.T) {
 						},
 					},
 					PreConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "x",
-										Pos:        ast.Position{Offset: 117, Line: 11, Column: 10},
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 101, Line: 10, Column: 3},
+							EndPos:   ast.Position{Offset: 127, Line: 12, Column: 3},
+						},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "x",
+											Pos:        ast.Position{Offset: 117, Line: 11, Column: 10},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 122, Line: 11, Column: 15},
-										EndPos:   ast.Position{Offset: 122, Line: 11, Column: 15},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 122, Line: 11, Column: 15},
+											EndPos:   ast.Position{Offset: 122, Line: 11, Column: 15},
+										},
 									},
 								},
 							},
 						},
 					},
 					PostConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "x",
-										Pos:        ast.Position{Offset: 197, Line: 19, Column: 11},
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 179, Line: 18, Column: 6},
+							EndPos:   ast.Position{Offset: 213, Line: 20, Column: 9},
+						},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "x",
+											Pos:        ast.Position{Offset: 197, Line: 19, Column: 11},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("2"),
-									Value:           big.NewInt(2),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 202, Line: 19, Column: 16},
-										EndPos:   ast.Position{Offset: 202, Line: 19, Column: 16},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("2"),
+										Value:           big.NewInt(2),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 202, Line: 19, Column: 16},
+											EndPos:   ast.Position{Offset: 202, Line: 19, Column: 16},
+										},
 									},
 								},
 							},
@@ -5463,44 +5487,56 @@ func TestParseTransactionDeclaration(t *testing.T) {
 						},
 					},
 					PreConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "x",
-										Pos:        ast.Position{Offset: 117, Line: 11, Column: 10},
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 101, Line: 10, Column: 3},
+							EndPos:   ast.Position{Offset: 127, Line: 12, Column: 3},
+						},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "x",
+											Pos:        ast.Position{Offset: 117, Line: 11, Column: 10},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 122, Line: 11, Column: 15},
-										EndPos:   ast.Position{Offset: 122, Line: 11, Column: 15},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 122, Line: 11, Column: 15},
+											EndPos:   ast.Position{Offset: 122, Line: 11, Column: 15},
+										},
 									},
 								},
 							},
 						},
 					},
 					PostConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "x",
-										Pos:        ast.Position{Offset: 154, Line: 15, Column: 11},
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 136, Line: 14, Column: 6},
+							EndPos:   ast.Position{Offset: 170, Line: 16, Column: 9},
+						},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "x",
+											Pos:        ast.Position{Offset: 154, Line: 15, Column: 11},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("2"),
-									Value:           big.NewInt(2),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 159, Line: 15, Column: 16},
-										EndPos:   ast.Position{Offset: 159, Line: 15, Column: 16},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("2"),
+										Value:           big.NewInt(2),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 159, Line: 15, Column: 16},
+											EndPos:   ast.Position{Offset: 159, Line: 15, Column: 16},
+										},
 									},
 								},
 							},
@@ -6259,64 +6295,76 @@ func TestParsePreAndPostConditions(t *testing.T) {
 						},
 					},
 					PreConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationNotEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "n",
-										Pos:        ast.Position{Offset: 62, Line: 4, Column: 16},
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 40, Line: 3, Column: 12},
+							EndPos:   ast.Position{Offset: 103, Line: 6, Column: 12},
+						},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationNotEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "n",
+											Pos:        ast.Position{Offset: 62, Line: 4, Column: 16},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 67, Line: 4, Column: 21},
-										EndPos:   ast.Position{Offset: 67, Line: 4, Column: 21},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 67, Line: 4, Column: 21},
+											EndPos:   ast.Position{Offset: 67, Line: 4, Column: 21},
+										},
 									},
 								},
 							},
-						},
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationGreater,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "n",
-										Pos:        ast.Position{Offset: 85, Line: 5, Column: 16},
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationGreater,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "n",
+											Pos:        ast.Position{Offset: 85, Line: 5, Column: 16},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 89, Line: 5, Column: 20},
-										EndPos:   ast.Position{Offset: 89, Line: 5, Column: 20},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 89, Line: 5, Column: 20},
+											EndPos:   ast.Position{Offset: 89, Line: 5, Column: 20},
+										},
 									},
 								},
 							},
 						},
 					},
 					PostConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "result",
-										Pos:        ast.Position{Offset: 140, Line: 8, Column: 16},
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 117, Line: 7, Column: 12},
+							EndPos:   ast.Position{Offset: 164, Line: 9, Column: 12},
+						},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "result",
+											Pos:        ast.Position{Offset: 140, Line: 8, Column: 16},
+										},
 									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 150, Line: 8, Column: 26},
-										EndPos:   ast.Position{Offset: 150, Line: 8, Column: 26},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 150, Line: 8, Column: 26},
+											EndPos:   ast.Position{Offset: 150, Line: 8, Column: 26},
+										},
 									},
 								},
 							},
@@ -6400,30 +6448,36 @@ func TestParseConditionMessage(t *testing.T) {
 						},
 					},
 					PreConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationGreaterEqual,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "n",
-										Pos:        ast.Position{Offset: 62, Line: 4, Column: 16},
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 40, Line: 3, Column: 12},
+							EndPos:   ast.Position{Offset: 103, Line: 5, Column: 12},
+						},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationGreaterEqual,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "n",
+											Pos:        ast.Position{Offset: 62, Line: 4, Column: 16},
+										},
+									},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 67, Line: 4, Column: 21},
+											EndPos:   ast.Position{Offset: 67, Line: 4, Column: 21},
+										},
 									},
 								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
+								Message: &ast.StringExpression{
+									Value: "n must be positive",
 									Range: ast.Range{
-										StartPos: ast.Position{Offset: 67, Line: 4, Column: 21},
-										EndPos:   ast.Position{Offset: 67, Line: 4, Column: 21},
+										StartPos: ast.Position{Offset: 70, Line: 4, Column: 24},
+										EndPos:   ast.Position{Offset: 89, Line: 4, Column: 43},
 									},
-								},
-							},
-							Message: &ast.StringExpression{
-								Value: "n must be positive",
-								Range: ast.Range{
-									StartPos: ast.Position{Offset: 70, Line: 4, Column: 24},
-									EndPos:   ast.Position{Offset: 89, Line: 4, Column: 43},
 								},
 							},
 						},
@@ -6563,73 +6617,85 @@ func TestParseEmitAndTestCondition(t *testing.T) {
 						},
 					},
 					PreConditions: &ast.Conditions{
-						&ast.EmitCondition{
-							InvocationExpression: &ast.InvocationExpression{
-								InvokedExpression: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "Foo",
-										Pos:        ast.Position{Offset: 67, Line: 4, Column: 21},
-									},
-								},
-								ArgumentsStartPos: ast.Position{Offset: 70, Line: 4, Column: 24},
-								EndPos:            ast.Position{Offset: 71, Line: 4, Column: 25},
-							},
-							StartPos: ast.Position{Offset: 62, Line: 4, Column: 16},
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 40, Line: 3, Column: 12},
+							EndPos:   ast.Position{Offset: 107, Line: 6, Column: 12},
 						},
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationGreater,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "n",
-										Pos:        ast.Position{Offset: 89, Line: 5, Column: 16},
+						Conditions: []ast.Condition{
+							&ast.EmitCondition{
+								InvocationExpression: &ast.InvocationExpression{
+									InvokedExpression: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "Foo",
+											Pos:        ast.Position{Offset: 67, Line: 4, Column: 21},
+										},
 									},
+									ArgumentsStartPos: ast.Position{Offset: 70, Line: 4, Column: 24},
+									EndPos:            ast.Position{Offset: 71, Line: 4, Column: 25},
 								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 93, Line: 5, Column: 20},
-										EndPos:   ast.Position{Offset: 93, Line: 5, Column: 20},
+								StartPos: ast.Position{Offset: 62, Line: 4, Column: 16},
+							},
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationGreater,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "n",
+											Pos:        ast.Position{Offset: 89, Line: 5, Column: 16},
+										},
+									},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 93, Line: 5, Column: 20},
+											EndPos:   ast.Position{Offset: 93, Line: 5, Column: 20},
+										},
 									},
 								},
 							},
 						},
 					},
 					PostConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BinaryExpression{
-								Operation: ast.OperationGreater,
-								Left: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "n",
-										Pos:        ast.Position{Offset: 144, Line: 8, Column: 16},
-									},
-								},
-								Right: &ast.IntegerExpression{
-									PositiveLiteral: []byte("0"),
-									Value:           new(big.Int),
-									Base:            10,
-									Range: ast.Range{
-										StartPos: ast.Position{Offset: 148, Line: 8, Column: 20},
-										EndPos:   ast.Position{Offset: 148, Line: 8, Column: 20},
-									},
-								},
-							},
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 121, Line: 7, Column: 12},
+							EndPos:   ast.Position{Offset: 189, Line: 10, Column: 12},
 						},
-						&ast.EmitCondition{
-							InvocationExpression: &ast.InvocationExpression{
-								InvokedExpression: &ast.IdentifierExpression{
-									Identifier: ast.Identifier{
-										Identifier: "Bar",
-										Pos:        ast.Position{Offset: 171, Line: 9, Column: 21},
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BinaryExpression{
+									Operation: ast.OperationGreater,
+									Left: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "n",
+											Pos:        ast.Position{Offset: 144, Line: 8, Column: 16},
+										},
+									},
+									Right: &ast.IntegerExpression{
+										PositiveLiteral: []byte("0"),
+										Value:           new(big.Int),
+										Base:            10,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 148, Line: 8, Column: 20},
+											EndPos:   ast.Position{Offset: 148, Line: 8, Column: 20},
+										},
 									},
 								},
-								ArgumentsStartPos: ast.Position{Offset: 174, Line: 9, Column: 24},
-								EndPos:            ast.Position{Offset: 175, Line: 9, Column: 25},
 							},
-							StartPos: ast.Position{Offset: 166, Line: 9, Column: 16},
+							&ast.EmitCondition{
+								InvocationExpression: &ast.InvocationExpression{
+									InvokedExpression: &ast.IdentifierExpression{
+										Identifier: ast.Identifier{
+											Identifier: "Bar",
+											Pos:        ast.Position{Offset: 171, Line: 9, Column: 21},
+										},
+									},
+									ArgumentsStartPos: ast.Position{Offset: 174, Line: 9, Column: 24},
+									EndPos:            ast.Position{Offset: 175, Line: 9, Column: 25},
+								},
+								StartPos: ast.Position{Offset: 166, Line: 9, Column: 16},
+							},
 						},
 					},
 				},
@@ -8031,39 +8097,45 @@ func TestParsePreconditionWithUnaryNegation(t *testing.T) {
 						},
 					},
 					PreConditions: &ast.Conditions{
-						&ast.TestCondition{
-							Test: &ast.BoolExpression{
-								Value: true,
-								Range: ast.Range{
-									StartPos: ast.Position{Offset: 47, Line: 4, Column: 14},
-									EndPos:   ast.Position{Offset: 50, Line: 4, Column: 17},
-								},
-							},
-							Message: &ast.StringExpression{
-								Value: "one",
-								Range: ast.Range{
-									StartPos: ast.Position{Offset: 53, Line: 4, Column: 20},
-									EndPos:   ast.Position{Offset: 57, Line: 4, Column: 24},
-								},
-							},
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 27, Line: 3, Column: 10},
+							EndPos:   ast.Position{Offset: 97, Line: 6, Column: 10},
 						},
-						&ast.TestCondition{
-							Test: &ast.UnaryExpression{
-								Operation: ast.OperationNegate,
-								Expression: &ast.BoolExpression{
-									Value: false,
+						Conditions: []ast.Condition{
+							&ast.TestCondition{
+								Test: &ast.BoolExpression{
+									Value: true,
 									Range: ast.Range{
-										StartPos: ast.Position{Offset: 74, Line: 5, Column: 15},
-										EndPos:   ast.Position{Offset: 78, Line: 5, Column: 19},
+										StartPos: ast.Position{Offset: 47, Line: 4, Column: 14},
+										EndPos:   ast.Position{Offset: 50, Line: 4, Column: 17},
 									},
 								},
-								StartPos: ast.Position{Offset: 73, Line: 5, Column: 14},
+								Message: &ast.StringExpression{
+									Value: "one",
+									Range: ast.Range{
+										StartPos: ast.Position{Offset: 53, Line: 4, Column: 20},
+										EndPos:   ast.Position{Offset: 57, Line: 4, Column: 24},
+									},
+								},
 							},
-							Message: &ast.StringExpression{
-								Value: "two",
-								Range: ast.Range{
-									StartPos: ast.Position{Offset: 81, Line: 5, Column: 22},
-									EndPos:   ast.Position{Offset: 85, Line: 5, Column: 26},
+							&ast.TestCondition{
+								Test: &ast.UnaryExpression{
+									Operation: ast.OperationNegate,
+									Expression: &ast.BoolExpression{
+										Value: false,
+										Range: ast.Range{
+											StartPos: ast.Position{Offset: 74, Line: 5, Column: 15},
+											EndPos:   ast.Position{Offset: 78, Line: 5, Column: 19},
+										},
+									},
+									StartPos: ast.Position{Offset: 73, Line: 5, Column: 14},
+								},
+								Message: &ast.StringExpression{
+									Value: "two",
+									Range: ast.Range{
+										StartPos: ast.Position{Offset: 81, Line: 5, Column: 22},
+										EndPos:   ast.Position{Offset: 85, Line: 5, Column: 26},
+									},
 								},
 							},
 						},

--- a/runtime/parser/transaction.go
+++ b/runtime/parser/transaction.go
@@ -125,14 +125,13 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 	if execute == nil {
 		p.skipSpaceAndComments()
 		if p.isToken(p.current, lexer.TokenIdentifier, KeywordPre) {
+			preStartPos := p.current.StartPos
 			// Skip the `pre` keyword
 			p.next()
-			conditions, err := parseConditions(p)
+			preConditions, err = parseConditions(p, preStartPos)
 			if err != nil {
 				return nil, err
 			}
-
-			preConditions = &conditions
 		}
 	}
 
@@ -166,14 +165,13 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 				if sawPost {
 					return nil, p.syntaxError("unexpected second post-conditions")
 				}
+				postStartPos := p.current.StartPos
 				// Skip the `post` keyword
 				p.next()
-				conditions, err := parseConditions(p)
+				postConditions, err = parseConditions(p, postStartPos)
 				if err != nil {
 					return nil, err
 				}
-
-				postConditions = &conditions
 				sawPost = true
 
 			default:

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -11480,3 +11480,30 @@ func TestRuntimeStorageEnumAsDictionaryKey(t *testing.T) {
 		loggedMessages,
 	)
 }
+
+func TestResultRedeclared(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := NewTestInterpreterRuntime()
+
+	script := []byte(`
+      access(all) fun main(): Int { let result = 1; return result }
+    `)
+
+	runtimeInterface := &TestRuntimeInterface{}
+
+	nextScriptLocation := NewScriptLocationGenerator()
+
+	_, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextScriptLocation(),
+		},
+	)
+	require.NoError(t, err)
+
+}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -11526,7 +11526,7 @@ func TestResultRedeclared(t *testing.T) {
               access(all)
               fun test(): Int {
                   post {
-                      result == 1
+                      result == 2
                   }
               }
           }
@@ -11537,7 +11537,7 @@ func TestResultRedeclared(t *testing.T) {
               access(all)
               fun test(): Int {
                   let result = 1
-                  return result
+                  return 2  // return a different value than the local variable
               }
           }
 

--- a/runtime/sema/check_conditions.go
+++ b/runtime/sema/check_conditions.go
@@ -66,11 +66,11 @@ func (checker *Checker) checkCondition(condition ast.Condition) {
 	}
 }
 
-func (checker *Checker) rewritePostConditions(postConditions ast.Conditions) PostConditionsRewrite {
+func (checker *Checker) rewritePostConditions(postConditions []ast.Condition) PostConditionsRewrite {
 
 	var beforeStatements []ast.Statement
 
-	var rewrittenPostConditions ast.Conditions
+	var rewrittenPostConditions []ast.Condition
 	var allExtractedExpressions []ast.ExtractedExpression
 
 	count := len(postConditions)

--- a/runtime/sema/check_transaction_declaration.go
+++ b/runtime/sema/check_transaction_declaration.go
@@ -66,12 +66,13 @@ func (checker *Checker) VisitTransactionDeclaration(declaration *ast.Transaction
 	checker.visitTransactionPrepareFunction(declaration.Prepare, transactionType, fieldMembers)
 
 	if declaration.PreConditions != nil {
-		checker.visitConditions(*declaration.PreConditions)
+		checker.visitConditions(declaration.PreConditions.Conditions)
 	}
 
 	checker.visitWithPostConditions(
 		declaration.PostConditions,
 		VoidType,
+		nil,
 		func() {
 			checker.withSelfResourceInvalidationAllowed(func() {
 				checker.visitTransactionExecuteFunction(declaration.Execute, transactionType)

--- a/runtime/sema/errors.go
+++ b/runtime/sema/errors.go
@@ -4809,3 +4809,76 @@ func (*NestedReferenceError) IsUserError() {}
 func (e *NestedReferenceError) Error() string {
 	return fmt.Sprintf("cannot create a nested reference to value of type %s", e.Type.QualifiedString())
 }
+
+// ResultVariableConflictError
+
+type ResultVariableConflictError struct {
+	Kind                common.DeclarationKind
+	Pos                 ast.Position
+	ReturnTypeRange     ast.Range
+	PostConditionsRange ast.Range
+}
+
+var _ SemanticError = &ResultVariableConflictError{}
+var _ errors.UserError = &ResultVariableConflictError{}
+var _ errors.SecondaryError = &ResultVariableConflictError{}
+
+func (*ResultVariableConflictError) isSemanticError() {}
+
+func (*ResultVariableConflictError) IsUserError() {}
+
+func (e *ResultVariableConflictError) Error() string {
+	return fmt.Sprintf(
+		"cannot declare %[1]s `%[2]s`: it conflicts with the `%[2]s` variable for the post-conditions",
+		e.Kind.Name(),
+		ResultIdentifier,
+	)
+}
+
+func (*ResultVariableConflictError) SecondaryError() string {
+	return "consider renaming the variable"
+}
+
+func (e *ResultVariableConflictError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *ResultVariableConflictError) EndPosition(memoryGauge common.MemoryGauge) ast.Position {
+	length := len(ResultIdentifier)
+	return e.Pos.Shifted(memoryGauge, length-1)
+}
+
+func (e *ResultVariableConflictError) ErrorNotes() []errors.ErrorNote {
+	return []errors.ErrorNote{
+		ResultVariableReturnTypeNote{
+			Range: e.ReturnTypeRange,
+		},
+		ResultVariablePostConditionsNote{
+			Range: e.PostConditionsRange,
+		},
+	}
+}
+
+// ResultVariableReturnTypeNote
+
+type ResultVariableReturnTypeNote struct {
+	ast.Range
+}
+
+var _ errors.ErrorNote = ResultVariableReturnTypeNote{}
+
+func (ResultVariableReturnTypeNote) Message() string {
+	return "non-Void return type declared here"
+}
+
+// ResultVariablePostConditionsNote
+
+type ResultVariablePostConditionsNote struct {
+	ast.Range
+}
+
+var _ errors.ErrorNote = ResultVariablePostConditionsNote{}
+
+func (ResultVariablePostConditionsNote) Message() string {
+	return "post-conditions declared here"
+}

--- a/runtime/sema/post_conditions_rewrite.go
+++ b/runtime/sema/post_conditions_rewrite.go
@@ -24,5 +24,5 @@ import (
 
 type PostConditionsRewrite struct {
 	BeforeStatements        []ast.Statement
-	RewrittenPostConditions ast.Conditions
+	RewrittenPostConditions []ast.Condition
 }

--- a/runtime/tests/checker/conditions_test.go
+++ b/runtime/tests/checker/conditions_test.go
@@ -696,7 +696,7 @@ func TestCheckInvalidFunctionWithReturnTypeAndLocalResultAndPostConditionWithRes
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.RedeclarationError{}, errs[0])
+		assert.IsType(t, &sema.ResultVariableConflictError{}, errs[0])
 	})
 
 	t.Run("emit condition", func(t *testing.T) {
@@ -716,7 +716,7 @@ func TestCheckInvalidFunctionWithReturnTypeAndLocalResultAndPostConditionWithRes
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.RedeclarationError{}, errs[0])
+		assert.IsType(t, &sema.ResultVariableConflictError{}, errs[0])
 	})
 }
 
@@ -738,7 +738,7 @@ func TestCheckInvalidFunctionWithReturnTypeAndResultParameterAndPostConditionWit
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.RedeclarationError{}, errs[0])
+		assert.IsType(t, &sema.ResultVariableConflictError{}, errs[0])
 	})
 
 	t.Run("test condition", func(t *testing.T) {
@@ -757,7 +757,7 @@ func TestCheckInvalidFunctionWithReturnTypeAndResultParameterAndPostConditionWit
 
 		errs := RequireCheckerErrors(t, err, 1)
 
-		assert.IsType(t, &sema.RedeclarationError{}, errs[0])
+		assert.IsType(t, &sema.ResultVariableConflictError{}, errs[0])
 	})
 }
 

--- a/runtime/tests/checker/function_test.go
+++ b/runtime/tests/checker/function_test.go
@@ -376,7 +376,7 @@ func TestCheckInvalidResourceCapturingJustMemberAccess(t *testing.T) {
 	assert.IsType(t, &sema.ResourceCapturingError{}, errs[0])
 }
 
-func TestCheckInvalidFunctionWithResult(t *testing.T) {
+func TestCheckFunctionWithResult(t *testing.T) {
 
 	t.Parallel()
 
@@ -386,10 +386,26 @@ func TestCheckInvalidFunctionWithResult(t *testing.T) {
          return result
      }
    `)
+	require.NoError(t, err)
+}
+
+func TestCheckInvalidFunctionWithResultAndPostCondition(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := ParseAndCheck(t, `
+     fun test(): Int {
+         post {
+             result == 0
+         }
+         let result = 0
+         return result
+     }
+   `)
 
 	errs := RequireCheckerErrors(t, err, 1)
 
-	assert.IsType(t, &sema.RedeclarationError{}, errs[0])
+	assert.IsType(t, &sema.ResultVariableConflictError{}, errs[0])
 }
 
 func TestCheckFunctionNonExistingField(t *testing.T) {


### PR DESCRIPTION
Closes #774

## Description

- Only declare the `result` variable if post conditions are declared
- Provide a better, dedicated error, with notes

<img width="735" alt="Screenshot 2024-09-25 at 2 08 44 PM" src="https://github.com/user-attachments/assets/bc56588b-c13a-4c16-b17f-2df861fe652b">


Best viewed without whitespace changes

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
