### PR TITLE
Prevent leaving unreferenced slabs in storage while updating dictionary with enum key

### DIFF
--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -20182,8 +20182,7 @@ func (v *DictionaryValue) Insert(
 	// Currently, we only need to handle enum composite type because it is the only type that:
 	// - can be used as dictionary key (hashable) and
 	// - is transferred to its own slab.
-	if keyComposite, ok := keyValue.(*CompositeValue); ok &&
-		keyComposite.Kind == common.CompositeKindEnum {
+	if keyComposite, ok := keyValue.(*CompositeValue); ok {
 
 		// Get SlabID of transferred enum value.
 		keyCompositeSlabID := keyComposite.SlabID()

--- a/runtime/interpreter/value.go
+++ b/runtime/interpreter/value.go
@@ -20164,6 +20164,40 @@ func (v *DictionaryValue) Insert(
 		return NilOptionalValue
 	}
 
+	// At this point, existingValueStorable is not nil, which means previous op updated existing
+	// dictionary element (instead of inserting new element).
+
+	// When existing dictionary element is updated, atree.OrderedMap reuses existing stored key
+	// so new key isn't stored or referenced in atree.OrderedMap.  This aspect of atree cannot change
+	// without API changes in atree to return existing key storable for updated element.
+
+	// Given this, remove the transferred key used to update existing dictionary element to
+	// prevent transferred key (in owner address) remaining in storage when it isn't
+	// referenced from dictionary.
+
+	// Remove content of transferred keyValue.
+	keyValue.DeepRemove(interpreter, true)
+
+	// Remove slab containing transferred keyValue from storage if needed.
+	// Currently, we only need to handle enum composite type because it is the only type that:
+	// - can be used as dictionary key (hashable) and
+	// - is transferred to its own slab.
+	if keyComposite, ok := keyValue.(*CompositeValue); ok &&
+		keyComposite.Kind == common.CompositeKindEnum {
+
+		// Get SlabID of transferred enum value.
+		keyCompositeSlabID := keyComposite.SlabID()
+
+		if keyCompositeSlabID == atree.SlabIDUndefined {
+			// It isn't possible for transferred enum value to be inlined in another container
+			// (SlabID as SlabIDUndefined) because it is transferred from stack by itself.
+			panic(errors.NewUnexpectedError("transferred enum value as dictionary key should not be inlined"))
+		}
+
+		// Remove slab containing transferred enum value from storage.
+		interpreter.RemoveReferencedSlab(atree.SlabIDStorable(keyCompositeSlabID))
+	}
+
 	storage := interpreter.Storage()
 
 	existingValue := StoredValue(

--- a/runtime/interpreter/value_test.go
+++ b/runtime/interpreter/value_test.go
@@ -4480,3 +4480,196 @@ func TestStringIsGraphemeBoundaryEnd(t *testing.T) {
 	test(flagESflagEE, 16, true)
 
 }
+
+func TestOverwriteDictionaryValueWhereKeyIsStoredInSeparateAtreeSlab(t *testing.T) {
+
+	t.Parallel()
+
+	owner := common.Address{0x1}
+
+	t.Run("enum as dict key", func(t *testing.T) {
+
+		newEnumValue := func(inter *Interpreter) Value {
+			return NewCompositeValue(
+				inter,
+				EmptyLocationRange,
+				utils.TestLocation,
+				"Test",
+				common.CompositeKindEnum,
+				[]CompositeField{
+					{
+						Name:  "rawValue",
+						Value: NewUnmeteredUInt8Value(42),
+					},
+				},
+				common.ZeroAddress,
+			)
+		}
+
+		storage := newUnmeteredInMemoryStorage()
+
+		elaboration := sema.NewElaboration(nil)
+		elaboration.SetCompositeType(
+			testCompositeValueType.ID(),
+			testCompositeValueType,
+		)
+
+		inter, err := NewInterpreter(
+			&Program{
+				Elaboration: elaboration,
+			},
+			utils.TestLocation,
+			&Config{
+				Storage:                       storage,
+				AtreeValueValidationEnabled:   true,
+				AtreeStorageValidationEnabled: true,
+			},
+		)
+		require.NoError(t, err)
+
+		// Create empty dictionary
+		dictionary := NewDictionaryValueWithAddress(
+			inter,
+			EmptyLocationRange,
+			&DictionaryStaticType{
+				KeyType:   PrimitiveStaticTypeAnyStruct,
+				ValueType: PrimitiveStaticTypeAnyStruct,
+			},
+			owner,
+		)
+		require.Equal(t, 0, dictionary.Count())
+
+		// Insert new key-value pair (enum as key) to dictionary
+		existingValue := dictionary.Insert(
+			inter,
+			EmptyLocationRange,
+			newEnumValue(inter),
+			NewUnmeteredInt64Value(int64(1)),
+		)
+		require.Equal(t, NilOptionalValue, existingValue)
+		require.Equal(t, 1, dictionary.Count())
+
+		// Test inserted dictionary element
+		v, found := dictionary.Get(
+			inter,
+			EmptyLocationRange,
+			newEnumValue(inter),
+		)
+		require.True(t, found)
+		require.Equal(t, Int64Value(1), v)
+
+		// Update existing key with new value
+		existingValue = dictionary.Insert(
+			inter,
+			EmptyLocationRange,
+			newEnumValue(inter),
+			NewUnmeteredInt64Value(int64(2)),
+		)
+		require.NotEqual(t, Int64Value(1), existingValue)
+		require.Equal(t, 1, dictionary.Count())
+
+		// Check updated dictionary element
+		v, found = dictionary.Get(
+			inter,
+			EmptyLocationRange,
+			newEnumValue(inter),
+		)
+		require.True(t, found)
+		require.Equal(t, Int64Value(2), v)
+
+		// Check storage containing only one root slab (dictionary root)
+		checkRootSlabIDsInStorage(t, storage, []atree.SlabID{dictionary.SlabID()})
+	})
+
+	t.Run("large string as dict key", func(t *testing.T) {
+		newStringValue := func() Value {
+			return NewUnmeteredStringValue(strings.Repeat("a", 1024))
+		}
+
+		storage := newUnmeteredInMemoryStorage()
+
+		elaboration := sema.NewElaboration(nil)
+
+		inter, err := NewInterpreter(
+			&Program{
+				Elaboration: elaboration,
+			},
+			utils.TestLocation,
+			&Config{
+				Storage:                       storage,
+				AtreeValueValidationEnabled:   true,
+				AtreeStorageValidationEnabled: true,
+			},
+		)
+		require.NoError(t, err)
+
+		// Create empty dictionary
+		dictionary := NewDictionaryValueWithAddress(
+			inter,
+			EmptyLocationRange,
+			&DictionaryStaticType{
+				KeyType:   PrimitiveStaticTypeAnyStruct,
+				ValueType: PrimitiveStaticTypeAnyStruct,
+			},
+			owner,
+		)
+		require.Equal(t, 0, dictionary.Count())
+
+		// Insert new key-value pair to dictionary
+		// Key is a large string which is stored in its own slab.
+		existingValue := dictionary.Insert(
+			inter,
+			EmptyLocationRange,
+			newStringValue(),
+			NewUnmeteredInt64Value(int64(1)),
+		)
+		require.Equal(t, NilOptionalValue, existingValue)
+		require.Equal(t, 1, dictionary.Count())
+
+		// Check new dictionary element
+		v, found := dictionary.Get(
+			inter,
+			EmptyLocationRange,
+			newStringValue(),
+		)
+		require.True(t, found)
+		require.Equal(t, Int64Value(1), v)
+
+		// Update existing key with new value
+		existingValue = dictionary.Insert(
+			inter,
+			EmptyLocationRange,
+			newStringValue(),
+			NewUnmeteredInt64Value(int64(2)),
+		)
+		require.NotEqual(t, Int64Value(1), existingValue)
+		require.Equal(t, 1, dictionary.Count())
+
+		// Check updated dictionary element
+		v, found = dictionary.Get(
+			inter,
+			EmptyLocationRange,
+			newStringValue(),
+		)
+		require.True(t, found)
+		require.Equal(t, Int64Value(2), v)
+
+		// Check storage containing only one root slab (dictionary root)
+		checkRootSlabIDsInStorage(t, storage, []atree.SlabID{dictionary.SlabID()})
+	})
+}
+
+func checkRootSlabIDsInStorage(t *testing.T, storage atree.SlabStorage, expectedRootSlabIDs []atree.SlabID) {
+	rootSlabIDs, err := atree.CheckStorageHealth(storage, -1)
+	require.NoError(t, err)
+
+	// Get non-temp address slab IDs from rootSlabIDs
+	nontempSlabIDs := make([]atree.SlabID, 0, len(rootSlabIDs))
+	for rootSlabID := range rootSlabIDs {
+		if !rootSlabID.HasTempAddress() {
+			nontempSlabIDs = append(nontempSlabIDs, rootSlabID)
+		}
+	}
+
+	require.ElementsMatch(t, expectedRootSlabIDs, nontempSlabIDs)
+}


### PR DESCRIPTION
Closes #3508

Port https://github.com/dapperlabs/cadence-internal/pull/242

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
