### PR TITLE
Fix backward compatibility job

### DIFF
--- a/.github/workflows/compatibility-check-template.yml
+++ b/.github/workflows/compatibility-check-template.yml
@@ -102,7 +102,7 @@ jobs:
       # Upload checking results for later use
 
       - name: Archive checking results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.chain }}-checking-results
           path: |

--- a/.github/workflows/get-contracts.yml
+++ b/.github/workflows/get-contracts.yml
@@ -45,7 +45,7 @@ jobs:
       # Upload
 
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.chain }}-contracts
           path: |


### PR DESCRIPTION

## Description

Update to latest supported version of the `actions/upload-artifact` action, v3 is now unsupported: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
