### PR TITLE
[Compiler+VM PoC] Refactor bytecode encoding

### DIFF
--- a/bbq/commons/constants.go
+++ b/bbq/commons/constants.go
@@ -18,11 +18,6 @@
 
 package commons
 
-import (
-	"github.com/onflow/cadence/ast"
-	"github.com/onflow/cadence/errors"
-)
-
 const (
 	InitFunctionName                = "init"
 	TransactionWrapperCompositeName = "transaction"
@@ -37,24 +32,3 @@ const (
 	ProgramInitFunctionName         = "$_init_"
 	TransactionGeneratedParamPrefix = "$_param_"
 )
-
-type CastKind byte
-
-const (
-	SimpleCast CastKind = iota
-	FailableCast
-	ForceCast
-)
-
-func CastKindFrom(operation ast.Operation) CastKind {
-	switch operation {
-	case ast.OperationCast:
-		return SimpleCast
-	case ast.OperationFailableCast:
-		return FailableCast
-	case ast.OperationForceCast:
-		return ForceCast
-	default:
-		panic(errors.NewUnreachableError())
-	}
-}

--- a/bbq/compiler/codegen.go
+++ b/bbq/compiler/codegen.go
@@ -31,21 +31,21 @@ type CodeGen interface {
 	EmitFalse()
 	EmitDup()
 	EmitDrop()
-	EmitGetConstant(index uint16)
+	EmitGetConstant(constantIndex uint16)
 	EmitJump(target uint16) int
 	EmitJumpIfFalse(target uint16) int
 	PatchJump(offset int, newTarget uint16)
 	EmitReturnValue()
 	EmitReturn()
-	EmitGetLocal(index uint16)
-	EmitSetLocal(index uint16)
-	EmitGetGlobal(index uint16)
-	EmitSetGlobal(index uint16)
+	EmitGetLocal(localIndex uint16)
+	EmitSetLocal(localIndex uint16)
+	EmitGetGlobal(globalIndex uint16)
+	EmitSetGlobal(globalIndex uint16)
 	EmitGetField()
 	EmitSetField()
 	EmitGetIndex()
 	EmitSetIndex()
-	EmitNewArray(index uint16, size uint16, isResource bool)
+	EmitNewArray(typeIndex uint16, size uint16, isResource bool)
 	EmitIntAdd()
 	EmitIntSubtract()
 	EmitIntMultiply()
@@ -58,12 +58,12 @@ type CodeGen interface {
 	EmitIntGreater()
 	EmitIntGreaterOrEqual()
 	EmitUnwrap()
-	EmitCast(index uint16, kind opcode.CastKind)
+	EmitCast(typeIndex uint16, kind opcode.CastKind)
 	EmitDestroy()
-	EmitTransfer(index uint16)
-	EmitNewRef(index uint16)
+	EmitTransfer(typeIndex uint16)
+	EmitNewRef(typeIndex uint16)
 	EmitPath(domain common.PathDomain, identifier string)
-	EmitNew(kind uint16, index uint16)
+	EmitNew(kind uint16, typeIndex uint16)
 	EmitInvoke(typeArgs []uint16)
 	EmitInvokeDynamic(name string, typeArgs []uint16, argCount uint16)
 }
@@ -102,8 +102,8 @@ func (g *BytecodeGen) EmitDrop() {
 	opcode.EmitDrop(&g.code)
 }
 
-func (g *BytecodeGen) EmitGetConstant(index uint16) {
-	opcode.EmitGetConstant(&g.code, index)
+func (g *BytecodeGen) EmitGetConstant(constantIndex uint16) {
+	opcode.EmitGetConstant(&g.code, constantIndex)
 }
 
 func (g *BytecodeGen) EmitJump(target uint16) int {
@@ -126,19 +126,19 @@ func (g *BytecodeGen) EmitReturn() {
 	opcode.EmitReturn(&g.code)
 }
 
-func (g *BytecodeGen) EmitGetLocal(index uint16) {
-	opcode.EmitGetLocal(&g.code, index)
+func (g *BytecodeGen) EmitGetLocal(localIndex uint16) {
+	opcode.EmitGetLocal(&g.code, localIndex)
 }
-func (g *BytecodeGen) EmitSetLocal(index uint16) {
-	opcode.EmitSetLocal(&g.code, index)
-}
-
-func (g *BytecodeGen) EmitGetGlobal(index uint16) {
-	opcode.EmitGetGlobal(&g.code, index)
+func (g *BytecodeGen) EmitSetLocal(localIndex uint16) {
+	opcode.EmitSetLocal(&g.code, localIndex)
 }
 
-func (g *BytecodeGen) EmitSetGlobal(index uint16) {
-	opcode.EmitSetGlobal(&g.code, index)
+func (g *BytecodeGen) EmitGetGlobal(globalIndex uint16) {
+	opcode.EmitGetGlobal(&g.code, globalIndex)
+}
+
+func (g *BytecodeGen) EmitSetGlobal(globalIndex uint16) {
+	opcode.EmitSetGlobal(&g.code, globalIndex)
 }
 
 func (g *BytecodeGen) EmitGetField() {
@@ -157,8 +157,8 @@ func (g *BytecodeGen) EmitSetIndex() {
 	opcode.EmitSetIndex(&g.code)
 }
 
-func (g *BytecodeGen) EmitNewArray(index uint16, size uint16, isResource bool) {
-	opcode.EmitNewArray(&g.code, index, size, isResource)
+func (g *BytecodeGen) EmitNewArray(typeIndex uint16, size uint16, isResource bool) {
+	opcode.EmitNewArray(&g.code, typeIndex, size, isResource)
 }
 
 func (g *BytecodeGen) EmitIntAdd() {
@@ -209,28 +209,28 @@ func (g *BytecodeGen) EmitUnwrap() {
 	opcode.EmitUnwrap(&g.code)
 }
 
-func (g *BytecodeGen) EmitCast(index uint16, kind opcode.CastKind) {
-	opcode.EmitCast(&g.code, index, kind)
+func (g *BytecodeGen) EmitCast(typeIndex uint16, kind opcode.CastKind) {
+	opcode.EmitCast(&g.code, typeIndex, kind)
 }
 
 func (g *BytecodeGen) EmitDestroy() {
 	opcode.EmitDestroy(&g.code)
 }
 
-func (g *BytecodeGen) EmitTransfer(index uint16) {
-	opcode.EmitTransfer(&g.code, index)
+func (g *BytecodeGen) EmitTransfer(typeIndex uint16) {
+	opcode.EmitTransfer(&g.code, typeIndex)
 }
 
-func (g *BytecodeGen) EmitNewRef(index uint16) {
-	opcode.EmitNewRef(&g.code, index)
+func (g *BytecodeGen) EmitNewRef(typeIndex uint16) {
+	opcode.EmitNewRef(&g.code, typeIndex)
 }
 
 func (g *BytecodeGen) EmitPath(domain common.PathDomain, identifier string) {
 	opcode.EmitPath(&g.code, domain, identifier)
 }
 
-func (g *BytecodeGen) EmitNew(kind uint16, index uint16) {
-	opcode.EmitNew(&g.code, kind, index)
+func (g *BytecodeGen) EmitNew(kind uint16, typeIndex uint16) {
+	opcode.EmitNew(&g.code, kind, typeIndex)
 }
 
 func (g *BytecodeGen) EmitInvoke(typeArgs []uint16) {

--- a/bbq/compiler/codegen.go
+++ b/bbq/compiler/codegen.go
@@ -1,0 +1,242 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compiler
+
+import (
+	"github.com/onflow/cadence/bbq/opcode"
+	"github.com/onflow/cadence/common"
+)
+
+type CodeGen interface {
+	Offset() int
+	Code() interface{}
+	EmitNil()
+	EmitTrue()
+	EmitFalse()
+	EmitDup()
+	EmitDrop()
+	EmitGetConstant(index uint16)
+	EmitJump(target uint16) int
+	EmitJumpIfFalse(target uint16) int
+	PatchJump(offset int, newTarget uint16)
+	EmitReturnValue()
+	EmitReturn()
+	EmitGetLocal(index uint16)
+	EmitSetLocal(index uint16)
+	EmitGetGlobal(index uint16)
+	EmitSetGlobal(index uint16)
+	EmitGetField()
+	EmitSetField()
+	EmitGetIndex()
+	EmitSetIndex()
+	EmitNewArray(index uint16, size uint16, isResource bool)
+	EmitIntAdd()
+	EmitIntSubtract()
+	EmitIntMultiply()
+	EmitIntDivide()
+	EmitIntMod()
+	EmitEqual()
+	EmitNotEqual()
+	EmitIntLess()
+	EmitIntLessOrEqual()
+	EmitIntGreater()
+	EmitIntGreaterOrEqual()
+	EmitUnwrap()
+	EmitCast(index uint16, kind opcode.CastKind)
+	EmitDestroy()
+	EmitTransfer(index uint16)
+	EmitNewRef(index uint16)
+	EmitPath(domain common.PathDomain, identifier string)
+	EmitNew(kind uint16, index uint16)
+	EmitInvoke(typeArgs []uint16)
+	EmitInvokeDynamic(name string, typeArgs []uint16, argCount uint16)
+}
+
+type BytecodeGen struct {
+	code []byte
+}
+
+var _ CodeGen = &BytecodeGen{}
+
+func (g *BytecodeGen) Offset() int {
+	return len(g.code)
+}
+
+func (g *BytecodeGen) Code() interface{} {
+	return g.code
+}
+
+func (g *BytecodeGen) EmitNil() {
+	opcode.EmitNil(&g.code)
+}
+
+func (g *BytecodeGen) EmitTrue() {
+	opcode.EmitTrue(&g.code)
+}
+
+func (g *BytecodeGen) EmitFalse() {
+	opcode.EmitFalse(&g.code)
+}
+
+func (g *BytecodeGen) EmitDup() {
+	opcode.EmitDup(&g.code)
+}
+
+func (g *BytecodeGen) EmitDrop() {
+	opcode.EmitDrop(&g.code)
+}
+
+func (g *BytecodeGen) EmitGetConstant(index uint16) {
+	opcode.EmitGetConstant(&g.code, index)
+}
+
+func (g *BytecodeGen) EmitJump(target uint16) int {
+	return opcode.EmitJump(&g.code, target)
+}
+
+func (g *BytecodeGen) EmitJumpIfFalse(target uint16) int {
+	return opcode.EmitJumpIfFalse(&g.code, target)
+}
+
+func (g *BytecodeGen) PatchJump(offset int, newTarget uint16) {
+	opcode.PatchJump(&g.code, offset, newTarget)
+}
+
+func (g *BytecodeGen) EmitReturnValue() {
+	opcode.EmitReturnValue(&g.code)
+}
+
+func (g *BytecodeGen) EmitReturn() {
+	opcode.EmitReturn(&g.code)
+}
+
+func (g *BytecodeGen) EmitGetLocal(index uint16) {
+	opcode.EmitGetLocal(&g.code, index)
+}
+func (g *BytecodeGen) EmitSetLocal(index uint16) {
+	opcode.EmitSetLocal(&g.code, index)
+}
+
+func (g *BytecodeGen) EmitGetGlobal(index uint16) {
+	opcode.EmitGetGlobal(&g.code, index)
+}
+
+func (g *BytecodeGen) EmitSetGlobal(index uint16) {
+	opcode.EmitSetGlobal(&g.code, index)
+}
+
+func (g *BytecodeGen) EmitGetField() {
+	opcode.EmitGetField(&g.code)
+}
+
+func (g *BytecodeGen) EmitSetField() {
+	opcode.EmitSetField(&g.code)
+}
+
+func (g *BytecodeGen) EmitGetIndex() {
+	opcode.EmitGetIndex(&g.code)
+}
+
+func (g *BytecodeGen) EmitSetIndex() {
+	opcode.EmitSetIndex(&g.code)
+}
+
+func (g *BytecodeGen) EmitNewArray(index uint16, size uint16, isResource bool) {
+	opcode.EmitNewArray(&g.code, index, size, isResource)
+}
+
+func (g *BytecodeGen) EmitIntAdd() {
+	opcode.EmitIntAdd(&g.code)
+}
+
+func (g *BytecodeGen) EmitIntSubtract() {
+	opcode.EmitIntSubtract(&g.code)
+}
+
+func (g *BytecodeGen) EmitIntMultiply() {
+	opcode.EmitIntMultiply(&g.code)
+}
+
+func (g *BytecodeGen) EmitIntDivide() {
+	opcode.EmitIntDivide(&g.code)
+}
+
+func (g *BytecodeGen) EmitIntMod() {
+	opcode.EmitIntMod(&g.code)
+}
+
+func (g *BytecodeGen) EmitEqual() {
+	opcode.EmitEqual(&g.code)
+}
+
+func (g *BytecodeGen) EmitNotEqual() {
+	opcode.EmitNotEqual(&g.code)
+}
+
+func (g *BytecodeGen) EmitIntLess() {
+	opcode.EmitIntLess(&g.code)
+}
+
+func (g *BytecodeGen) EmitIntLessOrEqual() {
+	opcode.EmitIntLessOrEqual(&g.code)
+}
+
+func (g *BytecodeGen) EmitIntGreater() {
+	opcode.EmitIntGreater(&g.code)
+}
+
+func (g *BytecodeGen) EmitIntGreaterOrEqual() {
+	opcode.EmitIntGreaterOrEqual(&g.code)
+}
+
+func (g *BytecodeGen) EmitUnwrap() {
+	opcode.EmitUnwrap(&g.code)
+}
+
+func (g *BytecodeGen) EmitCast(index uint16, kind opcode.CastKind) {
+	opcode.EmitCast(&g.code, index, kind)
+}
+
+func (g *BytecodeGen) EmitDestroy() {
+	opcode.EmitDestroy(&g.code)
+}
+
+func (g *BytecodeGen) EmitTransfer(index uint16) {
+	opcode.EmitTransfer(&g.code, index)
+}
+
+func (g *BytecodeGen) EmitNewRef(index uint16) {
+	opcode.EmitNewRef(&g.code, index)
+}
+
+func (g *BytecodeGen) EmitPath(domain common.PathDomain, identifier string) {
+	opcode.EmitPath(&g.code, domain, identifier)
+}
+
+func (g *BytecodeGen) EmitNew(kind uint16, index uint16) {
+	opcode.EmitNew(&g.code, kind, index)
+}
+
+func (g *BytecodeGen) EmitInvoke(typeArgs []uint16) {
+	opcode.EmitInvoke(&g.code, typeArgs)
+}
+
+func (g *BytecodeGen) EmitInvokeDynamic(name string, typeArgs []uint16, argCount uint16) {
+	opcode.EmitInvokeDynamic(&g.code, name, typeArgs, argCount)
+}

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -75,7 +75,7 @@ func TestCompileRecursionFib(t *testing.T) {
 			byte(opcode.IntAdd),
 			byte(opcode.ReturnValue),
 		},
-		compiler.functions[0].code,
+		compiler.functions[0].codeGen.Code(),
 	)
 
 	require.Equal(t,
@@ -167,7 +167,7 @@ func TestCompileImperativeFib(t *testing.T) {
 			byte(opcode.GetLocal), 0, 3,
 			byte(opcode.ReturnValue),
 		},
-		compiler.functions[0].code,
+		compiler.functions[0].codeGen.Code(),
 	)
 
 	require.Equal(t,
@@ -235,7 +235,7 @@ func TestCompileBreak(t *testing.T) {
 			byte(opcode.GetLocal), 0, 0,
 			byte(opcode.ReturnValue),
 		},
-		compiler.functions[0].code,
+		compiler.functions[0].codeGen.Code(),
 	)
 
 	require.Equal(t,
@@ -310,7 +310,7 @@ func TestCompileContinue(t *testing.T) {
 			byte(opcode.GetLocal), 0, 0,
 			byte(opcode.ReturnValue),
 		},
-		compiler.functions[0].code,
+		compiler.functions[0].codeGen.Code(),
 	)
 
 	require.Equal(t,

--- a/bbq/compiler/function.go
+++ b/bbq/compiler/function.go
@@ -22,15 +22,13 @@ import (
 	"math"
 
 	"github.com/onflow/cadence/activations"
-	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/errors"
 )
 
 type function struct {
-	name       string
-	localCount uint16
-	// TODO: use byte.Buffer?
-	code                []byte
+	name                string
+	localCount          uint16
+	codeGen             CodeGen
 	locals              *activations.Activations[*local]
 	parameterCount      uint16
 	isCompositeFunction bool
@@ -40,16 +38,10 @@ func newFunction(name string, parameterCount uint16, isCompositeFunction bool) *
 	return &function{
 		name:                name,
 		parameterCount:      parameterCount,
+		codeGen:             &BytecodeGen{},
 		locals:              activations.NewActivations[*local](nil),
 		isCompositeFunction: isCompositeFunction,
 	}
-}
-
-func (f *function) emit(opcode opcode.Opcode, args ...byte) int {
-	offset := len(f.code)
-	f.code = append(f.code, byte(opcode))
-	f.code = append(f.code, args...)
-	return offset
 }
 
 func (f *function) declareLocal(name string) *local {

--- a/bbq/opcode/castkind.go
+++ b/bbq/opcode/castkind.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package opcode
 
 import (

--- a/bbq/opcode/castkind.go
+++ b/bbq/opcode/castkind.go
@@ -1,0 +1,27 @@
+package opcode
+
+import (
+	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/errors"
+)
+
+type CastKind byte
+
+const (
+	SimpleCast CastKind = iota
+	FailableCast
+	ForceCast
+)
+
+func CastKindFrom(operation ast.Operation) CastKind {
+	switch operation {
+	case ast.OperationCast:
+		return SimpleCast
+	case ast.OperationFailableCast:
+		return FailableCast
+	case ast.OperationForceCast:
+		return ForceCast
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}

--- a/bbq/opcode/emit.go
+++ b/bbq/opcode/emit.go
@@ -55,8 +55,8 @@ func EmitDrop(code *[]byte) {
 	emit(code, Drop)
 }
 
-func EmitGetConstant(code *[]byte, index uint16) int {
-	first, second := encodeUint16(index)
+func EmitGetConstant(code *[]byte, constantIndex uint16) int {
+	first, second := encodeUint16(constantIndex)
 	return emit(code, GetConstant, first, second)
 }
 
@@ -84,22 +84,22 @@ func EmitReturnValue(code *[]byte) int {
 	return emit(code, ReturnValue)
 }
 
-func EmitGetLocal(code *[]byte, index uint16) {
-	first, second := encodeUint16(index)
+func EmitGetLocal(code *[]byte, localIndex uint16) {
+	first, second := encodeUint16(localIndex)
 	emit(code, GetLocal, first, second)
 }
 
-func EmitSetLocal(code *[]byte, index uint16) {
-	first, second := encodeUint16(index)
+func EmitSetLocal(code *[]byte, localIndex uint16) {
+	first, second := encodeUint16(localIndex)
 	emit(code, SetLocal, first, second)
 }
 
-func EmitGetGlobal(code *[]byte, index uint16) {
-	first, second := encodeUint16(index)
+func EmitGetGlobal(code *[]byte, globalIndex uint16) {
+	first, second := encodeUint16(globalIndex)
 	emit(code, GetGlobal, first, second)
 }
-func EmitSetGlobal(code *[]byte, index uint16) {
-	first, second := encodeUint16(index)
+func EmitSetGlobal(code *[]byte, globalIndex uint16) {
+	first, second := encodeUint16(globalIndex)
 	emit(code, SetGlobal, first, second)
 }
 
@@ -119,8 +119,8 @@ func EmitSetIndex(code *[]byte) {
 	emit(code, SetIndex)
 }
 
-func EmitNewArray(code *[]byte, index uint16, size uint16, isResource bool) {
-	indexFirst, indexSecond := encodeUint16(index)
+func EmitNewArray(code *[]byte, typeIndex uint16, size uint16, isResource bool) {
+	typeIndexFirst, typeIndexSecond := encodeUint16(typeIndex)
 	sizeFirst, sizeSecond := encodeUint16(size)
 	var isResourceFlag byte
 	if isResource {
@@ -129,7 +129,7 @@ func EmitNewArray(code *[]byte, index uint16, size uint16, isResource bool) {
 	emit(
 		code,
 		NewArray,
-		indexFirst, indexSecond,
+		typeIndexFirst, typeIndexSecond,
 		sizeFirst, sizeSecond,
 		isResourceFlag,
 	)
@@ -183,8 +183,8 @@ func EmitUnwrap(code *[]byte) {
 	emit(code, Unwrap)
 }
 
-func EmitCast(code *[]byte, index uint16, kind CastKind) {
-	first, second := encodeUint16(index)
+func EmitCast(code *[]byte, typeIndex uint16, kind CastKind) {
+	first, second := encodeUint16(typeIndex)
 	emit(code, Cast, first, second, byte(kind))
 }
 
@@ -192,13 +192,13 @@ func EmitDestroy(code *[]byte) {
 	emit(code, Destroy)
 }
 
-func EmitTransfer(code *[]byte, index uint16) {
-	first, second := encodeUint16(index)
+func EmitTransfer(code *[]byte, typeIndex uint16) {
+	first, second := encodeUint16(typeIndex)
 	emit(code, Transfer, first, second)
 }
 
-func EmitNewRef(code *[]byte, index uint16) {
-	first, second := encodeUint16(index)
+func EmitNewRef(code *[]byte, typeIndex uint16) {
+	first, second := encodeUint16(typeIndex)
 	emit(code, NewRef, first, second)
 }
 
@@ -229,14 +229,14 @@ func EmitInvoke(code *[]byte, typeArgs []uint16) {
 	emitTypeArgs(code, typeArgs)
 }
 
-func EmitNew(code *[]byte, kind uint16, index uint16) {
+func EmitNew(code *[]byte, kind uint16, typeIndex uint16) {
 	firstKind, secondKind := encodeUint16(kind)
-	firstIndex, secondIndex := encodeUint16(index)
+	firstTypeIndex, secondTypeIndex := encodeUint16(typeIndex)
 	emit(
 		code,
 		New,
 		firstKind, secondKind,
-		firstIndex, secondIndex,
+		firstTypeIndex, secondTypeIndex,
 	)
 }
 

--- a/bbq/opcode/emit.go
+++ b/bbq/opcode/emit.go
@@ -1,0 +1,255 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opcode
+
+import (
+	"github.com/onflow/cadence/common"
+)
+
+func emit(code *[]byte, opcode Opcode, args ...byte) int {
+	offset := len(*code)
+	*code = append(*code, byte(opcode))
+	*code = append(*code, args...)
+	return offset
+}
+
+// encodeUint16 encodes the given uint16 in big-endian representation
+func encodeUint16(v uint16) (byte, byte) {
+	return byte((v >> 8) & 0xff),
+		byte(v & 0xff)
+}
+
+func EmitTrue(code *[]byte) {
+	emit(code, True)
+}
+
+func EmitFalse(code *[]byte) {
+	emit(code, False)
+}
+
+func EmitNil(code *[]byte) {
+	emit(code, Nil)
+}
+
+func EmitDup(code *[]byte) {
+	emit(code, Dup)
+}
+
+func EmitDrop(code *[]byte) {
+	emit(code, Drop)
+}
+
+func EmitGetConstant(code *[]byte, index uint16) int {
+	first, second := encodeUint16(index)
+	return emit(code, GetConstant, first, second)
+}
+
+func EmitJump(code *[]byte, target uint16) int {
+	first, second := encodeUint16(target)
+	return emit(code, Jump, first, second)
+}
+
+func EmitJumpIfFalse(code *[]byte, target uint16) int {
+	first, second := encodeUint16(target)
+	return emit(code, JumpIfFalse, first, second)
+}
+
+func PatchJump(code *[]byte, opcodeOffset int, target uint16) {
+	first, second := encodeUint16(target)
+	(*code)[opcodeOffset+1] = first
+	(*code)[opcodeOffset+2] = second
+}
+
+func EmitReturn(code *[]byte) int {
+	return emit(code, Return)
+}
+
+func EmitReturnValue(code *[]byte) int {
+	return emit(code, ReturnValue)
+}
+
+func EmitGetLocal(code *[]byte, index uint16) {
+	first, second := encodeUint16(index)
+	emit(code, GetLocal, first, second)
+}
+
+func EmitSetLocal(code *[]byte, index uint16) {
+	first, second := encodeUint16(index)
+	emit(code, SetLocal, first, second)
+}
+
+func EmitGetGlobal(code *[]byte, index uint16) {
+	first, second := encodeUint16(index)
+	emit(code, GetGlobal, first, second)
+}
+func EmitSetGlobal(code *[]byte, index uint16) {
+	first, second := encodeUint16(index)
+	emit(code, SetGlobal, first, second)
+}
+
+func EmitGetField(code *[]byte) {
+	emit(code, GetField)
+}
+
+func EmitSetField(code *[]byte) {
+	emit(code, SetField)
+}
+
+func EmitGetIndex(code *[]byte) {
+	emit(code, GetIndex)
+}
+
+func EmitSetIndex(code *[]byte) {
+	emit(code, SetIndex)
+}
+
+func EmitNewArray(code *[]byte, index uint16, size uint16, isResource bool) {
+	indexFirst, indexSecond := encodeUint16(index)
+	sizeFirst, sizeSecond := encodeUint16(size)
+	var isResourceFlag byte
+	if isResource {
+		isResourceFlag = 1
+	}
+	emit(
+		code,
+		NewArray,
+		indexFirst, indexSecond,
+		sizeFirst, sizeSecond,
+		isResourceFlag,
+	)
+}
+
+func EmitIntAdd(code *[]byte) {
+	emit(code, IntAdd)
+}
+
+func EmitIntSubtract(code *[]byte) {
+	emit(code, IntSubtract)
+}
+
+func EmitIntMultiply(code *[]byte) {
+	emit(code, IntMultiply)
+}
+
+func EmitIntDivide(code *[]byte) {
+	emit(code, IntDivide)
+}
+
+func EmitIntMod(code *[]byte) {
+	emit(code, IntMod)
+}
+
+func EmitEqual(code *[]byte) {
+	emit(code, Equal)
+}
+
+func EmitNotEqual(code *[]byte) {
+	emit(code, NotEqual)
+}
+
+func EmitIntLess(code *[]byte) {
+	emit(code, IntLess)
+}
+
+func EmitIntLessOrEqual(code *[]byte) {
+	emit(code, IntLessOrEqual)
+}
+
+func EmitIntGreater(code *[]byte) {
+	emit(code, IntGreater)
+}
+
+func EmitIntGreaterOrEqual(code *[]byte) {
+	emit(code, IntGreaterOrEqual)
+}
+
+func EmitUnwrap(code *[]byte) {
+	emit(code, Unwrap)
+}
+
+func EmitCast(code *[]byte, index uint16, kind CastKind) {
+	first, second := encodeUint16(index)
+	emit(code, Cast, first, second, byte(kind))
+}
+
+func EmitDestroy(code *[]byte) {
+	emit(code, Destroy)
+}
+
+func EmitTransfer(code *[]byte, index uint16) {
+	first, second := encodeUint16(index)
+	emit(code, Transfer, first, second)
+}
+
+func EmitNewRef(code *[]byte, index uint16) {
+	first, second := encodeUint16(index)
+	emit(code, NewRef, first, second)
+}
+
+func EmitPath(code *[]byte, domain common.PathDomain, identifier string) {
+	emit(code, Path)
+
+	*code = append(*code, byte(domain))
+
+	identifierLength := len(identifier)
+
+	identifierSizeFirst, identifierSizeSecond := encodeUint16(uint16(identifierLength))
+	*code = append(*code, identifierSizeFirst, identifierSizeSecond)
+
+	*code = append(*code, identifier...)
+}
+
+func emitTypeArgs(code *[]byte, typeArgs []uint16) {
+	first, second := encodeUint16(uint16(len(typeArgs)))
+	*code = append(*code, first, second)
+	for _, typeArg := range typeArgs {
+		first, second := encodeUint16(typeArg)
+		*code = append(*code, first, second)
+	}
+}
+
+func EmitInvoke(code *[]byte, typeArgs []uint16) {
+	emit(code, Invoke)
+	emitTypeArgs(code, typeArgs)
+}
+
+func EmitNew(code *[]byte, kind uint16, index uint16) {
+	firstKind, secondKind := encodeUint16(kind)
+	firstIndex, secondIndex := encodeUint16(index)
+	emit(
+		code,
+		New,
+		firstKind, secondKind,
+		firstIndex, secondIndex,
+	)
+}
+
+func EmitInvokeDynamic(code *[]byte, name string, typeArgs []uint16, argCount uint16) {
+	emit(code, InvokeDynamic)
+
+	funcNameSizeFirst, funcNameSizeSecond := encodeUint16(uint16(len(name)))
+	*code = append(*code, funcNameSizeFirst, funcNameSizeSecond)
+
+	*code = append(*code, []byte(name)...)
+
+	emitTypeArgs(code, typeArgs)
+
+	argsCountFirst, argsCountSecond := encodeUint16(argCount)
+	*code = append(*code, argsCountFirst, argsCountSecond)
+}

--- a/bbq/opcode/print.go
+++ b/bbq/opcode/print.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package opcode
 
 import (

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package opcode
 
 import (

--- a/bbq/vm/test/interpreter_test.go
+++ b/bbq/vm/test/interpreter_test.go
@@ -1,13 +1,32 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test
 
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/onflow/cadence/test_utils/interpreter_utils"
 	"github.com/onflow/cadence/test_utils/runtime_utils"
 	"github.com/onflow/cadence/test_utils/sema_utils"
-	"strings"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/bbq/vm/test/vm_bench_test.go
+++ b/bbq/vm/test/vm_bench_test.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test
 
 import (

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/bbq/commons"
 	"github.com/onflow/cadence/bbq/constantkind"
@@ -577,7 +578,7 @@ func opPath(vm *VM) {
 func opCast(vm *VM) {
 	value := vm.pop()
 	targetType := vm.loadType()
-	castKind := commons.CastKind(vm.getByte())
+	castKind := opcode.CastKind(vm.getByte())
 
 	// TODO:
 	_ = castKind


### PR DESCRIPTION

## Description

Move the bytecode encoding out of the compiler, for now into the `opcode` package (we might want to rename it? or add a new package?).

Also, abstract the instruction emission from the compiler behind an interface. To begin with, only the bytecode emission is supported. Eventually we can also implement the interface to produce in-memory Go structs, because in a first milestone of the compiled execution environment, it will likely be unnecessary to encode to bytecode, because it is not stored. I named this interface `CodeGen` for a lack of better word, maybe "assembler" is a more fitting name? 

In the next PR I will move the bytecode decoding out of the VM and move it next to the encoding.

Finally, we can then look into generating bytecode encoding and decoding functions from a single source of truth.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
