### PR TITLE
[Compiler] Produce an un-encoded program by the compiler

### DIFF
--- a/bbq/commons/handlers.go
+++ b/bbq/commons/handlers.go
@@ -21,12 +21,11 @@ package commons
 import (
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/bbq"
-	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/sema"
 )
 
-type ImportHandler func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType]
+type ImportHandler func(location common.Location) *bbq.InstructionProgram
 
 type LocationHandler func(identifiers []ast.Identifier, location common.Location) ([]ResolvedLocation, error)
 

--- a/bbq/commons/handlers.go
+++ b/bbq/commons/handlers.go
@@ -26,7 +26,7 @@ import (
 	"github.com/onflow/cadence/sema"
 )
 
-type ImportHandler func(location common.Location) *bbq.Program[opcode.Instruction]
+type ImportHandler func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType]
 
 type LocationHandler func(identifiers []ast.Identifier, location common.Location) ([]ResolvedLocation, error)
 

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -36,7 +36,7 @@ import (
 	"github.com/onflow/cadence/sema"
 )
 
-type Compiler[E any] struct {
+type Compiler[E, T any] struct {
 	Program             *ast.Program
 	ExtendedElaboration *ExtendedElaboration
 	Config              *Config
@@ -52,7 +52,7 @@ type Compiler[E any] struct {
 	usedImportedGlobals []*global
 	controlFlows        []controlFlow
 	currentControlFlow  *controlFlow
-	staticTypes         [][]byte
+	staticTypes         []T
 
 	// Cache alike for staticTypes and constants in the pool.
 	typesInPool     map[sema.TypeID]uint16
@@ -61,7 +61,7 @@ type Compiler[E any] struct {
 	// TODO: initialize
 	memoryGauge common.MemoryGauge
 
-	codeGen CodeGen[E]
+	codeGen CodeGen[E, T]
 }
 
 type constantsCacheKey struct {
@@ -69,13 +69,13 @@ type constantsCacheKey struct {
 	kind constantkind.ConstantKind
 }
 
-var _ ast.DeclarationVisitor[struct{}] = &Compiler[any]{}
-var _ ast.StatementVisitor[struct{}] = &Compiler[any]{}
-var _ ast.ExpressionVisitor[struct{}] = &Compiler[any]{}
+var _ ast.DeclarationVisitor[struct{}] = &Compiler[any, any]{}
+var _ ast.StatementVisitor[struct{}] = &Compiler[any, any]{}
+var _ ast.ExpressionVisitor[struct{}] = &Compiler[any, any]{}
 
 func NewBytecodeCompiler(
 	checker *sema.Checker,
-) *Compiler[byte] {
+) *Compiler[byte, []byte] {
 	return newCompiler(
 		checker,
 		&ByteCodeGen{},
@@ -84,18 +84,18 @@ func NewBytecodeCompiler(
 
 func NewInstructionCompiler(
 	checker *sema.Checker,
-) *Compiler[opcode.Instruction] {
+) *Compiler[opcode.Instruction, bbq.StaticType] {
 	return newCompiler(
 		checker,
 		&InstructionCodeGen{},
 	)
 }
 
-func newCompiler[E any](
+func newCompiler[E, T any](
 	checker *sema.Checker,
-	codeGen CodeGen[E],
-) *Compiler[E] {
-	return &Compiler[E]{
+	codeGen CodeGen[E, T],
+) *Compiler[E, T] {
+	return &Compiler[E, T]{
 		Program:             checker.Program,
 		ExtendedElaboration: NewExtendedElaboration(checker.Elaboration),
 		Config:              &Config{},
@@ -111,12 +111,12 @@ func newCompiler[E any](
 	}
 }
 
-func (c *Compiler[E]) WithConfig(config *Config) *Compiler[E] {
+func (c *Compiler[E, T]) WithConfig(config *Config) *Compiler[E, T] {
 	c.Config = config
 	return c
 }
 
-func (c *Compiler[_]) findGlobal(name string) *global {
+func (c *Compiler[_, _]) findGlobal(name string) *global {
 	global, ok := c.Globals[name]
 	if ok {
 		return global
@@ -165,7 +165,7 @@ func (c *Compiler[_]) findGlobal(name string) *global {
 	return importedGlobal
 }
 
-func (c *Compiler[_]) addGlobal(name string) *global {
+func (c *Compiler[_, _]) addGlobal(name string) *global {
 	count := len(c.Globals)
 	if count >= math.MaxUint16 {
 		panic(errors.NewDefaultUserError("invalid global declaration"))
@@ -177,7 +177,7 @@ func (c *Compiler[_]) addGlobal(name string) *global {
 	return global
 }
 
-func (c *Compiler[_]) addImportedGlobal(location common.Location, name string) *global {
+func (c *Compiler[_, _]) addImportedGlobal(location common.Location, name string) *global {
 	// Index is not set here. It is set only if this imported global is used.
 	global := &global{
 		Location: location,
@@ -187,7 +187,7 @@ func (c *Compiler[_]) addImportedGlobal(location common.Location, name string) *
 	return global
 }
 
-func (c *Compiler[E]) addFunction(name string, parameterCount uint16) *function[E] {
+func (c *Compiler[E, T]) addFunction(name string, parameterCount uint16) *function[E] {
 	isCompositeFunction := !c.compositeTypeStack.isEmpty()
 
 	function := newFunction[E](name, parameterCount, isCompositeFunction)
@@ -197,7 +197,7 @@ func (c *Compiler[E]) addFunction(name string, parameterCount uint16) *function[
 	return function
 }
 
-func (c *Compiler[_]) addConstant(kind constantkind.ConstantKind, data []byte) *constant {
+func (c *Compiler[_, _]) addConstant(kind constantkind.ConstantKind, data []byte) *constant {
 	count := len(c.constants)
 	if count >= math.MaxUint16 {
 		panic(errors.NewDefaultUserError("invalid constant declaration"))
@@ -222,26 +222,26 @@ func (c *Compiler[_]) addConstant(kind constantkind.ConstantKind, data []byte) *
 	return constant
 }
 
-func (c *Compiler[_]) stringConstLoad(str string) {
+func (c *Compiler[_, _]) stringConstLoad(str string) {
 	constant := c.addStringConst(str)
 	c.codeGen.Emit(opcode.InstructionGetConstant{ConstantIndex: constant.index})
 }
 
-func (c *Compiler[_]) addStringConst(str string) *constant {
+func (c *Compiler[_, _]) addStringConst(str string) *constant {
 	return c.addConstant(constantkind.String, []byte(str))
 }
 
-func (c *Compiler[_]) intConstLoad(intKind constantkind.ConstantKind, i int64) {
+func (c *Compiler[_, _]) intConstLoad(intKind constantkind.ConstantKind, i int64) {
 	constant := c.addIntConst(intKind, i)
 	c.codeGen.Emit(opcode.InstructionGetConstant{ConstantIndex: constant.index})
 }
 
-func (c *Compiler[_]) addIntConst(intKind constantkind.ConstantKind, i int64) *constant {
+func (c *Compiler[_, _]) addIntConst(intKind constantkind.ConstantKind, i int64) *constant {
 	data := leb128.AppendInt64(nil, i)
 	return c.addConstant(intKind, data)
 }
 
-func (c *Compiler[_]) emitJump(target int) int {
+func (c *Compiler[_, _]) emitJump(target int) int {
 	if target >= math.MaxUint16 {
 		panic(errors.NewDefaultUserError("invalid jump"))
 	}
@@ -250,25 +250,25 @@ func (c *Compiler[_]) emitJump(target int) int {
 	return offset
 }
 
-func (c *Compiler[_]) emitUndefinedJump() int {
+func (c *Compiler[_, _]) emitUndefinedJump() int {
 	offset := c.codeGen.Offset()
 	c.codeGen.Emit(opcode.InstructionJump{Target: math.MaxUint16})
 	return offset
 }
 
-func (c *Compiler[_]) emitUndefinedJumpIfFalse() int {
+func (c *Compiler[_, _]) emitUndefinedJumpIfFalse() int {
 	offset := c.codeGen.Offset()
 	c.codeGen.Emit(opcode.InstructionJumpIfFalse{Target: math.MaxUint16})
 	return offset
 }
 
-func (c *Compiler[_]) emitUndefinedJumpIfNil() int {
+func (c *Compiler[_, _]) emitUndefinedJumpIfNil() int {
 	offset := c.codeGen.Offset()
 	c.codeGen.Emit(opcode.InstructionJumpIfNil{Target: math.MaxUint16})
 	return offset
 }
 
-func (c *Compiler[_]) patchJump(opcodeOffset int) {
+func (c *Compiler[_, _]) patchJump(opcodeOffset int) {
 	count := c.codeGen.Offset()
 	if count == 0 {
 		panic(errors.NewUnreachableError())
@@ -279,19 +279,19 @@ func (c *Compiler[_]) patchJump(opcodeOffset int) {
 	c.codeGen.PatchJump(opcodeOffset, uint16(count))
 }
 
-func (c *Compiler[_]) patchJumps(offsets []int) {
+func (c *Compiler[_, _]) patchJumps(offsets []int) {
 	for _, offset := range offsets {
 		c.patchJump(offset)
 	}
 }
 
-func (c *Compiler[_]) pushControlFlow(start int) {
+func (c *Compiler[_, _]) pushControlFlow(start int) {
 	index := len(c.controlFlows)
 	c.controlFlows = append(c.controlFlows, controlFlow{start: start})
 	c.currentControlFlow = &c.controlFlows[index]
 }
 
-func (c *Compiler[_]) popControlFlow() {
+func (c *Compiler[_, _]) popControlFlow() {
 	lastIndex := len(c.controlFlows) - 1
 	l := c.controlFlows[lastIndex]
 	c.controlFlows[lastIndex] = controlFlow{}
@@ -306,7 +306,7 @@ func (c *Compiler[_]) popControlFlow() {
 	c.currentControlFlow = previousControlFlow
 }
 
-func (c *Compiler[E]) Compile() *bbq.Program[E] {
+func (c *Compiler[E, T]) Compile() *bbq.Program[E, T] {
 
 	// Desugar the program before compiling.
 	desugar := NewDesugar(
@@ -356,7 +356,7 @@ func (c *Compiler[E]) Compile() *bbq.Program[E] {
 	imports := c.exportImports()
 	variables := c.exportVariables(variableDeclarations)
 
-	return &bbq.Program[E]{
+	return &bbq.Program[E, T]{
 		Functions: functions,
 		Constants: constants,
 		Types:     types,
@@ -366,7 +366,7 @@ func (c *Compiler[E]) Compile() *bbq.Program[E] {
 	}
 }
 
-func (c *Compiler[_]) reserveGlobalVars(
+func (c *Compiler[_, _]) reserveGlobalVars(
 	compositeTypeName string,
 	variableDecls []*ast.VariableDeclaration,
 	specialFunctionDecls []*ast.SpecialFunctionDeclaration,
@@ -440,7 +440,7 @@ func (c *Compiler[_]) reserveGlobalVars(
 	}
 }
 
-func (c *Compiler[_]) exportConstants() []*bbq.Constant {
+func (c *Compiler[_, _]) exportConstants() []*bbq.Constant {
 	constants := make([]*bbq.Constant, 0, len(c.constants))
 	for _, constant := range c.constants {
 		constants = append(
@@ -454,11 +454,11 @@ func (c *Compiler[_]) exportConstants() []*bbq.Constant {
 	return constants
 }
 
-func (c *Compiler[_]) exportTypes() [][]byte {
+func (c *Compiler[_, T]) exportTypes() []T {
 	return c.staticTypes
 }
 
-func (c *Compiler[_]) exportImports() []*bbq.Import {
+func (c *Compiler[_, _]) exportImports() []*bbq.Import {
 	exportedImports := make([]*bbq.Import, 0)
 	for _, importedGlobal := range c.usedImportedGlobals {
 		bbqImport := &bbq.Import{
@@ -471,7 +471,7 @@ func (c *Compiler[_]) exportImports() []*bbq.Import {
 	return exportedImports
 }
 
-func (c *Compiler[E]) ExportFunctions() []*bbq.Function[E] {
+func (c *Compiler[E, T]) ExportFunctions() []*bbq.Function[E] {
 	functions := make([]*bbq.Function[E], 0, len(c.functions))
 	for _, function := range c.functions {
 		functions = append(
@@ -488,7 +488,7 @@ func (c *Compiler[E]) ExportFunctions() []*bbq.Function[E] {
 	return functions
 }
 
-func (c *Compiler[_]) exportVariables(variableDecls []*ast.VariableDeclaration) []*bbq.Variable {
+func (c *Compiler[_, _]) exportVariables(variableDecls []*ast.VariableDeclaration) []*bbq.Variable {
 	variables := make([]*bbq.Variable, 0, len(c.functions))
 	for _, varDecl := range variableDecls {
 		variables = append(
@@ -501,7 +501,7 @@ func (c *Compiler[_]) exportVariables(variableDecls []*ast.VariableDeclaration) 
 	return variables
 }
 
-func (c *Compiler[_]) contractType() (contractType sema.CompositeKindedType) {
+func (c *Compiler[_, _]) contractType() (contractType sema.CompositeKindedType) {
 	contractDecl := c.Program.SoleContractDeclaration()
 	if contractDecl != nil {
 		contractType = c.ExtendedElaboration.CompositeDeclarationType(contractDecl)
@@ -517,7 +517,7 @@ func (c *Compiler[_]) contractType() (contractType sema.CompositeKindedType) {
 	return nil
 }
 
-func (c *Compiler[_]) exportContract() (*bbq.Contract, sema.CompositeKindedType) {
+func (c *Compiler[_, _]) exportContract() (*bbq.Contract, sema.CompositeKindedType) {
 	var location common.Location
 	var name string
 
@@ -539,11 +539,11 @@ func (c *Compiler[_]) exportContract() (*bbq.Contract, sema.CompositeKindedType)
 	}, contractType
 }
 
-func (c *Compiler[_]) compileDeclaration(declaration ast.Declaration) {
+func (c *Compiler[_, _]) compileDeclaration(declaration ast.Declaration) {
 	ast.AcceptDeclaration[struct{}](declaration, c)
 }
 
-func (c *Compiler[_]) compileBlock(block *ast.Block) {
+func (c *Compiler[_, _]) compileBlock(block *ast.Block) {
 	locals := c.currentFunction.locals
 	locals.PushNewWithCurrent()
 	defer locals.Pop()
@@ -553,7 +553,7 @@ func (c *Compiler[_]) compileBlock(block *ast.Block) {
 	}
 }
 
-func (c *Compiler[_]) compileFunctionBlock(functionBlock *ast.FunctionBlock) {
+func (c *Compiler[_, _]) compileFunctionBlock(functionBlock *ast.FunctionBlock) {
 	// Function conditions must have been desugared to statements.
 	// So there shouldn't be any condition at this point.
 	if functionBlock != nil {
@@ -561,15 +561,15 @@ func (c *Compiler[_]) compileFunctionBlock(functionBlock *ast.FunctionBlock) {
 	}
 }
 
-func (c *Compiler[_]) compileStatement(statement ast.Statement) {
+func (c *Compiler[_, _]) compileStatement(statement ast.Statement) {
 	ast.AcceptStatement[struct{}](statement, c)
 }
 
-func (c *Compiler[_]) compileExpression(expression ast.Expression) {
+func (c *Compiler[_, _]) compileExpression(expression ast.Expression) {
 	ast.AcceptExpression[struct{}](expression, c)
 }
 
-func (c *Compiler[_]) VisitReturnStatement(statement *ast.ReturnStatement) (_ struct{}) {
+func (c *Compiler[_, _]) VisitReturnStatement(statement *ast.ReturnStatement) (_ struct{}) {
 	expression := statement.Expression
 	if expression != nil {
 		// TODO: copy
@@ -581,13 +581,13 @@ func (c *Compiler[_]) VisitReturnStatement(statement *ast.ReturnStatement) (_ st
 	return
 }
 
-func (c *Compiler[_]) VisitBreakStatement(_ *ast.BreakStatement) (_ struct{}) {
+func (c *Compiler[_, _]) VisitBreakStatement(_ *ast.BreakStatement) (_ struct{}) {
 	offset := c.emitUndefinedJump()
 	c.currentControlFlow.appendBreak(offset)
 	return
 }
 
-func (c *Compiler[_]) VisitContinueStatement(_ *ast.ContinueStatement) (_ struct{}) {
+func (c *Compiler[_, _]) VisitContinueStatement(_ *ast.ContinueStatement) (_ struct{}) {
 	start := c.currentControlFlow.start
 	if start <= 0 {
 		panic(errors.NewUnreachableError())
@@ -596,7 +596,7 @@ func (c *Compiler[_]) VisitContinueStatement(_ *ast.ContinueStatement) (_ struct
 	return
 }
 
-func (c *Compiler[_]) VisitIfStatement(statement *ast.IfStatement) (_ struct{}) {
+func (c *Compiler[_, _]) VisitIfStatement(statement *ast.IfStatement) (_ struct{}) {
 	// If statements can be coming from inherited conditions.
 	// If so, use the corresponding elaboration.
 	c.withConditionExtendedElaboration(statement, func() {
@@ -660,7 +660,7 @@ func (c *Compiler[_]) VisitIfStatement(statement *ast.IfStatement) (_ struct{}) 
 	return
 }
 
-func (c *Compiler[_]) VisitWhileStatement(statement *ast.WhileStatement) (_ struct{}) {
+func (c *Compiler[_, _]) VisitWhileStatement(statement *ast.WhileStatement) (_ struct{}) {
 	testOffset := c.codeGen.Offset()
 
 	c.pushControlFlow(testOffset)
@@ -680,7 +680,7 @@ func (c *Compiler[_]) VisitWhileStatement(statement *ast.WhileStatement) (_ stru
 	return
 }
 
-func (c *Compiler[_]) VisitForStatement(statement *ast.ForStatement) (_ struct{}) {
+func (c *Compiler[_, _]) VisitForStatement(statement *ast.ForStatement) (_ struct{}) {
 	// Evaluate the expression
 	c.compileExpression(statement.Value)
 
@@ -759,7 +759,7 @@ func (c *Compiler[_]) VisitForStatement(statement *ast.ForStatement) (_ struct{}
 	return
 }
 
-func (c *Compiler[_]) VisitEmitStatement(statement *ast.EmitStatement) (_ struct{}) {
+func (c *Compiler[_, _]) VisitEmitStatement(statement *ast.EmitStatement) (_ struct{}) {
 	c.compileExpression(statement.InvocationExpression)
 	eventType := c.ExtendedElaboration.EmitStatementEventType(statement)
 	typeIndex := c.getOrAddType(eventType)
@@ -770,7 +770,7 @@ func (c *Compiler[_]) VisitEmitStatement(statement *ast.EmitStatement) (_ struct
 	return
 }
 
-func (c *Compiler[_]) VisitSwitchStatement(statement *ast.SwitchStatement) (_ struct{}) {
+func (c *Compiler[_, _]) VisitSwitchStatement(statement *ast.SwitchStatement) (_ struct{}) {
 	c.compileExpression(statement.Expression)
 	localIndex := c.currentFunction.generateLocalIndex()
 	c.codeGen.Emit(opcode.InstructionSetLocal{LocalIndex: localIndex})
@@ -813,7 +813,7 @@ func (c *Compiler[_]) VisitSwitchStatement(statement *ast.SwitchStatement) (_ st
 	return
 }
 
-func (c *Compiler[_]) VisitVariableDeclaration(declaration *ast.VariableDeclaration) (_ struct{}) {
+func (c *Compiler[_, _]) VisitVariableDeclaration(declaration *ast.VariableDeclaration) (_ struct{}) {
 	// Some variable declarations can be coming from inherited before-statements.
 	// If so, use the corresponding elaboration.
 	c.withConditionExtendedElaboration(declaration, func() {
@@ -841,7 +841,7 @@ func (c *Compiler[_]) VisitVariableDeclaration(declaration *ast.VariableDeclarat
 	return
 }
 
-func (c *Compiler[_]) VisitAssignmentStatement(statement *ast.AssignmentStatement) (_ struct{}) {
+func (c *Compiler[_, _]) VisitAssignmentStatement(statement *ast.AssignmentStatement) (_ struct{}) {
 
 	switch target := statement.Target.(type) {
 	case *ast.IdentifierExpression:
@@ -892,12 +892,12 @@ func (c *Compiler[_]) VisitAssignmentStatement(statement *ast.AssignmentStatemen
 	return
 }
 
-func (c *Compiler[_]) VisitSwapStatement(_ *ast.SwapStatement) (_ struct{}) {
+func (c *Compiler[_, _]) VisitSwapStatement(_ *ast.SwapStatement) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitExpressionStatement(statement *ast.ExpressionStatement) (_ struct{}) {
+func (c *Compiler[_, _]) VisitExpressionStatement(statement *ast.ExpressionStatement) (_ struct{}) {
 	c.compileExpression(statement.Expression)
 
 	switch statement.Expression.(type) {
@@ -911,12 +911,12 @@ func (c *Compiler[_]) VisitExpressionStatement(statement *ast.ExpressionStatemen
 	return
 }
 
-func (c *Compiler[_]) VisitVoidExpression(_ *ast.VoidExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitVoidExpression(_ *ast.VoidExpression) (_ struct{}) {
 	//TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitBoolExpression(expression *ast.BoolExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitBoolExpression(expression *ast.BoolExpression) (_ struct{}) {
 	if expression.Value {
 		c.codeGen.Emit(opcode.InstructionTrue{})
 	} else {
@@ -925,12 +925,12 @@ func (c *Compiler[_]) VisitBoolExpression(expression *ast.BoolExpression) (_ str
 	return
 }
 
-func (c *Compiler[_]) VisitNilExpression(_ *ast.NilExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitNilExpression(_ *ast.NilExpression) (_ struct{}) {
 	c.codeGen.Emit(opcode.InstructionNil{})
 	return
 }
 
-func (c *Compiler[_]) VisitIntegerExpression(expression *ast.IntegerExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitIntegerExpression(expression *ast.IntegerExpression) (_ struct{}) {
 	integerType := c.ExtendedElaboration.IntegerExpressionType(expression)
 	constantKind := constantkind.FromSemaType(integerType)
 
@@ -939,7 +939,7 @@ func (c *Compiler[_]) VisitIntegerExpression(expression *ast.IntegerExpression) 
 	return
 }
 
-func (c *Compiler[_]) VisitFixedPointExpression(expression *ast.FixedPointExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitFixedPointExpression(expression *ast.FixedPointExpression) (_ struct{}) {
 	// TODO: adjust once/if we support more fixed point types
 
 	fixedPointSubType := c.ExtendedElaboration.FixedPointExpressionType(expression)
@@ -976,17 +976,17 @@ func (c *Compiler[_]) VisitFixedPointExpression(expression *ast.FixedPointExpres
 	return
 }
 
-func (c *Compiler[_]) addUFix64Constant(value *big.Int) *constant {
+func (c *Compiler[_, _]) addUFix64Constant(value *big.Int) *constant {
 	data := leb128.AppendUint64(nil, value.Uint64())
 	return c.addConstant(constantkind.UFix64, data)
 }
 
-func (c *Compiler[_]) addFix64Constant(value *big.Int) *constant {
+func (c *Compiler[_, _]) addFix64Constant(value *big.Int) *constant {
 	data := leb128.AppendInt64(nil, value.Int64())
 	return c.addConstant(constantkind.Fix64, data)
 }
 
-func (c *Compiler[_]) VisitArrayExpression(array *ast.ArrayExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitArrayExpression(array *ast.ArrayExpression) (_ struct{}) {
 	arrayTypes := c.ExtendedElaboration.ArrayExpressionTypes(array)
 
 	typeIndex := c.getOrAddType(arrayTypes.ArrayType)
@@ -1011,7 +1011,7 @@ func (c *Compiler[_]) VisitArrayExpression(array *ast.ArrayExpression) (_ struct
 	return
 }
 
-func (c *Compiler[_]) VisitDictionaryExpression(dictionary *ast.DictionaryExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitDictionaryExpression(dictionary *ast.DictionaryExpression) (_ struct{}) {
 	dictionaryTypes := c.ExtendedElaboration.DictionaryExpressionTypes(dictionary)
 
 	typeIndex := c.getOrAddType(dictionaryTypes.DictionaryType)
@@ -1037,12 +1037,12 @@ func (c *Compiler[_]) VisitDictionaryExpression(dictionary *ast.DictionaryExpres
 	return
 }
 
-func (c *Compiler[_]) VisitIdentifierExpression(expression *ast.IdentifierExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitIdentifierExpression(expression *ast.IdentifierExpression) (_ struct{}) {
 	c.emitVariableLoad(expression.Identifier.Identifier)
 	return
 }
 
-func (c *Compiler[_]) emitVariableLoad(name string) {
+func (c *Compiler[_, _]) emitVariableLoad(name string) {
 	local := c.currentFunction.findLocal(name)
 	if local != nil {
 		c.codeGen.Emit(opcode.InstructionGetLocal{LocalIndex: local.index})
@@ -1053,7 +1053,7 @@ func (c *Compiler[_]) emitVariableLoad(name string) {
 	c.codeGen.Emit(opcode.InstructionGetGlobal{GlobalIndex: global.Index})
 }
 
-func (c *Compiler[_]) VisitInvocationExpression(expression *ast.InvocationExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitInvocationExpression(expression *ast.InvocationExpression) (_ struct{}) {
 	// TODO: copy
 
 	switch invokedExpr := expression.InvokedExpression.(type) {
@@ -1174,7 +1174,7 @@ func TypeName(typ sema.Type) string {
 	}
 }
 
-func (c *Compiler[_]) loadArguments(expression *ast.InvocationExpression) {
+func (c *Compiler[_, _]) loadArguments(expression *ast.InvocationExpression) {
 	invocationTypes := c.ExtendedElaboration.InvocationExpressionTypes(expression)
 	for index, argument := range expression.Arguments {
 		c.compileExpression(argument.Expression)
@@ -1188,7 +1188,7 @@ func (c *Compiler[_]) loadArguments(expression *ast.InvocationExpression) {
 	//}
 }
 
-func (c *Compiler[_]) loadTypeArguments(expression *ast.InvocationExpression) []uint16 {
+func (c *Compiler[_, _]) loadTypeArguments(expression *ast.InvocationExpression) []uint16 {
 	invocationTypes := c.ExtendedElaboration.InvocationExpressionTypes(expression)
 
 	typeArgsCount := invocationTypes.TypeArguments.Len()
@@ -1209,7 +1209,7 @@ func (c *Compiler[_]) loadTypeArguments(expression *ast.InvocationExpression) []
 	return typeArgs
 }
 
-func (c *Compiler[_]) VisitMemberExpression(expression *ast.MemberExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitMemberExpression(expression *ast.MemberExpression) (_ struct{}) {
 	c.compileExpression(expression.Expression)
 	constant := c.addStringConst(expression.Identifier.Identifier)
 	c.codeGen.Emit(opcode.InstructionGetField{
@@ -1218,19 +1218,19 @@ func (c *Compiler[_]) VisitMemberExpression(expression *ast.MemberExpression) (_
 	return
 }
 
-func (c *Compiler[_]) VisitIndexExpression(expression *ast.IndexExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitIndexExpression(expression *ast.IndexExpression) (_ struct{}) {
 	c.compileExpression(expression.TargetExpression)
 	c.compileExpression(expression.IndexingExpression)
 	c.codeGen.Emit(opcode.InstructionGetIndex{})
 	return
 }
 
-func (c *Compiler[_]) VisitConditionalExpression(_ *ast.ConditionalExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitConditionalExpression(_ *ast.ConditionalExpression) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitUnaryExpression(expression *ast.UnaryExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitUnaryExpression(expression *ast.UnaryExpression) (_ struct{}) {
 	switch expression.Operation {
 	case ast.OperationMove:
 		c.compileExpression(expression.Expression)
@@ -1245,7 +1245,7 @@ func (c *Compiler[_]) VisitUnaryExpression(expression *ast.UnaryExpression) (_ s
 	return
 }
 
-func (c *Compiler[_]) VisitBinaryExpression(expression *ast.BinaryExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitBinaryExpression(expression *ast.BinaryExpression) (_ struct{}) {
 	c.compileExpression(expression.Left)
 	// TODO: add support for other types
 
@@ -1303,22 +1303,22 @@ func (c *Compiler[_]) VisitBinaryExpression(expression *ast.BinaryExpression) (_
 	return
 }
 
-func (c *Compiler[_]) VisitFunctionExpression(_ *ast.FunctionExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitFunctionExpression(_ *ast.FunctionExpression) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitStringExpression(expression *ast.StringExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitStringExpression(expression *ast.StringExpression) (_ struct{}) {
 	c.stringConstLoad(expression.Value)
 	return
 }
 
-func (c *Compiler[_]) VisitStringTemplateExpression(_ *ast.StringTemplateExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitStringTemplateExpression(_ *ast.StringTemplateExpression) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitCastingExpression(expression *ast.CastingExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitCastingExpression(expression *ast.CastingExpression) (_ struct{}) {
 	c.compileExpression(expression.Expression)
 
 	castingTypes := c.ExtendedElaboration.CastingExpressionTypes(expression)
@@ -1346,18 +1346,18 @@ func (c *Compiler[_]) VisitCastingExpression(expression *ast.CastingExpression) 
 	return
 }
 
-func (c *Compiler[_]) VisitCreateExpression(expression *ast.CreateExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitCreateExpression(expression *ast.CreateExpression) (_ struct{}) {
 	c.compileExpression(expression.InvocationExpression)
 	return
 }
 
-func (c *Compiler[_]) VisitDestroyExpression(expression *ast.DestroyExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitDestroyExpression(expression *ast.DestroyExpression) (_ struct{}) {
 	c.compileExpression(expression.Expression)
 	c.codeGen.Emit(opcode.InstructionDestroy{})
 	return
 }
 
-func (c *Compiler[_]) VisitReferenceExpression(expression *ast.ReferenceExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitReferenceExpression(expression *ast.ReferenceExpression) (_ struct{}) {
 	c.compileExpression(expression.Expression)
 	borrowType := c.ExtendedElaboration.ReferenceExpressionBorrowType(expression)
 	index := c.getOrAddType(borrowType)
@@ -1365,12 +1365,12 @@ func (c *Compiler[_]) VisitReferenceExpression(expression *ast.ReferenceExpressi
 	return
 }
 
-func (c *Compiler[_]) VisitForceExpression(_ *ast.ForceExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitForceExpression(_ *ast.ForceExpression) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitPathExpression(expression *ast.PathExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitPathExpression(expression *ast.PathExpression) (_ struct{}) {
 	domain := common.PathDomainFromIdentifier(expression.Domain.Identifier)
 	identifier := expression.Identifier.Identifier
 	if len(identifier) >= math.MaxUint16 {
@@ -1388,7 +1388,7 @@ func (c *Compiler[_]) VisitPathExpression(expression *ast.PathExpression) (_ str
 	return
 }
 
-func (c *Compiler[_]) VisitSpecialFunctionDeclaration(declaration *ast.SpecialFunctionDeclaration) (_ struct{}) {
+func (c *Compiler[_, _]) VisitSpecialFunctionDeclaration(declaration *ast.SpecialFunctionDeclaration) (_ struct{}) {
 	kind := declaration.DeclarationKind()
 	switch kind {
 	case common.DeclarationKindInitializer:
@@ -1402,7 +1402,7 @@ func (c *Compiler[_]) VisitSpecialFunctionDeclaration(declaration *ast.SpecialFu
 	return
 }
 
-func (c *Compiler[_]) compileInitializer(declaration *ast.SpecialFunctionDeclaration) {
+func (c *Compiler[_, _]) compileInitializer(declaration *ast.SpecialFunctionDeclaration) {
 	enclosingCompositeTypeName := c.enclosingCompositeTypeFullyQualifiedName()
 	enclosingType := c.compositeTypeStack.top()
 	kind := enclosingType.GetCompositeKind()
@@ -1477,7 +1477,7 @@ func (c *Compiler[_]) compileInitializer(declaration *ast.SpecialFunctionDeclara
 	c.codeGen.Emit(opcode.InstructionReturnValue{})
 }
 
-func (c *Compiler[_]) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration, _ bool) (_ struct{}) {
+func (c *Compiler[_, _]) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration, _ bool) (_ struct{}) {
 	declareReceiver := !c.compositeTypeStack.isEmpty()
 	function := c.declareFunction(declaration, declareReceiver)
 
@@ -1487,7 +1487,7 @@ func (c *Compiler[_]) VisitFunctionDeclaration(declaration *ast.FunctionDeclarat
 	return
 }
 
-func (c *Compiler[E]) declareFunction(declaration *ast.FunctionDeclaration, declareReceiver bool) *function[E] {
+func (c *Compiler[E, T]) declareFunction(declaration *ast.FunctionDeclaration, declareReceiver bool) *function[E] {
 	enclosingCompositeTypeName := c.enclosingCompositeTypeFullyQualifiedName()
 	functionName := commons.TypeQualifiedName(enclosingCompositeTypeName, declaration.Identifier.Identifier)
 
@@ -1509,7 +1509,7 @@ func (c *Compiler[E]) declareFunction(declaration *ast.FunctionDeclaration, decl
 	return c.addFunction(functionName, uint16(parameterCount))
 }
 
-func (c *Compiler[_]) VisitCompositeDeclaration(declaration *ast.CompositeDeclaration) (_ struct{}) {
+func (c *Compiler[_, _]) VisitCompositeDeclaration(declaration *ast.CompositeDeclaration) (_ struct{}) {
 	compositeType := c.ExtendedElaboration.CompositeDeclarationType(declaration)
 	c.compositeTypeStack.push(compositeType)
 	defer func() {
@@ -1545,7 +1545,7 @@ func (c *Compiler[_]) VisitCompositeDeclaration(declaration *ast.CompositeDeclar
 	return
 }
 
-func (c *Compiler[_]) VisitInterfaceDeclaration(declaration *ast.InterfaceDeclaration) (_ struct{}) {
+func (c *Compiler[_, _]) VisitInterfaceDeclaration(declaration *ast.InterfaceDeclaration) (_ struct{}) {
 	interfaceType := c.ExtendedElaboration.InterfaceDeclarationType(declaration)
 	c.compositeTypeStack.push(interfaceType)
 	defer func() {
@@ -1564,17 +1564,17 @@ func (c *Compiler[_]) VisitInterfaceDeclaration(declaration *ast.InterfaceDeclar
 	return
 }
 
-func (c *Compiler[_]) VisitFieldDeclaration(_ *ast.FieldDeclaration) (_ struct{}) {
+func (c *Compiler[_, _]) VisitFieldDeclaration(_ *ast.FieldDeclaration) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitPragmaDeclaration(_ *ast.PragmaDeclaration) (_ struct{}) {
+func (c *Compiler[_, _]) VisitPragmaDeclaration(_ *ast.PragmaDeclaration) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitImportDeclaration(declaration *ast.ImportDeclaration) (_ struct{}) {
+func (c *Compiler[_, _]) VisitImportDeclaration(declaration *ast.ImportDeclaration) (_ struct{}) {
 	resolvedLocations, err := commons.ResolveLocation(
 		c.Config.LocationHandler,
 		declaration.Identifiers,
@@ -1611,66 +1611,64 @@ func (c *Compiler[_]) VisitImportDeclaration(declaration *ast.ImportDeclaration)
 	return
 }
 
-func (c *Compiler[_]) VisitTransactionDeclaration(_ *ast.TransactionDeclaration) (_ struct{}) {
+func (c *Compiler[_, _]) VisitTransactionDeclaration(_ *ast.TransactionDeclaration) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitEnumCaseDeclaration(_ *ast.EnumCaseDeclaration) (_ struct{}) {
+func (c *Compiler[_, _]) VisitEnumCaseDeclaration(_ *ast.EnumCaseDeclaration) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitAttachmentDeclaration(_ *ast.AttachmentDeclaration) (_ struct{}) {
+func (c *Compiler[_, _]) VisitAttachmentDeclaration(_ *ast.AttachmentDeclaration) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitEntitlementDeclaration(_ *ast.EntitlementDeclaration) (_ struct{}) {
+func (c *Compiler[_, _]) VisitEntitlementDeclaration(_ *ast.EntitlementDeclaration) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitEntitlementMappingDeclaration(_ *ast.EntitlementMappingDeclaration) (_ struct{}) {
+func (c *Compiler[_, _]) VisitEntitlementMappingDeclaration(_ *ast.EntitlementMappingDeclaration) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitRemoveStatement(_ *ast.RemoveStatement) (_ struct{}) {
+func (c *Compiler[_, _]) VisitRemoveStatement(_ *ast.RemoveStatement) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) VisitAttachExpression(_ *ast.AttachExpression) (_ struct{}) {
+func (c *Compiler[_, _]) VisitAttachExpression(_ *ast.AttachExpression) (_ struct{}) {
 	// TODO
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Compiler[_]) emitTransfer(targetType sema.Type) {
+func (c *Compiler[_, _]) emitTransfer(targetType sema.Type) {
 	index := c.getOrAddType(targetType)
 
 	c.codeGen.Emit(opcode.InstructionTransfer{TypeIndex: index})
 }
 
-func (c *Compiler[_]) getOrAddType(targetType sema.Type) uint16 {
+func (c *Compiler[_, T]) getOrAddType(targetType sema.Type) uint16 {
 	typeID := targetType.ID()
 
 	// Optimization: Re-use types in the pool.
 	index, ok := c.typesInPool[typeID]
+
 	if !ok {
 		staticType := interpreter.ConvertSemaToStaticType(c.memoryGauge, targetType)
-		bytes, err := interpreter.StaticTypeToBytes(staticType)
-		if err != nil {
-			panic(err)
-		}
-		index = c.addType(bytes)
+		typ := c.codeGen.AddType(staticType)
+		index = c.addType(typ)
 		c.typesInPool[typeID] = index
 	}
 
 	return index
 }
 
-func (c *Compiler[_]) addType(data []byte) uint16 {
+func (c *Compiler[_, T]) addType(data T) uint16 {
 	count := len(c.staticTypes)
 	if count >= math.MaxUint16 {
 		panic(errors.NewDefaultUserError("invalid type declaration"))
@@ -1680,7 +1678,7 @@ func (c *Compiler[_]) addType(data []byte) uint16 {
 	return uint16(count)
 }
 
-func (c *Compiler[_]) enclosingCompositeTypeFullyQualifiedName() string {
+func (c *Compiler[_, _]) enclosingCompositeTypeFullyQualifiedName() string {
 	if c.compositeTypeStack.isEmpty() {
 		return ""
 	}
@@ -1696,7 +1694,7 @@ func (c *Compiler[_]) enclosingCompositeTypeFullyQualifiedName() string {
 	return sb.String()
 }
 
-func (c *Compiler[E]) declareParameters(function *function[E], paramList *ast.ParameterList, declareReceiver bool) {
+func (c *Compiler[E, T]) declareParameters(function *function[E], paramList *ast.ParameterList, declareReceiver bool) {
 	if declareReceiver {
 		// Declare receiver as `self`.
 		// Receiver is always at the zero-th index of params.
@@ -1711,11 +1709,11 @@ func (c *Compiler[E]) declareParameters(function *function[E], paramList *ast.Pa
 	}
 }
 
-func (c *Compiler[_]) generateEmptyInit() {
+func (c *Compiler[_, _]) generateEmptyInit() {
 	c.VisitSpecialFunctionDeclaration(emptyInitializer)
 }
 
-func (c *Compiler[_]) withConditionExtendedElaboration(statement ast.Statement, f func()) {
+func (c *Compiler[_, _]) withConditionExtendedElaboration(statement ast.Statement, f func()) {
 	stmtElaboration, ok := c.ExtendedElaboration.conditionsElaborations[statement]
 	if ok {
 		prevElaboration := c.ExtendedElaboration

--- a/bbq/compiler/typegen.go
+++ b/bbq/compiler/typegen.go
@@ -16,16 +16,35 @@
  * limitations under the License.
  */
 
-package bbq
+package compiler
 
 import (
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/interpreter"
 )
 
-type StaticType = interpreter.StaticType
+type TypeGen[T any] interface {
+	CompileType(staticType bbq.StaticType) T
+}
 
-func StaticTypeFromBytes(bytes []byte) (StaticType, error) {
-	dec := interpreter.CBORDecMode.NewByteStreamDecoder(bytes)
-	typeDecoder := interpreter.NewTypeDecoder(dec, nil)
-	return typeDecoder.DecodeStaticType()
+type DecodedTypeGen struct {
+}
+
+var _ TypeGen[bbq.StaticType] = &DecodedTypeGen{}
+
+func (d DecodedTypeGen) CompileType(staticType bbq.StaticType) bbq.StaticType {
+	return staticType
+}
+
+type EncodedTypeGen struct {
+}
+
+var _ TypeGen[[]byte] = &EncodedTypeGen{}
+
+func (d EncodedTypeGen) CompileType(staticType bbq.StaticType) []byte {
+	bytes, err := interpreter.StaticTypeToBytes(staticType)
+	if err != nil {
+		panic(err)
+	}
+	return bytes
 }

--- a/bbq/program.go
+++ b/bbq/program.go
@@ -18,11 +18,15 @@
 
 package bbq
 
-type Program[E any] struct {
+import "github.com/onflow/cadence/bbq/opcode"
+
+type Program[E, T any] struct {
 	Contract  *Contract
 	Imports   []*Import
 	Functions []*Function[E]
 	Constants []*Constant
 	Variables []*Variable
-	Types     [][]byte
+	Types     []T
 }
+
+type InstructionProgram Program[opcode.Instruction, StaticType]

--- a/bbq/program.go
+++ b/bbq/program.go
@@ -29,4 +29,4 @@ type Program[E, T any] struct {
 	Types     []T
 }
 
-type InstructionProgram Program[opcode.Instruction, StaticType]
+type InstructionProgram = Program[opcode.Instruction, StaticType]

--- a/bbq/statictype.go
+++ b/bbq/statictype.go
@@ -16,27 +16,10 @@
  * limitations under the License.
  */
 
-package vm
+package bbq
 
 import (
-	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/interpreter"
 )
 
-func IsSubType(config *Config, sourceType, targetType bbq.StaticType) bool {
-	// TODO: Avoid conversion to sema types.
-	inter := config.interpreter()
-	return inter.IsSubType(sourceType, targetType)
-}
-
-// UnwrapOptionalType returns the type if it is not an optional type,
-// or the inner-most type if it is (optional types are repeatedly unwrapped)
-func UnwrapOptionalType(ty bbq.StaticType) bbq.StaticType {
-	for {
-		optionalType, ok := ty.(*interpreter.OptionalStaticType)
-		if !ok {
-			return ty
-		}
-		ty = optionalType.Type
-	}
-}
+type StaticType = interpreter.StaticType

--- a/bbq/vm/errors.go
+++ b/bbq/vm/errors.go
@@ -20,7 +20,7 @@ package vm
 
 import (
 	"fmt"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/errors"
 )
 
@@ -56,8 +56,8 @@ func (l MissingMemberValueError) Error() string {
 
 // ForceCastTypeMismatchError
 type ForceCastTypeMismatchError struct {
-	ExpectedType StaticType
-	ActualType   StaticType
+	ExpectedType bbq.StaticType
+	ActualType   bbq.StaticType
 }
 
 var _ errors.UserError = ForceCastTypeMismatchError{}

--- a/bbq/vm/errors.go
+++ b/bbq/vm/errors.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"fmt"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/errors"
 )

--- a/bbq/vm/executable_program.go
+++ b/bbq/vm/executable_program.go
@@ -20,7 +20,6 @@ package vm
 
 import (
 	"github.com/onflow/cadence/bbq"
-	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/common"
 )
 
@@ -31,7 +30,7 @@ import (
 // i.e: indexes used in opcodes refer to the indexes of its ExecutableProgram.
 type ExecutableProgram struct {
 	Location    common.Location
-	Program     *bbq.Program[opcode.Instruction, bbq.StaticType]
+	Program     *bbq.InstructionProgram
 	Globals     []Value
 	Constants   []Value
 	StaticTypes []bbq.StaticType
@@ -39,7 +38,7 @@ type ExecutableProgram struct {
 
 func NewExecutableProgram(
 	location common.Location,
-	program *bbq.Program[opcode.Instruction, bbq.StaticType],
+	program *bbq.InstructionProgram,
 	globals []Value,
 ) *ExecutableProgram {
 	return &ExecutableProgram{

--- a/bbq/vm/executable_program.go
+++ b/bbq/vm/executable_program.go
@@ -31,15 +31,15 @@ import (
 // i.e: indexes used in opcodes refer to the indexes of its ExecutableProgram.
 type ExecutableProgram struct {
 	Location    common.Location
-	Program     *bbq.Program[opcode.Instruction]
+	Program     *bbq.Program[opcode.Instruction, bbq.StaticType]
 	Globals     []Value
 	Constants   []Value
-	StaticTypes []StaticType
+	StaticTypes []bbq.StaticType
 }
 
 func NewExecutableProgram(
 	location common.Location,
-	program *bbq.Program[opcode.Instruction],
+	program *bbq.Program[opcode.Instruction, bbq.StaticType],
 	globals []Value,
 ) *ExecutableProgram {
 	return &ExecutableProgram{
@@ -47,23 +47,6 @@ func NewExecutableProgram(
 		Program:     program,
 		Globals:     globals,
 		Constants:   make([]Value, len(program.Constants)),
-		StaticTypes: make([]StaticType, len(program.Types)),
+		StaticTypes: program.Types,
 	}
-}
-
-// NewLoadedExecutableProgram returns an ExecutableProgram with types decoded.
-// Note that the returned program **doesn't** have the globals linked.
-func NewLoadedExecutableProgram(
-	location common.Location,
-	program *bbq.Program[opcode.Instruction],
-) *ExecutableProgram {
-	executable := NewExecutableProgram(location, program, nil)
-
-	// Optimization: Pre load/decode types
-	for index, bytes := range program.Types {
-		staticType := decodeType(bytes)
-		executable.StaticTypes[index] = staticType
-	}
-
-	return executable
 }

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -21,7 +21,6 @@ package vm
 import (
 	"fmt"
 	"github.com/onflow/cadence/bbq"
-	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/common"
 )
 
@@ -36,7 +35,7 @@ type LinkedGlobals struct {
 // LinkGlobals performs the linking of global functions and variables for a given program.
 func LinkGlobals(
 	location common.Location,
-	program *bbq.Program[opcode.Instruction, bbq.StaticType],
+	program *bbq.InstructionProgram,
 	conf *Config,
 	linkedGlobalsCache map[common.Location]LinkedGlobals,
 ) LinkedGlobals {

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"fmt"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 )

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -20,10 +20,8 @@ package vm
 
 import (
 	"fmt"
-
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/bbq/opcode"
-
 	"github.com/onflow/cadence/common"
 )
 
@@ -38,7 +36,7 @@ type LinkedGlobals struct {
 // LinkGlobals performs the linking of global functions and variables for a given program.
 func LinkGlobals(
 	location common.Location,
-	program *bbq.Program[opcode.Instruction],
+	program *bbq.Program[opcode.Instruction, bbq.StaticType],
 	conf *Config,
 	linkedGlobalsCache map[common.Location]LinkedGlobals,
 ) LinkedGlobals {
@@ -92,7 +90,7 @@ func LinkGlobals(
 		importedGlobals = append(importedGlobals, importedGlobal)
 	}
 
-	executable := NewLoadedExecutableProgram(location, program)
+	executable := NewExecutableProgram(location, program, nil)
 
 	globalsLen := len(program.Variables) + len(program.Functions) + len(importedGlobals) + 1
 	indexedGlobalsLen := len(program.Functions)

--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -20,10 +20,9 @@ package vm
 
 import (
 	"fmt"
+
 	"github.com/onflow/cadence/bbq"
-
 	"github.com/onflow/cadence/bbq/commons"
-
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/stdlib"

--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"fmt"
+	"github.com/onflow/cadence/bbq"
 
 	"github.com/onflow/cadence/bbq/commons"
 
@@ -59,7 +60,7 @@ func RegisterTypeBoundFunction(typeName, functionName string, functionValue Nati
 func init() {
 	RegisterFunction(commons.LogFunctionName, NativeFunctionValue{
 		ParameterCount: len(stdlib.LogFunctionType.Parameters),
-		Function: func(config *Config, typeArguments []StaticType, arguments ...Value) Value {
+		Function: func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
 			// TODO: Properly implement
 			fmt.Println(arguments[0].String())
 			return VoidValue{}
@@ -68,7 +69,7 @@ func init() {
 
 	RegisterFunction(commons.PanicFunctionName, NativeFunctionValue{
 		ParameterCount: len(stdlib.PanicFunctionType.Parameters),
-		Function: func(config *Config, typeArguments []StaticType, arguments ...Value) Value {
+		Function: func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
 			// TODO: Properly implement
 			messageValue, ok := arguments[0].(StringValue)
 			if !ok {
@@ -84,7 +85,7 @@ func init() {
 
 	RegisterFunction(commons.GetAccountFunctionName, NativeFunctionValue{
 		ParameterCount: len(stdlib.PanicFunctionType.Parameters),
-		Function: func(config *Config, typeArguments []StaticType, arguments ...Value) Value {
+		Function: func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
 			address := arguments[0].(AddressValue)
 			return NewAccountReferenceValue(config, common.Address(address))
 		},

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -20,7 +20,6 @@ package test
 
 import (
 	"fmt"
-	"github.com/onflow/cadence/bbq/opcode"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,7 +75,7 @@ func TestFTTransfer(t *testing.T) {
 		Storage:        storage,
 		AccountHandler: &testAccountHandler{},
 		TypeLoader:     typeLoader,
-		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 			imported, ok := programs[location]
 			if !ok {
 				return nil
@@ -99,7 +98,7 @@ func TestFTTransfer(t *testing.T) {
 
 	vmConfig := &vm.Config{
 		Storage: storage,
-		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 			imported, ok := programs[location]
 			if !ok {
 				return nil
@@ -253,7 +252,7 @@ func BenchmarkFTTransfer(b *testing.B) {
 
 	vmConfig := &vm.Config{
 		Storage: storage,
-		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 			imported, ok := programs[location]
 			if !ok {
 				return nil

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -20,13 +20,13 @@ package test
 
 import (
 	"fmt"
+	"github.com/onflow/cadence/bbq/opcode"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/bbq"
-	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/bbq/vm"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
@@ -76,7 +76,7 @@ func TestFTTransfer(t *testing.T) {
 		Storage:        storage,
 		AccountHandler: &testAccountHandler{},
 		TypeLoader:     typeLoader,
-		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			imported, ok := programs[location]
 			if !ok {
 				return nil
@@ -99,7 +99,7 @@ func TestFTTransfer(t *testing.T) {
 
 	vmConfig := &vm.Config{
 		Storage: storage,
-		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			imported, ok := programs[location]
 			if !ok {
 				return nil
@@ -253,7 +253,7 @@ func BenchmarkFTTransfer(b *testing.B) {
 
 	vmConfig := &vm.Config{
 		Storage: storage,
-		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			imported, ok := programs[location]
 			if !ok {
 				return nil
@@ -321,12 +321,11 @@ func BenchmarkFTTransfer(b *testing.B) {
 
 	tokenTransferTxAuthorizer := vm.NewAuthAccountReferenceValue(vmConfig, senderAddress)
 
-	tokenTransferTxProgram := parseCheckAndCompile(b, realFlowTokenTransferTransaction, nil, programs)
-
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
+		tokenTransferTxProgram := parseCheckAndCompile(b, realFlowTokenTransferTransaction, nil, programs)
 		tokenTransferTxVM := vm.NewVM(txLocation(), tokenTransferTxProgram, vmConfig)
 		err = tokenTransferTxVM.ExecuteTransaction(tokenTransferTxArgs, tokenTransferTxAuthorizer)
 		require.NoError(b, err)

--- a/bbq/vm/test/interpreter_test.go
+++ b/bbq/vm/test/interpreter_test.go
@@ -799,21 +799,21 @@ func BenchmarkInterpreterFTTransfer(b *testing.B) {
 	amount := interpreter.NewUnmeteredIntValueFromInt64(transferAmount)
 	receiver := interpreter.AddressValue(receiverAddress)
 
-	inter, err = parseCheckAndInterpretWithOptions(
-		b,
-		realFlowTokenTransferTransaction,
-		txLocation(),
-		ParseCheckAndInterpretOptions{
-			Config:        interConfig,
-			CheckerConfig: checkerConfig,
-		},
-	)
-	require.NoError(b, err)
-
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
+		inter, err = parseCheckAndInterpretWithOptions(
+			b,
+			realFlowTokenTransferTransaction,
+			txLocation(),
+			ParseCheckAndInterpretOptions{
+				Config:        interConfig,
+				CheckerConfig: checkerConfig,
+			},
+		)
+		require.NoError(b, err)
+
 		err = inter.InvokeTransaction(
 			0,
 			amount,

--- a/bbq/vm/test/runtime_test.go
+++ b/bbq/vm/test/runtime_test.go
@@ -148,7 +148,7 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 		contractsAddress.HexWithPrefix(),
 	)
 
-	importHandler := func(location common.Location) *bbq.Program[opcode.Instruction] {
+	importHandler := func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 		switch location {
 		case barLocation:
 			return barProgram

--- a/bbq/vm/test/runtime_test.go
+++ b/bbq/vm/test/runtime_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/test_utils/runtime_utils"
@@ -148,7 +147,7 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 		contractsAddress.HexWithPrefix(),
 	)
 
-	importHandler := func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+	importHandler := func(location common.Location) *bbq.InstructionProgram {
 		switch location {
 		case barLocation:
 			return barProgram

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -20,12 +20,12 @@ package test
 
 import (
 	"fmt"
+	"github.com/onflow/cadence/bbq/opcode"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/ast"
-	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
@@ -381,7 +381,7 @@ func singleIdentifierLocationResolver(t testing.TB) func(
 	}
 }
 
-func printProgram(name string, program *bbq.Program[opcode.Instruction]) { //nolint:unused
+func printProgram(name string, program *bbq.Program[opcode.Instruction, bbq.StaticType]) { //nolint:unused
 	printer := bbq.NewInstructionsProgramPrinter()
 	fmt.Println("===================", name, "===================")
 	fmt.Println(printer.PrintProgram(program))
@@ -401,7 +401,7 @@ func baseValueActivation(common.Location) *sema.VariableActivation {
 }
 
 type compiledProgram struct {
-	*bbq.Program[opcode.Instruction]
+	*bbq.Program[opcode.Instruction, bbq.StaticType]
 	*sema.Elaboration
 }
 
@@ -416,7 +416,7 @@ func parseCheckAndCompile(
 	code string,
 	location common.Location,
 	programs map[common.Location]*compiledProgram,
-) *bbq.Program[opcode.Instruction] {
+) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 	return parseCheckAndCompileCodeWithOptions(
 		t,
 		code,
@@ -432,7 +432,7 @@ func parseCheckAndCompileCodeWithOptions(
 	location common.Location,
 	options CompilerAndVMOptions,
 	programs map[common.Location]*compiledProgram,
-) *bbq.Program[opcode.Instruction] {
+) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 	checker := parseAndCheckWithOptions(
 		t,
 		code,
@@ -512,12 +512,12 @@ func compile(
 	config *compiler.Config,
 	checker *sema.Checker,
 	programs map[common.Location]*compiledProgram,
-) *bbq.Program[opcode.Instruction] {
+) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 
 	if config == nil {
 		config = &compiler.Config{
 			LocationHandler: singleIdentifierLocationResolver(t),
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				imported, ok := programs[location]
 				if !ok {
 					return nil

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -20,7 +20,6 @@ package test
 
 import (
 	"fmt"
-	"github.com/onflow/cadence/bbq/opcode"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -381,7 +380,7 @@ func singleIdentifierLocationResolver(t testing.TB) func(
 	}
 }
 
-func printProgram(name string, program *bbq.Program[opcode.Instruction, bbq.StaticType]) { //nolint:unused
+func printProgram(name string, program *bbq.InstructionProgram) { //nolint:unused
 	printer := bbq.NewInstructionsProgramPrinter()
 	fmt.Println("===================", name, "===================")
 	fmt.Println(printer.PrintProgram(program))
@@ -401,7 +400,7 @@ func baseValueActivation(common.Location) *sema.VariableActivation {
 }
 
 type compiledProgram struct {
-	*bbq.Program[opcode.Instruction, bbq.StaticType]
+	Program *bbq.InstructionProgram
 	*sema.Elaboration
 }
 
@@ -416,7 +415,7 @@ func parseCheckAndCompile(
 	code string,
 	location common.Location,
 	programs map[common.Location]*compiledProgram,
-) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+) *bbq.InstructionProgram {
 	return parseCheckAndCompileCodeWithOptions(
 		t,
 		code,
@@ -432,7 +431,7 @@ func parseCheckAndCompileCodeWithOptions(
 	location common.Location,
 	options CompilerAndVMOptions,
 	programs map[common.Location]*compiledProgram,
-) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+) *bbq.InstructionProgram {
 	checker := parseAndCheckWithOptions(
 		t,
 		code,
@@ -512,12 +511,12 @@ func compile(
 	config *compiler.Config,
 	checker *sema.Checker,
 	programs map[common.Location]*compiledProgram,
-) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+) *bbq.InstructionProgram {
 
 	if config == nil {
 		config = &compiler.Config{
 			LocationHandler: singleIdentifierLocationResolver(t),
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				imported, ok := programs[location]
 				if !ok {
 					return nil

--- a/bbq/vm/test/vm_bench_test.go
+++ b/bbq/vm/test/vm_bench_test.go
@@ -245,7 +245,7 @@ func BenchmarkContractImport(b *testing.B) {
 	require.NoError(b, err)
 
 	vmConfig := &vm.Config{
-		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			return importedProgram
 		},
 		ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -286,7 +286,7 @@ func BenchmarkContractImport(b *testing.B) {
 		require.NoError(b, err)
 
 		comp := compiler.NewInstructionCompiler(checker)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			return importedProgram
 		}
 		program := comp.Compile()
@@ -365,14 +365,14 @@ func BenchmarkMethodCall(b *testing.B) {
 		require.NoError(b, err)
 
 		comp := compiler.NewInstructionCompiler(checker)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -467,14 +467,14 @@ func BenchmarkMethodCall(b *testing.B) {
 		require.NoError(b, err)
 
 		comp := compiler.NewInstructionCompiler(checker)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {

--- a/bbq/vm/test/vm_bench_test.go
+++ b/bbq/vm/test/vm_bench_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/bbq"
-	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
@@ -245,7 +244,7 @@ func BenchmarkContractImport(b *testing.B) {
 	require.NoError(b, err)
 
 	vmConfig := &vm.Config{
-		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		},
 		ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -286,7 +285,7 @@ func BenchmarkContractImport(b *testing.B) {
 		require.NoError(b, err)
 
 		comp := compiler.NewInstructionCompiler(checker)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		}
 		program := comp.Compile()
@@ -365,14 +364,14 @@ func BenchmarkMethodCall(b *testing.B) {
 		require.NoError(b, err)
 
 		comp := compiler.NewInstructionCompiler(checker)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -467,14 +466,14 @@ func BenchmarkMethodCall(b *testing.B) {
 		require.NoError(b, err)
 
 		comp := compiler.NewInstructionCompiler(checker)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -20,9 +20,9 @@ package test
 
 import (
 	"fmt"
+	"github.com/onflow/cadence/bbq/opcode"
 	"testing"
 
-	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/interpreter"
 
 	"github.com/stretchr/testify/assert"
@@ -485,14 +485,14 @@ func TestImport(t *testing.T) {
 	require.NoError(t, err)
 
 	importCompiler := compiler.NewInstructionCompiler(checker)
-	importCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
+	importCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 		return importedProgram
 	}
 
 	program := importCompiler.Compile()
 
 	vmConfig := &vm.Config{
-		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			return importedProgram
 		},
 	}
@@ -572,14 +572,14 @@ func TestContractImport(t *testing.T) {
 		require.NoError(t, err)
 
 		comp := compiler.NewInstructionCompiler(checker)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				return importedProgram
 			},
 			ContractValueHandler: func(*vm.Config, common.Location) *vm.CompositeValue {
@@ -647,14 +647,14 @@ func TestContractImport(t *testing.T) {
 		require.NoError(t, err)
 
 		comp := compiler.NewInstructionCompiler(checker)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				return importedProgram
 			},
 			ContractValueHandler: func(*vm.Config, common.Location) *vm.CompositeValue {
@@ -739,7 +739,7 @@ func TestContractImport(t *testing.T) {
 
 		barCompiler := compiler.NewInstructionCompiler(barChecker)
 		barCompiler.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		barCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
+		barCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			require.Equal(t, fooLocation, location)
 			return fooProgram
 		}
@@ -747,7 +747,7 @@ func TestContractImport(t *testing.T) {
 		barProgram := barCompiler.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				require.Equal(t, fooLocation, location)
 				return fooProgram
 			},
@@ -796,7 +796,7 @@ func TestContractImport(t *testing.T) {
 
 		comp := compiler.NewInstructionCompiler(checker)
 		comp.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			switch location {
 			case fooLocation:
 				return fooProgram
@@ -811,7 +811,7 @@ func TestContractImport(t *testing.T) {
 		program := comp.Compile()
 
 		vmConfig = &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				switch location {
 				case fooLocation:
 					return fooProgram
@@ -906,7 +906,7 @@ func TestContractImport(t *testing.T) {
 
 		barCompiler := compiler.NewInstructionCompiler(barChecker)
 		barCompiler.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		barCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
+		barCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			require.Equal(t, fooLocation, location)
 			return fooProgram
 		}
@@ -925,7 +925,7 @@ func TestContractImport(t *testing.T) {
 		barProgram := barCompiler.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				require.Equal(t, fooLocation, location)
 				return fooProgram
 			},
@@ -970,7 +970,7 @@ func TestContractImport(t *testing.T) {
 
 		comp := compiler.NewInstructionCompiler(checker)
 		comp.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			switch location {
 			case fooLocation:
 				return fooProgram
@@ -985,7 +985,7 @@ func TestContractImport(t *testing.T) {
 		program := comp.Compile()
 
 		vmConfig = &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				switch location {
 				case fooLocation:
 					return fooProgram
@@ -1261,7 +1261,7 @@ func TestContractField(t *testing.T) {
 
 		comp := compiler.NewInstructionCompiler(checker).
 			WithConfig(&compiler.Config{
-				ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+				ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 					return importedProgram
 				},
 			})
@@ -1269,7 +1269,7 @@ func TestContractField(t *testing.T) {
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -1332,14 +1332,14 @@ func TestContractField(t *testing.T) {
 		require.NoError(t, err)
 
 		comp := compiler.NewInstructionCompiler(checker)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -1637,14 +1637,14 @@ func TestInterfaceMethodCall(t *testing.T) {
 
 		comp := compiler.NewInstructionCompiler(checker)
 		comp.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -1776,7 +1776,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		bazImportHandler := func(location common.Location) *bbq.Program[opcode.Instruction] {
+		bazImportHandler := func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			switch location {
 			case fooLocation:
 				return fooProgram
@@ -1851,7 +1851,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		scriptImportHandler := func(location common.Location) *bbq.Program[opcode.Instruction] {
+		scriptImportHandler := func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			switch location {
 			case barLocation:
 				return barProgram
@@ -1932,7 +1932,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		scriptImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction] {
+		scriptImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 			switch location {
 			case fooLocation:
 				return fooProgram
@@ -2332,7 +2332,7 @@ func TestDefaultFunctions(t *testing.T) {
 		vmConfig := &vm.Config{
 			Storage:        storage,
 			AccountHandler: &testAccountHandler{},
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				program, ok := programs[location]
 				if !ok {
 					assert.FailNow(t, "invalid location")
@@ -2445,7 +2445,7 @@ func TestDefaultFunctions(t *testing.T) {
 		vmConfig := &vm.Config{
 			Storage:        storage,
 			AccountHandler: &testAccountHandler{},
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				program, ok := programs[location]
 				if !ok {
 					assert.FailNow(t, "invalid location")
@@ -2549,7 +2549,7 @@ func TestDefaultFunctions(t *testing.T) {
 		vmConfig := &vm.Config{
 			Storage:        storage,
 			AccountHandler: &testAccountHandler{},
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				program, ok := programs[location]
 				if !ok {
 					assert.FailNow(t, "invalid location")
@@ -2878,7 +2878,7 @@ func TestFunctionPreConditions(t *testing.T) {
 		vmConfig := &vm.Config{
 			Storage:        storage,
 			AccountHandler: &testAccountHandler{},
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction] {
+			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
 				program, ok := programs[location]
 				if !ok {
 					assert.FailNow(t, "invalid location")

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -20,24 +20,22 @@ package test
 
 import (
 	"fmt"
-	"github.com/onflow/cadence/bbq/opcode"
 	"testing"
-
-	"github.com/onflow/cadence/interpreter"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/stdlib"
 	"github.com/onflow/cadence/test_utils/common_utils"
 	"github.com/onflow/cadence/test_utils/runtime_utils"
 	. "github.com/onflow/cadence/test_utils/sema_utils"
 
-	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/bbq/commons"
 	"github.com/onflow/cadence/bbq/compiler"
 	"github.com/onflow/cadence/bbq/vm"
@@ -485,14 +483,14 @@ func TestImport(t *testing.T) {
 	require.NoError(t, err)
 
 	importCompiler := compiler.NewInstructionCompiler(checker)
-	importCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+	importCompiler.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 		return importedProgram
 	}
 
 	program := importCompiler.Compile()
 
 	vmConfig := &vm.Config{
-		ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		},
 	}
@@ -572,14 +570,14 @@ func TestContractImport(t *testing.T) {
 		require.NoError(t, err)
 
 		comp := compiler.NewInstructionCompiler(checker)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
 			ContractValueHandler: func(*vm.Config, common.Location) *vm.CompositeValue {
@@ -647,14 +645,14 @@ func TestContractImport(t *testing.T) {
 		require.NoError(t, err)
 
 		comp := compiler.NewInstructionCompiler(checker)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
 			ContractValueHandler: func(*vm.Config, common.Location) *vm.CompositeValue {
@@ -739,7 +737,7 @@ func TestContractImport(t *testing.T) {
 
 		barCompiler := compiler.NewInstructionCompiler(barChecker)
 		barCompiler.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		barCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		barCompiler.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 			require.Equal(t, fooLocation, location)
 			return fooProgram
 		}
@@ -747,7 +745,7 @@ func TestContractImport(t *testing.T) {
 		barProgram := barCompiler.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				require.Equal(t, fooLocation, location)
 				return fooProgram
 			},
@@ -796,7 +794,7 @@ func TestContractImport(t *testing.T) {
 
 		comp := compiler.NewInstructionCompiler(checker)
 		comp.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 			switch location {
 			case fooLocation:
 				return fooProgram
@@ -811,7 +809,7 @@ func TestContractImport(t *testing.T) {
 		program := comp.Compile()
 
 		vmConfig = &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				switch location {
 				case fooLocation:
 					return fooProgram
@@ -906,7 +904,7 @@ func TestContractImport(t *testing.T) {
 
 		barCompiler := compiler.NewInstructionCompiler(barChecker)
 		barCompiler.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		barCompiler.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		barCompiler.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 			require.Equal(t, fooLocation, location)
 			return fooProgram
 		}
@@ -925,7 +923,7 @@ func TestContractImport(t *testing.T) {
 		barProgram := barCompiler.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				require.Equal(t, fooLocation, location)
 				return fooProgram
 			},
@@ -970,7 +968,7 @@ func TestContractImport(t *testing.T) {
 
 		comp := compiler.NewInstructionCompiler(checker)
 		comp.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 			switch location {
 			case fooLocation:
 				return fooProgram
@@ -985,7 +983,7 @@ func TestContractImport(t *testing.T) {
 		program := comp.Compile()
 
 		vmConfig = &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				switch location {
 				case fooLocation:
 					return fooProgram
@@ -1261,7 +1259,7 @@ func TestContractField(t *testing.T) {
 
 		comp := compiler.NewInstructionCompiler(checker).
 			WithConfig(&compiler.Config{
-				ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+				ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 					return importedProgram
 				},
 			})
@@ -1269,7 +1267,7 @@ func TestContractField(t *testing.T) {
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -1332,14 +1330,14 @@ func TestContractField(t *testing.T) {
 		require.NoError(t, err)
 
 		comp := compiler.NewInstructionCompiler(checker)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -1637,14 +1635,14 @@ func TestInterfaceMethodCall(t *testing.T) {
 
 		comp := compiler.NewInstructionCompiler(checker)
 		comp.Config.LocationHandler = singleIdentifierLocationResolver(t)
-		comp.Config.ImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		}
 
 		program := comp.Compile()
 
 		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
 			ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *vm.CompositeValue {
@@ -1776,7 +1774,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		bazImportHandler := func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		bazImportHandler := func(location common.Location) *bbq.InstructionProgram {
 			switch location {
 			case fooLocation:
 				return fooProgram
@@ -1851,7 +1849,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		scriptImportHandler := func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		scriptImportHandler := func(location common.Location) *bbq.InstructionProgram {
 			switch location {
 			case barLocation:
 				return barProgram
@@ -1932,7 +1930,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		scriptImportHandler = func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+		scriptImportHandler = func(location common.Location) *bbq.InstructionProgram {
 			switch location {
 			case fooLocation:
 				return fooProgram
@@ -2332,7 +2330,7 @@ func TestDefaultFunctions(t *testing.T) {
 		vmConfig := &vm.Config{
 			Storage:        storage,
 			AccountHandler: &testAccountHandler{},
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				program, ok := programs[location]
 				if !ok {
 					assert.FailNow(t, "invalid location")
@@ -2445,7 +2443,7 @@ func TestDefaultFunctions(t *testing.T) {
 		vmConfig := &vm.Config{
 			Storage:        storage,
 			AccountHandler: &testAccountHandler{},
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				program, ok := programs[location]
 				if !ok {
 					assert.FailNow(t, "invalid location")
@@ -2549,7 +2547,7 @@ func TestDefaultFunctions(t *testing.T) {
 		vmConfig := &vm.Config{
 			Storage:        storage,
 			AccountHandler: &testAccountHandler{},
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				program, ok := programs[location]
 				if !ok {
 					assert.FailNow(t, "invalid location")
@@ -2878,7 +2876,7 @@ func TestFunctionPreConditions(t *testing.T) {
 		vmConfig := &vm.Config{
 			Storage:        storage,
 			AccountHandler: &testAccountHandler{},
-			ImportHandler: func(location common.Location) *bbq.Program[opcode.Instruction, bbq.StaticType] {
+			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				program, ok := programs[location]
 				if !ok {
 					assert.FailNow(t, "invalid location")

--- a/bbq/vm/value.go
+++ b/bbq/vm/value.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/interpreter"
 )

--- a/bbq/vm/value.go
+++ b/bbq/vm/value.go
@@ -20,13 +20,13 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/interpreter"
 )
 
 type Value interface {
 	isValue()
-	StaticType(*Config) StaticType
+	StaticType(*Config) bbq.StaticType
 	Transfer(
 		config *Config,
 		address atree.Address,
@@ -73,13 +73,13 @@ type ValueIterator interface {
 // ConvertAndBox converts a value to a target type, and boxes in optionals and any value, if necessary
 func ConvertAndBox(
 	value Value,
-	valueType, targetType StaticType,
+	valueType, targetType bbq.StaticType,
 ) Value {
 	value = convert(value, valueType, targetType)
 	return BoxOptional(value, targetType)
 }
 
-func convert(value Value, valueType, targetType StaticType) Value {
+func convert(value Value, valueType, targetType bbq.StaticType) Value {
 	if valueType == nil {
 		return value
 	}
@@ -122,7 +122,7 @@ func Unbox(value Value) Value {
 // BoxOptional boxes a value in optionals, if necessary
 func BoxOptional(
 	value Value,
-	targetType StaticType,
+	targetType bbq.StaticType,
 ) Value {
 
 	inner := value

--- a/bbq/vm/value_account.go
+++ b/bbq/vm/value_account.go
@@ -19,6 +19,7 @@
 package vm
 
 import (
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
@@ -252,7 +253,7 @@ func checkAndIssueStorageCapabilityControllerWithType(
 	idGenerator AccountIDGenerator,
 	address common.Address,
 	targetPathValue PathValue,
-	ty StaticType,
+	ty bbq.StaticType,
 ) CapabilityValue {
 
 	borrowType, ok := ty.(*interpreter.ReferenceStaticType)

--- a/bbq/vm/value_account_capabilities.go
+++ b/bbq/vm/value_account_capabilities.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"

--- a/bbq/vm/value_account_capabilities.go
+++ b/bbq/vm/value_account_capabilities.go
@@ -20,7 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
@@ -67,7 +67,7 @@ func init() {
 		sema.Account_CapabilitiesTypeGetFunctionName,
 		NativeFunctionValue{
 			ParameterCount: len(sema.Account_CapabilitiesTypeGetFunctionType.Parameters),
-			Function: func(config *Config, typeArguments []StaticType, args ...Value) Value {
+			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.Capabilities)
 				address := getAddressMetaInfoFromValue(args[0])
 
@@ -108,7 +108,7 @@ func init() {
 		sema.Account_CapabilitiesTypePublishFunctionName,
 		NativeFunctionValue{
 			ParameterCount: len(sema.Account_CapabilitiesTypePublishFunctionType.Parameters),
-			Function: func(config *Config, typeArguments []StaticType, args ...Value) Value {
+			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.Capabilities)
 				accountAddress := getAddressMetaInfoFromValue(args[0])
 

--- a/bbq/vm/value_account_storage.go
+++ b/bbq/vm/value_account_storage.go
@@ -20,7 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
@@ -53,7 +53,7 @@ func init() {
 		sema.Account_StorageTypeSaveFunctionName,
 		NativeFunctionValue{
 			ParameterCount: len(sema.Account_StorageTypeSaveFunctionType.Parameters),
-			Function: func(config *Config, typeArs []StaticType, args ...Value) Value {
+			Function: func(config *Config, typeArs []bbq.StaticType, args ...Value) Value {
 				address := getAddressMetaInfoFromValue(args[0])
 
 				value := args[1]
@@ -104,7 +104,7 @@ func init() {
 		sema.Account_StorageTypeBorrowFunctionName,
 		NativeFunctionValue{
 			ParameterCount: len(sema.Account_StorageTypeBorrowFunctionType.Parameters),
-			Function: func(config *Config, typeArgs []StaticType, args ...Value) Value {
+			Function: func(config *Config, typeArgs []bbq.StaticType, args ...Value) Value {
 				address := getAddressMetaInfoFromValue(args[0])
 
 				path, ok := args[1].(PathValue)

--- a/bbq/vm/value_account_storage.go
+++ b/bbq/vm/value_account_storage.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"

--- a/bbq/vm/value_account_storagecapabilities.go
+++ b/bbq/vm/value_account_storagecapabilities.go
@@ -19,6 +19,7 @@
 package vm
 
 import (
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
@@ -50,7 +51,7 @@ func init() {
 		sema.Account_StorageCapabilitiesTypeIssueFunctionName,
 		NativeFunctionValue{
 			ParameterCount: len(sema.Account_StorageCapabilitiesTypeIssueFunctionType.Parameters),
-			Function: func(config *Config, typeArguments []StaticType, args ...Value) Value {
+			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.StorageCapabilities)
 				accountAddress := getAddressMetaInfoFromValue(args[0])
 

--- a/bbq/vm/value_address.go
+++ b/bbq/vm/value_address.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/format"

--- a/bbq/vm/value_address.go
+++ b/bbq/vm/value_address.go
@@ -20,7 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/interpreter"
@@ -32,7 +32,7 @@ var _ Value = AddressValue{}
 
 func (AddressValue) isValue() {}
 
-func (AddressValue) StaticType(*Config) StaticType {
+func (AddressValue) StaticType(*Config) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeAddress
 }
 

--- a/bbq/vm/value_array.go
+++ b/bbq/vm/value_array.go
@@ -20,8 +20,8 @@ package vm
 
 import (
 	goerrors "errors"
-
 	"github.com/onflow/atree"
+	"github.com/onflow/cadence/bbq"
 
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
@@ -139,7 +139,7 @@ func (v *ArrayValue) isValue() {
 	panic("implement me")
 }
 
-func (v *ArrayValue) StaticType(*Config) StaticType {
+func (v *ArrayValue) StaticType(*Config) bbq.StaticType {
 	return v.Type
 }
 
@@ -443,7 +443,7 @@ var _ ValueIterator = &ArrayIterator{}
 
 func (i *ArrayIterator) isValue() {}
 
-func (i *ArrayIterator) StaticType(_ *Config) StaticType {
+func (i *ArrayIterator) StaticType(_ *Config) bbq.StaticType {
 	// Iterator is an internal-only value.
 	// Hence, this should never be called.
 	panic(errors.NewUnreachableError())

--- a/bbq/vm/value_array.go
+++ b/bbq/vm/value_array.go
@@ -20,9 +20,10 @@ package vm
 
 import (
 	goerrors "errors"
-	"github.com/onflow/atree"
-	"github.com/onflow/cadence/bbq"
 
+	"github.com/onflow/atree"
+
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"

--- a/bbq/vm/value_bool.go
+++ b/bbq/vm/value_bool.go
@@ -20,7 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/interpreter"
 )
@@ -35,7 +35,7 @@ var _ EquatableValue = BoolValue(true)
 
 func (BoolValue) isValue() {}
 
-func (BoolValue) StaticType(*Config) StaticType {
+func (BoolValue) StaticType(*Config) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeBool
 }
 

--- a/bbq/vm/value_bool.go
+++ b/bbq/vm/value_bool.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/interpreter"

--- a/bbq/vm/value_capability.go
+++ b/bbq/vm/value_capability.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"

--- a/bbq/vm/value_capability.go
+++ b/bbq/vm/value_capability.go
@@ -20,7 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
@@ -32,13 +32,13 @@ import (
 
 type CapabilityValue struct {
 	Address    AddressValue
-	BorrowType StaticType
+	BorrowType bbq.StaticType
 	ID         IntValue // TODO: UInt64Value
 }
 
 var _ Value = CapabilityValue{}
 
-func NewCapabilityValue(address AddressValue, id IntValue, borrowType StaticType) CapabilityValue {
+func NewCapabilityValue(address AddressValue, id IntValue, borrowType bbq.StaticType) CapabilityValue {
 	return CapabilityValue{
 		Address:    address,
 		BorrowType: borrowType,
@@ -48,7 +48,7 @@ func NewCapabilityValue(address AddressValue, id IntValue, borrowType StaticType
 
 func NewInvalidCapabilityValue(
 	address common.Address,
-	borrowType StaticType,
+	borrowType bbq.StaticType,
 ) CapabilityValue {
 	return CapabilityValue{
 		ID:         InvalidCapabilityID,
@@ -59,7 +59,7 @@ func NewInvalidCapabilityValue(
 
 func (CapabilityValue) isValue() {}
 
-func (v CapabilityValue) StaticType(config *Config) StaticType {
+func (v CapabilityValue) StaticType(config *Config) bbq.StaticType {
 	return interpreter.NewCapabilityStaticType(config.MemoryGauge, v.BorrowType)
 }
 
@@ -90,7 +90,7 @@ func init() {
 		sema.CapabilityTypeBorrowFunctionName,
 		NativeFunctionValue{
 			ParameterCount: 0,
-			Function: func(config *Config, typeArguments []StaticType, args ...Value) Value {
+			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				capabilityValue := getReceiver[CapabilityValue](config, args[0])
 				capabilityID := capabilityValue.ID
 

--- a/bbq/vm/value_capability_controller.go
+++ b/bbq/vm/value_capability_controller.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"

--- a/bbq/vm/value_capability_controller.go
+++ b/bbq/vm/value_capability_controller.go
@@ -20,7 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
@@ -96,7 +96,7 @@ func (v *StorageCapabilityControllerValue) CapabilityControllerBorrowType() *int
 	return v.BorrowType
 }
 
-func (v *StorageCapabilityControllerValue) StaticType(*Config) StaticType {
+func (v *StorageCapabilityControllerValue) StaticType(*Config) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeStorageCapabilityController
 }
 
@@ -163,7 +163,7 @@ func init() {
 		sema.StorageCapabilityControllerTypeSetTagFunctionName,
 		NativeFunctionValue{
 			ParameterCount: 0,
-			Function: func(config *Config, typeArguments []StaticType, args ...Value) Value {
+			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				capabilityValue := args[0].(*StorageCapabilityControllerValue)
 
 				//stdlib.SetCapabilityControllerTag(config.interpreter())

--- a/bbq/vm/value_composite.go
+++ b/bbq/vm/value_composite.go
@@ -20,8 +20,8 @@ package vm
 
 import (
 	goerrors "errors"
-
 	"github.com/onflow/atree"
+	"github.com/onflow/cadence/bbq"
 
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
@@ -87,7 +87,7 @@ func newCompositeValueFromOrderedMap(
 
 func (*CompositeValue) isValue() {}
 
-func (v *CompositeValue) StaticType(*Config) StaticType {
+func (v *CompositeValue) StaticType(*Config) bbq.StaticType {
 	return v.CompositeType
 }
 

--- a/bbq/vm/value_composite.go
+++ b/bbq/vm/value_composite.go
@@ -20,9 +20,10 @@ package vm
 
 import (
 	goerrors "errors"
-	"github.com/onflow/atree"
-	"github.com/onflow/cadence/bbq"
 
+	"github.com/onflow/atree"
+
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"

--- a/bbq/vm/value_dictionary.go
+++ b/bbq/vm/value_dictionary.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/atree"
 
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
@@ -112,7 +113,7 @@ func newDictionaryValueFromAtreeMap(
 
 func (*DictionaryValue) isValue() {}
 
-func (v *DictionaryValue) StaticType(*Config) StaticType {
+func (v *DictionaryValue) StaticType(*Config) bbq.StaticType {
 	return v.Type
 }
 

--- a/bbq/vm/value_ephemeral_reference.go
+++ b/bbq/vm/value_ephemeral_reference.go
@@ -20,7 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/interpreter"
 )
@@ -73,7 +73,7 @@ func (v *EphemeralReferenceValue) BorrowType() interpreter.StaticType {
 	return v.BorrowedType
 }
 
-func (v *EphemeralReferenceValue) StaticType(config *Config) StaticType {
+func (v *EphemeralReferenceValue) StaticType(config *Config) bbq.StaticType {
 	return interpreter.NewReferenceStaticType(
 		config.MemoryGauge,
 		v.Authorization,

--- a/bbq/vm/value_ephemeral_reference.go
+++ b/bbq/vm/value_ephemeral_reference.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/interpreter"

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/errors"

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -20,7 +20,6 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/errors"
@@ -35,7 +34,7 @@ var _ Value = FunctionValue{}
 
 func (FunctionValue) isValue() {}
 
-func (FunctionValue) StaticType(*Config) StaticType {
+func (FunctionValue) StaticType(*Config) bbq.StaticType {
 	panic(errors.NewUnreachableError())
 }
 
@@ -48,7 +47,7 @@ func (v FunctionValue) String() string {
 	panic("implement me")
 }
 
-type NativeFunction func(config *Config, typeArguments []StaticType, arguments ...Value) Value
+type NativeFunction func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value
 
 type NativeFunctionValue struct {
 	Name           string
@@ -60,7 +59,7 @@ var _ Value = NativeFunctionValue{}
 
 func (NativeFunctionValue) isValue() {}
 
-func (NativeFunctionValue) StaticType(*Config) StaticType {
+func (NativeFunctionValue) StaticType(*Config) bbq.StaticType {
 	panic(errors.NewUnreachableError())
 }
 

--- a/bbq/vm/value_int.go
+++ b/bbq/vm/value_int.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/atree"
 
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 )
@@ -48,7 +49,7 @@ var _ NumberValue = IntValue{}
 
 func (IntValue) isValue() {}
 
-func (IntValue) StaticType(*Config) StaticType {
+func (IntValue) StaticType(*Config) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeInt
 }
 
@@ -144,7 +145,7 @@ func init() {
 
 	RegisterTypeBoundFunction(typeName, sema.ToStringFunctionName, NativeFunctionValue{
 		ParameterCount: len(sema.ToStringFunctionType.Parameters),
-		Function: func(config *Config, typeArguments []StaticType, value ...Value) Value {
+		Function: func(config *Config, typeArguments []bbq.StaticType, value ...Value) Value {
 			number := value[0].(IntValue)
 			return NewStringValue(number.String())
 		},

--- a/bbq/vm/value_nil.go
+++ b/bbq/vm/value_nil.go
@@ -20,7 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/interpreter"
 )
@@ -34,7 +34,7 @@ var Nil Value = NilValue{}
 
 func (NilValue) isValue() {}
 
-func (NilValue) StaticType(config *Config) StaticType {
+func (NilValue) StaticType(config *Config) bbq.StaticType {
 	return interpreter.NewOptionalStaticType(
 		config.MemoryGauge,
 		interpreter.PrimitiveStaticTypeNever,

--- a/bbq/vm/value_nil.go
+++ b/bbq/vm/value_nil.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/interpreter"

--- a/bbq/vm/value_path.go
+++ b/bbq/vm/value_path.go
@@ -20,7 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/format"
@@ -38,7 +38,7 @@ var _ Value = PathValue{}
 
 func (PathValue) isValue() {}
 
-func (v PathValue) StaticType(*Config) StaticType {
+func (v PathValue) StaticType(*Config) bbq.StaticType {
 	switch v.Domain {
 	case common.PathDomainStorage:
 		return interpreter.PrimitiveStaticTypeStoragePath

--- a/bbq/vm/value_path.go
+++ b/bbq/vm/value_path.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"

--- a/bbq/vm/value_simple_composite.go
+++ b/bbq/vm/value_simple_composite.go
@@ -20,13 +20,13 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 )
 
 type SimpleCompositeValue struct {
 	typeID     common.TypeID
-	staticType StaticType
+	staticType bbq.StaticType
 	Kind       common.CompositeKind
 
 	fields       map[string]Value
@@ -55,7 +55,7 @@ func NewSimpleCompositeValue(
 
 func (*SimpleCompositeValue) isValue() {}
 
-func (v *SimpleCompositeValue) StaticType(*Config) StaticType {
+func (v *SimpleCompositeValue) StaticType(*Config) bbq.StaticType {
 	return v.staticType
 }
 

--- a/bbq/vm/value_simple_composite.go
+++ b/bbq/vm/value_simple_composite.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 )

--- a/bbq/vm/value_some.go
+++ b/bbq/vm/value_some.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/interpreter"
 )

--- a/bbq/vm/value_some.go
+++ b/bbq/vm/value_some.go
@@ -20,7 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/interpreter"
 )
 
@@ -41,7 +41,7 @@ func NewSomeValueNonCopying(value Value) *SomeValue {
 
 func (*SomeValue) isValue() {}
 
-func (v *SomeValue) StaticType(config *Config) StaticType {
+func (v *SomeValue) StaticType(config *Config) bbq.StaticType {
 	innerType := v.value.StaticType(config)
 	if innerType == nil {
 		return nil

--- a/bbq/vm/value_storage_reference.go
+++ b/bbq/vm/value_storage_reference.go
@@ -20,9 +20,10 @@ package vm
 
 import (
 	"fmt"
-	"github.com/onflow/atree"
-	"github.com/onflow/cadence/bbq"
 
+	"github.com/onflow/atree"
+
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/interpreter"
@@ -104,6 +105,8 @@ func (v *StorageReferenceValue) dereference(config *Config) (*Value, error) {
 
 		if !IsSubType(config, staticType, v.BorrowedType) {
 			panic(fmt.Errorf("type mismatch: expected %s, found %s", v.BorrowedType, staticType))
+
+			// TODO:
 			//semaType := interpreter.MustConvertStaticToSemaType(staticType)
 			//
 			//return nil, ForceCastTypeMismatchError{

--- a/bbq/vm/value_storage_reference.go
+++ b/bbq/vm/value_storage_reference.go
@@ -20,8 +20,8 @@ package vm
 
 import (
 	"fmt"
-
 	"github.com/onflow/atree"
+	"github.com/onflow/cadence/bbq"
 
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/format"
@@ -70,7 +70,7 @@ func (v *StorageReferenceValue) BorrowType() interpreter.StaticType {
 	return v.BorrowedType
 }
 
-func (v *StorageReferenceValue) StaticType(config *Config) StaticType {
+func (v *StorageReferenceValue) StaticType(config *Config) bbq.StaticType {
 	referencedValue, err := v.dereference(config)
 	if err != nil {
 		panic(err)

--- a/bbq/vm/value_string.go
+++ b/bbq/vm/value_string.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/atree"
 
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 )
@@ -47,7 +48,7 @@ func NewStringValueFromBytes(bytes []byte) StringValue {
 
 func (StringValue) isValue() {}
 
-func (StringValue) StaticType(*Config) StaticType {
+func (StringValue) StaticType(*Config) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeString
 }
 
@@ -70,7 +71,7 @@ func init() {
 
 	RegisterTypeBoundFunction(typeName, StringConcatFunctionName, NativeFunctionValue{
 		ParameterCount: len(sema.StringTypeConcatFunctionType.Parameters),
-		Function: func(config *Config, typeArguments []StaticType, value ...Value) Value {
+		Function: func(config *Config, typeArguments []bbq.StaticType, value ...Value) Value {
 			first := value[0].(StringValue)
 			second := value[1].(StringValue)
 			var sb strings.Builder

--- a/bbq/vm/value_ufix64.go
+++ b/bbq/vm/value_ufix64.go
@@ -19,11 +19,11 @@
 package vm
 
 import (
-	"github.com/onflow/cadence/bbq"
 	"math/big"
 
 	"github.com/onflow/atree"
 
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"

--- a/bbq/vm/value_ufix64.go
+++ b/bbq/vm/value_ufix64.go
@@ -19,6 +19,7 @@
 package vm
 
 import (
+	"github.com/onflow/cadence/bbq"
 	"math/big"
 
 	"github.com/onflow/atree"
@@ -45,7 +46,7 @@ var _ NumberValue = UFix64Value(0)
 
 func (UFix64Value) isValue() {}
 
-func (UFix64Value) StaticType(*Config) StaticType {
+func (UFix64Value) StaticType(*Config) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeUFix64
 }
 

--- a/bbq/vm/value_void.go
+++ b/bbq/vm/value_void.go
@@ -20,7 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/interpreter"
 )
@@ -31,7 +31,7 @@ var Void Value = VoidValue{}
 
 func (VoidValue) isValue() {}
 
-func (VoidValue) StaticType(*Config) StaticType {
+func (VoidValue) StaticType(*Config) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeVoid
 }
 

--- a/bbq/vm/value_void.go
+++ b/bbq/vm/value_void.go
@@ -20,6 +20,7 @@ package vm
 
 import (
 	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/interpreter"

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -49,7 +49,7 @@ type VM struct {
 
 func NewVM(
 	location common.Location,
-	program *bbq.Program[opcode.Instruction, bbq.StaticType],
+	program *bbq.InstructionProgram,
 	conf *Config,
 ) *VM {
 	// TODO: Remove initializing config. Following is for testing purpose only.

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -49,7 +49,7 @@ type VM struct {
 
 func NewVM(
 	location common.Location,
-	program *bbq.Program[opcode.Instruction],
+	program *bbq.Program[opcode.Instruction, bbq.StaticType],
 	conf *Config,
 ) *VM {
 	// TODO: Remove initializing config. Following is for testing purpose only.
@@ -482,7 +482,7 @@ func opInvoke(vm *VM, ins opcode.InstructionInvoke) {
 	case NativeFunctionValue:
 		parameterCount := value.ParameterCount
 
-		var typeArguments []StaticType
+		var typeArguments []bbq.StaticType
 		for _, index := range ins.TypeArgs {
 			typeArg := vm.loadType(index)
 			typeArguments = append(typeArguments, typeArg)
@@ -503,7 +503,7 @@ func opInvokeDynamic(vm *VM, ins opcode.InstructionInvokeDynamic) {
 	receiver := vm.stack[stackHeight-int(ins.ArgCount)-1]
 
 	// TODO:
-	var typeArguments []StaticType
+	var typeArguments []bbq.StaticType
 	for _, index := range ins.TypeArgs {
 		typeArg := vm.loadType(index)
 		typeArguments = append(typeArguments, typeArg)
@@ -688,7 +688,7 @@ func opForceCast(vm *VM, ins opcode.InstructionForceCast) {
 	vm.push(result)
 }
 
-func castValueAndValueType(config *Config, targetType StaticType, value Value) (Value, StaticType) {
+func castValueAndValueType(config *Config, targetType bbq.StaticType, value Value) (Value, bbq.StaticType) {
 	valueType := value.StaticType(config)
 
 	// if the value itself has a mapped entitlement type in its authorization
@@ -958,31 +958,13 @@ func (vm *VM) initializeConstant(index uint16) (value Value) {
 	return value
 }
 
-func (vm *VM) loadType(index uint16) StaticType {
+func (vm *VM) loadType(index uint16) bbq.StaticType {
 	staticType := vm.callFrame.executable.StaticTypes[index]
 	if staticType == nil {
-		// TODO: Remove. Should never reach because of the
-		// pre loading-decoding of types.
-		staticType = vm.initializeType(index)
+		// Should never reach.
+		panic(errors.NewUnreachableError())
 	}
 
-	return staticType
-}
-
-func (vm *VM) initializeType(index uint16) interpreter.StaticType {
-	executable := vm.callFrame.executable
-	typeBytes := executable.Program.Types[index]
-	staticType := decodeType(typeBytes)
-	executable.StaticTypes[index] = staticType
-	return staticType
-}
-
-func decodeType(typeBytes []byte) interpreter.StaticType {
-	dec := interpreter.CBORDecMode.NewByteStreamDecoder(typeBytes)
-	staticType, err := interpreter.NewTypeDecoder(dec, nil).DecodeStaticType()
-	if err != nil {
-		panic(err)
-	}
 	return staticType
 }
 

--- a/bbq/vm/vm_test.go
+++ b/bbq/vm/vm_test.go
@@ -25,13 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/bbq"
-	"github.com/onflow/cadence/bbq/opcode"
 )
 
 func TestVM_pop(t *testing.T) {
 	t.Parallel()
 
-	program := &bbq.Program[opcode.Instruction]{}
+	program := &bbq.InstructionProgram{}
 	vm := NewVM(nil, program, nil)
 
 	vm.push(NewIntValue(1))
@@ -60,7 +59,7 @@ func TestVM_pop(t *testing.T) {
 func TestVM_peekPop(t *testing.T) {
 	t.Parallel()
 
-	program := &bbq.Program[opcode.Instruction]{}
+	program := &bbq.InstructionProgram{}
 	vm := NewVM(nil, program, nil)
 
 	vm.push(NewIntValue(1))
@@ -93,7 +92,7 @@ func TestVM_peekPop(t *testing.T) {
 func TestVM_replaceTop(t *testing.T) {
 	t.Parallel()
 
-	program := &bbq.Program[opcode.Instruction]{}
+	program := &bbq.InstructionProgram{}
 	vm := NewVM(nil, program, nil)
 
 	vm.push(NewIntValue(1))
@@ -121,7 +120,7 @@ func TestVM_replaceTop(t *testing.T) {
 func TestVM_pop2(t *testing.T) {
 	t.Parallel()
 
-	program := &bbq.Program[opcode.Instruction]{}
+	program := &bbq.InstructionProgram{}
 	vm := NewVM(nil, program, nil)
 
 	vm.push(NewIntValue(1))
@@ -144,7 +143,7 @@ func TestVM_pop2(t *testing.T) {
 func TestVM_pop3(t *testing.T) {
 	t.Parallel()
 
-	program := &bbq.Program[opcode.Instruction]{}
+	program := &bbq.InstructionProgram{}
 	vm := NewVM(nil, program, nil)
 
 	vm.push(NewIntValue(1))
@@ -179,7 +178,7 @@ func TestVM_pop3(t *testing.T) {
 func TestVM_peek(t *testing.T) {
 	t.Parallel()
 
-	program := &bbq.Program[opcode.Instruction]{}
+	program := &bbq.InstructionProgram{}
 	vm := NewVM(nil, program, nil)
 
 	vm.push(NewIntValue(1))
@@ -212,7 +211,7 @@ func TestVM_peek(t *testing.T) {
 func TestVM_peekN(t *testing.T) {
 	t.Parallel()
 
-	program := &bbq.Program[opcode.Instruction]{}
+	program := &bbq.InstructionProgram{}
 	vm := NewVM(nil, program, nil)
 
 	vm.push(NewIntValue(1))
@@ -246,7 +245,7 @@ func TestVM_peekN(t *testing.T) {
 func TestVM_dropN(t *testing.T) {
 	t.Parallel()
 
-	program := &bbq.Program[opcode.Instruction]{}
+	program := &bbq.InstructionProgram{}
 	vm := NewVM(nil, program, nil)
 
 	vm.push(NewIntValue(1))


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3769

## Description

Currently, the compiler produces a program where all types are encoded (converted to bytes), and in the VM, these types are decoded back again. However, given compilation happens on the same place, this encoding and then decoding of types is an unnecessary overhead.

Therefore, updated the compiler such that it produce the decoded type, and the VM can use it directly without having to decode. This is similar to emitting instructions vs bytecode.

Micro-benchmarks showed that this reduced about 17% of the compile+execution time for FT transfer.
```
             │ ft_existing │            ft_optimized            │
             │   sec/op    │   sec/op     vs base               │
FTTransfer-8   88.97µ ± 3%   73.54µ ± 2%  -17.34% (p=0.002 n=6)

             │ ft_existing  │            ft_optimized             │
             │     B/op     │     B/op      vs base               │
FTTransfer-8   65.76Ki ± 0%   55.75Ki ± 0%  -15.22% (p=0.002 n=6)

             │ ft_existing │            ft_optimized            │
             │  allocs/op  │  allocs/op   vs base               │
FTTransfer-8   1.268k ± 0%   1.033k ± 0%  -18.53% (p=0.002 n=6)
```

We could potentially do the same for constants as well.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
