### PR TITLE
Fix get-contracts workflow

### DIFF
--- a/.github/workflows/get-contracts.yml
+++ b/.github/workflows/get-contracts.yml
@@ -1,7 +1,7 @@
 name: Get contracts
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       chain:
         required: true


### PR DESCRIPTION


## Description

We want to be able to trigger `get-contracts` to be manually. This is done by `workflow_dispatch`, not `workflow_call`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
