### PR TITLE
[Account Storage Maps] Add more tests for register reads for GetDomainStorageMap()

### DIFF
--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -69,11 +69,10 @@ type Storage struct {
 var _ atree.SlabStorage = &Storage{}
 var _ interpreter.Storage = &Storage{}
 
-func NewStorage(
+func NewPersistentSlabStorage(
 	ledger atree.Ledger,
 	memoryGauge common.MemoryGauge,
-	config StorageConfig,
-) *Storage {
+) *atree.PersistentSlabStorage {
 	decodeStorable := func(
 		decoder *cbor.StreamDecoder,
 		slabID atree.SlabID,
@@ -95,13 +94,22 @@ func NewStorage(
 	}
 
 	ledgerStorage := atree.NewLedgerBaseStorage(ledger)
-	persistentSlabStorage := atree.NewPersistentSlabStorage(
+
+	return atree.NewPersistentSlabStorage(
 		ledgerStorage,
 		interpreter.CBOREncMode,
 		interpreter.CBORDecMode,
 		decodeStorable,
 		decodeTypeInfo,
 	)
+}
+
+func NewStorage(
+	ledger atree.Ledger,
+	memoryGauge common.MemoryGauge,
+	config StorageConfig,
+) *Storage {
+	persistentSlabStorage := NewPersistentSlabStorage(ledger, memoryGauge)
 
 	accountStorageV1 := NewAccountStorageV1(
 		ledger,

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fxamacker/cbor/v2"
 	"github.com/onflow/atree"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -8363,7 +8362,7 @@ func TestGetDomainStorageMapRegisterReadsForV1Account(t *testing.T) {
 		return func() (storedValues map[string][]byte, StorageIndices map[string]uint64) {
 			ledger := NewTestLedger(nil, nil)
 
-			persistentSlabStorage := newSlabStorage(ledger)
+			persistentSlabStorage := NewPersistentSlabStorage(ledger, nil)
 
 			orderedMap, err := atree.NewMap(
 				persistentSlabStorage,
@@ -8761,7 +8760,7 @@ func TestGetDomainStorageMapRegisterReadsForV2Account(t *testing.T) {
 		return func() (storedValues map[string][]byte, StorageIndices map[string]uint64) {
 			ledger := NewTestLedger(nil, nil)
 
-			persistentSlabStorage := newSlabStorage(ledger)
+			persistentSlabStorage := NewPersistentSlabStorage(ledger, nil)
 
 			accountOrderedMap, err := atree.NewMap(
 				persistentSlabStorage,
@@ -9142,38 +9141,6 @@ func checkAccountStorageMapData(
 	require.NoError(tb, err)
 	require.Equal(tb, 1, len(rootSlabIDs))
 	require.Contains(tb, rootSlabIDs, accountSlabID)
-}
-
-func newSlabStorage(ledger atree.Ledger) *atree.PersistentSlabStorage {
-	decodeStorable := func(
-		decoder *cbor.StreamDecoder,
-		slabID atree.SlabID,
-		inlinedExtraData []atree.ExtraData,
-	) (
-		atree.Storable,
-		error,
-	) {
-		return interpreter.DecodeStorable(
-			decoder,
-			slabID,
-			inlinedExtraData,
-			nil,
-		)
-	}
-
-	decodeTypeInfo := func(decoder *cbor.StreamDecoder) (atree.TypeInfo, error) {
-		return interpreter.DecodeTypeInfo(decoder, nil)
-	}
-
-	ledgerStorage := atree.NewLedgerBaseStorage(ledger)
-
-	return atree.NewPersistentSlabStorage(
-		ledgerStorage,
-		interpreter.CBOREncMode,
-		interpreter.CBORDecMode,
-		decodeStorable,
-		decodeTypeInfo,
-	)
 }
 
 func concatRegisterAddressAndKey(

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -23,12 +23,14 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
+	"runtime"
 	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/fxamacker/cbor/v2"
 	"github.com/onflow/atree"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -8081,6 +8083,940 @@ func TestDomainRegisterMigrationForLargeAccount(t *testing.T) {
 	checkAccountStorageMapData(t, ledger.StoredValues, ledger.StorageIndices, address, accountValues)
 }
 
+func TestGetDomainStorageMapRegisterReadsForNewAccount(t *testing.T) {
+	t.Parallel()
+
+	address := common.MustBytesToAddress([]byte{0x1})
+
+	testCases := []struct {
+		name                                       string
+		storageFormatV2Enabled                     bool
+		domain                                     common.StorageDomain
+		createIfNotExists                          bool
+		expectedDomainStorageMapIsNil              bool
+		expectedReadsFor1stGetDomainStorageMapCall []ownerKeyPair
+		expectedReadsFor2ndGetDomainStorageMapCall []ownerKeyPair
+		expectedReadsSet                           map[string]struct{}
+	}{
+		// Test cases with storageFormatV2Enabled = false
+		{
+			name:                          "storageFormatV2Enabled = false, domain storage map does not exist, createIfNotExists = false",
+			storageFormatV2Enabled:        false,
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             false,
+			expectedDomainStorageMapIsNil: true,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Read domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// Read domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+			},
+		},
+		{
+			name:                          "storageFormatV2Enabled = false, domain storage map does not exist, createIfNotExists = true",
+			storageFormatV2Enabled:        false,
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             true,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Read domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reads from the second GetDomainStorageMap() because
+				// domain storage map is created and cached in the first GetDomainStorageMap().
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+			},
+		},
+		// Test cases with storageFormatV2Enabled = true
+		{
+			name:                          "storageFormatV2Enabled = true, domain storage map does not exist, createIfNotExists = false",
+			storageFormatV2Enabled:        true,
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             false,
+			expectedDomainStorageMapIsNil: true,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Read all available domain registers to check if it is a new account
+				// Read returns no value.
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainStorage.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainPrivate.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainPublic.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainContract.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainInbox.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainCapabilityController.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainCapabilityControllerTag.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathCapability.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainAccountCapability.Identifier()),
+				},
+				// Try to read account register to create account storage map
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// Second GetDomainStorageMap() get cached account format v2 (cached during first GetDomainStorageMap()).
+
+				// Try to read account register to create account storage map
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + AccountStorageKey:                                        {},
+				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier():             {},
+				string(address[:]) + "|" + common.StorageDomainPathPrivate.Identifier():             {},
+				string(address[:]) + "|" + common.StorageDomainPathPublic.Identifier():              {},
+				string(address[:]) + "|" + common.StorageDomainContract.Identifier():                {},
+				string(address[:]) + "|" + common.StorageDomainInbox.Identifier():                   {},
+				string(address[:]) + "|" + common.StorageDomainCapabilityController.Identifier():    {},
+				string(address[:]) + "|" + common.StorageDomainCapabilityControllerTag.Identifier(): {},
+				string(address[:]) + "|" + common.StorageDomainPathCapability.Identifier():          {},
+				string(address[:]) + "|" + common.StorageDomainAccountCapability.Identifier():       {},
+			},
+		},
+		{
+			name:                          "storageFormatV2Enabled = true, domain storage map does not exist, createIfNotExists = true",
+			storageFormatV2Enabled:        true,
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             true,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Check all domain registers
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainStorage.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainPrivate.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainPublic.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainContract.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainInbox.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainCapabilityController.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainCapabilityControllerTag.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathCapability.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainAccountCapability.Identifier()),
+				},
+				// Read account register to load account storage map
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reads from the second GetDomainStorageMap() because
+				// domain storage map is created and cached in the first GetDomainStorageMap().
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + AccountStorageKey:                                        {},
+				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier():             {},
+				string(address[:]) + "|" + common.StorageDomainPathPrivate.Identifier():             {},
+				string(address[:]) + "|" + common.StorageDomainPathPublic.Identifier():              {},
+				string(address[:]) + "|" + common.StorageDomainContract.Identifier():                {},
+				string(address[:]) + "|" + common.StorageDomainInbox.Identifier():                   {},
+				string(address[:]) + "|" + common.StorageDomainCapabilityController.Identifier():    {},
+				string(address[:]) + "|" + common.StorageDomainCapabilityControllerTag.Identifier(): {},
+				string(address[:]) + "|" + common.StorageDomainPathCapability.Identifier():          {},
+				string(address[:]) + "|" + common.StorageDomainAccountCapability.Identifier():       {},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			var ledgerReads []ownerKeyPair
+			ledgerReadsSet := make(map[string]struct{})
+
+			// Create empty storage
+			ledger := NewTestLedger(
+				func(owner, key, _ []byte) {
+					ledgerReads = append(
+						ledgerReads,
+						ownerKeyPair{
+							owner: owner,
+							key:   key,
+						},
+					)
+					ledgerReadsSet[string(owner)+"|"+string(key)] = struct{}{}
+				},
+				nil)
+
+			storage := NewStorage(
+				ledger,
+				nil,
+				StorageConfig{
+					StorageFormatV2Enabled: tc.storageFormatV2Enabled,
+				},
+			)
+
+			inter := NewTestInterpreterWithStorage(t, storage)
+
+			domainStorageMap := storage.GetDomainStorageMap(inter, address, tc.domain, tc.createIfNotExists)
+			require.Equal(t, tc.expectedDomainStorageMapIsNil, domainStorageMap == nil)
+			require.Equal(t, tc.expectedReadsFor1stGetDomainStorageMapCall, ledgerReads)
+
+			ledgerReads = ledgerReads[:0]
+
+			// Call GetDomainStorageMap() again to test account status is cached and no register reading is needed.
+
+			domainStorageMap = storage.GetDomainStorageMap(inter, address, tc.domain, tc.createIfNotExists)
+			require.Equal(t, tc.expectedDomainStorageMapIsNil, domainStorageMap == nil)
+			require.Equal(t, tc.expectedReadsFor2ndGetDomainStorageMapCall, ledgerReads)
+
+			// Check underlying ledger reads
+			require.Equal(t, len(ledgerReadsSet), len(tc.expectedReadsSet))
+			for k := range ledgerReadsSet {
+				require.Contains(t, tc.expectedReadsSet, k)
+			}
+		})
+	}
+}
+
+func TestGetDomainStorageMapRegisterReadsForV1Account(t *testing.T) {
+
+	t.Parallel()
+
+	address := common.MustBytesToAddress([]byte{0x1})
+
+	type getStorageDataFunc func() (storedValues map[string][]byte, StorageIndices map[string]uint64)
+
+	createV1AccountWithDomain := func(
+		address common.Address,
+		domain common.StorageDomain,
+	) getStorageDataFunc {
+		return func() (storedValues map[string][]byte, StorageIndices map[string]uint64) {
+			ledger := NewTestLedger(nil, nil)
+
+			persistentSlabStorage := newSlabStorage(ledger)
+
+			orderedMap, err := atree.NewMap(
+				persistentSlabStorage,
+				atree.Address(address),
+				atree.NewDefaultDigesterBuilder(),
+				interpreter.EmptyTypeInfo{},
+			)
+			require.NoError(t, err)
+
+			slabIndex := orderedMap.SlabID().Index()
+
+			for i := range 3 {
+
+				key := interpreter.StringStorageMapKey(strconv.Itoa(i))
+
+				value := interpreter.NewUnmeteredIntValueFromInt64(int64(i))
+
+				existingStorable, err := orderedMap.Set(
+					key.AtreeValueCompare,
+					key.AtreeValueHashInput,
+					key.AtreeValue(),
+					value,
+				)
+				require.NoError(t, err)
+				require.Nil(t, existingStorable)
+			}
+
+			// Commit domain storage map
+			err = persistentSlabStorage.FastCommit(runtime.NumCPU())
+			require.NoError(t, err)
+
+			// Create domain register
+			err = ledger.SetValue(address[:], []byte(domain.Identifier()), slabIndex[:])
+			require.NoError(t, err)
+
+			return ledger.StoredValues, ledger.StorageIndices
+		}
+	}
+
+	testCases := []struct {
+		name                                       string
+		getStorageData                             getStorageDataFunc
+		storageFormatV2Enabled                     bool
+		domain                                     common.StorageDomain
+		createIfNotExists                          bool
+		expectedDomainStorageMapIsNil              bool
+		expectedReadsFor1stGetDomainStorageMapCall []ownerKeyPair
+		expectedReadsFor2ndGetDomainStorageMapCall []ownerKeyPair
+		expectedReadsSet                           map[string]struct{}
+	}{
+		// Test cases with storageFormatV2Enabled = false
+		{
+			name:                          "storageFormatV2Enabled = false, domain storage map does not exist, createIfNotExists = false",
+			storageFormatV2Enabled:        false,
+			getStorageData:                createV1AccountWithDomain(address, common.StorageDomainPathPublic),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             false,
+			expectedDomainStorageMapIsNil: true,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Read domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// Read domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+			},
+		},
+		{
+			name:                          "storageFormatV2Enabled = false, domain storage map does not exist, createIfNotExists = true",
+			storageFormatV2Enabled:        false,
+			getStorageData:                createV1AccountWithDomain(address, common.StorageDomainPathPublic),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             true,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Read domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reading in second GetDomainStorageMap() because
+				// domain storage map is created and cached in the first
+				// GetDomainStorageMap(0).
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+			},
+		},
+		{
+			name:                          "storageFormatV2Enabled = false, domain storage map exists, createIfNotExists = false",
+			storageFormatV2Enabled:        false,
+			getStorageData:                createV1AccountWithDomain(address, common.StorageDomainPathStorage),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             false,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Read domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+				// Read domain storage map register
+				{
+					owner: address[:],
+					key:   []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1},
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reading in second GetDomainStorageMap() because
+				// domain storage map is loaded and cached in the first
+				// GetDomainStorageMap(0).
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}):  {},
+			},
+		},
+		{
+			name:                          "storageFormatV2Enabled = false, domain storage map exists, createIfNotExists = true",
+			storageFormatV2Enabled:        false,
+			getStorageData:                createV1AccountWithDomain(address, common.StorageDomainPathStorage),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             true,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Read domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+				// Read domain storage map register
+				{
+					owner: address[:],
+					key:   []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1},
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reading in second GetDomainStorageMap() because
+				// domain storage map is loaded and cached in the first
+				// GetDomainStorageMap(0).
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}):  {},
+			},
+		},
+		// Test cases with storageFormatV2Enabled = true
+		{
+			name:                          "storageFormatV2Enabled = true, domain storage map does not exist, createIfNotExists = false",
+			storageFormatV2Enabled:        true,
+			getStorageData:                createV1AccountWithDomain(address, common.StorageDomainPathPublic),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             false,
+			expectedDomainStorageMapIsNil: true,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Check all domain registers until existing domain register is read
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainStorage.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainPrivate.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainPublic.Identifier()),
+				},
+				// Read requested domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// Read requested domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + AccountStorageKey:                            {},
+				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+				string(address[:]) + "|" + common.StorageDomainPathPrivate.Identifier(): {},
+				string(address[:]) + "|" + common.StorageDomainPathPublic.Identifier():  {},
+			},
+		},
+		{
+			name:                          "storageFormatV2Enabled = true, domain storage map does not exist, createIfNotExists = true",
+			storageFormatV2Enabled:        true,
+			getStorageData:                createV1AccountWithDomain(address, common.StorageDomainPathPublic),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             true,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Check all domain registers until existing domain register is read
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainStorage.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainPrivate.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainPublic.Identifier()),
+				},
+				// Read requested domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reading from second GetDomainStorageMap() because
+				// domain storage map is created and cached in the first
+				// GetDomainStorageMap().
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + AccountStorageKey:                            {},
+				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+				string(address[:]) + "|" + common.StorageDomainPathPrivate.Identifier(): {},
+				string(address[:]) + "|" + common.StorageDomainPathPublic.Identifier():  {},
+			},
+		},
+		{
+			name:                          "storageFormatV2Enabled = true, domain storage map exists, createIfNotExists = false",
+			storageFormatV2Enabled:        true,
+			getStorageData:                createV1AccountWithDomain(address, common.StorageDomainPathStorage),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             false,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Check domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+				// Read domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+				// Read domain storage map register
+				{
+					owner: address[:],
+					key:   []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1},
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reading from second GetDomainStorageMap() because
+				// domain storage map is created and cached in the first
+				// GetDomainStorageMap().
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + AccountStorageKey:                            {},
+				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}):  {},
+			},
+		},
+		{
+			name:                          "storageFormatV2Enabled = true, domain storage map exists, createIfNotExists = true",
+			storageFormatV2Enabled:        true,
+			getStorageData:                createV1AccountWithDomain(address, common.StorageDomainPathStorage),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             true,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Check given domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+				// Read given domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+				// Read domain storage map register
+				{
+					owner: address[:],
+					key:   []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1},
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reading from second GetDomainStorageMap() because
+				// domain storage map is created and cached in the first
+				// GetDomainStorageMap().
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + AccountStorageKey:                            {},
+				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}):  {},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			storedValues, storedIndices := tc.getStorageData()
+
+			var ledgerReads []ownerKeyPair
+			ledgerReadsSet := make(map[string]struct{})
+
+			ledger := NewTestLedgerWithData(
+				func(owner, key, _ []byte) {
+					ledgerReads = append(
+						ledgerReads,
+						ownerKeyPair{
+							owner: owner,
+							key:   key,
+						},
+					)
+					ledgerReadsSet[string(owner)+"|"+string(key)] = struct{}{}
+				},
+				nil,
+				storedValues,
+				storedIndices,
+			)
+
+			storage := NewStorage(
+				ledger,
+				nil,
+				StorageConfig{
+					StorageFormatV2Enabled: tc.storageFormatV2Enabled,
+				},
+			)
+
+			inter := NewTestInterpreterWithStorage(t, storage)
+
+			domainStorageMap := storage.GetDomainStorageMap(inter, address, tc.domain, tc.createIfNotExists)
+			require.Equal(t, tc.expectedDomainStorageMapIsNil, domainStorageMap == nil)
+			require.Equal(t, tc.expectedReadsFor1stGetDomainStorageMapCall, ledgerReads)
+
+			ledgerReads = ledgerReads[:0]
+
+			domainStorageMap = storage.GetDomainStorageMap(inter, address, tc.domain, tc.createIfNotExists)
+			require.Equal(t, tc.expectedDomainStorageMapIsNil, domainStorageMap == nil)
+			require.Equal(t, tc.expectedReadsFor2ndGetDomainStorageMapCall, ledgerReads)
+
+			// Check underlying ledger reads
+			require.Equal(t, len(ledgerReadsSet), len(tc.expectedReadsSet))
+			for k := range ledgerReadsSet {
+				require.Contains(t, tc.expectedReadsSet, k)
+			}
+		})
+	}
+}
+
+func TestGetDomainStorageMapRegisterReadsForV2Account(t *testing.T) {
+	t.Parallel()
+
+	address := common.MustBytesToAddress([]byte{0x1})
+
+	type getStorageDataFunc func() (storedValues map[string][]byte, StorageIndices map[string]uint64)
+
+	createV2AccountWithDomain := func(
+		address common.Address,
+		domain common.StorageDomain,
+	) getStorageDataFunc {
+		return func() (storedValues map[string][]byte, StorageIndices map[string]uint64) {
+			ledger := NewTestLedger(nil, nil)
+
+			persistentSlabStorage := newSlabStorage(ledger)
+
+			accountOrderedMap, err := atree.NewMap(
+				persistentSlabStorage,
+				atree.Address(address),
+				atree.NewDefaultDigesterBuilder(),
+				interpreter.EmptyTypeInfo{},
+			)
+			require.NoError(t, err)
+
+			slabIndex := accountOrderedMap.SlabID().Index()
+
+			domainOrderedMap, err := atree.NewMap(
+				persistentSlabStorage,
+				atree.Address(address),
+				atree.NewDefaultDigesterBuilder(),
+				interpreter.EmptyTypeInfo{},
+			)
+			require.NoError(t, err)
+
+			domainKey := interpreter.Uint64StorageMapKey(domain)
+
+			existingDomain, err := accountOrderedMap.Set(
+				domainKey.AtreeValueCompare,
+				domainKey.AtreeValueHashInput,
+				domainKey.AtreeValue(),
+				domainOrderedMap,
+			)
+			require.NoError(t, err)
+			require.Nil(t, existingDomain)
+
+			for i := range 3 {
+
+				key := interpreter.StringStorageMapKey(strconv.Itoa(i))
+
+				value := interpreter.NewUnmeteredIntValueFromInt64(int64(i))
+
+				existingStorable, err := domainOrderedMap.Set(
+					key.AtreeValueCompare,
+					key.AtreeValueHashInput,
+					key.AtreeValue(),
+					value,
+				)
+				require.NoError(t, err)
+				require.Nil(t, existingStorable)
+			}
+
+			// Commit domain storage map
+			err = persistentSlabStorage.FastCommit(runtime.NumCPU())
+			require.NoError(t, err)
+
+			// Create account register
+			err = ledger.SetValue(address[:], []byte(AccountStorageKey), slabIndex[:])
+			require.NoError(t, err)
+
+			return ledger.StoredValues, ledger.StorageIndices
+		}
+	}
+
+	testCases := []struct {
+		name                                       string
+		getStorageData                             getStorageDataFunc
+		domain                                     common.StorageDomain
+		createIfNotExists                          bool
+		expectedDomainStorageMapIsNil              bool
+		expectedReadsFor1stGetDomainStorageMapCall []ownerKeyPair
+		expectedReadsFor2ndGetDomainStorageMapCall []ownerKeyPair
+		expectedReadsSet                           map[string]struct{}
+	}{
+		{
+			name:                          "domain storage map does not exist, createIfNotExists = false",
+			getStorageData:                createV2AccountWithDomain(address, common.StorageDomainPathPublic),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             false,
+			expectedDomainStorageMapIsNil: true,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Read account register
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Read account storage map
+				{
+					owner: address[:],
+					key:   []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1},
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reading from second GetDomainStorageMap because
+				// account storage map is loaded and cached from first
+				// GetDomainStorageMap().
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + AccountStorageKey:                           {},
+				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
+			},
+		},
+		{
+			name:                          "domain storage map does not exist, createIfNotExists = true",
+			getStorageData:                createV2AccountWithDomain(address, common.StorageDomainPathPublic),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             true,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Read account register
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Read account storage map
+				{
+					owner: address[:],
+					key:   []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1},
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reading from second GetDomainStorageMap() because
+				// domain storage map is created and cached in the first
+				// GetDomainStorageMap().
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + AccountStorageKey:                           {},
+				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
+			},
+		},
+		{
+			name:                          "domain storage map exists, createIfNotExists = false",
+			getStorageData:                createV2AccountWithDomain(address, common.StorageDomainPathStorage),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             false,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Read account register
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Read account storage map
+				{
+					owner: address[:],
+					key:   []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1},
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reading from second GetDomainStorageMap() because
+				// domain storage map is created and cached in the first
+				// GetDomainStorageMap().
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + AccountStorageKey:                           {},
+				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
+			},
+		},
+		{
+			name:                          "domain storage map exists, createIfNotExists = true",
+			getStorageData:                createV2AccountWithDomain(address, common.StorageDomainPathStorage),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             true,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Read account register
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Read account storage map
+				{
+					owner: address[:],
+					key:   []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1},
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reading from second GetDomainStorageMap() because
+				// domain storage map is created and cached in the first
+				// GetDomainStorageMap().
+			},
+			expectedReadsSet: map[string]struct{}{
+				string(address[:]) + "|" + AccountStorageKey:                           {},
+				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			storedValues, storedIndices := tc.getStorageData()
+
+			var ledgerReads []ownerKeyPair
+			ledgerReadsSet := make(map[string]struct{})
+
+			ledger := NewTestLedgerWithData(
+				func(owner, key, _ []byte) {
+					ledgerReads = append(
+						ledgerReads,
+						ownerKeyPair{
+							owner: owner,
+							key:   key,
+						},
+					)
+					ledgerReadsSet[string(owner)+"|"+string(key)] = struct{}{}
+				},
+				nil,
+				storedValues,
+				storedIndices,
+			)
+
+			storage := NewStorage(
+				ledger,
+				nil,
+				StorageConfig{
+					StorageFormatV2Enabled: true,
+				},
+			)
+
+			inter := NewTestInterpreterWithStorage(t, storage)
+
+			domainStorageMap := storage.GetDomainStorageMap(inter, address, tc.domain, tc.createIfNotExists)
+			require.Equal(t, tc.expectedDomainStorageMapIsNil, domainStorageMap == nil)
+			require.Equal(t, tc.expectedReadsFor1stGetDomainStorageMapCall, ledgerReads)
+
+			ledgerReads = ledgerReads[:0]
+
+			domainStorageMap = storage.GetDomainStorageMap(inter, address, tc.domain, tc.createIfNotExists)
+			require.Equal(t, tc.expectedDomainStorageMapIsNil, domainStorageMap == nil)
+			require.Equal(t, tc.expectedReadsFor2ndGetDomainStorageMapCall, ledgerReads)
+
+			// Check underlying ledger reads
+			require.Equal(t, len(ledgerReadsSet), len(tc.expectedReadsSet))
+			for k := range ledgerReadsSet {
+				require.Contains(t, tc.expectedReadsSet, k)
+			}
+		})
+	}
+}
+
 // createAndWriteAccountStorageMap creates account storage map with given domains and writes random values to domain storage map.
 func createAndWriteAccountStorageMap(
 	t testing.TB,
@@ -8206,4 +9142,36 @@ func checkAccountStorageMapData(
 	require.NoError(tb, err)
 	require.Equal(tb, 1, len(rootSlabIDs))
 	require.Contains(tb, rootSlabIDs, accountSlabID)
+}
+
+func newSlabStorage(ledger atree.Ledger) *atree.PersistentSlabStorage {
+	decodeStorable := func(
+		decoder *cbor.StreamDecoder,
+		slabID atree.SlabID,
+		inlinedExtraData []atree.ExtraData,
+	) (
+		atree.Storable,
+		error,
+	) {
+		return interpreter.DecodeStorable(
+			decoder,
+			slabID,
+			inlinedExtraData,
+			nil,
+		)
+	}
+
+	decodeTypeInfo := func(decoder *cbor.StreamDecoder) (atree.TypeInfo, error) {
+		return interpreter.DecodeTypeInfo(decoder, nil)
+	}
+
+	ledgerStorage := atree.NewLedgerBaseStorage(ledger)
+
+	return atree.NewPersistentSlabStorage(
+		ledgerStorage,
+		interpreter.CBOREncMode,
+		interpreter.CBORDecMode,
+		decodeStorable,
+		decodeTypeInfo,
+	)
 }

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -8120,7 +8120,7 @@ func TestGetDomainStorageMapRegisterReadsForNewAccount(t *testing.T) {
 				},
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage): {},
 			},
 		},
 		{
@@ -8141,7 +8141,7 @@ func TestGetDomainStorageMapRegisterReadsForNewAccount(t *testing.T) {
 				// domain storage map is created and cached in the first GetDomainStorageMap().
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage): {},
 			},
 		},
 		// Test cases with storageFormatV2Enabled = true
@@ -8211,16 +8211,16 @@ func TestGetDomainStorageMapRegisterReadsForNewAccount(t *testing.T) {
 				},
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + AccountStorageKey:                                        {},
-				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier():             {},
-				string(address[:]) + "|" + common.StorageDomainPathPrivate.Identifier():             {},
-				string(address[:]) + "|" + common.StorageDomainPathPublic.Identifier():              {},
-				string(address[:]) + "|" + common.StorageDomainContract.Identifier():                {},
-				string(address[:]) + "|" + common.StorageDomainInbox.Identifier():                   {},
-				string(address[:]) + "|" + common.StorageDomainCapabilityController.Identifier():    {},
-				string(address[:]) + "|" + common.StorageDomainCapabilityControllerTag.Identifier(): {},
-				string(address[:]) + "|" + common.StorageDomainPathCapability.Identifier():          {},
-				string(address[:]) + "|" + common.StorageDomainAccountCapability.Identifier():       {},
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):                      {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage):             {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathPrivate):             {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathPublic):              {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainContract):                {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainInbox):                   {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainCapabilityController):    {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainCapabilityControllerTag): {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathCapability):          {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainAccountCapability):       {},
 			},
 		},
 		{
@@ -8283,16 +8283,16 @@ func TestGetDomainStorageMapRegisterReadsForNewAccount(t *testing.T) {
 				// domain storage map is created and cached in the first GetDomainStorageMap().
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + AccountStorageKey:                                        {},
-				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier():             {},
-				string(address[:]) + "|" + common.StorageDomainPathPrivate.Identifier():             {},
-				string(address[:]) + "|" + common.StorageDomainPathPublic.Identifier():              {},
-				string(address[:]) + "|" + common.StorageDomainContract.Identifier():                {},
-				string(address[:]) + "|" + common.StorageDomainInbox.Identifier():                   {},
-				string(address[:]) + "|" + common.StorageDomainCapabilityController.Identifier():    {},
-				string(address[:]) + "|" + common.StorageDomainCapabilityControllerTag.Identifier(): {},
-				string(address[:]) + "|" + common.StorageDomainPathCapability.Identifier():          {},
-				string(address[:]) + "|" + common.StorageDomainAccountCapability.Identifier():       {},
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):                      {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage):             {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathPrivate):             {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathPublic):              {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainContract):                {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainInbox):                   {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainCapabilityController):    {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainCapabilityControllerTag): {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathCapability):          {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainAccountCapability):       {},
 			},
 		},
 	}
@@ -8437,7 +8437,7 @@ func TestGetDomainStorageMapRegisterReadsForV1Account(t *testing.T) {
 				},
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage): {},
 			},
 		},
 		{
@@ -8460,7 +8460,7 @@ func TestGetDomainStorageMapRegisterReadsForV1Account(t *testing.T) {
 				// GetDomainStorageMap(0).
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage): {},
 			},
 		},
 		{
@@ -8488,8 +8488,8 @@ func TestGetDomainStorageMapRegisterReadsForV1Account(t *testing.T) {
 				// GetDomainStorageMap(0).
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
-				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}):  {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage):  {},
+				concatRegisterAddressAndKey(address, []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
 			},
 		},
 		{
@@ -8517,8 +8517,8 @@ func TestGetDomainStorageMapRegisterReadsForV1Account(t *testing.T) {
 				// GetDomainStorageMap(0).
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
-				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}):  {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage):  {},
+				concatRegisterAddressAndKey(address, []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
 			},
 		},
 		// Test cases with storageFormatV2Enabled = true
@@ -8562,10 +8562,10 @@ func TestGetDomainStorageMapRegisterReadsForV1Account(t *testing.T) {
 				},
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + AccountStorageKey:                            {},
-				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
-				string(address[:]) + "|" + common.StorageDomainPathPrivate.Identifier(): {},
-				string(address[:]) + "|" + common.StorageDomainPathPublic.Identifier():  {},
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):          {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage): {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathPrivate): {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathPublic):  {},
 			},
 		},
 		{
@@ -8606,10 +8606,10 @@ func TestGetDomainStorageMapRegisterReadsForV1Account(t *testing.T) {
 				// GetDomainStorageMap().
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + AccountStorageKey:                            {},
-				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
-				string(address[:]) + "|" + common.StorageDomainPathPrivate.Identifier(): {},
-				string(address[:]) + "|" + common.StorageDomainPathPublic.Identifier():  {},
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):          {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage): {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathPrivate): {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathPublic):  {},
 			},
 		},
 		{
@@ -8647,9 +8647,9 @@ func TestGetDomainStorageMapRegisterReadsForV1Account(t *testing.T) {
 				// GetDomainStorageMap().
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + AccountStorageKey:                            {},
-				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
-				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}):  {},
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):           {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage):  {},
+				concatRegisterAddressAndKey(address, []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
 			},
 		},
 		{
@@ -8687,9 +8687,9 @@ func TestGetDomainStorageMapRegisterReadsForV1Account(t *testing.T) {
 				// GetDomainStorageMap().
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + AccountStorageKey:                            {},
-				string(address[:]) + "|" + common.StorageDomainPathStorage.Identifier(): {},
-				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}):  {},
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):           {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage):  {},
+				concatRegisterAddressAndKey(address, []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
 			},
 		},
 	}
@@ -8859,8 +8859,8 @@ func TestGetDomainStorageMapRegisterReadsForV2Account(t *testing.T) {
 				// GetDomainStorageMap().
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + AccountStorageKey:                           {},
-				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):           {},
+				concatRegisterAddressAndKey(address, []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
 			},
 		},
 		{
@@ -8892,8 +8892,8 @@ func TestGetDomainStorageMapRegisterReadsForV2Account(t *testing.T) {
 				// GetDomainStorageMap().
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + AccountStorageKey:                           {},
-				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):           {},
+				concatRegisterAddressAndKey(address, []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
 			},
 		},
 		{
@@ -8925,8 +8925,8 @@ func TestGetDomainStorageMapRegisterReadsForV2Account(t *testing.T) {
 				// GetDomainStorageMap().
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + AccountStorageKey:                           {},
-				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):           {},
+				concatRegisterAddressAndKey(address, []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
 			},
 		},
 		{
@@ -8958,8 +8958,8 @@ func TestGetDomainStorageMapRegisterReadsForV2Account(t *testing.T) {
 				// GetDomainStorageMap().
 			},
 			expectedReadsSet: map[string]struct{}{
-				string(address[:]) + "|" + AccountStorageKey:                           {},
-				string(address[:]) + "|" + string([]byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):           {},
+				concatRegisterAddressAndKey(address, []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
 			},
 		},
 	}
@@ -9174,4 +9174,18 @@ func newSlabStorage(ledger atree.Ledger) *atree.PersistentSlabStorage {
 		decodeStorable,
 		decodeTypeInfo,
 	)
+}
+
+func concatRegisterAddressAndKey(
+	address common.Address,
+	key []byte,
+) string {
+	return string(address[:]) + "|" + string(key)
+}
+
+func concatRegisterAddressAndDomain(
+	address common.Address,
+	domain common.StorageDomain,
+) string {
+	return string(address[:]) + "|" + domain.Identifier()
 }


### PR DESCRIPTION
Updates #3584

This PR adds more tests for register reads from `GetDomainStorageMap()` for account storage format v1 and v2.  

### Context 

This PR addresses [comment](https://github.com/onflow/cadence/pull/3683#pullrequestreview-2455249744) in PR #3683.  Thanks @turbolent for great suggestion! :+1:

> Could we maybe add a test case to [feature/combine-domain-payloads-and-domain-storage-maps](https://github.com/onflow/cadence/tree/feature/combine-domain-payloads-and-domain-storage-maps) before this PR that demonstrates the inefficiency (unnecessary reads), and then this PR could would show more clearly how the unnecessary read(s) are removed?

This PR updates these tests ported from #3683:
- `TestGetDomainStorageMapRegisterReadsForNewAccount`
- `TestGetDomainStorageMapRegisterReadsForV1Account`
- `TestGetDomainStorageMapRegisterReadsForV2Account`

While at it, I also updated these tests to include unique register reads (in addition to sequence of register reads).  Same register can be read multiple times and all  reads are included in the sequence.  Since subsequent register reads are from ledger cache, unique register reads are more important for performance reasons.

Unique register reads differs from that in PR #3683 ("Reduce storage register reads when using StorageFormatV2Enabled") when using StorageFormatV2Enabled:
- For new accounts (neither v1 or v2 yet):
  - If domain storage map doesn't exist and `createIfNotExists` is false, old approach has [10 unique register reads](https://github.com/onflow/cadence/blob/3a71bf0e8e00ede8ebaf2e339159a272bd8b2814/runtime/storage_test.go#L8213-L8224), while new approach has [2 unique register reads](https://github.com/onflow/cadence/blob/9af92f66fac1926eea058c06c2f9bcc7cd3bd7a3/runtime/storage_test.go#L8181-L1884).
- For v1 accounts:
  - If domain storage map doesn't exist and `createIfNotExists` is false, old approach has [4 unique register reads in tests](https://github.com/onflow/cadence/blob/3a71bf0e8e00ede8ebaf2e339159a272bd8b2814/runtime/storage_test.go#L8564-L8569), while new approach has [2 unique register reads](https://github.com/onflow/cadence/blob/9af92f66fac1926eea058c06c2f9bcc7cd3bd7a3/runtime/storage_test.go#L8521-L8524).
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
