### PR TITLE
Decouple interpreter values from interpreter – Part 4

### DIFF
--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -996,7 +996,7 @@ func TestInterpretAccountStorageBorrow(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.AsBoolValue(true),
+				interpreter.BoolValue(true),
 				checkRes,
 			)
 
@@ -1035,7 +1035,7 @@ func TestInterpretAccountStorageBorrow(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.AsBoolValue(true),
+				interpreter.BoolValue(true),
 				checkRes,
 			)
 
@@ -1058,7 +1058,7 @@ func TestInterpretAccountStorageBorrow(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.AsBoolValue(false),
+				interpreter.BoolValue(false),
 				checkRes,
 			)
 
@@ -1085,7 +1085,7 @@ func TestInterpretAccountStorageBorrow(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.AsBoolValue(false),
+				interpreter.BoolValue(false),
 				checkRes,
 			)
 		})
@@ -1174,7 +1174,7 @@ func TestInterpretAccountStorageBorrow(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.AsBoolValue(true),
+				interpreter.BoolValue(true),
 				checkRes,
 			)
 
@@ -1213,7 +1213,7 @@ func TestInterpretAccountStorageBorrow(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.AsBoolValue(true),
+				interpreter.BoolValue(true),
 				checkRes,
 			)
 
@@ -1236,7 +1236,7 @@ func TestInterpretAccountStorageBorrow(t *testing.T) {
 			AssertValuesEqual(
 				t,
 				inter,
-				interpreter.AsBoolValue(false),
+				interpreter.BoolValue(false),
 				checkRes,
 			)
 

--- a/interpreter/decode.go
+++ b/interpreter/decode.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 var CBORDecMode = func() cbor.DecMode {
@@ -186,7 +187,7 @@ func (d StorableDecoder) decodeStorable() (atree.Storable, error) {
 		if err != nil {
 			return nil, err
 		}
-		storable = AsBoolValue(v)
+		storable = values.BoolValue(v)
 
 	case cbor.NilType:
 		err := d.decoder.DecodeNil()
@@ -245,137 +246,137 @@ func (d StorableDecoder) decodeStorable() (atree.Storable, error) {
 				d.inlinedExtraData,
 			)
 
-		case CBORTagVoidValue:
+		case values.CBORTagVoidValue:
 			err := d.decoder.Skip()
 			if err != nil {
 				return nil, err
 			}
 			storable = VoidStorable
 
-		case CBORTagStringValue:
+		case values.CBORTagStringValue:
 			storable, err = d.decodeStringValue()
 			if err != nil {
 				return nil, err
 			}
 
-		case CBORTagCharacterValue:
+		case values.CBORTagCharacterValue:
 			storable, err = d.decodeCharacter()
 			if err != nil {
 				return nil, err
 			}
 
-		case CBORTagSomeValue:
+		case values.CBORTagSomeValue:
 			storable, err = d.decodeSome()
 
-		case CBORTagSomeValueWithNestedLevels:
+		case values.CBORTagSomeValueWithNestedLevels:
 			storable, err = d.decodeSomeWithNestedLevels()
 
-		case CBORTagAddressValue:
+		case values.CBORTagAddressValue:
 			storable, err = d.decodeAddress()
 
 		// Int*
 
-		case CBORTagIntValue:
+		case values.CBORTagIntValue:
 			storable, err = d.decodeInt()
 
-		case CBORTagInt8Value:
+		case values.CBORTagInt8Value:
 			storable, err = d.decodeInt8()
 
-		case CBORTagInt16Value:
+		case values.CBORTagInt16Value:
 			storable, err = d.decodeInt16()
 
-		case CBORTagInt32Value:
+		case values.CBORTagInt32Value:
 			storable, err = d.decodeInt32()
 
-		case CBORTagInt64Value:
+		case values.CBORTagInt64Value:
 			storable, err = d.decodeInt64()
 
-		case CBORTagInt128Value:
+		case values.CBORTagInt128Value:
 			storable, err = d.decodeInt128()
 
-		case CBORTagInt256Value:
+		case values.CBORTagInt256Value:
 			storable, err = d.decodeInt256()
 
 		// UInt*
 
-		case CBORTagUIntValue:
+		case values.CBORTagUIntValue:
 			storable, err = d.decodeUInt()
 
-		case CBORTagUInt8Value:
+		case values.CBORTagUInt8Value:
 			storable, err = d.decodeUInt8()
 
-		case CBORTagUInt16Value:
+		case values.CBORTagUInt16Value:
 			storable, err = d.decodeUInt16()
 
-		case CBORTagUInt32Value:
+		case values.CBORTagUInt32Value:
 			storable, err = d.decodeUInt32()
 
-		case CBORTagUInt64Value:
+		case values.CBORTagUInt64Value:
 			storable, err = d.decodeUInt64()
 
-		case CBORTagUInt128Value:
+		case values.CBORTagUInt128Value:
 			storable, err = d.decodeUInt128()
 
-		case CBORTagUInt256Value:
+		case values.CBORTagUInt256Value:
 			storable, err = d.decodeUInt256()
 
 		// Word*
 
-		case CBORTagWord8Value:
+		case values.CBORTagWord8Value:
 			storable, err = d.decodeWord8()
 
-		case CBORTagWord16Value:
+		case values.CBORTagWord16Value:
 			storable, err = d.decodeWord16()
 
-		case CBORTagWord32Value:
+		case values.CBORTagWord32Value:
 			storable, err = d.decodeWord32()
 
-		case CBORTagWord64Value:
+		case values.CBORTagWord64Value:
 			storable, err = d.decodeWord64()
 
-		case CBORTagWord128Value:
+		case values.CBORTagWord128Value:
 			storable, err = d.decodeWord128()
 
-		case CBORTagWord256Value:
+		case values.CBORTagWord256Value:
 			storable, err = d.decodeWord256()
 
 		// Fix*
 
-		case CBORTagFix64Value:
+		case values.CBORTagFix64Value:
 			storable, err = d.decodeFix64()
 
 		// UFix*
 
-		case CBORTagUFix64Value:
+		case values.CBORTagUFix64Value:
 			storable, err = d.decodeUFix64()
 
 		// Storage
 
-		case CBORTagPathValue:
+		case values.CBORTagPathValue:
 			storable, err = d.decodePath()
 
-		case CBORTagCapabilityValue:
+		case values.CBORTagCapabilityValue:
 			storable, err = d.decodeCapability()
 
-		case CBORTagPublishedValue:
+		case values.CBORTagPublishedValue:
 			storable, err = d.decodePublishedValue()
 
-		case CBORTagTypeValue:
+		case values.CBORTagTypeValue:
 			storable, err = d.decodeType()
 
-		case CBORTagStorageCapabilityControllerValue:
+		case values.CBORTagStorageCapabilityControllerValue:
 			storable, err = d.decodeStorageCapabilityController()
 
-		case CBORTagAccountCapabilityControllerValue:
+		case values.CBORTagAccountCapabilityControllerValue:
 			storable, err = d.decodeAccountCapabilityController()
 
-		case CBORTagPathCapabilityValue:
+		case values.CBORTagPathCapabilityValue:
 			storable, err = d.decodePathCapability()
 
-		case CBORTagPathLinkValue:
+		case values.CBORTagPathLinkValue:
 			storable, err = d.decodePathLink()
 
-		case CBORTagAccountLinkValue:
+		case values.CBORTagAccountLinkValue:
 			storable, err = d.decodeAccountLink()
 
 		default:
@@ -1063,7 +1064,7 @@ func (d StorableDecoder) decodeCapability() (*IDCapabilityValue, error) {
 			err,
 		)
 	}
-	if num != CBORTagAddressValue {
+	if num != values.CBORTagAddressValue {
 		return nil, errors.NewUnexpectedError(
 			"invalid capability address: wrong tag %d",
 			num,
@@ -1154,10 +1155,10 @@ func (d StorableDecoder) decodeStorageCapabilityController() (*StorageCapability
 	if err != nil {
 		return nil, errors.NewUnexpectedError("invalid storage capability controller target path encoding: %w", err)
 	}
-	if num != CBORTagPathValue {
+	if num != values.CBORTagPathValue {
 		return nil, errors.NewUnexpectedError(
 			"invalid storage capability controller target path encoding: expected CBOR tag %d, got %d",
-			CBORTagPathValue,
+			values.CBORTagPathValue,
 			num,
 		)
 	}
@@ -1257,10 +1258,10 @@ func (d StorableDecoder) decodePublishedValue() (*PublishedValue, error) {
 	if err != nil {
 		return nil, errors.NewUnexpectedError("invalid published value recipient encoding: %w", err)
 	}
-	if num != CBORTagAddressValue {
+	if num != values.CBORTagAddressValue {
 		return nil, errors.NewUnexpectedError(
 			"invalid published value recipient encoding: expected CBOR tag %d, got %d",
-			CBORTagAddressValue,
+			values.CBORTagAddressValue,
 			num,
 		)
 	}
@@ -1363,7 +1364,7 @@ func (d StorableDecoder) decodePathCapability() (*PathCapabilityValue, error) {
 			err,
 		)
 	}
-	if num != CBORTagAddressValue {
+	if num != values.CBORTagAddressValue {
 		return nil, errors.NewUnexpectedError(
 			"invalid capability address: wrong tag %d",
 			num,
@@ -1447,8 +1448,8 @@ func (d StorableDecoder) decodePathLink() (PathLinkValue, error) {
 	if err != nil {
 		return EmptyPathLinkValue, errors.NewUnexpectedError("invalid link target path encoding: %w", err)
 	}
-	if num != CBORTagPathValue {
-		return EmptyPathLinkValue, errors.NewUnexpectedError("invalid link target path encoding: expected CBOR tag %d, got %d", CBORTagPathValue, num)
+	if num != values.CBORTagPathValue {
+		return EmptyPathLinkValue, errors.NewUnexpectedError("invalid link target path encoding: expected CBOR tag %d, got %d", values.CBORTagPathValue, num)
 	}
 	pathValue, err := d.decodePath()
 	if err != nil {
@@ -1510,37 +1511,37 @@ func (d TypeDecoder) DecodeStaticType() (StaticType, error) {
 	}
 
 	switch number {
-	case CBORTagPrimitiveStaticType:
+	case values.CBORTagPrimitiveStaticType:
 		return d.decodePrimitiveStaticType()
 
-	case CBORTagOptionalStaticType:
+	case values.CBORTagOptionalStaticType:
 		return d.decodeOptionalStaticType()
 
-	case CBORTagCompositeStaticType:
+	case values.CBORTagCompositeStaticType:
 		return d.decodeCompositeStaticType()
 
-	case CBORTagInterfaceStaticType:
+	case values.CBORTagInterfaceStaticType:
 		return d.decodeInterfaceStaticType()
 
-	case CBORTagVariableSizedStaticType:
+	case values.CBORTagVariableSizedStaticType:
 		return d.decodeVariableSizedStaticType()
 
-	case CBORTagConstantSizedStaticType:
+	case values.CBORTagConstantSizedStaticType:
 		return d.decodeConstantSizedStaticType()
 
-	case CBORTagReferenceStaticType:
+	case values.CBORTagReferenceStaticType:
 		return d.decodeReferenceStaticType()
 
-	case CBORTagDictionaryStaticType:
+	case values.CBORTagDictionaryStaticType:
 		return d.decodeDictionaryStaticType()
 
-	case CBORTagIntersectionStaticType:
+	case values.CBORTagIntersectionStaticType:
 		return d.decodeIntersectionStaticType()
 
-	case CBORTagCapabilityStaticType:
+	case values.CBORTagCapabilityStaticType:
 		return d.decodeCapabilityStaticType()
 
-	case CBORTagInclusiveRangeStaticType:
+	case values.CBORTagInclusiveRangeStaticType:
 		return d.decodeInclusiveRangeStaticType()
 
 	default:
@@ -1750,25 +1751,25 @@ func (d TypeDecoder) decodeStaticAuthorization() (Authorization, error) {
 		return nil, err
 	}
 	switch number {
-	case CBORTagUnauthorizedStaticAuthorization:
+	case values.CBORTagUnauthorizedStaticAuthorization:
 		err := d.decoder.DecodeNil()
 		if err != nil {
 			return nil, err
 		}
 		return UnauthorizedAccess, nil
-	case CBORTagInaccessibleStaticAuthorization:
+	case values.CBORTagInaccessibleStaticAuthorization:
 		err := d.decoder.DecodeNil()
 		if err != nil {
 			return nil, err
 		}
 		return InaccessibleAccess, nil
-	case CBORTagEntitlementMapStaticAuthorization:
+	case values.CBORTagEntitlementMapStaticAuthorization:
 		typeID, err := d.decoder.DecodeString()
 		if err != nil {
 			return nil, err
 		}
 		return NewEntitlementMapAuthorization(d.memoryGauge, common.TypeID(typeID)), nil
-	case CBORTagEntitlementSetStaticAuthorization:
+	case values.CBORTagEntitlementSetStaticAuthorization:
 		const expectedLength = encodedSetAuthorizationStaticTypeLength
 
 		arraySize, err := d.decoder.DecodeArrayHead()
@@ -2047,10 +2048,10 @@ func (d TypeDecoder) decodeIntersectionStaticType() (StaticType, error) {
 				)
 			}
 
-			if number != CBORTagInterfaceStaticType {
+			if number != values.CBORTagInterfaceStaticType {
 				return nil, errors.NewUnexpectedError(
 					"invalid intersection static type intersection encoding: expected CBOR tag %d, got %d",
-					CBORTagInterfaceStaticType,
+					values.CBORTagInterfaceStaticType,
 					number,
 				)
 			}
@@ -2169,13 +2170,13 @@ func DecodeTypeInfo(decoder *cbor.StreamDecoder, memoryGauge common.MemoryGauge)
 		}
 
 		switch tag {
-		case CBORTagConstantSizedStaticType:
+		case values.CBORTagConstantSizedStaticType:
 			return d.decodeConstantSizedStaticType()
-		case CBORTagVariableSizedStaticType:
+		case values.CBORTagVariableSizedStaticType:
 			return d.decodeVariableSizedStaticType()
-		case CBORTagDictionaryStaticType:
+		case values.CBORTagDictionaryStaticType:
 			return d.decodeDictionaryStaticType()
-		case CBORTagCompositeValue:
+		case values.CBORTagCompositeValue:
 			return d.decodeCompositeTypeInfo()
 		default:
 			return nil, errors.NewUnexpectedError("invalid type info CBOR tag: %d", tag)
@@ -2232,19 +2233,19 @@ func (d LocationDecoder) DecodeLocation() (common.Location, error) {
 	}
 
 	switch number {
-	case CBORTagAddressLocation:
+	case values.CBORTagAddressLocation:
 		return d.decodeAddressLocation()
 
-	case CBORTagStringLocation:
+	case values.CBORTagStringLocation:
 		return d.decodeStringLocation()
 
-	case CBORTagIdentifierLocation:
+	case values.CBORTagIdentifierLocation:
 		return d.decodeIdentifierLocation()
 
-	case CBORTagTransactionLocation:
+	case values.CBORTagTransactionLocation:
 		return d.decodeTransactionLocation()
 
-	case CBORTagScriptLocation:
+	case values.CBORTagScriptLocation:
 		return d.decodeScriptLocation()
 
 	default:

--- a/interpreter/decode.go
+++ b/interpreter/decode.go
@@ -370,13 +370,13 @@ func (d StorableDecoder) decodeStorable() (atree.Storable, error) {
 		case values.CBORTagAccountCapabilityControllerValue:
 			storable, err = d.decodeAccountCapabilityController()
 
-		case values.CBORTagPathCapabilityValue:
+		case values.CBORTagPathCapabilityValue: //nolint:staticcheck
 			storable, err = d.decodePathCapability()
 
-		case values.CBORTagPathLinkValue:
+		case values.CBORTagPathLinkValue: //nolint:staticcheck
 			storable, err = d.decodePathLink()
 
-		case values.CBORTagAccountLinkValue:
+		case values.CBORTagAccountLinkValue: //nolint:staticcheck
 			storable, err = d.decodeAccountLink()
 
 		default:

--- a/interpreter/encode.go
+++ b/interpreter/encode.go
@@ -21,223 +21,13 @@ package interpreter
 import (
 	"bytes"
 	"fmt"
-	"math"
-	"math/big"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
-)
-
-const cborTagSize = 2
-
-var bigOne = big.NewInt(1)
-
-func getBigIntCBORSize(v *big.Int) uint32 {
-	sign := v.Sign()
-	if sign < 0 {
-		v = new(big.Int).Abs(v)
-		v.Sub(v, bigOne)
-	}
-
-	// tag number + bytes
-	return 1 + getBytesCBORSize(v.Bytes())
-}
-
-func getIntCBORSize(v int64) uint32 {
-	if v < 0 {
-		return getUintCBORSize(uint64(-v - 1))
-	}
-	return getUintCBORSize(uint64(v))
-}
-
-func getUintCBORSize(v uint64) uint32 {
-	if v <= 23 {
-		return 1
-	}
-	if v <= math.MaxUint8 {
-		return 2
-	}
-	if v <= math.MaxUint16 {
-		return 3
-	}
-	if v <= math.MaxUint32 {
-		return 5
-	}
-	return 9
-}
-
-func getBytesCBORSize(b []byte) uint32 {
-	length := len(b)
-	if length == 0 {
-		return 1
-	}
-	return getUintCBORSize(uint64(length)) + uint32(length)
-}
-
-// Cadence needs to encode different kinds of objects in CBOR, for instance,
-// dictionaries, structs, resources, etc.
-//
-// However, CBOR only provides one native map type, and no support
-// for directly representing e.g. structs or resources.
-//
-// To be able to encode/decode such semantically different values,
-// we define custom CBOR tags.
-
-// !!! *WARNING* !!!
-//
-// Only add new fields to encoded structs by
-// appending new fields with the next highest key.
-//
-// DO *NOT* REPLACE EXISTING FIELDS!
-
-const CBORTagBase = 128
-
-// !!! *WARNING* !!!
-//
-// Only add new types by:
-// - replacing existing placeholders (`_`) with new types
-// - appending new types
-//
-// Only remove types by:
-// - replace existing types with a placeholder `_`
-//
-// DO *NOT* REPLACE EXISTING TYPES!
-// DO *NOT* ADD NEW TYPES IN BETWEEN!
-
-const (
-	CBORTagVoidValue = CBORTagBase + iota
-	_                // DO *NOT* REPLACE. Previously used for dictionary values
-	CBORTagSomeValue
-	CBORTagAddressValue
-	CBORTagCompositeValue
-	CBORTagTypeValue
-	_ // DO *NOT* REPLACE. Previously used for array values
-	CBORTagStringValue
-	CBORTagCharacterValue
-	CBORTagSomeValueWithNestedLevels
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-
-	// Int*
-	CBORTagIntValue
-	CBORTagInt8Value
-	CBORTagInt16Value
-	CBORTagInt32Value
-	CBORTagInt64Value
-	CBORTagInt128Value
-	CBORTagInt256Value
-	_
-
-	// UInt*
-	CBORTagUIntValue
-	CBORTagUInt8Value
-	CBORTagUInt16Value
-	CBORTagUInt32Value
-	CBORTagUInt64Value
-	CBORTagUInt128Value
-	CBORTagUInt256Value
-	_
-
-	// Word*
-	_
-	CBORTagWord8Value
-	CBORTagWord16Value
-	CBORTagWord32Value
-	CBORTagWord64Value
-	CBORTagWord128Value
-	CBORTagWord256Value
-	_
-
-	// Fix*
-	_
-	_ // future: Fix8
-	_ // future: Fix16
-	_ // future: Fix32
-	CBORTagFix64Value
-	_ // future: Fix128
-	_ // future: Fix256
-	_
-
-	// UFix*
-	_
-	_ // future: UFix8
-	_ // future: UFix16
-	_ // future: UFix32
-	CBORTagUFix64Value
-	_ // future: UFix128
-	_ // future: UFix256
-	_
-
-	// Locations
-	CBORTagAddressLocation
-	CBORTagStringLocation
-	CBORTagIdentifierLocation
-	CBORTagTransactionLocation
-	CBORTagScriptLocation
-	_
-	_
-	_
-
-	// Storage
-
-	CBORTagPathValue
-	// Deprecated: CBORTagPathCapabilityValue
-	CBORTagPathCapabilityValue
-	_ // DO NOT REPLACE! used to be used for storage references
-	// Deprecated: CBORTagPathLinkValue
-	CBORTagPathLinkValue
-	CBORTagPublishedValue
-	// Deprecated: CBORTagAccountLinkValue
-	CBORTagAccountLinkValue
-	CBORTagStorageCapabilityControllerValue
-	CBORTagAccountCapabilityControllerValue
-	CBORTagCapabilityValue
-	_
-	_
-	_
-
-	// Static Types
-	CBORTagPrimitiveStaticType
-	CBORTagCompositeStaticType
-	CBORTagInterfaceStaticType
-	CBORTagVariableSizedStaticType
-	CBORTagConstantSizedStaticType
-	CBORTagDictionaryStaticType
-	CBORTagOptionalStaticType
-	CBORTagReferenceStaticType
-	CBORTagIntersectionStaticType
-	CBORTagCapabilityStaticType
-	CBORTagUnauthorizedStaticAuthorization
-	CBORTagEntitlementMapStaticAuthorization
-	CBORTagEntitlementSetStaticAuthorization
-	CBORTagInaccessibleStaticAuthorization
-
-	_
-	_
-	_
-	_
-
-	CBORTagInclusiveRangeStaticType
-
-	// !!! *WARNING* !!!
-	// ADD NEW TYPES *BEFORE* THIS WARNING.
-	// DO *NOT* ADD NEW TYPES AFTER THIS LINE!
-	CBORTag_Count
+	"github.com/onflow/cadence/values"
 )
 
 // CBOREncMode
@@ -269,8 +59,8 @@ func init() {
 	// This allows Atree and Cadence more flexibility in case we need to revisit the
 	// allocation of adjacent unused ranges for Atree and Cadence.
 
-	minCBORTagNum := uint64(CBORTagBase)
-	maxCBORTagNum := uint64(CBORTag_Count) - 1
+	minCBORTagNum := uint64(values.CBORTagBase)
+	maxCBORTagNum := uint64(values.CBORTag_Count) - 1
 
 	tagNumOK, err := atree.IsCBORTagNumberRangeAvailable(minCBORTagNum, maxCBORTagNum)
 	if err != nil {
@@ -294,17 +84,11 @@ func (v NilValue) Encode(e *atree.Encoder) error {
 	return e.CBOR.EncodeNil()
 }
 
-// Encode encodes the value as a CBOR bool
-func (v BoolValue) Encode(e *atree.Encoder) error {
-	// NOTE: when updating, also update BoolValue.ByteSize
-	return e.CBOR.EncodeBool(bool(v))
-}
-
 // Encode encodes the value as a CBOR string
 func (v CharacterValue) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagCharacterValue,
+		0xd8, values.CBORTagCharacterValue,
 	})
 	if err != nil {
 		return err
@@ -316,7 +100,7 @@ func (v CharacterValue) Encode(e *atree.Encoder) error {
 func (v *StringValue) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagStringValue,
+		0xd8, values.CBORTagStringValue,
 	})
 	if err != nil {
 		return err
@@ -342,7 +126,7 @@ func (v Uint64AtreeValue) Encode(e *atree.Encoder) error {
 //	}
 var cborVoidValue = []byte{
 	// tag
-	0xd8, CBORTagVoidValue,
+	0xd8, values.CBORTagVoidValue,
 	// null
 	0xf6,
 }
@@ -365,7 +149,7 @@ func (VoidValue) Encode(e *atree.Encoder) error {
 func (v IntValue) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagIntValue,
+		0xd8, values.CBORTagIntValue,
 	})
 	if err != nil {
 		return err
@@ -382,7 +166,7 @@ func (v IntValue) Encode(e *atree.Encoder) error {
 func (v Int8Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagInt8Value,
+		0xd8, values.CBORTagInt8Value,
 	})
 	if err != nil {
 		return err
@@ -399,7 +183,7 @@ func (v Int8Value) Encode(e *atree.Encoder) error {
 func (v Int16Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagInt16Value,
+		0xd8, values.CBORTagInt16Value,
 	})
 	if err != nil {
 		return err
@@ -416,7 +200,7 @@ func (v Int16Value) Encode(e *atree.Encoder) error {
 func (v Int32Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagInt32Value,
+		0xd8, values.CBORTagInt32Value,
 	})
 	if err != nil {
 		return err
@@ -433,7 +217,7 @@ func (v Int32Value) Encode(e *atree.Encoder) error {
 func (v Int64Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagInt64Value,
+		0xd8, values.CBORTagInt64Value,
 	})
 	if err != nil {
 		return err
@@ -450,7 +234,7 @@ func (v Int64Value) Encode(e *atree.Encoder) error {
 func (v Int128Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagInt128Value,
+		0xd8, values.CBORTagInt128Value,
 	})
 	if err != nil {
 		return err
@@ -467,7 +251,7 @@ func (v Int128Value) Encode(e *atree.Encoder) error {
 func (v Int256Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagInt256Value,
+		0xd8, values.CBORTagInt256Value,
 	})
 	if err != nil {
 		return err
@@ -484,7 +268,7 @@ func (v Int256Value) Encode(e *atree.Encoder) error {
 func (v UIntValue) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagUIntValue,
+		0xd8, values.CBORTagUIntValue,
 	})
 	if err != nil {
 		return err
@@ -501,7 +285,7 @@ func (v UIntValue) Encode(e *atree.Encoder) error {
 func (v UInt8Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagUInt8Value,
+		0xd8, values.CBORTagUInt8Value,
 	})
 	if err != nil {
 		return err
@@ -518,7 +302,7 @@ func (v UInt8Value) Encode(e *atree.Encoder) error {
 func (v UInt16Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagUInt16Value,
+		0xd8, values.CBORTagUInt16Value,
 	})
 	if err != nil {
 		return err
@@ -535,7 +319,7 @@ func (v UInt16Value) Encode(e *atree.Encoder) error {
 func (v UInt32Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagUInt32Value,
+		0xd8, values.CBORTagUInt32Value,
 	})
 	if err != nil {
 		return err
@@ -552,7 +336,7 @@ func (v UInt32Value) Encode(e *atree.Encoder) error {
 func (v UInt64Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagUInt64Value,
+		0xd8, values.CBORTagUInt64Value,
 	})
 	if err != nil {
 		return err
@@ -569,7 +353,7 @@ func (v UInt64Value) Encode(e *atree.Encoder) error {
 func (v UInt128Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagUInt128Value,
+		0xd8, values.CBORTagUInt128Value,
 	})
 	if err != nil {
 		return err
@@ -586,7 +370,7 @@ func (v UInt128Value) Encode(e *atree.Encoder) error {
 func (v UInt256Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagUInt256Value,
+		0xd8, values.CBORTagUInt256Value,
 	})
 	if err != nil {
 		return err
@@ -603,7 +387,7 @@ func (v UInt256Value) Encode(e *atree.Encoder) error {
 func (v Word8Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagWord8Value,
+		0xd8, values.CBORTagWord8Value,
 	})
 	if err != nil {
 		return err
@@ -620,7 +404,7 @@ func (v Word8Value) Encode(e *atree.Encoder) error {
 func (v Word16Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagWord16Value,
+		0xd8, values.CBORTagWord16Value,
 	})
 	if err != nil {
 		return err
@@ -637,7 +421,7 @@ func (v Word16Value) Encode(e *atree.Encoder) error {
 func (v Word32Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagWord32Value,
+		0xd8, values.CBORTagWord32Value,
 	})
 	if err != nil {
 		return err
@@ -654,7 +438,7 @@ func (v Word32Value) Encode(e *atree.Encoder) error {
 func (v Word64Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagWord64Value,
+		0xd8, values.CBORTagWord64Value,
 	})
 	if err != nil {
 		return err
@@ -671,7 +455,7 @@ func (v Word64Value) Encode(e *atree.Encoder) error {
 func (v Word128Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagWord128Value,
+		0xd8, values.CBORTagWord128Value,
 	})
 	if err != nil {
 		return err
@@ -688,7 +472,7 @@ func (v Word128Value) Encode(e *atree.Encoder) error {
 func (v Word256Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagWord256Value,
+		0xd8, values.CBORTagWord256Value,
 	})
 	if err != nil {
 		return err
@@ -705,7 +489,7 @@ func (v Word256Value) Encode(e *atree.Encoder) error {
 func (v Fix64Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagFix64Value,
+		0xd8, values.CBORTagFix64Value,
 	})
 	if err != nil {
 		return err
@@ -722,7 +506,7 @@ func (v Fix64Value) Encode(e *atree.Encoder) error {
 func (v UFix64Value) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagUFix64Value,
+		0xd8, values.CBORTagUFix64Value,
 	})
 	if err != nil {
 		return err
@@ -750,7 +534,7 @@ func (s SomeStorable) encode(e *atree.Encoder) error {
 	// NOTE: when updating, also update SomeStorable.ByteSize
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagSomeValue,
+		0xd8, values.CBORTagSomeValue,
 	})
 	if err != nil {
 		return err
@@ -777,7 +561,7 @@ func (s SomeStorable) encodeMultipleNestedLevels(
 	// NOTE: when updating, also update SomeStorable.ByteSize
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagSomeValueWithNestedLevels,
+		0xd8, values.CBORTagSomeValueWithNestedLevels,
 		// array of 2 elements
 		0x82,
 	})
@@ -802,7 +586,7 @@ func (s SomeStorable) encodeMultipleNestedLevels(
 func (v AddressValue) Encode(e *atree.Encoder) error {
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagAddressValue,
+		0xd8, values.CBORTagAddressValue,
 	})
 	if err != nil {
 		return err
@@ -835,7 +619,7 @@ func (v PathValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagPathValue,
+		0xd8, values.CBORTagPathValue,
 		// array, 2 items follow
 		0x82,
 	})
@@ -880,7 +664,7 @@ func (v *IDCapabilityValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagCapabilityValue,
+		0xd8, values.CBORTagCapabilityValue,
 		// array, 3 items follow
 		0x83,
 	})
@@ -931,7 +715,7 @@ func encodeLocation(e *cbor.StreamEncoder, l common.Location) error {
 		// }
 		err := e.EncodeRawBytes([]byte{
 			// tag number
-			0xd8, CBORTagStringLocation,
+			0xd8, values.CBORTagStringLocation,
 		})
 		if err != nil {
 			return err
@@ -947,7 +731,7 @@ func encodeLocation(e *cbor.StreamEncoder, l common.Location) error {
 		// }
 		err := e.EncodeRawBytes([]byte{
 			// tag number
-			0xd8, CBORTagIdentifierLocation,
+			0xd8, values.CBORTagIdentifierLocation,
 		})
 		if err != nil {
 			return err
@@ -967,7 +751,7 @@ func encodeLocation(e *cbor.StreamEncoder, l common.Location) error {
 		// Encode tag number and array head
 		err := e.EncodeRawBytes([]byte{
 			// tag number
-			0xd8, CBORTagAddressLocation,
+			0xd8, values.CBORTagAddressLocation,
 			// array, 2 items follow
 			0x82,
 		})
@@ -993,7 +777,7 @@ func encodeLocation(e *cbor.StreamEncoder, l common.Location) error {
 		// Encode tag number and array head
 		err := e.EncodeRawBytes([]byte{
 			// tag number
-			0xd8, CBORTagTransactionLocation,
+			0xd8, values.CBORTagTransactionLocation,
 		})
 		if err != nil {
 			return err
@@ -1010,7 +794,7 @@ func encodeLocation(e *cbor.StreamEncoder, l common.Location) error {
 		// Encode tag number and array head
 		err := e.EncodeRawBytes([]byte{
 			// tag number
-			0xd8, CBORTagScriptLocation,
+			0xd8, values.CBORTagScriptLocation,
 		})
 		if err != nil {
 			return err
@@ -1048,7 +832,7 @@ func (v *PublishedValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagPublishedValue,
+		0xd8, values.CBORTagPublishedValue,
 		// array, 2 items follow
 		0x82,
 	})
@@ -1087,7 +871,7 @@ func (v TypeValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagTypeValue,
+		0xd8, values.CBORTagTypeValue,
 		// array, 1 item follow
 		0x81,
 	})
@@ -1130,7 +914,7 @@ func (v *StorageCapabilityControllerValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagStorageCapabilityControllerValue,
+		0xd8, values.CBORTagStorageCapabilityControllerValue,
 		// array, 3 items follow
 		0x83,
 	})
@@ -1179,7 +963,7 @@ func (v *AccountCapabilityControllerValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagAccountCapabilityControllerValue,
+		0xd8, values.CBORTagAccountCapabilityControllerValue,
 		// array, 2 items follow
 		0x82,
 	})
@@ -1223,7 +1007,7 @@ func StaticTypeToBytes(t StaticType) (cbor.RawMessage, error) {
 func (t PrimitiveStaticType) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagPrimitiveStaticType,
+		0xd8, values.CBORTagPrimitiveStaticType,
 	})
 	if err != nil {
 		return err
@@ -1240,7 +1024,7 @@ func (t PrimitiveStaticType) Encode(e *cbor.StreamEncoder) error {
 func (t *OptionalStaticType) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagOptionalStaticType,
+		0xd8, values.CBORTagOptionalStaticType,
 	})
 	if err != nil {
 		return err
@@ -1274,7 +1058,7 @@ func (t *CompositeStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagCompositeStaticType,
+		0xd8, values.CBORTagCompositeStaticType,
 		// array, 2 items follow
 		0x82,
 	})
@@ -1317,7 +1101,7 @@ func (t *InterfaceStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagInterfaceStaticType,
+		0xd8, values.CBORTagInterfaceStaticType,
 		// array, 2 items follow
 		0x82,
 	})
@@ -1344,7 +1128,7 @@ func (t *InterfaceStaticType) Encode(e *cbor.StreamEncoder) error {
 func (t *VariableSizedStaticType) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagVariableSizedStaticType,
+		0xd8, values.CBORTagVariableSizedStaticType,
 	})
 	if err != nil {
 		return err
@@ -1377,7 +1161,7 @@ func (t *ConstantSizedStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagConstantSizedStaticType,
+		0xd8, values.CBORTagConstantSizedStaticType,
 		// array, 2 items follow
 		0x82,
 	})
@@ -1396,7 +1180,7 @@ func (t *ConstantSizedStaticType) Encode(e *cbor.StreamEncoder) error {
 func (t Unauthorized) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagUnauthorizedStaticAuthorization,
+		0xd8, values.CBORTagUnauthorizedStaticAuthorization,
 	})
 	if err != nil {
 		return err
@@ -1407,7 +1191,7 @@ func (t Unauthorized) Encode(e *cbor.StreamEncoder) error {
 func (t Inaccessible) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagInaccessibleStaticAuthorization,
+		0xd8, values.CBORTagInaccessibleStaticAuthorization,
 	})
 	if err != nil {
 		return err
@@ -1418,7 +1202,7 @@ func (t Inaccessible) Encode(e *cbor.StreamEncoder) error {
 func (a EntitlementMapAuthorization) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagEntitlementMapStaticAuthorization,
+		0xd8, values.CBORTagEntitlementMapStaticAuthorization,
 	})
 	if err != nil {
 		return err
@@ -1441,7 +1225,7 @@ const (
 func (a EntitlementSetAuthorization) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagEntitlementSetStaticAuthorization,
+		0xd8, values.CBORTagEntitlementSetStaticAuthorization,
 		// array, 2 items follow
 		0x82,
 	})
@@ -1489,7 +1273,7 @@ func (t *ReferenceStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagReferenceStaticType,
+		0xd8, values.CBORTagReferenceStaticType,
 		// array, 2 items follow
 		0x82,
 	})
@@ -1530,7 +1314,7 @@ func (t *DictionaryStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagDictionaryStaticType,
+		0xd8, values.CBORTagDictionaryStaticType,
 		// array, 2 items follow
 		0x82,
 	})
@@ -1556,7 +1340,7 @@ func (t InclusiveRangeStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagInclusiveRangeStaticType,
+		0xd8, values.CBORTagInclusiveRangeStaticType,
 	})
 	if err != nil {
 		return err
@@ -1590,7 +1374,7 @@ func (t *IntersectionStaticType) Encode(e *cbor.StreamEncoder) error {
 	// Encode tag number and array head
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagIntersectionStaticType,
+		0xd8, values.CBORTagIntersectionStaticType,
 		// array, 2 items follow
 		0x82,
 	})
@@ -1636,7 +1420,7 @@ func (t *IntersectionStaticType) Encode(e *cbor.StreamEncoder) error {
 func (t *CapabilityStaticType) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagCapabilityStaticType,
+		0xd8, values.CBORTagCapabilityStaticType,
 	})
 	if err != nil {
 		return err
@@ -1692,7 +1476,7 @@ func (c compositeTypeInfo) Copy() atree.TypeInfo {
 func (c compositeTypeInfo) Encode(e *cbor.StreamEncoder) error {
 	err := e.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagCompositeValue,
+		0xd8, values.CBORTagCompositeValue,
 		// array, 3 items follow
 		0x83,
 	})

--- a/interpreter/encode.go
+++ b/interpreter/encode.go
@@ -140,23 +140,6 @@ func (VoidValue) Encode(e *atree.Encoder) error {
 	return e.CBOR.EncodeRawBytes(cborVoidValue)
 }
 
-// Encode encodes the value as
-//
-//	cbor.Tag{
-//			Number:  CBORTagIntValue,
-//			Content: *big.Int(v.BigInt),
-//	}
-func (v IntValue) Encode(e *atree.Encoder) error {
-	err := e.CBOR.EncodeRawBytes([]byte{
-		// tag number
-		0xd8, values.CBORTagIntValue,
-	})
-	if err != nil {
-		return err
-	}
-	return e.CBOR.EncodeBigInt(v.BigInt)
-}
-
 // Encode encodes Int8Value as
 //
 //	cbor.Tag{

--- a/interpreter/encoding_test.go
+++ b/interpreter/encoding_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/onflow/cadence/sema"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
+	"github.com/onflow/cadence/values"
 )
 
 type encodeDecodeTest struct {
@@ -168,7 +169,7 @@ func TestEncodeDecodeVoidValue(t *testing.T) {
 			value: Void,
 			encoded: []byte{
 				// tag
-				0xd8, CBORTagVoidValue,
+				0xd8, values.CBORTagVoidValue,
 				// null
 				0xf6,
 			},
@@ -226,7 +227,7 @@ func TestEncodeDecodeString(t *testing.T) {
 				value: expected,
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagStringValue,
+					0xd8, values.CBORTagStringValue,
 
 					//  UTF-8 string, 0 bytes follow
 					0x60,
@@ -245,7 +246,7 @@ func TestEncodeDecodeString(t *testing.T) {
 				value: expected,
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagStringValue,
+					0xd8, values.CBORTagStringValue,
 
 					// UTF-8 string, 3 bytes follow
 					0x63,
@@ -563,7 +564,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredIntValueFromInt64(0),
 				encoded: []byte{
-					0xd8, CBORTagIntValue,
+					0xd8, values.CBORTagIntValue,
 					// positive bignum
 					0xc2,
 					// byte string, length 0
@@ -580,7 +581,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredIntValueFromInt64(42),
 				encoded: []byte{
-					0xd8, CBORTagIntValue,
+					0xd8, values.CBORTagIntValue,
 					// positive bignum
 					0xc2,
 					// byte string, length 1
@@ -598,7 +599,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredIntValueFromInt64(-1),
 				encoded: []byte{
-					0xd8, CBORTagIntValue,
+					0xd8, values.CBORTagIntValue,
 					// negative bignum
 					0xc3,
 					// byte string, length 0
@@ -615,7 +616,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredIntValueFromInt64(-42),
 				encoded: []byte{
-					0xd8, CBORTagIntValue,
+					0xd8, values.CBORTagIntValue,
 					// negative bignum
 					0xc3,
 					// byte string, length 1
@@ -640,7 +641,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredIntValueFromBigInt(setString),
 				encoded: []byte{
-					0xd8, CBORTagIntValue,
+					0xd8, values.CBORTagIntValue,
 					// negative bignum
 					0xc3,
 					// byte string, length 9
@@ -663,7 +664,7 @@ func TestEncodeDecodeIntValue(t *testing.T) {
 				value: NewUnmeteredIntValueFromBigInt(bigInt),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagIntValue,
+					0xd8, values.CBORTagIntValue,
 					// positive bignum
 					0xc2,
 					// byte string, length 9
@@ -716,7 +717,7 @@ func TestEncodeDecodeInt8Value(t *testing.T) {
 				value: NewUnmeteredInt8Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt8Value,
+					0xd8, values.CBORTagInt8Value,
 					// integer 0
 					0x0,
 				},
@@ -732,7 +733,7 @@ func TestEncodeDecodeInt8Value(t *testing.T) {
 				value: NewUnmeteredInt8Value(-42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt8Value,
+					0xd8, values.CBORTagInt8Value,
 					// negative integer 42
 					0x38,
 					0x29,
@@ -749,7 +750,7 @@ func TestEncodeDecodeInt8Value(t *testing.T) {
 				value: NewUnmeteredInt8Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt8Value,
+					0xd8, values.CBORTagInt8Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -766,7 +767,7 @@ func TestEncodeDecodeInt8Value(t *testing.T) {
 				value: NewUnmeteredInt8Value(math.MinInt8),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt8Value,
+					0xd8, values.CBORTagInt8Value,
 					// negative integer 0x7f
 					0x38,
 					0x7f,
@@ -782,7 +783,7 @@ func TestEncodeDecodeInt8Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt8Value,
+					0xd8, values.CBORTagInt8Value,
 					// negative integer 0xf00
 					0x38,
 					0xff,
@@ -800,7 +801,7 @@ func TestEncodeDecodeInt8Value(t *testing.T) {
 				value: NewUnmeteredInt8Value(math.MaxInt8),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt8Value,
+					0xd8, values.CBORTagInt8Value,
 					// positive integer 0x7f00
 					0x18,
 					0x7f,
@@ -816,7 +817,7 @@ func TestEncodeDecodeInt8Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt8Value,
+					0xd8, values.CBORTagInt8Value,
 					// positive integer 0xff
 					0x18,
 					0xff,
@@ -839,7 +840,7 @@ func TestEncodeDecodeInt16Value(t *testing.T) {
 				value: NewUnmeteredInt16Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt16Value,
+					0xd8, values.CBORTagInt16Value,
 					// integer 0
 					0x0,
 				},
@@ -855,7 +856,7 @@ func TestEncodeDecodeInt16Value(t *testing.T) {
 				value: NewUnmeteredInt16Value(-42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt16Value,
+					0xd8, values.CBORTagInt16Value,
 					// negative integer 42
 					0x38,
 					0x29,
@@ -872,7 +873,7 @@ func TestEncodeDecodeInt16Value(t *testing.T) {
 				value: NewUnmeteredInt16Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt16Value,
+					0xd8, values.CBORTagInt16Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -889,7 +890,7 @@ func TestEncodeDecodeInt16Value(t *testing.T) {
 				value: NewUnmeteredInt16Value(math.MinInt16),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt16Value,
+					0xd8, values.CBORTagInt16Value,
 					// negative integer 0x7fff
 					0x39,
 					0x7f, 0xff,
@@ -905,7 +906,7 @@ func TestEncodeDecodeInt16Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt16Value,
+					0xd8, values.CBORTagInt16Value,
 					// negative integer 0xffff
 					0x39,
 					0xff, 0xff,
@@ -923,7 +924,7 @@ func TestEncodeDecodeInt16Value(t *testing.T) {
 				value: NewUnmeteredInt16Value(math.MaxInt16),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt16Value,
+					0xd8, values.CBORTagInt16Value,
 					// positive integer 0x7fff
 					0x19,
 					0x7f, 0xff,
@@ -939,7 +940,7 @@ func TestEncodeDecodeInt16Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt16Value,
+					0xd8, values.CBORTagInt16Value,
 					// positive integer 0xffff
 					0x19,
 					0xff, 0xff,
@@ -962,7 +963,7 @@ func TestEncodeDecodeInt32Value(t *testing.T) {
 				value: NewUnmeteredInt32Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt32Value,
+					0xd8, values.CBORTagInt32Value,
 					// integer 0
 					0x0,
 				},
@@ -978,7 +979,7 @@ func TestEncodeDecodeInt32Value(t *testing.T) {
 				value: NewUnmeteredInt32Value(-42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt32Value,
+					0xd8, values.CBORTagInt32Value,
 					// negative integer 42
 					0x38,
 					0x29,
@@ -995,7 +996,7 @@ func TestEncodeDecodeInt32Value(t *testing.T) {
 				value: NewUnmeteredInt32Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt32Value,
+					0xd8, values.CBORTagInt32Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -1012,7 +1013,7 @@ func TestEncodeDecodeInt32Value(t *testing.T) {
 				value: NewUnmeteredInt32Value(math.MinInt32),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt32Value,
+					0xd8, values.CBORTagInt32Value,
 					// negative integer 0x7fffffff
 					0x3a,
 					0x7f, 0xff, 0xff, 0xff,
@@ -1028,7 +1029,7 @@ func TestEncodeDecodeInt32Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt32Value,
+					0xd8, values.CBORTagInt32Value,
 					// negative integer 0xffffffff
 					0x3a,
 					0xff, 0xff, 0xff, 0xff,
@@ -1046,7 +1047,7 @@ func TestEncodeDecodeInt32Value(t *testing.T) {
 				value: NewUnmeteredInt32Value(math.MaxInt32),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt32Value,
+					0xd8, values.CBORTagInt32Value,
 					// positive integer 0x7fffffff
 					0x1a,
 					0x7f, 0xff, 0xff, 0xff,
@@ -1062,7 +1063,7 @@ func TestEncodeDecodeInt32Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt32Value,
+					0xd8, values.CBORTagInt32Value,
 					// positive integer 0xffffffff
 					0x1a,
 					0xff, 0xff, 0xff, 0xff,
@@ -1085,7 +1086,7 @@ func TestEncodeDecodeInt64Value(t *testing.T) {
 				value: NewUnmeteredInt64Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt64Value,
+					0xd8, values.CBORTagInt64Value,
 					// integer 0
 					0x0,
 				},
@@ -1101,7 +1102,7 @@ func TestEncodeDecodeInt64Value(t *testing.T) {
 				value: NewUnmeteredInt64Value(-42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt64Value,
+					0xd8, values.CBORTagInt64Value,
 					// negative integer 42
 					0x38,
 					0x29,
@@ -1118,7 +1119,7 @@ func TestEncodeDecodeInt64Value(t *testing.T) {
 				value: NewUnmeteredInt64Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt64Value,
+					0xd8, values.CBORTagInt64Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -1135,7 +1136,7 @@ func TestEncodeDecodeInt64Value(t *testing.T) {
 				value: NewUnmeteredInt64Value(math.MinInt64),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt64Value,
+					0xd8, values.CBORTagInt64Value,
 					// negative integer: 0x7fffffffffffffff
 					0x3b,
 					0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -1151,7 +1152,7 @@ func TestEncodeDecodeInt64Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt64Value,
+					0xd8, values.CBORTagInt64Value,
 					// negative integer 0xffffffffffffffff
 					0x3b,
 					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -1169,7 +1170,7 @@ func TestEncodeDecodeInt64Value(t *testing.T) {
 				value: NewUnmeteredInt64Value(math.MaxInt64),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt64Value,
+					0xd8, values.CBORTagInt64Value,
 					// positive integer: 0x7fffffffffffffff
 					0x1b,
 					0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -1185,7 +1186,7 @@ func TestEncodeDecodeInt64Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt64Value,
+					0xd8, values.CBORTagInt64Value,
 					// positive integer 0xffffffffffffffff
 					0x1b,
 					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -1207,7 +1208,7 @@ func TestEncodeDecodeInt128Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredInt128ValueFromInt64(0),
 				encoded: []byte{
-					0xd8, CBORTagInt128Value,
+					0xd8, values.CBORTagInt128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 0
@@ -1224,7 +1225,7 @@ func TestEncodeDecodeInt128Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredInt128ValueFromInt64(42),
 				encoded: []byte{
-					0xd8, CBORTagInt128Value,
+					0xd8, values.CBORTagInt128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 1
@@ -1242,7 +1243,7 @@ func TestEncodeDecodeInt128Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredInt128ValueFromInt64(-1),
 				encoded: []byte{
-					0xd8, CBORTagInt128Value,
+					0xd8, values.CBORTagInt128Value,
 					// negative bignum
 					0xc3,
 					// byte string, length 0
@@ -1259,7 +1260,7 @@ func TestEncodeDecodeInt128Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredInt128ValueFromInt64(-42),
 				encoded: []byte{
-					0xd8, CBORTagInt128Value,
+					0xd8, values.CBORTagInt128Value,
 					// negative bignum
 					0xc3,
 					// byte string, length 1
@@ -1277,7 +1278,7 @@ func TestEncodeDecodeInt128Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
 				encoded: []byte{
-					0xd8, CBORTagInt128Value,
+					0xd8, values.CBORTagInt128Value,
 					// negative bignum
 					0xc3,
 					// byte string, length 16
@@ -1295,7 +1296,7 @@ func TestEncodeDecodeInt128Value(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
-					0xd8, CBORTagInt128Value,
+					0xd8, values.CBORTagInt128Value,
 					// negative bignum
 					0xc3,
 					// byte string, length 16
@@ -1315,7 +1316,7 @@ func TestEncodeDecodeInt128Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
 				encoded: []byte{
-					0xd8, CBORTagInt128Value,
+					0xd8, values.CBORTagInt128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 16
@@ -1333,7 +1334,7 @@ func TestEncodeDecodeInt128Value(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
-					0xd8, CBORTagInt128Value,
+					0xd8, values.CBORTagInt128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 16
@@ -1358,7 +1359,7 @@ func TestEncodeDecodeInt128Value(t *testing.T) {
 				value: NewUnmeteredInt128ValueFromBigInt(rfcValue),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt128Value,
+					0xd8, values.CBORTagInt128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 9
@@ -1381,7 +1382,7 @@ func TestEncodeDecodeInt256Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredInt256ValueFromInt64(0),
 				encoded: []byte{
-					0xd8, CBORTagInt256Value,
+					0xd8, values.CBORTagInt256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 0
@@ -1398,7 +1399,7 @@ func TestEncodeDecodeInt256Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredInt256ValueFromInt64(42),
 				encoded: []byte{
-					0xd8, CBORTagInt256Value,
+					0xd8, values.CBORTagInt256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 1
@@ -1416,7 +1417,7 @@ func TestEncodeDecodeInt256Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredInt256ValueFromInt64(-1),
 				encoded: []byte{
-					0xd8, CBORTagInt256Value,
+					0xd8, values.CBORTagInt256Value,
 					// negative bignum
 					0xc3,
 					// byte string, length 0
@@ -1433,7 +1434,7 @@ func TestEncodeDecodeInt256Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredInt256ValueFromInt64(-42),
 				encoded: []byte{
-					0xd8, CBORTagInt256Value,
+					0xd8, values.CBORTagInt256Value,
 					// negative bignum
 					0xc3,
 					// byte string, length 1
@@ -1451,7 +1452,7 @@ func TestEncodeDecodeInt256Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
 				encoded: []byte{
-					0xd8, CBORTagInt256Value,
+					0xd8, values.CBORTagInt256Value,
 					// negative bignum
 					0xc3,
 					// byte string, length 32
@@ -1471,7 +1472,7 @@ func TestEncodeDecodeInt256Value(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
-					0xd8, CBORTagInt256Value,
+					0xd8, values.CBORTagInt256Value,
 					// negative bignum
 					0xc3,
 					// byte string, length 32
@@ -1493,7 +1494,7 @@ func TestEncodeDecodeInt256Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
 				encoded: []byte{
-					0xd8, CBORTagInt256Value,
+					0xd8, values.CBORTagInt256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 32
@@ -1513,7 +1514,7 @@ func TestEncodeDecodeInt256Value(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
-					0xd8, CBORTagInt256Value,
+					0xd8, values.CBORTagInt256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 32
@@ -1540,7 +1541,7 @@ func TestEncodeDecodeInt256Value(t *testing.T) {
 				value: NewUnmeteredInt256ValueFromBigInt(rfcValue),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagInt256Value,
+					0xd8, values.CBORTagInt256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 9
@@ -1563,7 +1564,7 @@ func TestEncodeDecodeUIntValue(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredUIntValueFromUint64(0),
 				encoded: []byte{
-					0xd8, CBORTagUIntValue,
+					0xd8, values.CBORTagUIntValue,
 					// positive bignum
 					0xc2,
 					// byte string, length 0
@@ -1579,7 +1580,7 @@ func TestEncodeDecodeUIntValue(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
-					0xd8, CBORTagUIntValue,
+					0xd8, values.CBORTagUIntValue,
 					// negative bignum
 					0xc3,
 					// byte string, length 1
@@ -1598,7 +1599,7 @@ func TestEncodeDecodeUIntValue(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredUIntValueFromUint64(42),
 				encoded: []byte{
-					0xd8, CBORTagUIntValue,
+					0xd8, values.CBORTagUIntValue,
 					// positive bignum
 					0xc2,
 					// byte string, length 1
@@ -1621,7 +1622,7 @@ func TestEncodeDecodeUIntValue(t *testing.T) {
 				value: NewUnmeteredUIntValueFromBigInt(rfcValue),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUIntValue,
+					0xd8, values.CBORTagUIntValue,
 					// positive bignum
 					0xc2,
 					// byte string, length 9
@@ -1674,7 +1675,7 @@ func TestEncodeDecodeUInt8Value(t *testing.T) {
 				value: NewUnmeteredUInt8Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt8Value,
+					0xd8, values.CBORTagUInt8Value,
 					// integer 0
 					0x0,
 				},
@@ -1689,7 +1690,7 @@ func TestEncodeDecodeUInt8Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt8Value,
+					0xd8, values.CBORTagUInt8Value,
 					// negative integer 42
 					0x38,
 					0x29,
@@ -1707,7 +1708,7 @@ func TestEncodeDecodeUInt8Value(t *testing.T) {
 				value: NewUnmeteredUInt8Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt8Value,
+					0xd8, values.CBORTagUInt8Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -1724,7 +1725,7 @@ func TestEncodeDecodeUInt8Value(t *testing.T) {
 				value: NewUnmeteredUInt8Value(math.MaxUint8),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt8Value,
+					0xd8, values.CBORTagUInt8Value,
 					// positive integer 0xff
 					0x18,
 					0xff,
@@ -1740,7 +1741,7 @@ func TestEncodeDecodeUInt8Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt8Value,
+					0xd8, values.CBORTagUInt8Value,
 					// positive integer 0xffff
 					0x19,
 					0xff, 0xff,
@@ -1763,7 +1764,7 @@ func TestEncodeDecodeUInt16Value(t *testing.T) {
 				value: NewUnmeteredUInt16Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt16Value,
+					0xd8, values.CBORTagUInt16Value,
 					// integer 0
 					0x0,
 				},
@@ -1778,7 +1779,7 @@ func TestEncodeDecodeUInt16Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt16Value,
+					0xd8, values.CBORTagUInt16Value,
 					// negative integer 42
 					0x38,
 					0x29,
@@ -1796,7 +1797,7 @@ func TestEncodeDecodeUInt16Value(t *testing.T) {
 				value: NewUnmeteredUInt16Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt16Value,
+					0xd8, values.CBORTagUInt16Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -1813,7 +1814,7 @@ func TestEncodeDecodeUInt16Value(t *testing.T) {
 				value: NewUnmeteredUInt16Value(math.MaxUint16),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt16Value,
+					0xd8, values.CBORTagUInt16Value,
 					// positive integer 0xffff
 					0x19,
 					0xff, 0xff,
@@ -1829,7 +1830,7 @@ func TestEncodeDecodeUInt16Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt16Value,
+					0xd8, values.CBORTagUInt16Value,
 					// positive integer 0xffffffff
 					0x1a,
 					0xff, 0xff, 0xff, 0xff,
@@ -1852,7 +1853,7 @@ func TestEncodeDecodeUInt32Value(t *testing.T) {
 				value: NewUnmeteredUInt32Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt32Value,
+					0xd8, values.CBORTagUInt32Value,
 					// integer 0
 					0x0,
 				},
@@ -1867,7 +1868,7 @@ func TestEncodeDecodeUInt32Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt32Value,
+					0xd8, values.CBORTagUInt32Value,
 					// negative integer 42
 					0x38,
 					0x29,
@@ -1885,7 +1886,7 @@ func TestEncodeDecodeUInt32Value(t *testing.T) {
 				value: NewUnmeteredUInt32Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt32Value,
+					0xd8, values.CBORTagUInt32Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -1902,7 +1903,7 @@ func TestEncodeDecodeUInt32Value(t *testing.T) {
 				value: NewUnmeteredUInt32Value(math.MaxUint32),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt32Value,
+					0xd8, values.CBORTagUInt32Value,
 					// positive integer 0xffffffff
 					0x1a,
 					0xff, 0xff, 0xff, 0xff,
@@ -1918,7 +1919,7 @@ func TestEncodeDecodeUInt32Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt32Value,
+					0xd8, values.CBORTagUInt32Value,
 					// positive integer 0xffffffffffffffff
 					0x1b,
 					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -1941,7 +1942,7 @@ func TestEncodeDecodeUInt64Value(t *testing.T) {
 				value: NewUnmeteredUInt64Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt64Value,
+					0xd8, values.CBORTagUInt64Value,
 					// integer 0
 					0x0,
 				},
@@ -1956,7 +1957,7 @@ func TestEncodeDecodeUInt64Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt64Value,
+					0xd8, values.CBORTagUInt64Value,
 					// negative integer 42
 					0x38,
 					0x29,
@@ -1974,7 +1975,7 @@ func TestEncodeDecodeUInt64Value(t *testing.T) {
 				value: NewUnmeteredUInt64Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt64Value,
+					0xd8, values.CBORTagUInt64Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -1991,7 +1992,7 @@ func TestEncodeDecodeUInt64Value(t *testing.T) {
 				value: NewUnmeteredUInt64Value(math.MaxUint64),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt64Value,
+					0xd8, values.CBORTagUInt64Value,
 					// positive integer 0xffffffffffffffff
 					0x1b,
 					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -2012,7 +2013,7 @@ func TestEncodeDecodeUInt128Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredUInt128ValueFromUint64(0),
 				encoded: []byte{
-					0xd8, CBORTagUInt128Value,
+					0xd8, values.CBORTagUInt128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 0
@@ -2029,7 +2030,7 @@ func TestEncodeDecodeUInt128Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredUInt128ValueFromUint64(42),
 				encoded: []byte{
-					0xd8, CBORTagUInt128Value,
+					0xd8, values.CBORTagUInt128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 1
@@ -2047,7 +2048,7 @@ func TestEncodeDecodeUInt128Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
 				encoded: []byte{
-					0xd8, CBORTagUInt128Value,
+					0xd8, values.CBORTagUInt128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 16
@@ -2065,7 +2066,7 @@ func TestEncodeDecodeUInt128Value(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
-					0xd8, CBORTagUInt128Value,
+					0xd8, values.CBORTagUInt128Value,
 					// negative bignum
 					0xc3,
 					// byte string, length 1
@@ -2083,7 +2084,7 @@ func TestEncodeDecodeUInt128Value(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
-					0xd8, CBORTagUInt128Value,
+					0xd8, values.CBORTagUInt128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 17
@@ -2109,7 +2110,7 @@ func TestEncodeDecodeUInt128Value(t *testing.T) {
 				value: NewUnmeteredUInt128ValueFromBigInt(rfcValue),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt128Value,
+					0xd8, values.CBORTagUInt128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 9
@@ -2132,7 +2133,7 @@ func TestEncodeDecodeUInt256Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredUInt256ValueFromUint64(0),
 				encoded: []byte{
-					0xd8, CBORTagUInt256Value,
+					0xd8, values.CBORTagUInt256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 0
@@ -2149,7 +2150,7 @@ func TestEncodeDecodeUInt256Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredUInt256ValueFromUint64(42),
 				encoded: []byte{
-					0xd8, CBORTagUInt256Value,
+					0xd8, values.CBORTagUInt256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 1
@@ -2166,7 +2167,7 @@ func TestEncodeDecodeUInt256Value(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
-					0xd8, CBORTagUInt256Value,
+					0xd8, values.CBORTagUInt256Value,
 					// negative bignum
 					0xc3,
 					// byte string, length 1
@@ -2184,7 +2185,7 @@ func TestEncodeDecodeUInt256Value(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
-					0xd8, CBORTagUInt256Value,
+					0xd8, values.CBORTagUInt256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 65
@@ -2216,7 +2217,7 @@ func TestEncodeDecodeUInt256Value(t *testing.T) {
 				value: NewUnmeteredUInt256ValueFromBigInt(rfcValue),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUInt256Value,
+					0xd8, values.CBORTagUInt256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 9
@@ -2240,7 +2241,7 @@ func TestEncodeDecodeWord8Value(t *testing.T) {
 				value: NewUnmeteredWord8Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord8Value,
+					0xd8, values.CBORTagWord8Value,
 					// integer 0
 					0x0,
 				},
@@ -2255,7 +2256,7 @@ func TestEncodeDecodeWord8Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord8Value,
+					0xd8, values.CBORTagWord8Value,
 					// negative integer 42
 					0x38,
 					0x29,
@@ -2273,7 +2274,7 @@ func TestEncodeDecodeWord8Value(t *testing.T) {
 				value: NewUnmeteredWord8Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord8Value,
+					0xd8, values.CBORTagWord8Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -2290,7 +2291,7 @@ func TestEncodeDecodeWord8Value(t *testing.T) {
 				value: NewUnmeteredWord8Value(math.MaxUint8),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord8Value,
+					0xd8, values.CBORTagWord8Value,
 					// positive integer 0xff
 					0x18,
 					0xff,
@@ -2306,7 +2307,7 @@ func TestEncodeDecodeWord8Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord8Value,
+					0xd8, values.CBORTagWord8Value,
 					// positive integer 0xffff
 					0x19,
 					0xff, 0xff,
@@ -2329,7 +2330,7 @@ func TestEncodeDecodeWord16Value(t *testing.T) {
 				value: NewUnmeteredWord16Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord16Value,
+					0xd8, values.CBORTagWord16Value,
 					// integer 0
 					0x0,
 				},
@@ -2345,7 +2346,7 @@ func TestEncodeDecodeWord16Value(t *testing.T) {
 				value: NewUnmeteredWord16Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord16Value,
+					0xd8, values.CBORTagWord16Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -2362,7 +2363,7 @@ func TestEncodeDecodeWord16Value(t *testing.T) {
 				value: NewUnmeteredWord16Value(math.MaxUint16),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord16Value,
+					0xd8, values.CBORTagWord16Value,
 					// positive integer 0xffff
 					0x19,
 					0xff, 0xff,
@@ -2378,7 +2379,7 @@ func TestEncodeDecodeWord16Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord16Value,
+					0xd8, values.CBORTagWord16Value,
 					// positive integer 0xffffffff
 					0x1a,
 					0xff, 0xff, 0xff, 0xff,
@@ -2401,7 +2402,7 @@ func TestEncodeDecodeWord32Value(t *testing.T) {
 				value: NewUnmeteredWord32Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord32Value,
+					0xd8, values.CBORTagWord32Value,
 					// integer 0
 					0x0,
 				},
@@ -2417,7 +2418,7 @@ func TestEncodeDecodeWord32Value(t *testing.T) {
 				value: NewUnmeteredWord32Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord32Value,
+					0xd8, values.CBORTagWord32Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -2434,7 +2435,7 @@ func TestEncodeDecodeWord32Value(t *testing.T) {
 				value: NewUnmeteredWord32Value(math.MaxUint32),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord32Value,
+					0xd8, values.CBORTagWord32Value,
 					// positive integer 0xffffffff
 					0x1a,
 					0xff, 0xff, 0xff, 0xff,
@@ -2450,7 +2451,7 @@ func TestEncodeDecodeWord32Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord32Value,
+					0xd8, values.CBORTagWord32Value,
 					// positive integer 0xffffffffffffffff
 					0x1b,
 					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -2473,7 +2474,7 @@ func TestEncodeDecodeWord64Value(t *testing.T) {
 				value: NewUnmeteredWord64Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord64Value,
+					0xd8, values.CBORTagWord64Value,
 					// integer 0
 					0x0,
 				},
@@ -2489,7 +2490,7 @@ func TestEncodeDecodeWord64Value(t *testing.T) {
 				value: NewUnmeteredWord64Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord64Value,
+					0xd8, values.CBORTagWord64Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -2506,7 +2507,7 @@ func TestEncodeDecodeWord64Value(t *testing.T) {
 				value: NewUnmeteredWord64Value(math.MaxUint64),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord64Value,
+					0xd8, values.CBORTagWord64Value,
 					// positive integer 0xffffffffffffffff
 					0x1b,
 					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -2527,7 +2528,7 @@ func TestEncodeDecodeWord128Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredWord128ValueFromUint64(0),
 				encoded: []byte{
-					0xd8, CBORTagWord128Value,
+					0xd8, values.CBORTagWord128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 0
@@ -2544,7 +2545,7 @@ func TestEncodeDecodeWord128Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredWord128ValueFromUint64(42),
 				encoded: []byte{
-					0xd8, CBORTagWord128Value,
+					0xd8, values.CBORTagWord128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 1
@@ -2562,7 +2563,7 @@ func TestEncodeDecodeWord128Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredWord128ValueFromBigInt(sema.Word128TypeMaxIntBig),
 				encoded: []byte{
-					0xd8, CBORTagWord128Value,
+					0xd8, values.CBORTagWord128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 16
@@ -2580,7 +2581,7 @@ func TestEncodeDecodeWord128Value(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
-					0xd8, CBORTagWord128Value,
+					0xd8, values.CBORTagWord128Value,
 					// negative bignum
 					0xc3,
 					// byte string, length 1
@@ -2598,7 +2599,7 @@ func TestEncodeDecodeWord128Value(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
-					0xd8, CBORTagWord128Value,
+					0xd8, values.CBORTagWord128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 17
@@ -2624,7 +2625,7 @@ func TestEncodeDecodeWord128Value(t *testing.T) {
 				value: NewUnmeteredWord128ValueFromBigInt(rfcValue),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord128Value,
+					0xd8, values.CBORTagWord128Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 9
@@ -2647,7 +2648,7 @@ func TestEncodeDecodeWord256Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredWord256ValueFromUint64(0),
 				encoded: []byte{
-					0xd8, CBORTagWord256Value,
+					0xd8, values.CBORTagWord256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 0
@@ -2664,7 +2665,7 @@ func TestEncodeDecodeWord256Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredWord256ValueFromUint64(42),
 				encoded: []byte{
-					0xd8, CBORTagWord256Value,
+					0xd8, values.CBORTagWord256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 1
@@ -2682,7 +2683,7 @@ func TestEncodeDecodeWord256Value(t *testing.T) {
 			encodeDecodeTest{
 				value: NewUnmeteredWord256ValueFromBigInt(sema.Word256TypeMaxIntBig),
 				encoded: []byte{
-					0xd8, CBORTagWord256Value,
+					0xd8, values.CBORTagWord256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 32
@@ -2702,7 +2703,7 @@ func TestEncodeDecodeWord256Value(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
-					0xd8, CBORTagWord256Value,
+					0xd8, values.CBORTagWord256Value,
 					// negative bignum
 					0xc3,
 					// byte string, length 1
@@ -2720,7 +2721,7 @@ func TestEncodeDecodeWord256Value(t *testing.T) {
 		testEncodeDecode(t,
 			encodeDecodeTest{
 				encoded: []byte{
-					0xd8, CBORTagWord256Value,
+					0xd8, values.CBORTagWord256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 65
@@ -2752,7 +2753,7 @@ func TestEncodeDecodeWord256Value(t *testing.T) {
 				value: NewUnmeteredWord256ValueFromBigInt(rfcValue),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagWord256Value,
+					0xd8, values.CBORTagWord256Value,
 					// positive bignum
 					0xc2,
 					// byte string, length 9
@@ -2777,7 +2778,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 				value: NewUnmeteredSomeValueNonCopying(Nil),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValue,
+					0xd8, values.CBORTagSomeValue,
 					// null
 					0xf6,
 				},
@@ -2795,7 +2796,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 					NewUnmeteredSomeValueNonCopying(Nil)),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValueWithNestedLevels,
+					0xd8, values.CBORTagSomeValueWithNestedLevels,
 					// array of 2 elements
 					0x82,
 					// nested levels: 2
@@ -2819,7 +2820,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 							Nil))),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValueWithNestedLevels,
+					0xd8, values.CBORTagSomeValueWithNestedLevels,
 					// array of 2 elements
 					0x82,
 					// nested levels: 3
@@ -2839,7 +2840,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 				value: NewUnmeteredSomeValueNonCopying(TrueValue),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValue,
+					0xd8, values.CBORTagSomeValue,
 					// true
 					0xf5,
 				},
@@ -2857,7 +2858,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 						TrueValue)),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValueWithNestedLevels,
+					0xd8, values.CBORTagSomeValueWithNestedLevels,
 					// array of 2 elements
 					0x82,
 					// nested levels: 2
@@ -2880,7 +2881,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 							TrueValue))),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValueWithNestedLevels,
+					0xd8, values.CBORTagSomeValueWithNestedLevels,
 					// array of 2 elements
 					0x82,
 					// nested levels: 3
@@ -2902,9 +2903,9 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 				value: NewUnmeteredSomeValueNonCopying(expectedString),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValue,
+					0xd8, values.CBORTagSomeValue,
 					// tag
-					0xd8, CBORTagStringValue,
+					0xd8, values.CBORTagStringValue,
 					// UTF-8 string, length 4
 					0x64,
 					// t, e, s, t
@@ -2926,13 +2927,13 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 						expectedString)),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValueWithNestedLevels,
+					0xd8, values.CBORTagSomeValueWithNestedLevels,
 					// array of 2 elements
 					0x82,
 					// nested levels: 2
 					0x02,
 					// tag
-					0xd8, CBORTagStringValue,
+					0xd8, values.CBORTagStringValue,
 					// UTF-8 string, length 4
 					0x64,
 					// t, e, s, t
@@ -2955,13 +2956,13 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 							expectedString))),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValueWithNestedLevels,
+					0xd8, values.CBORTagSomeValueWithNestedLevels,
 					// array of 2 elements
 					0x82,
 					// nested levels: 3
 					0x03,
 					// tag
-					0xd8, CBORTagStringValue,
+					0xd8, values.CBORTagStringValue,
 					// UTF-8 string, length 4
 					0x64,
 					// t, e, s, t
@@ -2975,17 +2976,13 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 
 		t.Parallel()
 
-		const (
-			cborTagSize = 2
-		)
-
 		var str *StringValue
 		maxInlineElementSize := uint64(64) // use a small max inline size for testing
 		for i := uint64(0); i < maxInlineElementSize; i++ {
 			str = NewUnmeteredStringValue(strings.Repeat("x", int(maxInlineElementSize-i)))
 			size, err := StorableSize(str)
 			require.NoError(t, err)
-			if uint64(size) < maxInlineElementSize-cborTagSize {
+			if uint64(size) < maxInlineElementSize-values.CBORTagSize {
 				break
 			}
 		}
@@ -2998,9 +2995,9 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 				maxInlineElementSize: maxInlineElementSize,
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValue,
+					0xd8, values.CBORTagSomeValue,
 					// tag
-					0xd8, CBORTagStringValue,
+					0xd8, values.CBORTagStringValue,
 					// text string (57 bytes)
 					0x78, 0x39,
 					0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78,
@@ -3021,7 +3018,6 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 		t.Parallel()
 
 		const (
-			cborTagSize      = 2
 			arraySize        = 1
 			nestedLevelsSize = 1
 		)
@@ -3032,7 +3028,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 			str = NewUnmeteredStringValue(strings.Repeat("x", int(maxInlineElementSize-i)))
 			size, err := StorableSize(str)
 			require.NoError(t, err)
-			if uint64(size) < maxInlineElementSize-cborTagSize-arraySize-nestedLevelsSize {
+			if uint64(size) < maxInlineElementSize-values.CBORTagSize-arraySize-nestedLevelsSize {
 				break
 			}
 		}
@@ -3045,13 +3041,13 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 				maxInlineElementSize: maxInlineElementSize,
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValueWithNestedLevels,
+					0xd8, values.CBORTagSomeValueWithNestedLevels,
 					// array of 2 elements
 					0x82,
 					// nested levels: 2
 					0x02,
 					// tag
-					0xd8, CBORTagStringValue,
+					0xd8, values.CBORTagStringValue,
 					// text string (55 bytes)
 					0x78, 0x37,
 					0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78,
@@ -3091,7 +3087,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 				maxInlineElementSize: maxInlineElementSize,
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValue,
+					0xd8, values.CBORTagSomeValue,
 					// value
 					0xd8, atree.CBORTagSlabID,
 					// storage ID
@@ -3126,7 +3122,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 				maxInlineElementSize: maxInlineElementSize,
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValueWithNestedLevels,
+					0xd8, values.CBORTagSomeValueWithNestedLevels,
 					// array of 2 elements
 					0x82,
 					// nested levels
@@ -3158,7 +3154,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 
 		expectedEncoded := []byte{
 			// tag
-			0xd8, CBORTagSomeValue,
+			0xd8, values.CBORTagSomeValue,
 
 			// tag
 			0xd8, atree.CBORTagInlinedArray,
@@ -3210,7 +3206,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 
 		expectedEncoded := []byte{
 			// tag
-			0xd8, CBORTagSomeValueWithNestedLevels,
+			0xd8, values.CBORTagSomeValueWithNestedLevels,
 
 			// array of 2 elements
 			0x82,
@@ -3278,7 +3274,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 				maxInlineElementSize: maxInlineElementSize,
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValue,
+					0xd8, values.CBORTagSomeValue,
 					// value
 					0xd8, atree.CBORTagSlabID,
 					// storage ID
@@ -3317,7 +3313,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 				maxInlineElementSize: maxInlineElementSize,
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagSomeValueWithNestedLevels,
+					0xd8, values.CBORTagSomeValueWithNestedLevels,
 					// array of 2 elements
 					0x82,
 					// nested levels: 2
@@ -3360,7 +3356,7 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 
 		expectedEncoded := []byte{
 			// tag
-			0xd8, CBORTagSomeValueWithNestedLevels,
+			0xd8, values.CBORTagSomeValueWithNestedLevels,
 			// array of 2 elements
 			0x82,
 			// nested levels: 2
@@ -3377,13 +3373,13 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 			0x99, 0x00, 0x01,
 			// element 0: SomeValue { SomeValue { SomeValue { 1 } } }
 			// tag
-			0xd8, CBORTagSomeValueWithNestedLevels,
+			0xd8, values.CBORTagSomeValueWithNestedLevels,
 			// array of 2 elements
 			0x82,
 			// nested levels: 3
 			0x03,
 			// tag
-			0xd8, CBORTagUInt64Value,
+			0xd8, values.CBORTagUInt64Value,
 			// integer 1
 			0x1,
 		}
@@ -3416,7 +3412,7 @@ func TestEncodeDecodeFix64Value(t *testing.T) {
 				value: NewUnmeteredFix64Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagFix64Value,
+					0xd8, values.CBORTagFix64Value,
 					// integer 0
 					0x0,
 				},
@@ -3432,7 +3428,7 @@ func TestEncodeDecodeFix64Value(t *testing.T) {
 				value: NewUnmeteredFix64Value(-42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagFix64Value,
+					0xd8, values.CBORTagFix64Value,
 					// negative integer 42
 					0x38,
 					0x29,
@@ -3449,7 +3445,7 @@ func TestEncodeDecodeFix64Value(t *testing.T) {
 				value: NewUnmeteredFix64Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagFix64Value,
+					0xd8, values.CBORTagFix64Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -3466,7 +3462,7 @@ func TestEncodeDecodeFix64Value(t *testing.T) {
 				value: NewUnmeteredFix64Value(math.MinInt64),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagFix64Value,
+					0xd8, values.CBORTagFix64Value,
 					// negative integer: 0x7fffffffffffffff
 					0x3b,
 					0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -3482,7 +3478,7 @@ func TestEncodeDecodeFix64Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagFix64Value,
+					0xd8, values.CBORTagFix64Value,
 					// negative integer 0xffffffffffffffff
 					0x3b,
 					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -3500,7 +3496,7 @@ func TestEncodeDecodeFix64Value(t *testing.T) {
 				value: NewUnmeteredFix64Value(math.MaxInt64),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagFix64Value,
+					0xd8, values.CBORTagFix64Value,
 					// positive integer: 0x7fffffffffffffff
 					0x1b,
 					0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -3516,7 +3512,7 @@ func TestEncodeDecodeFix64Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagFix64Value,
+					0xd8, values.CBORTagFix64Value,
 					// positive integer 0xffffffffffffffff
 					0x1b,
 					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -3540,7 +3536,7 @@ func TestEncodeDecodeUFix64Value(t *testing.T) {
 				value: NewUnmeteredUFix64Value(0),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUFix64Value,
+					0xd8, values.CBORTagUFix64Value,
 					// integer 0
 					0x0,
 				},
@@ -3555,7 +3551,7 @@ func TestEncodeDecodeUFix64Value(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUFix64Value,
+					0xd8, values.CBORTagUFix64Value,
 					// negative integer 42
 					0x38,
 					0x29,
@@ -3573,7 +3569,7 @@ func TestEncodeDecodeUFix64Value(t *testing.T) {
 				value: NewUnmeteredUFix64Value(42),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUFix64Value,
+					0xd8, values.CBORTagUFix64Value,
 					// positive integer 42
 					0x18,
 					0x2a,
@@ -3590,7 +3586,7 @@ func TestEncodeDecodeUFix64Value(t *testing.T) {
 				value: NewUnmeteredUFix64Value(math.MaxUint64),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagUFix64Value,
+					0xd8, values.CBORTagUFix64Value,
 					// positive integer 0xffffffffffffffff
 					0x1b,
 					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -3612,7 +3608,7 @@ func TestEncodeDecodeAddressValue(t *testing.T) {
 				value: AddressValue{},
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagAddressValue,
+					0xd8, values.CBORTagAddressValue,
 					// byte sequence, length 0
 					0x40,
 				},
@@ -3628,7 +3624,7 @@ func TestEncodeDecodeAddressValue(t *testing.T) {
 				value: AddressValue(common.MustBytesToAddress([]byte{0x42})),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagAddressValue,
+					0xd8, values.CBORTagAddressValue,
 					// byte sequence, length 1
 					0x41,
 					// address
@@ -3646,7 +3642,7 @@ func TestEncodeDecodeAddressValue(t *testing.T) {
 				value: AddressValue(common.MustBytesToAddress([]byte{0x0, 0x42})),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagAddressValue,
+					0xd8, values.CBORTagAddressValue,
 					// byte sequence, length 1
 					0x41,
 					// address
@@ -3664,7 +3660,7 @@ func TestEncodeDecodeAddressValue(t *testing.T) {
 				value: AddressValue(common.MustBytesToAddress([]byte{0x0, 0x42, 0x0, 0x43, 0x0})),
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagAddressValue,
+					0xd8, values.CBORTagAddressValue,
 					// byte sequence, length 4
 					0x44,
 					// address
@@ -3681,7 +3677,7 @@ func TestEncodeDecodeAddressValue(t *testing.T) {
 			encodeDecodeTest{
 				encoded: []byte{
 					// tag
-					0xd8, CBORTagAddressValue,
+					0xd8, values.CBORTagAddressValue,
 					// byte sequence, length 22
 					0x56,
 					// address
@@ -3715,7 +3711,7 @@ func TestEncodeDecodePathValue(t *testing.T) {
 
 		encoded := []byte{
 			// tag
-			0xd8, CBORTagPathValue,
+			0xd8, values.CBORTagPathValue,
 			// array, 2 items follow
 			0x82,
 			// positive integer 2
@@ -3740,7 +3736,7 @@ func TestEncodeDecodePathValue(t *testing.T) {
 
 		encoded := []byte{
 			// tag
-			0xd8, CBORTagPathValue,
+			0xd8, values.CBORTagPathValue,
 			// array, 2 items follow
 			0x82,
 			// positive integer 3
@@ -3797,11 +3793,11 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 
 		encoded := []byte{
 			// tag
-			0xd8, CBORTagCapabilityValue,
+			0xd8, values.CBORTagCapabilityValue,
 			// array, 3 items follow
 			0x83,
 			// tag for address
-			0xd8, CBORTagAddressValue,
+			0xd8, values.CBORTagAddressValue,
 			// byte sequence, length 1
 			0x41,
 			// address
@@ -3833,11 +3829,11 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 
 		encoded := []byte{
 			// tag
-			0xd8, CBORTagCapabilityValue,
+			0xd8, values.CBORTagCapabilityValue,
 			// array, 3 items follow
 			0x83,
 			// tag for address
-			0xd8, CBORTagAddressValue,
+			0xd8, values.CBORTagAddressValue,
 			// byte sequence, length 1
 			0x41,
 			// address
@@ -3845,7 +3841,7 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 			// positive integer 4
 			0x4,
 			// tag for borrow type
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			// bool
 			0x6,
 		}
@@ -3908,11 +3904,11 @@ func TestEncodeDecodeTypeValue(t *testing.T) {
 
 		encoded := []byte{
 			// tag
-			0xd8, CBORTagTypeValue,
+			0xd8, values.CBORTagTypeValue,
 			// array, 1 items follow
 			0x81,
 			// tag
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			// positive integer 0
 			0x6,
 		}
@@ -3935,11 +3931,11 @@ func TestEncodeDecodeTypeValue(t *testing.T) {
 
 		encoded := []byte{
 			// tag
-			0xd8, CBORTagTypeValue,
+			0xd8, values.CBORTagTypeValue,
 			// array, 1 items follow
 			0x81,
 			// tag
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			// positive integer 36
 			0x18, 0x24,
 		}
@@ -3964,13 +3960,13 @@ func TestEncodeDecodeTypeValue(t *testing.T) {
 
 		encoded := []byte{
 			// tag
-			0xd8, CBORTagTypeValue,
+			0xd8, values.CBORTagTypeValue,
 			// array, 1 items follow
 			0x81,
 			// tag
-			0xd8, CBORTagInclusiveRangeStaticType,
+			0xd8, values.CBORTagInclusiveRangeStaticType,
 			// tag
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			// positive integer 36
 			0x18, 0x24,
 		}
@@ -3995,13 +3991,13 @@ func TestEncodeDecodeTypeValue(t *testing.T) {
 
 		encoded := []byte{
 			// tag
-			0xd8, CBORTagTypeValue,
+			0xd8, values.CBORTagTypeValue,
 			// array, 1 items follow
 			0x81,
 			// tag
-			0xd8, CBORTagInclusiveRangeStaticType,
+			0xd8, values.CBORTagInclusiveRangeStaticType,
 			// tag
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			// positive integer 50
 			0x18, 0x32,
 		}
@@ -4024,7 +4020,7 @@ func TestEncodeDecodeTypeValue(t *testing.T) {
 
 		encoded := []byte{
 			// tag
-			0xd8, CBORTagTypeValue,
+			0xd8, values.CBORTagTypeValue,
 			// array, 1 items follow
 			0x81,
 			// nil
@@ -4090,7 +4086,7 @@ func TestEncodeDecodeStaticType(t *testing.T) {
 
 		encoded := cbor.RawMessage{
 			// tag
-			0xd8, CBORTagCompositeStaticType,
+			0xd8, values.CBORTagCompositeStaticType,
 			// array, 2 items follow
 			0x82,
 			// location: nil
@@ -4117,7 +4113,7 @@ func TestCBORTagValue(t *testing.T) {
 	t.Parallel()
 
 	t.Run("No new types added in between", func(t *testing.T) {
-		require.Equal(t, byte(231), byte(CBORTag_Count))
+		require.Equal(t, byte(231), byte(values.CBORTag_Count))
 	})
 }
 
@@ -4128,7 +4124,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 	assemble := func(bytes ...byte) []byte {
 		result := []byte{
 			// tag
-			0xd8, CBORTagStorageCapabilityControllerValue,
+			0xd8, values.CBORTagStorageCapabilityControllerValue,
 			// array, 3 items follow
 			0x83,
 		}
@@ -4136,7 +4132,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 		result = append(result,
 			// positive integer 42
 			0x18, 0x2A,
-			0xd8, CBORTagPathValue,
+			0xd8, values.CBORTagPathValue,
 			// array, 2 items follow
 			0x82,
 			// positive integer 3
@@ -4157,7 +4153,7 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		encoded := assemble(
 			// tag
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			0x6,
 		)
 
@@ -4185,16 +4181,16 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		encoded := assemble(
 			// tag
-			0xd8, CBORTagReferenceStaticType,
+			0xd8, values.CBORTagReferenceStaticType,
 			// array, 2 items follow
 			0x82,
 			// authorization:
 			// tag
-			0xd8, CBORTagUnauthorizedStaticAuthorization,
+			0xd8, values.CBORTagUnauthorizedStaticAuthorization,
 			// null
 			0xf6,
 			// tag
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			0x6,
 		)
 
@@ -4223,18 +4219,18 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		encoded := assemble(
 			// tag
-			0xd8, CBORTagReferenceStaticType,
+			0xd8, values.CBORTagReferenceStaticType,
 			// array, 2 items follow
 			0x82,
 			// authorization:
 			// tag
-			0xd8, CBORTagUnauthorizedStaticAuthorization,
+			0xd8, values.CBORTagUnauthorizedStaticAuthorization,
 			// null
 			0xf6,
 			// tag
-			0xd8, CBORTagOptionalStaticType,
+			0xd8, values.CBORTagOptionalStaticType,
 			// tag
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			0x6,
 		)
 
@@ -4265,20 +4261,20 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		encoded := assemble(
 			// tag
-			0xd8, CBORTagReferenceStaticType,
+			0xd8, values.CBORTagReferenceStaticType,
 			// array, 2 items follow
 			0x82,
 			// authorization:
 			// tag
-			0xd8, CBORTagUnauthorizedStaticAuthorization,
+			0xd8, values.CBORTagUnauthorizedStaticAuthorization,
 			// null
 			0xf6,
 			// tag
-			0xd8, CBORTagCompositeStaticType,
+			0xd8, values.CBORTagCompositeStaticType,
 			// array, 2 items follow
 			0x82,
 			// tag
-			0xd8, CBORTagStringLocation,
+			0xd8, values.CBORTagStringLocation,
 			// UTF-8 string, length 4
 			0x64,
 			// t, e, s, t
@@ -4312,20 +4308,20 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		encoded := assemble(
 			// tag
-			0xd8, CBORTagReferenceStaticType,
+			0xd8, values.CBORTagReferenceStaticType,
 			// array, 2 items follow
 			0x82,
 			// authorization:
 			// tag
-			0xd8, CBORTagUnauthorizedStaticAuthorization,
+			0xd8, values.CBORTagUnauthorizedStaticAuthorization,
 			// null
 			0xf6,
 			// tag
-			0xd8, CBORTagInterfaceStaticType,
+			0xd8, values.CBORTagInterfaceStaticType,
 			// array, 2 items follow
 			0x82,
 			// tag
-			0xd8, CBORTagStringLocation,
+			0xd8, values.CBORTagStringLocation,
 			// UTF-8 string, length 4
 			0x64,
 			// t, e, s, t
@@ -4361,18 +4357,18 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		encoded := assemble(
 			// tag
-			0xd8, CBORTagReferenceStaticType,
+			0xd8, values.CBORTagReferenceStaticType,
 			// array, 2 items follow
 			0x82,
 			// authorization:
 			// tag
-			0xd8, CBORTagUnauthorizedStaticAuthorization,
+			0xd8, values.CBORTagUnauthorizedStaticAuthorization,
 			// null
 			0xf6,
 			// tag
-			0xd8, CBORTagVariableSizedStaticType,
+			0xd8, values.CBORTagVariableSizedStaticType,
 			// tag
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			0x6,
 		)
 
@@ -4402,22 +4398,22 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		encoded := assemble(
 			// tag
-			0xd8, CBORTagReferenceStaticType,
+			0xd8, values.CBORTagReferenceStaticType,
 			// array, 2 items follow
 			0x82,
 			// authorization:
 			// tag
-			0xd8, CBORTagUnauthorizedStaticAuthorization,
+			0xd8, values.CBORTagUnauthorizedStaticAuthorization,
 			// null
 			0xf6,
 			// tag
-			0xd8, CBORTagConstantSizedStaticType,
+			0xd8, values.CBORTagConstantSizedStaticType,
 			// array, 2 items follow
 			0x82,
 			// positive integer 42
 			0x18, 0x2A,
 			// tag
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			0x6,
 		)
 
@@ -4447,23 +4443,23 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		encoded := assemble(
 			// tag
-			0xd8, CBORTagReferenceStaticType,
+			0xd8, values.CBORTagReferenceStaticType,
 			// array, 2 items follow
 			0x82,
 			// authorization:
 			// tag
-			0xd8, CBORTagUnauthorizedStaticAuthorization,
+			0xd8, values.CBORTagUnauthorizedStaticAuthorization,
 			// null
 			0xf6,
 			// tag
-			0xd8, CBORTagDictionaryStaticType,
+			0xd8, values.CBORTagDictionaryStaticType,
 			// array, 2 items follow
 			0x82,
 			// tag
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			0x6,
 			// tag
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			0x8,
 		)
 
@@ -4495,16 +4491,16 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 
 		encoded := assemble(
 			// tag
-			0xd8, CBORTagReferenceStaticType,
+			0xd8, values.CBORTagReferenceStaticType,
 			// array, 2 items follow
 			0x82,
 			// authorization:
 			// tag
-			0xd8, CBORTagUnauthorizedStaticAuthorization,
+			0xd8, values.CBORTagUnauthorizedStaticAuthorization,
 			// null
 			0xf6,
 			// tag
-			0xd8, CBORTagIntersectionStaticType,
+			0xd8, values.CBORTagIntersectionStaticType,
 			// array, length 2
 			0x82,
 			// nil
@@ -4512,11 +4508,11 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 			// array, length 2
 			0x82,
 			// tag
-			0xd8, CBORTagInterfaceStaticType,
+			0xd8, values.CBORTagInterfaceStaticType,
 			// array, 2 items follow
 			0x82,
 			// tag
-			0xd8, CBORTagStringLocation,
+			0xd8, values.CBORTagStringLocation,
 			// UTF-8 string, length 4
 			0x64,
 			// t, e, s, t
@@ -4526,11 +4522,11 @@ func TestEncodeDecodeStorageCapabilityControllerValue(t *testing.T) {
 			// I1
 			0x49, 0x31,
 			// tag
-			0xd8, CBORTagInterfaceStaticType,
+			0xd8, values.CBORTagInterfaceStaticType,
 			// array, 2 items follow
 			0x82,
 			// tag
-			0xd8, CBORTagStringLocation,
+			0xd8, values.CBORTagStringLocation,
 			// UTF-8 string, length 4
 			0x64,
 			// t, e, s, t
@@ -4593,7 +4589,7 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 	assemble := func(bytes ...byte) []byte {
 		result := []byte{
 			// tag
-			0xd8, CBORTagAccountCapabilityControllerValue,
+			0xd8, values.CBORTagAccountCapabilityControllerValue,
 			// array, 2 items follow
 			0x82,
 		}
@@ -4613,7 +4609,7 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 
 		encoded := assemble(
 			// tag
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			0x6,
 		)
 
@@ -4640,15 +4636,15 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 
 		encoded := assemble(
 			// tag
-			0xd8, CBORTagReferenceStaticType,
+			0xd8, values.CBORTagReferenceStaticType,
 			// array, 2 items follow
 			0x82,
 			// authorization:
 			// tag
-			0xd8, CBORTagUnauthorizedStaticAuthorization,
+			0xd8, values.CBORTagUnauthorizedStaticAuthorization,
 			// null
 			0xf6,
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			// unsigned 90
 			0x18, 0x5a,
 		)
@@ -4675,15 +4671,15 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 
 		encoded := assemble(
 			// tag
-			0xd8, CBORTagReferenceStaticType,
+			0xd8, values.CBORTagReferenceStaticType,
 			// array, 2 items follow
 			0x82,
 			// authorization:
 			// tag
-			0xd8, CBORTagUnauthorizedStaticAuthorization,
+			0xd8, values.CBORTagUnauthorizedStaticAuthorization,
 			// null
 			0xf6,
-			0xd8, CBORTagPrimitiveStaticType,
+			0xd8, values.CBORTagPrimitiveStaticType,
 			// unsigned 105
 			0x18, 0x69,
 		)
@@ -4714,16 +4710,16 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 
 		encoded := assemble(
 			// tag
-			0xd8, CBORTagReferenceStaticType,
+			0xd8, values.CBORTagReferenceStaticType,
 			// array, 2 items follow
 			0x82,
 			// authorization:
 			// tag
-			0xd8, CBORTagUnauthorizedStaticAuthorization,
+			0xd8, values.CBORTagUnauthorizedStaticAuthorization,
 			// null
 			0xf6,
 			// tag
-			0xd8, CBORTagIntersectionStaticType,
+			0xd8, values.CBORTagIntersectionStaticType,
 			// array, length 2
 			0x82,
 			// nil
@@ -4731,11 +4727,11 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 			// array, 1 item follows
 			0x81,
 			// tag
-			0xd8, CBORTagInterfaceStaticType,
+			0xd8, values.CBORTagInterfaceStaticType,
 			// array, 2 items follow
 			0x82,
 			// tag
-			0xd8, CBORTagStringLocation,
+			0xd8, values.CBORTagStringLocation,
 			// UTF-8 string, length 4
 			0x64,
 			// t, e, s, t

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -41,6 +41,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/fixedpoint"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 type getterSetter struct {
@@ -3010,18 +3011,18 @@ var fromBigEndianBytesFunctionValues = func() map[string]fromBigEndianBytesFunct
 		}),
 		newFromBigEndianBytesFunction(sema.Int128Type, 16, func(i *Interpreter, b []byte) Value {
 			return NewInt128ValueFromBigInt(i, func() *big.Int {
-				bi := BigEndianBytesToSignedBigInt(b)
+				bi := values.BigEndianBytesToSignedBigInt(b)
 				return bi
 			})
 		}),
 		newFromBigEndianBytesFunction(sema.Int256Type, 32, func(i *Interpreter, b []byte) Value {
 			return NewInt256ValueFromBigInt(i, func() *big.Int {
-				bi := BigEndianBytesToSignedBigInt(b)
+				bi := values.BigEndianBytesToSignedBigInt(b)
 				return bi
 			})
 		}),
 		newFromBigEndianBytesFunction(sema.IntType, 0, func(i *Interpreter, b []byte) Value {
-			bi := BigEndianBytesToSignedBigInt(b)
+			bi := values.BigEndianBytesToSignedBigInt(b)
 			memoryUsage := common.NewBigIntMemoryUsage(
 				common.BigIntByteLength(bi),
 			)
@@ -3055,16 +3056,16 @@ var fromBigEndianBytesFunctionValues = func() map[string]fromBigEndianBytesFunct
 		}),
 		newFromBigEndianBytesFunction(sema.UInt128Type, 16, func(i *Interpreter, b []byte) Value {
 			return NewUInt128ValueFromBigInt(i, func() *big.Int {
-				return BigEndianBytesToUnsignedBigInt(b)
+				return values.BigEndianBytesToUnsignedBigInt(b)
 			})
 		}),
 		newFromBigEndianBytesFunction(sema.UInt256Type, 32, func(i *Interpreter, b []byte) Value {
 			return NewUInt256ValueFromBigInt(i, func() *big.Int {
-				return BigEndianBytesToUnsignedBigInt(b)
+				return values.BigEndianBytesToUnsignedBigInt(b)
 			})
 		}),
 		newFromBigEndianBytesFunction(sema.UIntType, 0, func(i *Interpreter, b []byte) Value {
-			bi := BigEndianBytesToUnsignedBigInt(b)
+			bi := values.BigEndianBytesToUnsignedBigInt(b)
 			memoryUsage := common.NewBigIntMemoryUsage(
 				common.BigIntByteLength(bi),
 			)
@@ -3098,12 +3099,12 @@ var fromBigEndianBytesFunctionValues = func() map[string]fromBigEndianBytesFunct
 		}),
 		newFromBigEndianBytesFunction(sema.Word128Type, 16, func(i *Interpreter, b []byte) Value {
 			return NewWord128ValueFromBigInt(i, func() *big.Int {
-				return BigEndianBytesToUnsignedBigInt(b)
+				return values.BigEndianBytesToUnsignedBigInt(b)
 			})
 		}),
 		newFromBigEndianBytesFunction(sema.Word256Type, 32, func(i *Interpreter, b []byte) Value {
 			return NewWord256ValueFromBigInt(i, func() *big.Int {
-				return BigEndianBytesToUnsignedBigInt(b)
+				return values.BigEndianBytesToUnsignedBigInt(b)
 			})
 		}),
 
@@ -4608,7 +4609,7 @@ func (interpreter *Interpreter) authAccountCheckFunction(
 
 			valueStaticType := value.StaticType(interpreter)
 
-			return AsBoolValue(interpreter.IsSubTypeOfSemaType(valueStaticType, ty))
+			return BoolValue(interpreter.IsSubTypeOfSemaType(valueStaticType, ty))
 		},
 	)
 }
@@ -5115,7 +5116,7 @@ func (interpreter *Interpreter) isInstanceFunction(self Value) FunctionValue {
 
 			// NOTE: not invocation.Self, as that is only set for composite values
 			selfType := self.StaticType(interpreter)
-			return AsBoolValue(
+			return BoolValue(
 				interpreter.IsSubType(selfType, staticType),
 			)
 		},

--- a/interpreter/interpreter_expression.go
+++ b/interpreter/interpreter_expression.go
@@ -673,7 +673,7 @@ func (interpreter *Interpreter) testEqual(left, right Value, expression *ast.Bin
 		return FalseValue
 	}
 
-	return AsBoolValue(
+	return BoolValue(
 		leftEquatable.Equal(
 			interpreter,
 			LocationRange{
@@ -811,7 +811,7 @@ func (interpreter *Interpreter) VisitVoidExpression(_ *ast.VoidExpression) Value
 }
 
 func (interpreter *Interpreter) VisitBoolExpression(expression *ast.BoolExpression) Value {
-	return AsBoolValue(expression.Value)
+	return BoolValue(expression.Value)
 }
 
 func (interpreter *Interpreter) VisitNilExpression(_ *ast.NilExpression) Value {

--- a/interpreter/interpreter_statement.go
+++ b/interpreter/interpreter_statement.go
@@ -597,10 +597,10 @@ func (interpreter *Interpreter) VisitSwapStatement(swap *ast.SwapStatement) Stat
 	// Set right value to left target,
 	// and left value to right target
 
-	interpreter.checkInvalidatedResourceOrResourceReference(rightValue, swap.Right)
+	checkInvalidatedResourceOrResourceReference(rightValue, rightLocationRange, interpreter)
 	transferredRightValue := interpreter.transferAndConvert(rightValue, rightType, leftType, rightLocationRange)
 
-	interpreter.checkInvalidatedResourceOrResourceReference(leftValue, swap.Left)
+	checkInvalidatedResourceOrResourceReference(leftValue, leftLocationRange, interpreter)
 	transferredLeftValue := interpreter.transferAndConvert(leftValue, leftType, rightType, leftLocationRange)
 
 	leftGetterSetter.set(transferredRightValue)

--- a/interpreter/primitivestatictype.go
+++ b/interpreter/primitivestatictype.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 //go:generate go run golang.org/x/tools/cmd/stringer -type=PrimitiveStaticType -trimprefix=PrimitiveStaticType
@@ -274,13 +275,13 @@ func (t PrimitiveStaticType) elementSize() uint {
 		return uint(len(cborVoidValue))
 
 	case PrimitiveStaticTypeNever:
-		return cborTagSize + 1
+		return values.CBORTagSize + 1
 
 	case PrimitiveStaticTypeBool:
-		return cborTagSize + 1
+		return values.CBORTagSize + 1
 
 	case PrimitiveStaticTypeAddress:
-		return cborTagSize + 8 // address length is 8 bytes
+		return values.CBORTagSize + 8 // address length is 8 bytes
 
 	case PrimitiveStaticTypeString,
 		PrimitiveStaticTypeCharacter,
@@ -290,7 +291,7 @@ func (t PrimitiveStaticType) elementSize() uint {
 
 	case PrimitiveStaticTypeFixedPoint,
 		PrimitiveStaticTypeSignedFixedPoint:
-		return cborTagSize + 8
+		return values.CBORTagSize + 8
 
 	// values of these types may wrap big.Int
 	case PrimitiveStaticTypeInt,
@@ -311,24 +312,24 @@ func (t PrimitiveStaticType) elementSize() uint {
 	case PrimitiveStaticTypeInt8,
 		PrimitiveStaticTypeUInt8,
 		PrimitiveStaticTypeWord8:
-		return cborTagSize + 2
+		return values.CBORTagSize + 2
 
 	case PrimitiveStaticTypeInt16,
 		PrimitiveStaticTypeUInt16,
 		PrimitiveStaticTypeWord16:
-		return cborTagSize + 3
+		return values.CBORTagSize + 3
 
 	case PrimitiveStaticTypeInt32,
 		PrimitiveStaticTypeUInt32,
 		PrimitiveStaticTypeWord32:
-		return cborTagSize + 5
+		return values.CBORTagSize + 5
 
 	case PrimitiveStaticTypeInt64,
 		PrimitiveStaticTypeUInt64,
 		PrimitiveStaticTypeWord64,
 		PrimitiveStaticTypeFix64,
 		PrimitiveStaticTypeUFix64:
-		return cborTagSize + 9
+		return values.CBORTagSize + 9
 
 	case PrimitiveStaticTypePath,
 		PrimitiveStaticTypeCapability,

--- a/interpreter/range_value_test.go
+++ b/interpreter/range_value_test.go
@@ -451,9 +451,9 @@ func TestInclusiveRange(t *testing.T) {
 			for i, tc := range testCase.containsTests {
 				var expectedValue interpreter.Value
 				if withStep {
-					expectedValue = interpreter.AsBoolValue(tc.expectedWithStep)
+					expectedValue = interpreter.BoolValue(tc.expectedWithStep)
 				} else {
-					expectedValue = interpreter.AsBoolValue(tc.expectedWithoutStep)
+					expectedValue = interpreter.BoolValue(tc.expectedWithoutStep)
 				}
 
 				AssertValuesEqual(

--- a/interpreter/storage.go
+++ b/interpreter/storage.go
@@ -98,6 +98,9 @@ func ConvertStoredValue(gauge common.MemoryGauge, value atree.Value) (Value, err
 	case values.BoolValue:
 		return BoolValue(value), nil
 
+	case values.IntValue:
+		return IntValue{IntValue: value}, nil
+
 	case Value:
 		return value, nil
 

--- a/interpreter/storage.go
+++ b/interpreter/storage.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/values"
 
 	"github.com/onflow/cadence/common"
 )
@@ -93,6 +94,9 @@ func ConvertStoredValue(gauge common.MemoryGauge, value atree.Value) (Value, err
 		default:
 			return nil, errors.NewUnexpectedError("invalid ordered map type info: %T", staticType)
 		}
+
+	case values.BoolValue:
+		return BoolValue(value), nil
 
 	case Value:
 		return value, nil
@@ -259,24 +263,4 @@ func StorableSize(storable atree.Storable) (uint32, error) {
 	}
 
 	return uint32(size), nil
-}
-
-// maybeLargeImmutableStorable either returns the given immutable atree.Storable
-// if it can be stored inline inside its parent container,
-// or else stores it in a separate slab and returns an atree.SlabIDStorable.
-func maybeLargeImmutableStorable(
-	storable atree.Storable,
-	storage atree.SlabStorage,
-	address atree.Address,
-	maxInlineSize uint64,
-) (
-	atree.Storable,
-	error,
-) {
-
-	if uint64(storable.ByteSize()) < maxInlineSize {
-		return storable, nil
-	}
-
-	return atree.NewStorableSlab(storage, address, storable)
 }

--- a/interpreter/stringatreevalue.go
+++ b/interpreter/stringatreevalue.go
@@ -22,6 +22,7 @@ import (
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/values"
 )
 
 type StringAtreeValue string
@@ -38,7 +39,7 @@ func (v StringAtreeValue) Storable(
 	atree.Storable,
 	error,
 ) {
-	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
+	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
 func NewStringAtreeValue(gauge common.MemoryGauge, s string) StringAtreeValue {
@@ -47,7 +48,7 @@ func NewStringAtreeValue(gauge common.MemoryGauge, s string) StringAtreeValue {
 }
 
 func (v StringAtreeValue) ByteSize() uint32 {
-	return getBytesCBORSize([]byte(v))
+	return values.GetBytesCBORSize([]byte(v))
 }
 
 func (v StringAtreeValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/uint64atreevalue.go
+++ b/interpreter/uint64atreevalue.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/values"
 )
 
 type Uint64AtreeValue uint64
@@ -48,7 +49,7 @@ func NewUint64AtreeValue(gauge common.MemoryGauge, s uint64) Uint64AtreeValue {
 }
 
 func (v Uint64AtreeValue) ByteSize() uint32 {
-	return getUintCBORSize(uint64(v))
+	return values.GetUintCBORSize(uint64(v))
 }
 
 func (v Uint64AtreeValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // AccountCapabilityControllerValue
@@ -158,7 +159,7 @@ func (v *AccountCapabilityControllerValue) Storable(
 	atree.Storable,
 	error,
 ) {
-	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
+	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
 func (*AccountCapabilityControllerValue) NeedsStoreTo(_ atree.Address) bool {

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // AddressValue
@@ -255,7 +256,7 @@ func (AddressValue) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v AddressValue) ByteSize() uint32 {
-	return cborTagSize + getBytesCBORSize(v.ToAddress().Bytes())
+	return values.CBORTagSize + values.GetBytesCBORSize(v.ToAddress().Bytes())
 }
 
 func (v AddressValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -254,7 +254,7 @@ func (v *ArrayValue) iterate(
 			// atree.Array iteration provides low-level atree.Value,
 			// convert to high-level interpreter.Value
 			elementValue := MustConvertStoredValue(interpreter, element)
-			interpreter.checkInvalidatedResourceOrResourceReference(elementValue, locationRange)
+			checkInvalidatedResourceOrResourceReference(elementValue, locationRange, interpreter)
 
 			if transferElements {
 				// Each element must be transferred before passing onto the function.

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -820,7 +820,7 @@ func (v *ArrayValue) Contains(
 		locationRange,
 	)
 
-	return AsBoolValue(result)
+	return BoolValue(result)
 }
 
 func (v *ArrayValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -23,28 +23,20 @@ import (
 
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
-	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // BoolValue
 
-type BoolValue bool
+type BoolValue values.BoolValue
 
 var _ Value = BoolValue(false)
-var _ atree.Storable = BoolValue(false)
 var _ EquatableValue = BoolValue(false)
 var _ HashableValue = BoolValue(false)
 
 const TrueValue = BoolValue(true)
 const FalseValue = BoolValue(false)
-
-func AsBoolValue(v bool) BoolValue {
-	if v {
-		return TrueValue
-	}
-	return FalseValue
-}
 
 func (BoolValue) isValue() {}
 
@@ -65,10 +57,7 @@ func (BoolValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 }
 
 func (v BoolValue) Negate(_ *Interpreter) BoolValue {
-	if v == TrueValue {
-		return FalseValue
-	}
-	return TrueValue
+	return BoolValue(values.BoolValue(v).Negate())
 }
 
 func (v BoolValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -76,7 +65,10 @@ func (v BoolValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value)
 	if !ok {
 		return false
 	}
-	return bool(v) == bool(otherBool)
+	return bool(
+		values.BoolValue(v).
+			EqualBool(values.BoolValue(otherBool)),
+	)
 }
 
 func (v BoolValue) Less(_ ValueComparisonContext, other ComparableValue, _ LocationRange) BoolValue {
@@ -85,7 +77,10 @@ func (v BoolValue) Less(_ ValueComparisonContext, other ComparableValue, _ Locat
 		panic(errors.NewUnreachableError())
 	}
 
-	return !v && o
+	return BoolValue(
+		values.BoolValue(v).
+			LessBool(values.BoolValue(o)),
+	)
 }
 
 func (v BoolValue) LessEqual(_ ValueComparisonContext, other ComparableValue, _ LocationRange) BoolValue {
@@ -94,7 +89,10 @@ func (v BoolValue) LessEqual(_ ValueComparisonContext, other ComparableValue, _ 
 		panic(errors.NewUnreachableError())
 	}
 
-	return !v || o
+	return BoolValue(
+		values.BoolValue(v).
+			LessEqualBool(values.BoolValue(o)),
+	)
 }
 
 func (v BoolValue) Greater(_ ValueComparisonContext, other ComparableValue, _ LocationRange) BoolValue {
@@ -103,7 +101,10 @@ func (v BoolValue) Greater(_ ValueComparisonContext, other ComparableValue, _ Lo
 		panic(errors.NewUnreachableError())
 	}
 
-	return v && !o
+	return BoolValue(
+		values.BoolValue(v).
+			GreaterBool(values.BoolValue(o)),
+	)
 }
 
 func (v BoolValue) GreaterEqual(_ ValueComparisonContext, other ComparableValue, _ LocationRange) BoolValue {
@@ -112,7 +113,10 @@ func (v BoolValue) GreaterEqual(_ ValueComparisonContext, other ComparableValue,
 		panic(errors.NewUnreachableError())
 	}
 
-	return v || !o
+	return BoolValue(
+		values.BoolValue(v).
+			GreaterEqualBool(values.BoolValue(o)),
+	)
 }
 
 // HashInput returns a byte slice containing:
@@ -129,7 +133,7 @@ func (v BoolValue) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []by
 }
 
 func (v BoolValue) String() string {
-	return format.Bool(bool(v))
+	return values.BoolValue(v).String()
 }
 
 func (v BoolValue) RecursiveString(_ SeenReferences) string {
@@ -155,14 +159,14 @@ func (v BoolValue) ConformsToStaticType(
 }
 
 func (v BoolValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
-	return v, nil
+	return values.BoolValue(v), nil
 }
 
 func (BoolValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (BoolValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (BoolValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -187,16 +191,4 @@ func (v BoolValue) Clone(_ *Interpreter) Value {
 
 func (BoolValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
-}
-
-func (v BoolValue) ByteSize() uint32 {
-	return 1
-}
-
-func (v BoolValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
-	return v, nil
-}
-
-func (BoolValue) ChildStorables() []atree.Storable {
-	return nil
 }

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -79,7 +79,7 @@ func (v BoolValue) Less(_ ValueComparisonContext, other ComparableValue, _ Locat
 
 	return BoolValue(
 		values.BoolValue(v).
-			LessBool(values.BoolValue(o)),
+			Less(values.BoolValue(o)),
 	)
 }
 
@@ -91,7 +91,7 @@ func (v BoolValue) LessEqual(_ ValueComparisonContext, other ComparableValue, _ 
 
 	return BoolValue(
 		values.BoolValue(v).
-			LessEqualBool(values.BoolValue(o)),
+			LessEqual(values.BoolValue(o)),
 	)
 }
 
@@ -103,7 +103,7 @@ func (v BoolValue) Greater(_ ValueComparisonContext, other ComparableValue, _ Lo
 
 	return BoolValue(
 		values.BoolValue(v).
-			GreaterBool(values.BoolValue(o)),
+			Greater(values.BoolValue(o)),
 	)
 }
 
@@ -115,7 +115,7 @@ func (v BoolValue) GreaterEqual(_ ValueComparisonContext, other ComparableValue,
 
 	return BoolValue(
 		values.BoolValue(v).
-			GreaterEqualBool(values.BoolValue(o)),
+			GreaterEqual(values.BoolValue(o)),
 	)
 }
 

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 const InvalidCapabilityID UInt64Value = 0
@@ -205,7 +206,7 @@ func (v *IDCapabilityValue) Storable(
 	address atree.Address,
 	maxInlineSize uint64,
 ) (atree.Storable, error) {
-	return maybeLargeImmutableStorable(
+	return values.MaybeLargeImmutableStorable(
 		v,
 		storage,
 		address,

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // CharacterValue
@@ -207,7 +208,7 @@ func (CharacterValue) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v CharacterValue) ByteSize() uint32 {
-	return cborTagSize + getBytesCBORSize([]byte(v.Str))
+	return values.CBORTagSize + values.GetBytesCBORSize([]byte(v.Str))
 }
 
 func (v CharacterValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -1556,7 +1556,7 @@ func (v *CompositeValue) forEachField(
 ) {
 	err := atreeIterate(func(key atree.Value, atreeValue atree.Value) (resume bool, err error) {
 		value := MustConvertStoredValue(interpreter, atreeValue)
-		interpreter.checkInvalidatedResourceOrResourceReference(value, locationRange)
+		checkInvalidatedResourceOrResourceReference(value, locationRange, interpreter)
 
 		resume = f(
 			string(key.(StringAtreeValue)),
@@ -1819,7 +1819,7 @@ func forEachAttachment(
 
 	for {
 		// Check that the implicit composite reference was not invalidated during iteration
-		interpreter.checkInvalidatedResourceOrResourceReference(compositeReference, locationRange)
+		checkInvalidatedResourceOrResourceReference(compositeReference, locationRange, interpreter)
 		key, value, err := iterator.Next()
 		if err != nil {
 			panic(errors.NewExternalError(err))

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -343,7 +343,7 @@ func (v *DictionaryValue) Iterate(
 	v.iterate(interpreter, iterate, f, locationRange)
 }
 
-// IterateReadOnlyLoaded iterates over all LOADED key-valye pairs of the array.
+// IterateReadOnlyLoaded iterates over all LOADED key-value pairs of the array.
 // DO NOT perform storage mutations in the callback!
 func (v *DictionaryValue) IterateReadOnlyLoaded(
 	interpreter *Interpreter,
@@ -372,8 +372,8 @@ func (v *DictionaryValue) iterate(
 			keyValue := MustConvertStoredValue(interpreter, key)
 			valueValue := MustConvertStoredValue(interpreter, value)
 
-			interpreter.checkInvalidatedResourceOrResourceReference(keyValue, locationRange)
-			interpreter.checkInvalidatedResourceOrResourceReference(valueValue, locationRange)
+			checkInvalidatedResourceOrResourceReference(keyValue, locationRange, interpreter)
+			checkInvalidatedResourceOrResourceReference(valueValue, locationRange, interpreter)
 
 			resume = f(
 				keyValue,

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -593,7 +593,7 @@ func (v *DictionaryValue) ContainsKey(
 	if err != nil {
 		panic(errors.NewExternalError(err))
 	}
-	return AsBoolValue(exists)
+	return BoolValue(exists)
 }
 
 func (v *DictionaryValue) Get(

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -32,6 +32,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Fix64Value
@@ -411,7 +412,7 @@ func (v Fix64Value) Less(context ValueComparisonContext, other ComparableValue, 
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v Fix64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -425,7 +426,7 @@ func (v Fix64Value) LessEqual(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v Fix64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -439,7 +440,7 @@ func (v Fix64Value) Greater(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 }
 
 func (v Fix64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -453,7 +454,7 @@ func (v Fix64Value) GreaterEqual(context ValueComparisonContext, other Comparabl
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v Fix64Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -594,7 +595,7 @@ func (Fix64Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v Fix64Value) ByteSize() uint32 {
-	return cborTagSize + getIntCBORSize(int64(v))
+	return values.CBORTagSize + values.GetIntCBORSize(int64(v))
 }
 
 func (v Fix64Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -459,7 +459,7 @@ func (f BoundFunctionValue) invoke(invocation Invocation) Value {
 			})
 		}
 	} else {
-		inter.checkInvalidatedResourceOrResourceReference(f.SelfReference, locationRange)
+		checkInvalidatedResourceOrResourceReference(f.SelfReference, locationRange, inter)
 	}
 
 	return f.Function.invoke(invocation)

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Int
@@ -374,7 +375,7 @@ func (v IntValue) Less(context ValueComparisonContext, other ComparableValue, lo
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == -1)
+	return BoolValue(cmp == -1)
 }
 
 func (v IntValue) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -389,7 +390,7 @@ func (v IntValue) LessEqual(context ValueComparisonContext, other ComparableValu
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp <= 0)
+	return BoolValue(cmp <= 0)
 }
 
 func (v IntValue) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -404,7 +405,7 @@ func (v IntValue) Greater(context ValueComparisonContext, other ComparableValue,
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == 1)
+	return BoolValue(cmp == 1)
 
 }
 
@@ -420,7 +421,7 @@ func (v IntValue) GreaterEqual(context ValueComparisonContext, other ComparableV
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp >= 0)
+	return BoolValue(cmp >= 0)
 }
 
 func (v IntValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -436,7 +437,7 @@ func (v IntValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value) 
 // - HashInputTypeInt (1 byte)
 // - big int encoded in big-endian (n bytes)
 func (v IntValue) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []byte) []byte {
-	b := SignedBigIntToBigEndianBytes(v.BigInt)
+	b := values.SignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
 	var buffer []byte
@@ -595,7 +596,7 @@ func (IntValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bo
 }
 
 func (v IntValue) ToBigEndianBytes() []byte {
-	return SignedBigIntToBigEndianBytes(v.BigInt)
+	return values.SignedBigIntToBigEndianBytes(v.BigInt)
 }
 
 func (v IntValue) ConformsToStaticType(
@@ -607,7 +608,7 @@ func (v IntValue) ConformsToStaticType(
 }
 
 func (v IntValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
-	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
+	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
 func (IntValue) NeedsStoreTo(_ atree.Address) bool {
@@ -642,7 +643,7 @@ func (IntValue) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v IntValue) ByteSize() uint32 {
-	return cborTagSize + getBigIntCBORSize(v.BigInt)
+	return values.CBORTagSize + values.GetBigIntCBORSize(v.BigInt)
 }
 
 func (v IntValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -346,12 +346,7 @@ func (v IntValue) Less(context ValueComparisonContext, other ComparableValue, lo
 		})
 	}
 
-	result, err := v.IntValue.Less(o.IntValue)
-	if err != nil {
-		panic(err)
-	}
-
-	return BoolValue(result)
+	return BoolValue(v.IntValue.Less(o.IntValue))
 }
 
 func (v IntValue) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -365,12 +360,7 @@ func (v IntValue) LessEqual(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	result, err := v.IntValue.LessEqual(o.IntValue)
-	if err != nil {
-		panic(err)
-	}
-
-	return BoolValue(result)
+	return BoolValue(v.IntValue.LessEqual(o.IntValue))
 }
 
 func (v IntValue) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -384,12 +374,7 @@ func (v IntValue) Greater(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	result, err := v.IntValue.Greater(o.IntValue)
-	if err != nil {
-		panic(err)
-	}
-
-	return BoolValue(result)
+	return BoolValue(v.IntValue.Greater(o.IntValue))
 }
 
 func (v IntValue) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -403,12 +388,7 @@ func (v IntValue) GreaterEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	result, err := v.IntValue.GreaterEqual(o.IntValue)
-	if err != nil {
-		panic(err)
-	}
-
-	return BoolValue(result)
+	return BoolValue(v.IntValue.GreaterEqual(o.IntValue))
 }
 
 func (v IntValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -28,7 +28,6 @@ import (
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
-	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/values"
 )
@@ -36,21 +35,15 @@ import (
 // Int
 
 type IntValue struct {
-	BigInt *big.Int
+	values.IntValue
 }
 
 const int64Size = int(unsafe.Sizeof(int64(0)))
 
-var int64BigIntMemoryUsage = common.NewBigIntMemoryUsage(int64Size)
-
 func NewIntValueFromInt64(memoryGauge common.MemoryGauge, value int64) IntValue {
-	return NewIntValueFromBigInt(
-		memoryGauge,
-		int64BigIntMemoryUsage,
-		func() *big.Int {
-			return big.NewInt(value)
-		},
-	)
+	return IntValue{
+		IntValue: values.NewIntValueFromInt64(memoryGauge, value),
+	}
 }
 
 func NewUnmeteredIntValueFromInt64(value int64) IntValue {
@@ -62,14 +55,18 @@ func NewIntValueFromBigInt(
 	memoryUsage common.MemoryUsage,
 	bigIntConstructor func() *big.Int,
 ) IntValue {
-	common.UseMemory(memoryGauge, memoryUsage)
-	value := bigIntConstructor()
-	return NewUnmeteredIntValueFromBigInt(value)
+	return IntValue{
+		IntValue: values.NewIntValueFromBigInt(
+			memoryGauge,
+			memoryUsage,
+			bigIntConstructor,
+		),
+	}
 }
 
 func NewUnmeteredIntValueFromBigInt(value *big.Int) IntValue {
 	return IntValue{
-		BigInt: value,
+		IntValue: values.NewUnmeteredIntValueFromBigInt(value),
 	}
 }
 
@@ -119,12 +116,13 @@ func (IntValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 }
 
 func (v IntValue) ToInt(locationRange LocationRange) int {
-	if !v.BigInt.IsInt64() {
+	result, err := v.IntValue.ToInt()
+	if _, ok := err.(values.OverflowError); ok {
 		panic(OverflowError{
 			LocationRange: locationRange,
 		})
 	}
-	return int(v.BigInt.Int64())
+	return result
 }
 
 func (v IntValue) ToUint32(locationRange LocationRange) uint32 {
@@ -154,10 +152,6 @@ func (v IntValue) ToBigInt(memoryGauge common.MemoryGauge) *big.Int {
 	return new(big.Int).Set(v.BigInt)
 }
 
-func (v IntValue) String() string {
-	return format.BigInt(v.BigInt)
-}
-
 func (v IntValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
@@ -173,13 +167,9 @@ func (v IntValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ Lo
 }
 
 func (v IntValue) Negate(context NumberValueArithmeticContext, _ LocationRange) NumberValue {
-	return NewIntValueFromBigInt(
-		context,
-		common.NewNegateBigIntMemoryUsage(v.BigInt),
-		func() *big.Int {
-			return new(big.Int).Neg(v.BigInt)
-		},
-	)
+	return IntValue{
+		IntValue: v.IntValue.Negate(context).(values.IntValue),
+	}
 }
 
 func (v IntValue) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
@@ -192,15 +182,11 @@ func (v IntValue) Plus(context NumberValueArithmeticContext, other NumberValue, 
 			LocationRange: locationRange,
 		})
 	}
-
-	return NewIntValueFromBigInt(
-		context,
-		common.NewPlusBigIntMemoryUsage(v.BigInt, o.BigInt),
-		func() *big.Int {
-			res := new(big.Int)
-			return res.Add(v.BigInt, o.BigInt)
-		},
-	)
+	result, err := v.IntValue.Plus(context, o.IntValue)
+	if err != nil {
+		panic(err)
+	}
+	return IntValue{IntValue: result.(values.IntValue)}
 }
 
 func (v IntValue) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
@@ -230,14 +216,13 @@ func (v IntValue) Minus(context NumberValueArithmeticContext, other NumberValue,
 		})
 	}
 
-	return NewIntValueFromBigInt(
-		context,
-		common.NewMinusBigIntMemoryUsage(v.BigInt, o.BigInt),
-		func() *big.Int {
-			res := new(big.Int)
-			return res.Sub(v.BigInt, o.BigInt)
-		},
-	)
+	result, err := v.IntValue.Minus(context, o.IntValue)
+	if err != nil {
+		panic(err)
+	}
+	return IntValue{
+		IntValue: result.(values.IntValue),
+	}
 }
 
 func (v IntValue) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
@@ -267,20 +252,14 @@ func (v IntValue) Mod(context NumberValueArithmeticContext, other NumberValue, l
 		})
 	}
 
-	return NewIntValueFromBigInt(
-		context,
-		common.NewModBigIntMemoryUsage(v.BigInt, o.BigInt),
-		func() *big.Int {
-			res := new(big.Int)
-			// INT33-C
-			if o.BigInt.Cmp(res) == 0 {
-				panic(DivisionByZeroError{
-					LocationRange: locationRange,
-				})
-			}
-			return res.Rem(v.BigInt, o.BigInt)
-		},
-	)
+	result, err := v.IntValue.Mod(context, o.IntValue)
+	if err != nil {
+		panic(err)
+	}
+
+	return IntValue{
+		IntValue: result.(values.IntValue),
+	}
 }
 
 func (v IntValue) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
@@ -294,14 +273,13 @@ func (v IntValue) Mul(context NumberValueArithmeticContext, other NumberValue, l
 		})
 	}
 
-	return NewIntValueFromBigInt(
-		context,
-		common.NewMulBigIntMemoryUsage(v.BigInt, o.BigInt),
-		func() *big.Int {
-			res := new(big.Int)
-			return res.Mul(v.BigInt, o.BigInt)
-		},
-	)
+	result, err := v.IntValue.Mul(context, o.IntValue)
+	if err != nil {
+		panic(err)
+	}
+	return IntValue{
+		IntValue: result.(values.IntValue),
+	}
 }
 
 func (v IntValue) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
@@ -331,20 +309,14 @@ func (v IntValue) Div(context NumberValueArithmeticContext, other NumberValue, l
 		})
 	}
 
-	return NewIntValueFromBigInt(
-		context,
-		common.NewDivBigIntMemoryUsage(v.BigInt, o.BigInt),
-		func() *big.Int {
-			res := new(big.Int)
-			// INT33-C
-			if o.BigInt.Cmp(res) == 0 {
-				panic(DivisionByZeroError{
-					LocationRange: locationRange,
-				})
-			}
-			return res.Div(v.BigInt, o.BigInt)
-		},
-	)
+	result, err := v.IntValue.Div(context, o.IntValue)
+	if err != nil {
+		panic(err)
+	}
+
+	return IntValue{
+		IntValue: result.(values.IntValue),
+	}
 }
 
 func (v IntValue) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
@@ -374,8 +346,12 @@ func (v IntValue) Less(context ValueComparisonContext, other ComparableValue, lo
 		})
 	}
 
-	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == -1)
+	result, err := v.IntValue.Less(o.IntValue)
+	if err != nil {
+		panic(err)
+	}
+
+	return BoolValue(result)
 }
 
 func (v IntValue) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -389,8 +365,12 @@ func (v IntValue) LessEqual(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp <= 0)
+	result, err := v.IntValue.LessEqual(o.IntValue)
+	if err != nil {
+		panic(err)
+	}
+
+	return BoolValue(result)
 }
 
 func (v IntValue) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -404,9 +384,12 @@ func (v IntValue) Greater(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == 1)
+	result, err := v.IntValue.Greater(o.IntValue)
+	if err != nil {
+		panic(err)
+	}
 
+	return BoolValue(result)
 }
 
 func (v IntValue) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -420,8 +403,12 @@ func (v IntValue) GreaterEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp >= 0)
+	result, err := v.IntValue.GreaterEqual(o.IntValue)
+	if err != nil {
+		panic(err)
+	}
+
+	return BoolValue(result)
 }
 
 func (v IntValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -429,8 +416,8 @@ func (v IntValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value) 
 	if !ok {
 		return false
 	}
-	cmp := v.BigInt.Cmp(otherInt.BigInt)
-	return cmp == 0
+
+	return bool(v.IntValue.Equal(otherInt.IntValue))
 }
 
 // HashInput returns a byte slice containing:
@@ -463,14 +450,14 @@ func (v IntValue) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, 
 		})
 	}
 
-	return NewIntValueFromBigInt(
-		context,
-		common.NewBitwiseOrBigIntMemoryUsage(v.BigInt, o.BigInt),
-		func() *big.Int {
-			res := new(big.Int)
-			return res.Or(v.BigInt, o.BigInt)
-		},
-	)
+	result, err := v.IntValue.BitwiseOr(context, o.IntValue)
+	if err != nil {
+		panic(err)
+	}
+
+	return IntValue{
+		IntValue: result.(values.IntValue),
+	}
 }
 
 func (v IntValue) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
@@ -484,14 +471,14 @@ func (v IntValue) BitwiseXor(context ValueStaticTypeContext, other IntegerValue,
 		})
 	}
 
-	return NewIntValueFromBigInt(
-		context,
-		common.NewBitwiseXorBigIntMemoryUsage(v.BigInt, o.BigInt),
-		func() *big.Int {
-			res := new(big.Int)
-			return res.Xor(v.BigInt, o.BigInt)
-		},
-	)
+	result, err := v.IntValue.BitwiseXor(context, o.IntValue)
+	if err != nil {
+		panic(err)
+	}
+
+	return IntValue{
+		IntValue: result.(values.IntValue),
+	}
 }
 
 func (v IntValue) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
@@ -505,14 +492,14 @@ func (v IntValue) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue,
 		})
 	}
 
-	return NewIntValueFromBigInt(
-		context,
-		common.NewBitwiseAndBigIntMemoryUsage(v.BigInt, o.BigInt),
-		func() *big.Int {
-			res := new(big.Int)
-			return res.And(v.BigInt, o.BigInt)
-		},
-	)
+	result, err := v.IntValue.BitwiseAnd(context, o.IntValue)
+	if err != nil {
+		panic(err)
+	}
+
+	return IntValue{
+		IntValue: result.(values.IntValue),
+	}
 }
 
 func (v IntValue) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
@@ -526,26 +513,14 @@ func (v IntValue) BitwiseLeftShift(context ValueStaticTypeContext, other Integer
 		})
 	}
 
-	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
-			LocationRange: locationRange,
-		})
+	result, err := v.IntValue.BitwiseLeftShift(context, o.IntValue)
+	if err != nil {
+		panic(err)
 	}
 
-	if !o.BigInt.IsUint64() {
-		panic(OverflowError{
-			LocationRange: locationRange,
-		})
+	return IntValue{
+		IntValue: result.(values.IntValue),
 	}
-
-	return NewIntValueFromBigInt(
-		context,
-		common.NewBitwiseLeftShiftBigIntMemoryUsage(v.BigInt, o.BigInt),
-		func() *big.Int {
-			res := new(big.Int)
-			return res.Lsh(v.BigInt, uint(o.BigInt.Uint64()))
-		},
-	)
 }
 
 func (v IntValue) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
@@ -559,26 +534,14 @@ func (v IntValue) BitwiseRightShift(context ValueStaticTypeContext, other Intege
 		})
 	}
 
-	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
-			LocationRange: locationRange,
-		})
+	result, err := v.IntValue.BitwiseRightShift(context, o.IntValue)
+	if err != nil {
+		panic(err)
 	}
 
-	if !o.BigInt.IsUint64() {
-		panic(OverflowError{
-			LocationRange: locationRange,
-		})
+	return IntValue{
+		IntValue: result.(values.IntValue),
 	}
-
-	return NewIntValueFromBigInt(
-		context,
-		common.NewBitwiseRightShiftBigIntMemoryUsage(v.BigInt, o.BigInt),
-		func() *big.Int {
-			res := new(big.Int)
-			return res.Rsh(v.BigInt, uint(o.BigInt.Uint64()))
-		},
-	)
 }
 
 func (v IntValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
@@ -595,10 +558,6 @@ func (IntValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bo
 	panic(errors.NewUnreachableError())
 }
 
-func (v IntValue) ToBigEndianBytes() []byte {
-	return values.SignedBigIntToBigEndianBytes(v.BigInt)
-}
-
 func (v IntValue) ConformsToStaticType(
 	_ *Interpreter,
 	_ LocationRange,
@@ -607,15 +566,11 @@ func (v IntValue) ConformsToStaticType(
 	return true
 }
 
-func (v IntValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
-	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
-}
-
 func (IntValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (IntValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (IntValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -640,16 +595,4 @@ func (v IntValue) Clone(_ *Interpreter) Value {
 
 func (IntValue) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
-}
-
-func (v IntValue) ByteSize() uint32 {
-	return values.CBORTagSize + values.GetBigIntCBORSize(v.BigInt)
-}
-
-func (v IntValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
-	return v, nil
-}
-
-func (IntValue) ChildStorables() []atree.Storable {
-	return nil
 }

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -29,12 +29,13 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // toTwosComplement sets `res` to the two's complement representation of a big.Int `x` in the given target bit size.
 // `res` is returned and is awlways a positive big.Int.
 func toTwosComplement(res, x *big.Int, targetBitSize uint) *big.Int {
-	bytes := SignedBigIntToSizedBigEndianBytes(x, targetBitSize/8)
+	bytes := values.SignedBigIntToSizedBigEndianBytes(x, targetBitSize/8)
 	return res.SetBytes(bytes)
 }
 
@@ -43,7 +44,7 @@ func toTwosComplement(res, x *big.Int, targetBitSize uint) *big.Int {
 // `res` is returned and can be positive or negative.
 func fromTwosComplement(res *big.Int) *big.Int {
 	bytes := res.Bytes()
-	return BigEndianBytesToSignedBigInt(bytes)
+	return values.BigEndianBytesToSignedBigInt(bytes)
 }
 
 // truncate trims a big.Int to maxWords by directly modifying its underlying representation.
@@ -505,7 +506,7 @@ func (v Int128Value) Less(context ValueComparisonContext, other ComparableValue,
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == -1)
+	return BoolValue(cmp == -1)
 }
 
 func (v Int128Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -520,7 +521,7 @@ func (v Int128Value) LessEqual(context ValueComparisonContext, other ComparableV
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp <= 0)
+	return BoolValue(cmp <= 0)
 }
 
 func (v Int128Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -535,7 +536,7 @@ func (v Int128Value) Greater(context ValueComparisonContext, other ComparableVal
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == 1)
+	return BoolValue(cmp == 1)
 }
 
 func (v Int128Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -550,7 +551,7 @@ func (v Int128Value) GreaterEqual(context ValueComparisonContext, other Comparab
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp >= 0)
+	return BoolValue(cmp >= 0)
 }
 
 func (v Int128Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -566,7 +567,7 @@ func (v Int128Value) Equal(_ ValueComparisonContext, _ LocationRange, other Valu
 // - HashInputTypeInt128 (1 byte)
 // - big int value encoded in big-endian (n bytes)
 func (v Int128Value) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []byte) []byte {
-	b := SignedBigIntToBigEndianBytes(v.BigInt)
+	b := values.SignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
 	var buffer []byte
@@ -752,7 +753,7 @@ func (Int128Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value)
 }
 
 func (v Int128Value) ToBigEndianBytes() []byte {
-	return SignedBigIntToSizedBigEndianBytes(v.BigInt, sema.Int128TypeSize)
+	return values.SignedBigIntToSizedBigEndianBytes(v.BigInt, sema.Int128TypeSize)
 }
 
 func (v Int128Value) ConformsToStaticType(
@@ -799,7 +800,7 @@ func (Int128Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v Int128Value) ByteSize() uint32 {
-	return cborTagSize + getBigIntCBORSize(v.BigInt)
+	return values.CBORTagSize + values.GetBigIntCBORSize(v.BigInt)
 }
 
 func (v Int128Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Int16Value
@@ -410,7 +411,7 @@ func (v Int16Value) Less(context ValueComparisonContext, other ComparableValue, 
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v Int16Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -424,7 +425,7 @@ func (v Int16Value) LessEqual(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v Int16Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -438,7 +439,7 @@ func (v Int16Value) Greater(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 }
 
 func (v Int16Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -452,7 +453,7 @@ func (v Int16Value) GreaterEqual(context ValueComparisonContext, other Comparabl
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v Int16Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -676,7 +677,7 @@ func (Int16Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v Int16Value) ByteSize() uint32 {
-	return cborTagSize + getIntCBORSize(int64(v))
+	return values.CBORTagSize + values.GetIntCBORSize(int64(v))
 }
 
 func (v Int16Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Int256Value
@@ -472,7 +473,7 @@ func (v Int256Value) Less(context ValueComparisonContext, other ComparableValue,
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == -1)
+	return BoolValue(cmp == -1)
 }
 
 func (v Int256Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -487,7 +488,7 @@ func (v Int256Value) LessEqual(context ValueComparisonContext, other ComparableV
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp <= 0)
+	return BoolValue(cmp <= 0)
 }
 
 func (v Int256Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -502,7 +503,7 @@ func (v Int256Value) Greater(context ValueComparisonContext, other ComparableVal
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == 1)
+	return BoolValue(cmp == 1)
 }
 
 func (v Int256Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -517,7 +518,7 @@ func (v Int256Value) GreaterEqual(context ValueComparisonContext, other Comparab
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp >= 0)
+	return BoolValue(cmp >= 0)
 }
 
 func (v Int256Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -533,7 +534,7 @@ func (v Int256Value) Equal(_ ValueComparisonContext, _ LocationRange, other Valu
 // - HashInputTypeInt256 (1 byte)
 // - big int value encoded in big-endian (n bytes)
 func (v Int256Value) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []byte) []byte {
-	b := SignedBigIntToBigEndianBytes(v.BigInt)
+	b := values.SignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
 	var buffer []byte
@@ -719,7 +720,7 @@ func (Int256Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value)
 }
 
 func (v Int256Value) ToBigEndianBytes() []byte {
-	return SignedBigIntToSizedBigEndianBytes(v.BigInt, sema.Int256TypeSize)
+	return values.SignedBigIntToSizedBigEndianBytes(v.BigInt, sema.Int256TypeSize)
 }
 
 func (v Int256Value) ConformsToStaticType(
@@ -766,7 +767,7 @@ func (Int256Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v Int256Value) ByteSize() uint32 {
-	return cborTagSize + getBigIntCBORSize(v.BigInt)
+	return values.CBORTagSize + values.GetBigIntCBORSize(v.BigInt)
 }
 
 func (v Int256Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Int32Value
@@ -411,7 +412,7 @@ func (v Int32Value) Less(context ValueComparisonContext, other ComparableValue, 
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v Int32Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -425,7 +426,7 @@ func (v Int32Value) LessEqual(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v Int32Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -439,7 +440,7 @@ func (v Int32Value) Greater(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 }
 
 func (v Int32Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -453,7 +454,7 @@ func (v Int32Value) GreaterEqual(context ValueComparisonContext, other Comparabl
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v Int32Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -676,7 +677,7 @@ func (Int32Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v Int32Value) ByteSize() uint32 {
-	return cborTagSize + getIntCBORSize(int64(v))
+	return values.CBORTagSize + values.GetIntCBORSize(int64(v))
 }
 
 func (v Int32Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Int64Value
@@ -410,7 +411,7 @@ func (v Int64Value) Less(context ValueComparisonContext, other ComparableValue, 
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v Int64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -424,7 +425,7 @@ func (v Int64Value) LessEqual(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v Int64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -438,7 +439,7 @@ func (v Int64Value) Greater(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 
 }
 
@@ -453,7 +454,7 @@ func (v Int64Value) GreaterEqual(context ValueComparisonContext, other Comparabl
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v Int64Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -667,7 +668,7 @@ func (Int64Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v Int64Value) ByteSize() uint32 {
-	return cborTagSize + getIntCBORSize(int64(v))
+	return values.CBORTagSize + values.GetIntCBORSize(int64(v))
 }
 
 func (v Int64Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Int8Value
@@ -409,7 +410,7 @@ func (v Int8Value) Less(context ValueComparisonContext, other ComparableValue, l
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v Int8Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -423,7 +424,7 @@ func (v Int8Value) LessEqual(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v Int8Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -437,7 +438,7 @@ func (v Int8Value) Greater(context ValueComparisonContext, other ComparableValue
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 }
 
 func (v Int8Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -451,7 +452,7 @@ func (v Int8Value) GreaterEqual(context ValueComparisonContext, other Comparable
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v Int8Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -673,7 +674,7 @@ func (Int8Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v Int8Value) ByteSize() uint32 {
-	return cborTagSize + getIntCBORSize(int64(v))
+	return values.CBORTagSize + values.GetIntCBORSize(int64(v))
 }
 
 func (v Int8Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_link.go
+++ b/interpreter/value_link.go
@@ -308,7 +308,7 @@ func (v PathLinkValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, values.CBORTagPathLinkValue,
+		0xd8, values.CBORTagPathLinkValue, //nolint:staticcheck
 		// array, 2 items follow
 		0x82,
 	})
@@ -332,7 +332,7 @@ func (v PathLinkValue) Encode(e *atree.Encoder) error {
 //	}
 var cborAccountLinkValue = []byte{
 	// tag
-	0xd8, values.CBORTagAccountLinkValue,
+	0xd8, values.CBORTagAccountLinkValue, //nolint:staticcheck
 	// null
 	0xf6,
 }

--- a/interpreter/value_link.go
+++ b/interpreter/value_link.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/values"
 )
 
 // TODO: remove once migrated
@@ -113,7 +114,7 @@ func (PathLinkValue) IsStorable() bool {
 }
 
 func (v PathLinkValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
-	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
+	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
 func (PathLinkValue) NeedsStoreTo(_ atree.Address) bool {
@@ -236,7 +237,7 @@ func (AccountLinkValue) IsStorable() bool {
 }
 
 func (v AccountLinkValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
-	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
+	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
 func (AccountLinkValue) NeedsStoreTo(_ atree.Address) bool {
@@ -307,7 +308,7 @@ func (v PathLinkValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagPathLinkValue,
+		0xd8, values.CBORTagPathLinkValue,
 		// array, 2 items follow
 		0x82,
 	})
@@ -331,7 +332,7 @@ func (v PathLinkValue) Encode(e *atree.Encoder) error {
 //	}
 var cborAccountLinkValue = []byte{
 	// tag
-	0xd8, CBORTagAccountLinkValue,
+	0xd8, values.CBORTagAccountLinkValue,
 	// null
 	0xf6,
 }

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // PathValue
@@ -213,7 +214,7 @@ func (v PathValue) Storable(
 	address atree.Address,
 	maxInlineSize uint64,
 ) (atree.Storable, error) {
-	return maybeLargeImmutableStorable(
+	return values.MaybeLargeImmutableStorable(
 		v,
 		storage,
 		address,
@@ -254,7 +255,10 @@ func (PathValue) DeepRemove(_ *Interpreter, _ bool) {
 
 func (v PathValue) ByteSize() uint32 {
 	// tag number (2 bytes) + array head (1 byte) + domain (CBOR uint) + identifier (CBOR string)
-	return cborTagSize + 1 + getUintCBORSize(uint64(v.Domain)) + getBytesCBORSize([]byte(v.Identifier))
+	return values.CBORTagSize +
+		1 +
+		values.GetUintCBORSize(uint64(v.Domain)) +
+		values.GetBytesCBORSize([]byte(v.Identifier))
 }
 
 func (v PathValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -323,7 +323,7 @@ func (v *PathCapabilityValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, values.CBORTagPathCapabilityValue,
+		0xd8, values.CBORTagPathCapabilityValue, //nolint:staticcheck
 		// array, 3 items follow
 		0x83,
 	})

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -26,6 +26,7 @@ import (
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // TODO: remove once migrated
@@ -228,7 +229,7 @@ func (v *PathCapabilityValue) Storable(
 	address atree.Address,
 	maxInlineSize uint64,
 ) (atree.Storable, error) {
-	return maybeLargeImmutableStorable(
+	return values.MaybeLargeImmutableStorable(
 		v,
 		storage,
 		address,
@@ -322,7 +323,7 @@ func (v *PathCapabilityValue) Encode(e *atree.Encoder) error {
 	// Encode tag number and array head
 	err := e.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagPathCapabilityValue,
+		0xd8, values.CBORTagPathCapabilityValue,
 		// array, 3 items follow
 		0x83,
 	})

--- a/interpreter/value_published.go
+++ b/interpreter/value_published.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/values"
 )
 
 // PublishedValue
@@ -113,7 +114,7 @@ func (*PublishedValue) IsStorable() bool {
 }
 
 func (v *PublishedValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
-	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
+	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
 func (v *PublishedValue) NeedsStoreTo(address atree.Address) bool {

--- a/interpreter/value_range.go
+++ b/interpreter/value_range.go
@@ -221,7 +221,7 @@ func rangeContains(
 		result = mod.Equal(interpreter, locationRange, zeroValue)
 	}
 
-	return AsBoolValue(result)
+	return BoolValue(result)
 }
 
 func getFieldAsIntegerValue(memoryGauge common.MemoryGauge, rangeValue *CompositeValue, name string) IntegerValue {

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // SomeValue
@@ -451,9 +452,11 @@ func (s SomeStorable) HasPointer() bool {
 
 func getSomeStorableEncodedPrefixSize(nestedLevels uint64) uint32 {
 	if nestedLevels == 1 {
-		return cborTagSize
+		return values.CBORTagSize
 	}
-	return cborTagSize + someStorableWithMultipleNestedlevelsArraySize + getUintCBORSize(nestedLevels)
+	return values.CBORTagSize +
+		someStorableWithMultipleNestedlevelsArraySize +
+		values.GetUintCBORSize(nestedLevels)
 }
 
 func (s SomeStorable) ByteSize() uint32 {

--- a/interpreter/value_some_test.go
+++ b/interpreter/value_some_test.go
@@ -31,12 +31,12 @@ import (
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 	. "github.com/onflow/cadence/test_utils/common_utils"
+	"github.com/onflow/cadence/values"
 )
 
 func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 
 	const (
-		cborTagSize                                   = 2
 		someStorableWithMultipleNestedLevelsArraySize = 1
 	)
 
@@ -49,7 +49,7 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 
 		unwrappedValue, wrapperSize := v.UnwrapAtreeValue()
 		require.Equal(t, bv, unwrappedValue)
-		require.Equal(t, uint64(cborTagSize), wrapperSize)
+		require.Equal(t, uint64(values.CBORTagSize), wrapperSize)
 	})
 
 	t.Run("SomeValue(SomeValue(bool))", func(t *testing.T) {
@@ -61,7 +61,7 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 
 		unwrappedValue, wrapperSize := v.UnwrapAtreeValue()
 		require.Equal(t, bv, unwrappedValue)
-		require.Equal(t, uint64(cborTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
+		require.Equal(t, uint64(values.CBORTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
 	})
 
 	t.Run("SomeValue(SomeValue(ArrayValue(...)))", func(t *testing.T) {
@@ -86,7 +86,7 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 
 		address := common.Address{'A'}
 
-		values := []interpreter.Value{
+		elements := []interpreter.Value{
 			interpreter.NewUnmeteredUInt64Value(0),
 			interpreter.NewUnmeteredUInt64Value(1),
 		}
@@ -98,7 +98,7 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			address,
-			values...,
+			elements...,
 		)
 
 		v := interpreter.NewUnmeteredSomeValueNonCopying(
@@ -107,13 +107,13 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 
 		unwrappedValue, wrapperSize := v.UnwrapAtreeValue()
 		require.IsType(t, &atree.Array{}, unwrappedValue)
-		require.Equal(t, uint64(cborTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
+		require.Equal(t, uint64(values.CBORTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
 
 		atreeArray := unwrappedValue.(*atree.Array)
 		require.Equal(t, atree.Address(address), atreeArray.Address())
-		require.Equal(t, uint64(len(values)), atreeArray.Count())
+		require.Equal(t, uint64(len(elements)), atreeArray.Count())
 
-		for i, expectedValue := range values {
+		for i, expectedValue := range elements {
 			v, err := atreeArray.Get(uint64(i))
 			require.NoError(t, err)
 			require.Equal(t, expectedValue, v)
@@ -142,7 +142,7 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 
 		address := common.Address{'A'}
 
-		values := []interpreter.Value{
+		elements := []interpreter.Value{
 			interpreter.NewUnmeteredUInt64Value(0),
 			interpreter.NewUnmeteredStringValue("a"),
 			interpreter.NewUnmeteredUInt64Value(1),
@@ -157,7 +157,7 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 				ValueType: interpreter.PrimitiveStaticTypeAnyStruct,
 			},
 			address,
-			values...,
+			elements...,
 		)
 
 		v := interpreter.NewUnmeteredSomeValueNonCopying(
@@ -166,12 +166,12 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 
 		unwrappedValue, wrapperSize := v.UnwrapAtreeValue()
 		require.IsType(t, &atree.OrderedMap{}, unwrappedValue)
-		require.Equal(t, uint64(cborTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
+		require.Equal(t, uint64(values.CBORTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
 
 		// Verify unwrapped value
 		atreeMap := unwrappedValue.(*atree.OrderedMap)
 		require.Equal(t, atree.Address(address), atreeMap.Address())
-		require.Equal(t, uint64(len(values)/2), atreeMap.Count())
+		require.Equal(t, uint64(len(elements)/2), atreeMap.Count())
 
 		valueComparator := func(
 			storage atree.SlabStorage,
@@ -192,9 +192,9 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 			return hashInput, nil
 		}
 
-		for i := 0; i < len(values); i += 2 {
-			key := values[i]
-			expectedValue := values[i+1]
+		for i := 0; i < len(elements); i += 2 {
+			key := elements[i]
+			expectedValue := elements[i+1]
 
 			v, err := atreeMap.Get(
 				valueComparator,
@@ -264,7 +264,7 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 
 		unwrappedValue, wrapperSize := v.UnwrapAtreeValue()
 		require.IsType(t, &atree.OrderedMap{}, unwrappedValue)
-		require.Equal(t, uint64(cborTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
+		require.Equal(t, uint64(values.CBORTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
 
 		// Verify unwrapped value
 		atreeMap := unwrappedValue.(*atree.OrderedMap)
@@ -301,7 +301,7 @@ func TestSomeStorableUnwrapAtreeStorable(t *testing.T) {
 		require.IsType(t, interpreter.SomeStorable{}, storable)
 
 		unwrappedStorable := storable.(interpreter.SomeStorable).UnwrapAtreeStorable()
-		require.Equal(t, interpreter.BoolValue(true), unwrappedStorable)
+		require.Equal(t, values.BoolValue(true), unwrappedStorable)
 	})
 
 	t.Run("SomeValue(SomeValue(bool))", func(t *testing.T) {
@@ -317,7 +317,7 @@ func TestSomeStorableUnwrapAtreeStorable(t *testing.T) {
 		require.IsType(t, interpreter.SomeStorable{}, storable)
 
 		unwrappedStorable := storable.(interpreter.SomeStorable).UnwrapAtreeStorable()
-		require.Equal(t, interpreter.BoolValue(true), unwrappedStorable)
+		require.Equal(t, values.BoolValue(true), unwrappedStorable)
 	})
 
 	t.Run("SomeValue(SomeValue(ArrayValue(...))), small ArrayValue", func(t *testing.T) {

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -449,7 +449,7 @@ func forEachReference(
 		// The loop dereference the reference once, and hold onto that referenced-value.
 		// But the reference could get invalidated during the iteration, making that referenced-value invalid.
 		// So check the validity of the reference, before each iteration.
-		interpreter.checkInvalidatedResourceOrResourceReference(reference, locationRange)
+		checkInvalidatedResourceOrResourceReference(reference, locationRange, interpreter)
 
 		if isResultReference {
 			value = interpreter.getReferenceValue(value, elementType, locationRange)

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 type CapabilityControllerValue interface {
@@ -183,7 +184,7 @@ func (v *StorageCapabilityControllerValue) Storable(
 	atree.Storable,
 	error,
 ) {
-	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
+	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
 func (*StorageCapabilityControllerValue) NeedsStoreTo(_ atree.Address) bool {

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -34,6 +34,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // StringValue
@@ -162,7 +163,7 @@ func (v *StringValue) Less(context ValueComparisonContext, other ComparableValue
 		})
 	}
 
-	return AsBoolValue(v.Str < otherString.Str)
+	return BoolValue(v.Str < otherString.Str)
 }
 
 func (v *StringValue) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -176,7 +177,7 @@ func (v *StringValue) LessEqual(context ValueComparisonContext, other Comparable
 		})
 	}
 
-	return AsBoolValue(v.Str <= otherString.Str)
+	return BoolValue(v.Str <= otherString.Str)
 }
 
 func (v *StringValue) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -190,7 +191,7 @@ func (v *StringValue) Greater(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return AsBoolValue(v.Str > otherString.Str)
+	return BoolValue(v.Str > otherString.Str)
 }
 
 func (v *StringValue) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -204,7 +205,7 @@ func (v *StringValue) GreaterEqual(context ValueComparisonContext, other Compara
 		})
 	}
 
-	return AsBoolValue(v.Str >= otherString.Str)
+	return BoolValue(v.Str >= otherString.Str)
 }
 
 // HashInput returns a byte slice containing:
@@ -727,7 +728,7 @@ func (v *StringValue) ReplaceAll(
 }
 
 func (v *StringValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
-	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
+	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
 func (*StringValue) NeedsStoreTo(_ atree.Address) bool {
@@ -762,7 +763,7 @@ func (*StringValue) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v *StringValue) ByteSize() uint32 {
-	return cborTagSize + getBytesCBORSize([]byte(v.Str))
+	return values.CBORTagSize + values.GetBytesCBORSize([]byte(v.Str))
 }
 
 func (v *StringValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
@@ -1027,7 +1028,7 @@ func (v *StringValue) indexOf(inter *Interpreter, other *StringValue) (character
 
 func (v *StringValue) Contains(inter *Interpreter, other *StringValue) BoolValue {
 	characterIndex, _ := v.indexOf(inter, other)
-	return AsBoolValue(characterIndex >= 0)
+	return BoolValue(characterIndex >= 0)
 }
 
 func (v *StringValue) Count(inter *Interpreter, locationRange LocationRange, other *StringValue) IntValue {

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // TypeValue
@@ -153,7 +154,7 @@ func (v TypeValue) GetMember(interpreter *Interpreter, _ LocationRange, name str
 					MustConvertStaticToSemaType(staticType, interpreter),
 					MustConvertStaticToSemaType(otherStaticType, interpreter),
 				)
-				return AsBoolValue(result)
+				return BoolValue(result)
 			},
 		)
 
@@ -173,7 +174,7 @@ func (v TypeValue) GetMember(interpreter *Interpreter, _ LocationRange, name str
 			return FalseValue
 		}
 
-		return AsBoolValue(elaboration.IsRecovered)
+		return BoolValue(elaboration.IsRecovered)
 
 	case sema.MetaTypeAddressFieldName:
 		staticType := v.Type
@@ -282,7 +283,7 @@ func (v TypeValue) Storable(
 	address atree.Address,
 	maxInlineSize uint64,
 ) (atree.Storable, error) {
-	return maybeLargeImmutableStorable(
+	return values.MaybeLargeImmutableStorable(
 		v,
 		storage,
 		address,

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -32,6 +32,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // UFix64Value
@@ -356,7 +357,7 @@ func (v UFix64Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v UFix64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -370,7 +371,7 @@ func (v UFix64Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v UFix64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -384,7 +385,7 @@ func (v UFix64Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 }
 
 func (v UFix64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -398,7 +399,7 @@ func (v UFix64Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v UFix64Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -550,7 +551,7 @@ func (UFix64Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v UFix64Value) ByteSize() uint32 {
-	return cborTagSize + getUintCBORSize(uint64(v))
+	return values.CBORTagSize + values.GetUintCBORSize(uint64(v))
 }
 
 func (v UFix64Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // UIntValue
@@ -383,7 +384,7 @@ func (v UIntValue) Less(context ValueComparisonContext, other ComparableValue, l
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == -1)
+	return BoolValue(cmp == -1)
 }
 
 func (v UIntValue) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -398,7 +399,7 @@ func (v UIntValue) LessEqual(context ValueComparisonContext, other ComparableVal
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp <= 0)
+	return BoolValue(cmp <= 0)
 }
 
 func (v UIntValue) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -413,7 +414,7 @@ func (v UIntValue) Greater(context ValueComparisonContext, other ComparableValue
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == 1)
+	return BoolValue(cmp == 1)
 }
 
 func (v UIntValue) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -428,7 +429,7 @@ func (v UIntValue) GreaterEqual(context ValueComparisonContext, other Comparable
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp >= 0)
+	return BoolValue(cmp >= 0)
 }
 
 func (v UIntValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -444,7 +445,7 @@ func (v UIntValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value)
 // - HashInputTypeUInt (1 byte)
 // - big int value encoded in big-endian (n bytes)
 func (v UIntValue) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []byte) []byte {
-	b := UnsignedBigIntToBigEndianBytes(v.BigInt)
+	b := values.UnsignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
 	var buffer []byte
@@ -603,7 +604,7 @@ func (UIntValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) b
 }
 
 func (v UIntValue) ToBigEndianBytes() []byte {
-	return UnsignedBigIntToBigEndianBytes(v.BigInt)
+	return values.UnsignedBigIntToBigEndianBytes(v.BigInt)
 }
 
 func (v UIntValue) ConformsToStaticType(
@@ -615,7 +616,7 @@ func (v UIntValue) ConformsToStaticType(
 }
 
 func (v UIntValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
-	return maybeLargeImmutableStorable(v, storage, address, maxInlineSize)
+	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
 func (UIntValue) NeedsStoreTo(_ atree.Address) bool {
@@ -650,7 +651,7 @@ func (UIntValue) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v UIntValue) ByteSize() uint32 {
-	return cborTagSize + getBigIntCBORSize(v.BigInt)
+	return values.CBORTagSize + values.GetBigIntCBORSize(v.BigInt)
 }
 
 func (v UIntValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // UInt128Value
@@ -400,7 +401,7 @@ func (v UInt128Value) Less(context ValueComparisonContext, other ComparableValue
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == -1)
+	return BoolValue(cmp == -1)
 }
 
 func (v UInt128Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -415,7 +416,7 @@ func (v UInt128Value) LessEqual(context ValueComparisonContext, other Comparable
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp <= 0)
+	return BoolValue(cmp <= 0)
 }
 
 func (v UInt128Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -430,7 +431,7 @@ func (v UInt128Value) Greater(context ValueComparisonContext, other ComparableVa
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == 1)
+	return BoolValue(cmp == 1)
 }
 
 func (v UInt128Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -445,7 +446,7 @@ func (v UInt128Value) GreaterEqual(context ValueComparisonContext, other Compara
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp >= 0)
+	return BoolValue(cmp >= 0)
 }
 
 func (v UInt128Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -461,7 +462,7 @@ func (v UInt128Value) Equal(_ ValueComparisonContext, _ LocationRange, other Val
 // - HashInputTypeUInt128 (1 byte)
 // - big int encoded in big endian (n bytes)
 func (v UInt128Value) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []byte) []byte {
-	b := UnsignedBigIntToBigEndianBytes(v.BigInt)
+	b := values.UnsignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
 	var buffer []byte
@@ -649,7 +650,7 @@ func (UInt128Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value
 }
 
 func (v UInt128Value) ToBigEndianBytes() []byte {
-	return UnsignedBigIntToSizedBigEndianBytes(v.BigInt, sema.UInt128TypeSize)
+	return values.UnsignedBigIntToSizedBigEndianBytes(v.BigInt, sema.UInt128TypeSize)
 }
 
 func (v UInt128Value) ConformsToStaticType(
@@ -700,7 +701,7 @@ func (UInt128Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v UInt128Value) ByteSize() uint32 {
-	return cborTagSize + getBigIntCBORSize(v.BigInt)
+	return values.CBORTagSize + values.GetBigIntCBORSize(v.BigInt)
 }
 
 func (v UInt128Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // UInt16Value
@@ -323,7 +324,7 @@ func (v UInt16Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v UInt16Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -337,7 +338,7 @@ func (v UInt16Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v UInt16Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -351,7 +352,7 @@ func (v UInt16Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 }
 
 func (v UInt16Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -365,7 +366,7 @@ func (v UInt16Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v UInt16Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -563,7 +564,7 @@ func (UInt16Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v UInt16Value) ByteSize() uint32 {
-	return cborTagSize + getUintCBORSize(uint64(v))
+	return values.CBORTagSize + values.GetUintCBORSize(uint64(v))
 }
 
 func (v UInt16Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // UInt256Value
@@ -402,7 +403,7 @@ func (v UInt256Value) Less(context ValueComparisonContext, other ComparableValue
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == -1)
+	return BoolValue(cmp == -1)
 }
 
 func (v UInt256Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -417,7 +418,7 @@ func (v UInt256Value) LessEqual(context ValueComparisonContext, other Comparable
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp <= 0)
+	return BoolValue(cmp <= 0)
 }
 
 func (v UInt256Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -432,7 +433,7 @@ func (v UInt256Value) Greater(context ValueComparisonContext, other ComparableVa
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == 1)
+	return BoolValue(cmp == 1)
 }
 
 func (v UInt256Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -447,7 +448,7 @@ func (v UInt256Value) GreaterEqual(context ValueComparisonContext, other Compara
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp >= 0)
+	return BoolValue(cmp >= 0)
 }
 
 func (v UInt256Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -463,7 +464,7 @@ func (v UInt256Value) Equal(_ ValueComparisonContext, _ LocationRange, other Val
 // - HashInputTypeUInt256 (1 byte)
 // - big int encoded in big endian (n bytes)
 func (v UInt256Value) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []byte) []byte {
-	b := UnsignedBigIntToBigEndianBytes(v.BigInt)
+	b := values.UnsignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
 	var buffer []byte
@@ -649,7 +650,7 @@ func (UInt256Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value
 }
 
 func (v UInt256Value) ToBigEndianBytes() []byte {
-	return UnsignedBigIntToSizedBigEndianBytes(v.BigInt, sema.UInt256TypeSize)
+	return values.UnsignedBigIntToSizedBigEndianBytes(v.BigInt, sema.UInt256TypeSize)
 }
 
 func (v UInt256Value) ConformsToStaticType(
@@ -699,7 +700,7 @@ func (UInt256Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v UInt256Value) ByteSize() uint32 {
-	return cborTagSize + getBigIntCBORSize(v.BigInt)
+	return values.CBORTagSize + values.GetBigIntCBORSize(v.BigInt)
 }
 
 func (v UInt256Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // UInt32Value
@@ -324,7 +325,7 @@ func (v UInt32Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v UInt32Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -338,7 +339,7 @@ func (v UInt32Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v UInt32Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -352,7 +353,7 @@ func (v UInt32Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 }
 
 func (v UInt32Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -366,7 +367,7 @@ func (v UInt32Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v UInt32Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -564,7 +565,7 @@ func (UInt32Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v UInt32Value) ByteSize() uint32 {
-	return cborTagSize + getUintCBORSize(uint64(v))
+	return values.CBORTagSize + values.GetUintCBORSize(uint64(v))
 }
 
 func (v UInt32Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -31,6 +31,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // UInt64Value
@@ -354,7 +355,7 @@ func (v UInt64Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v UInt64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -368,7 +369,7 @@ func (v UInt64Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v UInt64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -382,7 +383,7 @@ func (v UInt64Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 }
 
 func (v UInt64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -396,7 +397,7 @@ func (v UInt64Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v UInt64Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -594,7 +595,7 @@ func (UInt64Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v UInt64Value) ByteSize() uint32 {
-	return cborTagSize + getUintCBORSize(uint64(v))
+	return values.CBORTagSize + values.GetUintCBORSize(uint64(v))
 }
 
 func (v UInt64Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // UInt8Value
@@ -318,7 +319,7 @@ func (v UInt8Value) Less(context ValueComparisonContext, other ComparableValue, 
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v UInt8Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -332,7 +333,7 @@ func (v UInt8Value) LessEqual(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v UInt8Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -346,7 +347,7 @@ func (v UInt8Value) Greater(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 }
 
 func (v UInt8Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -360,7 +361,7 @@ func (v UInt8Value) GreaterEqual(context ValueComparisonContext, other Comparabl
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v UInt8Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -608,7 +609,7 @@ func (UInt8Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v UInt8Value) ByteSize() uint32 {
-	return cborTagSize + getUintCBORSize(uint64(v))
+	return values.CBORTagSize + values.GetUintCBORSize(uint64(v))
 }
 
 func (v UInt8Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Word128Value
@@ -310,7 +311,7 @@ func (v Word128Value) Less(context ValueComparisonContext, other ComparableValue
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == -1)
+	return BoolValue(cmp == -1)
 }
 
 func (v Word128Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -325,7 +326,7 @@ func (v Word128Value) LessEqual(context ValueComparisonContext, other Comparable
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp <= 0)
+	return BoolValue(cmp <= 0)
 }
 
 func (v Word128Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -340,7 +341,7 @@ func (v Word128Value) Greater(context ValueComparisonContext, other ComparableVa
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == 1)
+	return BoolValue(cmp == 1)
 }
 
 func (v Word128Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -355,7 +356,7 @@ func (v Word128Value) GreaterEqual(context ValueComparisonContext, other Compara
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp >= 0)
+	return BoolValue(cmp >= 0)
 }
 
 func (v Word128Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -371,7 +372,7 @@ func (v Word128Value) Equal(_ ValueComparisonContext, _ LocationRange, other Val
 // - HashInputTypeWord128 (1 byte)
 // - big int encoded in big endian (n bytes)
 func (v Word128Value) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []byte) []byte {
-	b := UnsignedBigIntToBigEndianBytes(v.BigInt)
+	b := values.UnsignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
 	var buffer []byte
@@ -554,7 +555,7 @@ func (Word128Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value
 }
 
 func (v Word128Value) ToBigEndianBytes() []byte {
-	return UnsignedBigIntToBigEndianBytes(v.BigInt)
+	return values.UnsignedBigIntToBigEndianBytes(v.BigInt)
 }
 
 func (v Word128Value) ConformsToStaticType(
@@ -605,7 +606,7 @@ func (Word128Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v Word128Value) ByteSize() uint32 {
-	return cborTagSize + getBigIntCBORSize(v.BigInt)
+	return values.CBORTagSize + values.GetBigIntCBORSize(v.BigInt)
 }
 
 func (v Word128Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Word16Value
@@ -230,7 +231,7 @@ func (v Word16Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v Word16Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -244,7 +245,7 @@ func (v Word16Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v Word16Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -258,7 +259,7 @@ func (v Word16Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 }
 
 func (v Word16Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -272,7 +273,7 @@ func (v Word16Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v Word16Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -459,7 +460,7 @@ func (Word16Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v Word16Value) ByteSize() uint32 {
-	return cborTagSize + getUintCBORSize(uint64(v))
+	return values.CBORTagSize + values.GetUintCBORSize(uint64(v))
 }
 
 func (v Word16Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Word256Value
@@ -310,7 +311,7 @@ func (v Word256Value) Less(context ValueComparisonContext, other ComparableValue
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == -1)
+	return BoolValue(cmp == -1)
 }
 
 func (v Word256Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -325,7 +326,7 @@ func (v Word256Value) LessEqual(context ValueComparisonContext, other Comparable
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp <= 0)
+	return BoolValue(cmp <= 0)
 }
 
 func (v Word256Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -340,7 +341,7 @@ func (v Word256Value) Greater(context ValueComparisonContext, other ComparableVa
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp == 1)
+	return BoolValue(cmp == 1)
 }
 
 func (v Word256Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -355,7 +356,7 @@ func (v Word256Value) GreaterEqual(context ValueComparisonContext, other Compara
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return AsBoolValue(cmp >= 0)
+	return BoolValue(cmp >= 0)
 }
 
 func (v Word256Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -371,7 +372,7 @@ func (v Word256Value) Equal(_ ValueComparisonContext, _ LocationRange, other Val
 // - HashInputTypeWord256 (1 byte)
 // - big int encoded in big endian (n bytes)
 func (v Word256Value) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []byte) []byte {
-	b := UnsignedBigIntToBigEndianBytes(v.BigInt)
+	b := values.UnsignedBigIntToBigEndianBytes(v.BigInt)
 
 	length := 1 + len(b)
 	var buffer []byte
@@ -555,7 +556,7 @@ func (Word256Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value
 }
 
 func (v Word256Value) ToBigEndianBytes() []byte {
-	return UnsignedBigIntToBigEndianBytes(v.BigInt)
+	return values.UnsignedBigIntToBigEndianBytes(v.BigInt)
 }
 
 func (v Word256Value) ConformsToStaticType(
@@ -606,7 +607,7 @@ func (Word256Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v Word256Value) ByteSize() uint32 {
-	return cborTagSize + getBigIntCBORSize(v.BigInt)
+	return values.CBORTagSize + values.GetBigIntCBORSize(v.BigInt)
 }
 
 func (v Word256Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Word32Value
@@ -231,7 +232,7 @@ func (v Word32Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v Word32Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -245,7 +246,7 @@ func (v Word32Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v Word32Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -259,7 +260,7 @@ func (v Word32Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 }
 
 func (v Word32Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -273,7 +274,7 @@ func (v Word32Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v Word32Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -460,7 +461,7 @@ func (Word32Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v Word32Value) ByteSize() uint32 {
-	return cborTagSize + getUintCBORSize(uint64(v))
+	return values.CBORTagSize + values.GetUintCBORSize(uint64(v))
 }
 
 func (v Word32Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -31,6 +31,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Word64Value
@@ -259,7 +260,7 @@ func (v Word64Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v Word64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -273,7 +274,7 @@ func (v Word64Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v Word64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -287,7 +288,7 @@ func (v Word64Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 }
 
 func (v Word64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -301,7 +302,7 @@ func (v Word64Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v Word64Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -484,7 +485,7 @@ func (v Word64Value) Clone(_ *Interpreter) Value {
 }
 
 func (v Word64Value) ByteSize() uint32 {
-	return cborTagSize + getUintCBORSize(uint64(v))
+	return values.CBORTagSize + values.GetUintCBORSize(uint64(v))
 }
 
 func (Word64Value) DeepRemove(_ *Interpreter, _ bool) {

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -28,6 +28,7 @@ import (
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Word8Value
@@ -230,7 +231,7 @@ func (v Word8Value) Less(context ValueComparisonContext, other ComparableValue, 
 		})
 	}
 
-	return AsBoolValue(v < o)
+	return BoolValue(v < o)
 }
 
 func (v Word8Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -244,7 +245,7 @@ func (v Word8Value) LessEqual(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return AsBoolValue(v <= o)
+	return BoolValue(v <= o)
 }
 
 func (v Word8Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -258,7 +259,7 @@ func (v Word8Value) Greater(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	return AsBoolValue(v > o)
+	return BoolValue(v > o)
 }
 
 func (v Word8Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -272,7 +273,7 @@ func (v Word8Value) GreaterEqual(context ValueComparisonContext, other Comparabl
 		})
 	}
 
-	return AsBoolValue(v >= o)
+	return BoolValue(v >= o)
 }
 
 func (v Word8Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
@@ -457,7 +458,7 @@ func (Word8Value) DeepRemove(_ *Interpreter, _ bool) {
 }
 
 func (v Word8Value) ByteSize() uint32 {
-	return cborTagSize + getUintCBORSize(uint64(v))
+	return values.CBORTagSize + values.GetUintCBORSize(uint64(v))
 }
 
 func (v Word8Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/interpreter/variable.go
+++ b/interpreter/variable.go
@@ -113,7 +113,7 @@ func (v *SelfVariable) InitializeWithGetter(func() Value) {
 
 func (v *SelfVariable) GetValue(interpreter *Interpreter) Value {
 	// TODO: pass proper location range
-	interpreter.checkInvalidatedResourceOrResourceReference(v.selfRef, EmptyLocationRange)
+	checkInvalidatedResourceOrResourceReference(v.selfRef, EmptyLocationRange, interpreter)
 	return v.value
 }
 

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -827,7 +827,7 @@ func (i valueImporter) importValue(value cadence.Value, expectedType sema.Type) 
 	case cadence.Optional:
 		return i.importOptionalValue(v, expectedType)
 	case cadence.Bool:
-		return interpreter.AsBoolValue(bool(v)), nil
+		return interpreter.BoolValue(bool(v)), nil
 	case cadence.String:
 		return i.importString(v), nil
 	case cadence.Character:

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -2268,7 +2268,7 @@ func NewAccountKeyValue(
 			},
 			locationRange,
 		),
-		interpreter.AsBoolValue(accountKey.IsRevoked),
+		interpreter.BoolValue(accountKey.IsRevoked),
 	)
 }
 
@@ -3880,7 +3880,7 @@ func CheckCapabilityController(
 		false,
 	)
 
-	return interpreter.AsBoolValue(referencedValue != nil)
+	return interpreter.BoolValue(referencedValue != nil)
 }
 
 func newAccountCapabilitiesGetFunction(
@@ -4108,7 +4108,7 @@ func newAccountCapabilitiesExistsFunction(
 
 				storageMapKey := interpreter.StringStorageMapKey(identifier)
 
-				return interpreter.AsBoolValue(
+				return interpreter.BoolValue(
 					inter.StoredValueExists(address, domain, storageMapKey),
 				)
 			},

--- a/stdlib/publickey.go
+++ b/stdlib/publickey.go
@@ -285,7 +285,7 @@ func newPublicKeyVerifySignatureFunction(
 				panic(interpreter.WrappedExternalError(err))
 			}
 
-			return interpreter.AsBoolValue(valid)
+			return interpreter.BoolValue(valid)
 		},
 	)
 }
@@ -337,7 +337,7 @@ func newPublicKeyVerifyPoPFunction(
 			if err != nil {
 				panic(interpreter.WrappedExternalError(err))
 			}
-			return interpreter.AsBoolValue(valid)
+			return interpreter.BoolValue(valid)
 		},
 	)
 }

--- a/stdlib/test_contract.go
+++ b/stdlib/test_contract.go
@@ -566,7 +566,7 @@ func newTestTypeEqualFunction(
 							otherValue,
 						)
 
-						return interpreter.AsBoolValue(equal)
+						return interpreter.BoolValue(equal)
 					},
 				)
 
@@ -622,7 +622,7 @@ func newTestTypeBeEmptyFunction(
 							panic(errors.NewDefaultUserError("expected Array or Dictionary argument"))
 						}
 
-						return interpreter.AsBoolValue(isEmpty)
+						return interpreter.BoolValue(isEmpty)
 					},
 				)
 
@@ -688,7 +688,7 @@ func newTestTypeHaveElementCountFunction(
 							panic(errors.NewDefaultUserError("expected Array or Dictionary argument"))
 						}
 
-						return interpreter.AsBoolValue(matchingCount)
+						return interpreter.BoolValue(matchingCount)
 					},
 				)
 

--- a/values.go
+++ b/values.go
@@ -31,6 +31,7 @@ import (
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/values"
 )
 
 // Value
@@ -362,7 +363,7 @@ func (v Int) Big() *big.Int {
 }
 
 func (v Int) ToBigEndianBytes() []byte {
-	return interpreter.SignedBigIntToBigEndianBytes(v.Value)
+	return values.SignedBigIntToBigEndianBytes(v.Value)
 }
 
 func (v Int) String() string {
@@ -572,7 +573,7 @@ func (v Int128) Big() *big.Int {
 }
 
 func (v Int128) ToBigEndianBytes() []byte {
-	return interpreter.SignedBigIntToSizedBigEndianBytes(v.Value, sema.Int128TypeSize)
+	return values.SignedBigIntToSizedBigEndianBytes(v.Value, sema.Int128TypeSize)
 }
 
 func (v Int128) String() string {
@@ -636,7 +637,7 @@ func (v Int256) Big() *big.Int {
 }
 
 func (v Int256) ToBigEndianBytes() []byte {
-	return interpreter.SignedBigIntToSizedBigEndianBytes(v.Value, sema.Int256TypeSize)
+	return values.SignedBigIntToSizedBigEndianBytes(v.Value, sema.Int256TypeSize)
 }
 
 func (v Int256) String() string {
@@ -695,7 +696,7 @@ func (v UInt) Big() *big.Int {
 }
 
 func (v UInt) ToBigEndianBytes() []byte {
-	return interpreter.UnsignedBigIntToBigEndianBytes(v.Value)
+	return values.UnsignedBigIntToBigEndianBytes(v.Value)
 }
 
 func (v UInt) String() string {
@@ -905,7 +906,7 @@ func (v UInt128) Big() *big.Int {
 }
 
 func (v UInt128) ToBigEndianBytes() []byte {
-	return interpreter.UnsignedBigIntToSizedBigEndianBytes(v.Value, sema.UInt128TypeSize)
+	return values.UnsignedBigIntToSizedBigEndianBytes(v.Value, sema.UInt128TypeSize)
 }
 
 func (v UInt128) String() string {
@@ -969,7 +970,7 @@ func (v UInt256) Big() *big.Int {
 }
 
 func (v UInt256) ToBigEndianBytes() []byte {
-	return interpreter.UnsignedBigIntToSizedBigEndianBytes(v.Value, sema.UInt256TypeSize)
+	return values.UnsignedBigIntToSizedBigEndianBytes(v.Value, sema.UInt256TypeSize)
 }
 
 func (v UInt256) String() string {
@@ -1179,7 +1180,7 @@ func (v Word128) Big() *big.Int {
 }
 
 func (v Word128) ToBigEndianBytes() []byte {
-	return interpreter.UnsignedBigIntToBigEndianBytes(v.Value)
+	return values.UnsignedBigIntToBigEndianBytes(v.Value)
 }
 
 func (v Word128) String() string {
@@ -1243,7 +1244,7 @@ func (v Word256) Big() *big.Int {
 }
 
 func (v Word256) ToBigEndianBytes() []byte {
-	return interpreter.UnsignedBigIntToBigEndianBytes(v.Value)
+	return values.UnsignedBigIntToBigEndianBytes(v.Value)
 }
 
 func (v Word256) String() string {

--- a/values/big.go
+++ b/values/big.go
@@ -16,13 +16,15 @@
  * limitations under the License.
  */
 
-package interpreter
+package values
 
 import (
 	"math/big"
 
 	"github.com/onflow/cadence/errors"
 )
+
+var bigOne = big.NewInt(1)
 
 func SignedBigIntToBigEndianBytes(bigInt *big.Int) []byte {
 

--- a/values/encode.go
+++ b/values/encode.go
@@ -1,0 +1,253 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package values
+
+import (
+	"math"
+	"math/big"
+
+	"github.com/onflow/atree"
+)
+
+// Cadence needs to encode different kinds of objects in CBOR, for instance,
+// dictionaries, structs, resources, etc.
+//
+// However, CBOR only provides one native map type, and no support
+// for directly representing e.g. structs or resources.
+//
+// To be able to encode/decode such semantically different values,
+// we define custom CBOR tags.
+
+// !!! *WARNING* !!!
+//
+// Only add new fields to encoded structs by
+// appending new fields with the next highest key.
+//
+// DO *NOT* REPLACE EXISTING FIELDS!
+
+const CBORTagBase = 128
+
+// !!! *WARNING* !!!
+//
+// Only add new types by:
+// - replacing existing placeholders (`_`) with new types
+// - appending new types
+//
+// Only remove types by:
+// - replace existing types with a placeholder `_`
+//
+// DO *NOT* REPLACE EXISTING TYPES!
+// DO *NOT* ADD NEW TYPES IN BETWEEN!
+
+const (
+	CBORTagVoidValue = CBORTagBase + iota
+	_                // DO *NOT* REPLACE. Previously used for dictionary values
+	CBORTagSomeValue
+	CBORTagAddressValue
+	CBORTagCompositeValue
+	CBORTagTypeValue
+	_ // DO *NOT* REPLACE. Previously used for array values
+	CBORTagStringValue
+	CBORTagCharacterValue
+	CBORTagSomeValueWithNestedLevels
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+
+	// Int*
+	CBORTagIntValue
+	CBORTagInt8Value
+	CBORTagInt16Value
+	CBORTagInt32Value
+	CBORTagInt64Value
+	CBORTagInt128Value
+	CBORTagInt256Value
+	_
+
+	// UInt*
+	CBORTagUIntValue
+	CBORTagUInt8Value
+	CBORTagUInt16Value
+	CBORTagUInt32Value
+	CBORTagUInt64Value
+	CBORTagUInt128Value
+	CBORTagUInt256Value
+	_
+
+	// Word*
+	_
+	CBORTagWord8Value
+	CBORTagWord16Value
+	CBORTagWord32Value
+	CBORTagWord64Value
+	CBORTagWord128Value
+	CBORTagWord256Value
+	_
+
+	// Fix*
+	_
+	_ // future: Fix8
+	_ // future: Fix16
+	_ // future: Fix32
+	CBORTagFix64Value
+	_ // future: Fix128
+	_ // future: Fix256
+	_
+
+	// UFix*
+	_
+	_ // future: UFix8
+	_ // future: UFix16
+	_ // future: UFix32
+	CBORTagUFix64Value
+	_ // future: UFix128
+	_ // future: UFix256
+	_
+
+	// Locations
+	CBORTagAddressLocation
+	CBORTagStringLocation
+	CBORTagIdentifierLocation
+	CBORTagTransactionLocation
+	CBORTagScriptLocation
+	_
+	_
+	_
+
+	// Storage
+
+	CBORTagPathValue
+	// Deprecated: CBORTagPathCapabilityValue
+	CBORTagPathCapabilityValue
+	_ // DO NOT REPLACE! used to be used for storage references
+	// Deprecated: CBORTagPathLinkValue
+	CBORTagPathLinkValue
+	CBORTagPublishedValue
+	// Deprecated: CBORTagAccountLinkValue
+	CBORTagAccountLinkValue
+	CBORTagStorageCapabilityControllerValue
+	CBORTagAccountCapabilityControllerValue
+	CBORTagCapabilityValue
+	_
+	_
+	_
+
+	// Static Types
+	CBORTagPrimitiveStaticType
+	CBORTagCompositeStaticType
+	CBORTagInterfaceStaticType
+	CBORTagVariableSizedStaticType
+	CBORTagConstantSizedStaticType
+	CBORTagDictionaryStaticType
+	CBORTagOptionalStaticType
+	CBORTagReferenceStaticType
+	CBORTagIntersectionStaticType
+	CBORTagCapabilityStaticType
+	CBORTagUnauthorizedStaticAuthorization
+	CBORTagEntitlementMapStaticAuthorization
+	CBORTagEntitlementSetStaticAuthorization
+	CBORTagInaccessibleStaticAuthorization
+
+	_
+	_
+	_
+	_
+
+	CBORTagInclusiveRangeStaticType
+
+	// !!! *WARNING* !!!
+	// ADD NEW TYPES *BEFORE* THIS WARNING.
+	// DO *NOT* ADD NEW TYPES AFTER THIS LINE!
+	CBORTag_Count
+)
+
+const CBORTagSize = 2
+
+func GetBigIntCBORSize(v *big.Int) uint32 {
+	sign := v.Sign()
+	if sign < 0 {
+		v = new(big.Int).Abs(v)
+		v.Sub(v, bigOne)
+	}
+
+	// tag number + bytes
+	return 1 + GetBytesCBORSize(v.Bytes())
+}
+
+func GetIntCBORSize(v int64) uint32 {
+	if v < 0 {
+		return GetUintCBORSize(uint64(-v - 1))
+	}
+	return GetUintCBORSize(uint64(v))
+}
+
+func GetUintCBORSize(v uint64) uint32 {
+	if v <= 23 {
+		return 1
+	}
+	if v <= math.MaxUint8 {
+		return 2
+	}
+	if v <= math.MaxUint16 {
+		return 3
+	}
+	if v <= math.MaxUint32 {
+		return 5
+	}
+	return 9
+}
+
+func GetBytesCBORSize(b []byte) uint32 {
+	length := len(b)
+	if length == 0 {
+		return 1
+	}
+	return GetUintCBORSize(uint64(length)) + uint32(length)
+}
+
+// MaybeLargeImmutableStorable either returns the given immutable atree.Storable
+// if it can be stored inline inside its parent container,
+// or else stores it in a separate slab and returns an atree.SlabIDStorable.
+func MaybeLargeImmutableStorable(
+	storable atree.Storable,
+	storage atree.SlabStorage,
+	address atree.Address,
+	maxInlineSize uint64,
+) (
+	atree.Storable,
+	error,
+) {
+
+	if uint64(storable.ByteSize()) < maxInlineSize {
+		return storable, nil
+	}
+
+	return atree.NewStorableSlab(storage, address, storable)
+}

--- a/values/errors.go
+++ b/values/errors.go
@@ -1,0 +1,81 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package values
+
+import "github.com/onflow/cadence/errors"
+
+// InvalidOperandsError
+
+type InvalidOperandsError struct{}
+
+var _ errors.UserError = InvalidOperandsError{}
+
+func (InvalidOperandsError) IsUserError() {}
+
+func (InvalidOperandsError) Error() string {
+	return "invalid operands"
+}
+
+// UnderflowError
+
+type UnderflowError struct{}
+
+var _ errors.UserError = UnderflowError{}
+
+func (UnderflowError) IsUserError() {}
+
+func (UnderflowError) Error() string {
+	return "underflow"
+}
+
+// OverflowError
+
+type OverflowError struct{}
+
+var _ errors.UserError = OverflowError{}
+
+func (OverflowError) IsUserError() {}
+
+func (OverflowError) Error() string {
+	return "overflow"
+}
+
+// NegativeShiftError
+
+type NegativeShiftError struct{}
+
+var _ errors.UserError = NegativeShiftError{}
+
+func (NegativeShiftError) IsUserError() {}
+
+func (NegativeShiftError) Error() string {
+	return "negative shift"
+}
+
+// DivisionByZeroError
+
+type DivisionByZeroError struct{}
+
+var _ errors.UserError = DivisionByZeroError{}
+
+func (DivisionByZeroError) IsUserError() {}
+
+func (DivisionByZeroError) Error() string {
+	return "division by zero"
+}

--- a/values/value.go
+++ b/values/value.go
@@ -1,0 +1,26 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package values
+
+import "fmt"
+
+type Value interface {
+	isValue()
+	fmt.Stringer
+}

--- a/values/value_bool.go
+++ b/values/value_bool.go
@@ -1,0 +1,135 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package values
+
+import (
+	"github.com/onflow/atree"
+
+	"github.com/onflow/cadence/format"
+)
+
+// BoolValue
+
+type BoolValue bool
+
+var _ Value = BoolValue(false)
+var _ EquatableValue = BoolValue(false)
+var _ ComparableValue = BoolValue(false)
+var _ atree.Value = BoolValue(false)
+var _ atree.Storable = BoolValue(false)
+
+const TrueValue = BoolValue(true)
+const FalseValue = BoolValue(false)
+
+func (BoolValue) isValue() {}
+
+func (v BoolValue) String() string {
+	return format.Bool(bool(v))
+}
+
+func (v BoolValue) Negate() BoolValue {
+	if v == TrueValue {
+		return FalseValue
+	}
+	return TrueValue
+}
+
+func (v BoolValue) Equal(other Value) BoolValue {
+	otherBool, ok := other.(BoolValue)
+	if !ok {
+		return false
+	}
+	return v.EqualBool(otherBool)
+}
+
+func (v BoolValue) EqualBool(other BoolValue) BoolValue {
+	return bool(v) == bool(other)
+}
+
+func (v BoolValue) Less(other ComparableValue) (BoolValue, error) {
+	o, ok := other.(BoolValue)
+	if !ok {
+		return false, InvalidOperandsError{}
+	}
+	return v.LessBool(o), nil
+}
+
+func (v BoolValue) LessBool(other BoolValue) BoolValue {
+	return !v && other
+}
+
+func (v BoolValue) LessEqual(other ComparableValue) (BoolValue, error) {
+	o, ok := other.(BoolValue)
+	if !ok {
+		return false, InvalidOperandsError{}
+	}
+	return v.LessEqualBool(o), nil
+}
+
+func (v BoolValue) LessEqualBool(other BoolValue) BoolValue {
+	return !v || other
+}
+
+func (v BoolValue) Greater(other ComparableValue) (BoolValue, error) {
+	o, ok := other.(BoolValue)
+	if !ok {
+		return false, InvalidOperandsError{}
+	}
+
+	return v.GreaterBool(o), nil
+}
+
+func (v BoolValue) GreaterBool(o BoolValue) BoolValue {
+	return v && !o
+}
+
+func (v BoolValue) GreaterEqual(other ComparableValue) (BoolValue, error) {
+	o, ok := other.(BoolValue)
+	if !ok {
+		return false, InvalidOperandsError{}
+	}
+
+	return v.GreaterEqualBool(o), nil
+}
+
+func (v BoolValue) GreaterEqualBool(o BoolValue) BoolValue {
+	return v || !o
+}
+
+func (v BoolValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+	return v, nil
+}
+
+func (v BoolValue) ByteSize() uint32 {
+	return 1
+}
+
+func (v BoolValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
+	return v, nil
+}
+
+func (BoolValue) ChildStorables() []atree.Storable {
+	return nil
+}
+
+// Encode encodes the value as a CBOR bool
+func (v BoolValue) Encode(e *atree.Encoder) error {
+	// NOTE: when updating, also update BoolValue.ByteSize
+	return e.CBOR.EncodeBool(bool(v))
+}

--- a/values/value_bool.go
+++ b/values/value_bool.go
@@ -30,7 +30,7 @@ type BoolValue bool
 
 var _ Value = BoolValue(false)
 var _ EquatableValue = BoolValue(false)
-var _ ComparableValue = BoolValue(false)
+var _ ComparableValue[BoolValue] = BoolValue(false)
 var _ atree.Value = BoolValue(false)
 var _ atree.Storable = BoolValue(false)
 
@@ -62,54 +62,20 @@ func (v BoolValue) EqualBool(other BoolValue) BoolValue {
 	return bool(v) == bool(other)
 }
 
-func (v BoolValue) Less(other ComparableValue) (BoolValue, error) {
-	o, ok := other.(BoolValue)
-	if !ok {
-		return false, InvalidOperandsError{}
-	}
-	return v.LessBool(o), nil
+func (v BoolValue) Less(other BoolValue) bool {
+	return bool(!v && other)
 }
 
-func (v BoolValue) LessBool(other BoolValue) BoolValue {
-	return !v && other
+func (v BoolValue) LessEqual(other BoolValue) bool {
+	return bool(!v || other)
 }
 
-func (v BoolValue) LessEqual(other ComparableValue) (BoolValue, error) {
-	o, ok := other.(BoolValue)
-	if !ok {
-		return false, InvalidOperandsError{}
-	}
-	return v.LessEqualBool(o), nil
+func (v BoolValue) Greater(other BoolValue) bool {
+	return bool(v && !other)
 }
 
-func (v BoolValue) LessEqualBool(other BoolValue) BoolValue {
-	return !v || other
-}
-
-func (v BoolValue) Greater(other ComparableValue) (BoolValue, error) {
-	o, ok := other.(BoolValue)
-	if !ok {
-		return false, InvalidOperandsError{}
-	}
-
-	return v.GreaterBool(o), nil
-}
-
-func (v BoolValue) GreaterBool(o BoolValue) BoolValue {
-	return v && !o
-}
-
-func (v BoolValue) GreaterEqual(other ComparableValue) (BoolValue, error) {
-	o, ok := other.(BoolValue)
-	if !ok {
-		return false, InvalidOperandsError{}
-	}
-
-	return v.GreaterEqualBool(o), nil
-}
-
-func (v BoolValue) GreaterEqualBool(o BoolValue) BoolValue {
-	return v || !o
+func (v BoolValue) GreaterEqual(other BoolValue) bool {
+	return bool(v || !other)
 }
 
 func (v BoolValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {

--- a/values/value_comparable.go
+++ b/values/value_comparable.go
@@ -18,10 +18,10 @@
 
 package values
 
-type ComparableValue interface {
+type ComparableValue[T Value] interface {
 	EquatableValue
-	Less(other ComparableValue) (BoolValue, error)
-	LessEqual(other ComparableValue) (BoolValue, error)
-	Greater(other ComparableValue) (BoolValue, error)
-	GreaterEqual(other ComparableValue) (BoolValue, error)
+	Less(other T) bool
+	LessEqual(other T) bool
+	Greater(other T) bool
+	GreaterEqual(other T) bool
 }

--- a/values/value_comparable.go
+++ b/values/value_comparable.go
@@ -1,0 +1,27 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package values
+
+type ComparableValue interface {
+	EquatableValue
+	Less(other ComparableValue) (BoolValue, error)
+	LessEqual(other ComparableValue) (BoolValue, error)
+	Greater(other ComparableValue) (BoolValue, error)
+	GreaterEqual(other ComparableValue) (BoolValue, error)
+}

--- a/values/value_equatable.go
+++ b/values/value_equatable.go
@@ -1,0 +1,24 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package values
+
+type EquatableValue interface {
+	Value
+	Equal(other Value) BoolValue
+}

--- a/values/value_int.go
+++ b/values/value_int.go
@@ -68,7 +68,7 @@ func NewUnmeteredIntValueFromBigInt(value *big.Int) IntValue {
 
 var _ Value = IntValue{}
 var _ EquatableValue = IntValue{}
-var _ ComparableValue = IntValue{}
+var _ ComparableValue[IntValue] = IntValue{}
 var _ NumberValue[IntValue] = IntValue{}
 var _ IntegerValue[IntValue] = IntValue{}
 var _ atree.Storable = IntValue{}
@@ -171,45 +171,25 @@ func (v IntValue) SaturatingDiv(gauge common.MemoryGauge, other IntValue) (IntVa
 	return v.Div(gauge, other)
 }
 
-func (v IntValue) Less(other ComparableValue) (BoolValue, error) {
-	o, ok := other.(IntValue)
-	if !ok {
-		return false, InvalidOperandsError{}
-	}
-
-	cmp := v.BigInt.Cmp(o.BigInt)
-	return cmp == -1, nil
+func (v IntValue) Less(other IntValue) bool {
+	cmp := v.BigInt.Cmp(other.BigInt)
+	return cmp == -1
 }
 
-func (v IntValue) LessEqual(other ComparableValue) (BoolValue, error) {
-	o, ok := other.(IntValue)
-	if !ok {
-		return false, InvalidOperandsError{}
-	}
-
-	cmp := v.BigInt.Cmp(o.BigInt)
-	return cmp <= 0, nil
+func (v IntValue) LessEqual(other IntValue) bool {
+	cmp := v.BigInt.Cmp(other.BigInt)
+	return cmp <= 0
 }
 
-func (v IntValue) Greater(other ComparableValue) (BoolValue, error) {
-	o, ok := other.(IntValue)
-	if !ok {
-		return false, InvalidOperandsError{}
-	}
-
-	cmp := v.BigInt.Cmp(o.BigInt)
-	return cmp == 1, nil
+func (v IntValue) Greater(other IntValue) bool {
+	cmp := v.BigInt.Cmp(other.BigInt)
+	return cmp == 1
 
 }
 
-func (v IntValue) GreaterEqual(other ComparableValue) (BoolValue, error) {
-	o, ok := other.(IntValue)
-	if !ok {
-		return false, InvalidOperandsError{}
-	}
-
-	cmp := v.BigInt.Cmp(o.BigInt)
-	return cmp >= 0, nil
+func (v IntValue) GreaterEqual(other IntValue) bool {
+	cmp := v.BigInt.Cmp(other.BigInt)
+	return cmp >= 0
 }
 
 func (v IntValue) Equal(other Value) BoolValue {

--- a/values/value_int.go
+++ b/values/value_int.go
@@ -1,0 +1,387 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package values
+
+import (
+	"math/big"
+	"unsafe"
+
+	"github.com/onflow/atree"
+
+	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/format"
+)
+
+type IntValue struct {
+	BigInt *big.Int
+}
+
+const int64Size = int(unsafe.Sizeof(int64(0)))
+
+var int64BigIntMemoryUsage = common.NewBigIntMemoryUsage(int64Size)
+
+func NewIntValueFromInt64(memoryGauge common.MemoryGauge, value int64) IntValue {
+	return NewIntValueFromBigInt(
+		memoryGauge,
+		int64BigIntMemoryUsage,
+		func() *big.Int {
+			return big.NewInt(value)
+		},
+	)
+}
+
+func NewUnmeteredIntValueFromInt64(value int64) IntValue {
+	return NewUnmeteredIntValueFromBigInt(big.NewInt(value))
+}
+
+func NewIntValueFromBigInt(
+	memoryGauge common.MemoryGauge,
+	memoryUsage common.MemoryUsage,
+	bigIntConstructor func() *big.Int,
+) IntValue {
+	common.UseMemory(memoryGauge, memoryUsage)
+	value := bigIntConstructor()
+	return NewUnmeteredIntValueFromBigInt(value)
+}
+
+func NewUnmeteredIntValueFromBigInt(value *big.Int) IntValue {
+	return IntValue{
+		BigInt: value,
+	}
+}
+
+var _ Value = IntValue{}
+var _ EquatableValue = IntValue{}
+var _ ComparableValue = IntValue{}
+var _ NumberValue = IntValue{}
+var _ IntegerValue = IntValue{}
+var _ atree.Storable = IntValue{}
+var _ atree.Value = IntValue{}
+
+func (IntValue) isValue() {}
+
+func (v IntValue) String() string {
+	return format.BigInt(v.BigInt)
+}
+
+func (v IntValue) Negate(gauge common.MemoryGauge) NumberValue {
+	return NewIntValueFromBigInt(
+		gauge,
+		common.NewNegateBigIntMemoryUsage(v.BigInt),
+		func() *big.Int {
+			return new(big.Int).Neg(v.BigInt)
+		},
+	)
+}
+
+func (v IntValue) Plus(gauge common.MemoryGauge, other NumberValue) (NumberValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return nil, InvalidOperandsError{}
+	}
+
+	return NewIntValueFromBigInt(
+		gauge,
+		common.NewPlusBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Add(v.BigInt, o.BigInt)
+		},
+	), nil
+}
+
+func (v IntValue) SaturatingPlus(gauge common.MemoryGauge, other NumberValue) (NumberValue, error) {
+	return v.Plus(gauge, other)
+}
+
+func (v IntValue) Minus(gauge common.MemoryGauge, other NumberValue) (NumberValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return nil, InvalidOperandsError{}
+	}
+
+	return NewIntValueFromBigInt(
+		gauge,
+		common.NewMinusBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Sub(v.BigInt, o.BigInt)
+		},
+	), nil
+}
+
+func (v IntValue) SaturatingMinus(gauge common.MemoryGauge, other NumberValue) (NumberValue, error) {
+	return v.Minus(gauge, other)
+}
+
+func (v IntValue) Mod(gauge common.MemoryGauge, other NumberValue) (NumberValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return nil, InvalidOperandsError{}
+	}
+
+	// INT33-C
+	if o.BigInt.Sign() == 0 {
+		return nil, DivisionByZeroError{}
+	}
+
+	return NewIntValueFromBigInt(
+		gauge,
+		common.NewModBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Rem(v.BigInt, o.BigInt)
+		},
+	), nil
+}
+
+func (v IntValue) Mul(gauge common.MemoryGauge, other NumberValue) (NumberValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return nil, InvalidOperandsError{}
+	}
+
+	return NewIntValueFromBigInt(
+		gauge,
+		common.NewMulBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Mul(v.BigInt, o.BigInt)
+		},
+	), nil
+}
+
+func (v IntValue) SaturatingMul(gauge common.MemoryGauge, other NumberValue) (NumberValue, error) {
+	return v.Mul(gauge, other)
+}
+
+func (v IntValue) Div(gauge common.MemoryGauge, other NumberValue) (NumberValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return nil, InvalidOperandsError{}
+	}
+
+	// INT33-C
+	if o.BigInt.Sign() == 0 {
+		return nil, DivisionByZeroError{}
+	}
+
+	return NewIntValueFromBigInt(
+		gauge,
+		common.NewDivBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Div(v.BigInt, o.BigInt)
+		},
+	), nil
+}
+
+func (v IntValue) SaturatingDiv(gauge common.MemoryGauge, other NumberValue) (NumberValue, error) {
+	return v.Div(gauge, other)
+}
+
+func (v IntValue) Less(other ComparableValue) (BoolValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return false, InvalidOperandsError{}
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
+	return cmp == -1, nil
+}
+
+func (v IntValue) LessEqual(other ComparableValue) (BoolValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return false, InvalidOperandsError{}
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
+	return cmp <= 0, nil
+}
+
+func (v IntValue) Greater(other ComparableValue) (BoolValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return false, InvalidOperandsError{}
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
+	return cmp == 1, nil
+
+}
+
+func (v IntValue) GreaterEqual(other ComparableValue) (BoolValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return false, InvalidOperandsError{}
+	}
+
+	cmp := v.BigInt.Cmp(o.BigInt)
+	return cmp >= 0, nil
+}
+
+func (v IntValue) Equal(other Value) BoolValue {
+	otherInt, ok := other.(IntValue)
+	if !ok {
+		return false
+	}
+	cmp := v.BigInt.Cmp(otherInt.BigInt)
+	return cmp == 0
+}
+
+func (v IntValue) BitwiseOr(gauge common.MemoryGauge, other IntegerValue) (IntegerValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return nil, InvalidOperandsError{}
+	}
+
+	return NewIntValueFromBigInt(
+		gauge,
+		common.NewBitwiseOrBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Or(v.BigInt, o.BigInt)
+		},
+	), nil
+}
+
+func (v IntValue) BitwiseXor(gauge common.MemoryGauge, other IntegerValue) (IntegerValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return nil, InvalidOperandsError{}
+	}
+
+	return NewIntValueFromBigInt(
+		gauge,
+		common.NewBitwiseXorBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Xor(v.BigInt, o.BigInt)
+		},
+	), nil
+}
+
+func (v IntValue) BitwiseAnd(gauge common.MemoryGauge, other IntegerValue) (IntegerValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return nil, InvalidOperandsError{}
+	}
+
+	return NewIntValueFromBigInt(
+		gauge,
+		common.NewBitwiseAndBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.And(v.BigInt, o.BigInt)
+		},
+	), nil
+}
+
+func (v IntValue) BitwiseLeftShift(gauge common.MemoryGauge, other IntegerValue) (IntegerValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return nil, InvalidOperandsError{}
+	}
+
+	if o.BigInt.Sign() < 0 {
+		return nil, NegativeShiftError{}
+	}
+
+	if !o.BigInt.IsUint64() {
+		return nil, OverflowError{}
+	}
+
+	return NewIntValueFromBigInt(
+		gauge,
+		common.NewBitwiseLeftShiftBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Lsh(v.BigInt, uint(o.BigInt.Uint64()))
+		},
+	), nil
+}
+
+func (v IntValue) BitwiseRightShift(gauge common.MemoryGauge, other IntegerValue) (IntegerValue, error) {
+	o, ok := other.(IntValue)
+	if !ok {
+		return nil, InvalidOperandsError{}
+	}
+
+	if o.BigInt.Sign() < 0 {
+		return nil, NegativeShiftError{}
+	}
+
+	if !o.BigInt.IsUint64() {
+		return nil, OverflowError{}
+	}
+
+	return NewIntValueFromBigInt(
+		gauge,
+		common.NewBitwiseRightShiftBigIntMemoryUsage(v.BigInt, o.BigInt),
+		func() *big.Int {
+			res := new(big.Int)
+			return res.Rsh(v.BigInt, uint(o.BigInt.Uint64()))
+		},
+	), nil
+}
+
+func (v IntValue) ToInt() (int, error) {
+	if !v.BigInt.IsInt64() {
+		return 0, OverflowError{}
+	}
+	return int(v.BigInt.Int64()), nil
+}
+
+func (v IntValue) ToBigEndianBytes() []byte {
+	return SignedBigIntToBigEndianBytes(v.BigInt)
+}
+
+func (v IntValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
+	return MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
+}
+
+func (v IntValue) ByteSize() uint32 {
+	return CBORTagSize + GetBigIntCBORSize(v.BigInt)
+}
+
+func (v IntValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
+	return v, nil
+}
+
+func (IntValue) ChildStorables() []atree.Storable {
+	return nil
+}
+
+// Encode encodes the value as
+//
+//	cbor.Tag{
+//			Number:  CBORTagIntValue,
+//			Content: *big.Int(v.BigInt),
+//	}
+func (v IntValue) Encode(e *atree.Encoder) error {
+	err := e.CBOR.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, CBORTagIntValue,
+	})
+	if err != nil {
+		return err
+	}
+	return e.CBOR.EncodeBigInt(v.BigInt)
+}

--- a/values/value_integer.go
+++ b/values/value_integer.go
@@ -1,0 +1,30 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package values
+
+import "github.com/onflow/cadence/common"
+
+type IntegerValue interface {
+	NumberValue
+	BitwiseOr(gauge common.MemoryGauge, other IntegerValue) (IntegerValue, error)
+	BitwiseXor(gauge common.MemoryGauge, other IntegerValue) (IntegerValue, error)
+	BitwiseAnd(gauge common.MemoryGauge, other IntegerValue) (IntegerValue, error)
+	BitwiseLeftShift(gauge common.MemoryGauge, other IntegerValue) (IntegerValue, error)
+	BitwiseRightShift(gauge common.MemoryGauge, other IntegerValue) (IntegerValue, error)
+}

--- a/values/value_number.go
+++ b/values/value_number.go
@@ -21,7 +21,7 @@ package values
 import "github.com/onflow/cadence/common"
 
 type NumberValue[T Value] interface {
-	ComparableValue
+	ComparableValue[T]
 	ToInt() (int, error)
 	Negate(gauge common.MemoryGauge) T
 	Plus(gauge common.MemoryGauge, other T) (T, error)

--- a/values/value_number.go
+++ b/values/value_number.go
@@ -1,0 +1,37 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package values
+
+import "github.com/onflow/cadence/common"
+
+type NumberValue interface {
+	ComparableValue
+	ToInt() (int, error)
+	Negate(gauge common.MemoryGauge) NumberValue
+	Plus(gauge common.MemoryGauge, other NumberValue) (NumberValue, error)
+	SaturatingPlus(gauge common.MemoryGauge, other NumberValue) (NumberValue, error)
+	Minus(gauge common.MemoryGauge, other NumberValue) (NumberValue, error)
+	SaturatingMinus(gauge common.MemoryGauge, other NumberValue) (NumberValue, error)
+	Mod(gauge common.MemoryGauge, other NumberValue) (NumberValue, error)
+	Mul(gauge common.MemoryGauge, other NumberValue) (NumberValue, error)
+	SaturatingMul(gauge common.MemoryGauge, other NumberValue) (NumberValue, error)
+	Div(gauge common.MemoryGauge, other NumberValue) (NumberValue, error)
+	SaturatingDiv(gauge common.MemoryGauge, other NumberValue) (NumberValue, error)
+	ToBigEndianBytes() []byte
+}


### PR DESCRIPTION
Work towards #3693

## Description

Move the core functionality of the value implementations of `Bool` and `Int` out of the `interpreter` package and into a new `values` package. This demonstrates how we could decouple at least some of the more basic values from the interpreter and use them in the VM.

If this approach looks good, we can also refactor the other number value types, and some other primitive value types like e.g. `String`.

I'm happy with the `values` package itself, but honestly not really happy with how the integration looks in the `interpreter` package's `BoolValue` and `IntValue` types, especially all the unwrapping and wrapping, casting, type checking, error handling, etc. Maybe this is just temporary, and once we have refactored the value types in the `interpreter` package fully from the interpreter this ugliness will go away.

Another idea I had was not to create a whole new `values.Value` type hierarchy with methods, but instead just have global functions, e.g. instead of having `IntValue.LessEqual(other ComparableValue)`, just have `IntLessEqual(IntValue, IntValue)`.

Alternatively we would have to *duplicate* this code in the VM, which seems worse to me (e.g. potential for mismatch).

Let's discuss this in the Implemention Sync.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
