### PR TITLE
[Compiler] Compile fixed-point literals and add UFix64 to VM

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -20,6 +20,7 @@ package compiler
 
 import (
 	"math"
+	"math/big"
 	"strings"
 
 	"github.com/onflow/cadence/ast"
@@ -30,6 +31,7 @@ import (
 	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/fixedpoint"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 )
@@ -849,17 +851,59 @@ func (c *Compiler[_]) VisitIntegerExpression(expression *ast.IntegerExpression) 
 	constantKind := constantkind.FromSemaType(integerType)
 
 	// TODO:
-	var data []byte
-	data = leb128.AppendInt64(data, expression.Value.Int64())
+	data := leb128.AppendInt64(nil, expression.Value.Int64())
 
 	constant := c.addConstant(constantKind, data)
 	c.codeGen.Emit(opcode.InstructionGetConstant{ConstantIndex: constant.index})
+
 	return
 }
 
-func (c *Compiler[_]) VisitFixedPointExpression(_ *ast.FixedPointExpression) (_ struct{}) {
-	// TODO
-	panic(errors.NewUnreachableError())
+func (c *Compiler[_]) VisitFixedPointExpression(expression *ast.FixedPointExpression) (_ struct{}) {
+	// TODO: adjust once/if we support more fixed point types
+
+	fixedPointSubType := c.ExtendedElaboration.FixedPointExpressionType(expression)
+
+	value := fixedpoint.ConvertToFixedPointBigInt(
+		expression.Negative,
+		expression.UnsignedInteger,
+		expression.Fractional,
+		expression.Scale,
+		sema.Fix64Scale,
+	)
+
+	var con *constant
+
+	switch fixedPointSubType {
+	case sema.Fix64Type, sema.SignedFixedPointType:
+		con = c.addFix64Constant(value)
+
+	case sema.UFix64Type:
+		con = c.addUFix64Constant(value)
+
+	case sema.FixedPointType:
+		if expression.Negative {
+			con = c.addFix64Constant(value)
+		} else {
+			con = c.addUFix64Constant(value)
+		}
+	default:
+		panic(errors.NewUnreachableError())
+	}
+
+	c.codeGen.Emit(opcode.InstructionGetConstant{ConstantIndex: con.index})
+
+	return
+}
+
+func (c *Compiler[_]) addUFix64Constant(value *big.Int) *constant {
+	data := leb128.AppendUint64(nil, value.Uint64())
+	return c.addConstant(constantkind.UFix64, data)
+}
+
+func (c *Compiler[_]) addFix64Constant(value *big.Int) *constant {
+	data := leb128.AppendInt64(nil, value.Int64())
+	return c.addConstant(constantkind.Fix64, data)
 }
 
 func (c *Compiler[_]) VisitArrayExpression(array *ast.ArrayExpression) (_ struct{}) {

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -1889,7 +1889,7 @@ func TestCompileIntegers(t *testing.T) {
 
 	t.Parallel()
 
-	test := func(t *testing.T, integerType sema.Type) {
+	test := func(integerType sema.Type) {
 
 		t.Run(integerType.String(), func(t *testing.T) {
 
@@ -1957,7 +1957,7 @@ func TestCompileIntegers(t *testing.T) {
 		sema.AllUnsignedIntegerTypes,
 		sema.AllSignedIntegerTypes,
 	) {
-		test(t, integerType)
+		test(integerType)
 	}
 }
 
@@ -1965,7 +1965,7 @@ func TestCompileFixedPoint(t *testing.T) {
 
 	t.Parallel()
 
-	test := func(t *testing.T, fixedPointType sema.Type, isSigned bool) {
+	test := func(fixedPointType sema.Type, isSigned bool) {
 
 		t.Run(fixedPointType.String(), func(t *testing.T) {
 
@@ -2037,11 +2037,11 @@ func TestCompileFixedPoint(t *testing.T) {
 	}
 
 	for _, fixedPointType := range sema.AllUnsignedFixedPointTypes {
-		test(t, fixedPointType, false)
+		test(fixedPointType, false)
 	}
 
 	for _, fixedPointType := range sema.AllSignedFixedPointTypes {
-		test(t, fixedPointType, true)
+		test(fixedPointType, true)
 	}
 }
 

--- a/bbq/compiler/extended_elaboration.go
+++ b/bbq/compiler/extended_elaboration.go
@@ -223,6 +223,10 @@ func (e *ExtendedElaboration) IntegerExpressionType(expression *ast.IntegerExpre
 	return e.elaboration.IntegerExpressionType(expression)
 }
 
+func (e *ExtendedElaboration) FixedPointExpressionType(expression *ast.FixedPointExpression) sema.Type {
+	return e.elaboration.FixedPointExpression(expression)
+}
+
 func (e *ExtendedElaboration) ArrayExpressionTypes(expression *ast.ArrayExpression) sema.ArrayExpressionTypes {
 	return e.elaboration.ArrayExpressionTypes(expression)
 }

--- a/bbq/constantkind/constantkind.go
+++ b/bbq/constantkind/constantkind.go
@@ -57,8 +57,8 @@ const (
 	Word16
 	Word32
 	Word64
-	_ // future: Word128
-	_ // future: Word256
+	Word128
+	Word256
 	_
 
 	// Fix*
@@ -83,6 +83,9 @@ const (
 
 func FromSemaType(ty sema.Type) ConstantKind {
 	switch ty {
+	case sema.StringType:
+		return String
+
 	// Int*
 	case sema.IntType, sema.IntegerType:
 		return Int
@@ -124,6 +127,10 @@ func FromSemaType(ty sema.Type) ConstantKind {
 		return Word32
 	case sema.Word64Type:
 		return Word64
+	case sema.Word128Type:
+		return Word128
+	case sema.Word256Type:
+		return Word256
 
 	// Fix*
 	case sema.Fix64Type:

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -4390,3 +4390,42 @@ func TestIntegers(t *testing.T) {
 
 	test(sema.IntType)
 }
+
+func TestFixedPoint(t *testing.T) {
+
+	t.Parallel()
+
+	test := func(fixedPointType sema.Type) {
+
+		t.Run(fixedPointType.String(), func(t *testing.T) {
+
+			t.Parallel()
+
+			result, err := compileAndInvoke(t,
+				fmt.Sprintf(`
+                        fun test(): %s {
+                            return 2.1 + 7.9
+                        }
+                    `,
+					fixedPointType,
+				),
+				"test",
+			)
+			require.NoError(t, err)
+
+			assert.Equal(t,
+				vm.NewUFix64Value(10*sema.Fix64Factor),
+				result,
+			)
+		})
+	}
+
+	for _, fixedPointType := range sema.AllUnsignedFixedPointTypes {
+		test(fixedPointType)
+	}
+
+	// TODO:
+	//for _, fixedPointType := range sema.AllSignedFixedPointTypes {
+	//	test(fixedPointType)
+	//}
+}

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -4353,3 +4353,40 @@ func TestBlockScope2(t *testing.T) {
 		require.Equal(t, vm.NewIntValue(4), actual)
 	})
 }
+
+func TestIntegers(t *testing.T) {
+
+	t.Parallel()
+
+	test := func(integerType sema.Type) {
+
+		t.Run(integerType.String(), func(t *testing.T) {
+
+			t.Parallel()
+
+			result, err := compileAndInvoke(t,
+				fmt.Sprintf(`
+                        fun test(): %s {
+                            return 2 + 3
+                        }
+                    `,
+					integerType,
+				),
+				"test",
+			)
+			require.NoError(t, err)
+
+			assert.Equal(t, vm.NewIntValue(5), result)
+		})
+	}
+
+	// TODO:
+	//for _, integerType := range common.Concat(
+	//	sema.AllUnsignedIntegerTypes,
+	//	sema.AllSignedIntegerTypes,
+	//) {
+	//	test(t, integerType)
+	//}
+
+	test(sema.IntType)
+}

--- a/bbq/vm/value_ufix64.go
+++ b/bbq/vm/value_ufix64.go
@@ -1,0 +1,174 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vm
+
+import (
+	"math/big"
+
+	"github.com/onflow/atree"
+
+	"github.com/onflow/cadence/format"
+	"github.com/onflow/cadence/interpreter"
+	"github.com/onflow/cadence/sema"
+)
+
+type UFix64Value uint64
+
+func NewUFix64Value(value uint64) UFix64Value {
+	return UFix64Value(value)
+}
+
+func (v UFix64Value) String() string {
+	return format.UFix64(uint64(v))
+}
+
+var _ Value = UFix64Value(0)
+var _ EquatableValue = UFix64Value(0)
+var _ ComparableValue = UFix64Value(0)
+var _ NumberValue = UFix64Value(0)
+
+func (UFix64Value) isValue() {}
+
+func (UFix64Value) StaticType(*Config) StaticType {
+	return interpreter.PrimitiveStaticTypeUFix64
+}
+
+func (v UFix64Value) Transfer(*Config, atree.Address, bool, atree.Storable) Value {
+	return v
+}
+
+func (v UFix64Value) Add(other NumberValue) NumberValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic("invalid operand")
+	}
+	sum := safeAddUint64(uint64(v), uint64(o))
+	return NewUFix64Value(sum)
+}
+
+func (v UFix64Value) Subtract(other NumberValue) NumberValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic("invalid operand")
+	}
+
+	diff := v - o
+
+	// INT30-C
+	if diff > v {
+		panic(interpreter.UnderflowError{})
+	}
+
+	return diff
+}
+
+func (v UFix64Value) Multiply(other NumberValue) NumberValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic("invalid operand")
+	}
+
+	a := new(big.Int).SetUint64(uint64(v))
+	b := new(big.Int).SetUint64(uint64(o))
+
+	result := new(big.Int).Mul(a, b)
+	result.Div(result, sema.Fix64FactorBig)
+
+	if !result.IsUint64() {
+		panic(interpreter.OverflowError{})
+	}
+
+	return NewUFix64Value(result.Uint64())
+}
+
+func (v UFix64Value) Divide(other NumberValue) NumberValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic("invalid operand")
+	}
+
+	a := new(big.Int).SetUint64(uint64(v))
+	b := new(big.Int).SetUint64(uint64(o))
+
+	result := new(big.Int).Mul(a, sema.Fix64FactorBig)
+	result.Div(result, b)
+
+	return NewUFix64Value(result.Uint64())
+}
+
+func (v UFix64Value) Mod(other NumberValue) NumberValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic("invalid operand")
+	}
+
+	// v - int(v/o) * o
+	quotient, ok := v.Divide(o).(UFix64Value)
+	if !ok {
+		panic("invalid operand")
+	}
+
+	truncatedQuotient := NewUFix64Value(
+		(uint64(quotient) / sema.Fix64Factor) * sema.Fix64Factor,
+	)
+
+	return v.Subtract(
+		truncatedQuotient.Multiply(o),
+	)
+}
+
+func (v UFix64Value) Equal(other Value) BoolValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		return false
+	}
+	return v == o
+}
+
+func (v UFix64Value) Less(other ComparableValue) BoolValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic("invalid operand")
+	}
+	return v < o
+}
+
+func (v UFix64Value) LessEqual(other ComparableValue) BoolValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic("invalid operand")
+	}
+	return v <= o
+}
+
+func (v UFix64Value) Greater(other ComparableValue) BoolValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic("invalid operand")
+	}
+	return v > o
+}
+
+func (v UFix64Value) GreaterEqual(other ComparableValue) BoolValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic("invalid operand")
+	}
+	return v >= o
+}

--- a/bbq/vm/value_utils.go
+++ b/bbq/vm/value_utils.go
@@ -33,3 +33,12 @@ func safeAdd(a, b int) int {
 	}
 	return a + b
 }
+
+func safeAddUint64(a, b uint64) uint64 {
+	sum := a + b
+	// INT30-C
+	if sum < a {
+		panic(interpreter.OverflowError{})
+	}
+	return sum
+}

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -922,6 +922,11 @@ func (vm *VM) initializeConstant(index uint16) (value Value) {
 		value = NewIntValue(smallInt)
 	case constantkind.String:
 		value = NewStringValueFromBytes(constant.Data)
+
+	case constantkind.UFix64:
+		smallInt, _, _ := leb128.ReadUint64(constant.Data)
+		value = NewUFix64Value(smallInt)
+
 	default:
 		// TODO:
 		panic(errors.NewUnexpectedError("unsupported constant kind '%s'", constant.Kind.String()))


### PR DESCRIPTION
Closes #3762 

## Description

- Compile fixed-point expressions to constants
- Add UFix64 value implementation to VM
- Add support for loading UFix64 constants to VM

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
