### PR TITLE
Handle command failures in update tool

### DIFF
--- a/tools/update/main.ts
+++ b/tools/update/main.ts
@@ -385,7 +385,7 @@ class Updater {
         const rootRepoVersion = this.getExpectedVersion(rootFullRepoName)
         const branch = ['auto-update', rootRepoOwner, rootRepoName, rootRepoVersion].join('-')
         console.log(`Creating branch ${branch} ...`)
-        await exec(`git checkout -b ${branch}`)
+        await exec(`git checkout -b ${branch}`, {strict: true})
 
         // TODO: only update dependencies that are updatable
 
@@ -403,20 +403,20 @@ class Updater {
 
             console.log(`Updating mod ${fullModName} to ${deps.join(', ')} ...`)
 
-            await exec(`go get ${deps.join(' ')}`)
+            await exec(`go get ${deps.join(' ')}`, {strict: true})
 
             console.log(`Cleaning up mod ${fullModName} ...`)
-            await exec(`go mod tidy`)
+            await exec(`go mod tidy`, {strict: true})
         }
 
         console.log(`Committing update ...`)
 
         const message = `Update to ${capitalizeFirstLetter(rootRepoName)} ${rootRepoVersion}`
 
-        await exec(`git commit -a -m "${message}"`)
+        await exec(`git commit -a -m "${message}"`, {strict: true})
 
         console.log(`Pushing update ...`)
-        await exec(`git push -u origin ${branch}"`)
+        await exec(`git push -u origin ${branch}"`, {strict: true})
 
         console.log(`Creating PR ...`)
 
@@ -540,14 +540,14 @@ class Releaser {
         process.chdir(dir)
 
         console.log(`Tagging ${this.repo} version ${this.version} ...`)
-        await exec(`git tag ${tag}`)
+        await exec(`git tag ${tag}`, {strict: true})
 
         if (this.modPath !== '') {
             console.log(`Pushing ${this.repo} mod ${this.modPath} version ${this.version} ...`)
         } else {
             console.log(`Pushing ${this.repo} version ${this.version} ...`)
         }
-        await exec(`git push origin --tags`)
+        await exec(`git push origin --tags`, {strict: true})
 
         console.log(`Cleaning up clone of ${this.repo}`)
         await rm(dir, { recursive: true, force: true })
@@ -707,7 +707,8 @@ async function gitClone(protocol: Protocol, fullRepoName: string, dir: string, b
             console.error(`unsupported protocol: ${protocol}`)
             return
     }
-    await exec(`git clone --depth 1 ${branch ? `-b ${branch} ` : ""}${prefix}${fullRepoName} ${dir}`)
+    const command = `git clone --depth 1 ${branch ? `-b ${branch} ` : ""}${prefix}${fullRepoName} ${dir}`
+    await exec(command, {strict: true})
 }
 
 async function runWithConsoleGroup(func: () => Promise<boolean>): Promise<boolean> {


### PR DESCRIPTION
## Description

It turns out that `exec` does not fail (reject the promise) when the command exits with a bad exit code.
Make command execution strict

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
