### PR TITLE
Fix TestHashable

### DIFF
--- a/interpreter/value_test.go
+++ b/interpreter/value_test.go
@@ -3484,7 +3484,7 @@ func TestHashable(t *testing.T) {
 	pkgs, err := packages.Load(
 		&packages.Config{
 			// https://github.com/golang/go/issues/45218
-			Mode: packages.NeedImports | packages.NeedTypes,
+			Mode: packages.NeedImports | packages.NeedDeps | packages.NeedTypes,
 		},
 		"github.com/onflow/cadence/interpreter",
 	)


### PR DESCRIPTION
## Description

Probably due to the upgrade to Go 1.24, `TestHashable` started to fail for me with a nil-pointer exception, for the use of the nil result of `scope.Lookup`. I was not able to find an issue in the Go repo specifically related to this, but the changes fixes the problem and properly loads the type information for the package again.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
