### PR TITLE
[Compiler+VM POC] Add compilation for default functions

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -37,7 +37,7 @@ import (
 type Compiler[E any] struct {
 	Program     *ast.Program
 	Elaboration *sema.Elaboration
-	Config      *Config[E]
+	Config      *Config
 
 	currentFunction    *function[E]
 	compositeTypeStack *Stack[*sema.CompositeType]
@@ -100,7 +100,7 @@ func newCompiler[E any](
 	return &Compiler[E]{
 		Program:         program,
 		Elaboration:     elaboration,
-		Config:          &Config[E]{},
+		Config:          &Config{},
 		globals:         make(map[string]*global),
 		importedGlobals: NativeFunctions(),
 		typesInPool:     make(map[sema.TypeID]uint16),
@@ -294,7 +294,12 @@ func (c *Compiler[_]) popLoop() {
 func (c *Compiler[E]) Compile() *bbq.Program[E] {
 
 	// Desugar the program before compiling.
-	desugar := NewDesugar(c.memoryGauge, c.Elaboration, c.Program)
+	desugar := NewDesugar(
+		c.memoryGauge,
+		c.Config,
+		c.Program,
+		c.Elaboration,
+	)
 	c.Program = desugar.Run()
 
 	for _, declaration := range c.Program.ImportDeclarations() {

--- a/bbq/compiler/config.go
+++ b/bbq/compiler/config.go
@@ -20,9 +20,12 @@ package compiler
 
 import (
 	"github.com/onflow/cadence/bbq/commons"
+	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/sema"
 )
 
-type Config[E any] struct {
-	ImportHandler   commons.ImportHandler
-	LocationHandler commons.LocationHandler
+type Config struct {
+	ImportHandler       commons.ImportHandler
+	LocationHandler     commons.LocationHandler
+	ElaborationResolver func(common.Location) (*sema.Elaboration, error)
 }

--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -1,0 +1,260 @@
+package compiler
+
+import (
+	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/bbq/commons"
+	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/sema"
+)
+
+// Desugar will rewrite the AST from high-level abstraction to a much lower-level
+// abstractions, so the compiler and vm could work with a minimal set of language features.
+type Desugar struct {
+	memoryGauge common.MemoryGauge
+	elaboration *sema.Elaboration
+	program     *ast.Program
+
+	updatedDeclarations []ast.Declaration
+}
+
+var _ ast.DeclarationVisitor[ast.Declaration] = &Desugar{}
+
+func NewDesugar(
+	memoryGauge common.MemoryGauge,
+	elaboration *sema.Elaboration,
+	program *ast.Program) *Desugar {
+	return &Desugar{
+		memoryGauge: memoryGauge,
+		elaboration: elaboration,
+		program:     program,
+	}
+}
+
+func (d *Desugar) Run() *ast.Program {
+	// TODO: This assumes the program/elaboration is not cached.
+	//   i.e: Modifies the elaboration.
+	//   Handle this properly for cached transactions.
+
+	declarations := d.program.Declarations()
+	for _, declaration := range declarations {
+		d.desugarDeclaration(declaration)
+	}
+
+	return ast.NewProgram(d.memoryGauge, d.updatedDeclarations)
+}
+
+func (d *Desugar) desugarDeclaration(declaration ast.Declaration) {
+	updatedDecl := ast.AcceptDeclaration[ast.Declaration](declaration, d)
+	d.updatedDeclarations = append(d.updatedDeclarations, updatedDecl)
+}
+
+func (d *Desugar) VisitVariableDeclaration(declaration *ast.VariableDeclaration) ast.Declaration {
+	return declaration
+}
+
+func (d *Desugar) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration) ast.Declaration {
+	return declaration
+}
+
+func (d *Desugar) VisitSpecialFunctionDeclaration(declaration *ast.SpecialFunctionDeclaration) ast.Declaration {
+	return declaration
+}
+
+func (d *Desugar) VisitCompositeDeclaration(declaration *ast.CompositeDeclaration) ast.Declaration {
+	return declaration
+}
+
+func (d *Desugar) VisitAttachmentDeclaration(declaration *ast.AttachmentDeclaration) ast.Declaration {
+	return declaration
+}
+
+func (d *Desugar) VisitInterfaceDeclaration(declaration *ast.InterfaceDeclaration) ast.Declaration {
+	return declaration
+}
+
+func (d *Desugar) VisitEntitlementDeclaration(declaration *ast.EntitlementDeclaration) ast.Declaration {
+	return declaration
+}
+
+func (d *Desugar) VisitEntitlementMappingDeclaration(declaration *ast.EntitlementMappingDeclaration) ast.Declaration {
+	return declaration
+}
+
+func (d *Desugar) VisitTransactionDeclaration(transaction *ast.TransactionDeclaration) ast.Declaration {
+	// TODO: add pre/post conditions
+
+	// Converts a transaction into a composite type declaration.
+	// Transaction parameters are converted into global variables.
+	// An initializer is generated to set parameters to above generated global variables.
+
+	var varDeclarations []ast.Declaration
+	var initFunction *ast.FunctionDeclaration
+
+	if transaction.ParameterList != nil {
+		varDeclarations = make([]ast.Declaration, 0, len(transaction.ParameterList.Parameters))
+		statements := make([]ast.Statement, 0, len(transaction.ParameterList.Parameters))
+		parameters := make([]*ast.Parameter, 0, len(transaction.ParameterList.Parameters))
+
+		for index, parameter := range transaction.ParameterList.Parameters {
+			// Create global variables
+			// i.e: `var a: Type`
+			field := &ast.VariableDeclaration{
+				Access:         ast.AccessSelf,
+				IsConstant:     false,
+				Identifier:     parameter.Identifier,
+				TypeAnnotation: parameter.TypeAnnotation,
+			}
+			varDeclarations = append(varDeclarations, field)
+
+			// Create assignment from param to global var.
+			// i.e: `a = $param_a`
+			modifiedParamName := commons.TransactionGeneratedParamPrefix + parameter.Identifier.Identifier
+			modifiedParameter := &ast.Parameter{
+				Label: "",
+				Identifier: ast.Identifier{
+					Identifier: modifiedParamName,
+				},
+				TypeAnnotation: parameter.TypeAnnotation,
+			}
+			parameters = append(parameters, modifiedParameter)
+
+			assignment := &ast.AssignmentStatement{
+				Target: &ast.IdentifierExpression{
+					Identifier: parameter.Identifier,
+				},
+				Value: &ast.IdentifierExpression{
+					Identifier: ast.Identifier{
+						Identifier: modifiedParamName,
+					},
+				},
+				Transfer: &ast.Transfer{
+					Operation: ast.TransferOperationCopy,
+				},
+			}
+			statements = append(statements, assignment)
+
+			transactionTypes := d.elaboration.TransactionDeclarationType(transaction)
+			paramType := transactionTypes.Parameters[index].TypeAnnotation.Type
+			assignmentTypes := sema.AssignmentStatementTypes{
+				ValueType:  paramType,
+				TargetType: paramType,
+			}
+
+			d.elaboration.SetAssignmentStatementTypes(assignment, assignmentTypes)
+		}
+
+		// Create an init function.
+		// func $init($param_a: Type, $param_b: Type, ...) {
+		//     a = $param_a
+		//     b = $param_b
+		//     ...
+		// }
+		initFunction = &ast.FunctionDeclaration{
+			Access: ast.AccessNotSpecified,
+			Identifier: ast.Identifier{
+				Identifier: commons.ProgramInitFunctionName,
+			},
+			ParameterList: &ast.ParameterList{
+				Parameters: parameters,
+			},
+			ReturnTypeAnnotation: nil,
+			FunctionBlock: &ast.FunctionBlock{
+				Block: &ast.Block{
+					Statements: statements,
+				},
+			},
+		}
+	}
+
+	var members []ast.Declaration
+	if transaction.Execute != nil {
+		members = append(members, transaction.Execute.FunctionDeclaration)
+	}
+	if transaction.Prepare != nil {
+		members = append(members, transaction.Prepare)
+	}
+
+	compositeType := &sema.CompositeType{
+		Location:    nil,
+		Identifier:  commons.TransactionWrapperCompositeName,
+		Kind:        common.CompositeKindStructure,
+		NestedTypes: &sema.StringTypeOrderedMap{},
+		Members:     &sema.StringMemberOrderedMap{},
+	}
+
+	compositeDecl := ast.NewCompositeDeclaration(
+		d.memoryGauge,
+		ast.AccessNotSpecified,
+		common.CompositeKindStructure,
+		ast.NewIdentifier(
+			d.memoryGauge,
+			commons.TransactionWrapperCompositeName,
+			ast.EmptyPosition,
+		),
+		nil,
+		ast.NewMembers(d.memoryGauge, members),
+		"",
+		ast.EmptyRange,
+	)
+
+	d.elaboration.SetCompositeDeclarationType(compositeDecl, compositeType)
+
+	// We can only return one declaration.
+	// So manually add the rest of the declarations.
+	d.updatedDeclarations = append(d.updatedDeclarations, varDeclarations...)
+	if initFunction != nil {
+		d.updatedDeclarations = append(d.updatedDeclarations, initFunction)
+	}
+
+	return compositeDecl
+}
+
+func (d *Desugar) VisitFieldDeclaration(declaration *ast.FieldDeclaration) ast.Declaration {
+	return declaration
+}
+
+func (d *Desugar) VisitEnumCaseDeclaration(declaration *ast.EnumCaseDeclaration) ast.Declaration {
+	return declaration
+}
+
+func (d *Desugar) VisitPragmaDeclaration(declaration *ast.PragmaDeclaration) ast.Declaration {
+	return declaration
+}
+
+func (d *Desugar) VisitImportDeclaration(declaration *ast.ImportDeclaration) ast.Declaration {
+	return declaration
+}
+
+var emptyInitializer = func() *ast.SpecialFunctionDeclaration {
+	// This is created only once per compilation. So no need to meter memory.
+
+	initializer := ast.NewFunctionDeclaration(
+		nil,
+		ast.AccessNotSpecified,
+		ast.FunctionPurityUnspecified,
+		false,
+		false,
+		ast.NewIdentifier(
+			nil,
+			commons.InitFunctionName,
+			ast.EmptyPosition,
+		),
+		nil,
+		nil,
+		nil,
+		ast.NewFunctionBlock(
+			nil,
+			ast.NewBlock(nil, nil, ast.EmptyRange),
+			nil,
+			nil,
+		),
+		ast.Position{},
+		"",
+	)
+
+	return ast.NewSpecialFunctionDeclaration(
+		nil,
+		common.DeclarationKindInitializer,
+		initializer,
+	)
+}()

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -99,17 +99,17 @@ func TestPrintInstruction(t *testing.T) {
 		"JumpIfFalse target:258":        {byte(JumpIfFalse), 1, 2},
 		"Transfer typeIndex:258":        {byte(Transfer), 1, 2},
 
-		"New kind:258 typeIndex:772": {byte(New), 1, 2, 3, 4},
+		"New kind:CompositeKind(258) typeIndex:772": {byte(New), 1, 2, 3, 4},
 
 		"Cast typeIndex:258 kind:3": {byte(Cast), 1, 2, 3},
 
-		`Path domain:1 identifier:"hello"`: {byte(Path), 1, 0, 5, 'h', 'e', 'l', 'l', 'o'},
+		`Path domain:PathDomainStorage identifierIndex:5`: {byte(Path), 1, 0, 5},
 
-		`InvokeDynamic name:"abc" typeArgs:[772 1286] argCount:1800`: {
-			byte(InvokeDynamic), 0, 3, 'a', 'b', 'c', 0, 2, 3, 4, 5, 6, 7, 8,
+		`InvokeDynamic nameIndex:3 typeArgs:[772, 1286] argCount:1800`: {
+			byte(InvokeDynamic), 0, 3, 0, 2, 3, 4, 5, 6, 7, 8,
 		},
 
-		"Invoke typeArgs:[772 1286]": {
+		"Invoke typeArgs:[772, 1286]": {
 			byte(Invoke), 0, 2, 3, 4, 5, 6,
 		},
 
@@ -117,31 +117,31 @@ func TestPrintInstruction(t *testing.T) {
 
 		"NewArray typeIndex:258 size:772 isResource:true": {byte(NewArray), 1, 2, 3, 4, 1},
 
-		"Unknown":           {byte(Unknown)},
-		"Return":            {byte(Return)},
-		"ReturnValue":       {byte(ReturnValue)},
-		"IntAdd":            {byte(IntAdd)},
-		"IntSubtract":       {byte(IntSubtract)},
-		"IntMultiply":       {byte(IntMultiply)},
-		"IntDivide":         {byte(IntDivide)},
-		"IntMod":            {byte(IntMod)},
-		"IntLess":           {byte(IntLess)},
-		"IntGreater":        {byte(IntGreater)},
-		"IntLessOrEqual":    {byte(IntLessOrEqual)},
-		"IntGreaterOrEqual": {byte(IntGreaterOrEqual)},
-		"Equal":             {byte(Equal)},
-		"NotEqual":          {byte(NotEqual)},
-		"Unwrap":            {byte(Unwrap)},
-		"Destroy":           {byte(Destroy)},
-		"True":              {byte(True)},
-		"False":             {byte(False)},
-		"Nil":               {byte(Nil)},
-		"GetField":          {byte(GetField)},
-		"SetField":          {byte(SetField)},
-		"SetIndex":          {byte(SetIndex)},
-		"GetIndex":          {byte(GetIndex)},
-		"Drop":              {byte(Drop)},
-		"Dup":               {byte(Dup)},
+		"Unknown":                   {byte(Unknown)},
+		"Return":                    {byte(Return)},
+		"ReturnValue":               {byte(ReturnValue)},
+		"IntAdd":                    {byte(IntAdd)},
+		"IntSubtract":               {byte(IntSubtract)},
+		"IntMultiply":               {byte(IntMultiply)},
+		"IntDivide":                 {byte(IntDivide)},
+		"IntMod":                    {byte(IntMod)},
+		"IntLess":                   {byte(IntLess)},
+		"IntGreater":                {byte(IntGreater)},
+		"IntLessOrEqual":            {byte(IntLessOrEqual)},
+		"IntGreaterOrEqual":         {byte(IntGreaterOrEqual)},
+		"Equal":                     {byte(Equal)},
+		"NotEqual":                  {byte(NotEqual)},
+		"Unwrap":                    {byte(Unwrap)},
+		"Destroy":                   {byte(Destroy)},
+		"True":                      {byte(True)},
+		"False":                     {byte(False)},
+		"Nil":                       {byte(Nil)},
+		"GetField fieldNameIndex:1": {byte(GetField), 0, 1},
+		"SetField fieldNameIndex:1": {byte(SetField), 0, 1},
+		"SetIndex":                  {byte(SetIndex)},
+		"GetIndex":                  {byte(GetIndex)},
+		"Drop":                      {byte(Drop)},
+		"Dup":                       {byte(Dup)},
 	}
 
 	for expected, code := range instructions {

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -39,7 +39,7 @@ func TestFTTransfer(t *testing.T) {
 	// ---- Deploy FT Contract -----
 
 	storage := interpreter.NewInMemoryStorage(nil)
-	programs := map[common.Location]compiledProgram{}
+	programs := map[common.Location]*compiledProgram{}
 
 	typeLoader := func(location common.Location, typeID interpreter.TypeID) sema.CompositeKindedType {
 		program, ok := programs[location]
@@ -199,7 +199,7 @@ func BenchmarkFTTransfer(b *testing.B) {
 	// ---- Deploy FT Contract -----
 
 	storage := interpreter.NewInMemoryStorage(nil)
-	programs := map[common.Location]compiledProgram{}
+	programs := map[common.Location]*compiledProgram{}
 
 	typeLoader := func(location common.Location, typeID interpreter.TypeID) sema.CompositeKindedType {
 		program, ok := programs[location]

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -64,15 +64,13 @@ func TestFTTransfer(t *testing.T) {
 
 	ftLocation := common.NewAddressLocation(nil, contractsAddress, "FungibleToken")
 
-	ftContractProgram := compileCode(t, realFungibleTokenContractInterface, ftLocation, programs)
-	printProgram("FungibleToken", ftContractProgram)
+	compileCode(t, realFungibleTokenContractInterface, ftLocation, programs)
 
 	// ----- Deploy FlowToken Contract -----
 
 	flowTokenLocation := common.NewAddressLocation(nil, contractsAddress, "FlowToken")
 
 	flowTokenProgram := compileCode(t, realFlowContract, flowTokenLocation, programs)
-	printProgram("FlowToken", flowTokenProgram)
 
 	config := &vm.Config{
 		Storage:        storage,
@@ -136,7 +134,6 @@ func TestFTTransfer(t *testing.T) {
 	// Mint FLOW to sender
 
 	program := compileCode(t, realMintFlowTokenTransaction, nil, programs)
-	printProgram("Setup FlowToken Tx", program)
 
 	mintTxVM := vm.NewVM(txLocation(), program, vmConfig)
 
@@ -155,7 +152,6 @@ func TestFTTransfer(t *testing.T) {
 	// ----- Run token transfer transaction -----
 
 	tokenTransferTxProgram := compileCode(t, realFlowTokenTransferTransaction, nil, programs)
-	printProgram("FT Transfer Tx", tokenTransferTxProgram)
 
 	tokenTransferTxVM := vm.NewVM(txLocation(), tokenTransferTxProgram, vmConfig)
 

--- a/bbq/vm/test/runtime_test.go
+++ b/bbq/vm/test/runtime_test.go
@@ -43,7 +43,7 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 
 	storage := interpreter.NewInMemoryStorage(nil)
 
-	programs := map[common.Location]compiledProgram{}
+	programs := map[common.Location]*compiledProgram{}
 
 	contractsAddress := common.MustBytesToAddress([]byte{0x1})
 	authorizerAddress := common.MustBytesToAddress([]byte{0x2})
@@ -102,7 +102,7 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 
 	// --------- Execute Transaction ------------
 
-	tx := fmt.Sprintf(`
+	fooContract := fmt.Sprintf(`
         import Bar from %[1]s
 
         access(all) contract Foo {
@@ -158,7 +158,8 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 		}
 	}
 
-	program := compileCode(t, tx, nil, programs)
+	fooLocation := common.NewAddressLocation(nil, contractsAddress, "Foo")
+	program := compileCode(t, fooContract, fooLocation, programs)
 
 	vmConfig := &vm.Config{
 		Storage:       storage,

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -495,7 +495,7 @@ func compileAndInvoke(t testing.TB, code string, funcName string) (vm.Value, err
 	)
 
 	result, err := programVM.Invoke(funcName)
-	if err != nil {
+	if err == nil {
 		require.Equal(t, 0, programVM.StackSize())
 	}
 

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -2060,3 +2060,43 @@ func BenchmarkGoFib(b *testing.B) {
 		fib(46)
 	}
 }
+
+func TestDefaultFunctions(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("interface", func(t *testing.T) {
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+            struct interface IA {
+                fun test(): Int {
+                    return 42
+                }
+            }
+
+            struct Test: IA {}
+
+            //fun main(): Int {
+            //    return Test().test()
+            //}
+        `)
+		require.NoError(t, err)
+
+		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
+		program := comp.Compile()
+		printProgram("", program)
+
+		vmConfig := &vm.Config{}
+		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
+
+		result, err := vmInstance.Invoke("main")
+		require.NoError(t, err)
+		require.Equal(t, 0, vmInstance.StackSize())
+		require.Equal(
+			t,
+			vm.NewIntValue(42),
+			result,
+		)
+	})
+}

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -2034,8 +2034,6 @@ func TestResource(t *testing.T) {
 		comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
 		program := comp.Compile()
 
-		printProgram("", program)
-
 		vmConfig := &vm.Config{}
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
@@ -2224,7 +2222,6 @@ func TestDefaultFunctions(t *testing.T) {
 		)
 
 		fooProgram := compileCode(t, fooContract, fooLocation, programs)
-		printProgram("", fooProgram)
 
 		fooVM := vm.NewVM(fooLocation, fooProgram, vmConfig)
 

--- a/sema/type.go
+++ b/sema/type.go
@@ -321,8 +321,10 @@ type ConformingType interface {
 // CompositeKindedType is a type which has a composite kind
 type CompositeKindedType interface {
 	Type
+	LocatedType
 	EntitlementSupportingType
 	GetCompositeKind() common.CompositeKind
+	GetIdentifier() string
 }
 
 // LocatedType is a type which has a location
@@ -5426,6 +5428,10 @@ func (t *CompositeType) CheckInstantiated(pos ast.HasPosition, memoryGauge commo
 	}
 }
 
+func (t *CompositeType) GetIdentifier() string {
+	return t.Identifier
+}
+
 // Member
 
 type Member struct {
@@ -6025,6 +6031,10 @@ func (t *InterfaceType) initializeEffectiveInterfaceConformanceSet() {
 			t.effectiveInterfaceConformanceSet.Add(conformance.InterfaceType)
 		}
 	})
+}
+
+func (t *InterfaceType) GetIdentifier() string {
+	return t.Identifier
 }
 
 // distinctConformances recursively visit conformances and their conformances,


### PR DESCRIPTION
## Description

The default functions are brought/copied over at AST level, so that compiler can treat them similar to any other function that is defined within a composite type.

This PR introduces a separate desugar phase for such AST modifications, to decouple the tree re-writing logic from the compiler phase. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
