### PR TITLE
[Account Storage Maps] Refactor migration

### DIFF
--- a/common/address.go
+++ b/common/address.go
@@ -19,6 +19,7 @@
 package common
 
 import (
+	"bytes"
 	"encoding/hex"
 	goErrors "errors"
 	"fmt"
@@ -110,6 +111,10 @@ func (a Address) ShortHexWithPrefix() string {
 
 func (a Address) HexWithPrefix() string {
 	return fmt.Sprintf("0x%x", [AddressLength]byte(a))
+}
+
+func (a Address) Compare(other Address) int {
+	return bytes.Compare(a[:], other[:])
 }
 
 // HexToAddress converts a hex string to an Address after

--- a/interpreter/storage.go
+++ b/interpreter/storage.go
@@ -20,6 +20,7 @@ package interpreter
 
 import (
 	"bytes"
+	"cmp"
 	"io"
 	"math"
 	"strings"
@@ -104,6 +105,19 @@ func ConvertStoredValue(gauge common.MemoryGauge, value atree.Value) (Value, err
 type StorageDomainKey struct {
 	Domain  common.StorageDomain
 	Address common.Address
+}
+
+func (k StorageDomainKey) Compare(o StorageDomainKey) int {
+	switch bytes.Compare(k.Address[:], o.Address[:]) {
+	case -1:
+		return -1
+	case 0:
+		return cmp.Compare(k.Domain, o.Domain)
+	case 1:
+		return 1
+	default:
+		panic(errors.NewUnreachableError())
+	}
 }
 
 func NewStorageDomainKey(

--- a/runtime/account_storage_v2.go
+++ b/runtime/account_storage_v2.go
@@ -33,8 +33,7 @@ type AccountStorageV2 struct {
 	memoryGauge common.MemoryGauge
 
 	// cachedAccountStorageMaps is a cache of account storage maps.
-	// Key is StorageKey{address, accountStorageKey} and value is account storage map.
-	cachedAccountStorageMaps map[interpreter.StorageKey]*interpreter.AccountStorageMap
+	cachedAccountStorageMaps map[common.Address]*interpreter.AccountStorageMap
 
 	// newAccountStorageMapSlabIndices contains root slab index of new account storage maps.
 	// The indices are saved using Ledger.SetValue() during Commit().
@@ -94,12 +93,10 @@ func (s *AccountStorageV2) getAccountStorageMap(
 ) (
 	accountStorageMap *interpreter.AccountStorageMap,
 ) {
-	accountStorageKey := s.accountStorageKey(address)
-
 	// Return cached account storage map if it exists.
 
 	if s.cachedAccountStorageMaps != nil {
-		accountStorageMap = s.cachedAccountStorageMaps[accountStorageKey]
+		accountStorageMap = s.cachedAccountStorageMaps[address]
 		if accountStorageMap != nil {
 			return accountStorageMap
 		}
@@ -108,7 +105,7 @@ func (s *AccountStorageV2) getAccountStorageMap(
 	defer func() {
 		if accountStorageMap != nil {
 			s.cacheAccountStorageMap(
-				accountStorageKey,
+				address,
 				accountStorageMap,
 			)
 		}
@@ -130,13 +127,13 @@ func (s *AccountStorageV2) getAccountStorageMap(
 }
 
 func (s *AccountStorageV2) cacheAccountStorageMap(
-	accountStorageKey interpreter.StorageKey,
+	address common.Address,
 	accountStorageMap *interpreter.AccountStorageMap,
 ) {
 	if s.cachedAccountStorageMaps == nil {
-		s.cachedAccountStorageMaps = map[interpreter.StorageKey]*interpreter.AccountStorageMap{}
+		s.cachedAccountStorageMaps = map[common.Address]*interpreter.AccountStorageMap{}
 	}
-	s.cachedAccountStorageMaps[accountStorageKey] = accountStorageMap
+	s.cachedAccountStorageMaps[address] = accountStorageMap
 }
 
 func (s *AccountStorageV2) storeNewAccountStorageMap(
@@ -156,7 +153,7 @@ func (s *AccountStorageV2) storeNewAccountStorageMap(
 	s.SetNewAccountStorageMapSlabIndex(accountStorageKey, slabIndex)
 
 	s.cacheAccountStorageMap(
-		accountStorageKey,
+		address,
 		accountStorageMap,
 	)
 

--- a/runtime/migrate_domain_registers.go
+++ b/runtime/migrate_domain_registers.go
@@ -22,26 +22,16 @@ import (
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/common"
-	"github.com/onflow/cadence/common/orderedmap"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
 )
 
-type AccountStorageMaps = *orderedmap.OrderedMap[common.Address, *interpreter.AccountStorageMap]
-
-type GetDomainStorageMapFunc func(
-	ledger atree.Ledger,
-	storage atree.SlabStorage,
-	address common.Address,
-	domain common.StorageDomain,
-) (*interpreter.DomainStorageMap, error)
-
+// DomainRegisterMigration migrates domain registers to account storage maps.
 type DomainRegisterMigration struct {
-	ledger              atree.Ledger
-	storage             atree.SlabStorage
-	inter               *interpreter.Interpreter
-	memoryGauge         common.MemoryGauge
-	getDomainStorageMap GetDomainStorageMapFunc
+	ledger      atree.Ledger
+	storage     atree.SlabStorage
+	inter       *interpreter.Interpreter
+	memoryGauge common.MemoryGauge
 }
 
 func NewDomainRegisterMigration(
@@ -51,74 +41,30 @@ func NewDomainRegisterMigration(
 	memoryGauge common.MemoryGauge,
 ) *DomainRegisterMigration {
 	return &DomainRegisterMigration{
-		ledger:              ledger,
-		storage:             storage,
-		inter:               inter,
-		memoryGauge:         memoryGauge,
-		getDomainStorageMap: getDomainStorageMapFromV1DomainRegister,
+		ledger:      ledger,
+		storage:     storage,
+		inter:       inter,
+		memoryGauge: memoryGauge,
 	}
-}
-
-// SetGetDomainStorageMapFunc allows user to provide custom GetDomainStorageMap function.
-func (m *DomainRegisterMigration) SetGetDomainStorageMapFunc(
-	getDomainStorageMapFunc GetDomainStorageMapFunc,
-) {
-	m.getDomainStorageMap = getDomainStorageMapFunc
-}
-
-// MigrateAccounts migrates given accounts.
-func (m *DomainRegisterMigration) MigrateAccounts(
-	accounts *orderedmap.OrderedMap[common.Address, struct{}],
-	pred func(common.Address) bool,
-) (
-	AccountStorageMaps,
-	error,
-) {
-	if accounts == nil || accounts.Len() == 0 {
-		return nil, nil
-	}
-
-	var migratedAccounts AccountStorageMaps
-
-	for pair := accounts.Oldest(); pair != nil; pair = pair.Next() {
-		address := pair.Key
-
-		if !pred(address) {
-			continue
-		}
-
-		migrated, err := isMigrated(m.ledger, address)
-		if err != nil {
-			return nil, err
-		}
-		if migrated {
-			continue
-		}
-
-		accountStorageMap, err := m.MigrateAccount(address)
-		if err != nil {
-			return nil, err
-		}
-
-		if accountStorageMap == nil {
-			continue
-		}
-
-		if migratedAccounts == nil {
-			migratedAccounts = &orderedmap.OrderedMap[common.Address, *interpreter.AccountStorageMap]{}
-		}
-		migratedAccounts.Set(address, accountStorageMap)
-	}
-
-	return migratedAccounts, nil
 }
 
 func (m *DomainRegisterMigration) MigrateAccount(
 	address common.Address,
-) (*interpreter.AccountStorageMap, error) {
+) (
+	*interpreter.AccountStorageMap,
+	error,
+) {
+	exists, err := hasAccountStorageMap(m.ledger, address)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		// Account storage map already exists
+		return nil, nil
+	}
 
 	// Migrate existing domains
-	accountStorageMap, err := m.migrateDomains(address)
+	accountStorageMap, err := m.migrateDomainRegisters(address)
 	if err != nil {
 		return nil, err
 	}
@@ -128,14 +74,14 @@ func (m *DomainRegisterMigration) MigrateAccount(
 		return nil, nil
 	}
 
-	accountStorageMapSlabIndex := accountStorageMap.SlabID().Index()
+	slabIndex := accountStorageMap.SlabID().Index()
 
 	// Write account register
 	errors.WrapPanic(func() {
 		err = m.ledger.SetValue(
 			address[:],
 			[]byte(AccountStorageKey),
-			accountStorageMapSlabIndex[:],
+			slabIndex[:],
 		)
 	})
 	if err != nil {
@@ -145,16 +91,25 @@ func (m *DomainRegisterMigration) MigrateAccount(
 	return accountStorageMap, nil
 }
 
-// migrateDomains migrates existing domain storage maps and removes domain registers.
-func (m *DomainRegisterMigration) migrateDomains(
+// migrateDomainRegisters migrates all existing domain storage maps to a new account storage map,
+// and removes the domain registers.
+func (m *DomainRegisterMigration) migrateDomainRegisters(
 	address common.Address,
-) (*interpreter.AccountStorageMap, error) {
+) (
+	*interpreter.AccountStorageMap,
+	error,
+) {
 
 	var accountStorageMap *interpreter.AccountStorageMap
 
 	for _, domain := range common.AllStorageDomains {
 
-		domainStorageMap, err := m.getDomainStorageMap(m.ledger, m.storage, address, domain)
+		domainStorageMap, err := getDomainStorageMapFromV1DomainRegister(
+			m.ledger,
+			m.storage,
+			address,
+			domain,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -165,7 +120,11 @@ func (m *DomainRegisterMigration) migrateDomains(
 		}
 
 		if accountStorageMap == nil {
-			accountStorageMap = interpreter.NewAccountStorageMap(m.memoryGauge, m.storage, atree.Address(address))
+			accountStorageMap = interpreter.NewAccountStorageMap(
+				m.memoryGauge,
+				m.storage,
+				atree.Address(address),
+			)
 		}
 
 		// Migrate (insert) existing domain storage map to account storage map
@@ -193,12 +152,4 @@ func (m *DomainRegisterMigration) migrateDomains(
 	}
 
 	return accountStorageMap, nil
-}
-
-func isMigrated(ledger atree.Ledger, address common.Address) (bool, error) {
-	_, registerExists, err := getSlabIndexFromRegisterValue(ledger, address, []byte(AccountStorageKey))
-	if err != nil {
-		return false, err
-	}
-	return registerExists, nil
 }

--- a/runtime/migrate_domain_registers_test.go
+++ b/runtime/migrate_domain_registers_test.go
@@ -75,7 +75,13 @@ func TestMigrateDomainRegisters(t *testing.T) {
 
 		inter := NewTestInterpreterWithStorage(t, storage)
 
-		migrator := runtime.NewDomainRegisterMigration(ledger, storage, inter, nil)
+		migrator := runtime.NewDomainRegisterMigration(
+			ledger,
+			storage,
+			inter,
+			nil,
+			nil,
+		)
 
 		for _, address := range addresses {
 			accountStorageMap, err := migrator.MigrateAccount(address)
@@ -119,7 +125,13 @@ func TestMigrateDomainRegisters(t *testing.T) {
 
 		inter := NewTestInterpreterWithStorage(t, storage)
 
-		migrator := runtime.NewDomainRegisterMigration(ledger, storage, inter, nil)
+		migrator := runtime.NewDomainRegisterMigration(
+			ledger,
+			storage,
+			inter,
+			nil,
+			nil,
+		)
 
 		var accountStorageMaps []*interpreter.AccountStorageMap
 		for _, address := range addresses {
@@ -182,7 +194,13 @@ func TestMigrateDomainRegisters(t *testing.T) {
 
 		inter := NewTestInterpreterWithStorage(t, storage)
 
-		migrator := runtime.NewDomainRegisterMigration(ledger, storage, inter, nil)
+		migrator := runtime.NewDomainRegisterMigration(
+			ledger,
+			storage,
+			inter,
+			nil,
+			nil,
+		)
 
 		for _, address := range addresses {
 			accountStorageMap, err := migrator.MigrateAccount(address)

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -399,62 +399,6 @@ func (s *Storage) commit(inter *interpreter.Interpreter, commitContractUpdates b
 	}
 }
 
-// TODO:
-//func (s *Storage) migrateAccounts(inter *interpreter.Interpreter) error {
-//	// Predicate function allows migration for accounts with write ops.
-//	migrateAccountPred := func(address common.Address) bool {
-//		return s.PersistentSlabStorage.HasUnsavedChanges(atree.Address(address))
-//	}
-//
-//	// getDomainStorageMap function returns cached domain storage map if it is available
-//	// before loading domain storage map from storage.
-//	// This is necessary to migrate uncommitted (new) but cached domain storage map.
-//	getDomainStorageMap := func(
-//		ledger atree.Ledger,
-//		storage atree.SlabStorage,
-//		address common.Address,
-//		domain common.StorageDomain,
-//	) (*interpreter.DomainStorageMap, error) {
-//		domainStorageKey := interpreter.NewStorageDomainKey(s.memoryGauge, address, domain)
-//
-//		// Get cached domain storage map if available.
-//		domainStorageMap := s.cachedDomainStorageMaps[domainStorageKey]
-//
-//		if domainStorageMap != nil {
-//			return domainStorageMap, nil
-//		}
-//
-//		return getDomainStorageMapFromV1DomainRegister(ledger, storage, address, domain)
-//	}
-//
-//	migrator := NewDomainRegisterMigration(s.Ledger, s.PersistentSlabStorage, inter, s.memoryGauge)
-//	migrator.SetGetDomainStorageMapFunc(getDomainStorageMap)
-//
-//	migratedAccounts, err := migrator.MigrateAccounts(s.unmigratedAccounts, migrateAccountPred)
-//	if err != nil {
-//		return err
-//	}
-//
-//	if migratedAccounts == nil {
-//		return nil
-//	}
-//
-//	// Update internal state with migrated accounts
-//	for pair := migratedAccounts.Oldest(); pair != nil; pair = pair.Next() {
-//		address := pair.Key
-//		accountStorageMap := pair.Value
-//
-//		// Cache migrated account storage map
-//		accountStorageKey := interpreter.NewStorageKey(s.memoryGauge, address, AccountStorageKey)
-//		s.cachedAccountStorageMaps[accountStorageKey] = accountStorageMap
-//
-//		// Remove migrated accounts from unmigratedAccounts
-//		s.unmigratedAccounts.Delete(address)
-//	}
-//
-//	return nil
-//}
-
 func (s *Storage) CheckHealth() error {
 
 	// Check slab storage health

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -68,15 +68,10 @@ func withWritesToStorage(
 		var address common.Address
 		random.Read(address[:])
 
-		storageKey := interpreter.StorageKey{
-			Address: address,
-			Key:     AccountStorageKey,
-		}
-
 		var slabIndex atree.SlabIndex
 		binary.BigEndian.PutUint32(slabIndex[:], randomIndex)
 
-		storage.AccountStorageV2.SetNewAccountStorageMapSlabIndex(storageKey, slabIndex)
+		storage.AccountStorageV2.SetNewAccountStorageMapSlabIndex(address, slabIndex)
 	}
 
 	handler(storage, inter)

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -7181,6 +7181,8 @@ func TestRuntimeStorageForUnmigratedAccount(t *testing.T) {
 		domainStorageMap := storage.GetDomainStorageMap(inter, address, nonExistingDomain, createIfNotExists)
 		require.Nil(t, domainStorageMap)
 
+		storage.ScheduleV2MigrationForModifiedAccounts()
+
 		// Commit changes
 		const commitContractUpdates = false
 		err := storage.Commit(inter, commitContractUpdates)
@@ -7335,6 +7337,9 @@ func TestRuntimeStorageForUnmigratedAccount(t *testing.T) {
 				accountValues[domain] = writeToDomainStorageMap(inter, domainStorageMap, tc.newDomainStorageMapCount, random)
 			}
 
+			// TODO:
+			storage.ScheduleV2MigrationForModifiedAccounts()
+
 			// Commit changes
 			const commitContractUpdates = false
 			err := storage.Commit(inter, commitContractUpdates)
@@ -7480,6 +7485,9 @@ func TestRuntimeStorageForUnmigratedAccount(t *testing.T) {
 			}
 		}
 
+		// TODO:
+		storage.ScheduleV2MigrationForModifiedAccounts()
+
 		// Commit changes
 		const commitContractUpdates = false
 		err := storage.Commit(inter, commitContractUpdates)
@@ -7609,6 +7617,9 @@ func TestRuntimeStorageForUnmigratedAccount(t *testing.T) {
 					domainValues[k] = newValue
 				}
 			}
+
+			// TODO:
+			storage.ScheduleV2MigrationForModifiedAccounts()
 
 			// Commit changes
 			const commitContractUpdates = false
@@ -8036,6 +8047,9 @@ func TestDomainRegisterMigrationForLargeAccount(t *testing.T) {
 	require.NotNil(t, domainStorageMap)
 
 	accountValues[domain] = make(domainStorageMapValues)
+
+	// TODO:
+	storage.ScheduleV2MigrationForModifiedAccounts()
 
 	// Commit changes
 	const commitContractUpdates = false

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -7140,6 +7140,18 @@ func TestRuntimeStorageForUnmigratedAccount(t *testing.T) {
 		err := storage.Commit(inter, commitContractUpdates)
 		require.NoError(t, err)
 
+		migration := NewDomainRegisterMigration(ledger, storage, inter, nil)
+		accountStorageMap, err := migration.MigrateAccount(address)
+		require.NotNil(t, accountStorageMap)
+		require.NoError(t, err)
+
+		err = CommitSlabStorage(
+			storage.PersistentSlabStorage,
+			inter,
+			true,
+		)
+		require.NoError(t, err)
+
 		// Create a new storage
 		newLedger := NewTestLedgerWithData(onRead, onWrite, ledger.StoredValues, ledger.StorageIndices)
 
@@ -8028,6 +8040,18 @@ func TestDomainRegisterMigrationForLargeAccount(t *testing.T) {
 
 	// Check there are writes to underlying storage
 	require.True(t, writeCount > 0)
+
+	migration := NewDomainRegisterMigration(ledger, storage, inter, nil)
+	accountStorageMap, err := migration.MigrateAccount(address)
+	require.NotNil(t, accountStorageMap)
+	require.NoError(t, err)
+
+	err = CommitSlabStorage(
+		storage.PersistentSlabStorage,
+		inter,
+		true,
+	)
+	require.NoError(t, err)
 
 	// Check there isn't any domain registers
 	nonAtreeRegisters := make(map[string][]byte)

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -7140,18 +7140,6 @@ func TestRuntimeStorageForUnmigratedAccount(t *testing.T) {
 		err := storage.Commit(inter, commitContractUpdates)
 		require.NoError(t, err)
 
-		migration := NewDomainRegisterMigration(ledger, storage, inter, nil)
-		accountStorageMap, err := migration.MigrateAccount(address)
-		require.NotNil(t, accountStorageMap)
-		require.NoError(t, err)
-
-		err = CommitSlabStorage(
-			storage.PersistentSlabStorage,
-			inter,
-			true,
-		)
-		require.NoError(t, err)
-
 		// Create a new storage
 		newLedger := NewTestLedgerWithData(onRead, onWrite, ledger.StoredValues, ledger.StorageIndices)
 
@@ -8040,18 +8028,6 @@ func TestDomainRegisterMigrationForLargeAccount(t *testing.T) {
 
 	// Check there are writes to underlying storage
 	require.True(t, writeCount > 0)
-
-	migration := NewDomainRegisterMigration(ledger, storage, inter, nil)
-	accountStorageMap, err := migration.MigrateAccount(address)
-	require.NotNil(t, accountStorageMap)
-	require.NoError(t, err)
-
-	err = CommitSlabStorage(
-		storage.PersistentSlabStorage,
-		inter,
-		true,
-	)
-	require.NoError(t, err)
 
 	// Check there isn't any domain registers
 	nonAtreeRegisters := make(map[string][]byte)


### PR DESCRIPTION
Depends on #3678 

## Description

- Simplify the bookkeeping in V2: only keep a simple map, an ordered map is unnecessary
- Simplify the domain register migration to allow migration of a single account
- For now, bring back the automatic migration of written-to accounts during commit.
  We'll keep discussing this in the upcoming sync with the Execution team.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
