### PR TITLE
Support expressions in string template

### DIFF
--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -12509,4 +12509,53 @@ func TestInterpretStringTemplates(t *testing.T) {
 			inter.Globals.Get("x").GetValue(inter),
 		)
 	})
+
+	t.Run("func", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+			let add = fun(): Int {
+				return 2+2
+			}
+			let x: String = "\(add())"
+		`)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredStringValue("4"),
+			inter.Globals.Get("x").GetValue(inter),
+		)
+	})
+
+	t.Run("ternary", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+			let z = false
+			let x: String = "\(z ? "foo" : "bar" )"
+		`)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredStringValue("bar"),
+			inter.Globals.Get("x").GetValue(inter),
+		)
+	})
+
+	t.Run("nested", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+			let x: String = "\(2*(4-2) + 1 == 5)"
+		`)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredStringValue("true"),
+			inter.Globals.Get("x").GetValue(inter),
+		)
+	})
 }

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -1191,10 +1191,6 @@ func defineStringExpression() {
 					if err != nil {
 						return nil, err
 					}
-					// limit string templates to identifiers only
-					if _, ok := value.(*ast.IdentifierExpression); !ok {
-						return nil, p.syntaxError("expected identifier got: %s", value.String())
-					}
 					_, err = p.mustOne(lexer.TokenParenClose)
 					if err != nil {
 						return nil, err

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -6185,7 +6185,7 @@ func TestParseStringTemplate(t *testing.T) {
 		)
 	})
 
-	t.Run("invalid, num", func(t *testing.T) {
+	t.Run("valid, num", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -6200,16 +6200,7 @@ func TestParseStringTemplate(t *testing.T) {
 			}
 		}
 
-		require.Error(t, err)
-		AssertEqualWithDiff(t,
-			[]error{
-				&SyntaxError{
-					Message: "expected identifier got: 2 + 2",
-					Pos:     ast.Position{Offset: 13, Line: 2, Column: 12},
-				},
-			},
-			errs,
-		)
+		require.NoError(t, err)
 	})
 
 	t.Run("valid, nested identifier", func(t *testing.T) {
@@ -6278,7 +6269,7 @@ func TestParseStringTemplate(t *testing.T) {
 		)
 	})
 
-	t.Run("invalid, function identifier", func(t *testing.T) {
+	t.Run("valid, function identifier", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -6293,16 +6284,7 @@ func TestParseStringTemplate(t *testing.T) {
 			}
 		}
 
-		require.Error(t, err)
-		AssertEqualWithDiff(t,
-			[]error{
-				&SyntaxError{
-					Message: "expected identifier got: add()",
-					Pos:     ast.Position{Offset: 12, Line: 2, Column: 11},
-				},
-			},
-			errs,
-		)
+		require.NoError(t, err)
 	})
 
 	t.Run("invalid, unbalanced paren", func(t *testing.T) {

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/parser/lexer"
-	"github.com/onflow/cadence/runtime/tests/utils"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 )
 
@@ -6331,7 +6330,7 @@ func TestParseStringTemplate(t *testing.T) {
 		}
 
 		require.Error(t, err)
-		utils.AssertEqualWithDiff(t,
+		AssertEqualWithDiff(t,
 			[]error{
 				&SyntaxError{
 					Message: "expected token ')'",
@@ -6543,7 +6542,7 @@ func TestParseStringTemplate(t *testing.T) {
 			},
 		}
 
-		utils.AssertEqualWithDiff(t, expected, actual)
+		AssertEqualWithDiff(t, expected, actual)
 	})
 }
 

--- a/sema/string_test.go
+++ b/sema/string_test.go
@@ -743,6 +743,27 @@ func TestCheckStringTemplate(t *testing.T) {
 		assert.IsType(t, &sema.TypeMismatchWithDescriptionError{}, errs[0])
 	})
 
+	t.Run("invalid, struct with tostring", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			access(all)
+			struct SomeStruct {
+				access(all)
+				view fun toString(): String {
+					return "SomeStruct"
+				}
+			}
+			let a = SomeStruct()
+			let x: String = "\(a)" 
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeMismatchWithDescriptionError{}, errs[0])
+	})
+
 	t.Run("invalid, array", func(t *testing.T) {
 		t.Parallel()
 
@@ -782,6 +803,20 @@ func TestCheckStringTemplate(t *testing.T) {
 				destroy x
 				return y
 			} 
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeMismatchWithDescriptionError{}, errs[0])
+	})
+
+	t.Run("invalid, expression type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			let y: Int = 0
+			let x: String = "\(y > 0 ? "String" : true)"
 		`)
 
 		errs := RequireCheckerErrors(t, err, 1)


### PR DESCRIPTION
Working towards https://github.com/onflow/cadence/issues/3579
## Description

This PR extends the work in https://github.com/onflow/cadence/pull/3585, as planned to support expressions.

Reopening of #3625

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
