### PR TITLE
Optimize function calls

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1139,8 +1139,15 @@ func (c *Compiler) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration
 	c.declareParameters(function, declaration.ParameterList, declareReceiver)
 	c.compileFunctionBlock(declaration.FunctionBlock)
 
+	// Manually emit a return, if there are no explicit return statements.
 	if !declaration.FunctionBlock.HasStatements() {
 		c.emit(opcode.Return)
+	} else {
+		statements := declaration.FunctionBlock.Block.Statements
+		lastStmt := statements[len(statements)-1]
+		if _, isReturn := lastStmt.(*ast.ReturnStatement); !isReturn {
+			c.emit(opcode.Return)
+		}
 	}
 
 	return

--- a/bbq/vm/callframe.go
+++ b/bbq/vm/callframe.go
@@ -23,11 +23,12 @@ import (
 )
 
 type callFrame struct {
-	parent     *callFrame
-	executable *ExecutableProgram
-	locals     []Value
-	function   *bbq.Function
-	ip         uint16
+	parent       *callFrame
+	executable   *ExecutableProgram
+	localsOffset uint16
+	localsCount  uint16
+	function     *bbq.Function
+	ip           uint16
 }
 
 func (f *callFrame) getUint16() uint16 {

--- a/bbq/vm/callframe.go
+++ b/bbq/vm/callframe.go
@@ -23,36 +23,35 @@ import (
 )
 
 type callFrame struct {
-	parent       *callFrame
 	executable   *ExecutableProgram
 	localsOffset uint16
 	localsCount  uint16
 	function     *bbq.Function
-	ip           uint16
 }
 
-func (f *callFrame) getUint16() uint16 {
-	first := f.function.Code[f.ip]
-	last := f.function.Code[f.ip+1]
-	f.ip += 2
-	return uint16(first)<<8 | uint16(last)
-}
-
-func (f *callFrame) getByte() byte {
-	byt := f.function.Code[f.ip]
-	f.ip++
-	return byt
-}
-
-func (f *callFrame) getBool() bool {
-	byt := f.function.Code[f.ip]
-	f.ip++
-	return byt == 1
-}
-
-func (f *callFrame) getString() string {
-	strLen := f.getUint16()
-	str := string(f.function.Code[f.ip : f.ip+strLen])
-	f.ip += strLen
-	return str
-}
+//
+//func (f *callFrame) getUint16() uint16 {
+//	first := f.function.Code[f.ip]
+//	last := f.function.Code[f.ip+1]
+//	f.ip += 2
+//	return uint16(first)<<8 | uint16(last)
+//}
+//
+//func (f *callFrame) getByte() byte {
+//	byt := f.function.Code[f.ip]
+//	f.ip++
+//	return byt
+//}
+//
+//func (f *callFrame) getBool() bool {
+//	byt := f.function.Code[f.ip]
+//	f.ip++
+//	return byt == 1
+//}
+//
+//func (f *callFrame) getString() string {
+//	strLen := f.getUint16()
+//	str := string(f.function.Code[f.ip : f.ip+strLen])
+//	f.ip += strLen
+//	return str
+//}

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -93,8 +93,11 @@ func LinkGlobals(
 
 	executable := NewLoadedExecutableProgram(location, program)
 
-	globals := make([]Value, 0)
-	indexedGlobals := make(map[string]Value, 0)
+	globalsLen := len(program.Variables) + len(program.Functions) + len(importedGlobals) + 1
+	indexedGlobalsLen := len(program.Functions)
+
+	globals := make([]Value, 0, globalsLen)
+	indexedGlobals := make(map[string]Value, indexedGlobalsLen)
 
 	// If the current program is a contract, reserve a global variable for the contract value.
 	// The reserved position is always the zero-th index.

--- a/bbq/vm/reference_tracking.go
+++ b/bbq/vm/reference_tracking.go
@@ -59,14 +59,10 @@ func trackReferencedResourceKindedValue(
 
 func checkInvalidatedResourceOrResourceReference(value Value) {
 
-	// Unwrap SomeValue, to access references wrapped inside optionals.
-	someValue, isSomeValue := value.(*SomeValue)
-	for isSomeValue && someValue.value != nil {
-		value = someValue.value
-		someValue, isSomeValue = value.(*SomeValue)
-	}
-
 	switch value := value.(type) {
+	case *SomeValue:
+		checkInvalidatedResourceOrResourceReference(value.value)
+
 	// TODO:
 	//case ResourceKindedValue:
 	//	if value.isInvalidatedResource(interpreter) {

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -319,12 +319,12 @@ func BenchmarkFTTransfer(b *testing.B) {
 
 	tokenTransferTxChecker := parseAndCheck(b, realFlowTokenTransferTransaction, nil, programs)
 	tokenTransferTxProgram := compile(b, tokenTransferTxChecker, programs)
-	tokenTransferTxVM := vm.NewVM(txLocation(), tokenTransferTxProgram, vmConfig)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
+		tokenTransferTxVM := vm.NewVM(txLocation(), tokenTransferTxProgram, vmConfig)
 		err = tokenTransferTxVM.ExecuteTransaction(tokenTransferTxArgs, tokenTransferTxAuthorizer)
 		require.NoError(b, err)
 	}

--- a/bbq/vm/test/vm_bench_test.go
+++ b/bbq/vm/test/vm_bench_test.go
@@ -32,10 +32,10 @@ func BenchmarkRecursionFib(b *testing.B) {
 	vmConfig := &vm.Config{}
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
+	expected := vm.NewIntValue(377)
+
 	b.ReportAllocs()
 	b.ResetTimer()
-
-	expected := vm.NewIntValue(377)
 
 	for i := 0; i < b.N; i++ {
 

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -69,10 +69,10 @@ func TestRecursionFib(t *testing.T) {
 
 	result, err := vmInstance.Invoke(
 		"fib",
-		vm.NewIntValue(7),
+		vm.NewIntValue(35),
 	)
 	require.NoError(t, err)
-	require.Equal(t, vm.NewIntValue(13), result)
+	require.Equal(t, vm.NewIntValue(9227465), result)
 	require.Equal(t, 0, vmInstance.StackSize())
 }
 

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -2041,5 +2041,20 @@ func TestResource(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 	})
+}
 
+func fib(n int) int {
+	if n < 2 {
+		return n
+	}
+	return fib(n-1) + fib(n-2)
+}
+
+func BenchmarkGoFib(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		fib(46)
+	}
 }


### PR DESCRIPTION
## Description

Reduces the memory footprint of the call-frames by:
- Moving the local-variables out of the callframe. Instead, maintain one big slice at the vm level, and allocate sections of the slice for each new scope.
- Make the callframe a non-pointer, by converting the linked-list to a call-stack. Maintain a separate ip-stack to be able to resume from the [previous ip, when unwinding the callstack.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
