### PR TITLE
[Compiler] Inline inherited conditions instead generating a separate function

### DIFF
--- a/ast/variable_declaration.go
+++ b/ast/variable_declaration.go
@@ -153,11 +153,13 @@ func (d *VariableDeclaration) Doc() prettier.Doc {
 
 	// Desugared `result` variable is uninitialized at first,
 	// hence would not have a value.
-	var valueDoc prettier.Doc
+	var valueDoc, transferDoc prettier.Doc
 	if d.Value != nil {
 		valueDoc = d.Value.Doc()
+		transferDoc = d.Transfer.Doc()
 	} else {
 		valueDoc = prettier.Line{}
+		transferDoc = prettier.Line{}
 	}
 
 	var valuesDoc prettier.Doc
@@ -170,7 +172,7 @@ func (d *VariableDeclaration) Doc() prettier.Doc {
 				Doc: identifierTypeDoc,
 			},
 			prettier.Space,
-			d.Transfer.Doc(),
+			transferDoc,
 			prettier.Group{
 				Doc: prettier.Indent{
 					Doc: prettier.Concat{

--- a/bbq/compiler/extended_elaboration.go
+++ b/bbq/compiler/extended_elaboration.go
@@ -28,6 +28,10 @@ type ExtendedElaboration struct {
 	// since that would make it easy to mistakenly modify the original elaboration.
 	elaboration *sema.Elaboration
 
+	// Holds the elaborations associated with inherited pre-/post-conditions and
+	// before-statements of those post conditions.
+	conditionsElaborations map[ast.Statement]*ExtendedElaboration
+
 	interfaceMethodStaticCalls        map[*ast.InvocationExpression]struct{}
 	interfaceDeclarationTypes         map[*ast.InterfaceDeclaration]*sema.InterfaceType
 	compositeDeclarationTypes         map[ast.CompositeLikeDeclaration]*sema.CompositeType
@@ -43,7 +47,8 @@ type ExtendedElaboration struct {
 
 func NewExtendedElaboration(elaboration *sema.Elaboration) *ExtendedElaboration {
 	return &ExtendedElaboration{
-		elaboration: elaboration,
+		elaboration:            elaboration,
+		conditionsElaborations: map[ast.Statement]*ExtendedElaboration{},
 	}
 }
 

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestFTTransfer(t *testing.T) {
 
-	t.SkipNow()
+	//t.SkipNow()
 
 	// ---- Deploy FT Contract -----
 
@@ -80,6 +80,13 @@ func TestFTTransfer(t *testing.T) {
 		Storage:        storage,
 		AccountHandler: &testAccountHandler{},
 		TypeLoader:     typeLoader,
+		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			imported, ok := programs[location]
+			if !ok {
+				return nil
+			}
+			return imported.Program
+		},
 	}
 
 	flowTokenVM := vm.NewVM(

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -36,8 +36,6 @@ import (
 
 func TestFTTransfer(t *testing.T) {
 
-	//t.SkipNow()
-
 	// ---- Deploy FT Contract -----
 
 	storage := interpreter.NewInMemoryStorage(nil)

--- a/bbq/vm/value_some.go
+++ b/bbq/vm/value_some.go
@@ -31,6 +31,7 @@ type SomeValue struct {
 var _ Value = &SomeValue{}
 var _ MemberAccessibleValue = &SomeValue{}
 var _ ResourceKindedValue = &SomeValue{}
+var _ EquatableValue = &SomeValue{}
 
 func NewSomeValueNonCopying(value Value) *SomeValue {
 	return &SomeValue{
@@ -71,4 +72,18 @@ func (v *SomeValue) SetMember(config *Config, name string, value Value) {
 func (v *SomeValue) IsResourceKinded() bool {
 	resourceKinded, ok := v.value.(ResourceKindedValue)
 	return ok && resourceKinded.IsResourceKinded()
+}
+
+func (v *SomeValue) Equal(other Value) BoolValue {
+	otherSome, ok := other.(*SomeValue)
+	if !ok {
+		return false
+	}
+
+	equatableValue, ok := v.value.(EquatableValue)
+	if !ok {
+		return false
+	}
+
+	return equatableValue.Equal(otherSome.value)
 }

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -64,6 +64,10 @@ func NewVM(
 		conf.NativeFunctionsProvider = NativeFunctions
 	}
 
+	if conf.referencedResourceKindedValues == nil {
+		conf.referencedResourceKindedValues = ReferencedResourceKindedValues{}
+	}
+
 	// linkedGlobalsCache is a local cache-alike that is being used to hold already linked imports.
 	linkedGlobalsCache := map[common.Location]LinkedGlobals{
 		BuiltInLocation: {


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3742

## Description

Inline inherited-conditions at the concrete-type's function (by copying them over) instead of generating a separate function at the interface type.

No change to the default functions. They continue to be generated at the interface type.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
