### PR TITLE
Update CCF CDDL for IntersectionType to match CCF codec

### DIFF
--- a/encoding/ccf/decode_type.go
+++ b/encoding/ccf/decode_type.go
@@ -610,16 +610,14 @@ func (d *Decoder) decodeReferenceType(
 //
 //	; cbor-tag-intersection-type
 //	#6.143([
-//	  type: inline-type / nil,
-//	  types: [* inline-type]
+//	  types: [+ inline-type]
 //	])
 //
 // intersection-type-value =
 //
 //	; cbor-tag-intersection-type-value
 //	#6.191([
-//	  type: type-value / nil,
-//	  types: [* type-value]
+//	  types: [+ type-value]
 //	])
 //
 // NOTE: decodeTypeFn is responsible for decoding inline-type or type-value.

--- a/encoding/ccf/encode.go
+++ b/encoding/ccf/encode.go
@@ -1569,8 +1569,7 @@ func (e *Encoder) encodeReferenceTypeValue(typ *cadence.ReferenceType, visited c
 //
 //	; cbor-tag-intersection-type-value
 //	#6.191([
-//	  type: type-value / nil,
-//	  types: [* type-value]
+//	  types: [+ type-value]
 //	])
 func (e *Encoder) encodeIntersectionTypeValue(typ *cadence.IntersectionType, visited ccfTypeIDByCadenceType) error {
 	rawTagNum := []byte{0xd8, CBORTagIntersectionTypeValue}

--- a/encoding/ccf/encode_type.go
+++ b/encoding/ccf/encode_type.go
@@ -604,8 +604,7 @@ func (e *Encoder) encodeReferenceTypeWithRawTag(
 //
 //	; cbor-tag-intersection-type
 //	#6.143([
-//	  type: inline-type / nil,
-//	  types: [* inline-type]
+//	  types: [+ inline-type]
 //	])
 func (e *Encoder) encodeIntersectionType(typ *cadence.IntersectionType, tids ccfTypeIDByCadenceType) error {
 	rawTagNum := []byte{0xd8, CBORTagIntersectionType}


### PR DESCRIPTION
This updates CCF-related comments that use CDDL notation to make them match the CCF codec implementation.

This was identified while updating CCF Specs 1.0-RC3 to 1.0.0 at `onflow/ccf`:
- https://github.com/onflow/ccf/pull/7

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
