### PR TITLE
[Compiler+VM PoC] Allow compiler to generate instructions, retarget VM to use instructions

### DIFF
--- a/bbq/commons/handlers.go
+++ b/bbq/commons/handlers.go
@@ -21,11 +21,12 @@ package commons
 import (
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/bbq"
+	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/sema"
 )
 
-type ImportHandler func(location common.Location) *bbq.Program
+type ImportHandler func(location common.Location) *bbq.Program[opcode.Instruction]
 
 type LocationHandler func(identifiers []ast.Identifier, location common.Location) ([]ResolvedLocation, error)
 

--- a/bbq/compiler/codegen.go
+++ b/bbq/compiler/codegen.go
@@ -28,8 +28,6 @@ type CodeGen[E any] interface {
 	SetTarget(code *[]E)
 	Emit(instruction opcode.Instruction)
 	PatchJump(offset int, newTarget uint16)
-	// TODO: remove, by makeing bbq.Function generic
-	Assemble(code []E) []byte
 }
 
 // ByteCodeGen is a CodeGen implementation that emits bytecode
@@ -53,10 +51,6 @@ func (g *ByteCodeGen) Emit(instruction opcode.Instruction) {
 
 func (g *ByteCodeGen) PatchJump(offset int, newTarget uint16) {
 	opcode.PatchJump(g.target, offset, newTarget)
-}
-
-func (g *ByteCodeGen) Assemble(code []byte) []byte {
-	return code
 }
 
 // InstructionCodeGen is a CodeGen implementation that emits opcode.Instruction
@@ -87,15 +81,8 @@ func (g *InstructionCodeGen) PatchJump(offset int, newTarget uint16) {
 	case opcode.InstructionJumpIfFalse:
 		ins.Target = newTarget
 		(*g.target)[offset] = ins
-	}
 
-	panic(errors.NewUnreachableError())
-}
-
-func (g *InstructionCodeGen) Assemble(code []opcode.Instruction) []byte {
-	var result []byte
-	for _, ins := range code {
-		ins.Encode(&result)
+	default:
+		panic(errors.NewUnreachableError())
 	}
-	return result
 }

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -43,7 +43,7 @@ func TestCompileRecursionFib(t *testing.T) {
   `)
 	require.NoError(t, err)
 
-	compiler := NewCompiler(checker.Program, checker.Elaboration)
+	compiler := NewBytecodeCompiler(checker.Program, checker.Elaboration)
 	program := compiler.Compile()
 
 	require.Len(t, program.Functions, 1)
@@ -114,7 +114,7 @@ func TestCompileImperativeFib(t *testing.T) {
   `)
 	require.NoError(t, err)
 
-	compiler := NewCompiler(checker.Program, checker.Elaboration)
+	compiler := NewBytecodeCompiler(checker.Program, checker.Elaboration)
 	program := compiler.Compile()
 
 	require.Len(t, program.Functions, 1)
@@ -203,7 +203,7 @@ func TestCompileBreak(t *testing.T) {
   `)
 	require.NoError(t, err)
 
-	compiler := NewCompiler(checker.Program, checker.Elaboration)
+	compiler := NewBytecodeCompiler(checker.Program, checker.Elaboration)
 	program := compiler.Compile()
 
 	require.Len(t, program.Functions, 1)
@@ -276,7 +276,7 @@ func TestCompileContinue(t *testing.T) {
   `)
 	require.NoError(t, err)
 
-	compiler := NewCompiler(checker.Program, checker.Elaboration)
+	compiler := NewBytecodeCompiler(checker.Program, checker.Elaboration)
 	program := compiler.Compile()
 
 	require.Len(t, program.Functions, 1)

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -75,7 +75,7 @@ func TestCompileRecursionFib(t *testing.T) {
 			byte(opcode.IntAdd),
 			byte(opcode.ReturnValue),
 		},
-		compiler.functions[0].codeGen.Code(),
+		compiler.ExportFunctions()[0].Code,
 	)
 
 	require.Equal(t,
@@ -167,7 +167,7 @@ func TestCompileImperativeFib(t *testing.T) {
 			byte(opcode.GetLocal), 0, 3,
 			byte(opcode.ReturnValue),
 		},
-		compiler.functions[0].codeGen.Code(),
+		compiler.ExportFunctions()[0].Code,
 	)
 
 	require.Equal(t,
@@ -235,7 +235,7 @@ func TestCompileBreak(t *testing.T) {
 			byte(opcode.GetLocal), 0, 0,
 			byte(opcode.ReturnValue),
 		},
-		compiler.functions[0].codeGen.Code(),
+		compiler.ExportFunctions()[0].Code,
 	)
 
 	require.Equal(t,
@@ -310,7 +310,7 @@ func TestCompileContinue(t *testing.T) {
 			byte(opcode.GetLocal), 0, 0,
 			byte(opcode.ReturnValue),
 		},
-		compiler.functions[0].codeGen.Code(),
+		compiler.ExportFunctions()[0].Code,
 	)
 
 	require.Equal(t,

--- a/bbq/compiler/config.go
+++ b/bbq/compiler/config.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onflow/cadence/bbq/commons"
 )
 
-type Config struct {
+type Config[E any] struct {
 	ImportHandler   commons.ImportHandler
 	LocationHandler commons.LocationHandler
 }

--- a/bbq/compiler/function.go
+++ b/bbq/compiler/function.go
@@ -25,26 +25,25 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-type function struct {
+type function[E any] struct {
 	name                string
+	code                []E
 	localCount          uint16
-	codeGen             CodeGen
 	locals              *activations.Activations[*local]
 	parameterCount      uint16
 	isCompositeFunction bool
 }
 
-func newFunction(name string, parameterCount uint16, isCompositeFunction bool) *function {
-	return &function{
+func newFunction[E any](name string, parameterCount uint16, isCompositeFunction bool) *function[E] {
+	return &function[E]{
 		name:                name,
 		parameterCount:      parameterCount,
-		codeGen:             &ByteCodeGen{},
 		locals:              activations.NewActivations[*local](nil),
 		isCompositeFunction: isCompositeFunction,
 	}
 }
 
-func (f *function) declareLocal(name string) *local {
+func (f *function[E]) declareLocal(name string) *local {
 	if f.localCount >= math.MaxUint16 {
 		panic(errors.NewDefaultUserError("invalid local declaration"))
 	}
@@ -55,6 +54,6 @@ func (f *function) declareLocal(name string) *local {
 	return local
 }
 
-func (f *function) findLocal(name string) *local {
+func (f *function[E]) findLocal(name string) *local {
 	return f.locals.Find(name)
 }

--- a/bbq/function.go
+++ b/bbq/function.go
@@ -18,9 +18,9 @@
 
 package bbq
 
-type Function struct {
+type Function[E any] struct {
 	Name               string
-	Code               []byte
+	Code               []E
 	ParameterCount     uint16
 	TypeParameterCount uint16
 	LocalCount         uint16

--- a/bbq/opcode/print.go
+++ b/bbq/opcode/print.go
@@ -23,8 +23,12 @@ import (
 	"strings"
 )
 
-func PrintInstructions(builder *strings.Builder, code []byte) error {
+func PrintBytecode(builder *strings.Builder, code []byte) error {
 	instructions := DecodeInstructions(code)
+	return PrintInstructions(builder, instructions)
+}
+
+func PrintInstructions(builder *strings.Builder, instructions []Instruction) error {
 	for _, instruction := range instructions {
 		_, err := fmt.Fprint(builder, instruction)
 		if err != nil {

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -80,7 +80,7 @@ ReturnValue
 `
 
 	var builder strings.Builder
-	err := PrintInstructions(&builder, code)
+	err := PrintBytecode(&builder, code)
 	require.NoError(t, err)
 
 	assert.Equal(t, expected, builder.String())

--- a/bbq/program.go
+++ b/bbq/program.go
@@ -18,10 +18,10 @@
 
 package bbq
 
-type Program struct {
+type Program[E any] struct {
 	Contract  *Contract
 	Imports   []*Import
-	Functions []*Function
+	Functions []*Function[E]
 	Constants []*Constant
 	Variables []*Variable
 	Types     [][]byte

--- a/bbq/vm/callframe.go
+++ b/bbq/vm/callframe.go
@@ -20,38 +20,12 @@ package vm
 
 import (
 	"github.com/onflow/cadence/bbq"
+	"github.com/onflow/cadence/bbq/opcode"
 )
 
 type callFrame struct {
 	executable   *ExecutableProgram
 	localsOffset uint16
 	localsCount  uint16
-	function     *bbq.Function
+	function     *bbq.Function[opcode.Instruction]
 }
-
-//
-//func (f *callFrame) getUint16() uint16 {
-//	first := f.function.Code[f.ip]
-//	last := f.function.Code[f.ip+1]
-//	f.ip += 2
-//	return uint16(first)<<8 | uint16(last)
-//}
-//
-//func (f *callFrame) getByte() byte {
-//	byt := f.function.Code[f.ip]
-//	f.ip++
-//	return byt
-//}
-//
-//func (f *callFrame) getBool() bool {
-//	byt := f.function.Code[f.ip]
-//	f.ip++
-//	return byt == 1
-//}
-//
-//func (f *callFrame) getString() string {
-//	strLen := f.getUint16()
-//	str := string(f.function.Code[f.ip : f.ip+strLen])
-//	f.ip += strLen
-//	return str
-//}

--- a/bbq/vm/executable_program.go
+++ b/bbq/vm/executable_program.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/cadence/bbq"
+	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/common"
 )
 
@@ -30,7 +31,7 @@ import (
 // i.e: indexes used in opcodes refer to the indexes of its ExecutableProgram.
 type ExecutableProgram struct {
 	Location    common.Location
-	Program     *bbq.Program
+	Program     *bbq.Program[opcode.Instruction]
 	Globals     []Value
 	Constants   []Value
 	StaticTypes []StaticType
@@ -38,7 +39,7 @@ type ExecutableProgram struct {
 
 func NewExecutableProgram(
 	location common.Location,
-	program *bbq.Program,
+	program *bbq.Program[opcode.Instruction],
 	globals []Value,
 ) *ExecutableProgram {
 	return &ExecutableProgram{
@@ -52,7 +53,10 @@ func NewExecutableProgram(
 
 // NewLoadedExecutableProgram returns an ExecutableProgram with types decoded.
 // Note that the returned program **doesn't** have the globals linked.
-func NewLoadedExecutableProgram(location common.Location, program *bbq.Program) *ExecutableProgram {
+func NewLoadedExecutableProgram(
+	location common.Location,
+	program *bbq.Program[opcode.Instruction],
+) *ExecutableProgram {
 	executable := NewExecutableProgram(location, program, nil)
 
 	// Optimization: Pre load/decode types

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/onflow/cadence/bbq"
+	"github.com/onflow/cadence/bbq/opcode"
 
 	"github.com/onflow/cadence/common"
 )
@@ -37,7 +38,7 @@ type LinkedGlobals struct {
 // LinkGlobals performs the linking of global functions and variables for a given program.
 func LinkGlobals(
 	location common.Location,
-	program *bbq.Program,
+	program *bbq.Program[opcode.Instruction],
 	conf *Config,
 	linkedGlobalsCache map[common.Location]LinkedGlobals,
 ) LinkedGlobals {

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/bbq"
+	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/bbq/vm"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
@@ -93,7 +94,7 @@ func TestFTTransfer(t *testing.T) {
 
 	vmConfig := &vm.Config{
 		Storage: storage,
-		ImportHandler: func(location common.Location) *bbq.Program {
+		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 			imported, ok := programs[location]
 			if !ok {
 				return nil
@@ -249,7 +250,7 @@ func BenchmarkFTTransfer(b *testing.B) {
 
 	vmConfig := &vm.Config{
 		Storage: storage,
-		ImportHandler: func(location common.Location) *bbq.Program {
+		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 			imported, ok := programs[location]
 			if !ok {
 				return nil

--- a/bbq/vm/test/runtime_test.go
+++ b/bbq/vm/test/runtime_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/test_utils/runtime_utils"
@@ -147,7 +148,7 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 		contractsAddress.HexWithPrefix(),
 	)
 
-	importHandler := func(location common.Location) *bbq.Program {
+	importHandler := func(location common.Location) *bbq.Program[opcode.Instruction] {
 		switch location {
 		case barLocation:
 			return barProgram

--- a/bbq/vm/test/vm_bench_test.go
+++ b/bbq/vm/test/vm_bench_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/bbq"
+	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
@@ -44,7 +45,7 @@ func BenchmarkRecursionFib(b *testing.B) {
 	checker, err := ParseAndCheck(b, recursiveFib)
 	require.NoError(b, err)
 
-	comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+	comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 	program := comp.Compile()
 
 	vmConfig := &vm.Config{}
@@ -73,7 +74,7 @@ func BenchmarkImperativeFib(b *testing.B) {
 	checker, err := ParseAndCheck(b, imperativeFib)
 	require.NoError(b, err)
 
-	comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+	comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 	program := comp.Compile()
 
 	vmConfig := &vm.Config{}
@@ -115,7 +116,7 @@ func BenchmarkNewStruct(b *testing.B) {
 
 	value := vm.NewIntValue(10)
 
-	comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+	comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 	program := comp.Compile()
 
 	vmConfig := &vm.Config{}
@@ -161,7 +162,7 @@ func BenchmarkNewResource(b *testing.B) {
 	scriptLocation := runtime_utils.NewScriptLocationGenerator()
 
 	for i := 0; i < b.N; i++ {
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -236,7 +237,7 @@ func BenchmarkContractImport(b *testing.B) {
 	)
 	require.NoError(b, err)
 
-	importCompiler := compiler.NewCompiler(importedChecker.Program, importedChecker.Elaboration)
+	importCompiler := compiler.NewInstructionCompiler(importedChecker.Program, importedChecker.Elaboration)
 	importedProgram := importCompiler.Compile()
 
 	vmInstance := vm.NewVM(location, importedProgram, nil)
@@ -244,7 +245,7 @@ func BenchmarkContractImport(b *testing.B) {
 	require.NoError(b, err)
 
 	vmConfig := &vm.Config{
-		ImportHandler: func(location common.Location) *bbq.Program {
+		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 			return importedProgram
 		},
 		ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -284,8 +285,8 @@ func BenchmarkContractImport(b *testing.B) {
 		)
 		require.NoError(b, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program {
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 			return importedProgram
 		}
 		program := comp.Compile()
@@ -332,7 +333,7 @@ func BenchmarkMethodCall(b *testing.B) {
 		)
 		require.NoError(b, err)
 
-		importCompiler := compiler.NewCompiler(importedChecker.Program, importedChecker.Elaboration)
+		importCompiler := compiler.NewInstructionCompiler(importedChecker.Program, importedChecker.Elaboration)
 		importedProgram := importCompiler.Compile()
 
 		vmInstance := vm.NewVM(location, importedProgram, nil)
@@ -363,15 +364,15 @@ func BenchmarkMethodCall(b *testing.B) {
 		)
 		require.NoError(b, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program {
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -434,7 +435,7 @@ func BenchmarkMethodCall(b *testing.B) {
 		)
 		require.NoError(b, err)
 
-		importCompiler := compiler.NewCompiler(importedChecker.Program, importedChecker.Elaboration)
+		importCompiler := compiler.NewInstructionCompiler(importedChecker.Program, importedChecker.Elaboration)
 		importedProgram := importCompiler.Compile()
 
 		vmInstance := vm.NewVM(location, importedProgram, nil)
@@ -465,15 +466,15 @@ func BenchmarkMethodCall(b *testing.B) {
 		)
 		require.NoError(b, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program {
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -20,8 +20,10 @@ package test
 
 import (
 	"fmt"
-	"github.com/onflow/cadence/interpreter"
 	"testing"
+
+	"github.com/onflow/cadence/bbq/opcode"
+	"github.com/onflow/cadence/interpreter"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,7 +63,7 @@ func TestRecursionFib(t *testing.T) {
 	checker, err := ParseAndCheck(t, recursiveFib)
 	require.NoError(t, err)
 
-	comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+	comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 	program := comp.Compile()
 
 	vmConfig := &vm.Config{}
@@ -99,7 +101,7 @@ func TestImperativeFib(t *testing.T) {
 	checker, err := ParseAndCheck(t, imperativeFib)
 	require.NoError(t, err)
 
-	comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+	comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 	program := comp.Compile()
 
 	vmConfig := &vm.Config{}
@@ -132,7 +134,7 @@ func TestBreak(t *testing.T) {
   `)
 	require.NoError(t, err)
 
-	comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+	comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 	program := comp.Compile()
 
 	vmConfig := &vm.Config{}
@@ -164,7 +166,7 @@ func TestContinue(t *testing.T) {
   `)
 	require.NoError(t, err)
 
-	comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+	comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 	program := comp.Compile()
 
 	vmConfig := &vm.Config{}
@@ -193,7 +195,7 @@ func TestNilCoalesce(t *testing.T) {
         `)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -218,7 +220,7 @@ func TestNilCoalesce(t *testing.T) {
         `)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -258,7 +260,7 @@ func TestNewStruct(t *testing.T) {
   `)
 	require.NoError(t, err)
 
-	comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+	comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 	program := comp.Compile()
 
 	vmConfig := &vm.Config{}
@@ -304,7 +306,7 @@ func TestStructMethodCall(t *testing.T) {
   `)
 	require.NoError(t, err)
 
-	comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+	comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 	program := comp.Compile()
 
 	vmConfig := &vm.Config{}
@@ -347,7 +349,7 @@ func TestImport(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	subComp := compiler.NewCompiler(importedChecker.Program, importedChecker.Elaboration)
+	subComp := compiler.NewInstructionCompiler(importedChecker.Program, importedChecker.Elaboration)
 	importedProgram := subComp.Compile()
 
 	checker, err := ParseAndCheckWithOptions(t, `
@@ -370,15 +372,15 @@ func TestImport(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	importCompiler := compiler.NewCompiler(checker.Program, checker.Elaboration)
-	importCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program {
+	importCompiler := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
+	importCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 		return importedProgram
 	}
 
 	program := importCompiler.Compile()
 
 	vmConfig := &vm.Config{
-		ImportHandler: func(location common.Location) *bbq.Program {
+		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 			return importedProgram
 		},
 	}
@@ -430,7 +432,7 @@ func TestContractImport(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		importCompiler := compiler.NewCompiler(importedChecker.Program, importedChecker.Elaboration)
+		importCompiler := compiler.NewInstructionCompiler(importedChecker.Program, importedChecker.Elaboration)
 		importedProgram := importCompiler.Compile()
 
 		vmInstance := vm.NewVM(importLocation, importedProgram, nil)
@@ -457,15 +459,15 @@ func TestContractImport(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program {
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 				return importedProgram
 			},
 			ContractValueHandler: func(*vm.Config, common.Location) *vm.CompositeValue {
@@ -506,7 +508,7 @@ func TestContractImport(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		importCompiler := compiler.NewCompiler(importedChecker.Program, importedChecker.Elaboration)
+		importCompiler := compiler.NewInstructionCompiler(importedChecker.Program, importedChecker.Elaboration)
 		importedProgram := importCompiler.Compile()
 
 		vmInstance := vm.NewVM(importLocation, importedProgram, nil)
@@ -532,15 +534,15 @@ func TestContractImport(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program {
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 				return importedProgram
 			},
 			ContractValueHandler: func(*vm.Config, common.Location) *vm.CompositeValue {
@@ -584,7 +586,7 @@ func TestContractImport(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		fooCompiler := compiler.NewCompiler(fooChecker.Program, fooChecker.Elaboration)
+		fooCompiler := compiler.NewInstructionCompiler(fooChecker.Program, fooChecker.Elaboration)
 		fooProgram := fooCompiler.Compile()
 
 		vmInstance := vm.NewVM(fooLocation, fooProgram, nil)
@@ -623,9 +625,9 @@ func TestContractImport(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		barCompiler := compiler.NewCompiler(barChecker.Program, barChecker.Elaboration)
+		barCompiler := compiler.NewInstructionCompiler(barChecker.Program, barChecker.Elaboration)
 		barCompiler.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		barCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program {
+		barCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 			require.Equal(t, fooLocation, location)
 			return fooProgram
 		}
@@ -633,7 +635,7 @@ func TestContractImport(t *testing.T) {
 		barProgram := barCompiler.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 				require.Equal(t, fooLocation, location)
 				return fooProgram
 			},
@@ -680,9 +682,9 @@ func TestContractImport(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		comp.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 			switch location {
 			case fooLocation:
 				return fooProgram
@@ -697,7 +699,7 @@ func TestContractImport(t *testing.T) {
 		program := comp.Compile()
 
 		vmConfig = &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 				switch location {
 				case fooLocation:
 					return fooProgram
@@ -755,7 +757,7 @@ func TestContractImport(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		fooCompiler := compiler.NewCompiler(fooChecker.Program, fooChecker.Elaboration)
+		fooCompiler := compiler.NewInstructionCompiler(fooChecker.Program, fooChecker.Elaboration)
 		fooProgram := fooCompiler.Compile()
 
 		//vmInstance := NewVM(fooProgram, nil)
@@ -794,9 +796,9 @@ func TestContractImport(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		barCompiler := compiler.NewCompiler(barChecker.Program, barChecker.Elaboration)
+		barCompiler := compiler.NewInstructionCompiler(barChecker.Program, barChecker.Elaboration)
 		barCompiler.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		barCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program {
+		barCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 			require.Equal(t, fooLocation, location)
 			return fooProgram
 		}
@@ -804,7 +806,7 @@ func TestContractImport(t *testing.T) {
 		barProgram := barCompiler.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 				require.Equal(t, fooLocation, location)
 				return fooProgram
 			},
@@ -851,9 +853,9 @@ func TestContractImport(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		comp.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 			switch location {
 			case fooLocation:
 				return fooProgram
@@ -868,7 +870,7 @@ func TestContractImport(t *testing.T) {
 		program := comp.Compile()
 
 		vmConfig = &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 				switch location {
 				case fooLocation:
 					return fooProgram
@@ -919,7 +921,7 @@ func TestInitializeContract(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+	comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 	program := comp.Compile()
 
 	vmConfig := &vm.Config{}
@@ -956,7 +958,7 @@ func TestContractAccessDuringInit(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -989,7 +991,7 @@ func TestContractAccessDuringInit(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -1023,7 +1025,7 @@ func TestFunctionOrder(t *testing.T) {
       }`)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -1079,7 +1081,7 @@ func TestFunctionOrder(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -1116,7 +1118,7 @@ func TestContractField(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		importCompiler := compiler.NewCompiler(importedChecker.Program, importedChecker.Elaboration)
+		importCompiler := compiler.NewInstructionCompiler(importedChecker.Program, importedChecker.Elaboration)
 		importedProgram := importCompiler.Compile()
 
 		vmInstance := vm.NewVM(importLocation, importedProgram, nil)
@@ -1142,15 +1144,15 @@ func TestContractField(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program {
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -1185,7 +1187,7 @@ func TestContractField(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		importCompiler := compiler.NewCompiler(importedChecker.Program, importedChecker.Elaboration)
+		importCompiler := compiler.NewInstructionCompiler(importedChecker.Program, importedChecker.Elaboration)
 		importedProgram := importCompiler.Compile()
 
 		vmInstance := vm.NewVM(importLocation, importedProgram, nil)
@@ -1212,15 +1214,15 @@ func TestContractField(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program {
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -1282,7 +1284,7 @@ func TestNativeFunctions(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -1301,7 +1303,7 @@ func TestNativeFunctions(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -1334,7 +1336,7 @@ func TestTransaction(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -1385,7 +1387,7 @@ func TestTransaction(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -1470,7 +1472,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		importCompiler := compiler.NewCompiler(importedChecker.Program, importedChecker.Elaboration)
+		importCompiler := compiler.NewInstructionCompiler(importedChecker.Program, importedChecker.Elaboration)
 		importedProgram := importCompiler.Compile()
 
 		vmInstance := vm.NewVM(contractLocation, importedProgram, nil)
@@ -1502,16 +1504,16 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		comp.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -1561,7 +1563,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		interfaceCompiler := compiler.NewCompiler(fooChecker.Program, fooChecker.Elaboration)
+		interfaceCompiler := compiler.NewInstructionCompiler(fooChecker.Program, fooChecker.Elaboration)
 		fooProgram := interfaceCompiler.Compile()
 
 		interfaceVM := vm.NewVM(fooLocation, fooProgram, nil)
@@ -1592,7 +1594,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		barCompiler := compiler.NewCompiler(barChecker.Program, barChecker.Elaboration)
+		barCompiler := compiler.NewInstructionCompiler(barChecker.Program, barChecker.Elaboration)
 		barProgram := barCompiler.Compile()
 
 		barVM := vm.NewVM(barLocation, barProgram, nil)
@@ -1643,7 +1645,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		bazImportHandler := func(location common.Location) *bbq.Program {
+		bazImportHandler := func(location common.Location) *bbq.Program[opcode.Instruction] {
 			switch location {
 			case fooLocation:
 				return fooProgram
@@ -1654,7 +1656,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 			}
 		}
 
-		bazCompiler := compiler.NewCompiler(bazChecker.Program, bazChecker.Elaboration)
+		bazCompiler := compiler.NewInstructionCompiler(bazChecker.Program, bazChecker.Elaboration)
 		bazCompiler.Config.LocationHandler = singleIdentifierLocationResolver(t)
 		bazCompiler.Config.ImportHandler = bazImportHandler
 		bazProgram := bazCompiler.Compile()
@@ -1707,7 +1709,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		scriptImportHandler := func(location common.Location) *bbq.Program {
+		scriptImportHandler := func(location common.Location) *bbq.Program[opcode.Instruction] {
 			switch location {
 			case barLocation:
 				return barProgram
@@ -1718,7 +1720,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 			}
 		}
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		comp.Config.LocationHandler = singleIdentifierLocationResolver(t)
 		comp.Config.ImportHandler = scriptImportHandler
 
@@ -1788,7 +1790,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		scriptImportHandler = func(location common.Location) *bbq.Program {
+		scriptImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
 			switch location {
 			case fooLocation:
 				return fooProgram
@@ -1803,7 +1805,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 			return fooProgram
 		}
 
-		comp = compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp = compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		comp.Config.LocationHandler = singleIdentifierLocationResolver(t)
 		comp.Config.ImportHandler = scriptImportHandler
 
@@ -1849,7 +1851,7 @@ func TestArrayLiteral(t *testing.T) {
         `)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -1877,7 +1879,7 @@ func TestArrayLiteral(t *testing.T) {
         `)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -1901,7 +1903,7 @@ func TestArrayLiteral(t *testing.T) {
         `)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -1948,7 +1950,7 @@ func TestReference(t *testing.T) {
         `)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := vm.NewConfig(nil)
@@ -1987,7 +1989,7 @@ func TestResource(t *testing.T) {
         `)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{}
@@ -2029,7 +2031,7 @@ func TestResource(t *testing.T) {
         `)
 		require.NoError(t, err)
 
-		comp := compiler.NewCompiler(checker.Program, checker.Elaboration)
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
 		printProgram("", program)

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -22,11 +22,12 @@ import (
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/bbq"
+	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/errors"
 )
 
 type FunctionValue struct {
-	Function   *bbq.Function
+	Function   *bbq.Function[opcode.Instruction]
 	Executable *ExecutableProgram
 }
 


### PR DESCRIPTION

## Description

- Use one code generator instance in the compiler, and retarget it to the current function
- Provide constructors for compiling to bytecode and instructions
- Retarget the VM to instructions. This avoids decoding bytecode during execution
  
  This results in a bit of a performance improvement:

  Before:
  ```
  BenchmarkImperativeFib-10    	  558949	      2124 ns/op	      24 B/op	       3 allocs/op
  BenchmarkImperativeFib-10    	  557384	      2113 ns/op	      24 B/op	       3 allocs/op
  ```

  After:

  ```
  BenchmarkImperativeFib-10    	  626820	      1892 ns/op	      24 B/op	       3 allocs/op
  BenchmarkImperativeFib-10    	  631590	      1879 ns/op	      24 B/op	       3 allocs/op
  ```

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
