### PR TITLE
[Compiler+VM POC] Improve the custom instructions set

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -833,11 +833,12 @@ func (c *Compiler[_]) VisitInvocationExpression(expression *ast.InvocationExpres
 				panic(errors.NewDefaultUserError("invalid number of arguments"))
 			}
 
+			funcNameConst := c.addStringConst(funcName)
 			c.codeGen.Emit(
 				opcode.InstructionInvokeDynamic{
-					Name:     funcName,
-					TypeArgs: typeArgs,
-					ArgCount: uint16(argumentCount),
+					NameIndex: funcNameConst.index,
+					TypeArgs:  typeArgs,
+					ArgCount:  uint16(argumentCount),
 				},
 			)
 
@@ -1067,10 +1068,13 @@ func (c *Compiler[_]) VisitPathExpression(expression *ast.PathExpression) (_ str
 	if len(identifier) >= math.MaxUint16 {
 		panic(errors.NewDefaultUserError("invalid identifier"))
 	}
+
+	identifierConst := c.addStringConst(identifier)
+
 	c.codeGen.Emit(
 		opcode.InstructionPath{
-			Domain:     domain,
-			Identifier: identifier,
+			Domain:          domain,
+			IdentifierIndex: identifierConst.index,
 		},
 	)
 	return

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -244,8 +244,12 @@ func (c *Compiler[_]) addConstant(kind constantkind.ConstantKind, data []byte) *
 }
 
 func (c *Compiler[_]) stringConstLoad(str string) {
-	constant := c.addConstant(constantkind.String, []byte(str))
+	constant := c.addStringConst(str)
 	c.codeGen.Emit(opcode.InstructionGetConstant{ConstantIndex: constant.index})
+}
+
+func (c *Compiler[_]) addStringConst(str string) *constant {
+	return c.addConstant(constantkind.String, []byte(str))
 }
 
 func (c *Compiler[_]) emitJump(target int) int {
@@ -648,8 +652,8 @@ func (c *Compiler[_]) VisitAssignmentStatement(statement *ast.AssignmentStatemen
 
 	case *ast.MemberExpression:
 		c.compileExpression(target.Expression)
-		c.stringConstLoad(target.Identifier.Identifier)
-		c.codeGen.Emit(opcode.InstructionSetField{})
+		constant := c.addStringConst(target.Identifier.Identifier)
+		c.codeGen.Emit(opcode.InstructionSetField{FieldNameIndex: constant.index})
 
 	case *ast.IndexExpression:
 		c.compileExpression(target.TargetExpression)
@@ -914,8 +918,8 @@ func (c *Compiler[_]) loadTypeArguments(expression *ast.InvocationExpression) []
 
 func (c *Compiler[_]) VisitMemberExpression(expression *ast.MemberExpression) (_ struct{}) {
 	c.compileExpression(expression.Expression)
-	c.stringConstLoad(expression.Identifier.Identifier)
-	c.codeGen.Emit(opcode.InstructionGetField{})
+	constant := c.addStringConst(expression.Identifier.Identifier)
+	c.codeGen.Emit(opcode.InstructionGetField{FieldNameIndex: constant.index})
 	return
 }
 

--- a/bbq/opcode/gen/main.go
+++ b/bbq/opcode/gen/main.go
@@ -473,13 +473,19 @@ func instructionStringFuncDecl(ins instruction) *dst.FuncDecl {
 		)
 
 		for _, operand := range ins.Operands {
+			var funcName string
+			switch operand.Type {
+			case operandTypeIndices:
+				funcName = "printfUInt16ArrayArgument"
+			default:
+				funcName = "printfArgument"
+			}
 			stmts = append(
 				stmts,
 				&dst.ExprStmt{
 					X: &dst.CallExpr{
 						Fun: &dst.Ident{
-							Name: "Fprintf",
-							Path: "fmt",
+							Name: funcName,
 						},
 						Args: []dst.Expr{
 							&dst.UnaryExpr{
@@ -488,7 +494,7 @@ func instructionStringFuncDecl(ins instruction) *dst.FuncDecl {
 							},
 							&dst.BasicLit{
 								Kind:  token.STRING,
-								Value: fmt.Sprintf(`" %s:%%s"`, operand.Name),
+								Value: fmt.Sprintf(`"%s"`, operand.Name),
 							},
 							&dst.SelectorExpr{
 								X:   dst.NewIdent("i"),

--- a/bbq/opcode/instruction.go
+++ b/bbq/opcode/instruction.go
@@ -21,6 +21,9 @@
 package opcode
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/onflow/cadence/common"
 )
 
@@ -160,4 +163,22 @@ func DecodeInstructions(code []byte) []Instruction {
 		instructions = append(instructions, instruction)
 	}
 	return instructions
+}
+
+// Instruction pretty print
+
+func printfUInt16ArrayArgument(sb *strings.Builder, argName string, values []uint16) {
+	_, _ = fmt.Fprintf(sb, " %s:[", argName)
+	for i, value := range values {
+		if i > 0 {
+			_, _ = fmt.Fprint(sb, ", ")
+		}
+		_, _ = fmt.Fprintf(sb, "%d", value)
+	}
+
+	sb.WriteString("]")
+}
+
+func printfArgument(sb *strings.Builder, fieldName string, v any) {
+	_, _ = fmt.Fprintf(sb, " %s:%v", fieldName, v)
 }

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -314,8 +314,8 @@ func (i InstructionNil) Encode(code *[]byte) {
 //
 // Pushes the path with the given domain and identifier onto the stack.
 type InstructionPath struct {
-	Domain     common.PathDomain
-	Identifier string
+	Domain          common.PathDomain
+	IdentifierIndex uint16
 }
 
 var _ Instruction = InstructionPath{}
@@ -328,19 +328,19 @@ func (i InstructionPath) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
 	fmt.Fprintf(&sb, " domain:%s", i.Domain)
-	fmt.Fprintf(&sb, " identifier:%s", i.Identifier)
+	fmt.Fprintf(&sb, " identifierIndex:%s", i.IdentifierIndex)
 	return sb.String()
 }
 
 func (i InstructionPath) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
 	emitPathDomain(code, i.Domain)
-	emitString(code, i.Identifier)
+	emitUint16(code, i.IdentifierIndex)
 }
 
 func DecodePath(ip *uint16, code []byte) (i InstructionPath) {
 	i.Domain = decodePathDomain(ip, code)
-	i.Identifier = decodeString(ip, code)
+	i.IdentifierIndex = decodeUint16(ip, code)
 	return i
 }
 
@@ -510,9 +510,9 @@ func DecodeInvoke(ip *uint16, code []byte) (i InstructionInvoke) {
 //
 // Invokes the dynamic function with the given name, type arguments, and argument count.
 type InstructionInvokeDynamic struct {
-	Name     string
-	TypeArgs []uint16
-	ArgCount uint16
+	NameIndex uint16
+	TypeArgs  []uint16
+	ArgCount  uint16
 }
 
 var _ Instruction = InstructionInvokeDynamic{}
@@ -524,7 +524,7 @@ func (InstructionInvokeDynamic) Opcode() Opcode {
 func (i InstructionInvokeDynamic) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " name:%s", i.Name)
+	fmt.Fprintf(&sb, " nameIndex:%s", i.NameIndex)
 	fmt.Fprintf(&sb, " typeArgs:%s", i.TypeArgs)
 	fmt.Fprintf(&sb, " argCount:%s", i.ArgCount)
 	return sb.String()
@@ -532,13 +532,13 @@ func (i InstructionInvokeDynamic) String() string {
 
 func (i InstructionInvokeDynamic) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
-	emitString(code, i.Name)
+	emitUint16(code, i.NameIndex)
 	emitUint16Array(code, i.TypeArgs)
 	emitUint16(code, i.ArgCount)
 }
 
 func DecodeInvokeDynamic(ip *uint16, code []byte) (i InstructionInvokeDynamic) {
-	i.Name = decodeString(ip, code)
+	i.NameIndex = decodeUint16(ip, code)
 	i.TypeArgs = decodeUint16Array(ip, code)
 	i.ArgCount = decodeUint16(ip, code)
 	return i

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -154,6 +154,7 @@ func DecodeSetGlobal(ip *uint16, code []byte) (i InstructionSetGlobal) {
 //
 // Pushes the value of the field at the given index onto the stack.
 type InstructionGetField struct {
+	FieldNameIndex uint16
 }
 
 var _ Instruction = InstructionGetField{}
@@ -163,17 +164,27 @@ func (InstructionGetField) Opcode() Opcode {
 }
 
 func (i InstructionGetField) String() string {
-	return i.Opcode().String()
+	var sb strings.Builder
+	sb.WriteString(i.Opcode().String())
+	fmt.Fprintf(&sb, " fieldNameIndex:%s", i.FieldNameIndex)
+	return sb.String()
 }
 
 func (i InstructionGetField) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
+	emitUint16(code, i.FieldNameIndex)
+}
+
+func DecodeGetField(ip *uint16, code []byte) (i InstructionGetField) {
+	i.FieldNameIndex = decodeUint16(ip, code)
+	return i
 }
 
 // InstructionSetField
 //
 // Sets the value of the field at the given index to the top value on the stack.
 type InstructionSetField struct {
+	FieldNameIndex uint16
 }
 
 var _ Instruction = InstructionSetField{}
@@ -183,11 +194,20 @@ func (InstructionSetField) Opcode() Opcode {
 }
 
 func (i InstructionSetField) String() string {
-	return i.Opcode().String()
+	var sb strings.Builder
+	sb.WriteString(i.Opcode().String())
+	fmt.Fprintf(&sb, " fieldNameIndex:%s", i.FieldNameIndex)
+	return sb.String()
 }
 
 func (i InstructionSetField) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
+	emitUint16(code, i.FieldNameIndex)
+}
+
+func DecodeSetField(ip *uint16, code []byte) (i InstructionSetField) {
+	i.FieldNameIndex = decodeUint16(ip, code)
+	return i
 }
 
 // InstructionGetIndex
@@ -1001,9 +1021,9 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 	case SetGlobal:
 		return DecodeSetGlobal(ip, code)
 	case GetField:
-		return InstructionGetField{}
+		return DecodeGetField(ip, code)
 	case SetField:
-		return InstructionSetField{}
+		return DecodeSetField(ip, code)
 	case GetIndex:
 		return InstructionGetIndex{}
 	case SetIndex:

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -3,7 +3,6 @@
 package opcode
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/onflow/cadence/common"
@@ -46,7 +45,7 @@ func (InstructionGetLocal) Opcode() Opcode {
 func (i InstructionGetLocal) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " localIndex:%s", i.LocalIndex)
+	printfArgument(&sb, "localIndex", i.LocalIndex)
 	return sb.String()
 }
 
@@ -76,7 +75,7 @@ func (InstructionSetLocal) Opcode() Opcode {
 func (i InstructionSetLocal) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " localIndex:%s", i.LocalIndex)
+	printfArgument(&sb, "localIndex", i.LocalIndex)
 	return sb.String()
 }
 
@@ -106,7 +105,7 @@ func (InstructionGetGlobal) Opcode() Opcode {
 func (i InstructionGetGlobal) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " globalIndex:%s", i.GlobalIndex)
+	printfArgument(&sb, "globalIndex", i.GlobalIndex)
 	return sb.String()
 }
 
@@ -136,7 +135,7 @@ func (InstructionSetGlobal) Opcode() Opcode {
 func (i InstructionSetGlobal) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " globalIndex:%s", i.GlobalIndex)
+	printfArgument(&sb, "globalIndex", i.GlobalIndex)
 	return sb.String()
 }
 
@@ -166,7 +165,7 @@ func (InstructionGetField) Opcode() Opcode {
 func (i InstructionGetField) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " fieldNameIndex:%s", i.FieldNameIndex)
+	printfArgument(&sb, "fieldNameIndex", i.FieldNameIndex)
 	return sb.String()
 }
 
@@ -196,7 +195,7 @@ func (InstructionSetField) Opcode() Opcode {
 func (i InstructionSetField) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " fieldNameIndex:%s", i.FieldNameIndex)
+	printfArgument(&sb, "fieldNameIndex", i.FieldNameIndex)
 	return sb.String()
 }
 
@@ -327,8 +326,8 @@ func (InstructionPath) Opcode() Opcode {
 func (i InstructionPath) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " domain:%s", i.Domain)
-	fmt.Fprintf(&sb, " identifierIndex:%s", i.IdentifierIndex)
+	printfArgument(&sb, "domain", i.Domain)
+	printfArgument(&sb, "identifierIndex", i.IdentifierIndex)
 	return sb.String()
 }
 
@@ -361,8 +360,8 @@ func (InstructionNew) Opcode() Opcode {
 func (i InstructionNew) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " kind:%s", i.Kind)
-	fmt.Fprintf(&sb, " typeIndex:%s", i.TypeIndex)
+	printfArgument(&sb, "kind", i.Kind)
+	printfArgument(&sb, "typeIndex", i.TypeIndex)
 	return sb.String()
 }
 
@@ -396,9 +395,9 @@ func (InstructionNewArray) Opcode() Opcode {
 func (i InstructionNewArray) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " typeIndex:%s", i.TypeIndex)
-	fmt.Fprintf(&sb, " size:%s", i.Size)
-	fmt.Fprintf(&sb, " isResource:%s", i.IsResource)
+	printfArgument(&sb, "typeIndex", i.TypeIndex)
+	printfArgument(&sb, "size", i.Size)
+	printfArgument(&sb, "isResource", i.IsResource)
 	return sb.String()
 }
 
@@ -432,7 +431,7 @@ func (InstructionNewRef) Opcode() Opcode {
 func (i InstructionNewRef) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " typeIndex:%s", i.TypeIndex)
+	printfArgument(&sb, "typeIndex", i.TypeIndex)
 	return sb.String()
 }
 
@@ -462,7 +461,7 @@ func (InstructionGetConstant) Opcode() Opcode {
 func (i InstructionGetConstant) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " constantIndex:%s", i.ConstantIndex)
+	printfArgument(&sb, "constantIndex", i.ConstantIndex)
 	return sb.String()
 }
 
@@ -492,7 +491,7 @@ func (InstructionInvoke) Opcode() Opcode {
 func (i InstructionInvoke) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " typeArgs:%s", i.TypeArgs)
+	printfUInt16ArrayArgument(&sb, "typeArgs", i.TypeArgs)
 	return sb.String()
 }
 
@@ -524,9 +523,9 @@ func (InstructionInvokeDynamic) Opcode() Opcode {
 func (i InstructionInvokeDynamic) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " nameIndex:%s", i.NameIndex)
-	fmt.Fprintf(&sb, " typeArgs:%s", i.TypeArgs)
-	fmt.Fprintf(&sb, " argCount:%s", i.ArgCount)
+	printfArgument(&sb, "nameIndex", i.NameIndex)
+	printfUInt16ArrayArgument(&sb, "typeArgs", i.TypeArgs)
+	printfArgument(&sb, "argCount", i.ArgCount)
 	return sb.String()
 }
 
@@ -640,7 +639,7 @@ func (InstructionTransfer) Opcode() Opcode {
 func (i InstructionTransfer) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " typeIndex:%s", i.TypeIndex)
+	printfArgument(&sb, "typeIndex", i.TypeIndex)
 	return sb.String()
 }
 
@@ -671,8 +670,8 @@ func (InstructionCast) Opcode() Opcode {
 func (i InstructionCast) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " typeIndex:%s", i.TypeIndex)
-	fmt.Fprintf(&sb, " kind:%s", i.Kind)
+	printfArgument(&sb, "typeIndex", i.TypeIndex)
+	printfArgument(&sb, "kind", i.Kind)
 	return sb.String()
 }
 
@@ -704,7 +703,7 @@ func (InstructionJump) Opcode() Opcode {
 func (i InstructionJump) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " target:%s", i.Target)
+	printfArgument(&sb, "target", i.Target)
 	return sb.String()
 }
 
@@ -734,7 +733,7 @@ func (InstructionJumpIfFalse) Opcode() Opcode {
 func (i InstructionJumpIfFalse) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	fmt.Fprintf(&sb, " target:%s", i.Target)
+	printfArgument(&sb, "target", i.Target)
 	return sb.String()
 }
 

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -68,8 +68,8 @@
   operands:
     - name: "domain"
       type: "pathDomain"
-    - name: "identifier"
-      type: "string"
+    - name: "identifierIndex"
+      type: "index"
 
 - name: "new"
   description: Creates a new instance of the given type.
@@ -113,8 +113,8 @@
 - name: "invokeDynamic"
   description: Invokes the dynamic function with the given name, type arguments, and argument count.
   operands:
-    - name: "name"
-      type: "string"
+    - name: "nameIndex"
+      type: "index"
     - name: "typeArgs"
       type: "indices"
     - name: "argCount"

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -34,9 +34,15 @@
 
 - name: "getField"
   description: Pushes the value of the field at the given index onto the stack.
+  operands:
+    - name: "fieldNameIndex"
+      type: "index"
 
 - name: "setField"
   description: Sets the value of the field at the given index to the top value on the stack.
+  operands:
+    - name: "fieldNameIndex"
+      type: "index"
 
 # Index instructions
 

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -494,29 +494,31 @@ func opNew(vm *VM, ins opcode.InstructionNew) {
 	vm.push(value)
 }
 
-func opSetField(vm *VM) {
-	fieldName := vm.pop().(StringValue)
-	fieldNameStr := string(fieldName.Str)
-
+func opSetField(vm *VM, ins opcode.InstructionSetField) {
 	// TODO: support all container types
 	structValue := vm.pop().(MemberAccessibleValue)
 
 	fieldValue := vm.pop()
 
-	structValue.SetMember(vm.config, fieldNameStr, fieldValue)
+	// VM assumes the field name is always a string.
+	constant := vm.callFrame.executable.Program.Constants[ins.FieldNameIndex]
+	fieldName := string(constant.Data)
+
+	structValue.SetMember(vm.config, fieldName, fieldValue)
 }
 
-func opGetField(vm *VM) {
-	fieldName := vm.pop().(StringValue)
-	fieldNameStr := string(fieldName.Str)
-
+func opGetField(vm *VM, ins opcode.InstructionGetField) {
 	memberAccessibleValue := vm.pop().(MemberAccessibleValue)
 
-	fieldValue := memberAccessibleValue.GetMember(vm.config, fieldNameStr)
+	// VM assumes the field name is always a string.
+	constant := vm.callFrame.executable.Program.Constants[ins.FieldNameIndex]
+	fieldName := string(constant.Data)
+
+	fieldValue := memberAccessibleValue.GetMember(vm.config, fieldName)
 	if fieldValue == nil {
 		panic(MissingMemberValueError{
 			Parent: memberAccessibleValue,
-			Name:   fieldNameStr,
+			Name:   fieldName,
 		})
 	}
 
@@ -684,9 +686,9 @@ func (vm *VM) run() {
 		case opcode.InstructionNewRef:
 			opNewRef(vm, ins)
 		case opcode.InstructionSetField:
-			opSetField(vm)
+			opSetField(vm, ins)
 		case opcode.InstructionGetField:
-			opGetField(vm)
+			opGetField(vm, ins)
 		case opcode.InstructionTransfer:
 			opTransfer(vm, ins)
 		case opcode.InstructionDestroy:


### PR DESCRIPTION
## Description

- Make the field name in GetField/SetField instructions an argument of the instruction (as opposed to a value on the stack)
- Move string-typed arguments of instructions to the constant-pool.
- Improve pretty-printing of instructions
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
