### PR TITLE
Remove unused Identifier() function from structs implementing atree.TypeInfo

### DIFF
--- a/interpreter/encode.go
+++ b/interpreter/encode.go
@@ -1684,10 +1684,6 @@ func (c compositeTypeInfo) IsComposite() bool {
 	return true
 }
 
-func (c compositeTypeInfo) Identifier() string {
-	return string(c.location.TypeID(nil, c.qualifiedIdentifier))
-}
-
 func (c compositeTypeInfo) Copy() atree.TypeInfo {
 	// Return c as is because c is a value type.
 	return c
@@ -1739,10 +1735,6 @@ func (e EmptyTypeInfo) Encode(encoder *cbor.StreamEncoder) error {
 
 func (e EmptyTypeInfo) IsComposite() bool {
 	return false
-}
-
-func (e EmptyTypeInfo) Identifier() string {
-	return ""
 }
 
 func (e EmptyTypeInfo) Copy() atree.TypeInfo {

--- a/interpreter/statictype.go
+++ b/interpreter/statictype.go
@@ -252,10 +252,6 @@ func (t *VariableSizedStaticType) Copy() atree.TypeInfo {
 	return t
 }
 
-func (t *VariableSizedStaticType) Identifier() string {
-	return string(t.ID())
-}
-
 func (*VariableSizedStaticType) isStaticType() {}
 
 func (*VariableSizedStaticType) elementSize() uint {
@@ -382,10 +378,6 @@ func (t *ConstantSizedStaticType) Copy() atree.TypeInfo {
 	return t
 }
 
-func (t *ConstantSizedStaticType) Identifier() string {
-	return string(t.ID())
-}
-
 func (*ConstantSizedStaticType) isStaticType() {}
 
 func (*ConstantSizedStaticType) elementSize() uint {
@@ -462,10 +454,6 @@ func (*DictionaryStaticType) IsComposite() bool {
 func (t *DictionaryStaticType) Copy() atree.TypeInfo {
 	// DictionaryStaticType is never mutated, return a shallow copy
 	return t
-}
-
-func (t *DictionaryStaticType) Identifier() string {
-	return string(t.ID())
 }
 
 func (*DictionaryStaticType) isStaticType() {}


### PR DESCRIPTION
Closes #3674 

`atree.TypeInfo` interface used to include `Identifier()` function. However, `Identifier()` was removed later and is no longer part of `atree.TypeInfo` interface.

This PR removes `Identifier()` function from structs implementing `atree.TypeInfo` interface.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
