### PR TITLE
Prevent migration tests from using out-of-sync data

### DIFF
--- a/migrations/capcons/migration_test.go
+++ b/migrations/capcons/migration_test.go
@@ -511,18 +511,20 @@ func testPathCapabilityValueMigration(
 	)
 
 	// Create and store path and account links
+	{
+		// Create new runtime.Storage used for storing path and account links
+		storage, inter, err := rt.Storage(runtime.Context{
+			Interface: runtimeInterface,
+		})
+		require.NoError(t, err)
 
-	storage, inter, err := rt.Storage(runtime.Context{
-		Interface: runtimeInterface,
-	})
-	require.NoError(t, err)
+		storeTestPathLinks(t, pathLinks, storage, inter)
 
-	storeTestPathLinks(t, pathLinks, storage, inter)
+		storeTestAccountLinks(accountLinks, storage, inter)
 
-	storeTestAccountLinks(accountLinks, storage, inter)
-
-	err = storage.Commit(inter, false)
-	require.NoError(t, err)
+		err = storage.Commit(inter, false)
+		require.NoError(t, err)
+	}
 
 	// Save capability values into account
 
@@ -556,6 +558,15 @@ func testPathCapabilityValueMigration(
 	require.NoError(t, err)
 
 	// Migrate
+
+	// Create new runtime.Storage for migration.
+	// WARNING: don't reuse old storage (created for storing path and account links)
+	// because it has outdated cache after ExecuteTransaction() commits new data
+	// to underlying ledger.
+	storage, inter, err := rt.Storage(runtime.Context{
+		Interface: runtimeInterface,
+	})
+	require.NoError(t, err)
 
 	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
 	require.NoError(t, err)
@@ -2410,16 +2421,17 @@ func TestPublishedPathCapabilityValueMigration(t *testing.T) {
 	)
 
 	// Create and store path links
+	{
+		storage, inter, err := rt.Storage(runtime.Context{
+			Interface: runtimeInterface,
+		})
+		require.NoError(t, err)
 
-	storage, inter, err := rt.Storage(runtime.Context{
-		Interface: runtimeInterface,
-	})
-	require.NoError(t, err)
+		storeTestPathLinks(t, pathLinks, storage, inter)
 
-	storeTestPathLinks(t, pathLinks, storage, inter)
-
-	err = storage.Commit(inter, false)
-	require.NoError(t, err)
+		err = storage.Commit(inter, false)
+		require.NoError(t, err)
+	}
 
 	// Save capability values into account
 
@@ -2432,7 +2444,7 @@ func TestPublishedPathCapabilityValueMigration(t *testing.T) {
       }
     `
 
-	err = rt.ExecuteTransaction(
+	err := rt.ExecuteTransaction(
 		runtime.Script{
 			Source: []byte(setupTx),
 		},
@@ -2445,6 +2457,15 @@ func TestPublishedPathCapabilityValueMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Migrate
+
+	// Create new runtime.Storage for migration.
+	// WARNING: don't reuse old storage (created for storing path links)
+	// because it has outdated cache after ExecuteTransaction() commits new data
+	// to underlying ledger.
+	storage, inter, err := rt.Storage(runtime.Context{
+		Interface: runtimeInterface,
+	})
+	require.NoError(t, err)
 
 	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
 	require.NoError(t, err)
@@ -2663,16 +2684,17 @@ func TestUntypedPathCapabilityValueMigration(t *testing.T) {
 	)
 
 	// Create and store path links
+	{
+		storage, inter, err := rt.Storage(runtime.Context{
+			Interface: runtimeInterface,
+		})
+		require.NoError(t, err)
 
-	storage, inter, err := rt.Storage(runtime.Context{
-		Interface: runtimeInterface,
-	})
-	require.NoError(t, err)
+		storeTestPathLinks(t, pathLinks, storage, inter)
 
-	storeTestPathLinks(t, pathLinks, storage, inter)
-
-	err = storage.Commit(inter, false)
-	require.NoError(t, err)
+		err = storage.Commit(inter, false)
+		require.NoError(t, err)
+	}
 
 	// Save capability values into account
 
@@ -2686,7 +2708,7 @@ func TestUntypedPathCapabilityValueMigration(t *testing.T) {
       }
     `
 
-	err = rt.ExecuteTransaction(
+	err := rt.ExecuteTransaction(
 		runtime.Script{
 			Source: []byte(setupTx),
 		},
@@ -2699,6 +2721,15 @@ func TestUntypedPathCapabilityValueMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Migrate
+
+	// Create new runtime.Storage for migration.
+	// WARNING: don't reuse old storage (created for storing path links)
+	// because it has outdated cache after ExecuteTransaction() commits new data
+	// to underlying ledger.
+	storage, inter, err := rt.Storage(runtime.Context{
+		Interface: runtimeInterface,
+	})
+	require.NoError(t, err)
 
 	migration, err := migrations.NewStorageMigration(inter, storage, "test", testAddress)
 	require.NoError(t, err)

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v1.0.0-preview.52"
+const Version = "v1.0.0"


### PR DESCRIPTION
Currently, some migration tests reuse storage for migration. It can lead to tests failing when the storage cache gets out of sync with underlying storage.

For example:
1. Use storage 1 to store valueA in public domain directly.
2. Use storage 2 to store valueB in public domain via ExecuteTransaction().
3. Reuse storage 1 for migration.  Here, migration only sees valueA from cache instead of both values.

This PR prevents out-of-sync issues by creating new `runtime.Storage` for migrations instead of reusing old storage.

### Context

This test bug surfaced on the proof-of-concept I'm working on:
- #3584 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
