### PR TITLE
Add a GitHub Action to get all contracts

### DIFF
--- a/.github/workflows/compatibility-check-template.yml
+++ b/.github/workflows/compatibility-check-template.yml
@@ -108,6 +108,7 @@ jobs:
           path: |
             ./tmp/output-old.txt
             ./tmp/output-new.txt
+            ./tmp/contracts.csv
 
       # Check Diff
 

--- a/.github/workflows/get-contracts.yml
+++ b/.github/workflows/get-contracts.yml
@@ -1,0 +1,52 @@
+name: Get contracts
+
+on:
+  workflow_call:
+    inputs:
+      chain:
+        required: true
+        type: string
+    secrets:
+      FLOWDIVER_API_KEY:
+        required: true
+
+env:
+  GO_VERSION: '1.22'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}-${{ inputs.chain }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Make output dirs
+        run: |
+          mkdir tmp
+
+      # Get contracts
+
+      - name: Download contracts
+        env:
+          FLOWDIVER_API_KEY: ${{ secrets.FLOWDIVER_API_KEY }}
+        working-directory: ./tools/get-contracts
+        run: |
+          go run . --chain=${{ inputs.chain }} --apiKey="$FLOWDIVER_API_KEY" > ../../tmp/contracts.csv
+
+      # Upload
+
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.chain }}-contracts
+          path: |
+            ./tmp/contracts.csv


### PR DESCRIPTION

## Description

Add a separate GitHub Action that allows getting all contracts for a chain, extracted from the existing backward compatibility checking action, i.e. re-using the [`get-contracts` tool](https://github.com/onflow/cadence/tree/master/tools/get-contracts).

Also, include the contracts in the backward compatibility checking actions' artifacts.


______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
