### PR TITLE
[Account Storage Maps] Add return value to account migration scheduling functions

### DIFF
--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -370,16 +370,24 @@ func (s *Storage) commit(inter *interpreter.Interpreter, commitContractUpdates b
 	}
 }
 
-func (s *Storage) ScheduleV2Migration(address common.Address) {
+func (s *Storage) ScheduleV2Migration(address common.Address) bool {
+	if !s.Config.StorageFormatV2Enabled {
+		return false
+	}
 	s.scheduledV2Migrations = append(s.scheduledV2Migrations, address)
+	return true
 }
 
-func (s *Storage) ScheduleV2MigrationForModifiedAccounts() {
+func (s *Storage) ScheduleV2MigrationForModifiedAccounts() bool {
 	for address, isV1 := range s.cachedV1Accounts { //nolint:maprange
 		if isV1 && s.PersistentSlabStorage.HasUnsavedChanges(atree.Address(address)) {
-			s.ScheduleV2Migration(address)
+			if !s.ScheduleV2Migration(address) {
+				return false
+			}
 		}
 	}
+
+	return true
 }
 
 func (s *Storage) migrateV1AccountsToV2(inter *interpreter.Interpreter) error {


### PR DESCRIPTION
Work towards #3584

## Description

Add a return value to the functions which allow scheduling the migration of accounts.

We need this value in the system contract which will call the function to know if the V2 storage format is enabled, and the migration can be performed.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
