### PR TITLE
[Compiler] Decouple `value.Transfer` method from the interpreter

### DIFF
--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -37,7 +37,6 @@ type OnEventEmittedFunc func(
 ) error
 
 type Config struct {
-	interpreter.Storage
 	common.MemoryGauge
 	commons.ImportHandler
 	ContractValueHandler
@@ -46,6 +45,7 @@ type Config struct {
 	NativeFunctionsProvider
 
 	// TODO: Move these to a 'shared state'?
+	storage                                     interpreter.Storage
 	CapabilityControllerIterations              map[AddressPath]int
 	MutationDuringCapabilityControllerIteration bool
 	referencedResourceKindedValues              ReferencedResourceKindedValues
@@ -61,12 +61,13 @@ type Config struct {
 var _ ReferenceTracker = &Config{}
 var _ StaticTypeContext = &Config{}
 var _ TransferContext = &Config{}
+var _ StorageContext = &Config{}
 var _ interpreter.StaticTypeConversionHandler = &Config{}
 var _ interpreter.ValueComparisonContext = &Config{}
 
 func NewConfig(storage interpreter.Storage) *Config {
 	return &Config{
-		Storage:              storage,
+		storage:              storage,
 		MemoryGauge:          nil,
 		ImportHandler:        nil,
 		ContractValueHandler: nil,
@@ -90,7 +91,7 @@ func (c *Config) Interpreter() *interpreter.Interpreter {
 			nil,
 			common_utils.TestLocation,
 			&interpreter.Config{
-				Storage:               c.Storage,
+				Storage:               c.storage,
 				ImportLocationHandler: nil,
 				CompositeTypeHandler: func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 					return c.TypeLoader(location, typeID).(*sema.CompositeType)
@@ -119,28 +120,12 @@ func (c *Config) MeterMemory(usage common.MemoryUsage) error {
 	return c.MemoryGauge.MeterMemory(usage)
 }
 
-func (c *Config) TrackReferencedResourceKindedValue(
-	id atree.ValueID,
-	value *EphemeralReferenceValue,
-) {
-	values := c.referencedResourceKindedValues[id]
-	if values == nil {
-		values = map[*EphemeralReferenceValue]struct{}{}
-		c.referencedResourceKindedValues[id] = values
-	}
-	values[value] = struct{}{}
-}
-
-func (c *Config) ReferencedResourceKindedValues(valueID atree.ValueID) map[*EphemeralReferenceValue]struct{} {
-	return c.referencedResourceKindedValues[valueID]
-}
-
-func (c *Config) ClearReferenceTracking(valueID atree.ValueID) {
-	delete(c.referencedResourceKindedValues, valueID)
+func (c *Config) Storage() interpreter.Storage {
+	return c.storage
 }
 
 func (c *Config) ReadStored(storageAddress common.Address, domain common.StorageDomain, identifier interpreter.StorageMapKey) interpreter.Value {
-	accountStorage := c.GetDomainStorageMap(
+	accountStorage := c.storage.GetDomainStorageMap(
 		c.Interpreter(),
 		storageAddress,
 		domain,
@@ -160,7 +145,7 @@ func (c *Config) WriteStored(
 	value interpreter.Value,
 ) (existed bool) {
 	inter := c.Interpreter()
-	accountStorage := c.GetDomainStorageMap(inter, storageAddress, domain, true)
+	accountStorage := c.storage.GetDomainStorageMap(inter, storageAddress, domain, true)
 
 	return accountStorage.WriteValue(
 		inter,
@@ -208,6 +193,21 @@ func (c *Config) GetCompositeType(
 	qualifiedIdentifier string,
 	typeID interpreter.TypeID,
 ) (*sema.CompositeType, error) {
+	//TODO
+	panic(errors.NewUnreachableError())
+}
+
+func (c *Config) RemoveReferencedSlab(storable atree.Storable) {
+	//TODO
+	panic(errors.NewUnreachableError())
+}
+
+func (c *Config) MaybeValidateAtreeValue(v atree.Value) {
+	//TODO
+	panic(errors.NewUnreachableError())
+}
+
+func (c *Config) MaybeValidateAtreeStorage() {
 	//TODO
 	panic(errors.NewUnreachableError())
 }

--- a/bbq/vm/storage.go
+++ b/bbq/vm/storage.go
@@ -86,7 +86,7 @@ func StoredValueExists(
 	domain common.StorageDomain,
 	identifier interpreter.StorageMapKey,
 ) bool {
-	accountStorage := config.Storage.GetDomainStorageMap(
+	accountStorage := config.storage.GetDomainStorageMap(
 		config.Interpreter(),
 		storageAddress,
 		domain,

--- a/bbq/vm/test/runtime_test.go
+++ b/bbq/vm/test/runtime_test.go
@@ -87,13 +87,12 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 
 	barProgram := parseCheckAndCompile(t, contractCode, barLocation, programs)
 
+	config := vm.NewConfig(storage)
+
 	barVM := vm.NewVM(
 		barLocation,
 		barProgram,
-		&vm.Config{
-			Storage:        storage,
-			AccountHandler: &testAccountHandler{},
-		},
+		config,
 	)
 
 	barContractValue, err := barVM.InitializeContract()
@@ -160,18 +159,16 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 	fooLocation := common.NewAddressLocation(nil, contractsAddress, "Foo")
 	program := parseCheckAndCompile(t, fooContract, fooLocation, programs)
 
-	vmConfig := &vm.Config{
-		Storage:       storage,
-		ImportHandler: importHandler,
-		ContractValueHandler: func(_ *vm.Config, location common.Location) *vm.CompositeValue {
-			switch location {
-			case barLocation:
-				return barContractValue
-			default:
-				assert.FailNow(t, "invalid location")
-				return nil
-			}
-		},
+	vmConfig := vm.NewConfig(storage)
+	vmConfig.ImportHandler = importHandler
+	vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *vm.CompositeValue {
+		switch location {
+		case barLocation:
+			return barContractValue
+		default:
+			assert.FailNow(t, "invalid location")
+			return nil
+		}
 	}
 
 	txLocation := runtime_utils.NewTransactionLocationGenerator()

--- a/bbq/vm/test/vm_bench_test.go
+++ b/bbq/vm/test/vm_bench_test.go
@@ -174,9 +174,7 @@ func BenchmarkNewResource(b *testing.B) {
 func BenchmarkNewStructRaw(b *testing.B) {
 
 	storage := interpreter.NewInMemoryStorage(nil)
-	vmConfig := &vm.Config{
-		Storage: storage,
-	}
+	vmConfig := vm.NewConfig(storage)
 
 	fieldValue := vm.NewIntValue(7)
 

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -2637,23 +2637,21 @@ func TestDefaultFunctions(t *testing.T) {
 		programs := map[common.Location]*compiledProgram{}
 		contractValues := map[common.Location]*vm.CompositeValue{}
 
-		vmConfig := &vm.Config{
-			Storage:        storage,
-			AccountHandler: &testAccountHandler{},
-			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
-				program, ok := programs[location]
-				if !ok {
-					assert.FailNow(t, "invalid location")
-				}
-				return program.Program
-			},
-			ContractValueHandler: func(_ *vm.Config, location common.Location) *vm.CompositeValue {
-				contractValue, ok := contractValues[location]
-				if !ok {
-					assert.FailNow(t, "invalid location")
-				}
-				return contractValue
-			},
+		vmConfig := vm.NewConfig(storage)
+		vmConfig.AccountHandler = &testAccountHandler{}
+		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			program, ok := programs[location]
+			if !ok {
+				assert.FailNow(t, "invalid location")
+			}
+			return program.Program
+		}
+		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *vm.CompositeValue {
+			contractValue, ok := contractValues[location]
+			if !ok {
+				assert.FailNow(t, "invalid location")
+			}
+			return contractValue
 		}
 
 		contractsAddress := common.MustBytesToAddress([]byte{0x1})
@@ -2750,23 +2748,21 @@ func TestDefaultFunctions(t *testing.T) {
 		programs := map[common.Location]*compiledProgram{}
 		contractValues := map[common.Location]*vm.CompositeValue{}
 
-		vmConfig := &vm.Config{
-			Storage:        storage,
-			AccountHandler: &testAccountHandler{},
-			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
-				program, ok := programs[location]
-				if !ok {
-					assert.FailNow(t, "invalid location")
-				}
-				return program.Program
-			},
-			ContractValueHandler: func(_ *vm.Config, location common.Location) *vm.CompositeValue {
-				contractValue, ok := contractValues[location]
-				if !ok {
-					assert.FailNow(t, "invalid location")
-				}
-				return contractValue
-			},
+		vmConfig := vm.NewConfig(storage)
+		vmConfig.AccountHandler = &testAccountHandler{}
+		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			program, ok := programs[location]
+			if !ok {
+				assert.FailNow(t, "invalid location")
+			}
+			return program.Program
+		}
+		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *vm.CompositeValue {
+			contractValue, ok := contractValues[location]
+			if !ok {
+				assert.FailNow(t, "invalid location")
+			}
+			return contractValue
 		}
 
 		contractsAddress := common.MustBytesToAddress([]byte{0x1})
@@ -2854,23 +2850,21 @@ func TestDefaultFunctions(t *testing.T) {
 		programs := map[common.Location]*compiledProgram{}
 		contractValues := map[common.Location]*vm.CompositeValue{}
 
-		vmConfig := &vm.Config{
-			Storage:        storage,
-			AccountHandler: &testAccountHandler{},
-			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
-				program, ok := programs[location]
-				if !ok {
-					assert.FailNow(t, "invalid location")
-				}
-				return program.Program
-			},
-			ContractValueHandler: func(_ *vm.Config, location common.Location) *vm.CompositeValue {
-				contractValue, ok := contractValues[location]
-				if !ok {
-					assert.FailNow(t, "invalid location")
-				}
-				return contractValue
-			},
+		vmConfig := vm.NewConfig(storage)
+		vmConfig.AccountHandler = &testAccountHandler{}
+		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			program, ok := programs[location]
+			if !ok {
+				assert.FailNow(t, "invalid location")
+			}
+			return program.Program
+		}
+		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *vm.CompositeValue {
+			contractValue, ok := contractValues[location]
+			if !ok {
+				assert.FailNow(t, "invalid location")
+			}
+			return contractValue
 		}
 
 		contractsAddress := common.MustBytesToAddress([]byte{0x1})
@@ -3183,36 +3177,34 @@ func TestFunctionPreConditions(t *testing.T) {
 		contractValues := map[common.Location]*vm.CompositeValue{}
 		var logs []string
 
-		vmConfig := &vm.Config{
-			Storage:        storage,
-			AccountHandler: &testAccountHandler{},
-			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
-				program, ok := programs[location]
-				if !ok {
-					assert.FailNow(t, "invalid location")
-				}
-				return program.Program
-			},
-			ContractValueHandler: func(_ *vm.Config, location common.Location) *vm.CompositeValue {
-				contractValue, ok := contractValues[location]
-				if !ok {
-					assert.FailNow(t, "invalid location")
-				}
-				return contractValue
-			},
+		vmConfig := vm.NewConfig(storage)
+		vmConfig.AccountHandler = &testAccountHandler{}
+		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			program, ok := programs[location]
+			if !ok {
+				assert.FailNow(t, "invalid location")
+			}
+			return program.Program
+		}
+		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *vm.CompositeValue {
+			contractValue, ok := contractValues[location]
+			if !ok {
+				assert.FailNow(t, "invalid location")
+			}
+			return contractValue
+		}
 
-			NativeFunctionsProvider: func() map[string]vm.Value {
-				funcs := vm.NativeFunctions()
-				funcs[commons.LogFunctionName] = vm.NativeFunctionValue{
-					ParameterCount: len(stdlib.LogFunctionType.Parameters),
-					Function: func(config *vm.Config, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
-						logs = append(logs, arguments[0].String())
-						return vm.VoidValue{}
-					},
-				}
+		vmConfig.NativeFunctionsProvider = func() map[string]vm.Value {
+			funcs := vm.NativeFunctions()
+			funcs[commons.LogFunctionName] = vm.NativeFunctionValue{
+				ParameterCount: len(stdlib.LogFunctionType.Parameters),
+				Function: func(config *vm.Config, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
+					logs = append(logs, arguments[0].String())
+					return vm.VoidValue{}
+				},
+			}
 
-				return funcs
-			},
+			return funcs
 		}
 
 		activation := sema.NewVariableActivation(sema.BaseValueActivation)
@@ -3929,21 +3921,20 @@ func TestDefaultFunctionsWithConditions(t *testing.T) {
 		))
 
 		var logs []string
-		vmConfig := &vm.Config{
-			Storage:        storage,
-			AccountHandler: &testAccountHandler{},
-			NativeFunctionsProvider: func() map[string]vm.Value {
-				funcs := vm.NativeFunctions()
-				funcs[commons.LogFunctionName] = vm.NativeFunctionValue{
-					ParameterCount: len(stdlib.LogFunctionType.Parameters),
-					Function: func(config *vm.Config, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
-						logs = append(logs, arguments[0].String())
-						return vm.VoidValue{}
-					},
-				}
 
-				return funcs
-			},
+		vmConfig := vm.NewConfig(storage)
+		vmConfig.AccountHandler = &testAccountHandler{}
+		vmConfig.NativeFunctionsProvider = func() map[string]vm.Value {
+			funcs := vm.NativeFunctions()
+			funcs[commons.LogFunctionName] = vm.NativeFunctionValue{
+				ParameterCount: len(stdlib.LogFunctionType.Parameters),
+				Function: func(config *vm.Config, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
+					logs = append(logs, arguments[0].String())
+					return vm.VoidValue{}
+				},
+			}
+
+			return funcs
 		}
 
 		_, err := compileAndInvokeWithOptions(t, `
@@ -4026,21 +4017,19 @@ func TestDefaultFunctionsWithConditions(t *testing.T) {
 		))
 
 		var logs []string
-		vmConfig := &vm.Config{
-			Storage:        storage,
-			AccountHandler: &testAccountHandler{},
-			NativeFunctionsProvider: func() map[string]vm.Value {
-				funcs := vm.NativeFunctions()
-				funcs[commons.LogFunctionName] = vm.NativeFunctionValue{
-					ParameterCount: len(stdlib.LogFunctionType.Parameters),
-					Function: func(config *vm.Config, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
-						logs = append(logs, arguments[0].String())
-						return vm.VoidValue{}
-					},
-				}
+		vmConfig := vm.NewConfig(storage)
+		vmConfig.AccountHandler = &testAccountHandler{}
+		vmConfig.NativeFunctionsProvider = func() map[string]vm.Value {
+			funcs := vm.NativeFunctions()
+			funcs[commons.LogFunctionName] = vm.NativeFunctionValue{
+				ParameterCount: len(stdlib.LogFunctionType.Parameters),
+				Function: func(config *vm.Config, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
+					logs = append(logs, arguments[0].String())
+					return vm.VoidValue{}
+				},
+			}
 
-				return funcs
-			},
+			return funcs
 		}
 
 		_, err := compileAndInvokeWithOptions(t, `
@@ -4137,21 +4126,19 @@ func TestBeforeFunctionInPostConditions(t *testing.T) {
 		))
 
 		var logs []string
-		vmConfig := &vm.Config{
-			Storage:        storage,
-			AccountHandler: &testAccountHandler{},
-			NativeFunctionsProvider: func() map[string]vm.Value {
-				funcs := vm.NativeFunctions()
-				funcs[commons.LogFunctionName] = vm.NativeFunctionValue{
-					ParameterCount: len(stdlib.LogFunctionType.Parameters),
-					Function: func(config *vm.Config, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
-						logs = append(logs, arguments[0].String())
-						return vm.VoidValue{}
-					},
-				}
+		vmConfig := vm.NewConfig(storage)
+		vmConfig.AccountHandler = &testAccountHandler{}
+		vmConfig.NativeFunctionsProvider = func() map[string]vm.Value {
+			funcs := vm.NativeFunctions()
+			funcs[commons.LogFunctionName] = vm.NativeFunctionValue{
+				ParameterCount: len(stdlib.LogFunctionType.Parameters),
+				Function: func(config *vm.Config, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
+					logs = append(logs, arguments[0].String())
+					return vm.VoidValue{}
+				},
+			}
 
-				return funcs
-			},
+			return funcs
 		}
 
 		_, err := compileAndInvokeWithOptions(t, `
@@ -4229,21 +4216,19 @@ func TestBeforeFunctionInPostConditions(t *testing.T) {
 		))
 
 		var logs []string
-		vmConfig := &vm.Config{
-			Storage:        storage,
-			AccountHandler: &testAccountHandler{},
-			NativeFunctionsProvider: func() map[string]vm.Value {
-				funcs := vm.NativeFunctions()
-				funcs[commons.LogFunctionName] = vm.NativeFunctionValue{
-					ParameterCount: len(stdlib.LogFunctionType.Parameters),
-					Function: func(config *vm.Config, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
-						logs = append(logs, arguments[0].String())
-						return vm.VoidValue{}
-					},
-				}
+		vmConfig := vm.NewConfig(storage)
+		vmConfig.AccountHandler = &testAccountHandler{}
+		vmConfig.NativeFunctionsProvider = func() map[string]vm.Value {
+			funcs := vm.NativeFunctions()
+			funcs[commons.LogFunctionName] = vm.NativeFunctionValue{
+				ParameterCount: len(stdlib.LogFunctionType.Parameters),
+				Function: func(config *vm.Config, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
+					logs = append(logs, arguments[0].String())
+					return vm.VoidValue{}
+				},
+			}
 
-				return funcs
-			},
+			return funcs
 		}
 
 		_, err := compileAndInvokeWithOptions(t, `
@@ -4325,21 +4310,19 @@ func TestBeforeFunctionInPostConditions(t *testing.T) {
 		))
 
 		var logs []string
-		vmConfig := &vm.Config{
-			Storage:        storage,
-			AccountHandler: &testAccountHandler{},
-			NativeFunctionsProvider: func() map[string]vm.Value {
-				funcs := vm.NativeFunctions()
-				funcs[commons.LogFunctionName] = vm.NativeFunctionValue{
-					ParameterCount: len(stdlib.LogFunctionType.Parameters),
-					Function: func(config *vm.Config, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
-						logs = append(logs, arguments[0].String())
-						return vm.VoidValue{}
-					},
-				}
+		vmConfig := vm.NewConfig(storage)
+		vmConfig.AccountHandler = &testAccountHandler{}
+		vmConfig.NativeFunctionsProvider = func() map[string]vm.Value {
+			funcs := vm.NativeFunctions()
+			funcs[commons.LogFunctionName] = vm.NativeFunctionValue{
+				ParameterCount: len(stdlib.LogFunctionType.Parameters),
+				Function: func(config *vm.Config, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
+					logs = append(logs, arguments[0].String())
+					return vm.VoidValue{}
+				},
+			}
 
-				return funcs
-			},
+			return funcs
 		}
 
 		_, err := compileAndInvokeWithOptions(t, `

--- a/bbq/vm/value.go
+++ b/bbq/vm/value.go
@@ -22,7 +22,6 @@ import (
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/bbq"
-	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 )
 
@@ -40,26 +39,12 @@ type Value interface {
 
 type StaticTypeContext = interpreter.ValueStaticTypeContext
 
-type StorageContext interface {
-	StaticTypeContext
-	common.MemoryGauge
-	interpreter.Storage
-	interpreter.StorageWriter
-}
+type StorageContext = interpreter.StorageContext
 
+// TODO: Eventually use/switch-to `interpreter.ValueTransferContext`
 type TransferContext interface {
 	StorageContext
 	ReferenceTracker
-}
-
-type ReferenceTracker interface {
-	TrackReferencedResourceKindedValue(id atree.ValueID, value *EphemeralReferenceValue)
-	ReferencedResourceKindedValues(atree.ValueID) map[*EphemeralReferenceValue]struct{}
-	ClearReferenceTracking(atree.ValueID)
-}
-
-type TypeConverterContext interface {
-	Interpreter() *interpreter.Interpreter
 }
 
 type MemberAccessibleValue interface {

--- a/bbq/vm/value_account.go
+++ b/bbq/vm/value_account.go
@@ -375,7 +375,7 @@ func recordStorageCapabilityController(
 
 	storageMapKey := interpreter.StringStorageMapKey(identifier)
 
-	accountStorage := config.Storage.GetDomainStorageMap(
+	accountStorage := config.storage.GetDomainStorageMap(
 		config.Interpreter(),
 		address,
 		common.StorageDomainPathCapability,

--- a/bbq/vm/value_capability_controller.go
+++ b/bbq/vm/value_capability_controller.go
@@ -112,7 +112,7 @@ func (v *StorageCapabilityControllerValue) String() string {
 
 func (v *StorageCapabilityControllerValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	//if remove {
-	//	interpreter.RemoveReferencedSlab(storable)
+	//	context.RemoveReferencedSlab(storable)
 	//}
 	return v
 }

--- a/bbq/vm/value_ephemeral_reference.go
+++ b/bbq/vm/value_ephemeral_reference.go
@@ -57,7 +57,7 @@ func NewEphemeralReferenceValue(
 		BorrowedType:  borrowedType,
 	}
 
-	maybeTrackReferencedResourceKindedValue(referenceTracker, ref)
+	referenceTracker.MaybeTrackReferencedResourceKindedValue(ref)
 
 	return ref
 }

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -56,8 +56,8 @@ func NewVM(
 	if conf == nil {
 		conf = &Config{}
 	}
-	if conf.Storage == nil {
-		conf.Storage = interpreter.NewInMemoryStorage(nil)
+	if conf.storage == nil {
+		conf.storage = interpreter.NewInMemoryStorage(nil)
 	}
 
 	if conf.NativeFunctionsProvider == nil {
@@ -106,7 +106,7 @@ func (vm *VM) pop() Value {
 	vm.stack[lastIndex] = nil
 	vm.stack = vm.stack[:lastIndex]
 
-	checkInvalidatedResourceOrResourceReference(value)
+	vm.config.CheckInvalidatedResourceOrResourceReference(value)
 
 	return value
 }
@@ -120,8 +120,8 @@ func (vm *VM) pop2() (Value, Value) {
 	vm.stack[lastIndex-1], vm.stack[lastIndex] = nil, nil
 	vm.stack = vm.stack[:lastIndex-1]
 
-	checkInvalidatedResourceOrResourceReference(value1)
-	checkInvalidatedResourceOrResourceReference(value2)
+	vm.config.CheckInvalidatedResourceOrResourceReference(value1)
+	vm.config.CheckInvalidatedResourceOrResourceReference(value2)
 
 	return value1, value2
 }
@@ -135,9 +135,9 @@ func (vm *VM) pop3() (Value, Value, Value) {
 	vm.stack[lastIndex-2], vm.stack[lastIndex-1], vm.stack[lastIndex] = nil, nil, nil
 	vm.stack = vm.stack[:lastIndex-2]
 
-	checkInvalidatedResourceOrResourceReference(value1)
-	checkInvalidatedResourceOrResourceReference(value2)
-	checkInvalidatedResourceOrResourceReference(value3)
+	vm.config.CheckInvalidatedResourceOrResourceReference(value1)
+	vm.config.CheckInvalidatedResourceOrResourceReference(value2)
+	vm.config.CheckInvalidatedResourceOrResourceReference(value3)
 
 	return value1, value2, value3
 }
@@ -157,7 +157,7 @@ func (vm *VM) dropN(count int) {
 	stackHeight := len(vm.stack)
 	startIndex := stackHeight - count
 	for _, value := range vm.stack[startIndex:] {
-		checkInvalidatedResourceOrResourceReference(value)
+		vm.config.CheckInvalidatedResourceOrResourceReference(value)
 	}
 	clear(vm.stack[startIndex:])
 	vm.stack = vm.stack[:startIndex]
@@ -615,7 +615,7 @@ func opNew(vm *VM, ins opcode.InstructionNew) {
 	value := NewCompositeValue(
 		compositeKind,
 		compositeStaticType,
-		vm.config.Storage,
+		vm.config.Storage(),
 	)
 	vm.push(value)
 }

--- a/interpreter/account_storagemap.go
+++ b/interpreter/account_storagemap.go
@@ -205,7 +205,7 @@ func (s *AccountStorageMap) setDomain(
 		interpreter.RemoveReferencedSlab(existingValueStorable)
 	}
 
-	interpreter.maybeValidateAtreeValue(s.orderedMap)
+	interpreter.MaybeValidateAtreeValue(s.orderedMap)
 
 	// NOTE: Don't call maybeValidateAtreeStorage() here because it is possible
 	// that domain storage map is in the process of being migrated to account
@@ -254,8 +254,8 @@ func (s *AccountStorageMap) removeDomain(interpreter *Interpreter, domain common
 		interpreter.RemoveReferencedSlab(existingValueStorable)
 	}
 
-	interpreter.maybeValidateAtreeValue(s.orderedMap)
-	interpreter.maybeValidateAtreeStorage()
+	interpreter.MaybeValidateAtreeValue(s.orderedMap)
+	interpreter.MaybeValidateAtreeStorage()
 
 	return
 }

--- a/interpreter/domain_storagemap.go
+++ b/interpreter/domain_storagemap.go
@@ -177,8 +177,8 @@ func (s *DomainStorageMap) SetValue(interpreter *Interpreter, key StorageMapKey,
 		interpreter.RemoveReferencedSlab(existingStorable)
 	}
 
-	interpreter.maybeValidateAtreeValue(s.orderedMap)
-	interpreter.maybeValidateAtreeStorage()
+	interpreter.MaybeValidateAtreeValue(s.orderedMap)
+	interpreter.MaybeValidateAtreeStorage()
 
 	return
 }
@@ -215,25 +215,23 @@ func (s *DomainStorageMap) RemoveValue(interpreter *Interpreter, key StorageMapK
 		interpreter.RemoveReferencedSlab(existingValueStorable)
 	}
 
-	interpreter.maybeValidateAtreeValue(s.orderedMap)
-	interpreter.maybeValidateAtreeStorage()
+	interpreter.MaybeValidateAtreeValue(s.orderedMap)
+	interpreter.MaybeValidateAtreeStorage()
 
 	return
 }
 
 // DeepRemove removes all elements (and their slabs) of domain storage map.
-func (s *DomainStorageMap) DeepRemove(interpreter *Interpreter, hasNoParentContainer bool) {
+func (s *DomainStorageMap) DeepRemove(context ValueRemoveContext, hasNoParentContainer bool) {
 
-	config := interpreter.SharedState.Config
-
-	if config.TracingEnabled {
+	if context.TracingEnabled() {
 		startTime := time.Now()
 
 		typeInfo := "DomainStorageMap"
 		count := s.Count()
 
 		defer func() {
-			interpreter.reportDomainStorageMapDeepRemoveTrace(
+			context.reportDomainStorageMapDeepRemoveTrace(
 				typeInfo,
 				int(count),
 				time.Since(startTime),
@@ -252,21 +250,21 @@ func (s *DomainStorageMap) DeepRemove(interpreter *Interpreter, hasNoParentConta
 
 		// NOTE: Key is just an atree.Value, not an interpreter.Value,
 		// so do not need (can) convert and not need to deep remove
-		interpreter.RemoveReferencedSlab(keyStorable)
+		context.RemoveReferencedSlab(keyStorable)
 
 		// Value
 
-		value := StoredValue(interpreter, valueStorable, storage)
-		value.DeepRemove(interpreter, false) // value is an element of v.dictionary because it is from PopIterate() callback.
-		interpreter.RemoveReferencedSlab(valueStorable)
+		value := StoredValue(context, valueStorable, storage)
+		value.DeepRemove(context, false) // value is an element of v.dictionary because it is from PopIterate() callback.
+		context.RemoveReferencedSlab(valueStorable)
 	})
 	if err != nil {
 		panic(errors.NewExternalError(err))
 	}
 
-	interpreter.maybeValidateAtreeValue(s.orderedMap)
+	context.MaybeValidateAtreeValue(s.orderedMap)
 	if hasNoParentContainer {
-		interpreter.maybeValidateAtreeStorage()
+		context.MaybeValidateAtreeStorage()
 	}
 }
 

--- a/interpreter/interpreter_expression.go
+++ b/interpreter/interpreter_expression.go
@@ -1644,7 +1644,7 @@ func (interpreter *Interpreter) VisitAttachExpression(attachExpression *ast.Atta
 		true, // base is standalone.
 	).(*CompositeValue)
 
-	attachment.setBaseValue(interpreter, base)
+	attachment.setBaseValue(base)
 
 	// we enforce this in the checker
 	if !ok {

--- a/interpreter/interpreter_statement.go
+++ b/interpreter/interpreter_statement.go
@@ -440,7 +440,7 @@ func (interpreter *Interpreter) VisitRemoveStatement(removeStatement *ast.Remove
 
 	if attachment.IsResourceKinded(interpreter) {
 		// this attachment is no longer attached to its base, but the `base` variable is still available in the destructor
-		attachment.setBaseValue(interpreter, base)
+		attachment.setBaseValue(base)
 		attachment.Destroy(interpreter, locationRange)
 	}
 

--- a/interpreter/interpreter_tracing.go
+++ b/interpreter/interpreter_tracing.go
@@ -48,6 +48,21 @@ const (
 	tracingRemoveMemberPrefix = "removeMember."
 )
 
+type Tracer interface {
+	TracingEnabled() bool
+
+	reportArrayValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration)
+	reportArrayValueTransferTrace(info string, count int, since time.Duration)
+
+	reportDictionaryValueTransferTrace(info string, count int, since time.Duration)
+	reportDictionaryValueDeepRemoveTrace(info string, count int, since time.Duration)
+
+	reportCompositeValueDeepRemoveTrace(owner string, id string, kind string, since time.Duration)
+	reportCompositeValueTransferTrace(owner string, id string, kind string, since time.Duration)
+
+	reportDomainStorageMapDeepRemoveTrace(info string, i int, since time.Duration)
+}
+
 func (interpreter *Interpreter) reportFunctionTrace(functionName string, duration time.Duration) {
 	config := interpreter.SharedState.Config
 	config.OnRecordTrace(interpreter, tracingFunctionPrefix+functionName, duration, nil)

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -260,7 +260,7 @@ func (v *SimpleCompositeValue) IsResourceKinded(context ValueStaticTypeContext) 
 }
 
 func (v *SimpleCompositeValue) Transfer(
-	interpreter *Interpreter,
+	transferContext ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -270,7 +270,7 @@ func (v *SimpleCompositeValue) Transfer(
 ) Value {
 	// TODO: actually not needed, value is not storable
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		transferContext.RemoveReferencedSlab(storable)
 	}
 
 	if v.isTransaction {
@@ -303,6 +303,6 @@ func (v *SimpleCompositeValue) Clone(interpreter *Interpreter) Value {
 	}
 }
 
-func (v *SimpleCompositeValue) DeepRemove(_ *Interpreter, _ bool) {
+func (v *SimpleCompositeValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }

--- a/interpreter/storage_test.go
+++ b/interpreter/storage_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/onflow/atree"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -113,7 +113,7 @@ type Value interface {
 	IsResourceKinded(context ValueStaticTypeContext) bool
 	NeedsStoreTo(address atree.Address) bool
 	Transfer(
-		interpreter *Interpreter,
+		transferContext ValueTransferContext,
 		locationRange LocationRange,
 		address atree.Address,
 		remove bool,
@@ -122,7 +122,7 @@ type Value interface {
 		hasNoParentContainer bool, // hasNoParentContainer is true when transferred value isn't an element of another container.
 	) Value
 	DeepRemove(
-		interpreter *Interpreter,
+		removeContext ValueRemoveContext,
 		hasNoParentContainer bool, // hasNoParentContainer is true when transferred value isn't an element of another container.
 	)
 	// Clone returns a new value that is equal to this value.

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -170,7 +170,7 @@ func (*AccountCapabilityControllerValue) IsResourceKinded(context ValueStaticTyp
 }
 
 func (v *AccountCapabilityControllerValue) Transfer(
-	interpreter *Interpreter,
+	transferContext ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -179,7 +179,7 @@ func (v *AccountCapabilityControllerValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		transferContext.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -191,7 +191,7 @@ func (v *AccountCapabilityControllerValue) Clone(_ *Interpreter) Value {
 	}
 }
 
-func (v *AccountCapabilityControllerValue) DeepRemove(_ *Interpreter, _ bool) {
+func (v *AccountCapabilityControllerValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -232,7 +232,7 @@ func (AddressValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v AddressValue) Transfer(
-	interpreter *Interpreter,
+	transferContext ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -241,7 +241,7 @@ func (v AddressValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		transferContext.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -250,7 +250,7 @@ func (v AddressValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (AddressValue) DeepRemove(_ *Interpreter, _ bool) {
+func (AddressValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -167,7 +167,7 @@ func (BoolValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v BoolValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -176,7 +176,7 @@ func (v BoolValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -185,7 +185,7 @@ func (v BoolValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (BoolValue) DeepRemove(_ *Interpreter, _ bool) {
+func (BoolValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -222,7 +222,7 @@ func (*IDCapabilityValue) IsResourceKinded(context ValueStaticTypeContext) bool 
 }
 
 func (v *IDCapabilityValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -231,8 +231,8 @@ func (v *IDCapabilityValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		v.DeepRemove(interpreter, true)
-		interpreter.RemoveReferencedSlab(storable)
+		v.DeepRemove(context, true)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -245,8 +245,8 @@ func (v *IDCapabilityValue) Clone(interpreter *Interpreter) Value {
 	)
 }
 
-func (v *IDCapabilityValue) DeepRemove(interpreter *Interpreter, _ bool) {
-	v.address.DeepRemove(interpreter, false)
+func (v *IDCapabilityValue) DeepRemove(context ValueRemoveContext, _ bool) {
+	v.address.DeepRemove(context, false)
 }
 
 func (v *IDCapabilityValue) ByteSize() uint32 {

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -184,7 +184,7 @@ func (CharacterValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v CharacterValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -193,7 +193,7 @@ func (v CharacterValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -202,7 +202,7 @@ func (v CharacterValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (CharacterValue) DeepRemove(_ *Interpreter, _ bool) {
+func (CharacterValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -525,7 +525,7 @@ func (v *DictionaryValue) Destroy(interpreter *Interpreter, locationRange Locati
 
 	v.isDestroyed = true
 
-	interpreter.invalidateReferencedResources(v, locationRange)
+	interpreter.InvalidateReferencedResources(v, locationRange)
 
 	v.dictionary = nil
 }
@@ -950,8 +950,8 @@ func (v *DictionaryValue) RemoveWithoutTransfer(
 		panic(errors.NewExternalError(err))
 	}
 
-	interpreter.maybeValidateAtreeValue(v.dictionary)
-	interpreter.maybeValidateAtreeStorage()
+	interpreter.MaybeValidateAtreeValue(v.dictionary)
+	interpreter.MaybeValidateAtreeStorage()
 
 	return existingKeyStorable, existingValueStorable
 }
@@ -1030,8 +1030,8 @@ func (v *DictionaryValue) InsertWithoutTransfer(
 		panic(errors.NewExternalError(err))
 	}
 
-	interpreter.maybeValidateAtreeValue(v.dictionary)
-	interpreter.maybeValidateAtreeStorage()
+	interpreter.MaybeValidateAtreeValue(v.dictionary)
+	interpreter.MaybeValidateAtreeStorage()
 
 	return existingValueStorable
 }
@@ -1286,7 +1286,7 @@ func (v *DictionaryValue) UnwrapAtreeValue() (atree.Value, uint64) {
 func (v *DictionaryValue) IsReferenceTrackedResourceKindedValue() {}
 
 func (v *DictionaryValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	locationRange LocationRange,
 	address atree.Address,
 	remove bool,
@@ -1295,21 +1295,19 @@ func (v *DictionaryValue) Transfer(
 	hasNoParentContainer bool,
 ) Value {
 
-	config := interpreter.SharedState.Config
-
-	interpreter.ReportComputation(
+	context.ReportComputation(
 		common.ComputationKindTransferDictionaryValue,
 		uint(v.Count()),
 	)
 
-	if config.TracingEnabled {
+	if context.TracingEnabled() {
 		startTime := time.Now()
 
 		typeInfo := v.Type.String()
 		count := v.Count()
 
 		defer func() {
-			interpreter.reportDictionaryValueTransferTrace(
+			context.reportDictionaryValueTransferTrace(
 				typeInfo,
 				count,
 				time.Since(startTime),
@@ -1332,12 +1330,12 @@ func (v *DictionaryValue) Transfer(
 	dictionary := v.dictionary
 
 	needsStoreTo := v.NeedsStoreTo(address)
-	isResourceKinded := v.IsResourceKinded(interpreter)
+	isResourceKinded := v.IsResourceKinded(context)
 
 	if needsStoreTo || !isResourceKinded {
 
-		valueComparator := newValueComparator(interpreter, locationRange)
-		hashInputProvider := newHashInputProvider(interpreter, locationRange)
+		valueComparator := newValueComparator(context, locationRange)
+		hashInputProvider := newHashInputProvider(context, locationRange)
 
 		// Use non-readonly iterator here because iterated
 		// value can be removed if remove parameter is true.
@@ -1352,18 +1350,18 @@ func (v *DictionaryValue) Transfer(
 			elementCount,
 			v.elementSize,
 		)
-		common.UseMemory(interpreter, elementOverhead)
-		common.UseMemory(interpreter, dataUse)
-		common.UseMemory(interpreter, metaDataUse)
+		common.UseMemory(context, elementOverhead)
+		common.UseMemory(context, dataUse)
+		common.UseMemory(context, metaDataUse)
 
 		elementMemoryUse := common.NewAtreeMapPreAllocatedElementsMemoryUsage(
 			elementCount,
 			v.elementSize,
 		)
-		common.UseMemory(config.MemoryGauge, elementMemoryUse)
+		common.UseMemory(context, elementMemoryUse)
 
 		dictionary, err = atree.NewMapFromBatchData(
-			config.Storage,
+			context.Storage(),
 			address,
 			atree.NewDefaultDigesterBuilder(),
 			v.dictionary.Type(),
@@ -1380,9 +1378,9 @@ func (v *DictionaryValue) Transfer(
 					return nil, nil, nil
 				}
 
-				key := MustConvertStoredValue(interpreter, atreeKey).
+				key := MustConvertStoredValue(context, atreeKey).
 					Transfer(
-						interpreter,
+						context,
 						locationRange,
 						address,
 						remove,
@@ -1391,9 +1389,9 @@ func (v *DictionaryValue) Transfer(
 						false, // atreeKey has parent container because it is returned from iterator.
 					)
 
-				value := MustConvertStoredValue(interpreter, atreeValue).
+				value := MustConvertStoredValue(context, atreeValue).
 					Transfer(
-						interpreter,
+						context,
 						locationRange,
 						address,
 						remove,
@@ -1411,19 +1409,19 @@ func (v *DictionaryValue) Transfer(
 
 		if remove {
 			err = v.dictionary.PopIterate(func(keyStorable atree.Storable, valueStorable atree.Storable) {
-				interpreter.RemoveReferencedSlab(keyStorable)
-				interpreter.RemoveReferencedSlab(valueStorable)
+				context.RemoveReferencedSlab(keyStorable)
+				context.RemoveReferencedSlab(valueStorable)
 			})
 			if err != nil {
 				panic(errors.NewExternalError(err))
 			}
 
-			interpreter.maybeValidateAtreeValue(v.dictionary)
+			context.MaybeValidateAtreeValue(v.dictionary)
 			if hasNoParentContainer {
-				interpreter.maybeValidateAtreeStorage()
+				context.MaybeValidateAtreeStorage()
 			}
 
-			interpreter.RemoveReferencedSlab(storable)
+			context.RemoveReferencedSlab(storable)
 		}
 	}
 
@@ -1437,13 +1435,13 @@ func (v *DictionaryValue) Transfer(
 		// This allows raising an error when the resource array is attempted
 		// to be transferred/moved again (see beginning of this function)
 
-		interpreter.invalidateReferencedResources(v, locationRange)
+		context.InvalidateReferencedResources(v, locationRange)
 
 		v.dictionary = nil
 	}
 
 	res := NewDictionaryValueFromAtreeMap(
-		interpreter,
+		context,
 		v.Type,
 		v.elementSize,
 		dictionary,
@@ -1512,18 +1510,16 @@ func (v *DictionaryValue) Clone(interpreter *Interpreter) Value {
 	return dictionary
 }
 
-func (v *DictionaryValue) DeepRemove(interpreter *Interpreter, hasNoParentContainer bool) {
+func (v *DictionaryValue) DeepRemove(context ValueRemoveContext, hasNoParentContainer bool) {
 
-	config := interpreter.SharedState.Config
-
-	if config.TracingEnabled {
+	if context.TracingEnabled() {
 		startTime := time.Now()
 
 		typeInfo := v.Type.String()
 		count := v.Count()
 
 		defer func() {
-			interpreter.reportDictionaryValueDeepRemoveTrace(
+			context.reportDictionaryValueDeepRemoveTrace(
 				typeInfo,
 				count,
 				time.Since(startTime),
@@ -1537,21 +1533,21 @@ func (v *DictionaryValue) DeepRemove(interpreter *Interpreter, hasNoParentContai
 
 	err := v.dictionary.PopIterate(func(keyStorable atree.Storable, valueStorable atree.Storable) {
 
-		key := StoredValue(interpreter, keyStorable, storage)
-		key.DeepRemove(interpreter, false) // key is an element of v.dictionary because it is from PopIterate() callback.
-		interpreter.RemoveReferencedSlab(keyStorable)
+		key := StoredValue(context, keyStorable, storage)
+		key.DeepRemove(context, false) // key is an element of v.dictionary because it is from PopIterate() callback.
+		context.RemoveReferencedSlab(keyStorable)
 
-		value := StoredValue(interpreter, valueStorable, storage)
-		value.DeepRemove(interpreter, false) // value is an element of v.dictionary because it is from PopIterate() callback.
-		interpreter.RemoveReferencedSlab(valueStorable)
+		value := StoredValue(context, valueStorable, storage)
+		value.DeepRemove(context, false) // value is an element of v.dictionary because it is from PopIterate() callback.
+		context.RemoveReferencedSlab(valueStorable)
 	})
 	if err != nil {
 		panic(errors.NewExternalError(err))
 	}
 
-	interpreter.maybeValidateAtreeValue(v.dictionary)
+	context.MaybeValidateAtreeValue(v.dictionary)
 	if hasNoParentContainer {
-		interpreter.maybeValidateAtreeStorage()
+		context.MaybeValidateAtreeStorage()
 	}
 }
 

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -63,7 +63,7 @@ func NewUnmeteredEphemeralReferenceValue(
 		BorrowedType:  borrowedType,
 	}
 
-	interpreter.maybeTrackReferencedResourceKindedValue(ref)
+	interpreter.MaybeTrackReferencedResourceKindedValue(ref)
 
 	return ref
 }
@@ -310,7 +310,7 @@ func (*EphemeralReferenceValue) IsResourceKinded(context ValueStaticTypeContext)
 }
 
 func (v *EphemeralReferenceValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -319,7 +319,7 @@ func (v *EphemeralReferenceValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -328,7 +328,7 @@ func (v *EphemeralReferenceValue) Clone(inter *Interpreter) Value {
 	return NewUnmeteredEphemeralReferenceValue(inter, v.Authorization, v.Value, v.BorrowedType, EmptyLocationRange)
 }
 
-func (*EphemeralReferenceValue) DeepRemove(_ *Interpreter, _ bool) {
+func (*EphemeralReferenceValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -571,7 +571,7 @@ func (Fix64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v Fix64Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -580,7 +580,7 @@ func (v Fix64Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -589,7 +589,7 @@ func (v Fix64Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Fix64Value) DeepRemove(_ *Interpreter, _ bool) {
+func (Fix64Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -146,7 +146,7 @@ func (*InterpretedFunctionValue) IsResourceKinded(context ValueStaticTypeContext
 }
 
 func (f *InterpretedFunctionValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -156,7 +156,7 @@ func (f *InterpretedFunctionValue) Transfer(
 ) Value {
 	// TODO: actually not needed, value is not storable
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return f
 }
@@ -165,7 +165,7 @@ func (f *InterpretedFunctionValue) Clone(_ *Interpreter) Value {
 	return f
 }
 
-func (*InterpretedFunctionValue) DeepRemove(_ *Interpreter, _ bool) {
+func (*InterpretedFunctionValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 
@@ -299,7 +299,7 @@ func (*HostFunctionValue) IsResourceKinded(context ValueStaticTypeContext) bool 
 }
 
 func (f *HostFunctionValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -309,7 +309,7 @@ func (f *HostFunctionValue) Transfer(
 ) Value {
 	// TODO: actually not needed, value is not storable
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return f
 }
@@ -318,7 +318,7 @@ func (f *HostFunctionValue) Clone(_ *Interpreter) Value {
 	return f
 }
 
-func (*HostFunctionValue) DeepRemove(_ *Interpreter, _ bool) {
+func (*HostFunctionValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 
@@ -490,7 +490,7 @@ func (BoundFunctionValue) IsResourceKinded(context ValueStaticTypeContext) bool 
 }
 
 func (f BoundFunctionValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -500,7 +500,7 @@ func (f BoundFunctionValue) Transfer(
 ) Value {
 	// TODO: actually not needed, value is not storable
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return f
 }
@@ -509,7 +509,7 @@ func (f BoundFunctionValue) Clone(_ *Interpreter) Value {
 	return f
 }
 
-func (BoundFunctionValue) DeepRemove(_ *Interpreter, _ bool) {
+func (BoundFunctionValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -619,7 +619,7 @@ func (IntValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v IntValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -628,7 +628,7 @@ func (v IntValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -637,7 +637,7 @@ func (v IntValue) Clone(_ *Interpreter) Value {
 	return NewUnmeteredIntValueFromBigInt(v.BigInt)
 }
 
-func (IntValue) DeepRemove(_ *Interpreter, _ bool) {
+func (IntValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -776,7 +776,7 @@ func (Int128Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v Int128Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -785,7 +785,7 @@ func (v Int128Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -794,7 +794,7 @@ func (v Int128Value) Clone(_ *Interpreter) Value {
 	return NewUnmeteredInt128ValueFromBigInt(v.BigInt)
 }
 
-func (Int128Value) DeepRemove(_ *Interpreter, _ bool) {
+func (Int128Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -653,7 +653,7 @@ func (Int16Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v Int16Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -662,7 +662,7 @@ func (v Int16Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -671,7 +671,7 @@ func (v Int16Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Int16Value) DeepRemove(_ *Interpreter, _ bool) {
+func (Int16Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -743,7 +743,7 @@ func (Int256Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v Int256Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -752,7 +752,7 @@ func (v Int256Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -761,7 +761,7 @@ func (v Int256Value) Clone(_ *Interpreter) Value {
 	return NewUnmeteredInt256ValueFromBigInt(v.BigInt)
 }
 
-func (Int256Value) DeepRemove(_ *Interpreter, _ bool) {
+func (Int256Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -653,7 +653,7 @@ func (Int32Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v Int32Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -662,7 +662,7 @@ func (v Int32Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -671,7 +671,7 @@ func (v Int32Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Int32Value) DeepRemove(_ *Interpreter, _ bool) {
+func (Int32Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -644,7 +644,7 @@ func (Int64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v Int64Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -653,7 +653,7 @@ func (v Int64Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -662,7 +662,7 @@ func (v Int64Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Int64Value) DeepRemove(_ *Interpreter, _ bool) {
+func (Int64Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -650,7 +650,7 @@ func (Int8Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v Int8Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -659,7 +659,7 @@ func (v Int8Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -668,7 +668,7 @@ func (v Int8Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Int8Value) DeepRemove(_ *Interpreter, _ bool) {
+func (Int8Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_link.go
+++ b/interpreter/value_link.go
@@ -125,7 +125,7 @@ func (PathLinkValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v PathLinkValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -134,7 +134,7 @@ func (v PathLinkValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -146,7 +146,7 @@ func (v PathLinkValue) Clone(inter *Interpreter) Value {
 	}
 }
 
-func (PathLinkValue) DeepRemove(_ *Interpreter, _ bool) {
+func (PathLinkValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 
@@ -248,7 +248,7 @@ func (AccountLinkValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v AccountLinkValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -257,7 +257,7 @@ func (v AccountLinkValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -266,7 +266,7 @@ func (AccountLinkValue) Clone(_ *Interpreter) Value {
 	return AccountLinkValue{}
 }
 
-func (AccountLinkValue) DeepRemove(_ *Interpreter, _ bool) {
+func (AccountLinkValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -147,7 +147,7 @@ func (NilValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v NilValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -156,7 +156,7 @@ func (v NilValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -165,7 +165,7 @@ func (v NilValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (NilValue) DeepRemove(_ *Interpreter, _ bool) {
+func (NilValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -230,7 +230,7 @@ func (PathValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v PathValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -239,7 +239,7 @@ func (v PathValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -248,7 +248,7 @@ func (v PathValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (PathValue) DeepRemove(_ *Interpreter, _ bool) {
+func (PathValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -245,7 +245,7 @@ func (*PathCapabilityValue) IsResourceKinded(context ValueStaticTypeContext) boo
 }
 
 func (v *PathCapabilityValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -254,8 +254,8 @@ func (v *PathCapabilityValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		v.DeepRemove(interpreter, true)
-		interpreter.RemoveReferencedSlab(storable)
+		v.DeepRemove(context, true)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -268,9 +268,9 @@ func (v *PathCapabilityValue) Clone(interpreter *Interpreter) Value {
 	}
 }
 
-func (v *PathCapabilityValue) DeepRemove(interpreter *Interpreter, _ bool) {
-	v.address.DeepRemove(interpreter, false)
-	v.Path.DeepRemove(interpreter, false)
+func (v *PathCapabilityValue) DeepRemove(context ValueRemoveContext, _ bool) {
+	v.address.DeepRemove(context, false)
+	v.Path.DeepRemove(context, false)
 }
 
 func (v *PathCapabilityValue) ByteSize() uint32 {

--- a/interpreter/value_placeholder.go
+++ b/interpreter/value_placeholder.go
@@ -80,7 +80,7 @@ func (placeholderValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (f placeholderValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -90,7 +90,7 @@ func (f placeholderValue) Transfer(
 ) Value {
 	// TODO: actually not needed, value is not storable
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return f
 }
@@ -99,6 +99,6 @@ func (f placeholderValue) Clone(_ *Interpreter) Value {
 	return f
 }
 
-func (placeholderValue) DeepRemove(_ *Interpreter, _ bool) {
+func (placeholderValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }

--- a/interpreter/value_published.go
+++ b/interpreter/value_published.go
@@ -125,12 +125,13 @@ func (*PublishedValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v *PublishedValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	locationRange LocationRange,
 	address atree.Address,
 	remove bool,
 	storable atree.Storable,
-	preventTransfer map[atree.ValueID]struct{},
+	preventTransfer map[atree.ValueID]struct {
+	},
 	hasNoParentContainer bool,
 ) Value {
 	// NB: if the inner value of a PublishedValue can be a resource,
@@ -139,7 +140,7 @@ func (v *PublishedValue) Transfer(
 	if v.NeedsStoreTo(address) {
 
 		innerValue := v.Value.Transfer(
-			interpreter,
+			context,
 			locationRange,
 			address,
 			remove,
@@ -149,7 +150,7 @@ func (v *PublishedValue) Transfer(
 		).(*IDCapabilityValue)
 
 		addressValue := v.Recipient.Transfer(
-			interpreter,
+			context,
 			locationRange,
 			address,
 			remove,
@@ -159,10 +160,10 @@ func (v *PublishedValue) Transfer(
 		).(AddressValue)
 
 		if remove {
-			interpreter.RemoveReferencedSlab(storable)
+			context.RemoveReferencedSlab(storable)
 		}
 
-		return NewPublishedValue(interpreter, addressValue, innerValue)
+		return NewPublishedValue(context, addressValue, innerValue)
 	}
 
 	return v
@@ -176,7 +177,7 @@ func (v *PublishedValue) Clone(interpreter *Interpreter) Value {
 	}
 }
 
-func (*PublishedValue) DeepRemove(_ *Interpreter, _ bool) {
+func (*PublishedValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -383,7 +383,7 @@ func (*StorageReferenceValue) IsResourceKinded(context ValueStaticTypeContext) b
 }
 
 func (v *StorageReferenceValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -392,7 +392,7 @@ func (v *StorageReferenceValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -406,7 +406,7 @@ func (v *StorageReferenceValue) Clone(_ *Interpreter) Value {
 	)
 }
 
-func (*StorageReferenceValue) DeepRemove(_ *Interpreter, _ bool) {
+func (*StorageReferenceValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -195,7 +195,7 @@ func (*StorageCapabilityControllerValue) IsResourceKinded(context ValueStaticTyp
 }
 
 func (v *StorageCapabilityControllerValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -204,7 +204,7 @@ func (v *StorageCapabilityControllerValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -217,7 +217,7 @@ func (v *StorageCapabilityControllerValue) Clone(interpreter *Interpreter) Value
 	}
 }
 
-func (v *StorageCapabilityControllerValue) DeepRemove(_ *Interpreter, _ bool) {
+func (v *StorageCapabilityControllerValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -739,16 +739,17 @@ func (*StringValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v *StringValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
 	storable atree.Storable,
-	_ map[atree.ValueID]struct{},
+	_ map[atree.ValueID]struct {
+	},
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -757,7 +758,7 @@ func (v *StringValue) Clone(_ *Interpreter) Value {
 	return NewUnmeteredStringValue(v.Str)
 }
 
-func (*StringValue) DeepRemove(_ *Interpreter, _ bool) {
+func (*StringValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_test.go
+++ b/interpreter/value_test.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/tools/go/packages"
 
 	"github.com/onflow/atree"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -299,7 +299,7 @@ func (TypeValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v TypeValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -308,7 +308,7 @@ func (v TypeValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -317,7 +317,7 @@ func (v TypeValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (TypeValue) DeepRemove(_ *Interpreter, _ bool) {
+func (TypeValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -527,7 +527,7 @@ func (UFix64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v UFix64Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -536,7 +536,7 @@ func (v UFix64Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -545,7 +545,7 @@ func (v UFix64Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (UFix64Value) DeepRemove(_ *Interpreter, _ bool) {
+func (UFix64Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -627,7 +627,7 @@ func (UIntValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v UIntValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -636,7 +636,7 @@ func (v UIntValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -645,7 +645,7 @@ func (v UIntValue) Clone(_ *Interpreter) Value {
 	return NewUnmeteredUIntValueFromBigInt(v.BigInt)
 }
 
-func (UIntValue) DeepRemove(_ *Interpreter, _ bool) {
+func (UIntValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -677,7 +677,7 @@ func (UInt128Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v UInt128Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -686,7 +686,7 @@ func (v UInt128Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -695,7 +695,7 @@ func (v UInt128Value) Clone(_ *Interpreter) Value {
 	return NewUnmeteredUInt128ValueFromBigInt(v.BigInt)
 }
 
-func (UInt128Value) DeepRemove(_ *Interpreter, _ bool) {
+func (UInt128Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -540,7 +540,7 @@ func (UInt16Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v UInt16Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -549,7 +549,7 @@ func (v UInt16Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -558,7 +558,7 @@ func (v UInt16Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (UInt16Value) DeepRemove(_ *Interpreter, _ bool) {
+func (UInt16Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -676,7 +676,7 @@ func (UInt256Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 	return false
 }
 func (v UInt256Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -685,7 +685,7 @@ func (v UInt256Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -694,7 +694,7 @@ func (v UInt256Value) Clone(_ *Interpreter) Value {
 	return NewUnmeteredUInt256ValueFromBigInt(v.BigInt)
 }
 
-func (UInt256Value) DeepRemove(_ *Interpreter, _ bool) {
+func (UInt256Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -541,7 +541,7 @@ func (UInt32Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v UInt32Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -550,7 +550,7 @@ func (v UInt32Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -559,7 +559,7 @@ func (v UInt32Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (UInt32Value) DeepRemove(_ *Interpreter, _ bool) {
+func (UInt32Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -571,7 +571,7 @@ func (UInt64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v UInt64Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -580,7 +580,7 @@ func (v UInt64Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -589,7 +589,7 @@ func (v UInt64Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (UInt64Value) DeepRemove(_ *Interpreter, _ bool) {
+func (UInt64Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -585,7 +585,7 @@ func (UInt8Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v UInt8Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -594,7 +594,7 @@ func (v UInt8Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -603,7 +603,7 @@ func (v UInt8Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (UInt8Value) DeepRemove(_ *Interpreter, _ bool) {
+func (UInt8Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_void.go
+++ b/interpreter/value_void.go
@@ -94,7 +94,7 @@ func (VoidValue) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v VoidValue) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -103,7 +103,7 @@ func (v VoidValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -112,7 +112,7 @@ func (v VoidValue) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (VoidValue) DeepRemove(_ *Interpreter, _ bool) {
+func (VoidValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -582,7 +582,7 @@ func (Word128Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v Word128Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -591,7 +591,7 @@ func (v Word128Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -600,7 +600,7 @@ func (v Word128Value) Clone(_ *Interpreter) Value {
 	return NewUnmeteredWord128ValueFromBigInt(v.BigInt)
 }
 
-func (Word128Value) DeepRemove(_ *Interpreter, _ bool) {
+func (Word128Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -436,7 +436,7 @@ func (Word16Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v Word16Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -445,7 +445,7 @@ func (v Word16Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -454,7 +454,7 @@ func (v Word16Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Word16Value) DeepRemove(_ *Interpreter, _ bool) {
+func (Word16Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -583,7 +583,7 @@ func (Word256Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v Word256Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -592,7 +592,7 @@ func (v Word256Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -601,7 +601,7 @@ func (v Word256Value) Clone(_ *Interpreter) Value {
 	return NewUnmeteredWord256ValueFromBigInt(v.BigInt)
 }
 
-func (Word256Value) DeepRemove(_ *Interpreter, _ bool) {
+func (Word256Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -437,7 +437,7 @@ func (Word32Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v Word32Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -446,7 +446,7 @@ func (v Word32Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -455,7 +455,7 @@ func (v Word32Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Word32Value) DeepRemove(_ *Interpreter, _ bool) {
+func (Word32Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -465,7 +465,7 @@ func (Word64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v Word64Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -474,7 +474,7 @@ func (v Word64Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -487,7 +487,7 @@ func (v Word64Value) ByteSize() uint32 {
 	return cborTagSize + getUintCBORSize(uint64(v))
 }
 
-func (Word64Value) DeepRemove(_ *Interpreter, _ bool) {
+func (Word64Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -434,7 +434,7 @@ func (Word8Value) IsResourceKinded(context ValueStaticTypeContext) bool {
 }
 
 func (v Word8Value) Transfer(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	_ LocationRange,
 	_ atree.Address,
 	remove bool,
@@ -443,7 +443,7 @@ func (v Word8Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		interpreter.RemoveReferencedSlab(storable)
+		context.RemoveReferencedSlab(storable)
 	}
 	return v
 }
@@ -452,7 +452,7 @@ func (v Word8Value) Clone(_ *Interpreter) Value {
 	return v
 }
 
-func (Word8Value) DeepRemove(_ *Interpreter, _ bool) {
+func (Word8Value) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/onflow/atree"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 
 	"github.com/onflow/atree"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3693

Depends on #3817, #3820

## Description

Change the first parameter of `interpreter.Value.Transfer()` method from `interpreter *Interpreter,` to `ValueTransferContext`.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
