### PR TITLE
[Compiler] Compile bitwise operators, add bitwise instructions

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1341,6 +1341,17 @@ func (c *Compiler[_]) VisitBinaryExpression(expression *ast.BinaryExpression) (_
 		case ast.OperationMod:
 			c.codeGen.Emit(opcode.InstructionMod{})
 
+		case ast.OperationBitwiseOr:
+			c.codeGen.Emit(opcode.InstructionBitwiseOr{})
+		case ast.OperationBitwiseAnd:
+			c.codeGen.Emit(opcode.InstructionBitwiseAnd{})
+		case ast.OperationBitwiseXor:
+			c.codeGen.Emit(opcode.InstructionBitwiseXor{})
+		case ast.OperationBitwiseLeftShift:
+			c.codeGen.Emit(opcode.InstructionBitwiseLeftShift{})
+		case ast.OperationBitwiseRightShift:
+			c.codeGen.Emit(opcode.InstructionBitwiseRightShift{})
+
 		case ast.OperationEqual:
 			c.codeGen.Emit(opcode.InstructionEqual{})
 		case ast.OperationNotEqual:

--- a/bbq/opcode/gen/instructions.schema.json
+++ b/bbq/opcode/gen/instructions.schema.json
@@ -74,7 +74,8 @@
             "reference",
             "function",
             "resource",
-            "optional"
+            "optional",
+            "iterator"
           ]
         },
         "count": {

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -1181,6 +1181,106 @@ func (i InstructionGreaterOrEqual) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
 }
 
+// InstructionBitwiseOr
+//
+// Pops two integer values off the stack, performs a bitwise OR operation on them, and then pushes the result back on to the stack.
+type InstructionBitwiseOr struct {
+}
+
+var _ Instruction = InstructionBitwiseOr{}
+
+func (InstructionBitwiseOr) Opcode() Opcode {
+	return BitwiseOr
+}
+
+func (i InstructionBitwiseOr) String() string {
+	return i.Opcode().String()
+}
+
+func (i InstructionBitwiseOr) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+}
+
+// InstructionBitwiseXor
+//
+// Pops two integer values off the stack, performs a bitwise XOR operation on them, and then pushes the result back on to the stack.
+type InstructionBitwiseXor struct {
+}
+
+var _ Instruction = InstructionBitwiseXor{}
+
+func (InstructionBitwiseXor) Opcode() Opcode {
+	return BitwiseXor
+}
+
+func (i InstructionBitwiseXor) String() string {
+	return i.Opcode().String()
+}
+
+func (i InstructionBitwiseXor) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+}
+
+// InstructionBitwiseAnd
+//
+// Pops two integer values off the stack, performs a bitwise AND operation on them, and then pushes the result back on to the stack.
+type InstructionBitwiseAnd struct {
+}
+
+var _ Instruction = InstructionBitwiseAnd{}
+
+func (InstructionBitwiseAnd) Opcode() Opcode {
+	return BitwiseAnd
+}
+
+func (i InstructionBitwiseAnd) String() string {
+	return i.Opcode().String()
+}
+
+func (i InstructionBitwiseAnd) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+}
+
+// InstructionBitwiseLeftShift
+//
+// Pops two integer values off the stack, performs a bitwise left shift operation on them, and then pushes the result back on to the stack.
+type InstructionBitwiseLeftShift struct {
+}
+
+var _ Instruction = InstructionBitwiseLeftShift{}
+
+func (InstructionBitwiseLeftShift) Opcode() Opcode {
+	return BitwiseLeftShift
+}
+
+func (i InstructionBitwiseLeftShift) String() string {
+	return i.Opcode().String()
+}
+
+func (i InstructionBitwiseLeftShift) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+}
+
+// InstructionBitwiseRightShift
+//
+// Pops two integer values off the stack, performs a bitwise right shift operation on them, and then pushes the result back on to the stack.
+type InstructionBitwiseRightShift struct {
+}
+
+var _ Instruction = InstructionBitwiseRightShift{}
+
+func (InstructionBitwiseRightShift) Opcode() Opcode {
+	return BitwiseRightShift
+}
+
+func (i InstructionBitwiseRightShift) String() string {
+	return i.Opcode().String()
+}
+
+func (i InstructionBitwiseRightShift) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+}
+
 // InstructionIterator
 //
 // Pops an iterable value from the stack, get an iterator to it, and push the iterator back onto the stack.
@@ -1365,6 +1465,16 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 		return InstructionGreater{}
 	case GreaterOrEqual:
 		return InstructionGreaterOrEqual{}
+	case BitwiseOr:
+		return InstructionBitwiseOr{}
+	case BitwiseXor:
+		return InstructionBitwiseXor{}
+	case BitwiseAnd:
+		return InstructionBitwiseAnd{}
+	case BitwiseLeftShift:
+		return InstructionBitwiseLeftShift{}
+	case BitwiseRightShift:
+		return InstructionBitwiseRightShift{}
 	case Iterator:
 		return InstructionIterator{}
 	case IteratorHasNext:

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -615,7 +615,80 @@
       - name: "result"
         type: "bool"
 
-# Iterator
+# Bitwise instructions
+
+- name: "bitwiseOr"
+  description:
+    Pops two integer values off the stack, performs a bitwise OR operation on them,
+    and then pushes the result back on to the stack.
+  valueEffects:
+    pop:
+      - name: "left"
+        type: "integer"
+      - name: "right"
+        type: "integer"
+    push:
+      - name: "result"
+        type: "integer"
+
+
+- name: "bitwiseXor"
+  description:
+    Pops two integer values off the stack, performs a bitwise XOR operation on them,
+    and then pushes the result back on to the stack.
+  valueEffects:
+    pop:
+      - name: "left"
+        type: "integer"
+      - name: "right"
+        type: "integer"
+    push:
+      - name: "result"
+        type: "integer"
+
+- name: "bitwiseAnd"
+  description:
+    Pops two integer values off the stack, performs a bitwise AND operation on them,
+    and then pushes the result back on to the stack.
+  valueEffects:
+    pop:
+      - name: "left"
+        type: "integer"
+      - name: "right"
+        type: "integer"
+    push:
+      - name: "result"
+        type: "integer"
+
+- name: "bitwiseLeftShift"
+  description:
+    Pops two integer values off the stack, performs a bitwise left shift operation on them,
+    and then pushes the result back on to the stack.
+  valueEffects:
+    pop:
+      - name: "left"
+        type: "integer"
+      - name: "right"
+        type: "integer"
+    push:
+      - name: "result"
+        type: "integer"
+
+- name: "bitwiseRightShift"
+  description:
+      Pops two integer values off the stack, performs a bitwise right shift operation on them,
+      and then pushes the result back on to the stack.
+  valueEffects:
+    pop:
+      - name: "left"
+        type: "integer"
+      - name: "right"
+        type: "integer"
+    push:
+      - name: "result"
+        type: "integer"
+
+  # Iterator
 
 - name: "iterator"
   description:
@@ -623,7 +696,7 @@
   valueEffects:
     pop:
       - name: "iterable"
-        type: "iterable"
+        type: "value"
     push:
       - name: "iterator"
         type: "iterator"

--- a/bbq/opcode/opcode.go
+++ b/bbq/opcode/opcode.go
@@ -49,22 +49,30 @@ const (
 	_
 	_
 	_
+
+	// Bitwise operations
+
+	BitwiseOr
+	BitwiseAnd
+	BitwiseXor
+	BitwiseLeftShift
+	BitwiseRightShift
+	_
+
+	// Comparison
+
 	Less
 	Greater
 	LessOrEqual
 	GreaterOrEqual
-	_
-	_
-	_
-	_
-	_
-	_
-	_
 
-	// Unary/Binary operators
+	// Equality
 
 	Equal
 	NotEqual
+
+	// Unary/Binary operators
+
 	Not
 	_
 	_
@@ -158,5 +166,6 @@ const (
 	IteratorNext
 
 	// Other
+
 	EmitEvent
 )

--- a/bbq/opcode/opcode_string.go
+++ b/bbq/opcode/opcode_string.go
@@ -20,51 +20,56 @@ func _() {
 	_ = x[Multiply-13]
 	_ = x[Divide-14]
 	_ = x[Mod-15]
-	_ = x[Less-20]
-	_ = x[Greater-21]
-	_ = x[LessOrEqual-22]
-	_ = x[GreaterOrEqual-23]
-	_ = x[Equal-31]
-	_ = x[NotEqual-32]
-	_ = x[Not-33]
-	_ = x[Unwrap-37]
-	_ = x[Destroy-38]
-	_ = x[Transfer-39]
-	_ = x[SimpleCast-40]
-	_ = x[FailableCast-41]
-	_ = x[ForceCast-42]
-	_ = x[True-50]
-	_ = x[False-51]
-	_ = x[New-52]
-	_ = x[Path-53]
-	_ = x[Nil-54]
-	_ = x[NewArray-55]
-	_ = x[NewDictionary-56]
-	_ = x[NewRef-57]
-	_ = x[GetConstant-70]
-	_ = x[GetLocal-71]
-	_ = x[SetLocal-72]
-	_ = x[GetGlobal-73]
-	_ = x[SetGlobal-74]
-	_ = x[GetField-75]
-	_ = x[SetField-76]
-	_ = x[SetIndex-77]
-	_ = x[GetIndex-78]
-	_ = x[Invoke-90]
-	_ = x[InvokeDynamic-91]
-	_ = x[Drop-100]
-	_ = x[Dup-101]
-	_ = x[Iterator-108]
-	_ = x[IteratorHasNext-109]
-	_ = x[IteratorNext-110]
-	_ = x[EmitEvent-111]
+	_ = x[BitwiseOr-20]
+	_ = x[BitwiseAnd-21]
+	_ = x[BitwiseXor-22]
+	_ = x[BitwiseLeftShift-23]
+	_ = x[BitwiseRightShift-24]
+	_ = x[Less-26]
+	_ = x[Greater-27]
+	_ = x[LessOrEqual-28]
+	_ = x[GreaterOrEqual-29]
+	_ = x[Equal-30]
+	_ = x[NotEqual-31]
+	_ = x[Not-32]
+	_ = x[Unwrap-36]
+	_ = x[Destroy-37]
+	_ = x[Transfer-38]
+	_ = x[SimpleCast-39]
+	_ = x[FailableCast-40]
+	_ = x[ForceCast-41]
+	_ = x[True-49]
+	_ = x[False-50]
+	_ = x[New-51]
+	_ = x[Path-52]
+	_ = x[Nil-53]
+	_ = x[NewArray-54]
+	_ = x[NewDictionary-55]
+	_ = x[NewRef-56]
+	_ = x[GetConstant-69]
+	_ = x[GetLocal-70]
+	_ = x[SetLocal-71]
+	_ = x[GetGlobal-72]
+	_ = x[SetGlobal-73]
+	_ = x[GetField-74]
+	_ = x[SetField-75]
+	_ = x[SetIndex-76]
+	_ = x[GetIndex-77]
+	_ = x[Invoke-89]
+	_ = x[InvokeDynamic-90]
+	_ = x[Drop-99]
+	_ = x[Dup-100]
+	_ = x[Iterator-107]
+	_ = x[IteratorHasNext-108]
+	_ = x[IteratorNext-109]
+	_ = x[EmitEvent-110]
 }
 
 const (
 	_Opcode_name_0 = "UnknownReturnReturnValueJumpJumpIfFalseJumpIfTrueJumpIfNil"
 	_Opcode_name_1 = "AddSubtractMultiplyDivideMod"
-	_Opcode_name_2 = "LessGreaterLessOrEqualGreaterOrEqual"
-	_Opcode_name_3 = "EqualNotEqualNot"
+	_Opcode_name_2 = "BitwiseOrBitwiseAndBitwiseXorBitwiseLeftShiftBitwiseRightShift"
+	_Opcode_name_3 = "LessGreaterLessOrEqualGreaterOrEqualEqualNotEqualNot"
 	_Opcode_name_4 = "UnwrapDestroyTransferSimpleCastFailableCastForceCast"
 	_Opcode_name_5 = "TrueFalseNewPathNilNewArrayNewDictionaryNewRef"
 	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetGlobalSetGlobalGetFieldSetFieldSetIndexGetIndex"
@@ -76,8 +81,8 @@ const (
 var (
 	_Opcode_index_0 = [...]uint8{0, 7, 13, 24, 28, 39, 49, 58}
 	_Opcode_index_1 = [...]uint8{0, 3, 11, 19, 25, 28}
-	_Opcode_index_2 = [...]uint8{0, 4, 11, 22, 36}
-	_Opcode_index_3 = [...]uint8{0, 5, 13, 16}
+	_Opcode_index_2 = [...]uint8{0, 9, 19, 29, 45, 62}
+	_Opcode_index_3 = [...]uint8{0, 4, 11, 22, 36, 41, 49, 52}
 	_Opcode_index_4 = [...]uint8{0, 6, 13, 21, 31, 43, 52}
 	_Opcode_index_5 = [...]uint8{0, 4, 9, 12, 16, 19, 27, 40, 46}
 	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 36, 45, 53, 61, 69, 77}
@@ -93,29 +98,29 @@ func (i Opcode) String() string {
 	case 11 <= i && i <= 15:
 		i -= 11
 		return _Opcode_name_1[_Opcode_index_1[i]:_Opcode_index_1[i+1]]
-	case 20 <= i && i <= 23:
+	case 20 <= i && i <= 24:
 		i -= 20
 		return _Opcode_name_2[_Opcode_index_2[i]:_Opcode_index_2[i+1]]
-	case 31 <= i && i <= 33:
-		i -= 31
+	case 26 <= i && i <= 32:
+		i -= 26
 		return _Opcode_name_3[_Opcode_index_3[i]:_Opcode_index_3[i+1]]
-	case 37 <= i && i <= 42:
-		i -= 37
+	case 36 <= i && i <= 41:
+		i -= 36
 		return _Opcode_name_4[_Opcode_index_4[i]:_Opcode_index_4[i+1]]
-	case 50 <= i && i <= 57:
-		i -= 50
+	case 49 <= i && i <= 56:
+		i -= 49
 		return _Opcode_name_5[_Opcode_index_5[i]:_Opcode_index_5[i+1]]
-	case 70 <= i && i <= 78:
-		i -= 70
+	case 69 <= i && i <= 77:
+		i -= 69
 		return _Opcode_name_6[_Opcode_index_6[i]:_Opcode_index_6[i+1]]
-	case 90 <= i && i <= 91:
-		i -= 90
+	case 89 <= i && i <= 90:
+		i -= 89
 		return _Opcode_name_7[_Opcode_index_7[i]:_Opcode_index_7[i+1]]
-	case 100 <= i && i <= 101:
-		i -= 100
+	case 99 <= i && i <= 100:
+		i -= 99
 		return _Opcode_name_8[_Opcode_index_8[i]:_Opcode_index_8[i+1]]
-	case 108 <= i && i <= 111:
-		i -= 108
+	case 107 <= i && i <= 110:
+		i -= 107
 		return _Opcode_name_9[_Opcode_index_9[i]:_Opcode_index_9[i+1]]
 	default:
 		return "Opcode(" + strconv.FormatInt(int64(i), 10) + ")"

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -4732,3 +4732,56 @@ func TestCompileAnd(t *testing.T) {
 		require.Equal(t, vm.NewIntValue(21), actual)
 	})
 }
+
+func TestBinary(t *testing.T) {
+
+	t.Parallel()
+
+	test := func(op string, expected vm.Value) {
+
+		t.Run(op, func(t *testing.T) {
+
+			t.Parallel()
+
+			actual, err := compileAndInvoke(t,
+				fmt.Sprintf(`
+                        fun test(): AnyStruct {
+                            return 6 %s 4
+                        }
+                    `,
+					op,
+				),
+				"test",
+			)
+			require.NoError(t, err)
+
+			assert.Equal(t, expected, actual)
+		})
+	}
+
+	tests := map[string]vm.Value{
+		"+": vm.NewIntValue(10),
+		"-": vm.NewIntValue(2),
+		"*": vm.NewIntValue(24),
+		"/": vm.NewIntValue(1),
+		"%": vm.NewIntValue(2),
+
+		"<":  vm.BoolValue(false),
+		"<=": vm.BoolValue(false),
+		">":  vm.BoolValue(true),
+		">=": vm.BoolValue(true),
+
+		"==": vm.BoolValue(false),
+		"!=": vm.BoolValue(true),
+
+		"&":  vm.NewIntValue(4),
+		"|":  vm.NewIntValue(6),
+		"^":  vm.NewIntValue(2),
+		"<<": vm.NewIntValue(96),
+		">>": vm.NewIntValue(0),
+	}
+
+	for op, value := range tests {
+		test(op, value)
+	}
+}

--- a/bbq/vm/value_int.go
+++ b/bbq/vm/value_int.go
@@ -45,6 +45,7 @@ var _ Value = IntValue{}
 var _ EquatableValue = IntValue{}
 var _ ComparableValue = IntValue{}
 var _ NumberValue = IntValue{}
+var _ IntegerValue = IntValue{}
 
 func (IntValue) isValue() {}
 
@@ -94,7 +95,7 @@ func (v IntValue) Mod(other NumberValue) NumberValue {
 	if !ok {
 		panic("invalid operand")
 	}
-	return NewIntValue(v.SmallInt * otherInt.SmallInt)
+	return NewIntValue(v.SmallInt % otherInt.SmallInt)
 }
 
 func (v IntValue) Equal(other Value) BoolValue {
@@ -135,6 +136,64 @@ func (v IntValue) GreaterEqual(other ComparableValue) BoolValue {
 		panic("invalid operand")
 	}
 	return v.SmallInt >= otherInt.SmallInt
+}
+
+func (v IntValue) BitwiseOr(other IntegerValue) IntegerValue {
+	o, ok := other.(IntValue)
+	if !ok {
+		panic("invalid operand")
+
+	}
+
+	return NewIntValue(v.SmallInt | o.SmallInt)
+}
+
+func (v IntValue) BitwiseXor(other IntegerValue) IntegerValue {
+	o, ok := other.(IntValue)
+	if !ok {
+		panic("invalid operand")
+
+	}
+
+	return NewIntValue(v.SmallInt ^ o.SmallInt)
+}
+
+func (v IntValue) BitwiseAnd(other IntegerValue) IntegerValue {
+	o, ok := other.(IntValue)
+	if !ok {
+		panic("invalid operand")
+
+	}
+
+	return NewIntValue(v.SmallInt & o.SmallInt)
+}
+
+func (v IntValue) BitwiseLeftShift(other IntegerValue) IntegerValue {
+	o, ok := other.(IntValue)
+	if !ok {
+		panic("invalid operand")
+
+	}
+
+	if o.SmallInt < 0 {
+		panic(interpreter.NegativeShiftError{})
+	}
+
+	return NewIntValue(v.SmallInt << o.SmallInt)
+}
+
+func (v IntValue) BitwiseRightShift(other IntegerValue) IntegerValue {
+	o, ok := other.(IntValue)
+	if !ok {
+		panic("invalid operand")
+
+	}
+
+	if o.SmallInt < 0 {
+		panic(interpreter.NegativeShiftError{})
+	}
+
+	return NewIntValue(v.SmallInt >> o.SmallInt)
 }
 
 // members

--- a/bbq/vm/value_integer.go
+++ b/bbq/vm/value_integer.go
@@ -1,0 +1,28 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vm
+
+type IntegerValue interface {
+	NumberValue
+	BitwiseOr(other IntegerValue) IntegerValue
+	BitwiseXor(other IntegerValue) IntegerValue
+	BitwiseAnd(other IntegerValue) IntegerValue
+	BitwiseLeftShift(other IntegerValue) IntegerValue
+	BitwiseRightShift(other IntegerValue) IntegerValue
+}

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -397,6 +397,41 @@ func opMod(vm *VM) {
 	vm.replaceTop(leftNumber.Mod(rightNumber))
 }
 
+func opBitwiseOr(vm *VM) {
+	left, right := vm.peekPop()
+	leftNumber := left.(IntegerValue)
+	rightNumber := right.(IntegerValue)
+	vm.replaceTop(leftNumber.BitwiseOr(rightNumber))
+}
+
+func opBitwiseXor(vm *VM) {
+	left, right := vm.peekPop()
+	leftNumber := left.(IntegerValue)
+	rightNumber := right.(IntegerValue)
+	vm.replaceTop(leftNumber.BitwiseXor(rightNumber))
+}
+
+func opBitwiseAnd(vm *VM) {
+	left, right := vm.peekPop()
+	leftNumber := left.(IntegerValue)
+	rightNumber := right.(IntegerValue)
+	vm.replaceTop(leftNumber.BitwiseAnd(rightNumber))
+}
+
+func opBitwiseLeftShift(vm *VM) {
+	left, right := vm.peekPop()
+	leftNumber := left.(IntegerValue)
+	rightNumber := right.(IntegerValue)
+	vm.replaceTop(leftNumber.BitwiseLeftShift(rightNumber))
+}
+
+func opBitwiseRightShift(vm *VM) {
+	left, right := vm.peekPop()
+	leftNumber := left.(IntegerValue)
+	rightNumber := right.(IntegerValue)
+	vm.replaceTop(leftNumber.BitwiseRightShift(rightNumber))
+}
+
 func opLess(vm *VM) {
 	left, right := vm.peekPop()
 	leftNumber := left.(NumberValue)
@@ -841,6 +876,16 @@ func (vm *VM) run() {
 			opDivide(vm)
 		case opcode.InstructionMod:
 			opMod(vm)
+		case opcode.InstructionBitwiseOr:
+			opBitwiseOr(vm)
+		case opcode.InstructionBitwiseXor:
+			opBitwiseXor(vm)
+		case opcode.InstructionBitwiseAnd:
+			opBitwiseAnd(vm)
+		case opcode.InstructionBitwiseLeftShift:
+			opBitwiseLeftShift(vm)
+		case opcode.InstructionBitwiseRightShift:
+			opBitwiseRightShift(vm)
 		case opcode.InstructionLess:
 			opLess(vm)
 		case opcode.InstructionLessOrEqual:


### PR DESCRIPTION
Work towards #3769


## Description

- Add new bitwise instructions
- Compile bitwise binary operators to bitwise instructions
- Implement bitwise instructions in VM
- Test compilation of and instructions of currently implemented binary operators 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
