### PR TITLE
Decouple interpreter values from interpreter – Part 3

### DIFF
--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -24,10 +24,23 @@ import (
 )
 
 type TypeConverter interface {
-	MustConvertStaticToSemaType(staticType StaticType) sema.Type
+	ConvertStaticToSemaType(staticType StaticType) (sema.Type, error)
 }
 
 var _ TypeConverter = &Interpreter{}
+
+func MustConvertStaticToSemaType(staticType StaticType, typeConverter TypeConverter) sema.Type {
+	semaType, err := typeConverter.ConvertStaticToSemaType(staticType)
+	if err != nil {
+		panic(err)
+	}
+	return semaType
+}
+
+func MustSemaTypeOfValue(value Value, context ValueStaticTypeContext) sema.Type {
+	staticType := value.StaticType(context)
+	return MustConvertStaticToSemaType(staticType, context)
+}
 
 type SubTypeChecker interface {
 	IsSubTypeOfSemaType(staticSubType StaticType, superType sema.Type) bool

--- a/interpreter/interpreter_statement.go
+++ b/interpreter/interpreter_statement.go
@@ -597,10 +597,10 @@ func (interpreter *Interpreter) VisitSwapStatement(swap *ast.SwapStatement) Stat
 	// Set right value to left target,
 	// and left value to right target
 
-	interpreter.checkInvalidatedResourceOrResourceReference(rightValue, swap.Right)
+	checkInvalidatedResourceOrResourceReference(rightValue, rightLocationRange, interpreter)
 	transferredRightValue := interpreter.transferAndConvert(rightValue, rightType, leftType, rightLocationRange)
 
-	interpreter.checkInvalidatedResourceOrResourceReference(leftValue, swap.Left)
+	checkInvalidatedResourceOrResourceReference(leftValue, leftLocationRange, interpreter)
 	transferredLeftValue := interpreter.transferAndConvert(leftValue, leftType, rightType, leftLocationRange)
 
 	leftGetterSetter.set(transferredRightValue)

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -7461,7 +7461,7 @@ func TestInterpretReferenceEventParameter(t *testing.T) {
 		inter,
 		interpreter.UnauthorizedAccess,
 		arrayValue,
-		inter.MustConvertStaticToSemaType(arrayStaticType),
+		interpreter.MustConvertStaticToSemaType(arrayStaticType, inter),
 		interpreter.EmptyLocationRange,
 	)
 

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -110,7 +110,7 @@ func (v *SimpleCompositeValue) StaticType(_ ValueStaticTypeContext) StaticType {
 func (v *SimpleCompositeValue) IsImportable(inter *Interpreter, locationRange LocationRange) bool {
 	// Check type is importable
 	staticType := v.StaticType(inter)
-	semaType := inter.MustConvertStaticToSemaType(staticType)
+	semaType := MustConvertStaticToSemaType(staticType, inter)
 	if !semaType.IsImportable(map[*sema.Member]bool{}) {
 		return false
 	}

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -255,7 +255,7 @@ func (*SimpleCompositeValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (v *SimpleCompositeValue) IsResourceKinded(_ *Interpreter) bool {
+func (v *SimpleCompositeValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -110,7 +110,7 @@ type Value interface {
 	) bool
 	RecursiveString(seenReferences SeenReferences) string
 	MeteredString(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string
-	IsResourceKinded(interpreter *Interpreter) bool
+	IsResourceKinded(context ValueStaticTypeContext) bool
 	NeedsStoreTo(address atree.Address) bool
 	Transfer(
 		interpreter *Interpreter,

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -198,7 +198,7 @@ type ResourceKindedValue interface {
 	Value
 	Destroy(interpreter *Interpreter, locationRange LocationRange)
 	IsDestroyed() bool
-	isInvalidatedResource(*Interpreter) bool
+	isInvalidatedResource(context ValueStaticTypeContext) bool
 }
 
 func maybeDestroy(interpreter *Interpreter, locationRange LocationRange, value Value) {

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -165,7 +165,7 @@ func (*AccountCapabilityControllerValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*AccountCapabilityControllerValue) IsResourceKinded(_ *Interpreter) bool {
+func (*AccountCapabilityControllerValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -227,7 +227,7 @@ func (AddressValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (AddressValue) IsResourceKinded(_ *Interpreter) bool {
+func (AddressValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -1531,9 +1531,9 @@ func (v *ArrayValue) NeedsStoreTo(address atree.Address) bool {
 	return address != v.StorageAddress()
 }
 
-func (v *ArrayValue) IsResourceKinded(interpreter *Interpreter) bool {
+func (v *ArrayValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	if v.isResourceKinded == nil {
-		isResourceKinded := v.SemaType(interpreter).IsResourceType()
+		isResourceKinded := v.SemaType(context).IsResourceType()
 		v.isResourceKinded = &isResourceKinded
 	}
 	return *v.isResourceKinded

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -323,8 +323,8 @@ func (v *ArrayValue) IsImportable(inter *Interpreter, locationRange LocationRang
 	return importable
 }
 
-func (v *ArrayValue) isInvalidatedResource(interpreter *Interpreter) bool {
-	return v.isDestroyed || (v.array == nil && v.IsResourceKinded(interpreter))
+func (v *ArrayValue) isInvalidatedResource(context ValueStaticTypeContext) bool {
+	return v.isDestroyed || (v.array == nil && v.IsResourceKinded(context))
 }
 
 func (v *ArrayValue) IsStaleResource(interpreter *Interpreter) bool {

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -1522,7 +1522,7 @@ func (v *ArrayValue) GetOwner() common.Address {
 func (v *ArrayValue) SemaType(typeConverter TypeConverter) sema.ArrayType {
 	if v.semaType == nil {
 		// this function will panic already if this conversion fails
-		v.semaType, _ = typeConverter.MustConvertStaticToSemaType(v.Type).(sema.ArrayType)
+		v.semaType, _ = MustConvertStaticToSemaType(v.Type, typeConverter).(sema.ArrayType)
 	}
 	return v.semaType
 }

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -254,7 +254,7 @@ func (v *ArrayValue) iterate(
 			// atree.Array iteration provides low-level atree.Value,
 			// convert to high-level interpreter.Value
 			elementValue := MustConvertStoredValue(interpreter, element)
-			interpreter.checkInvalidatedResourceOrResourceReference(elementValue, locationRange)
+			checkInvalidatedResourceOrResourceReference(elementValue, locationRange, interpreter)
 
 			if transferElements {
 				// Each element must be transferred before passing onto the function.

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -162,7 +162,7 @@ func (BoolValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (BoolValue) IsResourceKinded(_ *Interpreter) bool {
+func (BoolValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -145,12 +145,12 @@ func (v *IDCapabilityValue) GetMember(interpreter *Interpreter, _ LocationRange,
 	switch name {
 	case sema.CapabilityTypeBorrowFunctionName:
 		// this function will panic already if this conversion fails
-		borrowType, _ := interpreter.MustConvertStaticToSemaType(v.BorrowType).(*sema.ReferenceType)
+		borrowType, _ := MustConvertStaticToSemaType(v.BorrowType, interpreter).(*sema.ReferenceType)
 		return interpreter.capabilityBorrowFunction(v, v.address, v.ID, borrowType)
 
 	case sema.CapabilityTypeCheckFunctionName:
 		// this function will panic already if this conversion fails
-		borrowType, _ := interpreter.MustConvertStaticToSemaType(v.BorrowType).(*sema.ReferenceType)
+		borrowType, _ := MustConvertStaticToSemaType(v.BorrowType, interpreter).(*sema.ReferenceType)
 		return interpreter.capabilityCheckFunction(v, v.address, v.ID, borrowType)
 
 	case sema.CapabilityTypeAddressFieldName:

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -217,7 +217,7 @@ func (*IDCapabilityValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*IDCapabilityValue) IsResourceKinded(_ *Interpreter) bool {
+func (*IDCapabilityValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -179,7 +179,7 @@ func (CharacterValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (CharacterValue) IsResourceKinded(_ *Interpreter) bool {
+func (CharacterValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -1556,7 +1556,7 @@ func (v *CompositeValue) forEachField(
 ) {
 	err := atreeIterate(func(key atree.Value, atreeValue atree.Value) (resume bool, err error) {
 		value := MustConvertStoredValue(interpreter, atreeValue)
-		interpreter.checkInvalidatedResourceOrResourceReference(value, locationRange)
+		checkInvalidatedResourceOrResourceReference(value, locationRange, interpreter)
 
 		resume = f(
 			string(key.(StringAtreeValue)),
@@ -1819,7 +1819,7 @@ func forEachAttachment(
 
 	for {
 		// Check that the implicit composite reference was not invalidated during iteration
-		interpreter.checkInvalidatedResourceOrResourceReference(compositeReference, locationRange)
+		checkInvalidatedResourceOrResourceReference(compositeReference, locationRange, interpreter)
 		key, value, err := iterator.Next()
 		if err != nil {
 			panic(errors.NewExternalError(err))

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -1159,9 +1159,9 @@ func (v *CompositeValue) NeedsStoreTo(address atree.Address) bool {
 	return address != v.StorageAddress()
 }
 
-func (v *CompositeValue) IsResourceKinded(interpreter *Interpreter) bool {
+func (v *CompositeValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	if v.Kind == common.CompositeKindAttachment {
-		return MustSemaTypeOfValue(v, interpreter).IsResourceType()
+		return MustSemaTypeOfValue(v, context).IsResourceType()
 	}
 	return v.Kind == common.CompositeKindResource
 }

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -501,7 +501,7 @@ func compositeMember(interpreter *Interpreter, compositeValue Value, memberValue
 	return memberValue
 }
 
-func (v *CompositeValue) isInvalidatedResource(_ *Interpreter) bool {
+func (v *CompositeValue) isInvalidatedResource(context ValueStaticTypeContext) bool {
 	return v.isDestroyed || (v.dictionary == nil && v.Kind == common.CompositeKindResource)
 }
 

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -474,8 +474,8 @@ func (v *DictionaryValue) IsDestroyed() bool {
 	return v.isDestroyed
 }
 
-func (v *DictionaryValue) isInvalidatedResource(interpreter *Interpreter) bool {
-	return v.isDestroyed || (v.dictionary == nil && v.IsResourceKinded(interpreter))
+func (v *DictionaryValue) isInvalidatedResource(context ValueStaticTypeContext) bool {
+	return v.isDestroyed || (v.dictionary == nil && v.IsResourceKinded(context))
 }
 
 func (v *DictionaryValue) IsStaleResource(interpreter *Interpreter) bool {

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -1571,10 +1571,10 @@ func (v *DictionaryValue) ValueID() atree.ValueID {
 	return v.dictionary.ValueID()
 }
 
-func (v *DictionaryValue) SemaType(interpreter *Interpreter) *sema.DictionaryType {
+func (v *DictionaryValue) SemaType(typeConverter TypeConverter) *sema.DictionaryType {
 	if v.semaType == nil {
 		// this function will panic already if this conversion fails
-		v.semaType, _ = MustConvertStaticToSemaType(v.Type, interpreter).(*sema.DictionaryType)
+		v.semaType, _ = MustConvertStaticToSemaType(v.Type, typeConverter).(*sema.DictionaryType)
 	}
 	return v.semaType
 }

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -343,7 +343,7 @@ func (v *DictionaryValue) Iterate(
 	v.iterate(interpreter, iterate, f, locationRange)
 }
 
-// IterateReadOnlyLoaded iterates over all LOADED key-valye pairs of the array.
+// IterateReadOnlyLoaded iterates over all LOADED key-value pairs of the array.
 // DO NOT perform storage mutations in the callback!
 func (v *DictionaryValue) IterateReadOnlyLoaded(
 	interpreter *Interpreter,
@@ -372,8 +372,8 @@ func (v *DictionaryValue) iterate(
 			keyValue := MustConvertStoredValue(interpreter, key)
 			valueValue := MustConvertStoredValue(interpreter, value)
 
-			interpreter.checkInvalidatedResourceOrResourceReference(keyValue, locationRange)
-			interpreter.checkInvalidatedResourceOrResourceReference(valueValue, locationRange)
+			checkInvalidatedResourceOrResourceReference(keyValue, locationRange, interpreter)
+			checkInvalidatedResourceOrResourceReference(valueValue, locationRange, interpreter)
 
 			resume = f(
 				keyValue,

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -1583,9 +1583,9 @@ func (v *DictionaryValue) NeedsStoreTo(address atree.Address) bool {
 	return address != v.StorageAddress()
 }
 
-func (v *DictionaryValue) IsResourceKinded(interpreter *Interpreter) bool {
+func (v *DictionaryValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	if v.isResourceKinded == nil {
-		isResourceKinded := v.SemaType(interpreter).IsResourceType()
+		isResourceKinded := v.SemaType(context).IsResourceType()
 		v.isResourceKinded = &isResourceKinded
 	}
 	return *v.isResourceKinded

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -1574,7 +1574,7 @@ func (v *DictionaryValue) ValueID() atree.ValueID {
 func (v *DictionaryValue) SemaType(interpreter *Interpreter) *sema.DictionaryType {
 	if v.semaType == nil {
 		// this function will panic already if this conversion fails
-		v.semaType, _ = interpreter.MustConvertStaticToSemaType(v.Type).(*sema.DictionaryType)
+		v.semaType, _ = MustConvertStaticToSemaType(v.Type, interpreter).(*sema.DictionaryType)
 	}
 	return v.semaType
 }

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -305,7 +305,7 @@ func (*EphemeralReferenceValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*EphemeralReferenceValue) IsResourceKinded(_ *Interpreter) bool {
+func (*EphemeralReferenceValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -566,7 +566,7 @@ func (Fix64Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Fix64Value) IsResourceKinded(_ *Interpreter) bool {
+func (Fix64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -459,7 +459,7 @@ func (f BoundFunctionValue) invoke(invocation Invocation) Value {
 			})
 		}
 	} else {
-		inter.checkInvalidatedResourceOrResourceReference(f.SelfReference, locationRange)
+		checkInvalidatedResourceOrResourceReference(f.SelfReference, locationRange, inter)
 	}
 
 	return f.Function.invoke(invocation)

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -352,7 +352,7 @@ func NewBoundFunctionValue(
 
 	selfRef, selfIsRef := (*self).(ReferenceValue)
 	if !selfIsRef {
-		semaType := interpreter.MustSemaTypeOfValue(*self)
+		semaType := MustSemaTypeOfValue(*self, interpreter)
 		selfRef = NewEphemeralReferenceValue(interpreter, boundAuth, *self, semaType, EmptyLocationRange)
 	}
 

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -141,7 +141,7 @@ func (*InterpretedFunctionValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*InterpretedFunctionValue) IsResourceKinded(_ *Interpreter) bool {
+func (*InterpretedFunctionValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -294,7 +294,7 @@ func (*HostFunctionValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*HostFunctionValue) IsResourceKinded(_ *Interpreter) bool {
+func (*HostFunctionValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -485,7 +485,7 @@ func (BoundFunctionValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (BoundFunctionValue) IsResourceKinded(_ *Interpreter) bool {
+func (BoundFunctionValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -614,7 +614,7 @@ func (IntValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (IntValue) IsResourceKinded(_ *Interpreter) bool {
+func (IntValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -451,19 +451,19 @@ func (v IntValue) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []byt
 	return buffer
 }
 
-func (v IntValue) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v IntValue) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewIntValueFromBigInt(
-		interpreter,
+		context,
 		common.NewBitwiseOrBigIntMemoryUsage(v.BigInt, o.BigInt),
 		func() *big.Int {
 			res := new(big.Int)
@@ -472,19 +472,19 @@ func (v IntValue) BitwiseOr(interpreter *Interpreter, other IntegerValue, locati
 	)
 }
 
-func (v IntValue) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v IntValue) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewIntValueFromBigInt(
-		interpreter,
+		context,
 		common.NewBitwiseXorBigIntMemoryUsage(v.BigInt, o.BigInt),
 		func() *big.Int {
 			res := new(big.Int)
@@ -493,19 +493,19 @@ func (v IntValue) BitwiseXor(interpreter *Interpreter, other IntegerValue, locat
 	)
 }
 
-func (v IntValue) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v IntValue) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewIntValueFromBigInt(
-		interpreter,
+		context,
 		common.NewBitwiseAndBigIntMemoryUsage(v.BigInt, o.BigInt),
 		func() *big.Int {
 			res := new(big.Int)
@@ -514,13 +514,13 @@ func (v IntValue) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locat
 	)
 }
 
-func (v IntValue) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v IntValue) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -538,7 +538,7 @@ func (v IntValue) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue,
 	}
 
 	return NewIntValueFromBigInt(
-		interpreter,
+		context,
 		common.NewBitwiseLeftShiftBigIntMemoryUsage(v.BigInt, o.BigInt),
 		func() *big.Int {
 			res := new(big.Int)
@@ -547,13 +547,13 @@ func (v IntValue) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue,
 	)
 }
 
-func (v IntValue) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v IntValue) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -571,7 +571,7 @@ func (v IntValue) BitwiseRightShift(interpreter *Interpreter, other IntegerValue
 	}
 
 	return NewIntValueFromBigInt(
-		interpreter,
+		context,
 		common.NewBitwiseRightShiftBigIntMemoryUsage(v.BigInt, o.BigInt),
 		func() *big.Int {
 			res := new(big.Int)

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -771,7 +771,7 @@ func (Int128Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Int128Value) IsResourceKinded(_ *Interpreter) bool {
+func (Int128Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -612,13 +612,13 @@ func ConvertInt128(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 	return NewInt128ValueFromBigInt(memoryGauge, converter)
 }
 
-func (v Int128Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int128Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -629,16 +629,16 @@ func (v Int128Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, loc
 		return res
 	}
 
-	return NewInt128ValueFromBigInt(interpreter, valueGetter)
+	return NewInt128ValueFromBigInt(context, valueGetter)
 }
 
-func (v Int128Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int128Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -649,16 +649,16 @@ func (v Int128Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, lo
 		return res
 	}
 
-	return NewInt128ValueFromBigInt(interpreter, valueGetter)
+	return NewInt128ValueFromBigInt(context, valueGetter)
 }
 
-func (v Int128Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int128Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -669,16 +669,16 @@ func (v Int128Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, lo
 		return res
 	}
 
-	return NewInt128ValueFromBigInt(interpreter, valueGetter)
+	return NewInt128ValueFromBigInt(context, valueGetter)
 }
 
-func (v Int128Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int128Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -689,13 +689,13 @@ func (v Int128Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVal
 		})
 	}
 	if !o.BigInt.IsUint64() || o.BigInt.Uint64() >= 128 {
-		return NewInt128ValueFromUint64(interpreter, 0)
+		return NewInt128ValueFromUint64(context, 0)
 	}
 
 	// The maximum shift value at this point is 127, which may lead to an
 	// additional allocation of up to 128 bits. Add usage for possible
 	// intermediate value.
-	common.UseMemory(interpreter, Int128MemoryUsage)
+	common.UseMemory(context, Int128MemoryUsage)
 
 	valueGetter := func() *big.Int {
 		res := new(big.Int)
@@ -705,16 +705,16 @@ func (v Int128Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVal
 		return fromTwosComplement(res)
 	}
 
-	return NewInt128ValueFromBigInt(interpreter, valueGetter)
+	return NewInt128ValueFromBigInt(context, valueGetter)
 }
 
-func (v Int128Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int128Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -725,7 +725,7 @@ func (v Int128Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 		})
 	}
 	if !o.BigInt.IsUint64() {
-		return NewInt128ValueFromUint64(interpreter, 0)
+		return NewInt128ValueFromUint64(context, 0)
 	}
 
 	valueGetter := func() *big.Int {
@@ -734,7 +734,7 @@ func (v Int128Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 		return res
 	}
 
-	return NewInt128ValueFromBigInt(interpreter, valueGetter)
+	return NewInt128ValueFromBigInt(context, valueGetter)
 }
 
 func (v Int128Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -510,13 +510,13 @@ func ConvertInt16(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 	return NewInt16Value(memoryGauge, converter)
 }
 
-func (v Int16Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int16Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -525,16 +525,16 @@ func (v Int16Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, loca
 		return int16(v | o)
 	}
 
-	return NewInt16Value(interpreter, valueGetter)
+	return NewInt16Value(context, valueGetter)
 }
 
-func (v Int16Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int16Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -543,16 +543,16 @@ func (v Int16Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, loc
 		return int16(v ^ o)
 	}
 
-	return NewInt16Value(interpreter, valueGetter)
+	return NewInt16Value(context, valueGetter)
 }
 
-func (v Int16Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int16Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -561,16 +561,16 @@ func (v Int16Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, loc
 		return int16(v & o)
 	}
 
-	return NewInt16Value(interpreter, valueGetter)
+	return NewInt16Value(context, valueGetter)
 }
 
-func (v Int16Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int16Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -585,16 +585,16 @@ func (v Int16Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValu
 		return int16(v << o)
 	}
 
-	return NewInt16Value(interpreter, valueGetter)
+	return NewInt16Value(context, valueGetter)
 }
 
-func (v Int16Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int16Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -609,7 +609,7 @@ func (v Int16Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVal
 		return int16(v >> o)
 	}
 
-	return NewInt16Value(interpreter, valueGetter)
+	return NewInt16Value(context, valueGetter)
 }
 
 func (v Int16Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -648,7 +648,7 @@ func (Int16Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Int16Value) IsResourceKinded(_ *Interpreter) bool {
+func (Int16Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -579,13 +579,13 @@ func ConvertInt256(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 	return NewInt256ValueFromBigInt(memoryGauge, converter)
 }
 
-func (v Int256Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int256Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -596,16 +596,16 @@ func (v Int256Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, loc
 		return res
 	}
 
-	return NewInt256ValueFromBigInt(interpreter, valueGetter)
+	return NewInt256ValueFromBigInt(context, valueGetter)
 }
 
-func (v Int256Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int256Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -616,16 +616,16 @@ func (v Int256Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, lo
 		return res
 	}
 
-	return NewInt256ValueFromBigInt(interpreter, valueGetter)
+	return NewInt256ValueFromBigInt(context, valueGetter)
 }
 
-func (v Int256Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int256Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -636,16 +636,16 @@ func (v Int256Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, lo
 		return res
 	}
 
-	return NewInt256ValueFromBigInt(interpreter, valueGetter)
+	return NewInt256ValueFromBigInt(context, valueGetter)
 }
 
-func (v Int256Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int256Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -656,13 +656,13 @@ func (v Int256Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVal
 		})
 	}
 	if !o.BigInt.IsUint64() || o.BigInt.Uint64() >= 256 {
-		return NewInt256ValueFromUint64(interpreter, 0)
+		return NewInt256ValueFromUint64(context, 0)
 	}
 
 	// The maximum shift value at this point is 255, which may lead to an
 	// additional allocation of up to 256 bits. Add usage for possible
 	// intermediate value.
-	common.UseMemory(interpreter, Int256MemoryUsage)
+	common.UseMemory(context, Int256MemoryUsage)
 
 	valueGetter := func() *big.Int {
 		res := new(big.Int)
@@ -672,16 +672,16 @@ func (v Int256Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVal
 		return fromTwosComplement(res)
 	}
 
-	return NewInt256ValueFromBigInt(interpreter, valueGetter)
+	return NewInt256ValueFromBigInt(context, valueGetter)
 }
 
-func (v Int256Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int256Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -692,7 +692,7 @@ func (v Int256Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 		})
 	}
 	if !o.BigInt.IsUint64() {
-		return NewInt256ValueFromUint64(interpreter, 0)
+		return NewInt256ValueFromUint64(context, 0)
 	}
 
 	valueGetter := func() *big.Int {
@@ -701,7 +701,7 @@ func (v Int256Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 		return res
 	}
 
-	return NewInt256ValueFromBigInt(interpreter, valueGetter)
+	return NewInt256ValueFromBigInt(context, valueGetter)
 }
 
 func (v Int256Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -738,7 +738,7 @@ func (Int256Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Int256Value) IsResourceKinded(_ *Interpreter) bool {
+func (Int256Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -648,7 +648,7 @@ func (Int32Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Int32Value) IsResourceKinded(_ *Interpreter) bool {
+func (Int32Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -510,13 +510,13 @@ func ConvertInt32(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 	return NewInt32Value(memoryGauge, converter)
 }
 
-func (v Int32Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int32Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -525,16 +525,16 @@ func (v Int32Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, loca
 		return int32(v | o)
 	}
 
-	return NewInt32Value(interpreter, valueGetter)
+	return NewInt32Value(context, valueGetter)
 }
 
-func (v Int32Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int32Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -543,16 +543,16 @@ func (v Int32Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, loc
 		return int32(v ^ o)
 	}
 
-	return NewInt32Value(interpreter, valueGetter)
+	return NewInt32Value(context, valueGetter)
 }
 
-func (v Int32Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int32Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -561,16 +561,16 @@ func (v Int32Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, loc
 		return int32(v & o)
 	}
 
-	return NewInt32Value(interpreter, valueGetter)
+	return NewInt32Value(context, valueGetter)
 }
 
-func (v Int32Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int32Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -585,16 +585,16 @@ func (v Int32Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValu
 		return int32(v << o)
 	}
 
-	return NewInt32Value(interpreter, valueGetter)
+	return NewInt32Value(context, valueGetter)
 }
 
-func (v Int32Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int32Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -609,7 +609,7 @@ func (v Int32Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVal
 		return int32(v >> o)
 	}
 
-	return NewInt32Value(interpreter, valueGetter)
+	return NewInt32Value(context, valueGetter)
 }
 
 func (v Int32Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -501,13 +501,13 @@ func ConvertInt64(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 	return NewInt64Value(memoryGauge, converter)
 }
 
-func (v Int64Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int64Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -516,16 +516,16 @@ func (v Int64Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, loca
 		return int64(v | o)
 	}
 
-	return NewInt64Value(interpreter, valueGetter)
+	return NewInt64Value(context, valueGetter)
 }
 
-func (v Int64Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int64Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -534,16 +534,16 @@ func (v Int64Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, loc
 		return int64(v ^ o)
 	}
 
-	return NewInt64Value(interpreter, valueGetter)
+	return NewInt64Value(context, valueGetter)
 }
 
-func (v Int64Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int64Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -552,16 +552,16 @@ func (v Int64Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, loc
 		return int64(v & o)
 	}
 
-	return NewInt64Value(interpreter, valueGetter)
+	return NewInt64Value(context, valueGetter)
 }
 
-func (v Int64Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int64Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -576,16 +576,16 @@ func (v Int64Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValu
 		return int64(v << o)
 	}
 
-	return NewInt64Value(interpreter, valueGetter)
+	return NewInt64Value(context, valueGetter)
 }
 
-func (v Int64Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int64Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -600,7 +600,7 @@ func (v Int64Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVal
 		return int64(v >> o)
 	}
 
-	return NewInt64Value(interpreter, valueGetter)
+	return NewInt64Value(context, valueGetter)
 }
 
 func (v Int64Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -639,7 +639,7 @@ func (Int64Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Int64Value) IsResourceKinded(_ *Interpreter) bool {
+func (Int64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -509,13 +509,13 @@ func ConvertInt8(memoryGauge common.MemoryGauge, value Value, locationRange Loca
 	return NewInt8Value(memoryGauge, converter)
 }
 
-func (v Int8Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int8Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -524,16 +524,16 @@ func (v Int8Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locat
 		return int8(v | o)
 	}
 
-	return NewInt8Value(interpreter, valueGetter)
+	return NewInt8Value(context, valueGetter)
 }
 
-func (v Int8Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int8Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -542,16 +542,16 @@ func (v Int8Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, loca
 		return int8(v ^ o)
 	}
 
-	return NewInt8Value(interpreter, valueGetter)
+	return NewInt8Value(context, valueGetter)
 }
 
-func (v Int8Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int8Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -560,16 +560,16 @@ func (v Int8Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, loca
 		return int8(v & o)
 	}
 
-	return NewInt8Value(interpreter, valueGetter)
+	return NewInt8Value(context, valueGetter)
 }
 
-func (v Int8Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int8Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -584,16 +584,16 @@ func (v Int8Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue
 		return int8(v << o)
 	}
 
-	return NewInt8Value(interpreter, valueGetter)
+	return NewInt8Value(context, valueGetter)
 }
 
-func (v Int8Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Int8Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -608,7 +608,7 @@ func (v Int8Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValu
 		return int8(v >> o)
 	}
 
-	return NewInt8Value(interpreter, valueGetter)
+	return NewInt8Value(context, valueGetter)
 }
 
 func (v Int8Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -645,7 +645,7 @@ func (Int8Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Int8Value) IsResourceKinded(_ *Interpreter) bool {
+func (Int8Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_link.go
+++ b/interpreter/value_link.go
@@ -120,7 +120,7 @@ func (PathLinkValue) NeedsStoreTo(_ atree.Address) bool {
 	panic(errors.NewUnreachableError())
 }
 
-func (PathLinkValue) IsResourceKinded(_ *Interpreter) bool {
+func (PathLinkValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	panic(errors.NewUnreachableError())
 }
 
@@ -243,7 +243,7 @@ func (AccountLinkValue) NeedsStoreTo(_ atree.Address) bool {
 	panic(errors.NewUnreachableError())
 }
 
-func (AccountLinkValue) IsResourceKinded(_ *Interpreter) bool {
+func (AccountLinkValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	panic(errors.NewUnreachableError())
 }
 

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -181,6 +181,6 @@ func (NilValue) ChildStorables() []atree.Storable {
 	return nil
 }
 
-func (NilValue) isInvalidatedResource(_ *Interpreter) bool {
+func (NilValue) isInvalidatedResource(context ValueStaticTypeContext) bool {
 	return false
 }

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -142,7 +142,7 @@ func (NilValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (NilValue) IsResourceKinded(_ *Interpreter) bool {
+func (NilValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -168,11 +168,11 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 
 type IntegerValue interface {
 	NumberValue
-	BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue
-	BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue
-	BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue
-	BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue
-	BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue
+	BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue
+	BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue
+	BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue
+	BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue
+	BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue
 }
 
 // BigNumberValue is a number value with an integer value outside the range of int64

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -225,7 +225,7 @@ func (PathValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (PathValue) IsResourceKinded(_ *Interpreter) bool {
+func (PathValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -161,7 +161,7 @@ func (v *PathCapabilityValue) GetMember(interpreter *Interpreter, _ LocationRang
 		var borrowType *sema.ReferenceType
 		if v.BorrowType != nil {
 			// this function will panic already if this conversion fails
-			borrowType, _ = interpreter.MustConvertStaticToSemaType(v.BorrowType).(*sema.ReferenceType)
+			borrowType, _ = MustConvertStaticToSemaType(v.BorrowType, interpreter).(*sema.ReferenceType)
 		}
 		return v.newBorrowFunction(interpreter, borrowType)
 
@@ -169,7 +169,7 @@ func (v *PathCapabilityValue) GetMember(interpreter *Interpreter, _ LocationRang
 		var borrowType *sema.ReferenceType
 		if v.BorrowType != nil {
 			// this function will panic already if this conversion fails
-			borrowType, _ = interpreter.MustConvertStaticToSemaType(v.BorrowType).(*sema.ReferenceType)
+			borrowType, _ = MustConvertStaticToSemaType(v.BorrowType, interpreter).(*sema.ReferenceType)
 		}
 		return v.newCheckFunction(interpreter, borrowType)
 

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -240,7 +240,7 @@ func (*PathCapabilityValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*PathCapabilityValue) IsResourceKinded(_ *Interpreter) bool {
+func (*PathCapabilityValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_placeholder.go
+++ b/interpreter/value_placeholder.go
@@ -75,7 +75,7 @@ func (placeholderValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (placeholderValue) IsResourceKinded(_ *Interpreter) bool {
+func (placeholderValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_published.go
+++ b/interpreter/value_published.go
@@ -120,7 +120,7 @@ func (v *PublishedValue) NeedsStoreTo(address atree.Address) bool {
 	return v.Value.NeedsStoreTo(address)
 }
 
-func (*PublishedValue) IsResourceKinded(_ *Interpreter) bool {
+func (*PublishedValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_range.go
+++ b/interpreter/value_range.go
@@ -45,7 +45,7 @@ func NewInclusiveRangeValue(
 
 	step := GetSmallIntegerValue(1, rangeStaticType.ElementType)
 	if startComparable.Greater(interpreter, endComparable, locationRange) {
-		elemSemaTy := interpreter.MustConvertStaticToSemaType(rangeStaticType.ElementType)
+		elemSemaTy := MustConvertStaticToSemaType(rangeStaticType.ElementType, interpreter)
 		if elemSemaTy.Tag().BelongsTo(sema.UnsignedIntegerTypeTag) {
 			panic(InclusiveRangeConstructionError{
 				LocationRange: locationRange,

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -404,7 +404,7 @@ func (v *SomeValue) InnerValue() Value {
 	return v.value
 }
 
-func (v *SomeValue) isInvalidatedResource(_ *Interpreter) bool {
+func (v *SomeValue) isInvalidatedResource(context ValueStaticTypeContext) bool {
 	return v.value == nil || v.IsDestroyed()
 }
 

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -322,13 +322,13 @@ func (v *SomeValue) NeedsStoreTo(address atree.Address) bool {
 	return v.value.NeedsStoreTo(address)
 }
 
-func (v *SomeValue) IsResourceKinded(interpreter *Interpreter) bool {
+func (v *SomeValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	// If the inner value is `nil`, then this is an invalidated resource.
 	if v.value == nil {
 		return true
 	}
 
-	return v.value.IsResourceKinded(interpreter)
+	return v.value.IsResourceKinded(context)
 }
 
 func (v *SomeValue) Transfer(

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -148,8 +148,9 @@ func (v *SomeValue) MeteredString(interpreter *Interpreter, seenReferences SeenR
 func (v *SomeValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
 	switch name {
 	case sema.OptionalTypeMapFunctionName:
-		innerValueType := interpreter.MustConvertStaticToSemaType(
+		innerValueType := MustConvertStaticToSemaType(
 			v.value.StaticType(interpreter),
+			interpreter,
 		)
 		return NewBoundHostFunctionValue(
 			interpreter,

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -144,7 +144,7 @@ func (v *StorageReferenceValue) dereference(context ValueStaticTypeContext, loca
 		staticType := referenced.StaticType(context)
 
 		if !context.IsSubTypeOfSemaType(staticType, v.BorrowedType) {
-			semaType := context.MustConvertStaticToSemaType(staticType)
+			semaType := MustConvertStaticToSemaType(staticType, context)
 
 			return nil, ForceCastTypeMismatchError{
 				ExpectedType:  v.BorrowedType,

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -378,7 +378,7 @@ func (*StorageReferenceValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*StorageReferenceValue) IsResourceKinded(_ *Interpreter) bool {
+func (*StorageReferenceValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -449,7 +449,7 @@ func forEachReference(
 		// The loop dereference the reference once, and hold onto that referenced-value.
 		// But the reference could get invalidated during the iteration, making that referenced-value invalid.
 		// So check the validity of the reference, before each iteration.
-		interpreter.checkInvalidatedResourceOrResourceReference(reference, locationRange)
+		checkInvalidatedResourceOrResourceReference(reference, locationRange, interpreter)
 
 		if isResultReference {
 			value = interpreter.getReferenceValue(value, elementType, locationRange)

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -190,7 +190,7 @@ func (*StorageCapabilityControllerValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*StorageCapabilityControllerValue) IsResourceKinded(_ *Interpreter) bool {
+func (*StorageCapabilityControllerValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -734,7 +734,7 @@ func (*StringValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*StringValue) IsResourceKinded(_ *Interpreter) bool {
+func (*StringValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -294,7 +294,7 @@ func (TypeValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (TypeValue) IsResourceKinded(_ *Interpreter) bool {
+func (TypeValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -150,8 +150,8 @@ func (v TypeValue) GetMember(interpreter *Interpreter, _ LocationRange, name str
 				}
 
 				result := sema.IsSubType(
-					interpreter.MustConvertStaticToSemaType(staticType),
-					interpreter.MustConvertStaticToSemaType(otherStaticType),
+					MustConvertStaticToSemaType(staticType, interpreter),
+					MustConvertStaticToSemaType(otherStaticType, interpreter),
 				)
 				return AsBoolValue(result)
 			},

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -522,7 +522,7 @@ func (UFix64Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UFix64Value) IsResourceKinded(_ *Interpreter) bool {
+func (UFix64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -622,7 +622,7 @@ func (UIntValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UIntValue) IsResourceKinded(_ *Interpreter) bool {
+func (UIntValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -459,19 +459,19 @@ func (v UIntValue) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []by
 	return buffer
 }
 
-func (v UIntValue) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UIntValue) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUIntValueFromBigInt(
-		interpreter,
+		context,
 		common.NewBitwiseOrBigIntMemoryUsage(v.BigInt, o.BigInt),
 		func() *big.Int {
 			res := new(big.Int)
@@ -480,19 +480,19 @@ func (v UIntValue) BitwiseOr(interpreter *Interpreter, other IntegerValue, locat
 	)
 }
 
-func (v UIntValue) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UIntValue) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUIntValueFromBigInt(
-		interpreter,
+		context,
 		common.NewBitwiseXorBigIntMemoryUsage(v.BigInt, o.BigInt),
 		func() *big.Int {
 			res := new(big.Int)
@@ -501,19 +501,19 @@ func (v UIntValue) BitwiseXor(interpreter *Interpreter, other IntegerValue, loca
 	)
 }
 
-func (v UIntValue) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UIntValue) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUIntValueFromBigInt(
-		interpreter,
+		context,
 		common.NewBitwiseAndBigIntMemoryUsage(v.BigInt, o.BigInt),
 		func() *big.Int {
 			res := new(big.Int)
@@ -522,13 +522,13 @@ func (v UIntValue) BitwiseAnd(interpreter *Interpreter, other IntegerValue, loca
 	)
 }
 
-func (v UIntValue) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UIntValue) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -546,7 +546,7 @@ func (v UIntValue) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue
 	}
 
 	return NewUIntValueFromBigInt(
-		interpreter,
+		context,
 		common.NewBitwiseLeftShiftBigIntMemoryUsage(v.BigInt, o.BigInt),
 		func() *big.Int {
 			res := new(big.Int)
@@ -556,13 +556,13 @@ func (v UIntValue) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue
 	)
 }
 
-func (v UIntValue) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UIntValue) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -579,7 +579,7 @@ func (v UIntValue) BitwiseRightShift(interpreter *Interpreter, other IntegerValu
 	}
 
 	return NewUIntValueFromBigInt(
-		interpreter,
+		context,
 		common.NewBitwiseRightShiftBigIntMemoryUsage(v.BigInt, o.BigInt),
 		func() *big.Int {
 			res := new(big.Int)

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -672,7 +672,7 @@ func (UInt128Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UInt128Value) IsResourceKinded(_ *Interpreter) bool {
+func (UInt128Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -37,9 +37,9 @@ type UInt128Value struct {
 	BigInt *big.Int
 }
 
-func NewUInt128ValueFromUint64(interpreter *Interpreter, value uint64) UInt128Value {
+func NewUInt128ValueFromUint64(memoryGauge common.MemoryGauge, value uint64) UInt128Value {
 	return NewUInt128ValueFromBigInt(
-		interpreter,
+		memoryGauge,
 		func() *big.Int {
 			return new(big.Int).SetUint64(value)
 		},
@@ -509,19 +509,19 @@ func ConvertUInt128(memoryGauge common.MemoryGauge, value Value, locationRange L
 	)
 }
 
-func (v UInt128Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt128Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt128ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.Or(v.BigInt, o.BigInt)
@@ -529,19 +529,19 @@ func (v UInt128Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, lo
 	)
 }
 
-func (v UInt128Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt128Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt128ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.Xor(v.BigInt, o.BigInt)
@@ -549,19 +549,19 @@ func (v UInt128Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, l
 	)
 }
 
-func (v UInt128Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt128Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt128ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.And(v.BigInt, o.BigInt)
@@ -570,13 +570,13 @@ func (v UInt128Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, l
 
 }
 
-func (v UInt128Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt128Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -587,16 +587,16 @@ func (v UInt128Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVa
 		})
 	}
 	if !o.BigInt.IsUint64() || o.BigInt.Uint64() >= 128 {
-		return NewUInt128ValueFromUint64(interpreter, 0)
+		return NewUInt128ValueFromUint64(context, 0)
 	}
 
 	// The maximum shift value at this point is 127, which may lead to an
 	// additional allocation of up to 128 bits. Add usage for possible
 	// intermediate value.
-	common.UseMemory(interpreter, Uint128MemoryUsage)
+	common.UseMemory(context, Uint128MemoryUsage)
 
 	return NewUInt128ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			res = res.Lsh(v.BigInt, uint(o.BigInt.Uint64()))
@@ -605,13 +605,13 @@ func (v UInt128Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVa
 	)
 }
 
-func (v UInt128Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt128Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -622,11 +622,11 @@ func (v UInt128Value) BitwiseRightShift(interpreter *Interpreter, other IntegerV
 		})
 	}
 	if !o.BigInt.IsUint64() {
-		return NewUInt128ValueFromUint64(interpreter, 0)
+		return NewUInt128ValueFromUint64(context, 0)
 	}
 
 	return NewUInt128ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.Rsh(v.BigInt, uint(o.BigInt.Uint64()))

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -400,95 +400,95 @@ func ConvertUInt16(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 	)
 }
 
-func (v UInt16Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt16Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt16Value(
-		interpreter,
+		context,
 		func() uint16 {
 			return uint16(v | o)
 		},
 	)
 }
 
-func (v UInt16Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt16Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt16Value(
-		interpreter,
+		context,
 		func() uint16 {
 			return uint16(v ^ o)
 		},
 	)
 }
 
-func (v UInt16Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt16Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt16Value(
-		interpreter,
+		context,
 		func() uint16 {
 			return uint16(v & o)
 		},
 	)
 }
 
-func (v UInt16Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt16Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt16Value(
-		interpreter,
+		context,
 		func() uint16 {
 			return uint16(v << o)
 		},
 	)
 }
 
-func (v UInt16Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt16Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt16Value(
-		interpreter,
+		context,
 		func() uint16 {
 			return uint16(v >> o)
 		},

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -535,7 +535,7 @@ func (UInt16Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UInt16Value) IsResourceKinded(_ *Interpreter) bool {
+func (UInt16Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -672,7 +672,7 @@ func (UInt256Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UInt256Value) IsResourceKinded(_ *Interpreter) bool {
+func (UInt256Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 func (v UInt256Value) Transfer(

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -37,9 +37,9 @@ type UInt256Value struct {
 	BigInt *big.Int
 }
 
-func NewUInt256ValueFromUint64(interpreter *Interpreter, value uint64) UInt256Value {
+func NewUInt256ValueFromUint64(memoryGauge common.MemoryGauge, value uint64) UInt256Value {
 	return NewUInt256ValueFromBigInt(
-		interpreter,
+		memoryGauge,
 		func() *big.Int {
 			return new(big.Int).SetUint64(value)
 		},
@@ -510,19 +510,19 @@ func ConvertUInt256(memoryGauge common.MemoryGauge, value Value, locationRange L
 	)
 }
 
-func (v UInt256Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt256Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt256ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.Or(v.BigInt, o.BigInt)
@@ -530,19 +530,19 @@ func (v UInt256Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, lo
 	)
 }
 
-func (v UInt256Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt256Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt256ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.Xor(v.BigInt, o.BigInt)
@@ -550,19 +550,19 @@ func (v UInt256Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, l
 	)
 }
 
-func (v UInt256Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt256Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt256ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.And(v.BigInt, o.BigInt)
@@ -570,13 +570,13 @@ func (v UInt256Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, l
 	)
 }
 
-func (v UInt256Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt256Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -587,16 +587,16 @@ func (v UInt256Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVa
 		})
 	}
 	if !o.BigInt.IsUint64() || o.BigInt.Uint64() >= 256 {
-		return NewUInt256ValueFromUint64(interpreter, 0)
+		return NewUInt256ValueFromUint64(context, 0)
 	}
 
 	// The maximum shift value at this point is 255, which may lead to an
 	// additional allocation of up to 256 bits. Add usage for possible
 	// intermediate value.
-	common.UseMemory(interpreter, Uint256MemoryUsage)
+	common.UseMemory(context, Uint256MemoryUsage)
 
 	return NewUInt256ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			res = res.Lsh(v.BigInt, uint(o.BigInt.Uint64()))
@@ -605,13 +605,13 @@ func (v UInt256Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVa
 	)
 }
 
-func (v UInt256Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt256Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -622,11 +622,11 @@ func (v UInt256Value) BitwiseRightShift(interpreter *Interpreter, other IntegerV
 		})
 	}
 	if !o.BigInt.IsUint64() {
-		return NewUInt256ValueFromUint64(interpreter, 0)
+		return NewUInt256ValueFromUint64(context, 0)
 	}
 
 	return NewUInt256ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.Rsh(v.BigInt, uint(o.BigInt.Uint64()))

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -401,95 +401,95 @@ func ConvertUInt32(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 	)
 }
 
-func (v UInt32Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt32Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt32Value(
-		interpreter,
+		context,
 		func() uint32 {
 			return uint32(v | o)
 		},
 	)
 }
 
-func (v UInt32Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt32Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt32Value(
-		interpreter,
+		context,
 		func() uint32 {
 			return uint32(v ^ o)
 		},
 	)
 }
 
-func (v UInt32Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt32Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt32Value(
-		interpreter,
+		context,
 		func() uint32 {
 			return uint32(v & o)
 		},
 	)
 }
 
-func (v UInt32Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt32Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt32Value(
-		interpreter,
+		context,
 		func() uint32 {
 			return uint32(v << o)
 		},
 	)
 }
 
-func (v UInt32Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt32Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt32Value(
-		interpreter,
+		context,
 		func() uint32 {
 			return uint32(v >> o)
 		},

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -536,7 +536,7 @@ func (UInt32Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UInt32Value) IsResourceKinded(_ *Interpreter) bool {
+func (UInt32Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -566,7 +566,7 @@ func (UInt64Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UInt64Value) IsResourceKinded(_ *Interpreter) bool {
+func (UInt64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -431,95 +431,95 @@ func ConvertUInt64(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 	)
 }
 
-func (v UInt64Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt64Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt64Value(
-		interpreter,
+		context,
 		func() uint64 {
 			return uint64(v | o)
 		},
 	)
 }
 
-func (v UInt64Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt64Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt64Value(
-		interpreter,
+		context,
 		func() uint64 {
 			return uint64(v ^ o)
 		},
 	)
 }
 
-func (v UInt64Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt64Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt64Value(
-		interpreter,
+		context,
 		func() uint64 {
 			return uint64(v & o)
 		},
 	)
 }
 
-func (v UInt64Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt64Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt64Value(
-		interpreter,
+		context,
 		func() uint64 {
 			return uint64(v << o)
 		},
 	)
 }
 
-func (v UInt64Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt64Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt64Value(
-		interpreter,
+		context,
 		func() uint64 {
 			return uint64(v >> o)
 		},

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -451,95 +451,95 @@ func ConvertUInt8(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 	)
 }
 
-func (v UInt8Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt8Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt8Value(
-		interpreter,
+		context,
 		func() uint8 {
 			return uint8(v | o)
 		},
 	)
 }
 
-func (v UInt8Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt8Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt8Value(
-		interpreter,
+		context,
 		func() uint8 {
 			return uint8(v ^ o)
 		},
 	)
 }
 
-func (v UInt8Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt8Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt8Value(
-		interpreter,
+		context,
 		func() uint8 {
 			return uint8(v & o)
 		},
 	)
 }
 
-func (v UInt8Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt8Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt8Value(
-		interpreter,
+		context,
 		func() uint8 {
 			return uint8(v << o)
 		},
 	)
 }
 
-func (v UInt8Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v UInt8Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewUInt8Value(
-		interpreter,
+		context,
 		func() uint8 {
 			return uint8(v >> o)
 		},

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -580,7 +580,7 @@ func (UInt8Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UInt8Value) IsResourceKinded(_ *Interpreter) bool {
+func (UInt8Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_void.go
+++ b/interpreter/value_void.go
@@ -89,7 +89,7 @@ func (VoidValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (VoidValue) IsResourceKinded(_ *Interpreter) bool {
+func (VoidValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -415,19 +415,19 @@ func ConvertWord128(memoryGauge common.MemoryGauge, value Value, locationRange L
 	)
 }
 
-func (v Word128Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word128Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewWord128ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.Or(v.BigInt, o.BigInt)
@@ -435,19 +435,19 @@ func (v Word128Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, lo
 	)
 }
 
-func (v Word128Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word128Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewWord128ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.Xor(v.BigInt, o.BigInt)
@@ -455,19 +455,19 @@ func (v Word128Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, l
 	)
 }
 
-func (v Word128Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word128Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewWord128ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.And(v.BigInt, o.BigInt)
@@ -476,13 +476,13 @@ func (v Word128Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, l
 
 }
 
-func (v Word128Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word128Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -493,16 +493,16 @@ func (v Word128Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVa
 		})
 	}
 	if !o.BigInt.IsUint64() || o.BigInt.Uint64() >= 128 {
-		return NewWord128ValueFromUint64(interpreter, 0)
+		return NewWord128ValueFromUint64(context, 0)
 	}
 
 	// The maximum shift value at this point is 127, which may lead to an
 	// additional allocation of up to 128 bits. Add usage for possible
 	// intermediate value.
-	common.UseMemory(interpreter, Uint128MemoryUsage)
+	common.UseMemory(context, Uint128MemoryUsage)
 
 	return NewWord128ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			res = res.Lsh(v.BigInt, uint(o.BigInt.Uint64()))
@@ -511,13 +511,13 @@ func (v Word128Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVa
 	)
 }
 
-func (v Word128Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word128Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word128Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
-			LeftType:  v.StaticType(interpreter),
-			RightType: other.StaticType(interpreter),
+			LeftType:  v.StaticType(context),
+			RightType: other.StaticType(context),
 		})
 	}
 
@@ -527,11 +527,11 @@ func (v Word128Value) BitwiseRightShift(interpreter *Interpreter, other IntegerV
 		})
 	}
 	if !o.BigInt.IsUint64() {
-		return NewWord128ValueFromUint64(interpreter, 0)
+		return NewWord128ValueFromUint64(context, 0)
 	}
 
 	return NewWord128ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.Rsh(v.BigInt, uint(o.BigInt.Uint64()))

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -577,7 +577,7 @@ func (Word128Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Word128Value) IsResourceKinded(_ *Interpreter) bool {
+func (Word128Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -431,7 +431,7 @@ func (Word16Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Word16Value) IsResourceKinded(_ *Interpreter) bool {
+func (Word16Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -301,13 +301,13 @@ func ConvertWord16(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 	)
 }
 
-func (v Word16Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word16Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -316,16 +316,16 @@ func (v Word16Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, loc
 		return uint16(v | o)
 	}
 
-	return NewWord16Value(interpreter, valueGetter)
+	return NewWord16Value(context, valueGetter)
 }
 
-func (v Word16Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word16Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -334,16 +334,16 @@ func (v Word16Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, lo
 		return uint16(v ^ o)
 	}
 
-	return NewWord16Value(interpreter, valueGetter)
+	return NewWord16Value(context, valueGetter)
 }
 
-func (v Word16Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word16Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -352,16 +352,16 @@ func (v Word16Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, lo
 		return uint16(v & o)
 	}
 
-	return NewWord16Value(interpreter, valueGetter)
+	return NewWord16Value(context, valueGetter)
 }
 
-func (v Word16Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word16Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -370,16 +370,16 @@ func (v Word16Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVal
 		return uint16(v << o)
 	}
 
-	return NewWord16Value(interpreter, valueGetter)
+	return NewWord16Value(context, valueGetter)
 }
 
-func (v Word16Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word16Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -388,7 +388,7 @@ func (v Word16Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 		return uint16(v >> o)
 	}
 
-	return NewWord16Value(interpreter, valueGetter)
+	return NewWord16Value(context, valueGetter)
 }
 
 func (v Word16Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -578,7 +578,7 @@ func (Word256Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Word256Value) IsResourceKinded(_ *Interpreter) bool {
+func (Word256Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -415,19 +415,19 @@ func ConvertWord256(memoryGauge common.MemoryGauge, value Value, locationRange L
 	)
 }
 
-func (v Word256Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word256Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewWord256ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.Or(v.BigInt, o.BigInt)
@@ -435,19 +435,19 @@ func (v Word256Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, lo
 	)
 }
 
-func (v Word256Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word256Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewWord256ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.Xor(v.BigInt, o.BigInt)
@@ -455,19 +455,19 @@ func (v Word256Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, l
 	)
 }
 
-func (v Word256Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word256Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
 
 	return NewWord256ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.And(v.BigInt, o.BigInt)
@@ -476,13 +476,13 @@ func (v Word256Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, l
 
 }
 
-func (v Word256Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word256Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -493,16 +493,16 @@ func (v Word256Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVa
 		})
 	}
 	if !o.BigInt.IsUint64() || o.BigInt.Uint64() >= 256 {
-		return NewWord256ValueFromUint64(interpreter, 0)
+		return NewWord256ValueFromUint64(context, 0)
 	}
 
 	// The maximum shift value at this point is 255, which may lead to an
 	// additional allocation of up to 256 bits. Add usage for possible
 	// intermediate value.
-	common.UseMemory(interpreter, Uint256MemoryUsage)
+	common.UseMemory(context, Uint256MemoryUsage)
 
 	return NewWord256ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			res = res.Lsh(v.BigInt, uint(o.BigInt.Uint64()))
@@ -511,13 +511,13 @@ func (v Word256Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVa
 	)
 }
 
-func (v Word256Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word256Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word256Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -528,11 +528,11 @@ func (v Word256Value) BitwiseRightShift(interpreter *Interpreter, other IntegerV
 		})
 	}
 	if !o.BigInt.IsUint64() {
-		return NewWord256ValueFromUint64(interpreter, 0)
+		return NewWord256ValueFromUint64(context, 0)
 	}
 
 	return NewWord256ValueFromBigInt(
-		interpreter,
+		context,
 		func() *big.Int {
 			res := new(big.Int)
 			return res.Rsh(v.BigInt, uint(o.BigInt.Uint64()))

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -302,13 +302,13 @@ func ConvertWord32(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 	)
 }
 
-func (v Word32Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word32Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -317,16 +317,16 @@ func (v Word32Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, loc
 		return uint32(v | o)
 	}
 
-	return NewWord32Value(interpreter, valueGetter)
+	return NewWord32Value(context, valueGetter)
 }
 
-func (v Word32Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word32Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -335,16 +335,16 @@ func (v Word32Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, lo
 		return uint32(v ^ o)
 	}
 
-	return NewWord32Value(interpreter, valueGetter)
+	return NewWord32Value(context, valueGetter)
 }
 
-func (v Word32Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word32Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -353,16 +353,16 @@ func (v Word32Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, lo
 		return uint32(v & o)
 	}
 
-	return NewWord32Value(interpreter, valueGetter)
+	return NewWord32Value(context, valueGetter)
 }
 
-func (v Word32Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word32Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -371,16 +371,16 @@ func (v Word32Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVal
 		return uint32(v << o)
 	}
 
-	return NewWord32Value(interpreter, valueGetter)
+	return NewWord32Value(context, valueGetter)
 }
 
-func (v Word32Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word32Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -389,7 +389,7 @@ func (v Word32Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 		return uint32(v >> o)
 	}
 
-	return NewWord32Value(interpreter, valueGetter)
+	return NewWord32Value(context, valueGetter)
 }
 
 func (v Word32Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -432,7 +432,7 @@ func (Word32Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Word32Value) IsResourceKinded(_ *Interpreter) bool {
+func (Word32Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -460,7 +460,7 @@ func (Word64Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Word64Value) IsResourceKinded(_ *Interpreter) bool {
+func (Word64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -330,13 +330,13 @@ func ConvertWord64(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 	)
 }
 
-func (v Word64Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word64Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -345,16 +345,16 @@ func (v Word64Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, loc
 		return uint64(v | o)
 	}
 
-	return NewWord64Value(interpreter, valueGetter)
+	return NewWord64Value(context, valueGetter)
 }
 
-func (v Word64Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word64Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -363,16 +363,16 @@ func (v Word64Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, lo
 		return uint64(v ^ o)
 	}
 
-	return NewWord64Value(interpreter, valueGetter)
+	return NewWord64Value(context, valueGetter)
 }
 
-func (v Word64Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word64Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -381,16 +381,16 @@ func (v Word64Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, lo
 		return uint64(v & o)
 	}
 
-	return NewWord64Value(interpreter, valueGetter)
+	return NewWord64Value(context, valueGetter)
 }
 
-func (v Word64Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word64Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -399,16 +399,16 @@ func (v Word64Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerVal
 		return uint64(v << o)
 	}
 
-	return NewWord64Value(interpreter, valueGetter)
+	return NewWord64Value(context, valueGetter)
 }
 
-func (v Word64Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word64Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -417,7 +417,7 @@ func (v Word64Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVa
 		return uint64(v >> o)
 	}
 
-	return NewWord64Value(interpreter, valueGetter)
+	return NewWord64Value(context, valueGetter)
 }
 
 func (v Word64Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -301,13 +301,13 @@ func ConvertWord8(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 	)
 }
 
-func (v Word8Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word8Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -316,16 +316,16 @@ func (v Word8Value) BitwiseOr(interpreter *Interpreter, other IntegerValue, loca
 		return uint8(v | o)
 	}
 
-	return NewWord8Value(interpreter, valueGetter)
+	return NewWord8Value(context, valueGetter)
 }
 
-func (v Word8Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word8Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -334,16 +334,16 @@ func (v Word8Value) BitwiseXor(interpreter *Interpreter, other IntegerValue, loc
 		return uint8(v ^ o)
 	}
 
-	return NewWord8Value(interpreter, valueGetter)
+	return NewWord8Value(context, valueGetter)
 }
 
-func (v Word8Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word8Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -352,16 +352,16 @@ func (v Word8Value) BitwiseAnd(interpreter *Interpreter, other IntegerValue, loc
 		return uint8(v & o)
 	}
 
-	return NewWord8Value(interpreter, valueGetter)
+	return NewWord8Value(context, valueGetter)
 }
 
-func (v Word8Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word8Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -370,16 +370,16 @@ func (v Word8Value) BitwiseLeftShift(interpreter *Interpreter, other IntegerValu
 		return uint8(v << o)
 	}
 
-	return NewWord8Value(interpreter, valueGetter)
+	return NewWord8Value(context, valueGetter)
 }
 
-func (v Word8Value) BitwiseRightShift(interpreter *Interpreter, other IntegerValue, locationRange LocationRange) IntegerValue {
+func (v Word8Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
 		panic(InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
-			LeftType:      v.StaticType(interpreter),
-			RightType:     other.StaticType(interpreter),
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
 			LocationRange: locationRange,
 		})
 	}
@@ -388,7 +388,7 @@ func (v Word8Value) BitwiseRightShift(interpreter *Interpreter, other IntegerVal
 		return uint8(v >> o)
 	}
 
-	return NewWord8Value(interpreter, valueGetter)
+	return NewWord8Value(context, valueGetter)
 }
 
 func (v Word8Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -429,7 +429,7 @@ func (Word8Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Word8Value) IsResourceKinded(_ *Interpreter) bool {
+func (Word8Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/variable.go
+++ b/interpreter/variable.go
@@ -113,7 +113,7 @@ func (v *SelfVariable) InitializeWithGetter(func() Value) {
 
 func (v *SelfVariable) GetValue(interpreter *Interpreter) Value {
 	// TODO: pass proper location range
-	interpreter.checkInvalidatedResourceOrResourceReference(v.selfRef, EmptyLocationRange)
+	checkInvalidatedResourceOrResourceReference(v.selfRef, EmptyLocationRange, interpreter)
 	return v.value
 }
 

--- a/interpreter/variable.go
+++ b/interpreter/variable.go
@@ -89,7 +89,7 @@ var _ Variable = &SelfVariable{}
 func NewSelfVariableWithValue(interpreter *Interpreter, value Value, locationRange LocationRange) Variable {
 	common.UseMemory(interpreter, variableMemoryUsage)
 
-	semaType := interpreter.MustSemaTypeOfValue(value)
+	semaType := MustSemaTypeOfValue(value, interpreter)
 
 	// Create an explicit reference to represent the implicit reference behavior of 'self' value.
 	// Authorization doesn't matter, we just need a reference to add to tracking.

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -688,7 +688,7 @@ func exportPathValue(gauge common.MemoryGauge, v interpreter.PathValue) (cadence
 func exportTypeValue(v interpreter.TypeValue, inter *interpreter.Interpreter) cadence.TypeValue {
 	var typ sema.Type
 	if v.Type != nil {
-		typ = inter.MustConvertStaticToSemaType(v.Type)
+		typ = interpreter.MustConvertStaticToSemaType(v.Type, inter)
 	}
 	return cadence.NewMeteredTypeValue(
 		inter,
@@ -700,7 +700,7 @@ func exportCapabilityValue(
 	v *interpreter.IDCapabilityValue,
 	inter *interpreter.Interpreter,
 ) (cadence.Capability, error) {
-	borrowType := inter.MustConvertStaticToSemaType(v.BorrowType)
+	borrowType := interpreter.MustConvertStaticToSemaType(v.BorrowType, inter)
 	exportedBorrowType := ExportMeteredType(inter, borrowType, map[sema.TypeID]cadence.Type{})
 
 	return cadence.NewMeteredCapability(
@@ -718,7 +718,7 @@ func exportPathCapabilityValue(
 	var exportedBorrowType cadence.Type
 
 	if v.BorrowType != nil {
-		borrowType := inter.MustConvertStaticToSemaType(v.BorrowType)
+		borrowType := interpreter.MustConvertStaticToSemaType(v.BorrowType, inter)
 		exportedBorrowType = ExportMeteredType(inter, borrowType, map[sema.TypeID]cadence.Type{})
 	}
 

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -1046,7 +1046,7 @@ func newAccountInboxUnpublishFunction(
 				if !inter.IsSubTypeOfSemaType(publishedType, ty) {
 					panic(interpreter.ForceCastTypeMismatchError{
 						ExpectedType:  ty,
-						ActualType:    inter.MustConvertStaticToSemaType(publishedType),
+						ActualType:    interpreter.MustConvertStaticToSemaType(publishedType, inter),
 						LocationRange: locationRange,
 					})
 				}
@@ -1136,7 +1136,7 @@ func newAccountInboxClaimFunction(
 				if !inter.IsSubTypeOfSemaType(publishedType, ty) {
 					panic(interpreter.ForceCastTypeMismatchError{
 						ExpectedType:  ty,
-						ActualType:    inter.MustConvertStaticToSemaType(publishedType),
+						ActualType:    interpreter.MustConvertStaticToSemaType(publishedType, inter),
 						LocationRange: locationRange,
 					})
 				}
@@ -3766,7 +3766,7 @@ func getCheckedCapabilityController(
 	controllerBorrowStaticType := controller.CapabilityControllerBorrowType()
 
 	controllerBorrowType, ok :=
-		inter.MustConvertStaticToSemaType(controllerBorrowStaticType).(*sema.ReferenceType)
+		interpreter.MustConvertStaticToSemaType(controllerBorrowStaticType, inter).(*sema.ReferenceType)
 	if !ok {
 		panic(errors.NewUnreachableError())
 	}
@@ -3995,7 +3995,7 @@ func newAccountCapabilitiesGetFunction(
 				}
 
 				capabilityBorrowType, ok :=
-					inter.MustConvertStaticToSemaType(capabilityStaticBorrowType).(*sema.ReferenceType)
+					interpreter.MustConvertStaticToSemaType(capabilityStaticBorrowType, inter).(*sema.ReferenceType)
 				if !ok {
 					panic(errors.NewUnreachableError())
 				}

--- a/stdlib/test.go
+++ b/stdlib/test.go
@@ -440,7 +440,7 @@ func newMatcherWithGenericTestFunction(
 				argumentStaticType := argument.StaticType(inter)
 
 				if !inter.IsSubTypeOfSemaType(argumentStaticType, parameterType) {
-					argumentSemaType := inter.MustConvertStaticToSemaType(argumentStaticType)
+					argumentSemaType := interpreter.MustConvertStaticToSemaType(argumentStaticType, inter)
 
 					panic(interpreter.TypeMismatchError{
 						ExpectedType:  parameterType,


### PR DESCRIPTION
## Description

Continue decoupling the values from the interpreter / cleaning up unnecessary code in the interpreter values.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
…decouple-values-from-interpreter-2