### PR TITLE
[Compiler] Compile and execute emit statement

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -634,9 +634,15 @@ func (c *Compiler[_]) VisitForStatement(_ *ast.ForStatement) (_ struct{}) {
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitEmitStatement(_ *ast.EmitStatement) (_ struct{}) {
-	// TODO
-	panic(errors.NewUnreachableError())
+func (c *Compiler[_]) VisitEmitStatement(statement *ast.EmitStatement) (_ struct{}) {
+	c.compileExpression(statement.InvocationExpression)
+	eventType := c.ExtendedElaboration.EmitStatementEventType(statement)
+	typeIndex := c.getOrAddType(eventType)
+	c.codeGen.Emit(opcode.InstructionEmitEvent{
+		TypeIndex: typeIndex,
+	})
+
+	return
 }
 
 func (c *Compiler[_]) VisitSwitchStatement(statement *ast.SwitchStatement) (_ struct{}) {

--- a/bbq/compiler/extended_elaboration.go
+++ b/bbq/compiler/extended_elaboration.go
@@ -230,6 +230,10 @@ func (e *ExtendedElaboration) CastingExpressionTypes(expression *ast.CastingExpr
 	return e.elaboration.CastingExpressionTypes(expression)
 }
 
+func (e *ExtendedElaboration) EmitStatementEventType(statement *ast.EmitStatement) *sema.CompositeType {
+	return e.elaboration.EmitStatementEventType(statement)
+}
+
 func (e *ExtendedElaboration) ResultVariableType(enclosingBlock ast.Element) (typ sema.Type, exist bool) {
 	if e.resultVariableTypes != nil {
 		types, ok := e.resultVariableTypes[enclosingBlock]

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -1095,6 +1095,36 @@ func (i InstructionGreaterOrEqual) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
 }
 
+// InstructionEmitEvent
+//
+// Pops an event off the stack and then emits it.
+type InstructionEmitEvent struct {
+	TypeIndex uint16
+}
+
+var _ Instruction = InstructionEmitEvent{}
+
+func (InstructionEmitEvent) Opcode() Opcode {
+	return EmitEvent
+}
+
+func (i InstructionEmitEvent) String() string {
+	var sb strings.Builder
+	sb.WriteString(i.Opcode().String())
+	printfArgument(&sb, "typeIndex", i.TypeIndex)
+	return sb.String()
+}
+
+func (i InstructionEmitEvent) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+	emitUint16(code, i.TypeIndex)
+}
+
+func DecodeEmitEvent(ip *uint16, code []byte) (i InstructionEmitEvent) {
+	i.TypeIndex = decodeUint16(ip, code)
+	return i
+}
+
 func DecodeInstruction(ip *uint16, code []byte) Instruction {
 	switch Opcode(decodeByte(ip, code)) {
 	case Unknown:
@@ -1183,6 +1213,8 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 		return InstructionGreater{}
 	case GreaterOrEqual:
 		return InstructionGreaterOrEqual{}
+	case EmitEvent:
+		return DecodeEmitEvent(ip, code)
 	}
 
 	panic(errors.NewUnreachableError())

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -572,3 +572,16 @@
     push:
       - name: "result"
         type: "bool"
+
+# Other
+
+- name: "emitEvent"
+  description:
+    Pops an event off the stack and then emits it.
+  operands:
+    - name: "typeIndex"
+      type: "index"
+  valueEffects:
+    pop:
+      - name: "event"
+        type: "value"

--- a/bbq/opcode/opcode.go
+++ b/bbq/opcode/opcode.go
@@ -142,4 +142,10 @@ const (
 	_
 	_
 	_
+	_
+	_
+	_
+
+	// Other
+	EmitEvent
 )

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -27,6 +27,12 @@ import (
 	"github.com/onflow/cadence/test_utils/common_utils"
 )
 
+// OnEventEmittedFunc is a function that is triggered when an event is emitted by the program.
+type OnEventEmittedFunc func(
+	event *CompositeValue,
+	eventType *interpreter.CompositeStaticType,
+) error
+
 type Config struct {
 	interpreter.Storage
 	common.MemoryGauge
@@ -40,6 +46,9 @@ type Config struct {
 	CapabilityControllerIterations              map[AddressPath]int
 	MutationDuringCapabilityControllerIteration bool
 	referencedResourceKindedValues              ReferencedResourceKindedValues
+
+	// OnEventEmitted is triggered when an event is emitted by the program
+	OnEventEmitted OnEventEmittedFunc
 
 	// TODO: These are temporary. Remove once storing/reading is supported for VM values.
 	inter      *interpreter.Interpreter

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -804,12 +804,29 @@ func (vm *VM) run() {
 			opNot(vm)
 		case opcode.InstructionUnwrap:
 			opUnwrap(vm)
+		case opcode.InstructionEmitEvent:
+			onEmitEvent(vm, ins)
 		default:
 			panic(errors.NewUnexpectedError("cannot execute instruction of type %T", ins))
 		}
 
 		// Faster in Go <1.19:
 		// vmOps[op](vm)
+	}
+}
+
+func onEmitEvent(vm *VM, ins opcode.InstructionEmitEvent) {
+	eventType := vm.loadType(ins.TypeIndex).(*interpreter.CompositeStaticType)
+	eventValue := vm.pop().(*CompositeValue)
+
+	onEventEmitted := vm.config.OnEventEmitted
+	if onEventEmitted == nil {
+		return
+	}
+
+	err := onEventEmitted(eventValue, eventType)
+	if err != nil {
+		panic(err)
 	}
 }
 


### PR DESCRIPTION
Work towards #3742

## Description

Compile `emit` statements to a new `EmitEvent` instruction, and execute the instruction by invoking a config callback.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
