### PR TITLE
fix syntax specification for import declaration

### DIFF
--- a/docs/syntax/Cadence.syntax
+++ b/docs/syntax/Cadence.syntax
@@ -286,17 +286,33 @@ execute:
     ;
 
 importDeclaration:
-        importKeyword *1importDeclarationFromPhrase importDeclarationSource // ast.ImportDeclaration
+        importKeyword *1importNamesFrom location // ast.ImportDeclaration
     ;
 
-importDeclarationFromPhrase:
-        1*identifier( "," ) fromKeyword // [ast.Identifier]
+importNamesFrom:
+        1*importName fromKeyword
     ;
 
-importDeclarationSource:
-        stringExpression
-    |   positiveHexadecimalExpression
-    |   identifier
+importName:
+        identifier
+    ;
+
+location:
+        stringLocation      // ast.StringLocation
+    |   identifierLocation  // ast.IdentifierLocation
+    |   addressLocation     // ast.AddressLocation
+    ;
+
+stringLocation:
+        stringExpression    // ast.StringLocation
+    ;
+
+identifierLocation:
+        identifier          // ast.IdentifierLocation
+    ;
+
+addressLocation:
+        positiveHexadecimalExpression   // ast.AddressLocation
     ;
 
 conformances:


### PR DESCRIPTION
Closes #3782

## Update Syntax Specification after Testing

Generated parser output was compared to interpreter's parser's output on 1626 Cadence 1.0 files. This pull request
has the changes necessary to correct the only significant difference in the AST.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
