### PR TITLE
[Compiler] Compile dictionary expressions, implement NewDictionary instruction

### DIFF
--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -40,7 +40,7 @@ func TestCompileRecursionFib(t *testing.T) {
           }
           return fib(n - 1) + fib(n - 2)
       }
-  `)
+    `)
 	require.NoError(t, err)
 
 	compiler := NewBytecodeCompiler(checker)
@@ -115,7 +115,7 @@ func TestCompileImperativeFib(t *testing.T) {
           }
           return fibonacci
       }
-  `)
+    `)
 	require.NoError(t, err)
 
 	compiler := NewBytecodeCompiler(checker)
@@ -208,7 +208,7 @@ func TestCompileBreak(t *testing.T) {
           }
           return i
       }
-  `)
+    `)
 	require.NoError(t, err)
 
 	compiler := NewBytecodeCompiler(checker)
@@ -285,7 +285,7 @@ func TestCompileContinue(t *testing.T) {
           }
           return i
       }
-  `)
+    `)
 	require.NoError(t, err)
 
 	compiler := NewBytecodeCompiler(checker)
@@ -338,6 +338,116 @@ func TestCompileContinue(t *testing.T) {
 			{
 				Data: []byte{0x1},
 				Kind: constantkind.Int,
+			},
+			{
+				Data: []byte{0x3},
+				Kind: constantkind.Int,
+			},
+		},
+		program.Constants,
+	)
+}
+
+func TestCompileArray(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+      fun test() {
+          let xs: [Int] = [1, 2, 3]
+      }
+    `)
+	require.NoError(t, err)
+
+	compiler := NewBytecodeCompiler(checker)
+	program := compiler.Compile()
+
+	require.Len(t, program.Functions, 1)
+
+	require.Equal(t,
+		[]byte{
+			byte(opcode.GetConstant), 0, 0,
+			byte(opcode.GetConstant), 0, 1,
+			byte(opcode.GetConstant), 0, 2,
+			byte(opcode.NewArray), 0, 0, 0, 3, 0,
+			byte(opcode.Transfer), 0, 0,
+			byte(opcode.SetLocal), 0, 0,
+			byte(opcode.Return),
+		},
+		compiler.ExportFunctions()[0].Code,
+	)
+
+	require.Equal(t,
+		[]*bbq.Constant{
+			{
+				Data: []byte{0x1},
+				Kind: constantkind.Int,
+			},
+			{
+				Data: []byte{0x2},
+				Kind: constantkind.Int,
+			},
+			{
+				Data: []byte{0x3},
+				Kind: constantkind.Int,
+			},
+		},
+		program.Constants,
+	)
+}
+func TestCompileDictionary(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+      fun test() {
+          let xs: {String: Int} = {"a": 1, "b": 2, "c": 3}
+      }
+    `)
+	require.NoError(t, err)
+
+	compiler := NewBytecodeCompiler(checker)
+	program := compiler.Compile()
+
+	require.Len(t, program.Functions, 1)
+
+	require.Equal(t,
+		[]byte{
+			byte(opcode.GetConstant), 0, 0,
+			byte(opcode.GetConstant), 0, 1,
+			byte(opcode.GetConstant), 0, 2,
+			byte(opcode.GetConstant), 0, 3,
+			byte(opcode.GetConstant), 0, 4,
+			byte(opcode.GetConstant), 0, 5,
+			byte(opcode.NewDictionary), 0, 0, 0, 3, 0,
+			byte(opcode.Transfer), 0, 0,
+			byte(opcode.SetLocal), 0, 0,
+			byte(opcode.Return),
+		},
+		compiler.ExportFunctions()[0].Code,
+	)
+
+	require.Equal(t,
+		[]*bbq.Constant{
+			{
+				Data: []byte{'a'},
+				Kind: constantkind.String,
+			},
+			{
+				Data: []byte{0x1},
+				Kind: constantkind.Int,
+			},
+			{
+				Data: []byte{'b'},
+				Kind: constantkind.String,
+			},
+			{
+				Data: []byte{0x2},
+				Kind: constantkind.Int,
+			},
+			{
+				Data: []byte{'c'},
+				Kind: constantkind.String,
 			},
 			{
 				Data: []byte{0x3},

--- a/bbq/compiler/extended_elaboration.go
+++ b/bbq/compiler/extended_elaboration.go
@@ -204,6 +204,10 @@ func (e *ExtendedElaboration) ArrayExpressionTypes(expression *ast.ArrayExpressi
 	return e.elaboration.ArrayExpressionTypes(expression)
 }
 
+func (e *ExtendedElaboration) DictionaryExpressionTypes(expression *ast.DictionaryExpression) sema.DictionaryExpressionTypes {
+	return e.elaboration.DictionaryExpressionTypes(expression)
+}
+
 func (e *ExtendedElaboration) CastingExpressionTypes(expression *ast.CastingExpression) sema.CastingExpressionTypes {
 	return e.elaboration.CastingExpressionTypes(expression)
 }

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -415,6 +415,44 @@ func DecodeNewArray(ip *uint16, code []byte) (i InstructionNewArray) {
 	return i
 }
 
+// InstructionNewDictionary
+//
+// Creates a new dictionary with the given type and size.
+type InstructionNewDictionary struct {
+	TypeIndex  uint16
+	Size       uint16
+	IsResource bool
+}
+
+var _ Instruction = InstructionNewDictionary{}
+
+func (InstructionNewDictionary) Opcode() Opcode {
+	return NewDictionary
+}
+
+func (i InstructionNewDictionary) String() string {
+	var sb strings.Builder
+	sb.WriteString(i.Opcode().String())
+	printfArgument(&sb, "typeIndex", i.TypeIndex)
+	printfArgument(&sb, "size", i.Size)
+	printfArgument(&sb, "isResource", i.IsResource)
+	return sb.String()
+}
+
+func (i InstructionNewDictionary) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+	emitUint16(code, i.TypeIndex)
+	emitUint16(code, i.Size)
+	emitBool(code, i.IsResource)
+}
+
+func DecodeNewDictionary(ip *uint16, code []byte) (i InstructionNewDictionary) {
+	i.TypeIndex = decodeUint16(ip, code)
+	i.Size = decodeUint16(ip, code)
+	i.IsResource = decodeBool(ip, code)
+	return i
+}
+
 // InstructionNewRef
 //
 // Creates a new reference with the given type.
@@ -1059,6 +1097,8 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 		return DecodeNew(ip, code)
 	case NewArray:
 		return DecodeNewArray(ip, code)
+	case NewDictionary:
+		return DecodeNewDictionary(ip, code)
 	case NewRef:
 		return DecodeNewRef(ip, code)
 	case GetConstant:

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -164,6 +164,26 @@
       - name: "array"
         type: "array"
 
+- name: "newDictionary"
+  description: Creates a new dictionary with the given type and size.
+  operands:
+    - name: "typeIndex"
+      type: "index"
+    - name: "size"
+      type: "size"
+    - name: "isResource"
+      type: "bool"
+  valueEffects:
+    pop:
+      - name: "entries"
+        type: "value"
+        # The number of elements taken from the stack is equal to the size operand of the opcode, multiplied by 2.
+        count: "size * 2"
+    push:
+      - name: "dictionary"
+        type: "dictionary"
+
+
 - name: "newRef"
   description: Creates a new reference with the given type.
   operands:

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -1945,6 +1945,44 @@ func TestArrayLiteral(t *testing.T) {
 	})
 }
 
+func TestDictionaryLiteral(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("dictionary literal", func(t *testing.T) {
+		t.Parallel()
+
+		checker, err := ParseAndCheck(t, `
+            fun test(): {String: Int} {
+                return {"b": 2, "e": 5}
+            }
+        `)
+		require.NoError(t, err)
+
+		comp := compiler.NewInstructionCompiler(checker)
+		program := comp.Compile()
+
+		vmConfig := &vm.Config{}
+		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
+
+		result, err := vmInstance.Invoke("test")
+		require.NoError(t, err)
+		require.Equal(t, 0, vmInstance.StackSize())
+
+		require.IsType(t, &vm.DictionaryValue{}, result)
+		dictionary := result.(*vm.DictionaryValue)
+		assert.Equal(t, 2, dictionary.Count())
+		assert.Equal(t,
+			vm.NewSomeValueNonCopying(vm.NewIntValue(2)),
+			dictionary.GetKey(vmConfig, vm.NewStringValue("b")),
+		)
+		assert.Equal(t,
+			vm.NewSomeValueNonCopying(vm.NewIntValue(5)),
+			dictionary.GetKey(vmConfig, vm.NewStringValue("e")),
+		)
+	})
+}
+
 func TestReference(t *testing.T) {
 
 	t.Parallel()

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -643,16 +643,22 @@ func opNewArray(vm *VM, ins opcode.InstructionNewArray) {
 
 	typ := vm.loadType(ins.TypeIndex).(interpreter.ArrayStaticType)
 
-	elements := make([]Value, ins.Size)
-
-	// Must be inserted in the reverse,
-	// since the stack if FILO.
-	for i := int(ins.Size) - 1; i >= 0; i-- {
-		elements[i] = vm.pop()
-	}
-
+	elements := vm.peekN(int(ins.Size))
 	array := NewArrayValue(vm.config, typ, ins.IsResource, elements...)
+	vm.dropN(len(elements))
+
 	vm.push(array)
+}
+
+func opNewDictionary(vm *VM, ins opcode.InstructionNewDictionary) {
+
+	typ := vm.loadType(ins.TypeIndex).(*interpreter.DictionaryStaticType)
+
+	entries := vm.peekN(int(ins.Size * 2))
+	dictionary := NewDictionaryValue(vm.config, typ, entries...)
+	vm.dropN(len(entries))
+
+	vm.push(dictionary)
 }
 
 func opNewRef(vm *VM, ins opcode.InstructionNewRef) {
@@ -734,6 +740,8 @@ func (vm *VM) run() {
 			opNew(vm, ins)
 		case opcode.InstructionNewArray:
 			opNewArray(vm, ins)
+		case opcode.InstructionNewDictionary:
+			opNewDictionary(vm, ins)
 		case opcode.InstructionNewRef:
 			opNewRef(vm, ins)
 		case opcode.InstructionSetField:


### PR DESCRIPTION

## Description

- Compile dictionary expression
- Add `NewDictionary` instruction in spec and implement it in the VM
- Add some tests for the compilation of arrays and dictionary expressions
- Fix bug in `DictionaryValue.Transfer`

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
