### PR TITLE
Decouple interpreter values from interpreter – Part 5

### DIFF
--- a/encoding/ccf/ccf_test.go
+++ b/encoding/ccf/ccf_test.go
@@ -7744,7 +7744,7 @@ func TestEncodeValueOfReferenceType(t *testing.T) {
 			cadence.NewReferenceType(
 				cadence.NewEntitlementMapAuthorization(
 					nil,
-					common.TypeID("foo"),
+					"foo",
 				),
 				cadence.StringType,
 			),

--- a/interpreter/decode.go
+++ b/interpreter/decode.go
@@ -851,9 +851,9 @@ func (d StorableDecoder) decodeUFix64() (UFix64Value, error) {
 	value, err := decodeUint64(d.decoder, d.memoryGauge)
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
-			return 0, errors.NewUnexpectedError("unknown UFix64 encoding: %s", e.ActualType.String())
+			return UFix64Value{}, errors.NewUnexpectedError("unknown UFix64 encoding: %s", e.ActualType.String())
 		}
-		return 0, err
+		return UFix64Value{}, err
 	}
 
 	// Already metered at `decodeUint64`

--- a/interpreter/encode.go
+++ b/interpreter/encode.go
@@ -480,23 +480,6 @@ func (v Fix64Value) Encode(e *atree.Encoder) error {
 	return e.CBOR.EncodeInt64(int64(v))
 }
 
-// Encode encodes UFix64Value as
-//
-//	cbor.Tag{
-//			Number:  CBORTagUFix64Value,
-//			Content: uint64(v),
-//	}
-func (v UFix64Value) Encode(e *atree.Encoder) error {
-	err := e.CBOR.EncodeRawBytes([]byte{
-		// tag number
-		0xd8, values.CBORTagUFix64Value,
-	})
-	if err != nil {
-		return err
-	}
-	return e.CBOR.EncodeUint64(uint64(v))
-}
-
 var _ atree.ContainerStorable = &SomeStorable{}
 
 func (s SomeStorable) Encode(e *atree.Encoder) error {

--- a/interpreter/storage.go
+++ b/interpreter/storage.go
@@ -101,6 +101,9 @@ func ConvertStoredValue(gauge common.MemoryGauge, value atree.Value) (Value, err
 	case values.IntValue:
 		return IntValue{IntValue: value}, nil
 
+	case values.UFix64Value:
+		return UFix64Value{UFix64Value: value}, nil
+
 	case Value:
 		return value, nil
 

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -65,10 +65,8 @@ func (v BoolValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value)
 	if !ok {
 		return false
 	}
-	return bool(
-		values.BoolValue(v).
-			EqualBool(values.BoolValue(otherBool)),
-	)
+	return values.BoolValue(v).
+		Equal(values.BoolValue(otherBool))
 }
 
 func (v BoolValue) Less(_ ValueComparisonContext, other ComparableValue, _ LocationRange) BoolValue {

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -480,7 +480,7 @@ func ConvertFix64(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 		return value
 
 	case UFix64Value:
-		if value > Fix64MaxValue {
+		if value.UFix64Value > Fix64MaxValue {
 			panic(OverflowError{
 				LocationRange: locationRange,
 			})
@@ -488,7 +488,7 @@ func ConvertFix64(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 		return NewFix64Value(
 			memoryGauge,
 			func() int64 {
-				return int64(value)
+				return int64(value.UFix64Value)
 			},
 		)
 

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -412,7 +412,7 @@ func (v Fix64Value) Less(context ValueComparisonContext, other ComparableValue, 
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v Fix64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -426,7 +426,7 @@ func (v Fix64Value) LessEqual(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v Fix64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -440,7 +440,7 @@ func (v Fix64Value) Greater(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 }
 
 func (v Fix64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -454,7 +454,7 @@ func (v Fix64Value) GreaterEqual(context ValueComparisonContext, other Comparabl
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v Fix64Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -21,7 +21,6 @@ package interpreter
 import (
 	"math"
 	"math/big"
-	"unsafe"
 
 	"github.com/onflow/atree"
 
@@ -37,8 +36,6 @@ import (
 type IntValue struct {
 	values.IntValue
 }
-
-const int64Size = int(unsafe.Sizeof(int64(0)))
 
 func NewIntValueFromInt64(memoryGauge common.MemoryGauge, value int64) IntValue {
 	return IntValue{
@@ -397,7 +394,7 @@ func (v IntValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value) 
 		return false
 	}
 
-	return bool(v.IntValue.Equal(otherInt.IntValue))
+	return v.IntValue.Equal(otherInt.IntValue)
 }
 
 // HashInput returns a byte slice containing:

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -506,7 +506,7 @@ func (v Int128Value) Less(context ValueComparisonContext, other ComparableValue,
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == -1)
+	return cmp == -1
 }
 
 func (v Int128Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -521,7 +521,7 @@ func (v Int128Value) LessEqual(context ValueComparisonContext, other ComparableV
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp <= 0)
+	return cmp <= 0
 }
 
 func (v Int128Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -536,7 +536,7 @@ func (v Int128Value) Greater(context ValueComparisonContext, other ComparableVal
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == 1)
+	return cmp == 1
 }
 
 func (v Int128Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -551,7 +551,7 @@ func (v Int128Value) GreaterEqual(context ValueComparisonContext, other Comparab
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp >= 0)
+	return cmp >= 0
 }
 
 func (v Int128Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -411,7 +411,7 @@ func (v Int16Value) Less(context ValueComparisonContext, other ComparableValue, 
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v Int16Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -425,7 +425,7 @@ func (v Int16Value) LessEqual(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v Int16Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -439,7 +439,7 @@ func (v Int16Value) Greater(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 }
 
 func (v Int16Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -453,7 +453,7 @@ func (v Int16Value) GreaterEqual(context ValueComparisonContext, other Comparabl
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v Int16Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -473,7 +473,7 @@ func (v Int256Value) Less(context ValueComparisonContext, other ComparableValue,
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == -1)
+	return cmp == -1
 }
 
 func (v Int256Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -488,7 +488,7 @@ func (v Int256Value) LessEqual(context ValueComparisonContext, other ComparableV
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp <= 0)
+	return cmp <= 0
 }
 
 func (v Int256Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -503,7 +503,7 @@ func (v Int256Value) Greater(context ValueComparisonContext, other ComparableVal
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == 1)
+	return cmp == 1
 }
 
 func (v Int256Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -518,7 +518,7 @@ func (v Int256Value) GreaterEqual(context ValueComparisonContext, other Comparab
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp >= 0)
+	return cmp >= 0
 }
 
 func (v Int256Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -412,7 +412,7 @@ func (v Int32Value) Less(context ValueComparisonContext, other ComparableValue, 
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v Int32Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -426,7 +426,7 @@ func (v Int32Value) LessEqual(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v Int32Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -440,7 +440,7 @@ func (v Int32Value) Greater(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 }
 
 func (v Int32Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -454,7 +454,7 @@ func (v Int32Value) GreaterEqual(context ValueComparisonContext, other Comparabl
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v Int32Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -21,6 +21,7 @@ package interpreter
 import (
 	"encoding/binary"
 	"math"
+	"unsafe"
 
 	"github.com/onflow/atree"
 
@@ -35,6 +36,8 @@ import (
 // Int64Value
 
 type Int64Value int64
+
+const int64Size = int(unsafe.Sizeof(int64(0)))
 
 var Int64MemoryUsage = common.NewNumberMemoryUsage(int64Size)
 

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -411,7 +411,7 @@ func (v Int64Value) Less(context ValueComparisonContext, other ComparableValue, 
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v Int64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -425,7 +425,7 @@ func (v Int64Value) LessEqual(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v Int64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -439,7 +439,7 @@ func (v Int64Value) Greater(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 
 }
 
@@ -454,7 +454,7 @@ func (v Int64Value) GreaterEqual(context ValueComparisonContext, other Comparabl
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v Int64Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -410,7 +410,7 @@ func (v Int8Value) Less(context ValueComparisonContext, other ComparableValue, l
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v Int8Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -424,7 +424,7 @@ func (v Int8Value) LessEqual(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v Int8Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -438,7 +438,7 @@ func (v Int8Value) Greater(context ValueComparisonContext, other ComparableValue
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 }
 
 func (v Int8Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -452,7 +452,7 @@ func (v Int8Value) GreaterEqual(context ValueComparisonContext, other Comparable
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v Int8Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -163,7 +163,7 @@ func (v *StringValue) Less(context ValueComparisonContext, other ComparableValue
 		})
 	}
 
-	return BoolValue(v.Str < otherString.Str)
+	return v.Str < otherString.Str
 }
 
 func (v *StringValue) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -177,7 +177,7 @@ func (v *StringValue) LessEqual(context ValueComparisonContext, other Comparable
 		})
 	}
 
-	return BoolValue(v.Str <= otherString.Str)
+	return v.Str <= otherString.Str
 }
 
 func (v *StringValue) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -191,7 +191,7 @@ func (v *StringValue) Greater(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return BoolValue(v.Str > otherString.Str)
+	return v.Str > otherString.Str
 }
 
 func (v *StringValue) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -205,7 +205,7 @@ func (v *StringValue) GreaterEqual(context ValueComparisonContext, other Compara
 		})
 	}
 
-	return BoolValue(v.Str >= otherString.Str)
+	return v.Str >= otherString.Str
 }
 
 // HashInput returns a byte slice containing:
@@ -1028,7 +1028,7 @@ func (v *StringValue) indexOf(inter *Interpreter, other *StringValue) (character
 
 func (v *StringValue) Contains(inter *Interpreter, other *StringValue) BoolValue {
 	characterIndex, _ := v.indexOf(inter, other)
-	return BoolValue(characterIndex >= 0)
+	return characterIndex >= 0
 }
 
 func (v *StringValue) Count(inter *Interpreter, locationRange LocationRange, other *StringValue) IntValue {

--- a/interpreter/value_test.go
+++ b/interpreter/value_test.go
@@ -1857,13 +1857,15 @@ func TestBlockValue(t *testing.T) {
 			ByteArrayStaticType,
 			common.ZeroAddress,
 		),
-		5.0,
+		NewUnmeteredUFix64ValueWithInteger(5, EmptyLocationRange),
 	)
 
 	// static type test
-	var actualTs = block.Fields[sema.BlockTypeTimestampFieldName]
-	const expectedTs UFix64Value = 5.0
-	assert.Equal(t, expectedTs, actualTs)
+
+	assert.Equal(t,
+		NewUnmeteredUFix64ValueWithInteger(5, EmptyLocationRange),
+		block.Fields[sema.BlockTypeTimestampFieldName],
+	)
 }
 
 func TestEphemeralReferenceTypeConformance(t *testing.T) {

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -22,401 +22,72 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"math/big"
-	"unsafe"
 
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
-	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/values"
 )
 
 // UFix64Value
-type UFix64Value uint64
+
+type UFix64Value struct {
+	values.UFix64Value
+}
 
 const UFix64MaxValue = math.MaxUint64
 
-const ufix64Size = int(unsafe.Sizeof(UFix64Value(0)))
-
-var ufix64MemoryUsage = common.NewNumberMemoryUsage(ufix64Size)
-
 func NewUFix64ValueWithInteger(gauge common.MemoryGauge, constructor func() uint64, locationRange LocationRange) UFix64Value {
-	common.UseMemory(gauge, ufix64MemoryUsage)
-	return NewUnmeteredUFix64ValueWithInteger(constructor(), locationRange)
-}
-
-func NewUnmeteredUFix64ValueWithInteger(integer uint64, locationRange LocationRange) UFix64Value {
-	if integer > sema.UFix64TypeMaxInt {
-		panic(OverflowError{
-			LocationRange: locationRange,
-		})
-	}
-
-	return NewUnmeteredUFix64Value(integer * sema.Fix64Factor)
-}
-
-func NewUFix64Value(gauge common.MemoryGauge, constructor func() uint64) UFix64Value {
-	common.UseMemory(gauge, ufix64MemoryUsage)
-	return NewUnmeteredUFix64Value(constructor())
-}
-
-func NewUnmeteredUFix64Value(integer uint64) UFix64Value {
-	return UFix64Value(integer)
-}
-
-var _ Value = UFix64Value(0)
-var _ atree.Storable = UFix64Value(0)
-var _ NumberValue = UFix64Value(0)
-var _ FixedPointValue = Fix64Value(0)
-var _ EquatableValue = UFix64Value(0)
-var _ ComparableValue = UFix64Value(0)
-var _ HashableValue = UFix64Value(0)
-var _ MemberAccessibleValue = UFix64Value(0)
-
-func (UFix64Value) isValue() {}
-
-func (v UFix64Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitUFix64Value(interpreter, v)
-}
-
-func (UFix64Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
-	// NO-OP
-}
-
-func (UFix64Value) StaticType(context ValueStaticTypeContext) StaticType {
-	return NewPrimitiveStaticType(context, PrimitiveStaticTypeUFix64)
-}
-
-func (UFix64Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
-	return true
-}
-
-func (v UFix64Value) String() string {
-	return format.UFix64(uint64(v))
-}
-
-func (v UFix64Value) RecursiveString(_ SeenReferences) string {
-	return v.String()
-}
-
-func (v UFix64Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
-	common.UseMemory(
-		interpreter,
-		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
-		),
-	)
-	return v.String()
-}
-
-func (v UFix64Value) ToInt(_ LocationRange) int {
-	return int(v / sema.Fix64Factor)
-}
-
-func (v UFix64Value) Negate(NumberValueArithmeticContext, LocationRange) NumberValue {
-	panic(errors.NewUnreachableError())
-}
-
-func (v UFix64Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
-	o, ok := other.(UFix64Value)
-	if !ok {
-		panic(InvalidOperandsError{
-			Operation:     ast.OperationPlus,
-			LeftType:      v.StaticType(context),
-			RightType:     other.StaticType(context),
-			LocationRange: locationRange,
-		})
-	}
-
-	valueGetter := func() uint64 {
-		return safeAddUint64(uint64(v), uint64(o), locationRange)
-	}
-
-	return NewUFix64Value(context, valueGetter)
-}
-
-func (v UFix64Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
-	o, ok := other.(UFix64Value)
-	if !ok {
-		panic(InvalidOperandsError{
-			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
-			LeftType:      v.StaticType(context),
-			RightType:     other.StaticType(context),
-			LocationRange: locationRange,
-		})
-	}
-
-	valueGetter := func() uint64 {
-		sum := v + o
-		// INT30-C
-		if sum < v {
-			return math.MaxUint64
-		}
-		return uint64(sum)
-	}
-
-	return NewUFix64Value(context, valueGetter)
-}
-
-func (v UFix64Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
-	o, ok := other.(UFix64Value)
-	if !ok {
-		panic(InvalidOperandsError{
-			Operation:     ast.OperationMinus,
-			LeftType:      v.StaticType(context),
-			RightType:     other.StaticType(context),
-			LocationRange: locationRange,
-		})
-	}
-
-	valueGetter := func() uint64 {
-		diff := v - o
-
-		// INT30-C
-		if diff > v {
-			panic(UnderflowError{
-				LocationRange: locationRange,
-			})
-		}
-		return uint64(diff)
-	}
-
-	return NewUFix64Value(context, valueGetter)
-}
-
-func (v UFix64Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
-	o, ok := other.(UFix64Value)
-	if !ok {
-		panic(InvalidOperandsError{
-			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
-			LeftType:      v.StaticType(context),
-			RightType:     other.StaticType(context),
-			LocationRange: locationRange,
-		})
-	}
-
-	valueGetter := func() uint64 {
-		diff := v - o
-
-		// INT30-C
-		if diff > v {
-			return 0
-		}
-		return uint64(diff)
-	}
-
-	return NewUFix64Value(context, valueGetter)
-}
-
-func (v UFix64Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
-	o, ok := other.(UFix64Value)
-	if !ok {
-		panic(InvalidOperandsError{
-			Operation:     ast.OperationMul,
-			LeftType:      v.StaticType(context),
-			RightType:     other.StaticType(context),
-			LocationRange: locationRange,
-		})
-	}
-
-	a := new(big.Int).SetUint64(uint64(v))
-	b := new(big.Int).SetUint64(uint64(o))
-
-	valueGetter := func() uint64 {
-		result := new(big.Int).Mul(a, b)
-		result.Div(result, sema.Fix64FactorBig)
-
-		if !result.IsUint64() {
+	ufix64Value, err := values.NewUFix64ValueWithInteger(gauge, func() (uint64, error) {
+		return constructor(), nil
+	})
+	if err != nil {
+		if _, ok := err.(values.OverflowError); ok {
 			panic(OverflowError{
 				LocationRange: locationRange,
 			})
 		}
-
-		return result.Uint64()
+		panic(err)
 	}
-
-	return NewUFix64Value(context, valueGetter)
+	return UFix64Value{
+		UFix64Value: ufix64Value,
+	}
 }
 
-func (v UFix64Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
-	o, ok := other.(UFix64Value)
-	if !ok {
-		panic(InvalidOperandsError{
-			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
-			LeftType:      v.StaticType(context),
-			RightType:     other.StaticType(context),
-			LocationRange: locationRange,
-		})
-	}
-
-	a := new(big.Int).SetUint64(uint64(v))
-	b := new(big.Int).SetUint64(uint64(o))
-
-	valueGetter := func() uint64 {
-		result := new(big.Int).Mul(a, b)
-		result.Div(result, sema.Fix64FactorBig)
-
-		if !result.IsUint64() {
-			return math.MaxUint64
-		}
-
-		return result.Uint64()
-	}
-
-	return NewUFix64Value(context, valueGetter)
-}
-
-func (v UFix64Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
-	o, ok := other.(UFix64Value)
-	if !ok {
-		panic(InvalidOperandsError{
-			Operation:     ast.OperationDiv,
-			LeftType:      v.StaticType(context),
-			RightType:     other.StaticType(context),
-			LocationRange: locationRange,
-		})
-	}
-
-	a := new(big.Int).SetUint64(uint64(v))
-	b := new(big.Int).SetUint64(uint64(o))
-
-	valueGetter := func() uint64 {
-		result := new(big.Int).Mul(a, sema.Fix64FactorBig)
-		result.Div(result, b)
-
-		return result.Uint64()
-	}
-
-	return NewUFix64Value(context, valueGetter)
-}
-
-func (v UFix64Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
-	defer func() {
-		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
-				FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
-				LeftType:      v.StaticType(context),
-				RightType:     other.StaticType(context),
+func NewUnmeteredUFix64ValueWithInteger(integer uint64, locationRange LocationRange) UFix64Value {
+	ufix64Value, err := values.NewUnmeteredUFix64ValueWithInteger(integer)
+	if err != nil {
+		if _, ok := err.(values.OverflowError); ok {
+			panic(OverflowError{
 				LocationRange: locationRange,
 			})
 		}
-	}()
-
-	return v.Div(context, other, locationRange)
+		panic(err)
+	}
+	return UFix64Value{
+		UFix64Value: ufix64Value,
+	}
 }
 
-func (v UFix64Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
-	o, ok := other.(UFix64Value)
-	if !ok {
-		panic(InvalidOperandsError{
-			Operation:     ast.OperationMod,
-			LeftType:      v.StaticType(context),
-			RightType:     other.StaticType(context),
-			LocationRange: locationRange,
-		})
+func NewUFix64Value(gauge common.MemoryGauge, constructor func() uint64) UFix64Value {
+	ufix64Value, err := values.NewUFix64Value(gauge, func() (uint64, error) {
+		return constructor(), nil
+	})
+	if err != nil {
+		panic(err)
 	}
-
-	// v - int(v/o) * o
-	quotient, ok := v.Div(context, o, locationRange).(UFix64Value)
-	if !ok {
-		panic(InvalidOperandsError{
-			Operation:     ast.OperationMod,
-			LeftType:      v.StaticType(context),
-			RightType:     other.StaticType(context),
-			LocationRange: locationRange,
-		})
+	return UFix64Value{
+		UFix64Value: ufix64Value,
 	}
-
-	truncatedQuotient := NewUFix64Value(
-		context,
-		func() uint64 {
-			return (uint64(quotient) / sema.Fix64Factor) * sema.Fix64Factor
-		},
-	)
-
-	return v.Minus(
-		context,
-		truncatedQuotient.Mul(context, o, locationRange),
-		locationRange,
-	)
 }
 
-func (v UFix64Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
-	o, ok := other.(UFix64Value)
-	if !ok {
-		panic(InvalidOperandsError{
-			Operation:     ast.OperationLess,
-			LeftType:      v.StaticType(context),
-			RightType:     other.StaticType(context),
-			LocationRange: locationRange,
-		})
+func NewUnmeteredUFix64Value(integer uint64) UFix64Value {
+	return UFix64Value{
+		UFix64Value: values.NewUnmeteredUFix64Value(integer),
 	}
-
-	return v < o
-}
-
-func (v UFix64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
-	o, ok := other.(UFix64Value)
-	if !ok {
-		panic(InvalidOperandsError{
-			Operation:     ast.OperationLessEqual,
-			LeftType:      v.StaticType(context),
-			RightType:     other.StaticType(context),
-			LocationRange: locationRange,
-		})
-	}
-
-	return v <= o
-}
-
-func (v UFix64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
-	o, ok := other.(UFix64Value)
-	if !ok {
-		panic(InvalidOperandsError{
-			Operation:     ast.OperationGreater,
-			LeftType:      v.StaticType(context),
-			RightType:     other.StaticType(context),
-			LocationRange: locationRange,
-		})
-	}
-
-	return v > o
-}
-
-func (v UFix64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
-	o, ok := other.(UFix64Value)
-	if !ok {
-		panic(InvalidOperandsError{
-			Operation:     ast.OperationGreaterEqual,
-			LeftType:      v.StaticType(context),
-			RightType:     other.StaticType(context),
-			LocationRange: locationRange,
-		})
-	}
-
-	return v >= o
-}
-
-func (v UFix64Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
-	otherUFix64, ok := other.(UFix64Value)
-	if !ok {
-		return false
-	}
-	return v == otherUFix64
-}
-
-// HashInput returns a byte slice containing:
-// - HashInputTypeUFix64 (1 byte)
-// - uint64 value encoded in big-endian (8 bytes)
-func (v UFix64Value) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []byte) []byte {
-	scratch[0] = byte(HashInputTypeUFix64)
-	binary.BigEndian.PutUint64(scratch[1:], uint64(v))
-	return scratch[:9]
 }
 
 func ConvertUFix64(memoryGauge common.MemoryGauge, value Value, locationRange LocationRange) UFix64Value {
@@ -483,6 +154,292 @@ func ConvertUFix64(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 	}
 }
 
+var _ Value = UFix64Value{}
+var _ atree.Storable = UFix64Value{}
+var _ NumberValue = UFix64Value{}
+var _ FixedPointValue = UFix64Value{}
+var _ EquatableValue = UFix64Value{}
+var _ ComparableValue = UFix64Value{}
+var _ HashableValue = UFix64Value{}
+var _ MemberAccessibleValue = UFix64Value{}
+
+func (UFix64Value) isValue() {}
+
+func (v UFix64Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
+	visitor.VisitUFix64Value(interpreter, v)
+}
+
+func (UFix64Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+	// NO-OP
+}
+
+func (UFix64Value) StaticType(context ValueStaticTypeContext) StaticType {
+	return NewPrimitiveStaticType(context, PrimitiveStaticTypeUFix64)
+}
+
+func (UFix64Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+	return true
+}
+
+func (v UFix64Value) RecursiveString(_ SeenReferences) string {
+	return v.String()
+}
+
+func (v UFix64Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+	common.UseMemory(
+		interpreter,
+		common.NewRawStringMemoryUsage(
+			OverEstimateNumberStringLength(interpreter, v),
+		),
+	)
+	return v.String()
+}
+
+func (v UFix64Value) ToInt(_ LocationRange) int {
+	result, err := v.UFix64Value.ToInt()
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+func (v UFix64Value) Negate(NumberValueArithmeticContext, LocationRange) NumberValue {
+	panic(errors.NewUnreachableError())
+}
+
+func (v UFix64Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation:     ast.OperationPlus,
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
+			LocationRange: locationRange,
+		})
+	}
+	result, err := v.UFix64Value.Plus(context, o.UFix64Value)
+	if err != nil {
+		panic(err)
+	}
+	return UFix64Value{UFix64Value: result}
+}
+
+func (v UFix64Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
+			LocationRange: locationRange,
+		})
+	}
+
+	result, err := v.UFix64Value.SaturatingPlus(context, o.UFix64Value)
+	if err != nil {
+		panic(err)
+	}
+	return UFix64Value{UFix64Value: result}
+}
+
+func (v UFix64Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation:     ast.OperationMinus,
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
+			LocationRange: locationRange,
+		})
+	}
+
+	result, err := v.UFix64Value.Minus(context, o.UFix64Value)
+	if err != nil {
+		panic(err)
+	}
+	return UFix64Value{UFix64Value: result}
+}
+
+func (v UFix64Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
+			LocationRange: locationRange,
+		})
+	}
+
+	result, err := v.UFix64Value.SaturatingMinus(context, o.UFix64Value)
+	if err != nil {
+		panic(err)
+	}
+	return UFix64Value{UFix64Value: result}
+}
+
+func (v UFix64Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation:     ast.OperationMul,
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
+			LocationRange: locationRange,
+		})
+	}
+
+	result, err := v.UFix64Value.Mul(context, o.UFix64Value)
+	if err != nil {
+		panic(err)
+	}
+	return UFix64Value{UFix64Value: result}
+}
+
+func (v UFix64Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
+			LocationRange: locationRange,
+		})
+	}
+
+	result, err := v.UFix64Value.SaturatingMul(context, o.UFix64Value)
+	if err != nil {
+		panic(err)
+	}
+	return UFix64Value{UFix64Value: result}
+}
+
+func (v UFix64Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation:     ast.OperationDiv,
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
+			LocationRange: locationRange,
+		})
+	}
+
+	result, err := v.UFix64Value.Div(context, o.UFix64Value)
+	if err != nil {
+		panic(err)
+	}
+	return UFix64Value{UFix64Value: result}
+}
+
+func (v UFix64Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
+	defer func() {
+		r := recover()
+		if _, ok := r.(InvalidOperandsError); ok {
+			panic(InvalidOperandsError{
+				FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
+				LeftType:      v.StaticType(context),
+				RightType:     other.StaticType(context),
+				LocationRange: locationRange,
+			})
+		}
+	}()
+
+	return v.Div(context, other, locationRange)
+}
+
+func (v UFix64Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation:     ast.OperationMod,
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
+			LocationRange: locationRange,
+		})
+	}
+
+	result, err := v.UFix64Value.Mod(context, o.UFix64Value)
+	if err != nil {
+		panic(err)
+	}
+	return UFix64Value{UFix64Value: result}
+}
+
+func (v UFix64Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation:     ast.OperationLess,
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
+			LocationRange: locationRange,
+		})
+	}
+
+	return BoolValue(v.UFix64Value.Less(o.UFix64Value))
+}
+
+func (v UFix64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation:     ast.OperationLessEqual,
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
+			LocationRange: locationRange,
+		})
+	}
+
+	return BoolValue(v.UFix64Value.LessEqual(o.UFix64Value))
+}
+
+func (v UFix64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation:     ast.OperationGreater,
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
+			LocationRange: locationRange,
+		})
+	}
+
+	return BoolValue(v.UFix64Value.Greater(o.UFix64Value))
+}
+
+func (v UFix64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
+	o, ok := other.(UFix64Value)
+	if !ok {
+		panic(InvalidOperandsError{
+			Operation:     ast.OperationGreaterEqual,
+			LeftType:      v.StaticType(context),
+			RightType:     other.StaticType(context),
+			LocationRange: locationRange,
+		})
+	}
+
+	return BoolValue(v.UFix64Value.GreaterEqual(o.UFix64Value))
+}
+
+func (v UFix64Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {
+	otherUFix64, ok := other.(UFix64Value)
+	if !ok {
+		return false
+	}
+
+	return v.UFix64Value.Equal(otherUFix64.UFix64Value)
+}
+
+// HashInput returns a byte slice containing:
+// - HashInputTypeUFix64 (1 byte)
+// - uint64 value encoded in big-endian (8 bytes)
+func (v UFix64Value) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []byte) []byte {
+	scratch[0] = byte(HashInputTypeUFix64)
+	binary.BigEndian.PutUint64(scratch[1:], uint64(v.UFix64Value))
+	return scratch[:9]
+}
+
 func (v UFix64Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
 	return getNumberValueMember(interpreter, v, name, sema.UFix64Type, locationRange)
 }
@@ -497,12 +454,6 @@ func (UFix64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value)
 	panic(errors.NewUnreachableError())
 }
 
-func (v UFix64Value) ToBigEndianBytes() []byte {
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, uint64(v))
-	return b
-}
-
 func (v UFix64Value) ConformsToStaticType(
 	_ *Interpreter,
 	_ LocationRange,
@@ -511,19 +462,11 @@ func (v UFix64Value) ConformsToStaticType(
 	return true
 }
 
-func (UFix64Value) IsStorable() bool {
-	return true
-}
-
-func (v UFix64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
-	return v, nil
-}
-
 func (UFix64Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UFix64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (UFix64Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -550,22 +493,6 @@ func (UFix64Value) DeepRemove(_ *Interpreter, _ bool) {
 	// NO-OP
 }
 
-func (v UFix64Value) ByteSize() uint32 {
-	return values.CBORTagSize + values.GetUintCBORSize(uint64(v))
-}
-
-func (v UFix64Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
-	return v, nil
-}
-
-func (UFix64Value) ChildStorables() []atree.Storable {
-	return nil
-}
-
 func (v UFix64Value) IntegerPart() NumberValue {
-	return UInt64Value(v / sema.Fix64Factor)
-}
-
-func (UFix64Value) Scale() int {
-	return sema.Fix64Scale
+	return UInt64Value(v.UFix64Value.IntegerPart())
 }

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -357,7 +357,7 @@ func (v UFix64Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v UFix64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -371,7 +371,7 @@ func (v UFix64Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v UFix64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -385,7 +385,7 @@ func (v UFix64Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 }
 
 func (v UFix64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -399,7 +399,7 @@ func (v UFix64Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v UFix64Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -384,7 +384,7 @@ func (v UIntValue) Less(context ValueComparisonContext, other ComparableValue, l
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == -1)
+	return cmp == -1
 }
 
 func (v UIntValue) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -399,7 +399,7 @@ func (v UIntValue) LessEqual(context ValueComparisonContext, other ComparableVal
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp <= 0)
+	return cmp <= 0
 }
 
 func (v UIntValue) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -414,7 +414,7 @@ func (v UIntValue) Greater(context ValueComparisonContext, other ComparableValue
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == 1)
+	return cmp == 1
 }
 
 func (v UIntValue) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -429,7 +429,7 @@ func (v UIntValue) GreaterEqual(context ValueComparisonContext, other Comparable
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp >= 0)
+	return cmp >= 0
 }
 
 func (v UIntValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -401,7 +401,7 @@ func (v UInt128Value) Less(context ValueComparisonContext, other ComparableValue
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == -1)
+	return cmp == -1
 }
 
 func (v UInt128Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -416,7 +416,7 @@ func (v UInt128Value) LessEqual(context ValueComparisonContext, other Comparable
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp <= 0)
+	return cmp <= 0
 }
 
 func (v UInt128Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -431,7 +431,7 @@ func (v UInt128Value) Greater(context ValueComparisonContext, other ComparableVa
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == 1)
+	return cmp == 1
 }
 
 func (v UInt128Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -446,7 +446,7 @@ func (v UInt128Value) GreaterEqual(context ValueComparisonContext, other Compara
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp >= 0)
+	return cmp >= 0
 }
 
 func (v UInt128Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -324,7 +324,7 @@ func (v UInt16Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v UInt16Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -338,7 +338,7 @@ func (v UInt16Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v UInt16Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -352,7 +352,7 @@ func (v UInt16Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 }
 
 func (v UInt16Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -366,7 +366,7 @@ func (v UInt16Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v UInt16Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -403,7 +403,7 @@ func (v UInt256Value) Less(context ValueComparisonContext, other ComparableValue
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == -1)
+	return cmp == -1
 }
 
 func (v UInt256Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -418,7 +418,7 @@ func (v UInt256Value) LessEqual(context ValueComparisonContext, other Comparable
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp <= 0)
+	return cmp <= 0
 }
 
 func (v UInt256Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -433,7 +433,7 @@ func (v UInt256Value) Greater(context ValueComparisonContext, other ComparableVa
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == 1)
+	return cmp == 1
 }
 
 func (v UInt256Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -448,7 +448,7 @@ func (v UInt256Value) GreaterEqual(context ValueComparisonContext, other Compara
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp >= 0)
+	return cmp >= 0
 }
 
 func (v UInt256Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -325,7 +325,7 @@ func (v UInt32Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v UInt32Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -339,7 +339,7 @@ func (v UInt32Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v UInt32Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -353,7 +353,7 @@ func (v UInt32Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 }
 
 func (v UInt32Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -367,7 +367,7 @@ func (v UInt32Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v UInt32Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -355,7 +355,7 @@ func (v UInt64Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v UInt64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -369,7 +369,7 @@ func (v UInt64Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v UInt64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -383,7 +383,7 @@ func (v UInt64Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 }
 
 func (v UInt64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -397,7 +397,7 @@ func (v UInt64Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v UInt64Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -319,7 +319,7 @@ func (v UInt8Value) Less(context ValueComparisonContext, other ComparableValue, 
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v UInt8Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -333,7 +333,7 @@ func (v UInt8Value) LessEqual(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v UInt8Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -347,7 +347,7 @@ func (v UInt8Value) Greater(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 }
 
 func (v UInt8Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -361,7 +361,7 @@ func (v UInt8Value) GreaterEqual(context ValueComparisonContext, other Comparabl
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v UInt8Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -311,7 +311,7 @@ func (v Word128Value) Less(context ValueComparisonContext, other ComparableValue
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == -1)
+	return cmp == -1
 }
 
 func (v Word128Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -326,7 +326,7 @@ func (v Word128Value) LessEqual(context ValueComparisonContext, other Comparable
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp <= 0)
+	return cmp <= 0
 }
 
 func (v Word128Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -341,7 +341,7 @@ func (v Word128Value) Greater(context ValueComparisonContext, other ComparableVa
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == 1)
+	return cmp == 1
 }
 
 func (v Word128Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -356,7 +356,7 @@ func (v Word128Value) GreaterEqual(context ValueComparisonContext, other Compara
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp >= 0)
+	return cmp >= 0
 }
 
 func (v Word128Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -231,7 +231,7 @@ func (v Word16Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v Word16Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -245,7 +245,7 @@ func (v Word16Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v Word16Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -259,7 +259,7 @@ func (v Word16Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 }
 
 func (v Word16Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -273,7 +273,7 @@ func (v Word16Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v Word16Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -311,7 +311,7 @@ func (v Word256Value) Less(context ValueComparisonContext, other ComparableValue
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == -1)
+	return cmp == -1
 }
 
 func (v Word256Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -326,7 +326,7 @@ func (v Word256Value) LessEqual(context ValueComparisonContext, other Comparable
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp <= 0)
+	return cmp <= 0
 }
 
 func (v Word256Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -341,7 +341,7 @@ func (v Word256Value) Greater(context ValueComparisonContext, other ComparableVa
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp == 1)
+	return cmp == 1
 }
 
 func (v Word256Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -356,7 +356,7 @@ func (v Word256Value) GreaterEqual(context ValueComparisonContext, other Compara
 	}
 
 	cmp := v.BigInt.Cmp(o.BigInt)
-	return BoolValue(cmp >= 0)
+	return cmp >= 0
 }
 
 func (v Word256Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -232,7 +232,7 @@ func (v Word32Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v Word32Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -246,7 +246,7 @@ func (v Word32Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v Word32Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -260,7 +260,7 @@ func (v Word32Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 }
 
 func (v Word32Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -274,7 +274,7 @@ func (v Word32Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v Word32Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -260,7 +260,7 @@ func (v Word64Value) Less(context ValueComparisonContext, other ComparableValue,
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v Word64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -274,7 +274,7 @@ func (v Word64Value) LessEqual(context ValueComparisonContext, other ComparableV
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v Word64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -288,7 +288,7 @@ func (v Word64Value) Greater(context ValueComparisonContext, other ComparableVal
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 }
 
 func (v Word64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -302,7 +302,7 @@ func (v Word64Value) GreaterEqual(context ValueComparisonContext, other Comparab
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v Word64Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -231,7 +231,7 @@ func (v Word8Value) Less(context ValueComparisonContext, other ComparableValue, 
 		})
 	}
 
-	return BoolValue(v < o)
+	return v < o
 }
 
 func (v Word8Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -245,7 +245,7 @@ func (v Word8Value) LessEqual(context ValueComparisonContext, other ComparableVa
 		})
 	}
 
-	return BoolValue(v <= o)
+	return v <= o
 }
 
 func (v Word8Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -259,7 +259,7 @@ func (v Word8Value) Greater(context ValueComparisonContext, other ComparableValu
 		})
 	}
 
-	return BoolValue(v > o)
+	return v > o
 }
 
 func (v Word8Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
@@ -273,7 +273,7 @@ func (v Word8Value) GreaterEqual(context ValueComparisonContext, other Comparabl
 		})
 	}
 
-	return BoolValue(v >= o)
+	return v >= o
 }
 
 func (v Word8Value) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -204,7 +204,7 @@ func exportValueWithInterpreter(
 	case interpreter.Fix64Value:
 		return cadence.Fix64(v), nil
 	case interpreter.UFix64Value:
-		return cadence.UFix64(v), nil
+		return cadence.UFix64(v.UFix64Value), nil
 	case *interpreter.CompositeValue:
 		return exportCompositeValue(
 			v,

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -827,7 +827,7 @@ func (i valueImporter) importValue(value cadence.Value, expectedType sema.Type) 
 	case cadence.Optional:
 		return i.importOptionalValue(v, expectedType)
 	case cadence.Bool:
-		return interpreter.BoolValue(bool(v)), nil
+		return interpreter.BoolValue(v), nil
 	case cadence.String:
 		return i.importString(v), nil
 	case cadence.Character:

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -3880,7 +3880,7 @@ func CheckCapabilityController(
 		false,
 	)
 
-	return interpreter.BoolValue(referencedValue != nil)
+	return referencedValue != nil
 }
 
 func newAccountCapabilitiesGetFunction(

--- a/values/safe_math.go
+++ b/values/safe_math.go
@@ -18,7 +18,11 @@
 
 package values
 
-type EquatableValue interface {
-	Value
-	Equal(other Value) bool
+func SafeAddUint64(a, b uint64) (uint64, error) {
+	sum := a + b
+	// INT30-C
+	if sum < a {
+		return 0, OverflowError{}
+	}
+	return sum, nil
 }

--- a/values/value_bool.go
+++ b/values/value_bool.go
@@ -50,16 +50,12 @@ func (v BoolValue) Negate() BoolValue {
 	return TrueValue
 }
 
-func (v BoolValue) Equal(other Value) BoolValue {
+func (v BoolValue) Equal(other Value) bool {
 	otherBool, ok := other.(BoolValue)
 	if !ok {
 		return false
 	}
-	return v.EqualBool(otherBool)
-}
-
-func (v BoolValue) EqualBool(other BoolValue) BoolValue {
-	return bool(v) == bool(other)
+	return bool(v) == bool(otherBool)
 }
 
 func (v BoolValue) Less(other BoolValue) bool {

--- a/values/value_fixedpoint.go
+++ b/values/value_fixedpoint.go
@@ -18,7 +18,9 @@
 
 package values
 
-type EquatableValue interface {
-	Value
-	Equal(other Value) bool
+// FixedPointValue is a fixed-point number value
+type FixedPointValue[T Value, U uint64 | int64] interface {
+	NumberValue[T]
+	IntegerPart() U
+	Scale() int
 }

--- a/values/value_int.go
+++ b/values/value_int.go
@@ -192,7 +192,7 @@ func (v IntValue) GreaterEqual(other IntValue) bool {
 	return cmp >= 0
 }
 
-func (v IntValue) Equal(other Value) BoolValue {
+func (v IntValue) Equal(other Value) bool {
 	otherInt, ok := other.(IntValue)
 	if !ok {
 		return false

--- a/values/value_ufix64.go
+++ b/values/value_ufix64.go
@@ -1,0 +1,293 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package values
+
+import (
+	"encoding/binary"
+	"math"
+	"math/big"
+	"unsafe"
+
+	"github.com/onflow/atree"
+
+	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/format"
+	"github.com/onflow/cadence/sema"
+)
+
+type UFix64Value uint64
+
+const ufix64Size = int(unsafe.Sizeof(UFix64Value(0)))
+
+var ufix64MemoryUsage = common.NewNumberMemoryUsage(ufix64Size)
+
+func NewUFix64ValueWithInteger(gauge common.MemoryGauge, constructor func() (uint64, error)) (UFix64Value, error) {
+	common.UseMemory(gauge, ufix64MemoryUsage)
+	v, err := constructor()
+	if err != nil {
+		return 0, err
+	}
+	return NewUnmeteredUFix64ValueWithInteger(v)
+}
+
+func NewUnmeteredUFix64ValueWithInteger(integer uint64) (UFix64Value, error) {
+	if integer > sema.UFix64TypeMaxInt {
+		return 0, OverflowError{}
+	}
+
+	return NewUnmeteredUFix64Value(integer * sema.Fix64Factor), nil
+}
+
+func NewUFix64Value(gauge common.MemoryGauge, constructor func() (uint64, error)) (UFix64Value, error) {
+	common.UseMemory(gauge, ufix64MemoryUsage)
+	v, err := constructor()
+	if err != nil {
+		return 0, err
+	}
+	return NewUnmeteredUFix64Value(v), nil
+}
+
+func NewUnmeteredUFix64Value(integer uint64) UFix64Value {
+	return UFix64Value(integer)
+}
+
+var _ Value = UFix64Value(0)
+var _ EquatableValue = UFix64Value(0)
+var _ ComparableValue[UFix64Value] = UFix64Value(0)
+var _ NumberValue[UFix64Value] = UFix64Value(0)
+var _ FixedPointValue[UFix64Value, uint64] = UFix64Value(0)
+var _ atree.Storable = UFix64Value(0)
+
+func (UFix64Value) isValue() {}
+
+func (v UFix64Value) String() string {
+	return format.UFix64(uint64(v))
+}
+
+func (v UFix64Value) Negate(_ common.MemoryGauge) UFix64Value {
+	panic(errors.NewUnreachableError())
+}
+
+func (v UFix64Value) Plus(gauge common.MemoryGauge, other UFix64Value) (UFix64Value, error) {
+
+	valueGetter := func() (uint64, error) {
+		return SafeAddUint64(uint64(v), uint64(other))
+	}
+
+	return NewUFix64Value(gauge, valueGetter)
+}
+
+func (v UFix64Value) SaturatingPlus(gauge common.MemoryGauge, other UFix64Value) (UFix64Value, error) {
+	valueGetter := func() (uint64, error) {
+		sum := v + other
+		// INT30-C
+		if sum < v {
+			return math.MaxUint64, nil
+		}
+		return uint64(sum), nil
+	}
+
+	return NewUFix64Value(gauge, valueGetter)
+}
+
+func (v UFix64Value) Minus(gauge common.MemoryGauge, other UFix64Value) (UFix64Value, error) {
+	valueGetter := func() (uint64, error) {
+		diff := v - other
+
+		// INT30-C
+		if diff > v {
+			return 0, UnderflowError{}
+		}
+		return uint64(diff), nil
+	}
+
+	return NewUFix64Value(gauge, valueGetter)
+}
+
+func (v UFix64Value) SaturatingMinus(gauge common.MemoryGauge, other UFix64Value) (UFix64Value, error) {
+	valueGetter := func() (uint64, error) {
+		diff := v - other
+
+		// INT30-C
+		if diff > v {
+			return 0, nil
+		}
+		return uint64(diff), nil
+	}
+
+	return NewUFix64Value(gauge, valueGetter)
+}
+
+func (v UFix64Value) Mul(gauge common.MemoryGauge, other UFix64Value) (UFix64Value, error) {
+
+	a := new(big.Int).SetUint64(uint64(v))
+	b := new(big.Int).SetUint64(uint64(other))
+
+	valueGetter := func() (uint64, error) {
+		result := new(big.Int).Mul(a, b)
+		result.Div(result, sema.Fix64FactorBig)
+
+		if !result.IsUint64() {
+			return 0, OverflowError{}
+		}
+
+		return result.Uint64(), nil
+	}
+
+	return NewUFix64Value(gauge, valueGetter)
+}
+
+func (v UFix64Value) SaturatingMul(gauge common.MemoryGauge, other UFix64Value) (UFix64Value, error) {
+
+	a := new(big.Int).SetUint64(uint64(v))
+	b := new(big.Int).SetUint64(uint64(other))
+
+	valueGetter := func() (uint64, error) {
+		result := new(big.Int).Mul(a, b)
+		result.Div(result, sema.Fix64FactorBig)
+
+		if !result.IsUint64() {
+			return math.MaxUint64, nil
+		}
+
+		return result.Uint64(), nil
+	}
+
+	return NewUFix64Value(gauge, valueGetter)
+}
+
+func (v UFix64Value) Div(gauge common.MemoryGauge, other UFix64Value) (UFix64Value, error) {
+
+	a := new(big.Int).SetUint64(uint64(v))
+	b := new(big.Int).SetUint64(uint64(other))
+
+	valueGetter := func() (uint64, error) {
+		result := new(big.Int).Mul(a, sema.Fix64FactorBig)
+		result.Div(result, b)
+
+		return result.Uint64(), nil
+	}
+
+	return NewUFix64Value(gauge, valueGetter)
+}
+
+func (v UFix64Value) SaturatingDiv(gauge common.MemoryGauge, other UFix64Value) (UFix64Value, error) {
+	return v.Div(gauge, other)
+}
+
+func (v UFix64Value) Mod(gauge common.MemoryGauge, other UFix64Value) (UFix64Value, error) {
+	// v - int(v/o) * o
+	quotient, err := v.Div(gauge, other)
+	if err != nil {
+		return 0, err
+	}
+
+	truncatedQuotient, err := NewUFix64Value(
+		gauge,
+		func() (uint64, error) {
+			return (uint64(quotient) / sema.Fix64Factor) * sema.Fix64Factor, nil
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	subtrahend, err := truncatedQuotient.Mul(gauge, other)
+	if err != nil {
+		return 0, err
+	}
+
+	return v.Minus(gauge, subtrahend)
+}
+
+func (v UFix64Value) Less(other UFix64Value) bool {
+	return v < other
+}
+
+func (v UFix64Value) LessEqual(other UFix64Value) bool {
+	return v <= other
+}
+
+func (v UFix64Value) Greater(other UFix64Value) bool {
+	return v > other
+}
+
+func (v UFix64Value) GreaterEqual(other UFix64Value) bool {
+	return v >= other
+}
+
+func (v UFix64Value) Equal(other Value) bool {
+	otherUFix64, ok := other.(UFix64Value)
+	if !ok {
+		return false
+	}
+	return v == otherUFix64
+}
+
+func (v UFix64Value) IntegerPart() uint64 {
+	return uint64(v / sema.Fix64Factor)
+}
+
+func (UFix64Value) Scale() int {
+	return sema.Fix64Scale
+}
+
+func (v UFix64Value) ToInt() (int, error) {
+	return int(v / sema.Fix64Factor), nil
+}
+
+func (v UFix64Value) ToBigEndianBytes() []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(v))
+	return b
+}
+
+func (v UFix64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+	return v, nil
+}
+
+func (v UFix64Value) ByteSize() uint32 {
+	return CBORTagSize + GetUintCBORSize(uint64(v))
+}
+
+func (v UFix64Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
+	return v, nil
+}
+
+func (UFix64Value) ChildStorables() []atree.Storable {
+	return nil
+}
+
+// Encode encodes UFix64Value as
+//
+//	cbor.Tag{
+//			Number:  CBORTagUFix64Value,
+//			Content: uint64(v),
+//	}
+func (v UFix64Value) Encode(e *atree.Encoder) error {
+	err := e.CBOR.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, CBORTagUFix64Value,
+	})
+	if err != nil {
+		return err
+	}
+	return e.CBOR.EncodeUint64(uint64(v))
+}


### PR DESCRIPTION
Work towards #3693

## Description

Like started in #3766, make the core `UFix64` value functionality reusable by decoupling it from the interpreter and moving it to the new `values` package.
 
Also, remove the unnecessary conversion to `BoolValue`, and make `values.EquatableValue.Equal` return just `bool`. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
