### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/cmd/info/main.go
+++ b/cmd/info/main.go
@@ -21,9 +21,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/common"

--- a/sema/access.go
+++ b/sema/access.go
@@ -19,10 +19,9 @@
 package sema
 
 import (
+	"slices"
 	"strings"
 	"sync"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/common"

--- a/sema/type.go
+++ b/sema/type.go
@@ -22,10 +22,9 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"slices"
 	"strings"
 	"sync"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/common"


### PR DESCRIPTION
Closes #???

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
