### PR TITLE
Add some benchmark programs

### DIFF
--- a/benchmarks/binarytrees.cdc
+++ b/benchmarks/binarytrees.cdc
@@ -1,0 +1,82 @@
+
+access(all)
+struct Tree {
+    access(all)
+    var left: Tree?
+
+    access(all)
+    var right: Tree?
+
+    init(left: Tree?, right: Tree?) {
+        self.left = left
+        self.right = right
+    }
+
+    access(all)
+    fun nodeCount(): Int {
+        return 1
+            + (self.left?.nodeCount() ?? 0)
+            + (self.right?.nodeCount() ?? 0)
+    }
+
+    access(all)
+    fun clear() {
+        if (self.left != nil) {
+            self.left?.clear()
+            self.left = nil
+            self.right?.clear()
+            self.right = nil
+        }
+    }
+}
+
+access(all)
+fun newTree(depth: Int): Tree {
+    if depth == 0 {
+        return Tree(left: nil, right: nil)
+    }
+    return Tree(
+        left: newTree(depth: depth - 1),
+        right: newTree(depth: depth - 1)
+    )
+}
+
+access(all)
+fun stretch(_ depth: Int) {
+   log("stretch tree of depth \(depth), check: \(count(depth))")
+}
+
+access(all)
+fun count(_ depth: Int): Int {
+    let t = newTree(depth: depth)
+    let c = t.nodeCount()
+    t.clear()
+    return c
+}
+
+access(all)
+fun run(_ n: Int) {
+    let minDepth = 4
+    let maxDepth = minDepth + 2 > n ? minDepth + 2 : n
+    let stretchDepth = maxDepth + 1
+
+    stretch(stretchDepth)
+    let longLivedTree = newTree(depth: maxDepth)
+
+    for depth in InclusiveRange(minDepth, maxDepth, step: 2) {
+        let iterations = 1 << (maxDepth - depth + minDepth)
+        var sum = 0
+        for _ in InclusiveRange(1, iterations, step: 1) {
+            sum = sum + count(depth)
+        }
+        log("\(iterations), trees of depth \(depth), check: \(sum)")
+    }
+    let count = longLivedTree.nodeCount()
+    longLivedTree.clear()
+    log("long lived tree of depth \(maxDepth), check: \(count)")
+}
+
+access(all)
+fun main() {
+    run(10)
+}

--- a/benchmarks/fannkuch.cdc
+++ b/benchmarks/fannkuch.cdc
@@ -1,0 +1,95 @@
+access(all)
+fun newArray(repeating value: Int, count: Int): [Int] {
+    let array: [Int] = []
+    for _ in InclusiveRange(0, count-1) {
+        array.append(value)
+    }
+    return array
+}
+
+access(all)
+fun fannkuch(_ n: Int): Int {
+    let perm = newArray(repeating: 0, count: n)
+    let count = newArray(repeating: 0, count: n)
+    let perm1 = newArray(repeating: 0, count: n)
+
+    for j in InclusiveRange(0, n-1) {
+        perm1[j] = j
+    }
+
+    var f = 0
+    var i = 0
+    var k = 0
+    var r = 0
+    var flips = 0
+    var nperm = 0
+    var checksum = 0
+
+    r = n
+    while r > 0 {
+        i = 0
+        while r != 1 {
+            count[r-1] = r
+            r = r - 1
+        }
+        while i < n {
+            perm[i] = perm1[i]
+            i = i + 1
+        }
+
+        // Count flips and update max  and checksum
+        f = 0
+        k = perm[0]
+        while k != 0 {
+            i = 0
+            while 2*i < k {
+                let t = perm[i]
+                perm[i] = perm[k-i]
+                perm[k-i] = t
+                i = i + 1
+            }
+            k = perm[0]
+            f = f + 1
+        }
+        if f > flips {
+            flips = f
+        }
+
+        if (nperm & 0x1) == 0 {
+            checksum = checksum + f
+        } else {
+            checksum = checksum - f
+        }
+
+        // Use incremental change to generate another permutation
+        var more = true
+        while more {
+            if r == n {
+                log(checksum)
+                return flips
+            }
+            let p0 = perm1[0]
+            i = 0
+            while i < r {
+                let j = i+1
+                perm1[i] = perm1[j]
+                i = j
+            }
+            perm1[r] = p0
+
+            count[r] = count[r] - 1
+            if count[r] > 0 {
+                more = false
+            } else {
+                r = r + 1
+            }
+        }
+        nperm = nperm + 1
+    }
+    return flips
+}
+
+access(all)
+fun main() {
+    assert(fannkuch(7) == 16)
+}

--- a/benchmarks/fib_dynamic.cdc
+++ b/benchmarks/fib_dynamic.cdc
@@ -1,0 +1,21 @@
+access(all)
+fun fib(_ n: Int): Int {
+    if n == 0 {
+        return 0
+    }
+
+    let f = [0, 1]
+
+    var i = 2
+    while i <= n {
+        f.append(f[i - 1] + f[i - 2])
+        i = i + 1
+    }
+
+    return f[n]
+}
+
+access(all)
+fun main() {
+    assert(fib(14) == 377)
+}

--- a/benchmarks/fib_dynamic.cdc
+++ b/benchmarks/fib_dynamic.cdc
@@ -17,5 +17,5 @@ fun fib(_ n: Int): Int {
 
 access(all)
 fun main() {
-    assert(fib(14) == 377)
+    assert(fib(23) == 28657)
 }

--- a/benchmarks/fib_iterative.cdc
+++ b/benchmarks/fib_iterative.cdc
@@ -1,0 +1,19 @@
+access(all)
+fun fib(_ n: Int): Int {
+    var fib1 = 1
+    var fib2 = 1
+    var fibonacci = fib1
+    var i = 2
+    while i < n {
+        fibonacci = fib1 + fib2
+        fib1 = fib2
+        fib2 = fibonacci
+        i = i + 1
+    }
+    return fibonacci
+}
+
+access(all)
+fun main() {
+    assert(fib(23) == 28657)
+}

--- a/benchmarks/fib_recursive.cdc
+++ b/benchmarks/fib_recursive.cdc
@@ -1,0 +1,12 @@
+access(all)
+fun fib(_ n: Int): Int {
+    if n < 2 {
+        return n
+    }
+    return fib(n - 1) + fib(n - 2)
+}
+
+access(all)
+fun main() {
+    assert(fib(23) == 28657)
+}


### PR DESCRIPTION
Work towards #3692

## Description

Add some benchmarks that we can use to evaluate the performance of the current interpreter and new execution environments:
- `fib_dynamic`: Fibonacci function, using dynamic programming
- `fib_iterative`: Fibonacci function, iterative
- `fib_recursive`: Fibonacci function, recursive
- `binarytrees`: https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/binarytrees.html#binarytrees
- `fannkuch`: https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/fannkuchredux.html#fannkuchredux

We can use these in the Go benchmarks with `go:embed`. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
