### PR TITLE
Lazily compute fields of account type values

### DIFF
--- a/interpreter/value_account.go
+++ b/interpreter/value_account.go
@@ -55,44 +55,29 @@ func NewAccountValue(
 		sema.AccountTypeAddressFieldName: address,
 	}
 
-	var storage Value
-	var contracts Value
-	var keys Value
-	var inbox Value
-	var capabilities Value
-
-	computeField := func(name string, inter *Interpreter, locationRange LocationRange) Value {
+	computeLazyStoredField := func(name string) Value {
 		switch name {
 		case sema.AccountTypeStorageFieldName:
-			if storage == nil {
-				storage = storageConstructor()
-			}
-			return storage
+			return storageConstructor()
 
 		case sema.AccountTypeContractsFieldName:
-			if contracts == nil {
-				contracts = contractsConstructor()
-			}
-			return contracts
+			return contractsConstructor()
 
 		case sema.AccountTypeKeysFieldName:
-			if keys == nil {
-				keys = keysConstructor()
-			}
-			return keys
+			return keysConstructor()
 
 		case sema.AccountTypeInboxFieldName:
-			if inbox == nil {
-				inbox = inboxConstructor()
-			}
-			return inbox
+			return inboxConstructor()
 
 		case sema.AccountTypeCapabilitiesFieldName:
-			if capabilities == nil {
-				capabilities = capabilitiesConstructor()
-			}
-			return capabilities
+			return capabilitiesConstructor()
+		}
 
+		return nil
+	}
+
+	computeField := func(name string, _ *Interpreter, _ LocationRange) Value {
+		switch name {
 		case sema.AccountTypeBalanceFieldName:
 			return accountBalanceGet()
 
@@ -100,7 +85,11 @@ func NewAccountValue(
 			return accountAvailableBalanceGet()
 		}
 
-		return nil
+		field := computeLazyStoredField(name)
+		if field != nil {
+			fields[name] = field
+		}
+		return field
 	}
 
 	var str string

--- a/interpreter/value_account_accountcapabilities.go
+++ b/interpreter/value_account_accountcapabilities.go
@@ -41,6 +41,35 @@ func NewAccountAccountCapabilitiesValue(
 	issueWithTypeFunction BoundFunctionGenerator,
 ) *SimpleCompositeValue {
 
+	var accountCapabilities *SimpleCompositeValue
+
+	fields := map[string]Value{}
+
+	computeLazyStoredField := func(name string) Value {
+		switch name {
+		case sema.Account_AccountCapabilitiesTypeGetControllerFunctionName:
+			return getControllerFunction(accountCapabilities)
+		case sema.Account_AccountCapabilitiesTypeGetControllersFunctionName:
+			return getControllersFunction(accountCapabilities)
+		case sema.Account_AccountCapabilitiesTypeForEachControllerFunctionName:
+			return forEachControllerFunction(accountCapabilities)
+		case sema.Account_AccountCapabilitiesTypeIssueFunctionName:
+			return issueFunction(accountCapabilities)
+		case sema.Account_AccountCapabilitiesTypeIssueWithTypeFunctionName:
+			return issueWithTypeFunction(accountCapabilities)
+		}
+
+		return nil
+	}
+
+	computeField := func(name string, _ *Interpreter, _ LocationRange) Value {
+		field := computeLazyStoredField(name)
+		if field != nil {
+			fields[name] = field
+		}
+		return field
+	}
+
 	var str string
 	stringer := func(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
 		if str == "" {
@@ -51,24 +80,16 @@ func NewAccountAccountCapabilitiesValue(
 		return str
 	}
 
-	accountCapabilities := NewSimpleCompositeValue(
+	accountCapabilities = NewSimpleCompositeValue(
 		gauge,
 		account_AccountCapabilitiesTypeID,
 		account_AccountCapabilitiesStaticType,
 		account_AccountCapabilitiesFieldNames,
-		nil,
-		nil,
+		fields,
+		computeField,
 		nil,
 		stringer,
 	)
-
-	accountCapabilities.Fields = map[string]Value{
-		sema.Account_AccountCapabilitiesTypeGetControllerFunctionName:     getControllerFunction(accountCapabilities),
-		sema.Account_AccountCapabilitiesTypeGetControllersFunctionName:    getControllersFunction(accountCapabilities),
-		sema.Account_AccountCapabilitiesTypeForEachControllerFunctionName: forEachControllerFunction(accountCapabilities),
-		sema.Account_AccountCapabilitiesTypeIssueFunctionName:             issueFunction(accountCapabilities),
-		sema.Account_AccountCapabilitiesTypeIssueWithTypeFunctionName:     issueWithTypeFunction(accountCapabilities),
-	}
 
 	return accountCapabilities
 }

--- a/interpreter/value_account_capabilities.go
+++ b/interpreter/value_account_capabilities.go
@@ -29,6 +29,10 @@ import (
 
 var account_CapabilitiesTypeID = sema.AccountCapabilitiesType.ID()
 var account_CapabilitiesStaticType StaticType = PrimitiveStaticTypeAccount_Capabilities
+var account_CapabilitiesFieldNames = []string{
+	sema.Account_CapabilitiesTypeStorageFieldName,
+	sema.Account_CapabilitiesTypeAccountFieldName,
+}
 
 func NewAccountCapabilitiesValue(
 	gauge common.MemoryGauge,
@@ -42,25 +46,37 @@ func NewAccountCapabilitiesValue(
 	accountCapabilitiesConstructor func() Value,
 ) Value {
 
-	var storageCapabilities Value
-	var accountCapabilities Value
+	var capabilities *SimpleCompositeValue
 
-	computeField := func(name string, inter *Interpreter, locationRange LocationRange) Value {
+	fields := map[string]Value{}
+
+	computeLazyStoredField := func(name string) Value {
 		switch name {
 		case sema.Account_CapabilitiesTypeStorageFieldName:
-			if storageCapabilities == nil {
-				storageCapabilities = storageCapabilitiesConstructor()
-			}
-			return storageCapabilities
-
+			return storageCapabilitiesConstructor()
 		case sema.Account_CapabilitiesTypeAccountFieldName:
-			if accountCapabilities == nil {
-				accountCapabilities = accountCapabilitiesConstructor()
-			}
-			return accountCapabilities
+			return accountCapabilitiesConstructor()
+		case sema.Account_CapabilitiesTypeGetFunctionName:
+			return getFunction(capabilities)
+		case sema.Account_CapabilitiesTypeBorrowFunctionName:
+			return borrowFunction(capabilities)
+		case sema.Account_CapabilitiesTypeExistsFunctionName:
+			return existsFunction(capabilities)
+		case sema.Account_CapabilitiesTypePublishFunctionName:
+			return publishFunction(capabilities)
+		case sema.Account_CapabilitiesTypeUnpublishFunctionName:
+			return unpublishFunction(capabilities)
 		}
 
 		return nil
+	}
+
+	computeField := func(name string, _ *Interpreter, _ LocationRange) Value {
+		field := computeLazyStoredField(name)
+		if field != nil {
+			fields[name] = field
+		}
+		return field
 	}
 
 	var str string
@@ -73,24 +89,16 @@ func NewAccountCapabilitiesValue(
 		return str
 	}
 
-	capabilities := NewSimpleCompositeValue(
+	capabilities = NewSimpleCompositeValue(
 		gauge,
 		account_CapabilitiesTypeID,
 		account_CapabilitiesStaticType,
-		nil,
-		nil,
+		account_CapabilitiesFieldNames,
+		fields,
 		computeField,
 		nil,
 		stringer,
 	)
-
-	capabilities.Fields = map[string]Value{
-		sema.Account_CapabilitiesTypeGetFunctionName:       getFunction(capabilities),
-		sema.Account_CapabilitiesTypeBorrowFunctionName:    borrowFunction(capabilities),
-		sema.Account_CapabilitiesTypeExistsFunctionName:    existsFunction(capabilities),
-		sema.Account_CapabilitiesTypePublishFunctionName:   publishFunction(capabilities),
-		sema.Account_CapabilitiesTypeUnpublishFunctionName: unpublishFunction(capabilities),
-	}
 
 	return capabilities
 }

--- a/interpreter/value_account_storagecapabilities.go
+++ b/interpreter/value_account_storagecapabilities.go
@@ -41,6 +41,35 @@ func NewAccountStorageCapabilitiesValue(
 	issueWithTypeFunction BoundFunctionGenerator,
 ) Value {
 
+	var storageCapabilities *SimpleCompositeValue
+
+	fields := map[string]Value{}
+
+	computeLazyStoredField := func(name string) Value {
+		switch name {
+		case sema.Account_StorageCapabilitiesTypeGetControllerFunctionName:
+			return getControllerFunction(storageCapabilities)
+		case sema.Account_StorageCapabilitiesTypeGetControllersFunctionName:
+			return getControllersFunction(storageCapabilities)
+		case sema.Account_StorageCapabilitiesTypeForEachControllerFunctionName:
+			return forEachControllerFunction(storageCapabilities)
+		case sema.Account_StorageCapabilitiesTypeIssueFunctionName:
+			return issueFunction(storageCapabilities)
+		case sema.Account_StorageCapabilitiesTypeIssueWithTypeFunctionName:
+			return issueWithTypeFunction(storageCapabilities)
+		}
+
+		return nil
+	}
+
+	computeField := func(name string, _ *Interpreter, _ LocationRange) Value {
+		field := computeLazyStoredField(name)
+		if field != nil {
+			fields[name] = field
+		}
+		return field
+	}
+
 	var str string
 	stringer := func(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
 		if str == "" {
@@ -51,24 +80,16 @@ func NewAccountStorageCapabilitiesValue(
 		return str
 	}
 
-	storageCapabilities := NewSimpleCompositeValue(
+	storageCapabilities = NewSimpleCompositeValue(
 		gauge,
 		account_StorageCapabilitiesTypeID,
 		account_StorageCapabilitiesStaticType,
 		account_StorageCapabilitiesFieldNames,
-		nil,
-		nil,
+		fields,
+		computeField,
 		nil,
 		stringer,
 	)
-
-	storageCapabilities.Fields = map[string]Value{
-		sema.Account_StorageCapabilitiesTypeGetControllerFunctionName:     getControllerFunction(storageCapabilities),
-		sema.Account_StorageCapabilitiesTypeGetControllersFunctionName:    getControllersFunction(storageCapabilities),
-		sema.Account_StorageCapabilitiesTypeForEachControllerFunctionName: forEachControllerFunction(storageCapabilities),
-		sema.Account_StorageCapabilitiesTypeIssueFunctionName:             issueFunction(storageCapabilities),
-		sema.Account_StorageCapabilitiesTypeIssueWithTypeFunctionName:     issueWithTypeFunction(storageCapabilities),
-	}
 
 	return storageCapabilities
 }


### PR DESCRIPTION

## Description

Identified by @SupunS: Accessing accounts is a common operation and currently causes many allocations.

Reduce allocations by optimizing the value construction for the `Account` and its nested types: Simplify existing caching of the field/function computation, and implement it consistently for all types.

Allocations for `BenchmarkRuntimeFungibleTokenTransfer`:

```
Before: 164481 B/op	    3229 allocs/op
After:  163011 B/op	    3186 allocs/op
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
