### PR TITLE
[Account Storage Maps] Reduce storage register reads when using `StorageFormatV2Enabled`

### DIFF
--- a/runtime/sharedstate_test.go
+++ b/runtime/sharedstate_test.go
@@ -255,11 +255,17 @@ func TestRuntimeSharedState(t *testing.T) {
 	test(
 		true,
 		[]ownerKeyPair{
-			// Read account domain register to check if it is a migrated account
+			// Read account register to check if it is a migrated account
 			// Read returns no value.
 			{
 				owner: signerAddress[:],
 				key:   []byte(AccountStorageKey),
+			},
+			// Read contract domain register.
+			// Read returns no value.
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainContract.Identifier()),
 			},
 			// Read all available domain registers to check if it is a new account
 			// Read returns no value.

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -46,7 +46,7 @@ const (
 	storageFormatUnknown storageFormat = iota
 	storageFormatNew
 	storageFormatV1
-	StorageFormatV2
+	storageFormatV2
 )
 
 type Storage struct {
@@ -211,7 +211,7 @@ func (s *Storage) GetDomainStorageMap(
 
 			s.cacheIsV1Account(address, true)
 
-		case StorageFormatV2, storageFormatNew:
+		case storageFormatV2, storageFormatNew:
 			domainStorageMap = s.AccountStorageV2.GetDomainStorageMap(
 				inter,
 				address,
@@ -272,7 +272,7 @@ func (s *Storage) getAccountStorageFormat(
 	// Check if account is v2 (by reading "stored" register).
 
 	if s.isV2Account(address) {
-		return StorageFormatV2
+		return storageFormatV2
 	}
 
 	// Check if account is v1 (by reading given domain register).
@@ -304,7 +304,7 @@ func (s *Storage) getCachedAccountFormat(address common.Address) (format storage
 	if isV1 {
 		return storageFormatV1, true
 	} else {
-		return StorageFormatV2, true
+		return storageFormatV2, true
 	}
 }
 

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -264,14 +264,9 @@ func (s *Storage) getAccountStorageFormat(
 
 	// Return cached account format (no register reading).
 
-	isCachedV1, isCachedV2 := s.getCachedAccountFormat(address)
-
-	if isCachedV1 {
-		return storageFormatV1
-	}
-
-	if isCachedV2 {
-		return StorageFormatV2
+	cachedFormat, known := s.getCachedAccountFormat(address)
+	if known {
+		return cachedFormat
 	}
 
 	// Check if account is v2 (by reading "stored" register).

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -356,14 +356,7 @@ func (s *Storage) isV1Account(address common.Address) (isV1 bool) {
 	// Check if a storage map register exists for any of the domains.
 	// Check the most frequently used domains first, such as storage, public, private.
 	for _, domain := range common.AllStorageDomains {
-		_, domainExists, err := readSlabIndexFromRegister(
-			s.Ledger,
-			address,
-			[]byte(domain.Identifier()),
-		)
-		if err != nil {
-			panic(err)
-		}
+		domainExists := s.hasDomainRegister(address, domain)
 		if domainExists {
 			return true
 		}

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -301,12 +301,16 @@ func (s *Storage) getAccountStorageFormat(
 	return storageFormatNew
 }
 
-func (s *Storage) getCachedAccountFormat(address common.Address) (isV1 bool, isV2 bool) {
+func (s *Storage) getCachedAccountFormat(address common.Address) (format storageFormat, known bool) {
 	isV1, cached := s.cachedV1Accounts[address]
 	if !cached {
-		return false, false
+		return storageFormatUnknown, false
 	}
-	return isV1, !isV1
+	if isV1 {
+		return storageFormatV1, true
+	} else {
+		return StorageFormatV2, true
+	}
 }
 
 // isV2Account returns true if given account is in account storage format v2.


### PR DESCRIPTION
Updates #3584

Currently in PR #3678, all domain registers are being read for a scenario that does not require it. This PR reduces register reads as [discussed](https://github.com/onflow/cadence/pull/3678#discussion_r1844477979).

### Problem

In some cases, we can reduce 10 register reads to only 2 register reads. :rocket:

When `StorageFormatV2` feature flag is enabled, `Storage.GetDomainStorageMap()` reads all domain registers to determine if account is new account or in v1 format.

These register reads are unnecessary when:
- the given domain register exists, or
- the given domain register doesn't exist and `createIfNotExists` param is false.

### Solution

This PR modifies `Storage.GetDomainStorageMap()` to read the given domain register first (before iterating all domain registers) to reduce register reads.

- If the given domain register exists, then account format is v1 and no more register reading is needed.

- If the given domain register doesn't exist and `createIfNotExists` is false, then `nil` domain storage map is returned and no more register reading is needed.

- Otherwise, account format (v1 account or new account) is determined by iterating all domain registers.

### Reduced Reads

When using StorageFormatV2Enabled:

For new accounts (neither v1 or v2 yet):
- If domain storage map doesn't exist and createIfNotExists is false, old approach has [10 unique register reads](https://github.com/onflow/cadence/blob/3a71bf0e8e00ede8ebaf2e339159a272bd8b2814/runtime/storage_test.go#L8213-L8224), while new approach has [2 unique register reads](https://github.com/onflow/cadence/blob/9af92f66fac1926eea058c06c2f9bcc7cd3bd7a3/runtime/storage_test.go#L8181-L1884).
    
For v1 accounts:
- If domain storage map doesn't exist and createIfNotExists is false, old approach has [4 unique register reads in tests](https://github.com/onflow/cadence/blob/3a71bf0e8e00ede8ebaf2e339159a272bd8b2814/runtime/storage_test.go#L8564-L8569), while new approach has [2 unique register reads](https://github.com/onflow/cadence/blob/9af92f66fac1926eea058c06c2f9bcc7cd3bd7a3/runtime/storage_test.go#L8521-L8524).

### Caveat

This change increases code complexity in order to avoid reading all domain registers for this scenario.  I added more comments to offset some of this tradeoff.  For more context, see [comment thread](https://github.com/onflow/cadence/pull/3678#discussion_r1844477979) at #3678.

UPDATE:

~~I can add more tests for register reading after sync with Cadence team about this approach.~~   
I added more tests in case we don't get chance to sync with Cadence team this week.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
