### PR TITLE
[Compiler] Decouple `Value.MeteredString` method from the interpreter

### DIFF
--- a/bbq/vm/value_conversions.go
+++ b/bbq/vm/value_conversions.go
@@ -38,7 +38,7 @@ func InterpreterValueToVMValue(value interpreter.Value) Value {
 	case interpreter.IntValue:
 		return NewIntValue(value.BigInt.Int64())
 	case interpreter.UFix64Value:
-		return UFix64Value(value)
+		return UFix64Value(value.UFix64Value)
 	case *interpreter.StringValue:
 		return NewStringValue(value.Str)
 	case *interpreter.CompositeValue:

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -148,7 +148,6 @@ func (n NoOpStringContext) MeterMemory(_ common.MemoryUsage) error {
 
 func (n NoOpStringContext) WithMutationPrevention(_ atree.ValueID, f func()) {
 	f()
-	return
 }
 
 func (n NoOpStringContext) ReadStored(_ common.Address, _ common.StorageDomain, _ StorageMapKey) Value {

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -19,9 +19,12 @@
 package interpreter
 
 import (
+	"time"
+
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/sema"
 )
 
@@ -117,4 +120,121 @@ type ValueRemoveContext = ValueTransferContext
 
 type ComputationReporter interface {
 	ReportComputation(compKind common.ComputationKind, intensity uint)
+}
+
+type ValueIterationContext interface {
+	ValueTransferContext
+	WithMutationPrevention(valueID atree.ValueID, f func())
+}
+
+type ValueStringContext interface {
+	ValueIterationContext
+}
+
+// NoOpStringContext is the ValueStringContext implementation used in Value.RecursiveString method.
+// Since Value.RecursiveString is a non-mutating operation, it should only need the no-op memory metering
+// and a WithMutationPrevention implementation.
+// All other methods should not be reachable, hence is safe to panic in them.
+//
+// TODO: Ideally, Value.RecursiveString shouldn't need the full ValueTransferContext.
+// But that would require refactoring the iterator methods for arrays and dictionaries.
+type NoOpStringContext struct{}
+
+var _ ValueStringContext = NoOpStringContext{}
+
+func (n NoOpStringContext) MeterMemory(_ common.MemoryUsage) error {
+	return nil
+}
+
+func (n NoOpStringContext) WithMutationPrevention(_ atree.ValueID, f func()) {
+	f()
+	return
+}
+
+func (n NoOpStringContext) ReadStored(_ common.Address, _ common.StorageDomain, _ StorageMapKey) Value {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) ConvertStaticToSemaType(_ StaticType) (sema.Type, error) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) IsSubType(_ StaticType, _ StaticType) bool {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) IsSubTypeOfSemaType(_ StaticType, _ sema.Type) bool {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) WriteStored(_ common.Address, _ common.StorageDomain, _ StorageMapKey, _ Value) (existed bool) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) Storage() Storage {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) RemoveReferencedSlab(_ atree.Storable) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) MaybeValidateAtreeValue(_ atree.Value) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) MaybeValidateAtreeStorage() {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) InvalidateReferencedResources(_ Value, _ LocationRange) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) CheckInvalidatedResourceOrResourceReference(_ Value, _ LocationRange) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) MaybeTrackReferencedResourceKindedValue(_ *EphemeralReferenceValue) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) ReportComputation(_ common.ComputationKind, _ uint) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) TracingEnabled() bool {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) reportArrayValueDeepRemoveTrace(_ string, _ int, _ time.Duration) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) reportArrayValueTransferTrace(_ string, _ int, _ time.Duration) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) reportDictionaryValueTransferTrace(_ string, _ int, _ time.Duration) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) reportDictionaryValueDeepRemoveTrace(_ string, _ int, _ time.Duration) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) reportCompositeValueDeepRemoveTrace(_ string, _ string, _ string, _ time.Duration) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) reportCompositeValueTransferTrace(_ string, _ string, _ string, _ time.Duration) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) reportDomainStorageMapDeepRemoveTrace(_ string, _ int, _ time.Duration) {
+	panic(errors.NewUnreachableError())
+}
+
+func (n NoOpStringContext) OnResourceOwnerChange(_ *CompositeValue, _ common.Address, _ common.Address) {
+	panic(errors.NewUnreachableError())
 }

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5695,7 +5695,7 @@ func (interpreter *Interpreter) validateMutation(valueID atree.ValueID, location
 	})
 }
 
-func (interpreter *Interpreter) withMutationPrevention(valueID atree.ValueID, f func()) {
+func (interpreter *Interpreter) WithMutationPrevention(valueID atree.ValueID, f func()) {
 	if interpreter == nil {
 		f()
 		return

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -109,7 +109,7 @@ type Value interface {
 		results TypeConformanceResults,
 	) bool
 	RecursiveString(seenReferences SeenReferences) string
-	MeteredString(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string
+	MeteredString(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string
 	IsResourceKinded(context ValueStaticTypeContext) bool
 	NeedsStoreTo(address atree.Address) bool
 	Transfer(

--- a/interpreter/value_account.go
+++ b/interpreter/value_account.go
@@ -93,10 +93,10 @@ func NewAccountValue(
 	}
 
 	var str string
-	stringer := func(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
+	stringer := func(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
 		if str == "" {
-			common.UseMemory(interpreter, common.AccountValueStringMemoryUsage)
-			addressStr := address.MeteredString(interpreter, seenReferences, locationRange)
+			common.UseMemory(context, common.AccountValueStringMemoryUsage)
+			addressStr := address.MeteredString(context, seenReferences, locationRange)
 			str = fmt.Sprintf("Account(%s)", addressStr)
 		}
 		return str

--- a/interpreter/value_account_accountcapabilities.go
+++ b/interpreter/value_account_accountcapabilities.go
@@ -71,10 +71,10 @@ func NewAccountAccountCapabilitiesValue(
 	}
 
 	var str string
-	stringer := func(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
+	stringer := func(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
 		if str == "" {
-			common.UseMemory(interpreter, common.AccountAccountCapabilitiesStringMemoryUsage)
-			addressStr := address.MeteredString(interpreter, seenReferences, locationRange)
+			common.UseMemory(context, common.AccountAccountCapabilitiesStringMemoryUsage)
+			addressStr := address.MeteredString(context, seenReferences, locationRange)
 			str = fmt.Sprintf("Account.AccountCapabilities(%s)", addressStr)
 		}
 		return str

--- a/interpreter/value_account_capabilities.go
+++ b/interpreter/value_account_capabilities.go
@@ -80,10 +80,10 @@ func NewAccountCapabilitiesValue(
 	}
 
 	var str string
-	stringer := func(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
+	stringer := func(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
 		if str == "" {
-			common.UseMemory(interpreter, common.AccountCapabilitiesStringMemoryUsage)
-			addressStr := address.MeteredString(interpreter, seenReferences, locationRange)
+			common.UseMemory(context, common.AccountCapabilitiesStringMemoryUsage)
+			addressStr := address.MeteredString(context, seenReferences, locationRange)
 			str = fmt.Sprintf("Account.Capabilities(%s)", addressStr)
 		}
 		return str

--- a/interpreter/value_account_contracts.go
+++ b/interpreter/value_account_contracts.go
@@ -82,10 +82,10 @@ func NewAccountContractsValue(
 	}
 
 	var str string
-	stringer := func(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
+	stringer := func(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
 		if str == "" {
-			common.UseMemory(interpreter, common.AccountContractsStringMemoryUsage)
-			addressStr := address.MeteredString(interpreter, seenReferences, locationRange)
+			common.UseMemory(context, common.AccountContractsStringMemoryUsage)
+			addressStr := address.MeteredString(context, seenReferences, locationRange)
 			str = fmt.Sprintf("Account.Contracts(%s)", addressStr)
 		}
 		return str

--- a/interpreter/value_account_inbox.go
+++ b/interpreter/value_account_inbox.go
@@ -66,10 +66,10 @@ func NewAccountInboxValue(
 	}
 
 	var str string
-	stringer := func(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
+	stringer := func(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
 		if str == "" {
-			common.UseMemory(interpreter, common.AccountInboxStringMemoryUsage)
-			addressStr := addressValue.MeteredString(interpreter, seenReferences, locationRange)
+			common.UseMemory(context, common.AccountInboxStringMemoryUsage)
+			addressStr := addressValue.MeteredString(context, seenReferences, locationRange)
 			str = fmt.Sprintf("Account.Inbox(%s)", addressStr)
 		}
 		return str

--- a/interpreter/value_account_storage.go
+++ b/interpreter/value_account_storage.go
@@ -108,10 +108,10 @@ func NewAccountStorageValue(
 	}
 
 	var str string
-	stringer := func(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
+	stringer := func(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
 		if str == "" {
-			common.UseMemory(interpreter, common.AccountStorageStringMemoryUsage)
-			addressStr := address.MeteredString(interpreter, seenReferences, locationRange)
+			common.UseMemory(context, common.AccountStorageStringMemoryUsage)
+			addressStr := address.MeteredString(context, seenReferences, locationRange)
 			str = fmt.Sprintf("Account.Storage(%s)", addressStr)
 		}
 		return str

--- a/interpreter/value_account_storagecapabilities.go
+++ b/interpreter/value_account_storagecapabilities.go
@@ -71,10 +71,10 @@ func NewAccountStorageCapabilitiesValue(
 	}
 
 	var str string
-	stringer := func(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
+	stringer := func(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
 		if str == "" {
-			common.UseMemory(interpreter, common.AccountStorageCapabilitiesStringMemoryUsage)
-			addressStr := address.MeteredString(interpreter, seenReferences, locationRange)
+			common.UseMemory(context, common.AccountStorageCapabilitiesStringMemoryUsage)
+			addressStr := address.MeteredString(context, seenReferences, locationRange)
 			str = fmt.Sprintf("Account.StorageCapabilities(%s)", addressStr)
 		}
 		return str

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -116,16 +116,12 @@ func (v *AccountCapabilityControllerValue) RecursiveString(seenReferences SeenRe
 	)
 }
 
-func (v *AccountCapabilityControllerValue) MeteredString(
-	interpreter *Interpreter,
-	seenReferences SeenReferences,
-	locationRange LocationRange,
-) string {
-	common.UseMemory(interpreter, common.AccountCapabilityControllerValueStringMemoryUsage)
+func (v *AccountCapabilityControllerValue) MeteredString(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
+	common.UseMemory(context, common.AccountCapabilityControllerValueStringMemoryUsage)
 
 	return format.AccountCapabilityController(
-		v.BorrowType.MeteredString(interpreter),
-		v.CapabilityID.MeteredString(interpreter, seenReferences, locationRange),
+		v.BorrowType.MeteredString(context),
+		v.CapabilityID.MeteredString(context, seenReferences, locationRange),
 	)
 }
 

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -118,8 +118,8 @@ func (v AddressValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v AddressValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
-	common.UseMemory(interpreter, common.AddressValueStringMemoryUsage)
+func (v AddressValue) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
+	common.UseMemory(context, common.AddressValueStringMemoryUsage)
 	return v.String()
 }
 

--- a/interpreter/value_authaccount_keys.go
+++ b/interpreter/value_authaccount_keys.go
@@ -75,10 +75,10 @@ func NewAccountKeysValue(
 	}
 
 	var str string
-	stringer := func(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
+	stringer := func(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
 		if str == "" {
-			common.UseMemory(interpreter, common.AccountKeysStringMemoryUsage)
-			addressStr := address.MeteredString(interpreter, seenReferences, locationRange)
+			common.UseMemory(context, common.AccountKeysStringMemoryUsage)
+			addressStr := address.MeteredString(context, seenReferences, locationRange)
 			str = fmt.Sprintf("Account.Keys(%s)", addressStr)
 		}
 		return str

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -138,11 +138,11 @@ func (v BoolValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v BoolValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v BoolValue) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	if v {
-		common.UseMemory(interpreter, common.TrueStringMemoryUsage)
+		common.UseMemory(context, common.TrueStringMemoryUsage)
 	} else {
-		common.UseMemory(interpreter, common.FalseStringMemoryUsage)
+		common.UseMemory(context, common.FalseStringMemoryUsage)
 	}
 
 	return v.String()

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -132,13 +132,13 @@ func (v *IDCapabilityValue) RecursiveString(seenReferences SeenReferences) strin
 	)
 }
 
-func (v *IDCapabilityValue) MeteredString(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
-	common.UseMemory(interpreter, common.IDCapabilityValueStringMemoryUsage)
+func (v *IDCapabilityValue) MeteredString(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
+	common.UseMemory(context, common.IDCapabilityValueStringMemoryUsage)
 
 	return format.Capability(
-		v.BorrowType.MeteredString(interpreter),
-		v.address.MeteredString(interpreter, seenReferences, locationRange),
-		v.ID.MeteredString(interpreter, seenReferences, locationRange),
+		v.BorrowType.MeteredString(context),
+		v.address.MeteredString(context, seenReferences, locationRange),
+		v.ID.MeteredString(context, seenReferences, locationRange),
 	)
 }
 

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -103,9 +103,9 @@ func (v CharacterValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v CharacterValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v CharacterValue) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	l := format.FormattedStringLength(v.Str)
-	common.UseMemory(interpreter, common.NewRawStringMemoryUsage(l))
+	common.UseMemory(context, common.NewRawStringMemoryUsage(l))
 	return v.String()
 }
 

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -95,19 +95,19 @@ func (v *EphemeralReferenceValue) String() string {
 }
 
 func (v *EphemeralReferenceValue) RecursiveString(seenReferences SeenReferences) string {
-	return v.MeteredString(nil, seenReferences, EmptyLocationRange)
+	return v.MeteredString(NoOpStringContext{}, seenReferences, EmptyLocationRange)
 }
 
-func (v *EphemeralReferenceValue) MeteredString(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
+func (v *EphemeralReferenceValue) MeteredString(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
 	if _, ok := seenReferences[v]; ok {
-		common.UseMemory(interpreter, common.SeenReferenceStringMemoryUsage)
+		common.UseMemory(context, common.SeenReferenceStringMemoryUsage)
 		return "..."
 	}
 
 	seenReferences[v] = struct{}{}
 	defer delete(seenReferences, v)
 
-	return v.Value.MeteredString(interpreter, seenReferences, locationRange)
+	return v.Value.MeteredString(context, seenReferences, locationRange)
 }
 
 func (v *EphemeralReferenceValue) StaticType(context ValueStaticTypeContext) StaticType {

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -110,11 +110,11 @@ func (v Fix64Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Fix64Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v Fix64Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -88,10 +88,10 @@ func (f *InterpretedFunctionValue) RecursiveString(_ SeenReferences) string {
 	return f.String()
 }
 
-func (f *InterpretedFunctionValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (f *InterpretedFunctionValue) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	// TODO: Meter sema.Type String conversion
 	typeString := f.Type.String()
-	common.UseMemory(interpreter, common.NewRawStringMemoryUsage(8+len(typeString)))
+	common.UseMemory(context, common.NewRawStringMemoryUsage(8+len(typeString)))
 	return f.String()
 }
 
@@ -186,8 +186,8 @@ func (f *HostFunctionValue) RecursiveString(_ SeenReferences) string {
 	return f.String()
 }
 
-func (f *HostFunctionValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
-	common.UseMemory(interpreter, common.HostFunctionValueStringMemoryUsage)
+func (f *HostFunctionValue) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
+	common.UseMemory(context, common.HostFunctionValueStringMemoryUsage)
 	return f.String()
 }
 
@@ -401,8 +401,8 @@ func (f BoundFunctionValue) RecursiveString(seenReferences SeenReferences) strin
 	return f.Function.RecursiveString(seenReferences)
 }
 
-func (f BoundFunctionValue) MeteredString(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
-	return f.Function.MeteredString(interpreter, seenReferences, locationRange)
+func (f BoundFunctionValue) MeteredString(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
+	return f.Function.MeteredString(context, seenReferences, locationRange)
 }
 
 func (f BoundFunctionValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -153,11 +153,11 @@ func (v IntValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v IntValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v IntValue) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -149,11 +149,11 @@ func (v Int128Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Int128Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v Int128Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -86,11 +86,11 @@ func (v Int16Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Int16Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v Int16Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -118,11 +118,11 @@ func (v Int256Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Int256Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v Int256Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -86,11 +86,11 @@ func (v Int32Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Int32Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v Int32Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -86,11 +86,11 @@ func (v Int64Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Int64Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v Int64Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -84,11 +84,11 @@ func (v Int8Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Int8Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v Int8Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()

--- a/interpreter/value_link.go
+++ b/interpreter/value_link.go
@@ -87,7 +87,7 @@ func (v PathLinkValue) RecursiveString(seenReferences SeenReferences) string {
 	)
 }
 
-func (v PathLinkValue) MeteredString(_ *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v PathLinkValue) MeteredString(_ ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	panic(errors.NewUnreachableError())
 }
 
@@ -215,7 +215,7 @@ func (v AccountLinkValue) RecursiveString(_ SeenReferences) string {
 	panic(errors.NewUnreachableError())
 }
 
-func (v AccountLinkValue) MeteredString(_ *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v AccountLinkValue) MeteredString(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
 	panic(errors.NewUnreachableError())
 }
 

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -84,8 +84,8 @@ func (v NilValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v NilValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
-	common.UseMemory(interpreter, common.NilValueStringMemoryUsage)
+func (v NilValue) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
+	common.UseMemory(context, common.NilValueStringMemoryUsage)
 	return v.String()
 }
 

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -103,10 +103,10 @@ func (v PathValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v PathValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v PathValue) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	// len(domain) + len(identifier) + '/' x2
 	strLen := len(v.Domain.Identifier()) + len(v.Identifier) + 2
-	common.UseMemory(interpreter, common.NewRawStringMemoryUsage(strLen))
+	common.UseMemory(context, common.NewRawStringMemoryUsage(strLen))
 	return v.String()
 }
 
@@ -226,7 +226,7 @@ func (PathValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (PathValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (PathValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -102,26 +102,22 @@ func (v *PathCapabilityValue) RecursiveString(seenReferences SeenReferences) str
 	}
 }
 
-func (v *PathCapabilityValue) MeteredString(
-	interpreter *Interpreter,
-	seenReferences SeenReferences,
-	locationRange LocationRange,
-) string {
-	common.UseMemory(interpreter, common.PathCapabilityValueStringMemoryUsage)
+func (v *PathCapabilityValue) MeteredString(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
+	common.UseMemory(context, common.PathCapabilityValueStringMemoryUsage)
 
 	borrowType := v.BorrowType
 	if borrowType == nil {
 		return fmt.Sprintf(
 			"Capability(address: %s, path: %s)",
-			v.address.MeteredString(interpreter, seenReferences, locationRange),
-			v.Path.MeteredString(interpreter, seenReferences, locationRange),
+			v.address.MeteredString(context, seenReferences, locationRange),
+			v.Path.MeteredString(context, seenReferences, locationRange),
 		)
 	} else {
 		return fmt.Sprintf(
 			"Capability<%s>(address: %s, path: %s)",
 			borrowType.String(),
-			v.address.MeteredString(interpreter, seenReferences, locationRange),
-			v.Path.MeteredString(interpreter, seenReferences, locationRange),
+			v.address.MeteredString(context, seenReferences, locationRange),
+			v.Path.MeteredString(context, seenReferences, locationRange),
 		)
 	}
 }

--- a/interpreter/value_placeholder.go
+++ b/interpreter/value_placeholder.go
@@ -39,7 +39,7 @@ func (f placeholderValue) RecursiveString(_ SeenReferences) string {
 	return ""
 }
 
-func (f placeholderValue) MeteredString(_ *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (f placeholderValue) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	return ""
 }
 
@@ -75,7 +75,7 @@ func (placeholderValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (placeholderValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (placeholderValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_published.go
+++ b/interpreter/value_published.go
@@ -76,13 +76,13 @@ func (v *PublishedValue) RecursiveString(seenReferences SeenReferences) string {
 	)
 }
 
-func (v *PublishedValue) MeteredString(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
-	common.UseMemory(interpreter, common.PublishedValueStringMemoryUsage)
+func (v *PublishedValue) MeteredString(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
+	common.UseMemory(context, common.PublishedValueStringMemoryUsage)
 
 	return fmt.Sprintf(
 		"PublishedValue<%s>(%s)",
-		v.Recipient.MeteredString(interpreter, seenReferences, locationRange),
-		v.Value.MeteredString(interpreter, seenReferences, locationRange),
+		v.Recipient.MeteredString(context, seenReferences, locationRange),
+		v.Value.MeteredString(context, seenReferences, locationRange),
 	)
 }
 
@@ -121,7 +121,7 @@ func (v *PublishedValue) NeedsStoreTo(address atree.Address) bool {
 	return v.Value.NeedsStoreTo(address)
 }
 
-func (*PublishedValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (*PublishedValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -142,8 +142,8 @@ func (v *SomeValue) RecursiveString(seenReferences SeenReferences) string {
 	return v.value.RecursiveString(seenReferences)
 }
 
-func (v *SomeValue) MeteredString(interpreter *Interpreter, seenReferences SeenReferences, locationRange LocationRange) string {
-	return v.value.MeteredString(interpreter, seenReferences, locationRange)
+func (v *SomeValue) MeteredString(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
+	return v.value.MeteredString(context, seenReferences, locationRange)
 }
 
 func (v *SomeValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
@@ -406,7 +406,7 @@ func (v *SomeValue) InnerValue() Value {
 	return v.value
 }
 
-func (v *SomeValue) isInvalidatedResource(context ValueStaticTypeContext) bool {
+func (v *SomeValue) isInvalidatedResource(_ ValueStaticTypeContext) bool {
 	return v.value == nil || v.IsDestroyed()
 }
 

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -93,8 +93,8 @@ func (v *StorageReferenceValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v *StorageReferenceValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
-	common.UseMemory(interpreter, common.StorageReferenceValueStringMemoryUsage)
+func (v *StorageReferenceValue) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
+	common.UseMemory(context, common.StorageReferenceValueStringMemoryUsage)
 	return v.String()
 }
 
@@ -378,7 +378,7 @@ func (*StorageReferenceValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*StorageReferenceValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (*StorageReferenceValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -139,17 +139,13 @@ func (v *StorageCapabilityControllerValue) RecursiveString(seenReferences SeenRe
 	)
 }
 
-func (v *StorageCapabilityControllerValue) MeteredString(
-	interpreter *Interpreter,
-	seenReferences SeenReferences,
-	locationRange LocationRange,
-) string {
-	common.UseMemory(interpreter, common.StorageCapabilityControllerValueStringMemoryUsage)
+func (v *StorageCapabilityControllerValue) MeteredString(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
+	common.UseMemory(context, common.StorageCapabilityControllerValueStringMemoryUsage)
 
 	return format.StorageCapabilityController(
-		v.BorrowType.MeteredString(interpreter),
-		v.CapabilityID.MeteredString(interpreter, seenReferences, locationRange),
-		v.TargetPath.MeteredString(interpreter, seenReferences, locationRange),
+		v.BorrowType.MeteredString(context),
+		v.CapabilityID.MeteredString(context, seenReferences, locationRange),
+		v.TargetPath.MeteredString(context, seenReferences, locationRange),
 	)
 }
 
@@ -191,7 +187,7 @@ func (*StorageCapabilityControllerValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*StorageCapabilityControllerValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (*StorageCapabilityControllerValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -138,9 +138,9 @@ func (v *StringValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v *StringValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v *StringValue) MeteredString(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
 	l := format.FormattedStringLength(v.Str)
-	common.UseMemory(interpreter, common.NewRawStringMemoryUsage(l))
+	common.UseMemory(context, common.NewRawStringMemoryUsage(l))
 	return v.String()
 }
 

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -88,12 +88,12 @@ func (v TypeValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v TypeValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
-	common.UseMemory(interpreter, common.TypeValueStringMemoryUsage)
+func (v TypeValue) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
+	common.UseMemory(context, common.TypeValueStringMemoryUsage)
 
 	var typeString string
 	if v.Type != nil {
-		typeString = v.Type.MeteredString(interpreter)
+		typeString = v.Type.MeteredString(context)
 	}
 
 	return format.TypeValue(typeString)
@@ -295,7 +295,7 @@ func (TypeValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (TypeValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (TypeValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -185,11 +185,11 @@ func (v UFix64Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v UFix64Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v UFix64Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -159,11 +159,11 @@ func (v UIntValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v UIntValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v UIntValue) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()
@@ -623,7 +623,7 @@ func (UIntValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UIntValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (UIntValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -118,11 +118,11 @@ func (v UInt128Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v UInt128Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v UInt128Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()
@@ -673,7 +673,7 @@ func (UInt128Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UInt128Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (UInt128Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -84,11 +84,11 @@ func (v UInt16Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v UInt16Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v UInt16Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()
@@ -536,7 +536,7 @@ func (UInt16Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UInt16Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (UInt16Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -119,11 +119,11 @@ func (v UInt256Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v UInt256Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v UInt256Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()
@@ -673,7 +673,7 @@ func (UInt256Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UInt256Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (UInt256Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 func (v UInt256Value) Transfer(

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -84,11 +84,11 @@ func (v UInt32Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v UInt32Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v UInt32Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()
@@ -537,7 +537,7 @@ func (UInt32Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UInt32Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (UInt32Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -91,11 +91,11 @@ func (v UInt64Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v UInt64Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v UInt64Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()
@@ -565,7 +565,7 @@ func (UInt64Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UInt64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (UInt64Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -84,11 +84,11 @@ func (v UInt8Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v UInt8Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v UInt8Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()
@@ -581,7 +581,7 @@ func (UInt8Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (UInt8Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (UInt8Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_void.go
+++ b/interpreter/value_void.go
@@ -63,8 +63,8 @@ func (v VoidValue) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v VoidValue) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
-	common.UseMemory(interpreter, common.VoidStringMemoryUsage)
+func (v VoidValue) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
+	common.UseMemory(context, common.VoidStringMemoryUsage)
 	return v.String()
 }
 
@@ -89,7 +89,7 @@ func (VoidValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (VoidValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (VoidValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -118,11 +118,11 @@ func (v Word128Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Word128Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v Word128Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()
@@ -578,7 +578,7 @@ func (Word128Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Word128Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (Word128Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -85,11 +85,11 @@ func (v Word16Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Word16Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v Word16Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()
@@ -432,7 +432,7 @@ func (Word16Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Word16Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (Word16Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -118,11 +118,11 @@ func (v Word256Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Word256Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v Word256Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()
@@ -579,7 +579,7 @@ func (Word256Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Word256Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (Word256Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -85,11 +85,11 @@ func (v Word32Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Word32Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v Word32Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()
@@ -433,7 +433,7 @@ func (Word32Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Word32Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (Word32Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -93,11 +93,11 @@ func (v Word64Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Word64Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v Word64Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()
@@ -461,7 +461,7 @@ func (Word64Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Word64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (Word64Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -84,11 +84,11 @@ func (v Word8Value) RecursiveString(_ SeenReferences) string {
 	return v.String()
 }
 
-func (v Word8Value) MeteredString(interpreter *Interpreter, _ SeenReferences, _ LocationRange) string {
+func (v Word8Value) MeteredString(context ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	common.UseMemory(
-		interpreter,
+		context,
 		common.NewRawStringMemoryUsage(
-			OverEstimateNumberStringLength(interpreter, v),
+			OverEstimateNumberStringLength(context, v),
 		),
 	)
 	return v.String()
@@ -430,7 +430,7 @@ func (Word8Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Word8Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (Word8Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3693

Depends on https://github.com/onflow/cadence/pull/3819


## Description

Removes the `Interpreter` parameter from the `Value.MeteredString` method.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
