### PR TITLE
Remove attachments enabling flag

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -119,7 +119,6 @@ func DefaultCheckerConfig(
 				Elaboration: importedChecker.Elaboration,
 			}, nil
 		},
-		AttachmentsEnabled: true,
 	}
 }
 

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -35,8 +35,6 @@ type Config struct {
 	ResourceOwnerChangeHandlerEnabled bool
 	// CoverageReport enables and collects coverage reporting metrics
 	CoverageReport *CoverageReport
-	// AttachmentsEnabled specifies if attachments are enabled
-	AttachmentsEnabled bool
 	// LegacyContractUpgradeEnabled enabled specifies whether to use the old parser when parsing an old contract
 	LegacyContractUpgradeEnabled bool
 	// ContractUpdateTypeRemovalEnabled specifies if type removal is enabled in contract updates

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -211,7 +211,6 @@ func (e *interpreterEnvironment) newCheckerConfig() *sema.Config {
 		LocationHandler:                  e.ResolveLocation,
 		ImportHandler:                    e.resolveImport,
 		CheckHandler:                     e.newCheckHandler(),
-		AttachmentsEnabled:               e.config.AttachmentsEnabled,
 	}
 }
 

--- a/sema/check_attach_expression.go
+++ b/sema/check_attach_expression.go
@@ -25,12 +25,6 @@ import (
 
 func (checker *Checker) VisitAttachExpression(expression *ast.AttachExpression) Type {
 
-	if !checker.Config.AttachmentsEnabled {
-		checker.report(&AttachmentsNotEnabledError{
-			Range: ast.NewRangeFromPositioned(checker.memoryGauge, expression),
-		})
-	}
-
 	attachment := expression.Attachment
 	baseExpression := expression.Base
 

--- a/sema/check_composite_declaration.go
+++ b/sema/check_composite_declaration.go
@@ -145,13 +145,6 @@ func (checker *Checker) VisitAttachmentDeclaration(declaration *ast.AttachmentDe
 }
 
 func (checker *Checker) visitAttachmentDeclaration(declaration *ast.AttachmentDeclaration) (_ struct{}) {
-
-	if !checker.Config.AttachmentsEnabled {
-		checker.report(&AttachmentsNotEnabledError{
-			Range: ast.NewRangeFromPositioned(checker.memoryGauge, declaration),
-		})
-	}
-
 	checker.visitCompositeLikeDeclaration(declaration)
 	attachmentType := checker.Elaboration.CompositeDeclarationType(declaration)
 	checker.checkAttachmentMembersAccess(attachmentType)

--- a/sema/check_expression.go
+++ b/sema/check_expression.go
@@ -444,12 +444,6 @@ func (checker *Checker) checkTypeIndexingExpression(
 
 	targetExpression := indexExpression.TargetExpression
 
-	if !checker.Config.AttachmentsEnabled {
-		checker.report(&AttachmentsNotEnabledError{
-			Range: ast.NewRangeFromPositioned(checker.memoryGauge, indexExpression),
-		})
-	}
-
 	expressionType := ast.ExpressionAsType(indexExpression.IndexingExpression)
 	if expressionType == nil {
 		return InvalidType

--- a/sema/check_remove_statement.go
+++ b/sema/check_remove_statement.go
@@ -25,12 +25,6 @@ import (
 
 func (checker *Checker) VisitRemoveStatement(statement *ast.RemoveStatement) (_ struct{}) {
 
-	if !checker.Config.AttachmentsEnabled {
-		checker.report(&AttachmentsNotEnabledError{
-			Range: ast.NewRangeFromPositioned(checker.memoryGauge, statement),
-		})
-	}
-
 	nominalType := checker.convertNominalType(statement.Attachment)
 	base := checker.VisitExpression(statement.Value, statement, nil)
 	checker.checkUnusedExpressionResourceLoss(base, statement.Value)

--- a/sema/config.go
+++ b/sema/config.go
@@ -53,6 +53,4 @@ type Config struct {
 	AllowNativeDeclarations bool
 	// AllowStaticDeclarations determines if declarations may be static
 	AllowStaticDeclarations bool
-	// AttachmentsEnabled determines if attachments are enabled
-	AttachmentsEnabled bool
 }

--- a/sema/errors.go
+++ b/sema/errors.go
@@ -4639,22 +4639,6 @@ func (e *InvalidTypeIndexingError) Error() string {
 	)
 }
 
-// AttachmentsNotEnabledError
-type AttachmentsNotEnabledError struct {
-	ast.Range
-}
-
-var _ SemanticError = &AttachmentsNotEnabledError{}
-var _ errors.UserError = &AttachmentsNotEnabledError{}
-
-func (*AttachmentsNotEnabledError) isSemanticError() {}
-
-func (*AttachmentsNotEnabledError) IsUserError() {}
-
-func (e *AttachmentsNotEnabledError) Error() string {
-	return "attachments are not enabled and cannot be used in this environment"
-}
-
 // InvalidAttachmentEntitlementError
 type InvalidAttachmentEntitlementError struct {
 	Attachment         *CompositeType

--- a/stdlib/cadence_v0.42_to_v1_contract_upgrade_validation_test.go
+++ b/stdlib/cadence_v0.42_to_v1_contract_upgrade_validation_test.go
@@ -49,8 +49,7 @@ func testContractUpdate(t *testing.T, oldCode string, newCode string) error {
 		utils.TestLocation,
 		nil,
 		&sema.Config{
-			AccessCheckMode:    sema.AccessCheckModeStrict,
-			AttachmentsEnabled: true,
+			AccessCheckMode: sema.AccessCheckModeStrict,
 		})
 	require.NoError(t, err)
 
@@ -130,8 +129,7 @@ func parseAndCheckPrograms(
 			location,
 			nil,
 			&sema.Config{
-				AccessCheckMode:    sema.AccessCheckModeStrict,
-				AttachmentsEnabled: true,
+				AccessCheckMode: sema.AccessCheckModeStrict,
 			},
 		)
 
@@ -171,7 +169,6 @@ func parseAndCheckPrograms(
 
 				return
 			},
-			AttachmentsEnabled: true,
 		})
 	require.NoError(t, err)
 

--- a/tests/attachments_test.go
+++ b/tests/attachments_test.go
@@ -36,7 +36,7 @@ func TestRuntimeAccountAttachmentSaveAndLoad(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntimeWithAttachments()
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -147,7 +147,7 @@ func TestRuntimeAccountAttachmentExportFailure(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntimeWithAttachments()
+	rt := NewTestInterpreterRuntime()
 
 	logs := make([]string, 0)
 	events := make([]string, 0)
@@ -238,7 +238,7 @@ func TestRuntimeAccountAttachmentExport(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntimeWithAttachments()
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -323,7 +323,7 @@ func TestRuntimeAccountAttachedExport(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntimeWithAttachments()
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -411,7 +411,7 @@ func TestRuntimeAccountAttachmentSaveAndBorrow(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntimeWithAttachments()
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -525,7 +525,7 @@ func TestRuntimeAccountAttachmentCapability(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntimeWithAttachments()
+	rt := NewTestInterpreterRuntime()
 
 	var logs []string
 	var events []string
@@ -666,7 +666,7 @@ func TestRuntimeAttachmentStorage(t *testing.T) {
 	address := common.MustBytesToAddress([]byte{0x1})
 
 	newRuntime := func() (TestInterpreterRuntime, *TestRuntimeInterface) {
-		runtime := NewTestInterpreterRuntimeWithAttachments()
+		runtime := NewTestInterpreterRuntime()
 
 		accountCodes := map[common.Location][]byte{}
 

--- a/tests/checker/access_test.go
+++ b/tests/checker/access_test.go
@@ -603,8 +603,7 @@ func TestCheckAccessModifierGlobalCompositeDeclaration(t *testing.T) {
 							),
 							ParseAndCheckOptions{
 								Config: &sema.Config{
-									AccessCheckMode:    checkMode,
-									AttachmentsEnabled: true,
+									AccessCheckMode: checkMode,
 								},
 							},
 						)

--- a/tests/checker/attachments_test.go
+++ b/tests/checker/attachments_test.go
@@ -3816,7 +3816,6 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 				`,
 			ParseAndCheckOptions{Config: &sema.Config{
 				SuggestionsEnabled: true,
-				AttachmentsEnabled: true,
 			}},
 		)
 
@@ -3896,7 +3895,6 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 				`,
 			ParseAndCheckOptions{Config: &sema.Config{
 				SuggestionsEnabled: true,
-				AttachmentsEnabled: true,
 			}},
 		)
 
@@ -3970,7 +3968,6 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 				`,
 			ParseAndCheckOptions{Config: &sema.Config{
 				SuggestionsEnabled: true,
-				AttachmentsEnabled: true,
 			}},
 		)
 
@@ -4386,95 +4383,6 @@ func TestCheckAttachmentsResourceReference(t *testing.T) {
 
 		errs := RequireCheckerErrors(t, err, 1)
 		assert.IsType(t, &sema.InvalidatedResourceReferenceError{}, errs[0])
-	})
-}
-
-func TestCheckAttachmentsNotEnabled(t *testing.T) {
-
-	t.Parallel()
-
-	parseAndCheckWithoutAttachments := func(t *testing.T, code string) (*sema.Checker, error) {
-		return ParseAndCheckWithOptions(t, code, ParseAndCheckOptions{})
-	}
-
-	t.Run("declaration", func(t *testing.T) {
-
-		t.Parallel()
-
-		_, err := parseAndCheckWithoutAttachments(t,
-			`
-			struct S {}
-			attachment Test for S {}`,
-		)
-
-		errs := RequireCheckerErrors(t, err, 1)
-		assert.IsType(t, &sema.AttachmentsNotEnabledError{}, errs[0])
-	})
-
-	t.Run("attach", func(t *testing.T) {
-
-		t.Parallel()
-
-		_, err := parseAndCheckWithoutAttachments(t,
-			`
-			struct S {}
-			let s = attach A() to S() 
-			`,
-		)
-
-		errs := RequireCheckerErrors(t, err, 2)
-		assert.IsType(t, &sema.AttachmentsNotEnabledError{}, errs[0])
-		assert.IsType(t, &sema.NotDeclaredError{}, errs[1])
-	})
-
-	t.Run("remove", func(t *testing.T) {
-
-		t.Parallel()
-
-		_, err := parseAndCheckWithoutAttachments(t,
-			`
-			struct S {}
-			fun foo() {
-				remove A from S() 
-			}
-			`,
-		)
-
-		errs := RequireCheckerErrors(t, err, 2)
-		assert.IsType(t, &sema.AttachmentsNotEnabledError{}, errs[0])
-		assert.IsType(t, &sema.NotDeclaredError{}, errs[1])
-	})
-
-	t.Run("type indexing", func(t *testing.T) {
-
-		t.Parallel()
-
-		_, err := parseAndCheckWithoutAttachments(t,
-			`
-			struct S {}
-			attachment A for S {}
-			let s = S()
-			let r = s[A]
-			`,
-		)
-
-		errs := RequireCheckerErrors(t, err, 2)
-		assert.IsType(t, &sema.AttachmentsNotEnabledError{}, errs[0])
-		assert.IsType(t, &sema.AttachmentsNotEnabledError{}, errs[1])
-	})
-
-	t.Run("regular indexing ok", func(t *testing.T) {
-
-		t.Parallel()
-
-		_, err := parseAndCheckWithoutAttachments(t,
-			`
-			let x = [1, 2, 3]
-			let y = x[2]
-			`,
-		)
-
-		require.NoError(t, err)
 	})
 }
 

--- a/tests/checker/storable_test.go
+++ b/tests/checker/storable_test.go
@@ -47,7 +47,6 @@ func TestCheckStorable(t *testing.T) {
 					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},
-					AttachmentsEnabled: true,
 				},
 			},
 		)

--- a/tests/checker/utils.go
+++ b/tests/checker/utils.go
@@ -37,12 +37,7 @@ import (
 )
 
 func ParseAndCheck(t testing.TB, code string) (*sema.Checker, error) {
-	return ParseAndCheckWithOptions(t, code, ParseAndCheckOptions{
-		// allow attachments is on by default for testing purposes
-		Config: &sema.Config{
-			AttachmentsEnabled: true,
-		},
-	})
+	return ParseAndCheckWithOptions(t, code, ParseAndCheckOptions{})
 }
 
 type ParseAndCheckOptions struct {

--- a/tests/convertValues_test.go
+++ b/tests/convertValues_test.go
@@ -5270,7 +5270,7 @@ func TestRuntimeNestedStructArgPassing(t *testing.T) {
 func TestRuntimeDestroyedResourceReferenceExport(t *testing.T) {
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntimeWithAttachments()
+	rt := NewTestInterpreterRuntime()
 
 	script := []byte(`
         access(all) resource S {}

--- a/tests/entitlements_test.go
+++ b/tests/entitlements_test.go
@@ -221,7 +221,7 @@ func TestRuntimeAccountEntitlementAttachment(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntimeWithAttachments()
+	rt := NewTestInterpreterRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -507,7 +507,7 @@ func TestRuntimeAccountEntitlementCapabilityCasting(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntimeWithAttachments()
+	rt := NewTestInterpreterRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -607,7 +607,7 @@ func TestRuntimeAccountEntitlementCapabilityDictionary(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntimeWithAttachments()
+	rt := NewTestInterpreterRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -722,7 +722,7 @@ func TestRuntimeAccountEntitlementGenericCapabilityDictionary(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntimeWithAttachments()
+	rt := NewTestInterpreterRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`

--- a/tests/interpreter/attachments_test.go
+++ b/tests/interpreter/attachments_test.go
@@ -1265,9 +1265,6 @@ func TestInterpretAttachmentDestructor(t *testing.T) {
 					return nil
 				},
 			},
-			CheckerConfig: &sema.Config{
-				AttachmentsEnabled: true,
-			},
 		})
 		require.NoError(t, err)
 
@@ -1315,9 +1312,6 @@ func TestInterpretAttachmentDestructor(t *testing.T) {
 					return nil
 				},
 			},
-			CheckerConfig: &sema.Config{
-				AttachmentsEnabled: true,
-			},
 		})
 		require.NoError(t, err)
 
@@ -1360,9 +1354,6 @@ func TestInterpretAttachmentDestructor(t *testing.T) {
 					events = append(events, event)
 					return nil
 				},
-			},
-			CheckerConfig: &sema.Config{
-				AttachmentsEnabled: true,
 			},
 		})
 		require.NoError(t, err)
@@ -1409,9 +1400,6 @@ func TestInterpretAttachmentDestructor(t *testing.T) {
 					events = append(events, event)
 					return nil
 				},
-			},
-			CheckerConfig: &sema.Config{
-				AttachmentsEnabled: true,
 			},
 		})
 		require.NoError(t, err)
@@ -1462,9 +1450,6 @@ func TestInterpretAttachmentDestructor(t *testing.T) {
 					events = append(events, event)
 					return nil
 				},
-			},
-			CheckerConfig: &sema.Config{
-				AttachmentsEnabled: true,
 			},
 		})
 		require.NoError(t, err)
@@ -1524,9 +1509,6 @@ func TestInterpretAttachmentDestructor(t *testing.T) {
 					return nil
 				},
 			},
-			CheckerConfig: &sema.Config{
-				AttachmentsEnabled: true,
-			},
 		})
 		require.NoError(t, err)
 
@@ -1582,9 +1564,9 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
 
 		    access(all) fun returnSameRef(_ ref: &A): &A {
 		        return ref
-		    }`, sema.Config{
-			AttachmentsEnabled: true,
-		})
+		    }`,
+			sema.Config{},
+		)
 
 		_, err := inter.Invoke("test")
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
@@ -1611,9 +1593,9 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
 
 		    access(all) fun returnSameRef(_ ref: &A): &A {
 		        return ref
-		    }`, sema.Config{
-			AttachmentsEnabled: true,
-		})
+		    }`,
+			sema.Config{},
+		)
 
 		_, err := inter.Invoke("test")
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
@@ -1661,9 +1643,9 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
 
 		    access(all) fun returnSameRef(_ ref: &A): &A {
 		        return ref
-		    }`, sema.Config{
-			AttachmentsEnabled: true,
-		})
+		    }`,
+			sema.Config{},
+		)
 
 		_, err := inter.Invoke("test")
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
@@ -1706,9 +1688,9 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
                 r2.setID(5)
                 authAccount.storage.save(<-r2, to: /storage/foo)
                 return ref!.id
-            }`, sema.Config{
-			AttachmentsEnabled: true,
-		})
+            }`,
+			sema.Config{},
+		)
 
 		_, err := inter.Invoke("test")
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
@@ -1740,9 +1722,9 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
 
 		    access(all) fun returnSameRef(_ ref: &A): &A {
 		        return ref
-		    }`, sema.Config{
-			AttachmentsEnabled: true,
-		})
+		    }`,
+			sema.Config{},
+		)
 
 		_, err := inter.Invoke("test")
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
@@ -1784,9 +1766,9 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
                 a.setID(5)
                 authAccount.storage.save(<-r2, to: /storage/foo)
                 return ref!.id
-            }`, sema.Config{
-			AttachmentsEnabled: true,
-		})
+            }`,
+			sema.Config{},
+		)
 
 		_, err := inter.Invoke("test")
 		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
@@ -2524,7 +2506,6 @@ func TestInterpretBuiltinCompositeAttachment(t *testing.T) {
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
-				AttachmentsEnabled: true,
 			},
 			Config: &interpreter.Config{
 				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {

--- a/tests/interpreter/entitlements_test.go
+++ b/tests/interpreter/entitlements_test.go
@@ -1441,9 +1441,9 @@ func TestInterpretEntitlementMappingFields(t *testing.T) {
 			let i = ref?.foo()
 			return i!
 		}
-		`, sema.Config{
-			AttachmentsEnabled: false,
-		})
+		`,
+			sema.Config{},
+		)
 
 		value, err := inter.Invoke("test")
 		require.NoError(t, err)
@@ -2534,9 +2534,9 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 				let ref = account.storage.borrow<auth(E) &R>(from: /storage/foo)!
 				return ref[A]!
 			}
-		`, sema.Config{
-			AttachmentsEnabled: true,
-		})
+		`,
+			sema.Config{},
+		)
 
 		value, err := inter.Invoke("test")
 		require.NoError(t, err)
@@ -2576,9 +2576,9 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 				let ref = account.storage.borrow<auth(X, E, G) &R>(from: /storage/foo)!
 				return ref[A]!.entitled()
 			}
-		`, sema.Config{
-			AttachmentsEnabled: true,
-		})
+		`,
+			sema.Config{},
+		)
 
 		value, err := inter.Invoke("test")
 		require.NoError(t, err)
@@ -2618,9 +2618,9 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 				let ref = account.storage.borrow<auth(E, X, G) &R>(from: /storage/foo)!
 				return ref[A]!.entitled()
 			}
-		`, sema.Config{
-			AttachmentsEnabled: true,
-		})
+		`,
+			sema.Config{},
+		)
 
 		value, err := inter.Invoke("test")
 		require.NoError(t, err)

--- a/tests/interpreter/interpreter_test.go
+++ b/tests/interpreter/interpreter_test.go
@@ -50,12 +50,7 @@ type ParseCheckAndInterpretOptions struct {
 }
 
 func parseCheckAndInterpret(t testing.TB, code string) *interpreter.Interpreter {
-	inter, err := parseCheckAndInterpretWithOptions(t, code, ParseCheckAndInterpretOptions{
-		// attachments should be on by default in tests
-		CheckerConfig: &sema.Config{
-			AttachmentsEnabled: true,
-		},
-	})
+	inter, err := parseCheckAndInterpretWithOptions(t, code, ParseCheckAndInterpretOptions{})
 	require.NoError(t, err)
 	return inter
 }

--- a/tests/interpreter/resources_test.go
+++ b/tests/interpreter/resources_test.go
@@ -2537,9 +2537,6 @@ func TestInterpreterDefaultDestroyEventBaseShadowing(t *testing.T) {
 			destroy trollAttachment
 		}	
         `, ParseCheckAndInterpretOptions{
-			CheckerConfig: &sema.Config{
-				AttachmentsEnabled: true,
-			},
 			Config: &interpreter.Config{
 				OnEventEmitted: func(inter *interpreter.Interpreter, locationRange interpreter.LocationRange, event *interpreter.CompositeValue, eventType *sema.CompositeType) error {
 					events = append(events, event)
@@ -2588,9 +2585,6 @@ func TestInterpreterDefaultDestroyEventBaseShadowing(t *testing.T) {
 			destroy trollAttachment
 		}	
         `, ParseCheckAndInterpretOptions{
-			CheckerConfig: &sema.Config{
-				AttachmentsEnabled: true,
-			},
 			Config: &interpreter.Config{
 				OnEventEmitted: func(inter *interpreter.Interpreter, locationRange interpreter.LocationRange, event *interpreter.CompositeValue, eventType *sema.CompositeType) error {
 					events = append(events, event)

--- a/tests/runtime_test.go
+++ b/tests/runtime_test.go
@@ -3356,7 +3356,7 @@ func TestRuntimeStorageLoadedDestructionConcreteTypeWithAttachment(t *testing.T)
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntimeWithAttachments()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -3486,7 +3486,7 @@ func TestRuntimeStorageLoadedDestructionConcreteTypeWithAttachmentUnloadedContra
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntimeWithAttachments()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -3620,7 +3620,7 @@ func TestRuntimeStorageLoadedDestructionConcreteTypeSameNamedInterface(t *testin
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntimeWithAttachments()
+	runtime := NewTestInterpreterRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -10560,7 +10560,7 @@ func TestRuntimeNonPublicAccessModifierInInterface(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntimeWithAttachments()
+	runtime := NewTestInterpreterRuntime()
 
 	address1 := common.MustBytesToAddress([]byte{0x1})
 	address2 := common.MustBytesToAddress([]byte{0x2})
@@ -10693,7 +10693,7 @@ func TestRuntimeContractWithInvalidCapability(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntimeWithAttachments()
+	runtime := NewTestInterpreterRuntime()
 
 	address := common.MustBytesToAddress([]byte{0x1})
 

--- a/tests/runtime_utils/testruntime.go
+++ b/tests/runtime_utils/testruntime.go
@@ -38,17 +38,10 @@ func NewTestInterpreterRuntimeWithConfig(config runtime.Config) TestInterpreterR
 
 var DefaultTestInterpreterConfig = runtime.Config{
 	AtreeValidationEnabled: true,
-	AttachmentsEnabled:     true,
 }
 
 func NewTestInterpreterRuntime() TestInterpreterRuntime {
 	return NewTestInterpreterRuntimeWithConfig(DefaultTestInterpreterConfig)
-}
-
-func NewTestInterpreterRuntimeWithAttachments() TestInterpreterRuntime {
-	config := DefaultTestInterpreterConfig
-	config.AttachmentsEnabled = true
-	return NewTestInterpreterRuntimeWithConfig(config)
 }
 
 func (r TestInterpreterRuntime) ExecuteTransaction(script runtime.Script, context runtime.Context) error {

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -5941,7 +5941,7 @@ func TestRuntimeStorageReferenceBoundFunction(t *testing.T) {
 	t.Run("struct", func(t *testing.T) {
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntimeWithAttachments()
+		runtime := NewTestInterpreterRuntime()
 
 		tx := []byte(`
             transaction {


### PR DESCRIPTION
## Description

Attachments are enabled on all networks now. So the flag is no longer needed.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
