### PR TITLE
Standardize internal error messages

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -30,6 +30,8 @@ func NewUnreachableError() InternalError {
 	return NewUnexpectedError("unreachable")
 }
 
+const InternalErrorMessagePrefix = "internal error:"
+
 // InternalError is an implementation error, e.g: an unreachable code path (UnreachableError).
 // A program should never throw an InternalError in an ideal world.
 //
@@ -174,9 +176,18 @@ func (e UnexpectedError) Unwrap() error {
 func (e UnexpectedError) Error() string {
 	message := e.Err.Error()
 	if len(e.Stack) == 0 {
-		return fmt.Sprintf("unexpected error: %s", message)
+		return fmt.Sprintf(
+			"%s unexpected: %s",
+			InternalErrorMessagePrefix,
+			message,
+		)
 	} else {
-		return fmt.Sprintf("unexpected error: %s\n%s", message, e.Stack)
+		return fmt.Sprintf(
+			"%s unexpected: %s\n%s",
+			InternalErrorMessagePrefix,
+			message,
+			e.Stack,
+		)
 	}
 }
 

--- a/interpreter/decode.go
+++ b/interpreter/decode.go
@@ -54,7 +54,8 @@ func (UnsupportedTagDecodingError) IsInternalError() {}
 
 func (e UnsupportedTagDecodingError) Error() string {
 	return fmt.Sprintf(
-		"internal error: unsupported decoded tag: %d",
+		"%s unsupported decoded tag: %d",
+		errors.InternalErrorMessagePrefix,
 		e.Tag,
 	)
 }
@@ -69,7 +70,8 @@ func (InvalidStringLengthError) IsInternalError() {}
 
 func (e InvalidStringLengthError) Error() string {
 	return fmt.Sprintf(
-		"internal error: invalid string length: got %d, expected max %d",
+		"%s invalid string length: got %d, expected max %d",
+		errors.InternalErrorMessagePrefix,
 		e.Length,
 		goMaxInt,
 	)

--- a/interpreter/errors.go
+++ b/interpreter/errors.go
@@ -44,7 +44,8 @@ func (*unsupportedOperation) IsInternalError() {}
 
 func (e *unsupportedOperation) Error() string {
 	return fmt.Sprintf(
-		"internal error: cannot evaluate unsupported %s operation: %s",
+		"%s cannot evaluate unsupported %s operation: %s",
+		errors.InternalErrorMessagePrefix,
 		e.kind.Name(),
 		e.operation.Symbol(),
 	)
@@ -323,7 +324,10 @@ var _ errors.InternalError = InvalidatedResourceError{}
 func (InvalidatedResourceError) IsInternalError() {}
 
 func (e InvalidatedResourceError) Error() string {
-	return "internal error: resource is invalidated and cannot be used anymore"
+	return fmt.Sprintf(
+		"%s resource is invalidated and cannot be used anymore",
+		errors.InternalErrorMessagePrefix,
+	)
 }
 
 // DestroyedResourceError is the error which is reported
@@ -633,7 +637,8 @@ func (MemberAccessTypeError) IsInternalError() {}
 
 func (e MemberAccessTypeError) Error() string {
 	return fmt.Sprintf(
-		"invalid member access: expected `%s`, got `%s`",
+		"%s invalid member access: expected `%s`, got `%s`",
+		errors.InternalErrorMessagePrefix,
 		e.ExpectedType.QualifiedString(),
 		e.ActualType.QualifiedString(),
 	)
@@ -657,7 +662,8 @@ func (e ValueTransferTypeError) Error() string {
 	)
 
 	return fmt.Sprintf(
-		"invalid transfer of value: expected `%s`, got `%s`",
+		"%s invalid transfer of value: expected `%s`, got `%s`",
+		errors.InternalErrorMessagePrefix,
 		expected,
 		actual,
 	)
@@ -675,7 +681,8 @@ func (UnexpectedMappedEntitlementError) IsInternalError() {}
 
 func (e UnexpectedMappedEntitlementError) Error() string {
 	return fmt.Sprintf(
-		"invalid transfer of value: found an unexpected runtime mapped entitlement `%s`",
+		"%s invalid transfer of value: found an unexpected runtime mapped entitlement `%s`",
+		errors.InternalErrorMessagePrefix,
 		e.Type.QualifiedString(),
 	)
 }
@@ -692,7 +699,8 @@ func (ResourceConstructionError) IsInternalError() {}
 
 func (e ResourceConstructionError) Error() string {
 	return fmt.Sprintf(
-		"cannot create resource `%s`: outside of declaring location %s",
+		"%s cannot create resource `%s`: outside of declaring location %s",
+		errors.InternalErrorMessagePrefix,
 		e.CompositeType.QualifiedString(),
 		e.CompositeType.Location.String(),
 	)
@@ -952,7 +960,8 @@ func (InvalidAttachmentOperationTargetError) IsInternalError() {}
 
 func (e InvalidAttachmentOperationTargetError) Error() string {
 	return fmt.Sprintf(
-		"cannot add or remove attachment with non-owned value (%T)",
+		"%s cannot add or remove attachment with non-owned value (%T)",
+		errors.InternalErrorMessagePrefix,
 		e.Value,
 	)
 }
@@ -1092,7 +1101,10 @@ var _ errors.InternalError = ResourceReferenceDereferenceError{}
 func (ResourceReferenceDereferenceError) IsInternalError() {}
 
 func (e ResourceReferenceDereferenceError) Error() string {
-	return "internal error: resource-references cannot be dereferenced"
+	return fmt.Sprintf(
+		"%s resource-references cannot be dereferenced",
+		errors.InternalErrorMessagePrefix,
+	)
 }
 
 // ResourceLossError
@@ -1117,7 +1129,10 @@ var _ errors.InternalError = InvalidCapabilityIDError{}
 func (InvalidCapabilityIDError) IsInternalError() {}
 
 func (e InvalidCapabilityIDError) Error() string {
-	return "capability created with invalid ID"
+	return fmt.Sprintf(
+		"%s capability created with invalid ID",
+		errors.InternalErrorMessagePrefix,
+	)
 }
 
 // ReferencedValueChangedError

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -380,5 +380,9 @@ var _ errors.InternalError = UnreferencedRootSlabsError{}
 func (UnreferencedRootSlabsError) IsInternalError() {}
 
 func (e UnreferencedRootSlabsError) Error() string {
-	return fmt.Sprintf("slabs not referenced: %s", e.UnreferencedRootSlabIDs)
+	return fmt.Sprintf(
+		"%s slabs not referenced: %s",
+		errors.InternalErrorMessagePrefix,
+		e.UnreferencedRootSlabIDs,
+	)
 }


### PR DESCRIPTION
Closes #3688 

## Description

Add same prefix to all internal error messages

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
