### PR TITLE
[Compiler] Optimize allocations and program components

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -451,17 +451,23 @@ func (c *Compiler[_, _]) reserveGlobalVars(
 	}
 }
 
-func (c *Compiler[_, _]) exportConstants() []*bbq.Constant {
-	constants := make([]*bbq.Constant, 0, len(c.constants))
-	for _, constant := range c.constants {
-		constants = append(
-			constants,
-			&bbq.Constant{
-				Data: constant.data,
-				Kind: constant.kind,
-			},
-		)
+func (c *Compiler[_, _]) exportConstants() []bbq.Constant {
+	var constants []bbq.Constant
+
+	count := len(c.constants)
+	if count > 0 {
+		constants = make([]bbq.Constant, 0, count)
+		for _, constant := range c.constants {
+			constants = append(
+				constants,
+				bbq.Constant{
+					Data: constant.data,
+					Kind: constant.kind,
+				},
+			)
+		}
 	}
+
 	return constants
 }
 
@@ -469,46 +475,63 @@ func (c *Compiler[_, T]) exportTypes() []T {
 	return c.staticTypes
 }
 
-func (c *Compiler[_, _]) exportImports() []*bbq.Import {
-	exportedImports := make([]*bbq.Import, 0)
-	for _, importedGlobal := range c.usedImportedGlobals {
-		bbqImport := &bbq.Import{
-			Location: importedGlobal.Location,
-			Name:     importedGlobal.Name,
+func (c *Compiler[_, _]) exportImports() []bbq.Import {
+	var exportedImports []bbq.Import
+
+	count := len(c.usedImportedGlobals)
+	if count > 0 {
+		exportedImports = make([]bbq.Import, 0, count)
+		for _, importedGlobal := range c.usedImportedGlobals {
+			bbqImport := bbq.Import{
+				Location: importedGlobal.Location,
+				Name:     importedGlobal.Name,
+			}
+			exportedImports = append(exportedImports, bbqImport)
 		}
-		exportedImports = append(exportedImports, bbqImport)
 	}
 
 	return exportedImports
 }
 
-func (c *Compiler[E, T]) ExportFunctions() []*bbq.Function[E] {
-	functions := make([]*bbq.Function[E], 0, len(c.functions))
-	for _, function := range c.functions {
-		functions = append(
-			functions,
-			&bbq.Function[E]{
-				Name:                function.name,
-				Code:                function.code,
-				LocalCount:          function.localCount,
-				ParameterCount:      function.parameterCount,
-				IsCompositeFunction: function.isCompositeFunction,
-			},
-		)
+func (c *Compiler[E, T]) ExportFunctions() []bbq.Function[E] {
+	var functions []bbq.Function[E]
+
+	count := len(c.functions)
+	if count > 0 {
+		functions = make([]bbq.Function[E], 0, count)
+		for _, function := range c.functions {
+			functions = append(
+				functions,
+				bbq.Function[E]{
+					Name:                function.name,
+					Code:                function.code,
+					LocalCount:          function.localCount,
+					ParameterCount:      function.parameterCount,
+					IsCompositeFunction: function.isCompositeFunction,
+				},
+			)
+		}
 	}
+
 	return functions
 }
 
-func (c *Compiler[_, _]) exportVariables(variableDecls []*ast.VariableDeclaration) []*bbq.Variable {
-	variables := make([]*bbq.Variable, 0, len(c.functions))
-	for _, varDecl := range variableDecls {
-		variables = append(
-			variables,
-			&bbq.Variable{
-				Name: varDecl.Identifier.Identifier,
-			},
-		)
+func (c *Compiler[_, _]) exportVariables(variableDecls []*ast.VariableDeclaration) []bbq.Variable {
+	var variables []bbq.Variable
+
+	count := len(c.functions)
+	if count > 0 {
+		variables = make([]bbq.Variable, 0, count)
+		for _, varDecl := range variableDecls {
+			variables = append(
+				variables,
+				bbq.Variable{
+					Name: varDecl.Identifier.Identifier,
+				},
+			)
+		}
 	}
+
 	return variables
 }
 
@@ -1214,15 +1237,14 @@ func (c *Compiler[_, _]) loadTypeArguments(expression *ast.InvocationExpression)
 		panic(errors.NewDefaultUserError("invalid number of type arguments: %d", typeArgsCount))
 	}
 
-	if typeArgsCount == 0 {
-		return nil
+	var typeArgs []uint16
+	if typeArgsCount > 0 {
+		typeArgs = make([]uint16, 0, typeArgsCount)
+
+		invocationTypes.TypeArguments.Foreach(func(key *sema.TypeParameter, typeParam sema.Type) {
+			typeArgs = append(typeArgs, c.getOrAddType(typeParam))
+		})
 	}
-
-	typeArgs := make([]uint16, 0, typeArgsCount)
-
-	invocationTypes.TypeArguments.Foreach(func(key *sema.TypeParameter, typeParam sema.Type) {
-		typeArgs = append(typeArgs, c.getOrAddType(typeParam))
-	})
 
 	return typeArgs
 }

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -93,7 +93,7 @@ func TestCompileRecursionFib(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x2},
 				Kind: constantkind.Int,
@@ -228,7 +228,7 @@ func TestCompileImperativeFib(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x1},
 				Kind: constantkind.Int,
@@ -324,7 +324,7 @@ func TestCompileBreak(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x0},
 				Kind: constantkind.Int,
@@ -428,7 +428,7 @@ func TestCompileContinue(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x0},
 				Kind: constantkind.Int,
@@ -498,7 +498,7 @@ func TestCompileArray(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x1},
 				Kind: constantkind.Int,
@@ -570,7 +570,7 @@ func TestCompileDictionary(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{'a'},
 				Kind: constantkind.String,
@@ -660,7 +660,7 @@ func TestCompileIfLet(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x2},
 				Kind: constantkind.Int,
@@ -769,7 +769,7 @@ func TestCompileIfLetScope(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{1},
 				Kind: constantkind.Int,
@@ -889,7 +889,7 @@ func TestCompileSwitch(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x0},
 				Kind: constantkind.Int,
@@ -989,7 +989,7 @@ func TestSwitchBreak(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x1},
 				Kind: constantkind.Int,
@@ -1094,7 +1094,7 @@ func TestWhileSwitchBreak(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x0},
 				Kind: constantkind.Int,
@@ -1129,13 +1129,13 @@ func TestCompileEmit(t *testing.T) {
 	functions := comp.ExportFunctions()
 	require.Equal(t, len(program.Functions), len(functions))
 
-	var testFunction *bbq.Function[opcode.Instruction]
+	var testFunction bbq.Function[opcode.Instruction]
 	for _, f := range functions {
 		if f.Name == "test" {
 			testFunction = f
 		}
 	}
-	require.NotNil(t, testFunction)
+	require.NotNil(t, testFunction.Code)
 
 	// xIndex is the index of the parameter `x`, which is the first parameter
 	const xIndex = 0
@@ -1425,7 +1425,7 @@ func TestCompileNestedLoop(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x0},
 				Kind: constantkind.Int,
@@ -1492,7 +1492,7 @@ func TestCompileAssignLocal(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x0},
 				Kind: constantkind.Int,
@@ -1542,7 +1542,7 @@ func TestCompileAssignGlobal(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x1},
 				Kind: constantkind.Int,
@@ -1731,7 +1731,7 @@ func TestCompileMember(t *testing.T) {
 	}
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte("foo"),
 				Kind: constantkind.String,
@@ -1878,7 +1878,7 @@ func TestCompileString(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte("Hello, world!"),
 				Kind: constantkind.String,
@@ -1945,7 +1945,7 @@ func TestCompileIntegers(t *testing.T) {
 			expectedConstantKind := constantkind.FromSemaType(integerType)
 
 			assert.Equal(t,
-				[]*bbq.Constant{
+				[]bbq.Constant{
 					{
 						Data: []byte{0x2},
 						Kind: expectedConstantKind,
@@ -2028,7 +2028,7 @@ func TestCompileFixedPoint(t *testing.T) {
 			}
 
 			assert.Equal(t,
-				[]*bbq.Constant{
+				[]bbq.Constant{
 					{
 						Data: expectedData,
 						Kind: expectedConstantKind,
@@ -2250,7 +2250,7 @@ func TestCompileBinary(t *testing.T) {
 			)
 
 			assert.Equal(t,
-				[]*bbq.Constant{
+				[]bbq.Constant{
 					{
 						Data: []byte{0x6},
 						Kind: constantkind.Int,
@@ -2346,7 +2346,7 @@ func TestCompileNilCoalesce(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0},
 				Kind: constantkind.Int,
@@ -2566,7 +2566,7 @@ func TestCompilePath(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte("foo"),
 				Kind: constantkind.String,
@@ -2659,7 +2659,7 @@ func TestCompileBlockScope(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{1},
 				Kind: constantkind.Int,
@@ -2771,7 +2771,7 @@ func TestCompileBlockScope2(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{1},
 				Kind: constantkind.Int,
@@ -3689,7 +3689,7 @@ func TestCompileIf(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x0},
 				Kind: constantkind.Int,
@@ -3760,7 +3760,7 @@ func TestCompileConditional(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		[]*bbq.Constant{
+		[]bbq.Constant{
 			{
 				Data: []byte{0x1},
 				Kind: constantkind.Int,

--- a/bbq/program.go
+++ b/bbq/program.go
@@ -22,10 +22,10 @@ import "github.com/onflow/cadence/bbq/opcode"
 
 type Program[E, T any] struct {
 	Contract  *Contract
-	Imports   []*Import
-	Functions []*Function[E]
-	Constants []*Constant
-	Variables []*Variable
+	Imports   []Import
+	Functions []Function[E]
+	Constants []Constant
+	Variables []Variable
 	Types     []T
 }
 

--- a/bbq/program_printer.go
+++ b/bbq/program_printer.go
@@ -63,7 +63,7 @@ func (p *ProgramPrinter[E, T]) PrintProgram(program *Program[E, T]) string {
 	return p.stringBuilder.String()
 }
 
-func (p *ProgramPrinter[E, T]) printFunction(function *Function[E]) {
+func (p *ProgramPrinter[E, T]) printFunction(function Function[E]) {
 	p.stringBuilder.WriteString("-- " + function.Name + " --\n")
 	err := p.codePrinter(&p.stringBuilder, function.Code)
 	if err != nil {
@@ -72,7 +72,7 @@ func (p *ProgramPrinter[E, T]) printFunction(function *Function[E]) {
 	}
 }
 
-func (p *ProgramPrinter[_, T]) printConstantPool(constants []*Constant) {
+func (p *ProgramPrinter[_, T]) printConstantPool(constants []Constant) {
 	p.stringBuilder.WriteString("-- Constant Pool --\n")
 
 	for index, constant := range constants {
@@ -118,7 +118,7 @@ func (p *ProgramPrinter[_, T]) printTypePool(types []T) {
 	p.stringBuilder.WriteRune('\n')
 }
 
-func (p *ProgramPrinter[_, _]) printImports(imports []*Import) {
+func (p *ProgramPrinter[_, _]) printImports(imports []Import) {
 	p.stringBuilder.WriteString("-- Imports --\n")
 	for _, impt := range imports {
 		location := impt.Location

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -113,7 +113,8 @@ func LinkGlobals(
 	// Iterate through `program.Functions` to be deterministic.
 	// Order of globals must be same as index set at `Compiler.addGlobal()`.
 	// TODO: include non-function globals
-	for _, function := range program.Functions {
+	for i := range program.Functions {
+		function := &program.Functions[i]
 		value := FunctionValue{
 			Function:   function,
 			Executable: executable,


### PR DESCRIPTION


## Description

Optimize `bbq.Program` and the allocation of it a bit:

- Avoid allocations of empty slices
- Make components non-pointers (pointers are AFAICS unnecessary)

Best viewed with whitespace changes disabled

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
