### PR TITLE
[Compiler+VM POC] Add compilation for inherited pre/post conditions

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -112,6 +112,11 @@ func newCompiler[E any](
 	}
 }
 
+func (c *Compiler[E]) WithConfig(config *Config) *Compiler[E] {
+	c.Config = config
+	return c
+}
+
 func (c *Compiler[_]) findGlobal(name string) *global {
 	global, ok := c.globals[name]
 	if ok {

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	ContractValueHandler
 	stdlib.AccountHandler
 
+	NativeFunctionsProvider
+
 	// TODO: Move these to a 'shared state'?
 	CapabilityControllerIterations              map[AddressPath]int
 	MutationDuringCapabilityControllerIteration bool

--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -34,6 +34,8 @@ var nativeFunctions = map[string]Value{}
 // It's always nil.
 var BuiltInLocation common.Location = nil
 
+type NativeFunctionsProvider func() map[string]Value
+
 func NativeFunctions() map[string]Value {
 	funcs := make(map[string]Value, len(nativeFunctions))
 	for name, value := range nativeFunctions {

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -64,14 +64,14 @@ func TestFTTransfer(t *testing.T) {
 
 	ftLocation := common.NewAddressLocation(nil, contractsAddress, "FungibleToken")
 
-	ftContractProgram := compileCode(t, realFungibleTokenContractInterface, ftLocation, programs)
+	ftContractProgram := parseCheckAndCompile(t, realFungibleTokenContractInterface, ftLocation, programs)
 	printProgram("FungibleToken", ftContractProgram)
 
 	// ----- Deploy FlowToken Contract -----
 
 	flowTokenLocation := common.NewAddressLocation(nil, contractsAddress, "FlowToken")
 
-	flowTokenProgram := compileCode(t, realFlowContract, flowTokenLocation, programs)
+	flowTokenProgram := parseCheckAndCompile(t, realFlowContract, flowTokenLocation, programs)
 	printProgram("FlowToken", flowTokenProgram)
 
 	config := &vm.Config{
@@ -123,7 +123,7 @@ func TestFTTransfer(t *testing.T) {
 		senderAddress,
 		receiverAddress,
 	} {
-		program := compileCode(t, realSetupFlowTokenAccountTransaction, nil, programs)
+		program := parseCheckAndCompile(t, realSetupFlowTokenAccountTransaction, nil, programs)
 
 		setupTxVM := vm.NewVM(txLocation(), program, vmConfig)
 
@@ -135,7 +135,7 @@ func TestFTTransfer(t *testing.T) {
 
 	// Mint FLOW to sender
 
-	program := compileCode(t, realMintFlowTokenTransaction, nil, programs)
+	program := parseCheckAndCompile(t, realMintFlowTokenTransaction, nil, programs)
 	printProgram("Setup FlowToken Tx", program)
 
 	mintTxVM := vm.NewVM(txLocation(), program, vmConfig)
@@ -154,7 +154,7 @@ func TestFTTransfer(t *testing.T) {
 
 	// ----- Run token transfer transaction -----
 
-	tokenTransferTxProgram := compileCode(t, realFlowTokenTransferTransaction, nil, programs)
+	tokenTransferTxProgram := parseCheckAndCompile(t, realFlowTokenTransferTransaction, nil, programs)
 	printProgram("FT Transfer Tx", tokenTransferTxProgram)
 
 	tokenTransferTxVM := vm.NewVM(txLocation(), tokenTransferTxProgram, vmConfig)
@@ -177,7 +177,7 @@ func TestFTTransfer(t *testing.T) {
 		senderAddress,
 		receiverAddress,
 	} {
-		program := compileCode(t, realFlowTokenBalanceScript, nil, programs)
+		program := parseCheckAndCompile(t, realFlowTokenBalanceScript, nil, programs)
 
 		validationScriptVM := vm.NewVM(scriptLocation(), program, vmConfig)
 
@@ -222,12 +222,12 @@ func BenchmarkFTTransfer(b *testing.B) {
 	txLocation := runtime_utils.NewTransactionLocationGenerator()
 
 	ftLocation := common.NewAddressLocation(nil, contractsAddress, "FungibleToken")
-	_ = compileCode(b, realFungibleTokenContractInterface, ftLocation, programs)
+	_ = parseCheckAndCompile(b, realFungibleTokenContractInterface, ftLocation, programs)
 
 	// ----- Deploy FlowToken Contract -----
 
 	flowTokenLocation := common.NewAddressLocation(nil, contractsAddress, "FlowToken")
-	flowTokenProgram := compileCode(b, realFlowContract, flowTokenLocation, programs)
+	flowTokenProgram := parseCheckAndCompile(b, realFlowContract, flowTokenLocation, programs)
 
 	config := &vm.Config{
 		Storage:        storage,
@@ -279,7 +279,7 @@ func BenchmarkFTTransfer(b *testing.B) {
 		senderAddress,
 		receiverAddress,
 	} {
-		program := compileCode(b, realSetupFlowTokenAccountTransaction, nil, programs)
+		program := parseCheckAndCompile(b, realSetupFlowTokenAccountTransaction, nil, programs)
 
 		setupTxVM := vm.NewVM(txLocation(), program, vmConfig)
 
@@ -291,7 +291,7 @@ func BenchmarkFTTransfer(b *testing.B) {
 
 	// Mint FLOW to sender
 
-	program := compileCode(b, realMintFlowTokenTransaction, nil, programs)
+	program := parseCheckAndCompile(b, realMintFlowTokenTransaction, nil, programs)
 
 	mintTxVM := vm.NewVM(txLocation(), program, vmConfig)
 
@@ -318,8 +318,7 @@ func BenchmarkFTTransfer(b *testing.B) {
 
 	tokenTransferTxAuthorizer := vm.NewAuthAccountReferenceValue(vmConfig, senderAddress)
 
-	tokenTransferTxChecker := parseAndCheck(b, realFlowTokenTransferTransaction, nil, programs)
-	tokenTransferTxProgram := compile(b, tokenTransferTxChecker, programs)
+	tokenTransferTxProgram := parseCheckAndCompile(b, realFlowTokenTransferTransaction, nil, programs)
 	tokenTransferTxVM := vm.NewVM(txLocation(), tokenTransferTxProgram, vmConfig)
 
 	b.ReportAllocs()
@@ -341,7 +340,7 @@ func BenchmarkFTTransfer(b *testing.B) {
 		senderAddress,
 		receiverAddress,
 	} {
-		program := compileCode(b, realFlowTokenBalanceScript, nil, programs)
+		program := parseCheckAndCompile(b, realFlowTokenBalanceScript, nil, programs)
 
 		validationScriptVM := vm.NewVM(scriptLocation(), program, vmConfig)
 

--- a/bbq/vm/test/runtime_test.go
+++ b/bbq/vm/test/runtime_test.go
@@ -86,7 +86,7 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
     `
 	barLocation := common.NewAddressLocation(nil, contractsAddress, "Bar")
 
-	barProgram := compileCode(t, contractCode, barLocation, programs)
+	barProgram := parseCheckAndCompile(t, contractCode, barLocation, programs)
 
 	barVM := vm.NewVM(
 		barLocation,
@@ -159,7 +159,7 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 	}
 
 	fooLocation := common.NewAddressLocation(nil, contractsAddress, "Foo")
-	program := compileCode(t, fooContract, fooLocation, programs)
+	program := parseCheckAndCompile(t, fooContract, fooLocation, programs)
 
 	vmConfig := &vm.Config{
 		Storage:       storage,

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -405,18 +405,51 @@ type compiledProgram struct {
 	*sema.Elaboration
 }
 
-func compileCode(
+type CompilerAndVMOptions struct {
+	*sema_utils.ParseAndCheckOptions
+	CompilerConfig *compiler.Config
+	VMConfig       *vm.Config
+}
+
+func parseCheckAndCompile(
 	t testing.TB,
 	code string,
 	location common.Location,
 	programs map[common.Location]*compiledProgram,
 ) *bbq.Program[opcode.Instruction] {
-	checker := parseAndCheck(t, code, location, programs)
+	return parseCheckAndCompileCodeWithOptions(
+		t,
+		code,
+		location,
+		CompilerAndVMOptions{},
+		programs,
+	)
+}
+
+func parseCheckAndCompileCodeWithOptions(
+	t testing.TB,
+	code string,
+	location common.Location,
+	options CompilerAndVMOptions,
+	programs map[common.Location]*compiledProgram,
+) *bbq.Program[opcode.Instruction] {
+	checker := parseAndCheckWithOptions(
+		t,
+		code,
+		location,
+		options.ParseAndCheckOptions,
+		programs,
+	)
 	programs[location] = &compiledProgram{
 		Elaboration: checker.Elaboration,
 	}
 
-	program := compile(t, checker, programs)
+	program := compile(
+		t,
+		options.CompilerConfig,
+		checker,
+		programs,
+	)
 	programs[location].Program = program
 
 	return program
@@ -428,10 +461,22 @@ func parseAndCheck(
 	location common.Location,
 	programs map[common.Location]*compiledProgram,
 ) *sema.Checker {
-	checker, err := sema_utils.ParseAndCheckWithOptions(
-		t,
-		code,
-		sema_utils.ParseAndCheckOptions{
+	return parseAndCheckWithOptions(t, code, location, nil, programs)
+}
+
+func parseAndCheckWithOptions(
+	t testing.TB,
+	code string,
+	location common.Location,
+	options *sema_utils.ParseAndCheckOptions,
+	programs map[common.Location]*compiledProgram,
+) *sema.Checker {
+
+	var parseAndCheckOptions sema_utils.ParseAndCheckOptions
+	if options != nil {
+		parseAndCheckOptions = *options
+	} else {
+		parseAndCheckOptions = sema_utils.ParseAndCheckOptions{
 			Location: location,
 			Config: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
@@ -447,7 +492,13 @@ func parseAndCheck(
 				LocationHandler:            singleIdentifierLocationResolver(t),
 				BaseValueActivationHandler: baseValueActivation,
 			},
-		},
+		}
+	}
+
+	checker, err := sema_utils.ParseAndCheckWithOptions(
+		t,
+		code,
+		parseAndCheckOptions,
 	)
 	require.NoError(t, err)
 	return checker
@@ -455,43 +506,123 @@ func parseAndCheck(
 
 func compile(
 	t testing.TB,
+	config *compiler.Config,
 	checker *sema.Checker,
 	programs map[common.Location]*compiledProgram,
 ) *bbq.Program[opcode.Instruction] {
-	comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration)
-	comp.Config.LocationHandler = singleIdentifierLocationResolver(t)
-	comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
-		imported, ok := programs[location]
-		if !ok {
-			return nil
-		}
-		return imported.Program
-	}
 
-	comp.Config.ElaborationResolver = func(location common.Location) (*sema.Elaboration, error) {
-		imported, ok := programs[location]
-		if !ok {
-			return nil, fmt.Errorf("cannot find elaboration for %s", location)
+	if config == nil {
+		config = &compiler.Config{
+			LocationHandler: singleIdentifierLocationResolver(t),
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+				imported, ok := programs[location]
+				if !ok {
+					return nil
+				}
+				return imported.Program
+			},
+			ElaborationResolver: func(location common.Location) (*sema.Elaboration, error) {
+				imported, ok := programs[location]
+				if !ok {
+					return nil, fmt.Errorf("cannot find elaboration for %s", location)
+				}
+				return imported.Elaboration, nil
+			},
 		}
-		return imported.Elaboration, nil
 	}
+	comp := compiler.NewInstructionCompiler(checker.Program, checker.Elaboration).
+		WithConfig(config)
 
 	program := comp.Compile()
 	return program
 }
 
-func compileAndInvoke(t testing.TB, code string, funcName string, arguments ...vm.Value) (vm.Value, error) {
+func compileAndInvoke(
+	t testing.TB,
+	code string,
+	funcName string,
+	arguments ...vm.Value,
+) (vm.Value, error) {
+	return compileAndInvokeWithOptions(
+		t,
+		code,
+		funcName,
+		CompilerAndVMOptions{},
+		arguments...,
+	)
+}
+
+func compileAndInvokeWithOptions(
+	t testing.TB,
+	code string,
+	funcName string,
+	options CompilerAndVMOptions,
+	arguments ...vm.Value,
+) (vm.Value, error) {
+
 	location := common.ScriptLocation{0x1}
-	program := compileCode(t, code, location, map[common.Location]*compiledProgram{})
-	storage := interpreter.NewInMemoryStorage(nil)
+	program := parseCheckAndCompileCodeWithOptions(
+		t,
+		code,
+		location,
+		options,
+		map[common.Location]*compiledProgram{},
+	)
+
+	vmConfig := options.VMConfig
+	if vmConfig == nil {
+		storage := interpreter.NewInMemoryStorage(nil)
+		vmConfig = vm.NewConfig(storage).
+			WithAccountHandler(&testAccountHandler{})
+	}
 
 	scriptLocation := runtime_utils.NewScriptLocationGenerator()
 
 	programVM := vm.NewVM(
 		scriptLocation(),
 		program,
-		vm.NewConfig(storage).
-			WithAccountHandler(&testAccountHandler{}),
+		vmConfig,
+	)
+
+	result, err := programVM.Invoke(funcName, arguments...)
+	if err == nil {
+		require.Equal(t, 0, programVM.StackSize())
+	}
+
+	return result, err
+}
+
+func compileAndInvokeWithOptionsAndPrograms(
+	t testing.TB,
+	code string,
+	funcName string,
+	options CompilerAndVMOptions,
+	programs map[common.Location]*compiledProgram,
+	arguments ...vm.Value,
+) (vm.Value, error) {
+
+	location := common.ScriptLocation{0x1}
+	program := parseCheckAndCompileCodeWithOptions(
+		t,
+		code,
+		location,
+		options,
+		programs,
+	)
+
+	vmConfig := options.VMConfig
+	if vmConfig == nil {
+		storage := interpreter.NewInMemoryStorage(nil)
+		vmConfig = vm.NewConfig(storage).
+			WithAccountHandler(&testAccountHandler{})
+	}
+
+	scriptLocation := runtime_utils.NewScriptLocationGenerator()
+
+	programVM := vm.NewVM(
+		scriptLocation(),
+		program,
+		vmConfig,
 	)
 
 	result, err := programVM.Invoke(funcName, arguments...)

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -60,13 +60,17 @@ func NewVM(
 		conf.Storage = interpreter.NewInMemoryStorage(nil)
 	}
 
+	if conf.NativeFunctionsProvider == nil {
+		conf.NativeFunctionsProvider = NativeFunctions
+	}
+
 	// linkedGlobalsCache is a local cache-alike that is being used to hold already linked imports.
 	linkedGlobalsCache := map[common.Location]LinkedGlobals{
 		BuiltInLocation: {
 			// It is NOT safe to re-use native functions map here because,
 			// once put into the cache, it will be updated by adding the
 			// globals of the current program.
-			indexedGlobals: NativeFunctions(),
+			indexedGlobals: conf.NativeFunctionsProvider(),
 		},
 	}
 


### PR DESCRIPTION
Depends on https://github.com/onflow/cadence/pull/3727 and https://github.com/onflow/cadence/pull/3728

## Description

Similar to default functions (https://github.com/onflow/cadence/pull/3727), inherited function pre/post conditions are also copied over at AST level. Once they are copied over, they get compiled similar to normal inlined pre-post conditions (https://github.com/onflow/cadence/pull/3728)

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
