### PR TITLE
[Compiler] Fix operand order for SetField and SetIndex instructions, check resource invalidation

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -616,7 +616,7 @@ func (c *Compiler[_]) VisitVariableDeclaration(declaration *ast.VariableDeclarat
 	c.compileExpression(declaration.Value)
 
 	varDeclTypes := c.Elaboration.VariableDeclarationTypes(declaration)
-	c.emitCheckType(varDeclTypes.TargetType)
+	c.emitTransfer(varDeclTypes.TargetType)
 
 	local := c.currentFunction.declareLocal(declaration.Identifier.Identifier)
 	c.codeGen.Emit(opcode.InstructionSetLocal{LocalIndex: local.index})
@@ -624,31 +624,47 @@ func (c *Compiler[_]) VisitVariableDeclaration(declaration *ast.VariableDeclarat
 }
 
 func (c *Compiler[_]) VisitAssignmentStatement(statement *ast.AssignmentStatement) (_ struct{}) {
-	c.compileExpression(statement.Value)
-
-	assignmentTypes := c.Elaboration.AssignmentStatementTypes(statement)
-	c.emitCheckType(assignmentTypes.TargetType)
 
 	switch target := statement.Target.(type) {
 	case *ast.IdentifierExpression:
+		c.compileExpression(statement.Value)
+		assignmentTypes := c.Elaboration.AssignmentStatementTypes(statement)
+		c.emitTransfer(assignmentTypes.TargetType)
+
 		varName := target.Identifier.Identifier
 		local := c.currentFunction.findLocal(varName)
 		if local != nil {
-			c.codeGen.Emit(opcode.InstructionSetLocal{LocalIndex: local.index})
+			c.codeGen.Emit(opcode.InstructionSetLocal{
+				LocalIndex: local.index,
+			})
 			return
 		}
 
 		global := c.findGlobal(varName)
-		c.codeGen.Emit(opcode.InstructionSetGlobal{GlobalIndex: global.index})
+		c.codeGen.Emit(opcode.InstructionSetGlobal{
+			GlobalIndex: global.index,
+		})
 
 	case *ast.MemberExpression:
 		c.compileExpression(target.Expression)
+
+		c.compileExpression(statement.Value)
+		assignmentTypes := c.Elaboration.AssignmentStatementTypes(statement)
+		c.emitTransfer(assignmentTypes.TargetType)
+
 		constant := c.addStringConst(target.Identifier.Identifier)
-		c.codeGen.Emit(opcode.InstructionSetField{FieldNameIndex: constant.index})
+		c.codeGen.Emit(opcode.InstructionSetField{
+			FieldNameIndex: constant.index,
+		})
 
 	case *ast.IndexExpression:
 		c.compileExpression(target.TargetExpression)
 		c.compileExpression(target.IndexingExpression)
+
+		c.compileExpression(statement.Value)
+		assignmentTypes := c.Elaboration.AssignmentStatementTypes(statement)
+		c.emitTransfer(assignmentTypes.TargetType)
+
 		c.codeGen.Emit(opcode.InstructionSetIndex{})
 
 	default:
@@ -877,7 +893,7 @@ func (c *Compiler[_]) loadArguments(expression *ast.InvocationExpression) {
 	invocationTypes := c.Elaboration.InvocationExpressionTypes(expression)
 	for index, argument := range expression.Arguments {
 		c.compileExpression(argument.Expression)
-		c.emitCheckType(invocationTypes.ArgumentTypes[index])
+		c.emitTransfer(invocationTypes.ArgumentTypes[index])
 	}
 
 	// TODO: Is this needed?
@@ -911,7 +927,9 @@ func (c *Compiler[_]) loadTypeArguments(expression *ast.InvocationExpression) []
 func (c *Compiler[_]) VisitMemberExpression(expression *ast.MemberExpression) (_ struct{}) {
 	c.compileExpression(expression.Expression)
 	constant := c.addStringConst(expression.Identifier.Identifier)
-	c.codeGen.Emit(opcode.InstructionGetField{FieldNameIndex: constant.index})
+	c.codeGen.Emit(opcode.InstructionGetField{
+		FieldNameIndex: constant.index,
+	})
 	return
 }
 
@@ -1308,7 +1326,7 @@ func (c *Compiler[_]) patchLoop(l *loop) {
 	}
 }
 
-func (c *Compiler[_]) emitCheckType(targetType sema.Type) {
+func (c *Compiler[_]) emitTransfer(targetType sema.Type) {
 	index := c.getOrAddType(targetType)
 
 	c.codeGen.Emit(opcode.InstructionTransfer{TypeIndex: index})

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -68,7 +68,7 @@
       type: "index"
   valueEffects:
     pop:
-      - name: "container"
+      - name: "target"
         type: "value"
       - name: "value"
         type: "value"

--- a/bbq/vm/vm_test.go
+++ b/bbq/vm/vm_test.go
@@ -118,7 +118,7 @@ func TestVM_replaceTop(t *testing.T) {
 	)
 }
 
-func TestVM_pop2NonResource(t *testing.T) {
+func TestVM_pop2(t *testing.T) {
 	t.Parallel()
 
 	program := &bbq.Program[opcode.Instruction]{}
@@ -128,7 +128,7 @@ func TestVM_pop2NonResource(t *testing.T) {
 	vm.push(NewIntValue(2))
 	vm.push(NewIntValue(3))
 
-	a, b := vm.pop2NonResource()
+	a, b := vm.pop2()
 
 	assert.Equal(t, NewIntValue(2), a)
 	assert.Equal(t, NewIntValue(3), b)
@@ -141,7 +141,7 @@ func TestVM_pop2NonResource(t *testing.T) {
 	)
 }
 
-func TestVM_pop3NonResource(t *testing.T) {
+func TestVM_pop3(t *testing.T) {
 	t.Parallel()
 
 	program := &bbq.Program[opcode.Instruction]{}
@@ -162,7 +162,7 @@ func TestVM_pop3NonResource(t *testing.T) {
 		},
 	)
 
-	a, b, c := vm.pop3NonResource()
+	a, b, c := vm.pop3()
 
 	assert.Equal(t, NewIntValue(2), a)
 	assert.Equal(t, NewIntValue(3), b)


### PR DESCRIPTION
## Description

Fix operand order for `SetField` and `SetIndex` instructions, so it aligns better with other existing instruction sets (e.g. JVM and CIL) to `target, value`. This was already documented in the instructions spec as such.

While implementing the change I noticed that the `SetField` instruction was implemented as two `pop()` calls, and `pop` checks for resource invalidation, but `SetIndex` was implemented as "pop3", which only exists in the non-resource form, i.e. that instruction did not check resource invalidation.

For now, focus on correctness and always ensure all operand stack operations perform resource invalidation.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
