### PR TITLE
Source Compatibility Suite: Switch to main Green Goo Dao repo

### DIFF
--- a/compat/suite/green-goo-dao-flow-utils.yaml
+++ b/compat/suite/green-goo-dao-flow-utils.yaml
@@ -1,8 +1,8 @@
 description: Green Goo Dao flow-utils
 maintainers:
   - bastian.mueller@flowfoundation.org
-url: https://github.com/turbolent/flow-utils.git
-branch: improvements
+url: https://github.com/green-goo-dao/flow-utils.git
+branch: main
 cadence_tests:
 - path: .
   command: npm i && ./run-tests.sh


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3595

## Description

https://github.com/green-goo-dao/flow-utils/pull/33 got merged, so we can now switch from the fork fixing the CLI usage to the main repo.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
