### PR TITLE
[Compiler] Reenable compiler tests

### DIFF
--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -104,8 +104,6 @@ func TestCompileImperativeFib(t *testing.T) {
 
 	t.Parallel()
 
-	t.SkipNow()
-
 	checker, err := ParseAndCheck(t, `
       fun fib(_ n: Int): Int {
           var fib1 = 1
@@ -126,58 +124,93 @@ func TestCompileImperativeFib(t *testing.T) {
 	compiler := NewInstructionCompiler(checker)
 	program := compiler.Compile()
 
+	const parameterCount = 1
+
+	// nIndex is the index of the parameter `n`, which is the first parameter
+	const nIndex = 0
+
+	// resultIndex is the index of the $result variable
+	const resultIndex = parameterCount
+
+	// localsOffset is the offset of the first local variable
+	const localsOffset = resultIndex + 1
+
+	const (
+		// fib1Index is the index of the local variable `fib1`, which is the first local variable
+		fib1Index = localsOffset + iota
+		// fib2Index is the index of the local variable `fib2`, which is the second local variable
+		fib2Index
+		// fibonacciIndex is the index of the local variable `fibonacci`, which is the third local variable
+		fibonacciIndex
+		// iIndex is the index of the local variable `i`, which is the fourth local variable
+		iIndex
+	)
+
 	require.Len(t, program.Functions, 1)
 	assert.Equal(t,
 		[]opcode.Instruction{
 			// var fib1 = 1
-			opcode.InstructionGetConstant{ConstantIndex: 0x0},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x1},
+			opcode.InstructionGetConstant{ConstantIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: fib1Index},
+
 			// var fib2 = 1
-			opcode.InstructionGetConstant{ConstantIndex: 0x0},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x2},
+			opcode.InstructionGetConstant{ConstantIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: fib2Index},
+
 			// var fibonacci = fib1
-			opcode.InstructionGetLocal{LocalIndex: 0x1},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x3},
+			opcode.InstructionGetLocal{LocalIndex: fib1Index},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: fibonacciIndex},
+
 			// var i = 2
-			opcode.InstructionGetConstant{ConstantIndex: 0x1},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x4},
+			opcode.InstructionGetConstant{ConstantIndex: 1},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: iIndex},
+
 			// while i < n
-			opcode.InstructionGetLocal{LocalIndex: 0x4},
-			opcode.InstructionGetLocal{LocalIndex: 0x0},
+			opcode.InstructionGetLocal{LocalIndex: iIndex},
+			opcode.InstructionGetLocal{LocalIndex: nIndex},
 			opcode.InstructionLess{},
 			opcode.InstructionJumpIfFalse{Target: 33},
+
 			// fibonacci = fib1 + fib2
-			opcode.InstructionGetLocal{LocalIndex: 0x1},
-			opcode.InstructionGetLocal{LocalIndex: 0x2},
+			opcode.InstructionGetLocal{LocalIndex: fib1Index},
+			opcode.InstructionGetLocal{LocalIndex: fib2Index},
 			opcode.InstructionAdd{},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x3},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: fibonacciIndex},
+
 			// fib1 = fib2
-			opcode.InstructionGetLocal{LocalIndex: 0x2},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x1},
+			opcode.InstructionGetLocal{LocalIndex: fib2Index},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: fib1Index},
+
 			// fib2 = fibonacci
-			opcode.InstructionGetLocal{LocalIndex: 0x3},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x2},
+			opcode.InstructionGetLocal{LocalIndex: fibonacciIndex},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: fib2Index},
+
 			// i = i + 1
-			opcode.InstructionGetLocal{LocalIndex: 0x4},
-			opcode.InstructionGetConstant{ConstantIndex: 0x0},
+			opcode.InstructionGetLocal{LocalIndex: iIndex},
+			opcode.InstructionGetConstant{ConstantIndex: 0},
 			opcode.InstructionAdd{},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x4},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: iIndex},
+
 			// continue loop
 			opcode.InstructionJump{Target: 12},
+
+			// return fibonacci
+			opcode.InstructionGetLocal{LocalIndex: fibonacciIndex},
+
 			// assign to temp $result
-			opcode.InstructionGetLocal{LocalIndex: 0x3},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x5},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: resultIndex},
+
 			// return $result
-			opcode.InstructionGetLocal{LocalIndex: 0x5},
+			opcode.InstructionGetLocal{LocalIndex: resultIndex},
 			opcode.InstructionReturnValue{},
 		},
 		compiler.ExportFunctions()[0].Code,
@@ -202,8 +235,6 @@ func TestCompileBreak(t *testing.T) {
 
 	t.Parallel()
 
-	t.SkipNow()
-
 	checker, err := ParseAndCheck(t, `
       fun test(): Int {
           var i = 0
@@ -221,37 +252,57 @@ func TestCompileBreak(t *testing.T) {
 	compiler := NewInstructionCompiler(checker)
 	program := compiler.Compile()
 
+	const parameterCount = 0
+
+	// resultIndex is the index of the $result variable
+	const resultIndex = parameterCount
+
+	// localsOffset is the offset of the first local variable
+	const localsOffset = resultIndex + 1
+
+	// iIndex is the index of the local variable `i`, which is the first local variable
+	const iIndex = localsOffset
+
 	require.Len(t, program.Functions, 1)
 	assert.Equal(t,
 		[]opcode.Instruction{
 			// var i = 0
-			opcode.InstructionGetConstant{ConstantIndex: 0x0},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x0},
+			opcode.InstructionGetConstant{ConstantIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: iIndex},
+
 			// while true
 			opcode.InstructionTrue{},
 			opcode.InstructionJumpIfFalse{Target: 16},
+
 			// if i > 3
-			opcode.InstructionGetLocal{LocalIndex: 0x0},
-			opcode.InstructionGetConstant{ConstantIndex: 0x1},
+			opcode.InstructionGetLocal{LocalIndex: iIndex},
+			opcode.InstructionGetConstant{ConstantIndex: 1},
 			opcode.InstructionGreater{},
 			opcode.InstructionJumpIfFalse{Target: 10},
+
 			// break
 			opcode.InstructionJump{Target: 16},
+
 			// i = i + 1
-			opcode.InstructionGetLocal{LocalIndex: 0x0},
-			opcode.InstructionGetConstant{ConstantIndex: 0x2},
+			opcode.InstructionGetLocal{LocalIndex: iIndex},
+			opcode.InstructionGetConstant{ConstantIndex: 2},
 			opcode.InstructionAdd{},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x0},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: iIndex},
+
 			// repeat
 			opcode.InstructionJump{Target: 3},
-			// assign i to temp $result
-			opcode.InstructionGetLocal{LocalIndex: 0x0},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x1},
+
+			// return i
+			opcode.InstructionGetLocal{LocalIndex: iIndex},
+
+			// assign to temp $result
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: resultIndex},
+
 			// return $result
-			opcode.InstructionGetLocal{LocalIndex: 0x1},
+			opcode.InstructionGetLocal{LocalIndex: resultIndex},
 			opcode.InstructionReturnValue{},
 		},
 		compiler.ExportFunctions()[0].Code,
@@ -280,8 +331,6 @@ func TestCompileContinue(t *testing.T) {
 
 	t.Parallel()
 
-	t.SkipNow()
-
 	checker, err := ParseAndCheck(t, `
       fun test(): Int {
           var i = 0
@@ -300,39 +349,60 @@ func TestCompileContinue(t *testing.T) {
 	compiler := NewInstructionCompiler(checker)
 	program := compiler.Compile()
 
+	const parameterCount = 0
+
+	// resultIndex is the index of the $result variable
+	const resultIndex = parameterCount
+
+	// localsOffset is the offset of the first local variable
+	const localsOffset = resultIndex + 1
+
+	// iIndex is the index of the local variable `i`, which is the first local variable
+	const iIndex = localsOffset
+
 	require.Len(t, program.Functions, 1)
 	assert.Equal(t,
 		[]opcode.Instruction{
 			// var i = 0
-			opcode.InstructionGetConstant{ConstantIndex: 0x0},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x0},
+			opcode.InstructionGetConstant{ConstantIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: iIndex},
+
 			// while true
 			opcode.InstructionTrue{},
 			opcode.InstructionJumpIfFalse{Target: 17},
+
 			// i = i + 1
-			opcode.InstructionGetLocal{LocalIndex: 0x0},
-			opcode.InstructionGetConstant{ConstantIndex: 0x1},
+			opcode.InstructionGetLocal{LocalIndex: iIndex},
+			opcode.InstructionGetConstant{ConstantIndex: 1},
 			opcode.InstructionAdd{},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x0},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: iIndex},
+
 			// if i < 3
-			opcode.InstructionGetLocal{LocalIndex: 0x0},
-			opcode.InstructionGetConstant{ConstantIndex: 0x2},
+			opcode.InstructionGetLocal{LocalIndex: iIndex},
+			opcode.InstructionGetConstant{ConstantIndex: 2},
 			opcode.InstructionLess{},
 			opcode.InstructionJumpIfFalse{Target: 15},
+
 			// continue
 			opcode.InstructionJump{Target: 3},
+
 			// break
 			opcode.InstructionJump{Target: 17},
+
 			// repeat
 			opcode.InstructionJump{Target: 3},
-			// assign i to temp $result
-			opcode.InstructionGetLocal{LocalIndex: 0x0},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x1},
+
+			// return i
+			opcode.InstructionGetLocal{LocalIndex: iIndex},
+
+			// assign to temp $result
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: resultIndex},
+
 			// return $result
-			opcode.InstructionGetLocal{LocalIndex: 0x1},
+			opcode.InstructionGetLocal{LocalIndex: resultIndex},
 			opcode.InstructionReturnValue{},
 		},
 		compiler.ExportFunctions()[0].Code,
@@ -361,8 +431,6 @@ func TestCompileArray(t *testing.T) {
 
 	t.Parallel()
 
-	t.SkipNow()
-
 	checker, err := ParseAndCheck(t, `
       fun test() {
           let xs: [Int] = [1, 2, 3]
@@ -375,21 +443,32 @@ func TestCompileArray(t *testing.T) {
 
 	require.Len(t, program.Functions, 1)
 
+	const parameterCount = 0
+
+	// resultIndex is the index of the $result variable
+	const resultIndex = parameterCount
+
+	// localsOffset is the offset of the first local variable
+	const localsOffset = resultIndex + 1
+
+	// xsIndex is the index of the local variable `xs`, which is the first local variable
+	const xsIndex = localsOffset
+
 	assert.Equal(t,
 		[]opcode.Instruction{
 			// [1, 2, 3]
-			opcode.InstructionGetConstant{ConstantIndex: 0x0},
-			opcode.InstructionGetConstant{ConstantIndex: 0x1},
-			opcode.InstructionGetConstant{ConstantIndex: 0x2},
+			opcode.InstructionGetConstant{ConstantIndex: 0},
+			opcode.InstructionGetConstant{ConstantIndex: 1},
+			opcode.InstructionGetConstant{ConstantIndex: 2},
 			opcode.InstructionNewArray{
-				TypeIndex:  0x0,
-				Size:       0x3,
+				TypeIndex:  0,
+				Size:       3,
 				IsResource: false,
 			},
 
 			// let xs =
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x0},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: xsIndex},
 
 			opcode.InstructionReturn{},
 		},
@@ -419,8 +498,6 @@ func TestCompileDictionary(t *testing.T) {
 
 	t.Parallel()
 
-	t.SkipNow()
-
 	checker, err := ParseAndCheck(t, `
       fun test() {
           let xs: {String: Int} = {"a": 1, "b": 2, "c": 3}
@@ -433,23 +510,34 @@ func TestCompileDictionary(t *testing.T) {
 
 	require.Len(t, program.Functions, 1)
 
+	const parameterCount = 0
+
+	// resultIndex is the index of the $result variable
+	const resultIndex = parameterCount
+
+	// localsOffset is the offset of the first local variable
+	const localsOffset = resultIndex + 1
+
+	// xsIndex is the index of the local variable `xs`, which is the first local variable
+	const xsIndex = localsOffset
+
 	assert.Equal(t,
 		[]opcode.Instruction{
 			// {"a": 1, "b": 2, "c": 3}
-			opcode.InstructionGetConstant{ConstantIndex: 0x0},
-			opcode.InstructionGetConstant{ConstantIndex: 0x1},
-			opcode.InstructionGetConstant{ConstantIndex: 0x2},
-			opcode.InstructionGetConstant{ConstantIndex: 0x3},
-			opcode.InstructionGetConstant{ConstantIndex: 0x4},
-			opcode.InstructionGetConstant{ConstantIndex: 0x5},
+			opcode.InstructionGetConstant{ConstantIndex: 0},
+			opcode.InstructionGetConstant{ConstantIndex: 1},
+			opcode.InstructionGetConstant{ConstantIndex: 2},
+			opcode.InstructionGetConstant{ConstantIndex: 3},
+			opcode.InstructionGetConstant{ConstantIndex: 4},
+			opcode.InstructionGetConstant{ConstantIndex: 5},
 			opcode.InstructionNewDictionary{
-				TypeIndex:  0x0,
-				Size:       0x3,
+				TypeIndex:  0,
+				Size:       3,
 				IsResource: false,
 			},
 			// let xs =
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x0},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: xsIndex},
 
 			opcode.InstructionReturn{},
 		},
@@ -554,8 +642,6 @@ func TestCompileSwitch(t *testing.T) {
 
 	t.Parallel()
 
-	t.SkipNow()
-
 	checker, err := ParseAndCheck(t, `
       fun test(x: Int): Int {
           var a = 0
@@ -577,56 +663,78 @@ func TestCompileSwitch(t *testing.T) {
 
 	require.Len(t, program.Functions, 1)
 
+	const parameterCount = 1
+
+	// xIndex is the index of the parameter `x`, which is the first parameter
+	const xIndex = 0
+
+	// resultIndex is the index of the $result variable
+	const resultIndex = parameterCount
+
+	// localsOffset is the offset of the first local variable
+	const localsOffset = resultIndex + 1
+
+	const (
+		// aIndex is the index of the local variable `a`, which is the first local variable
+		aIndex = localsOffset + iota
+		// switchIndex is the index of the local variable used to store the value of the switch expression
+		switchIndex
+	)
+
 	assert.Equal(t,
 		[]opcode.Instruction{
 			// var a = 0
-			opcode.InstructionGetConstant{ConstantIndex: 0x0},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x1},
+			opcode.InstructionGetConstant{ConstantIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: aIndex},
 
 			// switch x
-			opcode.InstructionGetLocal{LocalIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x2},
+			opcode.InstructionGetLocal{LocalIndex: xIndex},
+			opcode.InstructionSetLocal{LocalIndex: switchIndex},
 
 			// case 1:
-			opcode.InstructionGetLocal{LocalIndex: 0x2},
-			opcode.InstructionGetConstant{ConstantIndex: 0x1},
+			opcode.InstructionGetLocal{LocalIndex: switchIndex},
+			opcode.InstructionGetConstant{ConstantIndex: 1},
 			opcode.InstructionEqual{},
 			opcode.InstructionJumpIfFalse{Target: 13},
 
 			// a = 1
-			opcode.InstructionGetConstant{ConstantIndex: 0x1},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x1},
+			opcode.InstructionGetConstant{ConstantIndex: 1},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: aIndex},
 
 			// jump to end
 			opcode.InstructionJump{Target: 24},
 
 			// case 2:
-			opcode.InstructionGetLocal{LocalIndex: 0x2},
-			opcode.InstructionGetConstant{ConstantIndex: 0x2},
+			opcode.InstructionGetLocal{LocalIndex: switchIndex},
+			opcode.InstructionGetConstant{ConstantIndex: 2},
 			opcode.InstructionEqual{},
 			opcode.InstructionJumpIfFalse{Target: 21},
 
 			// a = 2
-			opcode.InstructionGetConstant{ConstantIndex: 0x2},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x1},
+			opcode.InstructionGetConstant{ConstantIndex: 2},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: aIndex},
 
 			// jump to end
 			opcode.InstructionJump{Target: 24},
 
 			// default:
 			// a = 3
-			opcode.InstructionGetConstant{ConstantIndex: 0x3},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x1},
+			opcode.InstructionGetConstant{ConstantIndex: 3},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: aIndex},
 
 			// return a
-			opcode.InstructionGetLocal{LocalIndex: 0x1},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionSetLocal{LocalIndex: 0x3},
-			opcode.InstructionGetLocal{LocalIndex: 0x3},
+			opcode.InstructionGetLocal{LocalIndex: aIndex},
+
+			// assign to temp $result
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: resultIndex},
+
+			// return $result
+			opcode.InstructionGetLocal{LocalIndex: resultIndex},
 			opcode.InstructionReturnValue{},
 		},
 		compiler.ExportFunctions()[0].Code,
@@ -681,13 +789,19 @@ func TestCompileEmit(t *testing.T) {
 	}
 	require.NotNil(t, testFunction)
 
+	// xIndex is the index of the parameter `x`, which is the first parameter
+	const xIndex = 0
+
 	assert.Equal(t,
 		[]opcode.Instruction{
-			opcode.InstructionGetLocal{LocalIndex: 0},
+			// Inc(val: x)
+			opcode.InstructionGetLocal{LocalIndex: xIndex},
 			opcode.InstructionTransfer{TypeIndex: 0},
 			opcode.InstructionGetGlobal{GlobalIndex: 1},
 			opcode.InstructionInvoke{},
+			// emit
 			opcode.InstructionEmitEvent{TypeIndex: 1},
+
 			opcode.InstructionReturn{},
 		},
 		testFunction.Code,
@@ -712,13 +826,26 @@ func TestCompileSimpleCast(t *testing.T) {
 
 	require.Len(t, program.Functions, 1)
 
+	const parameterCount = 1
+
+	// xIndex is the index of the parameter `x`, which is the first parameter
+	const xIndex = 0
+
+	// resultIndex is the index of the $result variable
+	const resultIndex = parameterCount
+
 	assert.Equal(t,
 		[]opcode.Instruction{
-			opcode.InstructionGetLocal{LocalIndex: 0},
+			// x as Int?
+			opcode.InstructionGetLocal{LocalIndex: xIndex},
 			opcode.InstructionSimpleCast{TypeIndex: 0},
+
+			// assign to temp $result
 			opcode.InstructionTransfer{TypeIndex: 1},
-			opcode.InstructionSetLocal{LocalIndex: 1},
-			opcode.InstructionGetLocal{LocalIndex: 1},
+			opcode.InstructionSetLocal{LocalIndex: resultIndex},
+
+			// return $result
+			opcode.InstructionGetLocal{LocalIndex: resultIndex},
 			opcode.InstructionReturnValue{},
 		},
 		compiler.ExportFunctions()[0].Code,
@@ -741,13 +868,26 @@ func TestCompileForceCast(t *testing.T) {
 
 	require.Len(t, program.Functions, 1)
 
+	const parameterCount = 1
+
+	// xIndex is the index of the parameter `x`, which is the first parameter
+	const xIndex = 0
+
+	// resultIndex is the index of the $result variable
+	const resultIndex = parameterCount
+
 	assert.Equal(t,
 		[]opcode.Instruction{
-			opcode.InstructionGetLocal{LocalIndex: 0},
+			// x as! Int
+			opcode.InstructionGetLocal{LocalIndex: xIndex},
 			opcode.InstructionForceCast{TypeIndex: 0},
+
+			// assign to temp $result
 			opcode.InstructionTransfer{TypeIndex: 0},
-			opcode.InstructionSetLocal{LocalIndex: 1},
-			opcode.InstructionGetLocal{LocalIndex: 1},
+			opcode.InstructionSetLocal{LocalIndex: resultIndex},
+
+			// return $result
+			opcode.InstructionGetLocal{LocalIndex: resultIndex},
 			opcode.InstructionReturnValue{},
 		},
 		compiler.ExportFunctions()[0].Code,
@@ -770,13 +910,26 @@ func TestCompileFailableCast(t *testing.T) {
 
 	require.Len(t, program.Functions, 1)
 
+	const parameterCount = 1
+
+	// xIndex is the index of the parameter `x`, which is the first parameter
+	const xIndex = 0
+
+	// resultIndex is the index of the $result variable
+	const resultIndex = parameterCount
+
 	assert.Equal(t,
 		[]opcode.Instruction{
-			opcode.InstructionGetLocal{LocalIndex: 0},
+			// x as? Int
+			opcode.InstructionGetLocal{LocalIndex: xIndex},
 			opcode.InstructionFailableCast{TypeIndex: 0},
+
+			// assign to temp $result
 			opcode.InstructionTransfer{TypeIndex: 1},
-			opcode.InstructionSetLocal{LocalIndex: 1},
-			opcode.InstructionGetLocal{LocalIndex: 1},
+			opcode.InstructionSetLocal{LocalIndex: resultIndex},
+
+			// return $result
+			opcode.InstructionGetLocal{LocalIndex: resultIndex},
 			opcode.InstructionReturnValue{},
 		},
 		compiler.ExportFunctions()[0].Code,


### PR DESCRIPTION
Work towards #3758

## Description

- Re-enable skipped compiler test cases that don't rely on #3772
- Improve local indicies

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
