### PR TITLE
[Compiler] Compile switch

### DIFF
--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -3239,6 +3239,7 @@ func TestCompileSwitch(t *testing.T) {
 
 	t.Run("1", func(t *testing.T) {
 		t.Parallel()
+
 		result, err := compileAndInvoke(t,
 			`
               fun test(x: Int): Int {
@@ -3262,6 +3263,7 @@ func TestCompileSwitch(t *testing.T) {
 	})
 
 	t.Run("2", func(t *testing.T) {
+		t.Parallel()
 
 		result, err := compileAndInvoke(t,
 			`
@@ -3286,6 +3288,7 @@ func TestCompileSwitch(t *testing.T) {
 	})
 
 	t.Run("4", func(t *testing.T) {
+		t.Parallel()
 
 		result, err := compileAndInvoke(t,
 			`

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -3194,7 +3194,7 @@ func TestIfLet(t *testing.T) {
 		t.Parallel()
 
 		result, err := compileAndInvoke(t, `
-			  fun main(x: Int?): Int {
+              fun main(x: Int?): Int {
                   if let y = x {
                      return y
                   } else {
@@ -3216,7 +3216,7 @@ func TestIfLet(t *testing.T) {
 		t.Parallel()
 
 		result, err := compileAndInvoke(t, `
-            fun main(x: Int?): Int {
+              fun main(x: Int?): Int {
                   if let y = x {
                      return y
                   } else {
@@ -3230,5 +3230,82 @@ func TestIfLet(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, vm.NewIntValue(2), result)
+	})
+}
+
+func TestCompileSwitch(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("1", func(t *testing.T) {
+
+		result, err := compileAndInvoke(t,
+			`
+              fun test(x: Int): Int {
+                  var a = 0
+                  switch x {
+                      case 1:
+                          a = a + 1
+                      case 2:
+                          a = a + 2
+                      default:
+                          a = a + 3
+                  }
+                  return a
+              }
+            `,
+			"test",
+			vm.NewIntValue(1),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, vm.NewIntValue(1), result)
+	})
+
+	t.Run("2", func(t *testing.T) {
+
+		result, err := compileAndInvoke(t,
+			`
+              fun test(x: Int): Int {
+                  var a = 0
+                  switch x {
+                      case 1:
+                          a = a + 1
+                      case 2:
+                          a = a + 2
+                      default:
+                          a = a + 3
+                  }
+                  return a
+              }
+            `,
+			"test",
+			vm.NewIntValue(2),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, vm.NewIntValue(2), result)
+	})
+
+	t.Run("4", func(t *testing.T) {
+
+		result, err := compileAndInvoke(t,
+			`
+              fun test(x: Int): Int {
+                  var a = 0
+                  switch x {
+                      case 1:
+                          a = a + 1
+                      case 2:
+                          a = a + 2
+                      default:
+                          a = a + 3
+                  }
+                  return a
+              }
+            `,
+			"test",
+			vm.NewIntValue(4),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, vm.NewIntValue(3), result)
 	})
 }

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -3238,7 +3238,7 @@ func TestCompileSwitch(t *testing.T) {
 	t.Parallel()
 
 	t.Run("1", func(t *testing.T) {
-
+		t.Parallel()
 		result, err := compileAndInvoke(t,
 			`
               fun test(x: Int): Int {


### PR DESCRIPTION
Depends on #3756
Work towards #3742

## Description

Compile `switch` statements. To begin with, compile to a chain of "`if else` statements". Later we should maybe think about optimizing the common case of all cases having constants by adding a "branch table instruction", e.g. something like JVM's `tableswitch` / `lookupswitch`, WebAssembly's `br_table`, etc. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
