### PR TITLE
Disable CodeQL action in private repo and update to latest version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,7 @@ jobs:
   CodeQL-Build:
     name: CodeQL
     runs-on: ubuntu-latest
+    if: !github.event.repository.private
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -34,7 +35,7 @@ jobs:
         cache: true
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: go
 
@@ -42,4 +43,4 @@ jobs:
       run: make build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Description

Port of https://github.com/onflow/cadence-internal/pull/301

> The CodeQL action does not currently work in the private repo, as it requires the "Advanced Security" feature of GitHub to be enabled (it is enabled for all public repos for free).
>
> Also, update to the latest version of the action.

Please also review the original PR.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
