### PR TITLE
Re-enable skipped entitlement mapping tests

### DIFF
--- a/interpreter/entitlements_test.go
+++ b/interpreter/entitlements_test.go
@@ -3047,7 +3047,7 @@ func TestInterpretIdentityMapping(t *testing.T) {
 	})
 }
 
-func NoTestInterpretMappingInclude(t *testing.T) {
+func TestInterpretMappingInclude(t *testing.T) {
 
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Looks like this was accidentally disabled during a master-branch sync/merge (https://github.com/onflow/cadence/blame/e583b53ad4ca72f085b96608db7c250fe2aaf384/interpreter/entitlements_test.go#L3050C6-L3050C35)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
