### PR TITLE
[Compiler] Adjust parameters to reduce run-time when race detector is enabled

### DIFF
--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -71,10 +71,10 @@ func TestRecursionFib(t *testing.T) {
 
 	result, err := vmInstance.Invoke(
 		"fib",
-		vm.NewIntValue(35),
+		vm.NewIntValue(23),
 	)
 	require.NoError(t, err)
-	require.Equal(t, vm.NewIntValue(9227465), result)
+	require.Equal(t, vm.NewIntValue(28657), result)
 	require.Equal(t, 0, vmInstance.StackSize())
 }
 


### PR DESCRIPTION

## Description

`TestRecursiveFib` takes longer than the default timeout of 10min when the race detector is enabled, which is the case on CI. I don't know/understand why.

Testing a smaller is sufficient and brings down the run-time to a reasonable sub-second amount.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
