### PR TITLE
[Compiler] Refactor `vm.Value` and related operations to be independent of the `vm.Config`

### DIFF
--- a/bbq/vm/storage.go
+++ b/bbq/vm/storage.go
@@ -43,24 +43,13 @@ func MustConvertStoredValue(gauge common.MemoryGauge, storedValue atree.Value) V
 }
 
 func ReadStored(
-	storageContext StorageContext,
+	storageReader interpreter.StorageReader,
 	address common.Address,
 	domain string,
 	identifier string,
 ) Value {
 	storageDomain, _ := common.StorageDomainFromIdentifier(domain)
-
-	accountStorage := storageContext.GetDomainStorageMap(
-		storageContext.Interpreter(),
-		address,
-		storageDomain,
-		false,
-	)
-	if accountStorage == nil {
-		return nil
-	}
-
-	referenced := accountStorage.ReadValue(storageContext, interpreter.StringStorageMapKey(identifier))
+	referenced := storageReader.ReadStored(address, storageDomain, interpreter.StringStorageMapKey(identifier))
 	return InterpreterValueToVMValue(referenced)
 }
 
@@ -72,16 +61,9 @@ func WriteStored(
 	value Value,
 ) (existed bool) {
 
-	inter := storageContext.Interpreter()
-
-	accountStorage := storageContext.GetDomainStorageMap(inter, storageAddress, domain, true)
 	interValue := VMValueToInterpreterValue(storageContext, value)
 
-	return accountStorage.WriteValue(
-		inter,
-		key,
-		interValue,
-	)
+	return storageContext.WriteStored(storageAddress, domain, key, interValue)
 	//interpreter.recordStorageMutation()
 }
 

--- a/bbq/vm/storage.go
+++ b/bbq/vm/storage.go
@@ -34,26 +34,24 @@ import (
 
 func StoredValue(gauge common.MemoryGauge, storable atree.Storable, storage interpreter.Storage) Value {
 	value := interpreter.StoredValue(gauge, storable, storage)
-	return InterpreterValueToVMValue(storage, value)
+	return InterpreterValueToVMValue(value)
 }
 
-func MustConvertStoredValue(gauge common.MemoryGauge, storage interpreter.Storage, storedValue atree.Value) Value {
+func MustConvertStoredValue(gauge common.MemoryGauge, storedValue atree.Value) Value {
 	value := interpreter.MustConvertStoredValue(gauge, storedValue)
-	return InterpreterValueToVMValue(storage, value)
+	return InterpreterValueToVMValue(value)
 }
 
 func ReadStored(
-	config *Config,
+	storageContext StorageContext,
 	address common.Address,
 	domain string,
 	identifier string,
 ) Value {
-	storage := config.Storage
-
 	storageDomain, _ := common.StorageDomainFromIdentifier(domain)
 
-	accountStorage := storage.GetDomainStorageMap(
-		config.Interpreter(),
+	accountStorage := storageContext.GetDomainStorageMap(
+		storageContext.Interpreter(),
 		address,
 		storageDomain,
 		false,
@@ -62,22 +60,22 @@ func ReadStored(
 		return nil
 	}
 
-	referenced := accountStorage.ReadValue(config.MemoryGauge, interpreter.StringStorageMapKey(identifier))
-	return InterpreterValueToVMValue(storage, referenced)
+	referenced := accountStorage.ReadValue(storageContext, interpreter.StringStorageMapKey(identifier))
+	return InterpreterValueToVMValue(referenced)
 }
 
 func WriteStored(
-	config *Config,
+	storageContext StorageContext,
 	storageAddress common.Address,
 	domain common.StorageDomain,
 	key interpreter.StorageMapKey,
 	value Value,
 ) (existed bool) {
 
-	inter := config.Interpreter()
+	inter := storageContext.Interpreter()
 
-	accountStorage := config.Storage.GetDomainStorageMap(inter, storageAddress, domain, true)
-	interValue := VMValueToInterpreterValue(config, value)
+	accountStorage := storageContext.GetDomainStorageMap(inter, storageAddress, domain, true)
+	interValue := VMValueToInterpreterValue(storageContext, value)
 
 	return accountStorage.WriteValue(
 		inter,

--- a/bbq/vm/types.go
+++ b/bbq/vm/types.go
@@ -23,12 +23,6 @@ import (
 	"github.com/onflow/cadence/interpreter"
 )
 
-func IsSubType(context TypeConverterContext, sourceType, targetType bbq.StaticType) bool {
-	// TODO: Avoid conversion to sema types.
-	inter := context.Interpreter()
-	return inter.IsSubType(sourceType, targetType)
-}
-
 // UnwrapOptionalType returns the type if it is not an optional type,
 // or the inner-most type if it is (optional types are repeatedly unwrapped)
 func UnwrapOptionalType(ty bbq.StaticType) bbq.StaticType {

--- a/bbq/vm/types.go
+++ b/bbq/vm/types.go
@@ -23,9 +23,9 @@ import (
 	"github.com/onflow/cadence/interpreter"
 )
 
-func IsSubType(config *Config, sourceType, targetType bbq.StaticType) bool {
+func IsSubType(context TypeConverterContext, sourceType, targetType bbq.StaticType) bool {
 	// TODO: Avoid conversion to sema types.
-	inter := config.Interpreter()
+	inter := context.Interpreter()
 	return inter.IsSubType(sourceType, targetType)
 }
 

--- a/bbq/vm/value.go
+++ b/bbq/vm/value.go
@@ -38,14 +38,13 @@ type Value interface {
 	String() string
 }
 
-type StaticTypeContext interface {
-	StorageContext
-}
+type StaticTypeContext = interpreter.ValueStaticTypeContext
 
 type StorageContext interface {
-	interpreter.Storage
+	StaticTypeContext
 	common.MemoryGauge
-	TypeConverterContext
+	interpreter.Storage
+	interpreter.StorageWriter
 }
 
 type TransferContext interface {

--- a/bbq/vm/value.go
+++ b/bbq/vm/value.go
@@ -22,14 +22,15 @@ import (
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/bbq"
+	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 )
 
 type Value interface {
 	isValue()
-	StaticType(*Config) bbq.StaticType
+	StaticType(StaticTypeContext) bbq.StaticType
 	Transfer(
-		config *Config,
+		transferContext TransferContext,
 		address atree.Address,
 		remove bool,
 		storable atree.Storable,
@@ -37,13 +38,43 @@ type Value interface {
 	String() string
 }
 
+type StaticTypeContext interface {
+	StorageContext
+}
+
+type StorageContext interface {
+	interpreter.Storage
+	common.MemoryGauge
+	TypeConverterContext
+}
+
+type TransferContext interface {
+	StorageContext
+	ReferenceTracker
+}
+
+type ReferenceTracker interface {
+	TrackReferencedResourceKindedValue(id atree.ValueID, value *EphemeralReferenceValue)
+	ReferencedResourceKindedValues(atree.ValueID) map[*EphemeralReferenceValue]struct{}
+	ClearReferenceTracking(atree.ValueID)
+}
+
+type TypeConverterContext interface {
+	Interpreter() *interpreter.Interpreter
+}
+
 type MemberAccessibleValue interface {
+	// TODO: See whether `Config` parameter can be removed from the below functions.
+	// Currently it's unknown because `AccountCapabilityControllerValue` members
+	// are not yet implemented.
+
 	GetMember(config *Config, name string) Value
-	SetMember(conf *Config, name string, value Value)
+	SetMember(config *Config, name string, value Value)
 }
 
 type ResourceKindedValue interface {
 	Value
+	// TODO:
 	//Destroy(interpreter *Interpreter, locationRange LocationRange)
 	//IsDestroyed() bool
 	//isInvalidatedResource(*Interpreter) bool

--- a/bbq/vm/value_account.go
+++ b/bbq/vm/value_account.go
@@ -383,7 +383,7 @@ func recordStorageCapabilityController(
 	)
 
 	referenced := accountStorage.ReadValue(config.MemoryGauge, interpreter.StringStorageMapKey(identifier))
-	readValue := InterpreterValueToVMValue(config.Storage, referenced)
+	readValue := InterpreterValueToVMValue(referenced)
 
 	setKey := capabilityIDValue
 	setValue := Nil

--- a/bbq/vm/value_address.go
+++ b/bbq/vm/value_address.go
@@ -33,11 +33,11 @@ var _ Value = AddressValue{}
 
 func (AddressValue) isValue() {}
 
-func (AddressValue) StaticType(*Config) bbq.StaticType {
+func (AddressValue) StaticType(StaticTypeContext) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeAddress
 }
 
-func (v AddressValue) Transfer(*Config, atree.Address, bool, atree.Storable) Value {
+func (v AddressValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	return v
 }
 

--- a/bbq/vm/value_bool.go
+++ b/bbq/vm/value_bool.go
@@ -36,11 +36,11 @@ var _ EquatableValue = BoolValue(true)
 
 func (BoolValue) isValue() {}
 
-func (BoolValue) StaticType(*Config) bbq.StaticType {
+func (BoolValue) StaticType(StaticTypeContext) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeBool
 }
 
-func (v BoolValue) Transfer(*Config, atree.Address, bool, atree.Storable) Value {
+func (v BoolValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	return v
 }
 

--- a/bbq/vm/value_capability_controller.go
+++ b/bbq/vm/value_capability_controller.go
@@ -97,7 +97,7 @@ func (v *StorageCapabilityControllerValue) CapabilityControllerBorrowType() *int
 	return v.BorrowType
 }
 
-func (v *StorageCapabilityControllerValue) StaticType(*Config) bbq.StaticType {
+func (v *StorageCapabilityControllerValue) StaticType(StaticTypeContext) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeStorageCapabilityController
 }
 
@@ -110,12 +110,7 @@ func (v *StorageCapabilityControllerValue) String() string {
 	)
 }
 
-func (v *StorageCapabilityControllerValue) Transfer(
-	config *Config,
-	address atree.Address,
-	remove bool,
-	storable atree.Storable,
-) Value {
+func (v *StorageCapabilityControllerValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	//if remove {
 	//	interpreter.RemoveReferencedSlab(storable)
 	//}

--- a/bbq/vm/value_conversions.go
+++ b/bbq/vm/value_conversions.go
@@ -99,7 +99,7 @@ func InterpreterValueToVMValue(value interpreter.Value) Value {
 	}
 }
 
-func VMValueToInterpreterValue(typeConverterContext TypeConverterContext, value Value) interpreter.Value {
+func VMValueToInterpreterValue(typeConverter interpreter.TypeConverter, value Value) interpreter.Value {
 	switch value := value.(type) {
 	case nil:
 		return nil
@@ -137,7 +137,7 @@ func VMValueToInterpreterValue(typeConverterContext TypeConverterContext, value 
 		return interpreter.NewCapabilityValue(
 			nil,
 			interpreter.NewUnmeteredUInt64Value(uint64(value.ID.SmallInt)), // TODO: properly convert
-			VMValueToInterpreterValue(typeConverterContext, value.Address).(interpreter.AddressValue),
+			VMValueToInterpreterValue(typeConverter, value.Address).(interpreter.AddressValue),
 			value.BorrowType,
 		)
 	//case LinkValue:
@@ -158,7 +158,7 @@ func VMValueToInterpreterValue(typeConverterContext TypeConverterContext, value 
 
 		// TODO: Fields names order matters. However, this is temporary. So ignore for now.
 		for name, field := range value.fields { //nolint:maprange
-			fields[name] = VMValueToInterpreterValue(typeConverterContext, field)
+			fields[name] = VMValueToInterpreterValue(typeConverter, field)
 			fieldNames = append(fieldNames, name)
 		}
 
@@ -173,8 +173,7 @@ func VMValueToInterpreterValue(typeConverterContext TypeConverterContext, value 
 			nil,
 		)
 	case *StorageReferenceValue:
-		inter := typeConverterContext.Interpreter()
-		semaBorrowType, err := inter.ConvertStaticToSemaType(value.BorrowedType)
+		semaBorrowType, err := typeConverter.ConvertStaticToSemaType(value.BorrowedType)
 		if err != nil {
 			panic(err)
 		}
@@ -182,7 +181,7 @@ func VMValueToInterpreterValue(typeConverterContext TypeConverterContext, value 
 			nil,
 			value.Authorization,
 			value.TargetStorageAddress,
-			VMValueToInterpreterValue(typeConverterContext, value.TargetPath).(interpreter.PathValue),
+			VMValueToInterpreterValue(typeConverter, value.TargetPath).(interpreter.PathValue),
 			semaBorrowType,
 		)
 	case *StorageCapabilityControllerValue:
@@ -190,7 +189,7 @@ func VMValueToInterpreterValue(typeConverterContext TypeConverterContext, value 
 			nil,
 			value.BorrowType,
 			interpreter.NewUnmeteredUInt64Value(uint64(value.CapabilityID.SmallInt)),
-			VMValueToInterpreterValue(typeConverterContext, value.TargetPath).(interpreter.PathValue),
+			VMValueToInterpreterValue(typeConverter, value.TargetPath).(interpreter.PathValue),
 		)
 	default:
 		panic(errors.NewUnreachableError())

--- a/bbq/vm/value_conversions.go
+++ b/bbq/vm/value_conversions.go
@@ -27,7 +27,7 @@ import (
 // Utility methods to convert between old and new values.
 // These are temporary until all parts of the interpreter are migrated to the vm.
 
-func InterpreterValueToVMValue(storage interpreter.Storage, value interpreter.Value) Value {
+func InterpreterValueToVMValue(value interpreter.Value) Value {
 	switch value := value.(type) {
 	case nil:
 		return nil
@@ -62,7 +62,7 @@ func InterpreterValueToVMValue(storage interpreter.Storage, value interpreter.Va
 	case *interpreter.SimpleCompositeValue:
 		fields := make(map[string]Value)
 		for name, field := range value.Fields { //nolint:maprange
-			fields[name] = InterpreterValueToVMValue(storage, field)
+			fields[name] = InterpreterValueToVMValue(field)
 		}
 		return NewSimpleCompositeValue(
 			common.CompositeKindStructure,
@@ -85,13 +85,13 @@ func InterpreterValueToVMValue(storage interpreter.Storage, value interpreter.Va
 		return NewStorageCapabilityControllerValue(
 			value.BorrowType,
 			NewIntValue(int64(value.CapabilityID.ToInt(interpreter.EmptyLocationRange))),
-			InterpreterValueToVMValue(storage, value.TargetPath).(PathValue),
+			InterpreterValueToVMValue(value.TargetPath).(PathValue),
 		)
 	case *interpreter.StorageReferenceValue:
 		return NewStorageReferenceValue(
 			value.Authorization,
 			value.TargetStorageAddress,
-			InterpreterValueToVMValue(storage, value.TargetPath).(PathValue),
+			InterpreterValueToVMValue(value.TargetPath).(PathValue),
 			interpreter.ConvertSemaToStaticType(nil, value.BorrowedType),
 		)
 	default:
@@ -99,7 +99,7 @@ func InterpreterValueToVMValue(storage interpreter.Storage, value interpreter.Va
 	}
 }
 
-func VMValueToInterpreterValue(config *Config, value Value) interpreter.Value {
+func VMValueToInterpreterValue(typeConverterContext TypeConverterContext, value Value) interpreter.Value {
 	switch value := value.(type) {
 	case nil:
 		return nil
@@ -137,7 +137,7 @@ func VMValueToInterpreterValue(config *Config, value Value) interpreter.Value {
 		return interpreter.NewCapabilityValue(
 			nil,
 			interpreter.NewUnmeteredUInt64Value(uint64(value.ID.SmallInt)), // TODO: properly convert
-			VMValueToInterpreterValue(config, value.Address).(interpreter.AddressValue),
+			VMValueToInterpreterValue(typeConverterContext, value.Address).(interpreter.AddressValue),
 			value.BorrowType,
 		)
 	//case LinkValue:
@@ -158,7 +158,7 @@ func VMValueToInterpreterValue(config *Config, value Value) interpreter.Value {
 
 		// TODO: Fields names order matters. However, this is temporary. So ignore for now.
 		for name, field := range value.fields { //nolint:maprange
-			fields[name] = VMValueToInterpreterValue(config, field)
+			fields[name] = VMValueToInterpreterValue(typeConverterContext, field)
 			fieldNames = append(fieldNames, name)
 		}
 
@@ -173,7 +173,7 @@ func VMValueToInterpreterValue(config *Config, value Value) interpreter.Value {
 			nil,
 		)
 	case *StorageReferenceValue:
-		inter := config.Interpreter()
+		inter := typeConverterContext.Interpreter()
 		semaBorrowType, err := inter.ConvertStaticToSemaType(value.BorrowedType)
 		if err != nil {
 			panic(err)
@@ -182,7 +182,7 @@ func VMValueToInterpreterValue(config *Config, value Value) interpreter.Value {
 			nil,
 			value.Authorization,
 			value.TargetStorageAddress,
-			VMValueToInterpreterValue(config, value.TargetPath).(interpreter.PathValue),
+			VMValueToInterpreterValue(typeConverterContext, value.TargetPath).(interpreter.PathValue),
 			semaBorrowType,
 		)
 	case *StorageCapabilityControllerValue:
@@ -190,7 +190,7 @@ func VMValueToInterpreterValue(config *Config, value Value) interpreter.Value {
 			nil,
 			value.BorrowType,
 			interpreter.NewUnmeteredUInt64Value(uint64(value.CapabilityID.SmallInt)),
-			VMValueToInterpreterValue(config, value.TargetPath).(interpreter.PathValue),
+			VMValueToInterpreterValue(typeConverterContext, value.TargetPath).(interpreter.PathValue),
 		)
 	default:
 		panic(errors.NewUnreachableError())

--- a/bbq/vm/value_dictionary.go
+++ b/bbq/vm/value_dictionary.go
@@ -431,13 +431,12 @@ func (v *DictionaryValue) iterate(
 	iterate()
 }
 
-func newValueComparator(typeConverterContext TypeConverterContext) atree.ValueComparator {
+func newValueComparator(comparisonContext interpreter.ValueComparisonContext) atree.ValueComparator {
 	return func(storage atree.SlabStorage, atreeValue atree.Value, otherStorable atree.Storable) (bool, error) {
-		inter := typeConverterContext.Interpreter()
 		locationRange := interpreter.EmptyLocationRange
-		value := interpreter.MustConvertStoredValue(inter, atreeValue)
-		otherValue := interpreter.StoredValue(inter, otherStorable, storage)
-		return value.(interpreter.EquatableValue).Equal(inter, locationRange, otherValue), nil
+		value := interpreter.MustConvertStoredValue(comparisonContext, atreeValue)
+		otherValue := interpreter.StoredValue(comparisonContext, otherStorable, storage)
+		return value.(interpreter.EquatableValue).Equal(comparisonContext, locationRange, otherValue), nil
 	}
 }
 

--- a/bbq/vm/value_ephemeral_reference.go
+++ b/bbq/vm/value_ephemeral_reference.go
@@ -46,7 +46,7 @@ var _ MemberAccessibleValue = &EphemeralReferenceValue{}
 var _ ReferenceValue = &EphemeralReferenceValue{}
 
 func NewEphemeralReferenceValue(
-	conf *Config,
+	referenceTracker ReferenceTracker,
 	value Value,
 	authorization interpreter.Authorization,
 	borrowedType interpreter.StaticType,
@@ -57,7 +57,7 @@ func NewEphemeralReferenceValue(
 		BorrowedType:  borrowedType,
 	}
 
-	maybeTrackReferencedResourceKindedValue(conf, ref)
+	maybeTrackReferencedResourceKindedValue(referenceTracker, ref)
 
 	return ref
 }
@@ -74,15 +74,15 @@ func (v *EphemeralReferenceValue) BorrowType() interpreter.StaticType {
 	return v.BorrowedType
 }
 
-func (v *EphemeralReferenceValue) StaticType(config *Config) bbq.StaticType {
+func (v *EphemeralReferenceValue) StaticType(staticTypeContext StaticTypeContext) bbq.StaticType {
 	return interpreter.NewReferenceStaticType(
-		config.MemoryGauge,
+		staticTypeContext,
 		v.Authorization,
-		v.Value.StaticType(config),
+		v.Value.StaticType(staticTypeContext),
 	)
 }
 
-func (v *EphemeralReferenceValue) Transfer(*Config, atree.Address, bool, atree.Storable) Value {
+func (v *EphemeralReferenceValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	return v
 }
 

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -35,11 +35,11 @@ var _ Value = FunctionValue{}
 
 func (FunctionValue) isValue() {}
 
-func (FunctionValue) StaticType(*Config) bbq.StaticType {
+func (FunctionValue) StaticType(StaticTypeContext) bbq.StaticType {
 	panic(errors.NewUnreachableError())
 }
 
-func (v FunctionValue) Transfer(*Config, atree.Address, bool, atree.Storable) Value {
+func (v FunctionValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	return v
 }
 
@@ -60,11 +60,11 @@ var _ Value = NativeFunctionValue{}
 
 func (NativeFunctionValue) isValue() {}
 
-func (NativeFunctionValue) StaticType(*Config) bbq.StaticType {
+func (NativeFunctionValue) StaticType(StaticTypeContext) bbq.StaticType {
 	panic(errors.NewUnreachableError())
 }
 
-func (v NativeFunctionValue) Transfer(*Config, atree.Address, bool, atree.Storable) Value {
+func (v NativeFunctionValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	return v
 }
 

--- a/bbq/vm/value_int.go
+++ b/bbq/vm/value_int.go
@@ -50,11 +50,11 @@ var _ IntegerValue = IntValue{}
 
 func (IntValue) isValue() {}
 
-func (IntValue) StaticType(*Config) bbq.StaticType {
+func (IntValue) StaticType(StaticTypeContext) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeInt
 }
 
-func (v IntValue) Transfer(*Config, atree.Address, bool, atree.Storable) Value {
+func (v IntValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	return v
 }
 

--- a/bbq/vm/value_nil.go
+++ b/bbq/vm/value_nil.go
@@ -35,14 +35,14 @@ var Nil Value = NilValue{}
 
 func (NilValue) isValue() {}
 
-func (NilValue) StaticType(config *Config) bbq.StaticType {
+func (NilValue) StaticType(staticTypeContext StaticTypeContext) bbq.StaticType {
 	return interpreter.NewOptionalStaticType(
-		config.MemoryGauge,
+		staticTypeContext,
 		interpreter.PrimitiveStaticTypeNever,
 	)
 }
 
-func (v NilValue) Transfer(*Config, atree.Address, bool, atree.Storable) Value {
+func (v NilValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	return v
 }
 

--- a/bbq/vm/value_path.go
+++ b/bbq/vm/value_path.go
@@ -39,7 +39,7 @@ var _ Value = PathValue{}
 
 func (PathValue) isValue() {}
 
-func (v PathValue) StaticType(*Config) bbq.StaticType {
+func (v PathValue) StaticType(StaticTypeContext) bbq.StaticType {
 	switch v.Domain {
 	case common.PathDomainStorage:
 		return interpreter.PrimitiveStaticTypeStoragePath
@@ -52,7 +52,7 @@ func (v PathValue) StaticType(*Config) bbq.StaticType {
 	}
 }
 
-func (v PathValue) Transfer(*Config, atree.Address, bool, atree.Storable) Value {
+func (v PathValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	return v
 }
 

--- a/bbq/vm/value_simple_composite.go
+++ b/bbq/vm/value_simple_composite.go
@@ -56,7 +56,7 @@ func NewSimpleCompositeValue(
 
 func (*SimpleCompositeValue) isValue() {}
 
-func (v *SimpleCompositeValue) StaticType(*Config) bbq.StaticType {
+func (v *SimpleCompositeValue) StaticType(StaticTypeContext) bbq.StaticType {
 	return v.staticType
 }
 
@@ -82,12 +82,7 @@ func (v *SimpleCompositeValue) String() string {
 	panic("implement me")
 }
 
-func (v *SimpleCompositeValue) Transfer(
-	conf *Config,
-	address atree.Address,
-	remove bool,
-	storable atree.Storable,
-) Value {
+func (v *SimpleCompositeValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	return v
 }
 

--- a/bbq/vm/value_some.go
+++ b/bbq/vm/value_some.go
@@ -42,18 +42,18 @@ func NewSomeValueNonCopying(value Value) *SomeValue {
 
 func (*SomeValue) isValue() {}
 
-func (v *SomeValue) StaticType(config *Config) bbq.StaticType {
-	innerType := v.value.StaticType(config)
+func (v *SomeValue) StaticType(staticTypeContext StaticTypeContext) bbq.StaticType {
+	innerType := v.value.StaticType(staticTypeContext)
 	if innerType == nil {
 		return nil
 	}
 	return interpreter.NewOptionalStaticType(
-		config.MemoryGauge,
+		staticTypeContext,
 		innerType,
 	)
 }
 
-func (v *SomeValue) Transfer(*Config, atree.Address, bool, atree.Storable) Value {
+func (v *SomeValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	return v
 }
 

--- a/bbq/vm/value_storage_reference.go
+++ b/bbq/vm/value_storage_reference.go
@@ -101,7 +101,7 @@ func (v *StorageReferenceValue) dereference(context StaticTypeContext) (*Value, 
 	if v.BorrowedType != nil {
 		staticType := vmReferencedValue.StaticType(context)
 
-		if !IsSubType(context, staticType, v.BorrowedType) {
+		if !context.IsSubType(staticType, v.BorrowedType) {
 			panic(fmt.Errorf("type mismatch: expected %s, found %s", v.BorrowedType, staticType))
 
 			// TODO:

--- a/bbq/vm/value_string.go
+++ b/bbq/vm/value_string.go
@@ -48,11 +48,11 @@ func NewStringValueFromBytes(bytes []byte) StringValue {
 
 func (StringValue) isValue() {}
 
-func (StringValue) StaticType(*Config) bbq.StaticType {
+func (StringValue) StaticType(StaticTypeContext) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeString
 }
 
-func (v StringValue) Transfer(*Config, atree.Address, bool, atree.Storable) Value {
+func (v StringValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	return v
 }
 

--- a/bbq/vm/value_ufix64.go
+++ b/bbq/vm/value_ufix64.go
@@ -47,11 +47,11 @@ var _ NumberValue = UFix64Value(0)
 
 func (UFix64Value) isValue() {}
 
-func (UFix64Value) StaticType(*Config) bbq.StaticType {
+func (UFix64Value) StaticType(StaticTypeContext) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeUFix64
 }
 
-func (v UFix64Value) Transfer(*Config, atree.Address, bool, atree.Storable) Value {
+func (v UFix64Value) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	return v
 }
 

--- a/bbq/vm/value_void.go
+++ b/bbq/vm/value_void.go
@@ -32,11 +32,11 @@ var Void Value = VoidValue{}
 
 func (VoidValue) isValue() {}
 
-func (VoidValue) StaticType(*Config) bbq.StaticType {
+func (VoidValue) StaticType(StaticTypeContext) bbq.StaticType {
 	return interpreter.PrimitiveStaticTypeVoid
 }
 
-func (v VoidValue) Transfer(*Config, atree.Address, bool, atree.Storable) Value {
+func (v VoidValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	return v
 }
 

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -665,7 +665,7 @@ func opTransfer(vm *VM, ins opcode.InstructionTransfer) {
 	)
 
 	valueType := transferredValue.StaticType(config)
-	if !IsSubType(config, valueType, targetType) {
+	if !vm.config.IsSubType(valueType, targetType) {
 		panic(errors.NewUnexpectedError(
 			"invalid transfer: expected '%s', found '%s'",
 			targetType,
@@ -707,7 +707,7 @@ func opFailableCast(vm *VM, ins opcode.InstructionFailableCast) {
 
 	targetType := vm.loadType(ins.TypeIndex)
 	value, valueType := castValueAndValueType(vm.config, targetType, value)
-	isSubType := IsSubType(vm.config, valueType, targetType)
+	isSubType := vm.config.IsSubType(valueType, targetType)
 
 	var result Value
 	if isSubType {
@@ -731,7 +731,7 @@ func opForceCast(vm *VM, ins opcode.InstructionForceCast) {
 
 	targetType := vm.loadType(ins.TypeIndex)
 	value, valueType := castValueAndValueType(vm.config, targetType, value)
-	isSubType := IsSubType(vm.config, valueType, targetType)
+	isSubType := vm.config.IsSubType(valueType, targetType)
 
 	var result Value
 	if !isSubType {

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -43,6 +43,7 @@ func MustSemaTypeOfValue(value Value, context ValueStaticTypeContext) sema.Type 
 }
 
 type SubTypeChecker interface {
+	IsSubType(subType StaticType, superType StaticType) bool
 	IsSubTypeOfSemaType(staticSubType StaticType, superType sema.Type) bool
 }
 
@@ -54,6 +55,15 @@ type StorageReader interface {
 		domain common.StorageDomain,
 		identifier StorageMapKey,
 	) Value
+}
+
+type StorageWriter interface {
+	WriteStored(
+		storageAddress common.Address,
+		domain common.StorageDomain,
+		key StorageMapKey,
+		value Value,
+	) (existed bool)
 }
 
 var _ StorageReader = &Interpreter{}

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -61,7 +61,7 @@ func (v *VMInvokable) Invoke(functionName string, arguments ...interpreter.Value
 	for _, argument := range arguments {
 		vmArguments = append(
 			vmArguments,
-			vm.InterpreterValueToVMValue(v.config.Storage, argument),
+			vm.InterpreterValueToVMValue(argument),
 		)
 	}
 


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3693

## Description

Similar to the refactor in the interpreter, avoid the `vm.Config` from being passed into value related functions (`StaticType`, `Transfer`, etc.) at the VM side. Instead, pass only what is needed for each function, as an interface (re-use interpreter's interfaces wherever possible).

In the follow-up PR https://github.com/onflow/cadence/pull/3819, similar interfaces are defined at the interpreter (e.g: `ValueTransferContext`) and decoupled more of `interpreter.Value`s.

The idea is to gradually decouple values of both sides (both vm and interpreter), and make bring the interfaces defined in both sides to an exact match, which will allow us to switch and replace vm-values from the interpreter-values.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
