### PR TITLE
[Custom VM] Improve and test instruction printer

### DIFF
--- a/bbq/opcode/print.go
+++ b/bbq/opcode/print.go
@@ -1,0 +1,211 @@
+package opcode
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+func PrintInstructions(builder *strings.Builder, reader *bytes.Reader) error {
+	for reader.Len() > 0 {
+		offset := reader.Size() - int64(reader.Len())
+		err := PrintInstruction(builder, reader)
+		if err != nil {
+			return fmt.Errorf("failed to print instruction at offset %d: %w", offset, err)
+		}
+		builder.WriteByte('\n')
+	}
+	return nil
+}
+
+func PrintInstruction(builder *strings.Builder, reader *bytes.Reader) error {
+
+	rawOpcode, err := reader.ReadByte()
+	if err != nil {
+		return fmt.Errorf("failed to read opcode: %w", err)
+	}
+	opcode := Opcode(rawOpcode)
+
+	builder.WriteString(opcode.String())
+
+	switch opcode {
+
+	// opcodes with one operand
+	case GetConstant,
+		GetLocal,
+		SetLocal,
+		GetGlobal,
+		SetGlobal,
+		Jump,
+		JumpIfFalse,
+		Transfer:
+
+		operand, err := readIntOperand(reader)
+		if err != nil {
+			return fmt.Errorf("failed to read operand: %w", err)
+		}
+
+		builder.WriteByte(' ')
+		_, _ = fmt.Fprint(builder, operand)
+
+	case New:
+		kind, err := readIntOperand(reader)
+		if err != nil {
+			return fmt.Errorf("failed to read kind operand: %w", err)
+		}
+
+		typeIndex, err := readIntOperand(reader)
+		if err != nil {
+			return fmt.Errorf("failed to read type index operand: %w", err)
+		}
+
+		_, _ = fmt.Fprintf(builder, " kind:%d typeIndex:%d", kind, typeIndex)
+
+	case Cast:
+		typeIndex, err := readIntOperand(reader)
+		if err != nil {
+			return fmt.Errorf("failed to read type index operand: %w", err)
+		}
+
+		castKind, err := reader.ReadByte()
+		if err != nil {
+			return fmt.Errorf("failed to read cast kind operand: %w", err)
+		}
+
+		_, _ = fmt.Fprintf(builder, " typeIndex:%d castKind:%d", typeIndex, castKind)
+
+	case Path:
+		domain, err := reader.ReadByte()
+		if err != nil {
+			return fmt.Errorf("failed to read domain operand: %w", err)
+		}
+
+		identifier, err := readStringOperand(reader)
+		if err != nil {
+			return fmt.Errorf("failed to read identifier operand: %w", err)
+		}
+
+		_, _ = fmt.Fprintf(builder, " domain:%d identifier:%q", domain, identifier)
+
+	case InvokeDynamic:
+		// Function name
+		funcName, err := readStringOperand(reader)
+		if err != nil {
+			return fmt.Errorf("failed to read function name operand: %w", err)
+		}
+		_, _ = fmt.Fprintf(builder, " funcName:%q", funcName)
+
+		// Type parameters
+		err = printTypeParameters(builder, reader)
+		if err != nil {
+			return fmt.Errorf("failed to read type parameters: %w", err)
+		}
+
+		// Argument count
+		argsCount, err := readIntOperand(reader)
+		if err != nil {
+			return fmt.Errorf("failed to read argument count operand: %w", err)
+		}
+		_, _ = fmt.Fprintf(builder, " argsCount:%d", argsCount)
+
+	case Invoke:
+		err := printTypeParameters(builder, reader)
+		if err != nil {
+			return fmt.Errorf("failed to read type parameters: %w", err)
+		}
+
+	// opcodes with no operands
+	case Unknown,
+		Return,
+		ReturnValue,
+		IntAdd,
+		IntSubtract,
+		IntMultiply,
+		IntDivide,
+		IntMod,
+		IntLess,
+		IntGreater,
+		IntLessOrEqual,
+		IntGreaterOrEqual,
+		Equal,
+		NotEqual,
+		Unwrap,
+		Destroy,
+		True,
+		False,
+		Nil,
+		NewArray,
+		NewDictionary,
+		NewRef,
+		GetField,
+		SetField,
+		SetIndex,
+		GetIndex,
+		Drop,
+		Dup:
+		// no operands
+	}
+
+	return nil
+}
+
+func readIntOperand(reader *bytes.Reader) (operand int, err error) {
+	first, err := reader.ReadByte()
+	if err != nil {
+		return 0, fmt.Errorf("failed to read first byte of int operand: %w", err)
+	}
+
+	second, err := reader.ReadByte()
+	if err != nil {
+		return 0, fmt.Errorf("failed to read second byte of int operand: %w", err)
+	}
+
+	operand = int(uint16(first)<<8 | uint16(second))
+	return operand, nil
+}
+
+func readStringOperand(reader *bytes.Reader) (operand string, err error) {
+	stringLength, err := readIntOperand(reader)
+	if err != nil {
+		return "", fmt.Errorf("failed to read string length of string operand: %w", err)
+	}
+
+	stringBytes := make([]byte, stringLength)
+	readLength, err := reader.Read(stringBytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to read string bytes of string operand: %w", err)
+	}
+	if readLength != stringLength {
+		return "", fmt.Errorf(
+			"failed to read all bytes of string operand: expected %d, got %d",
+			stringLength,
+			readLength,
+		)
+	}
+
+	return string(stringBytes), nil
+}
+
+func printTypeParameters(builder *strings.Builder, reader *bytes.Reader) error {
+	typeParamCount, err := readIntOperand(reader)
+	if err != nil {
+		return fmt.Errorf("failed to read type parameter count operand: %w", err)
+	}
+	_, _ = fmt.Fprintf(builder, " typeParamCount:%d typeParams:[", typeParamCount)
+
+	for i := 0; i < typeParamCount; i++ {
+		if i > 0 {
+			builder.WriteString(", ")
+		}
+
+		typeIndex, err := readIntOperand(reader)
+		if err != nil {
+			return fmt.Errorf("failed to read type index operand: %w", err)
+		}
+
+		_, _ = fmt.Fprint(builder, typeIndex)
+	}
+	builder.WriteByte(']')
+
+	return nil
+}

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -1,0 +1,141 @@
+package opcode
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintRecursionFib(t *testing.T) {
+	t.Parallel()
+
+	code := []byte{
+		// if n < 2
+		byte(GetLocal), 0, 0,
+		byte(GetConstant), 0, 0,
+		byte(IntLess),
+		byte(JumpIfFalse), 0, 14,
+		// then return n
+		byte(GetLocal), 0, 0,
+		byte(ReturnValue),
+		// fib(n - 1)
+		byte(GetLocal), 0, 0,
+		byte(GetConstant), 0, 1,
+		byte(IntSubtract),
+		byte(Transfer), 0, 0,
+		byte(GetGlobal), 0, 0,
+		byte(Invoke), 0, 0,
+		// fib(n - 2)
+		byte(GetLocal), 0, 0,
+		byte(GetConstant), 0, 0,
+		byte(IntSubtract),
+		byte(Transfer), 0, 0,
+		byte(GetGlobal), 0, 0,
+		byte(Invoke), 0, 0,
+		// return sum
+		byte(IntAdd),
+		byte(ReturnValue),
+	}
+
+	const expected = `GetLocal 0
+GetConstant 0
+IntLess
+JumpIfFalse 14
+GetLocal 0
+ReturnValue
+GetLocal 0
+GetConstant 1
+IntSubtract
+Transfer 0
+GetGlobal 0
+Invoke typeParamCount:0 typeParams:[]
+GetLocal 0
+GetConstant 0
+IntSubtract
+Transfer 0
+GetGlobal 0
+Invoke typeParamCount:0 typeParams:[]
+IntAdd
+ReturnValue
+`
+
+	var builder strings.Builder
+	reader := bytes.NewReader(code)
+	err := PrintInstructions(&builder, reader)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, builder.String())
+}
+
+func TestPrintInstruction(t *testing.T) {
+	t.Parallel()
+
+	instructions := map[string][]byte{
+		"GetConstant 258": {byte(GetConstant), 1, 2},
+		"GetLocal 258":    {byte(GetLocal), 1, 2},
+		"SetLocal 258":    {byte(SetLocal), 1, 2},
+		"GetGlobal 258":   {byte(GetGlobal), 1, 2},
+		"SetGlobal 258":   {byte(SetGlobal), 1, 2},
+		"Jump 258":        {byte(Jump), 1, 2},
+		"JumpIfFalse 258": {byte(JumpIfFalse), 1, 2},
+		"Transfer 258":    {byte(Transfer), 1, 2},
+
+		"New kind:258 typeIndex:772": {byte(New), 1, 2, 3, 4},
+
+		"Cast typeIndex:258 castKind:3": {byte(Cast), 1, 2, 3},
+
+		`Path domain:1 identifier:"hello"`: {byte(Path), 1, 0, 5, 'h', 'e', 'l', 'l', 'o'},
+
+		`InvokeDynamic funcName:"abc" typeParamCount:2 typeParams:[772, 1286] argsCount:1800`: {
+			byte(InvokeDynamic), 0, 3, 'a', 'b', 'c', 0, 2, 3, 4, 5, 6, 7, 8,
+		},
+
+		"Invoke typeParamCount:2 typeParams:[772, 1286]": {
+			byte(Invoke), 0, 2, 3, 4, 5, 6,
+		},
+
+		"Unknown":           {byte(Unknown)},
+		"Return":            {byte(Return)},
+		"ReturnValue":       {byte(ReturnValue)},
+		"IntAdd":            {byte(IntAdd)},
+		"IntSubtract":       {byte(IntSubtract)},
+		"IntMultiply":       {byte(IntMultiply)},
+		"IntDivide":         {byte(IntDivide)},
+		"IntMod":            {byte(IntMod)},
+		"IntLess":           {byte(IntLess)},
+		"IntGreater":        {byte(IntGreater)},
+		"IntLessOrEqual":    {byte(IntLessOrEqual)},
+		"IntGreaterOrEqual": {byte(IntGreaterOrEqual)},
+		"Equal":             {byte(Equal)},
+		"NotEqual":          {byte(NotEqual)},
+		"Unwrap":            {byte(Unwrap)},
+		"Destroy":           {byte(Destroy)},
+		"True":              {byte(True)},
+		"False":             {byte(False)},
+		"Nil":               {byte(Nil)},
+		"NewArray":          {byte(NewArray)},
+		"NewDictionary":     {byte(NewDictionary)},
+		"NewRef":            {byte(NewRef)},
+		"GetField":          {byte(GetField)},
+		"SetField":          {byte(SetField)},
+		"SetIndex":          {byte(SetIndex)},
+		"GetIndex":          {byte(GetIndex)},
+		"Drop":              {byte(Drop)},
+		"Dup":               {byte(Dup)},
+	}
+
+	for expected, instruction := range instructions {
+		t.Run(expected, func(t *testing.T) {
+
+			var builder strings.Builder
+			reader := bytes.NewReader(instruction)
+			err := PrintInstruction(&builder, reader)
+			require.NoError(t, err)
+			assert.Equal(t, 0, reader.Len())
+			assert.Equal(t, expected, builder.String())
+		})
+	}
+}


### PR DESCRIPTION

## Description

- Use a `bytes.Reader` to avoid manual index calculations
- Return helpful errors
- Add tests

Eventually we can maybe generate the decoding and printing (as well as encoding) from a specification (e.g. Go code), similar to how it was done for the WebAssembly instructions in https://github.com/onflow/cadence/pull/3705/files#diff-82ca63eac37e62fe45b1499cde54ac1e090fd495ba7ef9716d03708d656daa8dL484

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
