### PR TITLE
[Compiler] Improve default functions existence with conditions

### DIFF
--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -1231,17 +1231,6 @@ func (d *Desugar) VisitInterfaceDeclaration(declaration *ast.InterfaceDeclaratio
 		d.modifiedDeclarations = append(d.modifiedDeclarations, desugaredMember)
 	}
 
-	// Add inherited default functions.
-	existingFunctions := declaration.Members.FunctionsByIdentifier()
-	inheritedDefaultFuncs := d.inheritedDefaultFunctions(
-		interfaceType,
-		existingFunctions,
-		declaration.StartPos,
-		declaration.Range,
-	)
-
-	d.modifiedDeclarations = append(d.modifiedDeclarations, inheritedDefaultFuncs...)
-
 	// TODO: Optimize: If none of the existing members got updated or,
 	// if there are no inherited members, then return the same declaration as-is.
 

--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -445,11 +445,8 @@ func (d *Desugar) desugarPreConditions(
 		}
 	}
 
-	// If this is a method of a concrete-type, or an interface default method,
-	// then return with the updated statements, and continue desugaring the rest.
-
-	// TODO: Handle default functions with conditions
-
+	// If this is a method of a concrete-type then return with the updated statements,
+	// and continue desugaring the rest.
 	if d.canInlineConditions(funcBlock, conditions) {
 		return desugaredConditions
 	}
@@ -526,11 +523,8 @@ func (d *Desugar) desugarPostConditions(
 		}
 	}
 
-	// If this is a method of a concrete-type, or an interface default method,
-	// then return with the updated statements, and continue desugaring the rest.
-
-	// TODO: Handle default functions with conditions
-
+	// If this is a method of a concrete-type then return with the updated statements,
+	// and continue desugaring the rest.
 	if d.canInlineConditions(funcBlock, conditions) {
 		return desugaredConditions
 	}
@@ -550,16 +544,11 @@ func (d *Desugar) desugarPostConditions(
 }
 
 func (d *Desugar) canInlineConditions(funcBlock *ast.FunctionBlock, conditions *ast.Conditions) bool {
-
 	// Conditions can be inlined if one of the conditions are satisfied:
 	//  - There are no conditions
 	//  - This is a method of a concrete-type (i.e: enclosingInterfaceType is `nil`)
-	//  - This method is an interface default method (i.e: funcBlock has statements)
-
 	return conditions == nil ||
-		d.enclosingInterfaceType == nil ||
-		funcBlock.HasStatements()
-
+		d.enclosingInterfaceType == nil
 }
 
 // Generates a separate function for the provided conditions.

--- a/bbq/compiler/extended_elaboration.go
+++ b/bbq/compiler/extended_elaboration.go
@@ -37,6 +37,8 @@ type ExtendedElaboration struct {
 	assignmentStatementTypes          map[*ast.AssignmentStatement]sema.AssignmentStatementTypes
 	resultVariableTypes               map[ast.Element]sema.Type
 	referenceExpressionBorrowTypes    map[*ast.ReferenceExpression]sema.Type
+	functionDeclarationFunctionTypes  map[*ast.FunctionDeclaration]*sema.FunctionType
+	returnStatementTypes              map[*ast.ReturnStatement]sema.ReturnStatementTypes
 }
 
 func NewExtendedElaboration(elaboration *sema.Elaboration) *ExtendedElaboration {
@@ -83,7 +85,21 @@ func (e *ExtendedElaboration) InterfaceDeclarationType(decl *ast.InterfaceDeclar
 }
 
 func (e *ExtendedElaboration) ReturnStatementTypes(statement *ast.ReturnStatement) sema.ReturnStatementTypes {
+	if e.returnStatementTypes != nil {
+		typ, ok := e.returnStatementTypes[statement]
+		if ok {
+			return typ
+		}
+	}
+
 	return e.elaboration.ReturnStatementTypes(statement)
+}
+
+func (e *ExtendedElaboration) SetReturnStatementTypes(statement *ast.ReturnStatement, types sema.ReturnStatementTypes) {
+	if e.returnStatementTypes == nil {
+		e.returnStatementTypes = map[*ast.ReturnStatement]sema.ReturnStatementTypes{}
+	}
+	e.returnStatementTypes[statement] = types
 }
 
 func (e *ExtendedElaboration) VariableDeclarationTypes(declaration *ast.VariableDeclaration) sema.VariableDeclarationTypes {
@@ -210,10 +226,6 @@ func (e *ExtendedElaboration) CastingExpressionTypes(expression *ast.CastingExpr
 	return e.elaboration.CastingExpressionTypes(expression)
 }
 
-func (e *ExtendedElaboration) FunctionDeclarationFunctionType(declaration *ast.FunctionDeclaration) *sema.FunctionType {
-	return e.elaboration.FunctionDeclarationFunctionType(declaration)
-}
-
 func (e *ExtendedElaboration) ResultVariableType(enclosingBlock ast.Element) (typ sema.Type, exist bool) {
 	if e.resultVariableTypes != nil {
 		types, ok := e.resultVariableTypes[enclosingBlock]
@@ -246,4 +258,24 @@ func (e *ExtendedElaboration) SetReferenceExpressionBorrowType(expression *ast.R
 		e.referenceExpressionBorrowTypes = map[*ast.ReferenceExpression]sema.Type{}
 	}
 	e.referenceExpressionBorrowTypes[expression] = ty
+}
+
+func (e *ExtendedElaboration) FunctionDeclarationFunctionType(declaration *ast.FunctionDeclaration) *sema.FunctionType {
+	if e.functionDeclarationFunctionTypes != nil {
+		typ, ok := e.functionDeclarationFunctionTypes[declaration]
+		if ok {
+			return typ
+		}
+	}
+	return e.elaboration.FunctionDeclarationFunctionType(declaration)
+}
+
+func (e *ExtendedElaboration) SetFunctionDeclarationFunctionType(
+	declaration *ast.FunctionDeclaration,
+	functionType *sema.FunctionType,
+) {
+	if e.functionDeclarationFunctionTypes == nil {
+		e.functionDeclarationFunctionTypes = map[*ast.FunctionDeclaration]*sema.FunctionType{}
+	}
+	e.functionDeclarationFunctionTypes[declaration] = functionType
 }

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -440,7 +440,7 @@ func parseCheckAndCompileCodeWithOptions(
 		options.ParseAndCheckOptions,
 		programs,
 	)
-	programs[location] = &compiledProgram{
+	programs[checker.Location] = &compiledProgram{
 		Elaboration: checker.Elaboration,
 	}
 
@@ -450,7 +450,7 @@ func parseCheckAndCompileCodeWithOptions(
 		checker,
 		programs,
 	)
-	programs[location].Program = program
+	programs[checker.Location].Program = program
 
 	return program
 }

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -3539,4 +3539,109 @@ func TestDefaultFunctionsWithConditions(t *testing.T) {
 			}, logs,
 		)
 	})
+
+	t.Run("default and conditions in parent, more conditions in child", func(t *testing.T) {
+		t.Parallel()
+
+		storage := interpreter.NewInMemoryStorage(nil)
+
+		activation := sema.NewVariableActivation(sema.BaseValueActivation)
+		activation.DeclareValue(stdlib.PanicFunction)
+		activation.DeclareValue(stdlib.NewStandardLibraryStaticFunction(
+			"log",
+			sema.NewSimpleFunctionType(
+				sema.FunctionPurityView,
+				[]sema.Parameter{
+					{
+						Label:          sema.ArgumentLabelNotRequired,
+						Identifier:     "value",
+						TypeAnnotation: sema.AnyStructTypeAnnotation,
+					},
+				},
+				sema.VoidTypeAnnotation,
+			),
+			"",
+			nil,
+		))
+
+		var logs []string
+		vmConfig := &vm.Config{
+			Storage:        storage,
+			AccountHandler: &testAccountHandler{},
+			NativeFunctionsProvider: func() map[string]vm.Value {
+				funcs := vm.NativeFunctions()
+				funcs[commons.LogFunctionName] = vm.NativeFunctionValue{
+					ParameterCount: len(stdlib.LogFunctionType.Parameters),
+					Function: func(config *vm.Config, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
+						logs = append(logs, arguments[0].String())
+						return vm.VoidValue{}
+					},
+				}
+
+				return funcs
+			},
+		}
+
+		_, err := compileAndInvokeWithOptions(t, `
+            struct interface Foo {
+                fun test(_ a: Int) {
+                    pre {
+                         printMessage("invoked Foo.test() pre-condition")
+                    }
+                    post {
+                         printMessage("invoked Foo.test() post-condition")
+                    }
+                    printMessage("invoked Foo.test()")
+                }
+            }
+
+            struct interface Bar: Foo {
+                fun test(_ a: Int) {
+                    pre {
+                         printMessage("invoked Bar.test() pre-condition")
+                    }
+
+                    post {
+                         printMessage("invoked Bar.test() post-condition")
+                    }
+                }
+            }
+
+            struct Test: Bar {}
+
+            access(all) view fun printMessage(_ msg: String): Bool {
+                log(msg)
+                return true
+            }
+
+            fun main() {
+               Test().test(5)
+            }
+        `,
+			"main",
+			CompilerAndVMOptions{
+				VMConfig: vmConfig,
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Config: &sema.Config{
+						LocationHandler: singleIdentifierLocationResolver(t),
+						BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
+							return activation
+						},
+					},
+				},
+			},
+		)
+
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			[]string{
+				"invoked Bar.test() pre-condition",
+				"invoked Foo.test() pre-condition",
+				"invoked Foo.test()",
+				"invoked Foo.test() post-condition",
+				"invoked Bar.test() post-condition",
+			}, logs,
+		)
+	})
 }

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -3471,21 +3471,6 @@ func TestDefaultFunctionsWithConditions(t *testing.T) {
 		vmConfig := &vm.Config{
 			Storage:        storage,
 			AccountHandler: &testAccountHandler{},
-			//ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
-			//	program, ok := programs[location]
-			//	if !ok {
-			//		assert.FailNow(t, "invalid location")
-			//	}
-			//	return program.Program
-			//},
-			//ContractValueHandler: func(_ *vm.Config, location common.Location) *vm.CompositeValue {
-			//	contractValue, ok := contractValues[location]
-			//	if !ok {
-			//		assert.FailNow(t, "invalid location")
-			//	}
-			//	return contractValue
-			//},
-
 			NativeFunctionsProvider: func() map[string]vm.Value {
 				funcs := vm.NativeFunctions()
 				funcs[commons.LogFunctionName] = vm.NativeFunctionValue{

--- a/interpreter/function_test.go
+++ b/interpreter/function_test.go
@@ -323,3 +323,36 @@ func TestInterpretFunctionSubtyping(t *testing.T) {
 		result,
 	)
 }
+
+func TestInterpretDefaultFunctionWithConditions(t *testing.T) {
+
+	t.Parallel()
+
+	inter, getLogs, err := parseCheckAndInterpretWithLogs(t, `
+            struct interface Foo {
+                fun test(_ a: Int) {
+                    log("Calling to Foo.test")
+                }
+            }
+
+            struct interface Bar: Foo {
+                fun test(_ a: Int) {
+                    pre {
+                        a > 10: "a must be greater than 10"
+                    }
+                }
+            }
+
+            struct Test: Bar {}
+
+            fun main() {
+               Test().test(12)
+            }`,
+	)
+
+	_, err = inter.Invoke("main")
+	require.NoError(t, err)
+
+	logs := getLogs()
+	require.Empty(t, logs)
+}

--- a/interpreter/function_test.go
+++ b/interpreter/function_test.go
@@ -323,36 +323,3 @@ func TestInterpretFunctionSubtyping(t *testing.T) {
 		result,
 	)
 }
-
-func TestInterpretDefaultFunctionWithConditions(t *testing.T) {
-
-	t.Parallel()
-
-	inter, getLogs, err := parseCheckAndInterpretWithLogs(t, `
-            struct interface Foo {
-                fun test(_ a: Int) {
-                    log("Calling to Foo.test")
-                }
-            }
-
-            struct interface Bar: Foo {
-                fun test(_ a: Int) {
-                    pre {
-                        a > 10: "a must be greater than 10"
-                    }
-                }
-            }
-
-            struct Test: Bar {}
-
-            fun main() {
-               Test().test(12)
-            }`,
-	)
-
-	_, err = inter.Invoke("main")
-	require.NoError(t, err)
-
-	logs := getLogs()
-	require.Empty(t, logs)
-}

--- a/sema/simple_type.go
+++ b/sema/simple_type.go
@@ -56,12 +56,15 @@ type SimpleType struct {
 	// e.g. StructStringer
 	conformances                         []*InterfaceType
 	effectiveInterfaceConformanceSet     *InterfaceSet
+	effectiveInterfaceConformances       []Conformance
 	effectiveInterfaceConformanceSetOnce sync.Once
+	effectiveInterfaceConformancesOnce   sync.Once
 }
 
 var _ Type = &SimpleType{}
 var _ ValueIndexableType = &SimpleType{}
 var _ ContainerType = &SimpleType{}
+var _ ConformingType = &SimpleType{}
 
 func (*SimpleType) IsType() {}
 
@@ -215,4 +218,16 @@ func (t *SimpleType) initializeEffectiveInterfaceConformanceSet() {
 			t.effectiveInterfaceConformanceSet.Add(conformance)
 		}
 	})
+}
+
+func (t *SimpleType) EffectiveInterfaceConformances() []Conformance {
+	t.effectiveInterfaceConformancesOnce.Do(func() {
+		t.effectiveInterfaceConformances = distinctConformances(
+			t.conformances,
+			nil,
+			map[*InterfaceType]struct{}{},
+		)
+	})
+
+	return t.effectiveInterfaceConformances
 }

--- a/sema/type.go
+++ b/sema/type.go
@@ -316,6 +316,7 @@ func TypeActivationNestedType(typeActivation *VariableActivation, qualifiedIdent
 type ConformingType interface {
 	Type
 	EffectiveInterfaceConformanceSet() *InterfaceSet
+	EffectiveInterfaceConformances() []Conformance
 }
 
 // CompositeKindedType is a type which has a composite kind

--- a/sema/type.go
+++ b/sema/type.go
@@ -1212,6 +1212,7 @@ type NumericType struct {
 var _ Type = &NumericType{}
 var _ IntegerRangedType = &NumericType{}
 var _ SaturatingArithmeticType = &NumericType{}
+var _ ConformingType = &NumericType{}
 
 func NewNumericType(typeName string) *NumericType {
 	return &NumericType{
@@ -1395,14 +1396,31 @@ func (*NumericType) CheckInstantiated(_ ast.HasPosition, _ common.MemoryGauge, _
 }
 
 var numericTypeEffectiveInterfaceConformanceSet *InterfaceSet
+var numericTypeEffectiveInterfaceConformances []Conformance
 
 func init() {
+	numericTypeInterfaces := []*InterfaceType{
+		StructStringerType,
+	}
+
 	numericTypeEffectiveInterfaceConformanceSet = NewInterfaceSet()
-	numericTypeEffectiveInterfaceConformanceSet.Add(StructStringerType)
+	for _, interfaceType := range numericTypeInterfaces {
+		numericTypeEffectiveInterfaceConformanceSet.Add(interfaceType)
+	}
+
+	numericTypeEffectiveInterfaceConformances = distinctConformances(
+		numericTypeInterfaces,
+		nil,
+		map[*InterfaceType]struct{}{},
+	)
 }
 
 func (t *NumericType) EffectiveInterfaceConformanceSet() *InterfaceSet {
 	return numericTypeEffectiveInterfaceConformanceSet
+}
+
+func (t *NumericType) EffectiveInterfaceConformances() []Conformance {
+	return numericTypeEffectiveInterfaceConformances
 }
 
 // FixedPointNumericType represents all the types in the fixed-point range.
@@ -4795,6 +4813,7 @@ var _ ContainedType = &CompositeType{}
 var _ LocatedType = &CompositeType{}
 var _ CompositeKindedType = &CompositeType{}
 var _ TypeIndexableType = &CompositeType{}
+var _ ConformingType = &CompositeType{}
 
 func (t *CompositeType) Tag() TypeTag {
 	return CompositeTypeTag
@@ -5733,6 +5752,7 @@ var _ ContainerType = &InterfaceType{}
 var _ ContainedType = &InterfaceType{}
 var _ LocatedType = &InterfaceType{}
 var _ CompositeKindedType = &InterfaceType{}
+var _ ConformingType = &InterfaceType{}
 
 func (*InterfaceType) IsType() {}
 


### PR DESCRIPTION
Work towards #3742

## Description

Improves the compilation (desugaring in particular), to support co-existence of default functions and function conditions.
Similar to pre/post conditions, default functions are also flattened.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
