### PR TITLE
[Compiler+VM POC] Add compilation for function pre/post conditions

### DIFF
--- a/ast/block.go
+++ b/ast/block.go
@@ -24,6 +24,7 @@ import (
 	"github.com/turbolent/prettier"
 
 	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/errors"
 )
 
 type Block struct {
@@ -351,6 +352,45 @@ func (c *EmitCondition) ElementType() ElementType {
 
 func (c *EmitCondition) Walk(walkChild func(Element)) {
 	(*EmitStatement)(c).Walk(walkChild)
+}
+
+// DesugaredCondition is only used in desugar phase.
+type DesugaredCondition struct {
+	Condition Statement
+}
+
+var _ Condition = &DesugaredCondition{}
+
+func NewDesugaredCondition(condition Statement) *DesugaredCondition {
+	return &DesugaredCondition{
+		Condition: condition,
+	}
+}
+
+func (c DesugaredCondition) StartPosition() Position {
+	return c.Condition.StartPosition()
+}
+
+func (c DesugaredCondition) EndPosition(memoryGauge common.MemoryGauge) Position {
+	return c.Condition.EndPosition(memoryGauge)
+}
+
+func (c DesugaredCondition) ElementType() ElementType {
+	return ElementTypeUnknown
+}
+
+func (c DesugaredCondition) Walk(walkChild func(Element)) {
+	walkChild(c.Condition)
+}
+
+func (c DesugaredCondition) isCondition() {}
+
+func (c DesugaredCondition) CodeElement() Element {
+	return c.Condition
+}
+
+func (c DesugaredCondition) Doc() prettier.Doc {
+	panic(errors.NewUnreachableError())
 }
 
 // Conditions

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -827,6 +827,26 @@ func (i InstructionNotEqual) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
 }
 
+// InstructionNot
+//
+// Negates the boolean value at the top of the stack.
+type InstructionNot struct {
+}
+
+var _ Instruction = InstructionNot{}
+
+func (InstructionNot) Opcode() Opcode {
+	return Not
+}
+
+func (i InstructionNot) String() string {
+	return i.Opcode().String()
+}
+
+func (i InstructionNot) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+}
+
 // InstructionIntAdd
 //
 // Adds the top two values on the stack.
@@ -1071,6 +1091,8 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 		return InstructionEqual{}
 	case NotEqual:
 		return InstructionNotEqual{}
+	case Not:
+		return InstructionNot{}
 	case IntAdd:
 		return InstructionIntAdd{}
 	case IntSubtract:

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -182,6 +182,11 @@
 - name: "notEqual"
   description: Compares the top two values on the stack for inequality.
 
+# Logical instructions
+
+- name: "not"
+  description: Negates the boolean value at the top of the stack.
+
 # Integer arithmetic instructions
 
 - name: "intAdd"

--- a/bbq/opcode/opcode.go
+++ b/bbq/opcode/opcode.go
@@ -65,6 +65,10 @@ const (
 
 	Equal
 	NotEqual
+	Not
+	_
+	_
+	_
 	Unwrap
 	Destroy
 	Transfer

--- a/bbq/opcode/opcode_string.go
+++ b/bbq/opcode/opcode_string.go
@@ -24,51 +24,54 @@ func _() {
 	_ = x[IntGreaterOrEqual-19]
 	_ = x[Equal-31]
 	_ = x[NotEqual-32]
-	_ = x[Unwrap-33]
-	_ = x[Destroy-34]
-	_ = x[Transfer-35]
-	_ = x[Cast-36]
-	_ = x[True-41]
-	_ = x[False-42]
-	_ = x[New-43]
-	_ = x[Path-44]
-	_ = x[Nil-45]
-	_ = x[NewArray-46]
-	_ = x[NewDictionary-47]
-	_ = x[NewRef-48]
-	_ = x[GetConstant-61]
-	_ = x[GetLocal-62]
-	_ = x[SetLocal-63]
-	_ = x[GetGlobal-64]
-	_ = x[SetGlobal-65]
-	_ = x[GetField-66]
-	_ = x[SetField-67]
-	_ = x[SetIndex-68]
-	_ = x[GetIndex-69]
-	_ = x[Invoke-81]
-	_ = x[InvokeDynamic-82]
-	_ = x[Drop-91]
-	_ = x[Dup-92]
+	_ = x[Not-33]
+	_ = x[Unwrap-37]
+	_ = x[Destroy-38]
+	_ = x[Transfer-39]
+	_ = x[Cast-40]
+	_ = x[True-45]
+	_ = x[False-46]
+	_ = x[New-47]
+	_ = x[Path-48]
+	_ = x[Nil-49]
+	_ = x[NewArray-50]
+	_ = x[NewDictionary-51]
+	_ = x[NewRef-52]
+	_ = x[GetConstant-65]
+	_ = x[GetLocal-66]
+	_ = x[SetLocal-67]
+	_ = x[GetGlobal-68]
+	_ = x[SetGlobal-69]
+	_ = x[GetField-70]
+	_ = x[SetField-71]
+	_ = x[SetIndex-72]
+	_ = x[GetIndex-73]
+	_ = x[Invoke-85]
+	_ = x[InvokeDynamic-86]
+	_ = x[Drop-95]
+	_ = x[Dup-96]
 }
 
 const (
 	_Opcode_name_0 = "UnknownReturnReturnValueJumpJumpIfFalse"
 	_Opcode_name_1 = "IntAddIntSubtractIntMultiplyIntDivideIntModIntLessIntGreaterIntLessOrEqualIntGreaterOrEqual"
-	_Opcode_name_2 = "EqualNotEqualUnwrapDestroyTransferCast"
-	_Opcode_name_3 = "TrueFalseNewPathNilNewArrayNewDictionaryNewRef"
-	_Opcode_name_4 = "GetConstantGetLocalSetLocalGetGlobalSetGlobalGetFieldSetFieldSetIndexGetIndex"
-	_Opcode_name_5 = "InvokeInvokeDynamic"
-	_Opcode_name_6 = "DropDup"
+	_Opcode_name_2 = "EqualNotEqualNot"
+	_Opcode_name_3 = "UnwrapDestroyTransferCast"
+	_Opcode_name_4 = "TrueFalseNewPathNilNewArrayNewDictionaryNewRef"
+	_Opcode_name_5 = "GetConstantGetLocalSetLocalGetGlobalSetGlobalGetFieldSetFieldSetIndexGetIndex"
+	_Opcode_name_6 = "InvokeInvokeDynamic"
+	_Opcode_name_7 = "DropDup"
 )
 
 var (
 	_Opcode_index_0 = [...]uint8{0, 7, 13, 24, 28, 39}
 	_Opcode_index_1 = [...]uint8{0, 6, 17, 28, 37, 43, 50, 60, 74, 91}
-	_Opcode_index_2 = [...]uint8{0, 5, 13, 19, 26, 34, 38}
-	_Opcode_index_3 = [...]uint8{0, 4, 9, 12, 16, 19, 27, 40, 46}
-	_Opcode_index_4 = [...]uint8{0, 11, 19, 27, 36, 45, 53, 61, 69, 77}
-	_Opcode_index_5 = [...]uint8{0, 6, 19}
-	_Opcode_index_6 = [...]uint8{0, 4, 7}
+	_Opcode_index_2 = [...]uint8{0, 5, 13, 16}
+	_Opcode_index_3 = [...]uint8{0, 6, 13, 21, 25}
+	_Opcode_index_4 = [...]uint8{0, 4, 9, 12, 16, 19, 27, 40, 46}
+	_Opcode_index_5 = [...]uint8{0, 11, 19, 27, 36, 45, 53, 61, 69, 77}
+	_Opcode_index_6 = [...]uint8{0, 6, 19}
+	_Opcode_index_7 = [...]uint8{0, 4, 7}
 )
 
 func (i Opcode) String() string {
@@ -78,21 +81,24 @@ func (i Opcode) String() string {
 	case 11 <= i && i <= 19:
 		i -= 11
 		return _Opcode_name_1[_Opcode_index_1[i]:_Opcode_index_1[i+1]]
-	case 31 <= i && i <= 36:
+	case 31 <= i && i <= 33:
 		i -= 31
 		return _Opcode_name_2[_Opcode_index_2[i]:_Opcode_index_2[i+1]]
-	case 41 <= i && i <= 48:
-		i -= 41
+	case 37 <= i && i <= 40:
+		i -= 37
 		return _Opcode_name_3[_Opcode_index_3[i]:_Opcode_index_3[i+1]]
-	case 61 <= i && i <= 69:
-		i -= 61
+	case 45 <= i && i <= 52:
+		i -= 45
 		return _Opcode_name_4[_Opcode_index_4[i]:_Opcode_index_4[i+1]]
-	case 81 <= i && i <= 82:
-		i -= 81
+	case 65 <= i && i <= 73:
+		i -= 65
 		return _Opcode_name_5[_Opcode_index_5[i]:_Opcode_index_5[i+1]]
-	case 91 <= i && i <= 92:
-		i -= 91
+	case 85 <= i && i <= 86:
+		i -= 85
 		return _Opcode_name_6[_Opcode_index_6[i]:_Opcode_index_6[i+1]]
+	case 95 <= i && i <= 96:
+		i -= 95
+		return _Opcode_name_7[_Opcode_index_7[i]:_Opcode_index_7[i+1]]
 	default:
 		return "Opcode(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -73,7 +73,10 @@ func init() {
 				panic(errors.NewUnreachableError())
 			}
 
-			panic(string(messageValue.Str))
+			panic(stdlib.PanicError{
+				Message: string(messageValue.Str),
+				// TODO: pass location
+			})
 		},
 	})
 

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -480,7 +480,7 @@ func compile(
 	return program
 }
 
-func compileAndInvoke(t testing.TB, code string, funcName string) (vm.Value, error) {
+func compileAndInvoke(t testing.TB, code string, funcName string, arguments ...vm.Value) (vm.Value, error) {
 	location := common.ScriptLocation{0x1}
 	program := compileCode(t, code, location, map[common.Location]*compiledProgram{})
 	storage := interpreter.NewInMemoryStorage(nil)
@@ -494,8 +494,8 @@ func compileAndInvoke(t testing.TB, code string, funcName string) (vm.Value, err
 			WithAccountHandler(&testAccountHandler{}),
 	)
 
-	result, err := programVM.Invoke(funcName)
-	if err != nil {
+	result, err := programVM.Invoke(funcName, arguments...)
+	if err == nil {
 		require.Equal(t, 0, programVM.StackSize())
 	}
 

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -2258,3 +2258,127 @@ func TestDefaultFunctions(t *testing.T) {
 		require.Equal(t, vm.NewIntValue(7), result)
 	})
 }
+
+func TestFunctionPreConditions(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("pre condition failed", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := compileAndInvoke(t, `
+            fun main(x: Int): Int {
+                pre {
+                    x == 0
+                }
+                return x
+            }`,
+			"main",
+			vm.NewIntValue(3),
+		)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "pre/post condition failed")
+	})
+
+	t.Run("pre condition failed with message", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := compileAndInvoke(t, `
+            fun main(x: Int): Int {
+                pre {
+                    x == 0: "x must be zero"
+                }
+                return x
+            }`,
+			"main",
+			vm.NewIntValue(3),
+		)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "x must be zero")
+	})
+
+	t.Run("pre condition passed", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, err := compileAndInvoke(t, `
+            fun main(x: Int): Int {
+                pre {
+                    x != 0
+                }
+                return x
+            }`,
+			"main",
+			vm.NewIntValue(3),
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, vm.NewIntValue(3), result)
+	})
+}
+
+func TestFunctionPostConditions(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("post condition failed", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := compileAndInvoke(t, `
+            fun main(x: Int): Int {
+                post {
+                    x == 0
+                }
+                return x
+            }`,
+			"main",
+			vm.NewIntValue(3),
+		)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "pre/post condition failed")
+	})
+
+	t.Run("post condition failed with message", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := compileAndInvoke(t, `
+            fun main(x: Int): Int {
+                post {
+                    x == 0: "x must be zero"
+                }
+                return x
+            }`,
+			"main",
+			vm.NewIntValue(3),
+		)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "x must be zero")
+	})
+
+	t.Run("post condition passed", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, err := compileAndInvoke(t, `
+            fun main(x: Int): Int {
+                post {
+                    x != 0
+                }
+                return x
+            }`,
+			"main",
+			vm.NewIntValue(3),
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, vm.NewIntValue(3), result)
+	})
+}

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -2381,4 +2381,44 @@ func TestFunctionPostConditions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, vm.NewIntValue(3), result)
 	})
+
+	t.Run("post condition on local var", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, err := compileAndInvoke(t, `
+            fun main(x: Int): Int {
+                post {
+                    y == 5
+                }
+                var y = x + 2
+                return y
+            }`,
+			"main",
+			vm.NewIntValue(3),
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, vm.NewIntValue(5), result)
+	})
+
+	t.Run("post condition on local var failed with message", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := compileAndInvoke(t, `
+            fun main(x: Int): Int {
+                post {
+                    y == 5: "x must be 5"
+                }
+                var y = x + 2
+                return y
+            }`,
+			"main",
+			vm.NewIntValue(4),
+		)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "x must be 5")
+	})
 }

--- a/bbq/vm/value_int.go
+++ b/bbq/vm/value_int.go
@@ -68,8 +68,22 @@ func (v IntValue) Less(other IntValue) Value {
 	return FalseValue
 }
 
+func (v IntValue) LessOrEqual(other IntValue) Value {
+	if v.SmallInt <= other.SmallInt {
+		return TrueValue
+	}
+	return FalseValue
+}
+
 func (v IntValue) Greater(other IntValue) Value {
 	if v.SmallInt > other.SmallInt {
+		return TrueValue
+	}
+	return FalseValue
+}
+
+func (v IntValue) GreaterOrEqual(other IntValue) Value {
+	if v.SmallInt >= other.SmallInt {
 		return TrueValue
 	}
 	return FalseValue

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -342,11 +342,25 @@ func opBinaryIntLess(vm *VM) {
 	vm.replaceTop(leftNumber.Less(rightNumber))
 }
 
+func opBinaryIntLessOrEqual(vm *VM) {
+	left, right := vm.peekPop()
+	leftNumber := left.(IntValue)
+	rightNumber := right.(IntValue)
+	vm.replaceTop(leftNumber.LessOrEqual(rightNumber))
+}
+
 func opBinaryIntGreater(vm *VM) {
 	left, right := vm.peekPop()
 	leftNumber := left.(IntValue)
 	rightNumber := right.(IntValue)
 	vm.replaceTop(leftNumber.Greater(rightNumber))
+}
+
+func opBinaryIntGreaterOrEqual(vm *VM) {
+	left, right := vm.peekPop()
+	leftNumber := left.(IntValue)
+	rightNumber := right.(IntValue)
+	vm.replaceTop(leftNumber.GreaterOrEqual(rightNumber))
 }
 
 func opTrue(vm *VM) {
@@ -662,8 +676,12 @@ func (vm *VM) run() {
 			opBinaryIntSubtract(vm)
 		case opcode.InstructionIntLess:
 			opBinaryIntLess(vm)
+		case opcode.InstructionIntLessOrEqual:
+			opBinaryIntLessOrEqual(vm)
 		case opcode.InstructionIntGreater:
 			opBinaryIntGreater(vm)
+		case opcode.InstructionIntGreaterOrEqual:
+			opBinaryIntGreaterOrEqual(vm)
 		case opcode.InstructionTrue:
 			opTrue(vm)
 		case opcode.InstructionFalse:

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -590,6 +590,11 @@ func opNotEqual(vm *VM) {
 	vm.replaceTop(BoolValue(left != right))
 }
 
+func opNot(vm *VM) {
+	value := vm.peek().(BoolValue)
+	vm.replaceTop(!value)
+}
+
 func opUnwrap(vm *VM) {
 	value := vm.peek()
 	if someValue, ok := value.(*SomeValue); ok {
@@ -709,6 +714,8 @@ func (vm *VM) run() {
 			opEqual(vm)
 		case opcode.InstructionNotEqual:
 			opNotEqual(vm)
+		case opcode.InstructionNot:
+			opNot(vm)
 		case opcode.InstructionUnwrap:
 			opUnwrap(vm)
 		default:


### PR DESCRIPTION
Depends on https://github.com/onflow/cadence/pull/3727

## Description

Add support for compiling function pre/post conditions. This only compile conditions defined in the function it-self, and inherited pre/post conditions are not supported (added in a follow-up PR)

Pre/post conditions are desugared to normal statements:
- Test-conditions are desguared to be if-statements
- Emit-conditions are desugared to be emit-statements

And then added to the begining/end of the regular statements of the function.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
