### PR TITLE
[Compiler] Decouple `GetMember` and `SetMember` methods of `interpreter.Value` from the interpreter

### DIFF
--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -154,19 +154,9 @@ func (c *Config) WriteStored(
 	)
 }
 
-func (c *Config) ConvertStaticToSemaType(staticType interpreter.StaticType) (sema.Type, error) {
-	inter := c.Interpreter()
-	return interpreter.ConvertStaticToSemaType(inter, staticType)
-}
-
 func (c *Config) IsSubType(subType interpreter.StaticType, superType interpreter.StaticType) bool {
 	inter := c.Interpreter()
 	return interpreter.IsSubType(inter, subType, superType)
-}
-
-func (c *Config) IsSubTypeOfSemaType(staticSubType interpreter.StaticType, superType sema.Type) bool {
-	inter := c.Interpreter()
-	return interpreter.IsSubTypeOfSemaType(inter, staticSubType, superType)
 }
 
 func (c *Config) GetInterfaceType(
@@ -229,22 +219,22 @@ func (c *Config) GetEntitlementMapType(typeID interpreter.TypeID) (*sema.Entitle
 
 func (c *Config) MaybeValidateAtreeValue(v atree.Value) {
 	//TODO
-	panic(errors.NewUnreachableError())
+	// NO-OP: no validation happens for now
 }
 
 func (c *Config) MaybeValidateAtreeStorage() {
 	//TODO
-	panic(errors.NewUnreachableError())
+	// NO-OP: no validation happens for now
 }
 
 func (c *Config) RecordStorageMutation() {
-	//TODO
-	panic(errors.NewUnreachableError())
+	// TODO
+	// NO-OP
 }
 
 func (c *Config) IsRecovered(location common.Location) bool {
 	//TODO
-	panic(errors.NewUnreachableError())
+	return false
 }
 
 type ContractValueHandler func(conf *Config, location common.Location) *CompositeValue

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -169,30 +169,60 @@ func (c *Config) IsSubTypeOfSemaType(staticSubType interpreter.StaticType, super
 	return interpreter.IsSubTypeOfSemaType(inter, staticSubType, superType)
 }
 
+func (c *Config) GetInterfaceType(
+	location common.Location,
+	_ string,
+	typeID interpreter.TypeID,
+) (*sema.InterfaceType, error) {
+
+	// TODO: Lookup in built-in types
+
+	compositeKindedType := c.TypeLoader(location, typeID)
+	if compositeKindedType != nil {
+
+		inter, ok := compositeKindedType.(*sema.InterfaceType)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		return inter, nil
+	}
+
+	return nil, interpreter.TypeLoadingError{
+		TypeID: typeID,
+	}
+}
+
+func (c *Config) GetCompositeType(
+	location common.Location,
+	_ string,
+	typeID interpreter.TypeID,
+) (*sema.CompositeType, error) {
+
+	// TODO: Lookup in built-in types
+
+	compositeKindedType := c.TypeLoader(location, typeID)
+	if compositeKindedType != nil {
+
+		compositeType, ok := compositeKindedType.(*sema.CompositeType)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		return compositeType, nil
+	}
+
+	return nil, interpreter.TypeLoadingError{
+		TypeID: typeID,
+	}
+}
+
 func (c *Config) GetEntitlementType(typeID interpreter.TypeID) (*sema.EntitlementType, error) {
 	//TODO
 	panic(errors.NewUnreachableError())
 }
 
 func (c *Config) GetEntitlementMapType(typeID interpreter.TypeID) (*sema.EntitlementMapType, error) {
-	//TODO
-	panic(errors.NewUnreachableError())
-}
-
-func (c *Config) GetInterfaceType(
-	location common.Location,
-	qualifiedIdentifier string,
-	typeID interpreter.TypeID,
-) (*sema.InterfaceType, error) {
-	//TODO
-	panic(errors.NewUnreachableError())
-}
-
-func (c *Config) GetCompositeType(
-	location common.Location,
-	qualifiedIdentifier string,
-	typeID interpreter.TypeID,
-) (*sema.CompositeType, error) {
 	//TODO
 	panic(errors.NewUnreachableError())
 }

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -156,17 +156,17 @@ func (c *Config) WriteStored(
 
 func (c *Config) ConvertStaticToSemaType(staticType interpreter.StaticType) (sema.Type, error) {
 	inter := c.Interpreter()
-	return inter.ConvertStaticToSemaType(staticType)
+	return interpreter.ConvertStaticToSemaType(inter, staticType)
 }
 
 func (c *Config) IsSubType(subType interpreter.StaticType, superType interpreter.StaticType) bool {
 	inter := c.Interpreter()
-	return inter.IsSubType(subType, superType)
+	return interpreter.IsSubType(inter, subType, superType)
 }
 
 func (c *Config) IsSubTypeOfSemaType(staticSubType interpreter.StaticType, superType sema.Type) bool {
 	inter := c.Interpreter()
-	return inter.IsSubTypeOfSemaType(staticSubType, superType)
+	return interpreter.IsSubTypeOfSemaType(inter, staticSubType, superType)
 }
 
 func (c *Config) GetEntitlementType(typeID interpreter.TypeID) (*sema.EntitlementType, error) {
@@ -197,17 +197,22 @@ func (c *Config) GetCompositeType(
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Config) RemoveReferencedSlab(storable atree.Storable) {
-	//TODO
-	panic(errors.NewUnreachableError())
-}
-
 func (c *Config) MaybeValidateAtreeValue(v atree.Value) {
 	//TODO
 	panic(errors.NewUnreachableError())
 }
 
 func (c *Config) MaybeValidateAtreeStorage() {
+	//TODO
+	panic(errors.NewUnreachableError())
+}
+
+func (c *Config) RecordStorageMutation() {
+	//TODO
+	panic(errors.NewUnreachableError())
+}
+
+func (c *Config) IsRecovered(location common.Location) bool {
 	//TODO
 	panic(errors.NewUnreachableError())
 }

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -232,7 +232,7 @@ func (c *Config) RecordStorageMutation() {
 	// NO-OP
 }
 
-func (c *Config) IsRecovered(location common.Location) bool {
+func (c *Config) IsTypeInfoRecovered(location common.Location) bool {
 	//TODO
 	return false
 }

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -44,7 +44,7 @@ type testAccountHandler struct {
 	generateAccountID          func(address common.Address) (uint64, error)
 	getAccountBalance          func(address common.Address) (uint64, error)
 	getAccountAvailableBalance func(address common.Address) (uint64, error)
-	commitStorageTemporarily   func(inter *interpreter.Interpreter) error
+	commitStorageTemporarily   func(context interpreter.ValueTransferContext) error
 	getStorageUsed             func(address common.Address) (uint64, error)
 	getStorageCapacity         func(address common.Address) (uint64, error)
 	validatePublicKey          func(key *stdlib.PublicKey) error
@@ -133,11 +133,11 @@ func (t *testAccountHandler) GetAccountAvailableBalance(address common.Address) 
 	return t.getAccountAvailableBalance(address)
 }
 
-func (t *testAccountHandler) CommitStorageTemporarily(inter *interpreter.Interpreter) error {
+func (t *testAccountHandler) CommitStorageTemporarily(context interpreter.ValueTransferContext) error {
 	if t.commitStorageTemporarily == nil {
 		panic(errors.NewUnexpectedError("unexpected call to CommitStorageTemporarily"))
 	}
-	return t.commitStorageTemporarily(inter)
+	return t.commitStorageTemporarily(context)
 }
 
 func (t *testAccountHandler) GetStorageUsed(address common.Address) (uint64, error) {

--- a/bbq/vm/value_account.go
+++ b/bbq/vm/value_account.go
@@ -259,7 +259,7 @@ func checkAndIssueStorageCapabilityControllerWithType(
 	borrowType, ok := ty.(*interpreter.ReferenceStaticType)
 	if !ok {
 		// TODO: remove conversion. se static type in error
-		semaType, err := config.Interpreter().ConvertStaticToSemaType(ty)
+		semaType, err := interpreter.ConvertStaticToSemaType(config.Interpreter(), ty)
 		if err != nil {
 			panic(err)
 		}

--- a/bbq/vm/value_capability.go
+++ b/bbq/vm/value_capability.go
@@ -241,11 +241,13 @@ func canBorrow(
 
 	// Ensure the wanted borrow type is a subtype or supertype of the capability borrow type
 
-	return context.IsSubType(
+	return interpreter.IsSubType(
+		context,
 		wantedBorrowType.ReferencedType,
 		capabilityBorrowType.ReferencedType,
 	) ||
-		context.IsSubType(
+		interpreter.IsSubType(
+			context,
 			capabilityBorrowType.ReferencedType,
 			wantedBorrowType.ReferencedType,
 		)

--- a/bbq/vm/value_capability_controller.go
+++ b/bbq/vm/value_capability_controller.go
@@ -112,7 +112,7 @@ func (v *StorageCapabilityControllerValue) String() string {
 
 func (v *StorageCapabilityControllerValue) Transfer(TransferContext, atree.Address, bool, atree.Storable) Value {
 	//if remove {
-	//	context.RemoveReferencedSlab(storable)
+	//	RemoveReferencedSlab(context, storable)
 	//}
 	return v
 }

--- a/bbq/vm/value_conversions.go
+++ b/bbq/vm/value_conversions.go
@@ -173,7 +173,7 @@ func VMValueToInterpreterValue(typeConverter interpreter.TypeConverter, value Va
 			nil,
 		)
 	case *StorageReferenceValue:
-		semaBorrowType, err := typeConverter.ConvertStaticToSemaType(value.BorrowedType)
+		semaBorrowType, err := interpreter.ConvertStaticToSemaType(typeConverter, value.BorrowedType)
 		if err != nil {
 			panic(err)
 		}

--- a/bbq/vm/value_storage_reference.go
+++ b/bbq/vm/value_storage_reference.go
@@ -101,7 +101,7 @@ func (v *StorageReferenceValue) dereference(context StaticTypeContext) (*Value, 
 	if v.BorrowedType != nil {
 		staticType := vmReferencedValue.StaticType(context)
 
-		if !context.IsSubType(staticType, v.BorrowedType) {
+		if !interpreter.IsSubType(context, staticType, v.BorrowedType) {
 			panic(fmt.Errorf("type mismatch: expected %s, found %s", v.BorrowedType, staticType))
 
 			// TODO:

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -261,7 +261,7 @@ func (*StandardLibraryHandler) GetAccountAvailableBalance(_ common.Address) (uin
 	return 0, goerrors.New("accounts are not supported in this environment")
 }
 
-func (*StandardLibraryHandler) CommitStorageTemporarily(_ *interpreter.Interpreter) error {
+func (*StandardLibraryHandler) CommitStorageTemporarily(_ interpreter.ValueTransferContext) error {
 	// NO-OP
 	return nil
 }

--- a/cmd/decode-state-values/main.go
+++ b/cmd/decode-state-values/main.go
@@ -235,7 +235,7 @@ type interpreterStorage struct {
 var _ interpreter.Storage = &interpreterStorage{}
 
 func (i interpreterStorage) GetDomainStorageMap(
-	_ *interpreter.Interpreter,
+	_ interpreter.StorageMutationTracker,
 	_ common.Address,
 	_ common.StorageDomain,
 	_ bool,

--- a/interpreter/account_storagemap.go
+++ b/interpreter/account_storagemap.go
@@ -95,7 +95,7 @@ func (s *AccountStorageMap) DomainExists(domain common.StorageDomain) bool {
 // is created and inserted into account storage map with given domain as key.
 func (s *AccountStorageMap) GetDomain(
 	gauge common.MemoryGauge,
-	interpreter *Interpreter,
+	storageMutationTracker StorageMutationTracker,
 	domain common.StorageDomain,
 	createIfNotExists bool,
 ) *DomainStorageMap {
@@ -112,7 +112,7 @@ func (s *AccountStorageMap) GetDomain(
 			// Create domain storage map if needed.
 
 			if createIfNotExists {
-				return s.NewDomain(gauge, interpreter, domain)
+				return s.NewDomain(gauge, storageMutationTracker, domain)
 			}
 
 			return nil
@@ -128,10 +128,10 @@ func (s *AccountStorageMap) GetDomain(
 // NewDomain creates new domain storage map and inserts it to AccountStorageMap with given domain as key.
 func (s *AccountStorageMap) NewDomain(
 	gauge common.MemoryGauge,
-	interpreter *Interpreter,
+	storageMutationTracker StorageMutationTracker,
 	domain common.StorageDomain,
 ) *DomainStorageMap {
-	interpreter.recordStorageMutation()
+	storageMutationTracker.RecordStorageMutation()
 
 	domainStorageMap := NewDomainStorageMap(gauge, s.orderedMap.Storage, s.orderedMap.Address())
 
@@ -162,24 +162,24 @@ func (s *AccountStorageMap) NewDomain(
 // If the given storage map is non-nil, domain is added/updated.
 // Returns true if domain storage map previously existed at the given domain.
 func (s *AccountStorageMap) WriteDomain(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	domain common.StorageDomain,
 	domainStorageMap *DomainStorageMap,
 ) (existed bool) {
 	if domainStorageMap == nil {
-		return s.removeDomain(interpreter, domain)
+		return s.removeDomain(context, domain)
 	}
-	return s.setDomain(interpreter, domain, domainStorageMap)
+	return s.setDomain(context, domain, domainStorageMap)
 }
 
 // setDomain sets domain storage map in the account storage map and returns true if domain previously existed.
 // If the given domain already stores a domain storage map, it is overwritten.
 func (s *AccountStorageMap) setDomain(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	domain common.StorageDomain,
 	newDomainStorageMap *DomainStorageMap,
 ) (existed bool) {
-	interpreter.recordStorageMutation()
+	context.RecordStorageMutation()
 
 	key := Uint64StorageMapKey(domain)
 
@@ -199,13 +199,13 @@ func (s *AccountStorageMap) setDomain(
 		existingDomainStorageMap := newDomainStorageMapWithAtreeStorable(s.orderedMap.Storage, existingValueStorable)
 
 		// Deep remove elements in domain storage map
-		existingDomainStorageMap.DeepRemove(interpreter, true)
+		existingDomainStorageMap.DeepRemove(context, true)
 
 		// Remove domain storage map slab
-		interpreter.RemoveReferencedSlab(existingValueStorable)
+		RemoveReferencedSlab(context, existingValueStorable)
 	}
 
-	interpreter.MaybeValidateAtreeValue(s.orderedMap)
+	context.MaybeValidateAtreeValue(s.orderedMap)
 
 	// NOTE: Don't call maybeValidateAtreeStorage() here because it is possible
 	// that domain storage map is in the process of being migrated to account
@@ -215,8 +215,8 @@ func (s *AccountStorageMap) setDomain(
 }
 
 // removeDomain removes domain storage map with given domain in account storage map, if it exists.
-func (s *AccountStorageMap) removeDomain(interpreter *Interpreter, domain common.StorageDomain) (existed bool) {
-	interpreter.recordStorageMutation()
+func (s *AccountStorageMap) removeDomain(context ValueTransferContext, domain common.StorageDomain) (existed bool) {
+	context.RecordStorageMutation()
 
 	key := Uint64StorageMapKey(domain)
 
@@ -238,7 +238,7 @@ func (s *AccountStorageMap) removeDomain(interpreter *Interpreter, domain common
 
 	// NOTE: Key is just an atree.Value (Uint64AtreeValue), not an interpreter.Value,
 	// so do not need (can) convert and not need to deep remove
-	interpreter.RemoveReferencedSlab(existingKeyStorable)
+	RemoveReferencedSlab(context, existingKeyStorable)
 
 	// Value
 
@@ -248,14 +248,14 @@ func (s *AccountStorageMap) removeDomain(interpreter *Interpreter, domain common
 		domainStorageMap := newDomainStorageMapWithAtreeStorable(s.orderedMap.Storage, existingValueStorable)
 
 		// Deep remove elements in domain storage map
-		domainStorageMap.DeepRemove(interpreter, true)
+		domainStorageMap.DeepRemove(context, true)
 
 		// Remove domain storage map slab
-		interpreter.RemoveReferencedSlab(existingValueStorable)
+		RemoveReferencedSlab(context, existingValueStorable)
 	}
 
-	interpreter.MaybeValidateAtreeValue(s.orderedMap)
-	interpreter.MaybeValidateAtreeStorage()
+	context.MaybeValidateAtreeValue(s.orderedMap)
+	context.MaybeValidateAtreeStorage()
 
 	return
 }

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -437,7 +437,7 @@ func (n NoOpFunctionCreationContext) GetCompositeType(location common.Location, 
 	return nil, nil
 }
 
-func (n NoOpFunctionCreationContext) IsRecovered(location common.Location) bool {
+func (n NoOpFunctionCreationContext) IsTypeInfoRecovered(location common.Location) bool {
 	// NO-OP
 	return false
 }

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -71,7 +71,7 @@ type testAccountHandler struct {
 	generateAccountID          func(address common.Address) (uint64, error)
 	getAccountBalance          func(address common.Address) (uint64, error)
 	getAccountAvailableBalance func(address common.Address) (uint64, error)
-	commitStorageTemporarily   func(inter *interpreter.Interpreter) error
+	commitStorageTemporarily   func(context interpreter.ValueTransferContext) error
 	getStorageUsed             func(address common.Address) (uint64, error)
 	getStorageCapacity         func(address common.Address) (uint64, error)
 	validatePublicKey          func(key *stdlib.PublicKey) error
@@ -160,11 +160,11 @@ func (t *testAccountHandler) GetAccountAvailableBalance(address common.Address) 
 	return t.getAccountAvailableBalance(address)
 }
 
-func (t *testAccountHandler) CommitStorageTemporarily(inter *interpreter.Interpreter) error {
+func (t *testAccountHandler) CommitStorageTemporarily(context interpreter.ValueTransferContext) error {
 	if t.commitStorageTemporarily == nil {
 		panic(errors.NewUnexpectedError("unexpected call to CommitStorageTemporarily"))
 	}
-	return t.commitStorageTemporarily(inter)
+	return t.commitStorageTemporarily(context)
 }
 
 func (t *testAccountHandler) GetStorageUsed(address common.Address) (uint64, error) {
@@ -471,8 +471,8 @@ func testAccountWithErrorHandler(
 					return baseActivation
 				},
 				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
-				AccountHandler: func(inter *interpreter.Interpreter, address interpreter.AddressValue) interpreter.Value {
-					return stdlib.NewAccountValue(inter, nil, address)
+				AccountHandler: func(context interpreter.FunctionCreationContext, address interpreter.AddressValue) interpreter.Value {
+					return stdlib.NewAccountValue(context, nil, address)
 				},
 			},
 			HandleCheckerError: checkerErrorHandler,
@@ -1333,7 +1333,7 @@ func TestInterpretAccountStorageFields(t *testing.T) {
 	const storageCapacity = 43
 
 	handler := &testAccountHandler{
-		commitStorageTemporarily: func(_ *interpreter.Interpreter) error {
+		commitStorageTemporarily: func(_ interpreter.ValueTransferContext) error {
 			return nil
 		},
 		getStorageUsed: func(_ common.Address) (uint64, error) {

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -387,6 +387,68 @@ func (t *testAccountHandler) IsContractBeingAdded(common.AddressLocation) bool {
 	return false
 }
 
+type NoOpReferenceCreationContext struct{}
+
+var _ interpreter.ReferenceCreationContext = NoOpReferenceCreationContext{}
+
+func (n NoOpReferenceCreationContext) InvalidateReferencedResources(v interpreter.Value, locationRange interpreter.LocationRange) {
+	// NO-OP
+}
+
+func (n NoOpReferenceCreationContext) CheckInvalidatedResourceOrResourceReference(value interpreter.Value, locationRange interpreter.LocationRange) {
+	// NO-OP
+}
+
+func (n NoOpReferenceCreationContext) MaybeTrackReferencedResourceKindedValue(ref *interpreter.EphemeralReferenceValue) {
+	// NO-OP
+}
+
+func (n NoOpReferenceCreationContext) MeterMemory(usage common.MemoryUsage) error {
+	// NO-OP
+	return nil
+}
+
+type NoOpFunctionCreationContext struct {
+	NoOpReferenceCreationContext
+}
+
+func (n NoOpFunctionCreationContext) ReadStored(storageAddress common.Address, domain common.StorageDomain, identifier interpreter.StorageMapKey) interpreter.Value {
+	// NO-OP
+	return nil
+}
+
+func (n NoOpFunctionCreationContext) GetEntitlementType(typeID interpreter.TypeID) (*sema.EntitlementType, error) {
+	// NO-OP
+	return nil, nil
+}
+
+func (n NoOpFunctionCreationContext) GetEntitlementMapType(typeID interpreter.TypeID) (*sema.EntitlementMapType, error) {
+	// NO-OP
+	return nil, nil
+}
+
+func (n NoOpFunctionCreationContext) GetInterfaceType(location common.Location, qualifiedIdentifier string, typeID interpreter.TypeID) (*sema.InterfaceType, error) {
+	// NO-OP
+	return nil, nil
+}
+
+func (n NoOpFunctionCreationContext) GetCompositeType(location common.Location, qualifiedIdentifier string, typeID interpreter.TypeID) (*sema.CompositeType, error) {
+	// NO-OP
+	return nil, nil
+}
+
+func (n NoOpFunctionCreationContext) IsRecovered(location common.Location) bool {
+	// NO-OP
+	return false
+}
+
+func (n NoOpFunctionCreationContext) GetCompositeValueFunctions(v *interpreter.CompositeValue, locationRange interpreter.LocationRange) *interpreter.FunctionOrderedMap {
+	// NO-OP
+	return nil
+}
+
+var _ interpreter.FunctionCreationContext = NoOpFunctionCreationContext{}
+
 func testAccountWithErrorHandler(
 	t *testing.T,
 	address interpreter.AddressValue,
@@ -407,7 +469,7 @@ func testAccountWithErrorHandler(
 		Name: "authAccount",
 		Type: sema.FullyEntitledAccountReferenceType,
 		Value: interpreter.NewEphemeralReferenceValue(
-			nil,
+			NoOpReferenceCreationContext{},
 			interpreter.FullyEntitledAccountAccess,
 			account,
 			sema.AccountType,
@@ -423,7 +485,7 @@ func testAccountWithErrorHandler(
 		Name: "pubAccount",
 		Type: sema.AccountReferenceType,
 		Value: interpreter.NewEphemeralReferenceValue(
-			nil,
+			NoOpReferenceCreationContext{},
 			interpreter.UnauthorizedAccess,
 			account,
 			sema.AccountType,

--- a/interpreter/composite_value_test.go
+++ b/interpreter/composite_value_test.go
@@ -110,7 +110,7 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 		map[string]interpreter.Value{
 			"name": interpreter.NewUnmeteredStringValue("Apple"),
 		},
-		func(name string, _ *interpreter.Interpreter, _ interpreter.LocationRange) interpreter.Value {
+		func(name string, _ interpreter.MemberAccessibleContext, _ interpreter.LocationRange) interpreter.Value {
 			if name == "color" {
 				return interpreter.NewUnmeteredStringValue("Red")
 			}

--- a/interpreter/container_mutation_test.go
+++ b/interpreter/container_mutation_test.go
@@ -934,7 +934,7 @@ func TestInterpretDictionaryMutation(t *testing.T) {
         `)
 
 		owner := stdlib.NewAccountReferenceValue(
-			nil,
+			inter,
 			nil,
 			interpreter.AddressValue{1},
 			interpreter.UnauthorizedAccess,

--- a/interpreter/conversion.go
+++ b/interpreter/conversion.go
@@ -95,9 +95,9 @@ func ByteValueToByte(memoryGauge common.MemoryGauge, element Value, locationRang
 	return b, nil
 }
 
-func ByteSliceToByteArrayValue(interpreter *Interpreter, buf []byte) *ArrayValue {
+func ByteSliceToByteArrayValue(context ArrayCreationContext, buf []byte) *ArrayValue {
 
-	common.UseMemory(interpreter, common.NewBytesMemoryUsage(len(buf)))
+	common.UseMemory(context, common.NewBytesMemoryUsage(len(buf)))
 
 	var values []Value
 
@@ -110,7 +110,7 @@ func ByteSliceToByteArrayValue(interpreter *Interpreter, buf []byte) *ArrayValue
 	}
 
 	return NewArrayValue(
-		interpreter,
+		context,
 		EmptyLocationRange,
 		ByteArrayStaticType,
 		common.ZeroAddress,

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -73,7 +73,7 @@ type ValueStaticTypeContext interface {
 	common.MemoryGauge
 	StorageReader
 	TypeConverter
-	IsRecovered(location common.Location) bool
+	IsTypeInfoRecovered(location common.Location) bool
 }
 
 var _ ValueStaticTypeContext = &Interpreter{}
@@ -338,6 +338,6 @@ func (n NoOpStringContext) GetCompositeType(_ common.Location, _ string, _ TypeI
 	panic(errors.NewUnreachableError())
 }
 
-func (n NoOpStringContext) IsRecovered(location common.Location) bool {
+func (n NoOpStringContext) IsTypeInfoRecovered(location common.Location) bool {
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -48,8 +48,6 @@ func MustSemaTypeOfValue(value Value, context ValueStaticTypeContext) sema.Type 
 	return MustConvertStaticToSemaType(staticType, context)
 }
 
-//var _ SubTypeChecker = &Interpreter{}
-
 type StorageReader interface {
 	ReadStored(
 		storageAddress common.Address,
@@ -57,6 +55,8 @@ type StorageReader interface {
 		identifier StorageMapKey,
 	) Value
 }
+
+var _ StorageReader = &Interpreter{}
 
 type StorageWriter interface {
 	WriteStored(
@@ -67,7 +67,7 @@ type StorageWriter interface {
 	) (existed bool)
 }
 
-var _ StorageReader = &Interpreter{}
+var _ StorageWriter = &Interpreter{}
 
 type ValueStaticTypeContext interface {
 	common.MemoryGauge
@@ -90,11 +90,15 @@ type StorageContext interface {
 	MaybeValidateAtreeStorage()
 }
 
+var _ StorageContext = &Interpreter{}
+
 type ReferenceTracker interface {
 	InvalidateReferencedResources(v Value, locationRange LocationRange)
 	CheckInvalidatedResourceOrResourceReference(value Value, locationRange LocationRange)
 	MaybeTrackReferencedResourceKindedValue(ref *EphemeralReferenceValue)
 }
+
+var _ ReferenceTracker = &Interpreter{}
 
 type ValueTransferContext interface {
 	StorageContext
@@ -113,23 +117,33 @@ var _ ValueTransferContext = &Interpreter{}
 
 type ValueRemoveContext = ValueTransferContext
 
+var _ ValueRemoveContext = &Interpreter{}
+
 type ComputationReporter interface {
 	ReportComputation(compKind common.ComputationKind, intensity uint)
 }
+
+var _ ComputationReporter = &Interpreter{}
 
 type ValueIterationContext interface {
 	ValueTransferContext
 	WithMutationPrevention(valueID atree.ValueID, f func())
 }
 
+var _ ValueIterationContext = &Interpreter{}
+
 type ValueStringContext interface {
 	ValueIterationContext
 }
+
+var _ ValueStringContext = &Interpreter{}
 
 type ReferenceCreationContext interface {
 	common.MemoryGauge
 	ReferenceTracker
 }
+
+var _ ReferenceCreationContext = &Interpreter{}
 
 type MemberAccessibleContext interface {
 	FunctionCreationContext
@@ -141,16 +155,22 @@ type MemberAccessibleContext interface {
 	GetMemberAccessContextForLocation(location common.Location) MemberAccessibleContext
 }
 
+var _ MemberAccessibleContext = &Interpreter{}
+
 type FunctionCreationContext interface {
 	StaticTypeAndReferenceContext
 	GetCompositeValueFunctions(v *CompositeValue, locationRange LocationRange) *FunctionOrderedMap
 }
+
+var _ FunctionCreationContext = &Interpreter{}
 
 type StaticTypeAndReferenceContext interface {
 	common.MemoryGauge
 	ValueStaticTypeContext
 	ReferenceTracker
 }
+
+var _ StaticTypeAndReferenceContext = &Interpreter{}
 
 type ArrayCreationContext interface {
 	common.MemoryGauge
@@ -162,9 +182,13 @@ type ArrayCreationContext interface {
 	ValueTransferContext
 }
 
+var _ ArrayCreationContext = &Interpreter{}
+
 type StorageMutationTracker interface {
 	RecordStorageMutation()
 }
+
+var _ StorageMutationTracker = &Interpreter{}
 
 type ResourceDestructionHandler interface {
 	EnforceNotResourceDestruction(
@@ -172,6 +196,8 @@ type ResourceDestructionHandler interface {
 		locationRange LocationRange,
 	)
 }
+
+var _ ResourceDestructionHandler = &Interpreter{}
 
 // NoOpStringContext is the ValueStringContext implementation used in Value.RecursiveString method.
 // Since Value.RecursiveString is a non-mutating operation, it should only need the no-op memory metering

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -138,6 +138,7 @@ type MemberAccessibleContext interface {
 
 	AccountHandler() AccountHandlerFunc
 	InjectedCompositeFieldsHandler() InjectedCompositeFieldsHandlerFunc
+	GetMemberAccessContextForLocation(location common.Location) MemberAccessibleContext
 }
 
 type FunctionCreationContext interface {

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5809,7 +5809,7 @@ func (interpreter *Interpreter) CheckInvalidatedResourceOrResourceReference(valu
 	checkInvalidatedResourceOrResourceReference(value, locationRange, interpreter)
 }
 
-func (interpreter *Interpreter) IsRecovered(location common.Location) bool {
+func (interpreter *Interpreter) IsTypeInfoRecovered(location common.Location) bool {
 	elaboration := interpreter.getElaboration(location)
 	if elaboration == nil {
 		return false

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5831,3 +5831,11 @@ func (interpreter *Interpreter) MaybeSetMutationDuringCapConIteration(addressPat
 		interpreter.SharedState.MutationDuringCapabilityControllerIteration = true
 	}
 }
+
+func (interpreter *Interpreter) GetMemberAccessContextForLocation(location common.Location) MemberAccessibleContext {
+	if location == nil || interpreter.Location == location {
+		return interpreter
+	}
+
+	return interpreter.EnsureLoaded(location)
+}

--- a/interpreter/interpreter_expression.go
+++ b/interpreter/interpreter_expression.go
@@ -294,7 +294,7 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(
 		},
 		set: func(value Value) {
 			interpreter.checkMemberAccess(memberExpression, target, locationRange)
-			interpreter.setMember(target, locationRange, identifier, value)
+			setMember(interpreter, target, locationRange, identifier, value)
 		},
 	}
 }
@@ -323,7 +323,7 @@ func (interpreter *Interpreter) getReferenceValue(value Value, resultType sema.T
 		// result reference type is unauthorized
 
 		staticType := value.StaticType(interpreter)
-		if referenceType.Authorization != sema.UnauthorizedAccess || !interpreter.IsSubTypeOfSemaType(staticType, resultType) {
+		if referenceType.Authorization != sema.UnauthorizedAccess || !IsSubTypeOfSemaType(interpreter, staticType, resultType) {
 			panic(InvalidMemberReferenceError{
 				ExpectedType:  resultType,
 				ActualType:    MustConvertStaticToSemaType(staticType, interpreter),
@@ -406,7 +406,7 @@ func (interpreter *Interpreter) checkMemberAccess(
 		}
 	}
 
-	if !interpreter.IsSubTypeOfSemaType(targetStaticType, expectedType) {
+	if !IsSubTypeOfSemaType(interpreter, targetStaticType, expectedType) {
 		targetSemaType := MustConvertStaticToSemaType(targetStaticType, interpreter)
 
 		panic(MemberAccessTypeError{
@@ -1387,7 +1387,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 		}
 		valueSemaType := interpreter.SubstituteMappedEntitlements(MustSemaTypeOfValue(value, interpreter))
 		valueStaticType := ConvertSemaToStaticType(interpreter, valueSemaType)
-		isSubType := interpreter.IsSubTypeOfSemaType(valueStaticType, expectedType)
+		isSubType := IsSubTypeOfSemaType(interpreter, valueStaticType, expectedType)
 
 		switch expression.Operation {
 		case ast.OperationFailableCast:

--- a/interpreter/interpreter_import.go
+++ b/interpreter/interpreter_import.go
@@ -100,7 +100,7 @@ func (interpreter *Interpreter) importResolvedLocation(resolvedLocation sema.Res
 			}
 
 			staticType := compositeValue.StaticType(interpreter)
-			semaType, err := interpreter.ConvertStaticToSemaType(staticType)
+			semaType, err := ConvertStaticToSemaType(interpreter, staticType)
 			if err != nil {
 				panic(err)
 			}

--- a/interpreter/interpreter_tracing.go
+++ b/interpreter/interpreter_tracing.go
@@ -53,12 +53,16 @@ type Tracer interface {
 
 	reportArrayValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration)
 	reportArrayValueTransferTrace(info string, count int, since time.Duration)
+	reportArrayValueConstructTrace(typeInfo string, count int, duration time.Duration)
 
 	reportDictionaryValueTransferTrace(info string, count int, since time.Duration)
 	reportDictionaryValueDeepRemoveTrace(info string, count int, since time.Duration)
+	reportDictionaryValueGetMemberTrace(info string, count int, name string, since time.Duration)
 
 	reportCompositeValueDeepRemoveTrace(owner string, id string, kind string, since time.Duration)
 	reportCompositeValueTransferTrace(owner string, id string, kind string, since time.Duration)
+	reportCompositeValueSetMemberTrace(owner string, id string, kind string, name string, since time.Duration)
+	reportCompositeValueGetMemberTrace(owner string, typeID string, kind string, name string, duration time.Duration)
 
 	reportDomainStorageMapDeepRemoveTrace(info string, i int, since time.Duration)
 }

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -8805,7 +8805,7 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 				Config: &interpreter.Config{
 					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 					InjectedCompositeFieldsHandler: func(
-						inter *interpreter.Interpreter,
+						_ interpreter.FunctionCreationContext,
 						_ common.Location,
 						_ string,
 						_ common.CompositeKind,
@@ -9398,8 +9398,8 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 					return baseActivation
 				},
-				AccountHandler: func(inter *interpreter.Interpreter, address interpreter.AddressValue) interpreter.Value {
-					return stdlib.NewAccountValue(inter, nil, address)
+				AccountHandler: func(context interpreter.FunctionCreationContext, address interpreter.AddressValue) interpreter.Value {
+					return stdlib.NewAccountValue(context, nil, address)
 				},
 			},
 		},

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -8805,14 +8805,14 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 				Config: &interpreter.Config{
 					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 					InjectedCompositeFieldsHandler: func(
-						_ interpreter.FunctionCreationContext,
+						context interpreter.FunctionCreationContext,
 						_ common.Location,
 						_ string,
 						_ common.CompositeKind,
 					) map[string]interpreter.Value {
 
 						accountRef := stdlib.NewAccountReferenceValue(
-							nil,
+							context,
 							nil,
 							addressValue,
 							interpreter.FullyEntitledAccountAccess,
@@ -9371,7 +9371,7 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 		Name: "account",
 		Type: sema.FullyEntitledAccountReferenceType,
 		Value: stdlib.NewAccountReferenceValue(
-			nil,
+			NoOpFunctionCreationContext{},
 			nil,
 			interpreter.AddressValue(address),
 			interpreter.FullyEntitledAccountAccess,

--- a/interpreter/statictype.go
+++ b/interpreter/statictype.go
@@ -1215,20 +1215,19 @@ type StaticTypeConversionHandler interface {
 }
 
 func ConvertStaticToSemaType(
-	memoryGauge common.MemoryGauge,
+	context TypeConverter,
 	typ StaticType,
-	handler StaticTypeConversionHandler,
 ) (_ sema.Type, err error) {
 	switch t := typ.(type) {
 	case *CompositeStaticType:
-		return handler.GetCompositeType(
+		return context.GetCompositeType(
 			t.Location,
 			t.QualifiedIdentifier,
 			t.TypeID,
 		)
 
 	case *InterfaceStaticType:
-		return handler.GetInterfaceType(
+		return context.GetInterfaceType(
 			t.Location,
 			t.QualifiedIdentifier,
 			t.TypeID,
@@ -1236,90 +1235,83 @@ func ConvertStaticToSemaType(
 
 	case *VariableSizedStaticType:
 		ty, err := ConvertStaticToSemaType(
-			memoryGauge,
+			context,
 			t.Type,
-			handler,
 		)
 		if err != nil {
 			return nil, err
 		}
-		return sema.NewVariableSizedType(memoryGauge, ty), nil
+		return sema.NewVariableSizedType(context, ty), nil
 
 	case *ConstantSizedStaticType:
 		ty, err := ConvertStaticToSemaType(
-			memoryGauge,
+			context,
 			t.Type,
-			handler,
 		)
 		if err != nil {
 			return nil, err
 		}
 
 		return sema.NewConstantSizedType(
-			memoryGauge,
+			context,
 			ty,
 			t.Size,
 		), nil
 
 	case *DictionaryStaticType:
 		keyType, err := ConvertStaticToSemaType(
-			memoryGauge,
+			context,
 			t.KeyType,
-			handler,
 		)
 		if err != nil {
 			return nil, err
 		}
 
 		valueType, err := ConvertStaticToSemaType(
-			memoryGauge,
+			context,
 			t.ValueType,
-			handler,
 		)
 		if err != nil {
 			return nil, err
 		}
 
 		return sema.NewDictionaryType(
-			memoryGauge,
+			context,
 			keyType,
 			valueType,
 		), nil
 
 	case InclusiveRangeStaticType:
 		elementType, err := ConvertStaticToSemaType(
-			memoryGauge,
+			context,
 			t.ElementType,
-			handler,
 		)
 		if err != nil {
 			return nil, err
 		}
 
 		return sema.NewInclusiveRangeType(
-			memoryGauge,
+			context,
 			elementType,
 		), nil
 
 	case *OptionalStaticType:
 		ty, err := ConvertStaticToSemaType(
-			memoryGauge,
+			context,
 			t.Type,
-			handler,
 		)
 		if err != nil {
 			return nil, err
 		}
-		return sema.NewOptionalType(memoryGauge, ty), err
+		return sema.NewOptionalType(context, ty), err
 
 	case *IntersectionStaticType:
 		var convertedLegacyType sema.Type
 		legacyType := t.LegacyType
 		if legacyType != nil {
 			convertedLegacyType, err = ConvertStaticToSemaType(
-				memoryGauge,
+				context,
 				legacyType,
-				handler,
 			)
 			if err != nil {
 				return nil, err
@@ -1333,7 +1325,7 @@ func ConvertStaticToSemaType(
 			intersectedTypes = make([]*sema.InterfaceType, typeCount)
 
 			for i, typ := range t.Types {
-				intersectedTypes[i], err = handler.GetInterfaceType(
+				intersectedTypes[i], err = context.GetInterfaceType(
 					typ.Location,
 					typ.QualifiedIdentifier,
 					typ.TypeID,
@@ -1345,43 +1337,41 @@ func ConvertStaticToSemaType(
 		}
 
 		return sema.NewIntersectionType(
-			memoryGauge,
+			context,
 			convertedLegacyType,
 			intersectedTypes,
 		), nil
 
 	case *ReferenceStaticType:
 		ty, err := ConvertStaticToSemaType(
-			memoryGauge,
+			context,
 			t.ReferencedType,
-			handler,
 		)
 		if err != nil {
 			return nil, err
 		}
 
-		access, err := ConvertStaticAuthorizationToSemaAccess(t.Authorization, handler)
+		access, err := ConvertStaticAuthorizationToSemaAccess(t.Authorization, context)
 
 		if err != nil {
 			return nil, err
 		}
 
-		return sema.NewReferenceType(memoryGauge, access, ty), nil
+		return sema.NewReferenceType(context, access, ty), nil
 
 	case *CapabilityStaticType:
 		var borrowType sema.Type
 		if t.BorrowType != nil {
 			borrowType, err = ConvertStaticToSemaType(
-				memoryGauge,
+				context,
 				t.BorrowType,
-				handler,
 			)
 			if err != nil {
 				return nil, err
 			}
 		}
 
-		return sema.NewCapabilityType(memoryGauge, borrowType), nil
+		return sema.NewCapabilityType(context, borrowType), nil
 
 	case FunctionStaticType:
 		return t.Type, nil

--- a/interpreter/statictype_test.go
+++ b/interpreter/statictype_test.go
@@ -1725,14 +1725,13 @@ func TestStaticTypeConversion(t *testing.T) {
 }
 
 type staticTypeConversionHandler struct {
-	common.MemoryGauge
 	getInterfaceType      func(location common.Location, qualifiedIdentifier string, typeID TypeID) (*sema.InterfaceType, error)
 	getCompositeType      func(location common.Location, qualifiedIdentifier string, typeID TypeID) (*sema.CompositeType, error)
 	getEntitlementType    func(typeID common.TypeID) (*sema.EntitlementType, error)
 	getEntitlementMapType func(typeID common.TypeID) (*sema.EntitlementMapType, error)
 }
 
-var _ StaticTypeConversionHandler = staticTypeConversionHandler{}
+var _ TypeConverter = staticTypeConversionHandler{}
 
 func (s staticTypeConversionHandler) GetInterfaceType(
 	location common.Location,
@@ -1756,6 +1755,11 @@ func (s staticTypeConversionHandler) GetEntitlementType(typeID TypeID) (*sema.En
 
 func (s staticTypeConversionHandler) GetEntitlementMapType(typeID TypeID) (*sema.EntitlementMapType, error) {
 	return s.getEntitlementMapType(typeID)
+}
+
+func (s staticTypeConversionHandler) MeterMemory(_ common.MemoryUsage) error {
+	// NO-OP
+	return nil
 }
 
 func TestIntersectionStaticType_ID(t *testing.T) {

--- a/interpreter/statictype_test.go
+++ b/interpreter/statictype_test.go
@@ -1695,9 +1695,8 @@ func TestStaticTypeConversion(t *testing.T) {
 			}
 
 			convertedSemaType, err := ConvertStaticToSemaType(
-				nil,
-				test.staticType,
 				handler,
+				test.staticType,
 			)
 			require.NoError(t, err)
 			require.Equal(t,
@@ -1726,6 +1725,7 @@ func TestStaticTypeConversion(t *testing.T) {
 }
 
 type staticTypeConversionHandler struct {
+	common.MemoryGauge
 	getInterfaceType      func(location common.Location, qualifiedIdentifier string, typeID TypeID) (*sema.InterfaceType, error)
 	getCompositeType      func(location common.Location, qualifiedIdentifier string, typeID TypeID) (*sema.CompositeType, error)
 	getEntitlementType    func(typeID common.TypeID) (*sema.EntitlementType, error)

--- a/interpreter/storage.go
+++ b/interpreter/storage.go
@@ -205,7 +205,7 @@ func NewInMemoryStorage(memoryGauge common.MemoryGauge) InMemoryStorage {
 }
 
 func (i InMemoryStorage) GetDomainStorageMap(
-	_ *Interpreter,
+	_ StorageMutationTracker,
 	address common.Address,
 	domain common.StorageDomain,
 	createIfNotExists bool,

--- a/interpreter/transactions_test.go
+++ b/interpreter/transactions_test.go
@@ -254,8 +254,21 @@ func TestInterpretTransactions(t *testing.T) {
           }
         `)
 
-		signer1 := stdlib.NewAccountReferenceValue(nil, nil, interpreter.AddressValue{1}, interpreter.UnauthorizedAccess, interpreter.EmptyLocationRange)
-		signer2 := stdlib.NewAccountReferenceValue(nil, nil, interpreter.AddressValue{2}, interpreter.UnauthorizedAccess, interpreter.EmptyLocationRange)
+		signer1 := stdlib.NewAccountReferenceValue(
+			inter,
+			nil,
+			interpreter.AddressValue{1},
+			interpreter.UnauthorizedAccess,
+			interpreter.EmptyLocationRange,
+		)
+
+		signer2 := stdlib.NewAccountReferenceValue(
+			inter,
+			nil,
+			interpreter.AddressValue{2},
+			interpreter.UnauthorizedAccess,
+			interpreter.EmptyLocationRange,
+		)
 
 		// first transaction
 		err := inter.InvokeTransaction(0, signer1)
@@ -291,7 +304,7 @@ func TestInterpretTransactions(t *testing.T) {
 		address := common.MustBytesToAddress([]byte{0x1})
 
 		account := stdlib.NewAccountReferenceValue(
-			nil,
+			NoOpFunctionCreationContext{},
 			nil,
 			interpreter.AddressValue(address),
 			interpreter.UnauthorizedAccess,
@@ -361,7 +374,7 @@ func TestInterpretTransactions(t *testing.T) {
 		address := common.MustBytesToAddress([]byte{0x1})
 
 		account := stdlib.NewAccountReferenceValue(
-			nil,
+			NoOpFunctionCreationContext{},
 			nil,
 			interpreter.AddressValue(address),
 			interpreter.UnauthorizedAccess,
@@ -428,7 +441,7 @@ func TestRuntimeInvalidTransferInExecute(t *testing.T) {
 		},
 	})
 
-	signer1 := stdlib.NewAccountReferenceValue(nil, nil, interpreter.AddressValue{1}, interpreter.UnauthorizedAccess, interpreter.EmptyLocationRange)
+	signer1 := stdlib.NewAccountReferenceValue(inter, nil, interpreter.AddressValue{1}, interpreter.UnauthorizedAccess, interpreter.EmptyLocationRange)
 	err := inter.InvokeTransaction(0, signer1)
 	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
 }

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -153,10 +153,10 @@ type TypeIndexableValue interface {
 
 type MemberAccessibleValue interface {
 	Value
-	GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value
+	GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value
 	RemoveMember(interpreter *Interpreter, locationRange LocationRange, name string) Value
 	// returns whether a value previously existed with this name
-	SetMember(interpreter *Interpreter, locationRange LocationRange, name string, value Value) bool
+	SetMember(context MemberAccessibleContext, locationRange LocationRange, name string, value Value) bool
 }
 
 type ValueComparisonContext interface {

--- a/interpreter/value_account.go
+++ b/interpreter/value_account.go
@@ -76,7 +76,7 @@ func NewAccountValue(
 		return nil
 	}
 
-	computeField := func(name string, _ *Interpreter, _ LocationRange) Value {
+	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
 		switch name {
 		case sema.AccountTypeBalanceFieldName:
 			return accountBalanceGet()

--- a/interpreter/value_account_accountcapabilities.go
+++ b/interpreter/value_account_accountcapabilities.go
@@ -62,7 +62,7 @@ func NewAccountAccountCapabilitiesValue(
 		return nil
 	}
 
-	computeField := func(name string, _ *Interpreter, _ LocationRange) Value {
+	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
 		field := computeLazyStoredField(name)
 		if field != nil {
 			fields[name] = field

--- a/interpreter/value_account_capabilities.go
+++ b/interpreter/value_account_capabilities.go
@@ -71,7 +71,7 @@ func NewAccountCapabilitiesValue(
 		return nil
 	}
 
-	computeField := func(name string, _ *Interpreter, _ LocationRange) Value {
+	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
 		field := computeLazyStoredField(name)
 		if field != nil {
 			fields[name] = field

--- a/interpreter/value_account_contracts.go
+++ b/interpreter/value_account_contracts.go
@@ -31,7 +31,7 @@ var account_ContractsTypeID = sema.Account_ContractsType.ID()
 var account_ContractsStaticType StaticType = PrimitiveStaticTypeAccount_Contracts // unmetered
 var account_ContractsFieldNames []string = nil
 
-type ContractNamesGetter func(interpreter *Interpreter, locationRange LocationRange) *ArrayValue
+type ContractNamesGetter func(context MemberAccessibleContext, locationRange LocationRange) *ArrayValue
 
 func NewAccountContractsValue(
 	gauge common.MemoryGauge,
@@ -68,10 +68,10 @@ func NewAccountContractsValue(
 		return nil
 	}
 
-	computeField := func(name string, inter *Interpreter, locationRange LocationRange) Value {
+	computeField := func(name string, context MemberAccessibleContext, locationRange LocationRange) Value {
 		switch name {
 		case sema.Account_ContractsTypeNamesFieldName:
-			return namesGetter(inter, locationRange)
+			return namesGetter(context, locationRange)
 		}
 
 		field := computeLazyStoredField(name)

--- a/interpreter/value_account_inbox.go
+++ b/interpreter/value_account_inbox.go
@@ -57,7 +57,7 @@ func NewAccountInboxValue(
 		return nil
 	}
 
-	computeField := func(name string, _ *Interpreter, _ LocationRange) Value {
+	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
 		field := computeLazyStoredField(name)
 		if field != nil {
 			fields[name] = field

--- a/interpreter/value_account_storage.go
+++ b/interpreter/value_account_storage.go
@@ -35,18 +35,19 @@ var account_StorageFieldNames []string = nil
 func NewAccountStorageValue(
 	gauge common.MemoryGauge,
 	address AddressValue,
-	storageUsedGet func(interpreter *Interpreter) UInt64Value,
-	storageCapacityGet func(interpreter *Interpreter) UInt64Value,
+	storageUsedGet func(context MemberAccessibleContext) UInt64Value,
+	storageCapacityGet func(context MemberAccessibleContext) UInt64Value,
 ) Value {
 
 	var storageValue *SimpleCompositeValue
 
 	fields := map[string]Value{}
 
-	computeLazyStoredField := func(name string, inter *Interpreter) Value {
+	computeLazyStoredField := func(name string, context MemberAccessibleContext) Value {
 		switch name {
 		case sema.Account_StorageTypeForEachPublicFunctionName:
-			return inter.newStorageIterationFunction(
+			return newStorageIterationFunction(
+				context,
 				storageValue,
 				sema.Account_StorageTypeForEachPublicFunctionType,
 				address,
@@ -55,7 +56,8 @@ func NewAccountStorageValue(
 			)
 
 		case sema.Account_StorageTypeForEachStoredFunctionName:
-			return inter.newStorageIterationFunction(
+			return newStorageIterationFunction(
+				context,
 				storageValue,
 				sema.Account_StorageTypeForEachStoredFunctionType,
 				address,
@@ -64,43 +66,43 @@ func NewAccountStorageValue(
 			)
 
 		case sema.Account_StorageTypeTypeFunctionName:
-			return inter.authAccountTypeFunction(storageValue, address)
+			return authAccountTypeFunction(context, storageValue, address)
 
 		case sema.Account_StorageTypeLoadFunctionName:
-			return inter.authAccountLoadFunction(storageValue, address)
+			return authAccountLoadFunction(context, storageValue, address)
 
 		case sema.Account_StorageTypeCopyFunctionName:
-			return inter.authAccountCopyFunction(storageValue, address)
+			return authAccountCopyFunction(context, storageValue, address)
 
 		case sema.Account_StorageTypeSaveFunctionName:
-			return inter.authAccountSaveFunction(storageValue, address)
+			return authAccountSaveFunction(context, storageValue, address)
 
 		case sema.Account_StorageTypeBorrowFunctionName:
-			return inter.authAccountBorrowFunction(storageValue, address)
+			return authAccountBorrowFunction(context, storageValue, address)
 
 		case sema.Account_StorageTypeCheckFunctionName:
-			return inter.authAccountCheckFunction(storageValue, address)
+			return authAccountCheckFunction(context, storageValue, address)
 		}
 
 		return nil
 	}
 
-	computeField := func(name string, inter *Interpreter, locationRange LocationRange) Value {
+	computeField := func(name string, context MemberAccessibleContext, locationRange LocationRange) Value {
 		switch name {
 		case sema.Account_StorageTypePublicPathsFieldName:
-			return inter.publicAccountPaths(address, locationRange)
+			return publicAccountPaths(context, address, locationRange)
 
 		case sema.Account_StorageTypeStoragePathsFieldName:
-			return inter.storageAccountPaths(address, locationRange)
+			return storageAccountPaths(context, address, locationRange)
 
 		case sema.Account_StorageTypeUsedFieldName:
-			return storageUsedGet(inter)
+			return storageUsedGet(context)
 
 		case sema.Account_StorageTypeCapacityFieldName:
-			return storageCapacityGet(inter)
+			return storageCapacityGet(context)
 		}
 
-		field := computeLazyStoredField(name, inter)
+		field := computeLazyStoredField(name, context)
 		if field != nil {
 			fields[name] = field
 		}

--- a/interpreter/value_account_storagecapabilities.go
+++ b/interpreter/value_account_storagecapabilities.go
@@ -62,7 +62,7 @@ func NewAccountStorageCapabilitiesValue(
 		return nil
 	}
 
-	computeField := func(name string, _ *Interpreter, _ LocationRange) Value {
+	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
 		field := computeLazyStoredField(name)
 		if field != nil {
 			fields[name] = field

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -156,12 +156,12 @@ func (v AddressValue) ToAddress() common.Address {
 	return common.Address(v)
 }
 
-func (v AddressValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
+func (v AddressValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
 	switch name {
 
 	case sema.ToStringFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.ToStringFunctionType,
 			func(v AddressValue, invocation Invocation) Value {
@@ -184,7 +184,7 @@ func (v AddressValue) GetMember(interpreter *Interpreter, _ LocationRange, name 
 
 	case sema.AddressTypeToBytesFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.AddressTypeToBytesFunctionType,
 			func(v AddressValue, invocation Invocation) Value {
@@ -203,7 +203,7 @@ func (AddressValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Valu
 	panic(errors.NewUnreachableError())
 }
 
-func (AddressValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (AddressValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Addresses have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -242,7 +242,7 @@ func (v AddressValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		transferContext.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(transferContext, storable)
 	}
 	return v
 }

--- a/interpreter/value_authaccount_keys.go
+++ b/interpreter/value_authaccount_keys.go
@@ -61,7 +61,7 @@ func NewAccountKeysValue(
 		return nil
 	}
 
-	computeField := func(name string, _ *Interpreter, _ LocationRange) Value {
+	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
 		switch name {
 		case sema.Account_KeysTypeCountFieldName:
 			return getKeysCount()

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -178,7 +178,7 @@ func (v BoolValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -142,17 +142,17 @@ func (v *IDCapabilityValue) MeteredString(context ValueStringContext, seenRefere
 	)
 }
 
-func (v *IDCapabilityValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
+func (v *IDCapabilityValue) GetMember(context MemberAccessibleContext, _ LocationRange, name string) Value {
 	switch name {
 	case sema.CapabilityTypeBorrowFunctionName:
 		// this function will panic already if this conversion fails
-		borrowType, _ := MustConvertStaticToSemaType(v.BorrowType, interpreter).(*sema.ReferenceType)
-		return interpreter.capabilityBorrowFunction(v, v.address, v.ID, borrowType)
+		borrowType, _ := MustConvertStaticToSemaType(v.BorrowType, context).(*sema.ReferenceType)
+		return capabilityBorrowFunction(context, v, v.address, v.ID, borrowType)
 
 	case sema.CapabilityTypeCheckFunctionName:
 		// this function will panic already if this conversion fails
-		borrowType, _ := MustConvertStaticToSemaType(v.BorrowType, interpreter).(*sema.ReferenceType)
-		return interpreter.capabilityCheckFunction(v, v.address, v.ID, borrowType)
+		borrowType, _ := MustConvertStaticToSemaType(v.BorrowType, context).(*sema.ReferenceType)
+		return capabilityCheckFunction(context, v, v.address, v.ID, borrowType)
 
 	case sema.CapabilityTypeAddressFieldName:
 		return v.address
@@ -169,7 +169,7 @@ func (*IDCapabilityValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string
 	panic(errors.NewUnreachableError())
 }
 
-func (*IDCapabilityValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (*IDCapabilityValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Capabilities have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -233,7 +233,7 @@ func (v *IDCapabilityValue) Transfer(
 ) Value {
 	if remove {
 		v.DeepRemove(context, true)
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -194,7 +194,7 @@ func (v CharacterValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }
@@ -219,11 +219,11 @@ func (CharacterValue) ChildStorables() []atree.Storable {
 	return nil
 }
 
-func (v CharacterValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
+func (v CharacterValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
 	switch name {
 	case sema.ToStringFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.ToStringFunctionType,
 			func(v CharacterValue, invocation Invocation) Value {
@@ -242,8 +242,8 @@ func (v CharacterValue) GetMember(interpreter *Interpreter, _ LocationRange, nam
 		)
 
 	case sema.CharacterTypeUtf8FieldName:
-		common.UseMemory(interpreter, common.NewBytesMemoryUsage(len(v.Str)))
-		return ByteSliceToByteArrayValue(interpreter, []byte(v.Str))
+		common.UseMemory(context, common.NewBytesMemoryUsage(len(v.Str)))
+		return ByteSliceToByteArrayValue(context, []byte(v.Str))
 	}
 	return nil
 }
@@ -253,7 +253,7 @@ func (CharacterValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Va
 	panic(errors.NewUnreachableError())
 }
 
-func (CharacterValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (CharacterValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Characters have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -472,7 +472,6 @@ func (v *CompositeValue) GetMember(context MemberAccessibleContext, locationRang
 		}
 	}
 
-	// TODO:
 	context = context.GetMemberAccessContextForLocation(v.Location)
 
 	// Dynamically link in the computed fields, injected fields, and functions

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -473,7 +473,7 @@ func (v *CompositeValue) GetMember(context MemberAccessibleContext, locationRang
 	}
 
 	// TODO:
-	//context = v.getInterpreter(context)
+	context = context.GetMemberAccessContextForLocation(v.Location)
 
 	// Dynamically link in the computed fields, injected fields, and functions
 

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -527,8 +527,8 @@ func ConvertFix64(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 	}
 }
 
-func (v Fix64Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.Fix64Type, locationRange)
+func (v Fix64Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.Fix64Type, locationRange)
 }
 
 func (Fix64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -536,7 +536,7 @@ func (Fix64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value 
 	panic(errors.NewUnreachableError())
 }
 
-func (Fix64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (Fix64Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -581,7 +581,7 @@ func (v Fix64Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -521,8 +521,8 @@ func (v IntValue) BitwiseRightShift(context ValueStaticTypeContext, other Intege
 	}
 }
 
-func (v IntValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.IntType, locationRange)
+func (v IntValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.IntType, locationRange)
 }
 
 func (IntValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -530,7 +530,7 @@ func (IntValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	panic(errors.NewUnreachableError())
 }
 
-func (IntValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (IntValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -561,7 +561,7 @@ func (v IntValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -738,8 +738,8 @@ func (v Int128Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 	return NewInt128ValueFromBigInt(context, valueGetter)
 }
 
-func (v Int128Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.Int128Type, locationRange)
+func (v Int128Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.Int128Type, locationRange)
 }
 
 func (Int128Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -747,7 +747,7 @@ func (Int128Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value
 	panic(errors.NewUnreachableError())
 }
 
-func (Int128Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (Int128Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -786,7 +786,7 @@ func (v Int128Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -613,8 +613,8 @@ func (v Int16Value) BitwiseRightShift(context ValueStaticTypeContext, other Inte
 	return NewInt16Value(context, valueGetter)
 }
 
-func (v Int16Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.Int16Type, locationRange)
+func (v Int16Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.Int16Type, locationRange)
 }
 
 func (Int16Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -622,7 +622,7 @@ func (Int16Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value 
 	panic(errors.NewUnreachableError())
 }
 
-func (Int16Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (Int16Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -663,7 +663,7 @@ func (v Int16Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -705,8 +705,8 @@ func (v Int256Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 	return NewInt256ValueFromBigInt(context, valueGetter)
 }
 
-func (v Int256Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.Int256Type, locationRange)
+func (v Int256Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.Int256Type, locationRange)
 }
 
 func (Int256Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -714,7 +714,7 @@ func (Int256Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value
 	panic(errors.NewUnreachableError())
 }
 
-func (Int256Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (Int256Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -753,7 +753,7 @@ func (v Int256Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -613,8 +613,8 @@ func (v Int32Value) BitwiseRightShift(context ValueStaticTypeContext, other Inte
 	return NewInt32Value(context, valueGetter)
 }
 
-func (v Int32Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.Int32Type, locationRange)
+func (v Int32Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.Int32Type, locationRange)
 }
 
 func (Int32Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -622,7 +622,7 @@ func (Int32Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value 
 	panic(errors.NewUnreachableError())
 }
 
-func (Int32Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (Int32Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -663,7 +663,7 @@ func (v Int32Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -607,8 +607,8 @@ func (v Int64Value) BitwiseRightShift(context ValueStaticTypeContext, other Inte
 	return NewInt64Value(context, valueGetter)
 }
 
-func (v Int64Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.Int64Type, locationRange)
+func (v Int64Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.Int64Type, locationRange)
 }
 
 func (Int64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -616,7 +616,7 @@ func (Int64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value 
 	panic(errors.NewUnreachableError())
 }
 
-func (Int64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (Int64Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -657,7 +657,7 @@ func (v Int64Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -612,8 +612,8 @@ func (v Int8Value) BitwiseRightShift(context ValueStaticTypeContext, other Integ
 	return NewInt8Value(context, valueGetter)
 }
 
-func (v Int8Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.Int8Type, locationRange)
+func (v Int8Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.Int8Type, locationRange)
 }
 
 func (Int8Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -621,7 +621,7 @@ func (Int8Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	panic(errors.NewUnreachableError())
 }
 
-func (Int8Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (Int8Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -660,7 +660,7 @@ func (v Int8Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_link.go
+++ b/interpreter/value_link.go
@@ -135,7 +135,7 @@ func (v PathLinkValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }
@@ -258,7 +258,7 @@ func (v AccountLinkValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -98,7 +98,7 @@ var nilValueMapFunction = NewUnmeteredStaticHostFunctionValue(
 	},
 )
 
-func (v NilValue) GetMember(_ *Interpreter, _ LocationRange, name string) Value {
+func (v NilValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
 	switch name {
 	case sema.OptionalTypeMapFunctionName:
 		return nilValueMapFunction
@@ -112,7 +112,7 @@ func (NilValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	panic(errors.NewUnreachableError())
 }
 
-func (NilValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (NilValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Nil has no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -156,7 +156,7 @@ func (v NilValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -49,12 +49,12 @@ type NumberValue interface {
 	ToBigEndianBytes() []byte
 }
 
-func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, typ sema.Type, locationRange LocationRange) Value {
+func getNumberValueMember(context MemberAccessibleContext, v NumberValue, name string, typ sema.Type, locationRange LocationRange) Value {
 	switch name {
 
 	case sema.ToStringFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.ToStringFunctionType,
 			func(v NumberValue, invocation Invocation) Value {
@@ -75,7 +75,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 
 	case sema.ToBigEndianBytesFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.ToBigEndianBytesFunctionType,
 			func(v NumberValue, invocation Invocation) Value {
@@ -88,7 +88,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 
 	case sema.NumericTypeSaturatingAddFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.SaturatingArithmeticTypeFunctionTypes[typ],
 			func(v NumberValue, invocation Invocation) Value {
@@ -107,7 +107,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 
 	case sema.NumericTypeSaturatingSubtractFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.SaturatingArithmeticTypeFunctionTypes[typ],
 			func(v NumberValue, invocation Invocation) Value {
@@ -126,7 +126,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 
 	case sema.NumericTypeSaturatingMultiplyFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.SaturatingArithmeticTypeFunctionTypes[typ],
 			func(v NumberValue, invocation Invocation) Value {
@@ -145,7 +145,7 @@ func getNumberValueMember(interpreter *Interpreter, v NumberValue, name string, 
 
 	case sema.NumericTypeSaturatingDivideFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.SaturatingArithmeticTypeFunctionTypes[typ],
 			func(v NumberValue, invocation Invocation) Value {

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -110,12 +110,12 @@ func (v PathValue) MeteredString(context ValueStringContext, _ SeenReferences, _
 	return v.String()
 }
 
-func (v PathValue) GetMember(inter *Interpreter, locationRange LocationRange, name string) Value {
+func (v PathValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
 	switch name {
 
 	case sema.ToStringFunctionName:
 		return NewBoundHostFunctionValue(
-			inter,
+			context,
 			v,
 			sema.ToStringFunctionType,
 			func(v PathValue, invocation Invocation) Value {
@@ -145,7 +145,7 @@ func (PathValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	panic(errors.NewUnreachableError())
 }
 
-func (PathValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (PathValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Paths have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -240,7 +240,7 @@ func (v PathValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -123,11 +123,11 @@ func (v *PathCapabilityValue) MeteredString(context ValueStringContext, seenRefe
 }
 
 func (v *PathCapabilityValue) newBorrowFunction(
-	interpreter *Interpreter,
+	context FunctionCreationContext,
 	borrowType *sema.ReferenceType,
 ) BoundFunctionValue {
 	return NewBoundHostFunctionValue(
-		interpreter,
+		context,
 		v,
 		sema.CapabilityTypeBorrowFunctionType(borrowType),
 		func(_ Value, _ Invocation) Value {
@@ -138,11 +138,11 @@ func (v *PathCapabilityValue) newBorrowFunction(
 }
 
 func (v *PathCapabilityValue) newCheckFunction(
-	interpreter *Interpreter,
+	context FunctionCreationContext,
 	borrowType *sema.ReferenceType,
 ) BoundFunctionValue {
 	return NewBoundHostFunctionValue(
-		interpreter,
+		context,
 		v,
 		sema.CapabilityTypeCheckFunctionType(borrowType),
 		func(_ Value, _ Invocation) Value {
@@ -152,23 +152,23 @@ func (v *PathCapabilityValue) newCheckFunction(
 	)
 }
 
-func (v *PathCapabilityValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
+func (v *PathCapabilityValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
 	switch name {
 	case sema.CapabilityTypeBorrowFunctionName:
 		var borrowType *sema.ReferenceType
 		if v.BorrowType != nil {
 			// this function will panic already if this conversion fails
-			borrowType, _ = MustConvertStaticToSemaType(v.BorrowType, interpreter).(*sema.ReferenceType)
+			borrowType, _ = MustConvertStaticToSemaType(v.BorrowType, context).(*sema.ReferenceType)
 		}
-		return v.newBorrowFunction(interpreter, borrowType)
+		return v.newBorrowFunction(context, borrowType)
 
 	case sema.CapabilityTypeCheckFunctionName:
 		var borrowType *sema.ReferenceType
 		if v.BorrowType != nil {
 			// this function will panic already if this conversion fails
-			borrowType, _ = MustConvertStaticToSemaType(v.BorrowType, interpreter).(*sema.ReferenceType)
+			borrowType, _ = MustConvertStaticToSemaType(v.BorrowType, context).(*sema.ReferenceType)
 		}
-		return v.newCheckFunction(interpreter, borrowType)
+		return v.newCheckFunction(context, borrowType)
 
 	case sema.CapabilityTypeAddressFieldName:
 		return v.address
@@ -184,7 +184,7 @@ func (*PathCapabilityValue) RemoveMember(_ *Interpreter, _ LocationRange, _ stri
 	panic(errors.NewUnreachableError())
 }
 
-func (*PathCapabilityValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (*PathCapabilityValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	panic(errors.NewUnreachableError())
 }
 
@@ -252,7 +252,7 @@ func (v *PathCapabilityValue) Transfer(
 ) Value {
 	if remove {
 		v.DeepRemove(context, true)
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_placeholder.go
+++ b/interpreter/value_placeholder.go
@@ -90,7 +90,7 @@ func (f placeholderValue) Transfer(
 ) Value {
 	// TODO: actually not needed, value is not storable
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return f
 }

--- a/interpreter/value_published.go
+++ b/interpreter/value_published.go
@@ -161,7 +161,7 @@ func (v *PublishedValue) Transfer(
 		).(AddressValue)
 
 		if remove {
-			context.RemoveReferencedSlab(storable)
+			RemoveReferencedSlab(context, storable)
 		}
 
 		return NewPublishedValue(context, addressValue, innerValue)

--- a/interpreter/value_reference.go
+++ b/interpreter/value_reference.go
@@ -28,7 +28,7 @@ type ReferenceValue interface {
 	Value
 	AuthorizedValue
 	isReference()
-	ReferencedValue(interpreter *Interpreter, locationRange LocationRange, errorOnFailedDereference bool) *Value
+	ReferencedValue(context ValueStaticTypeContext, locationRange LocationRange, errorOnFailedDereference bool) *Value
 	BorrowType() sema.Type
 }
 

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -146,15 +146,15 @@ func (v *SomeValue) MeteredString(context ValueStringContext, seenReferences See
 	return v.value.MeteredString(context, seenReferences, locationRange)
 }
 
-func (v *SomeValue) GetMember(interpreter *Interpreter, _ LocationRange, name string) Value {
+func (v *SomeValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
 	switch name {
 	case sema.OptionalTypeMapFunctionName:
 		innerValueType := MustConvertStaticToSemaType(
-			v.value.StaticType(interpreter),
-			interpreter,
+			v.value.StaticType(context),
+			context,
 		)
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.OptionalTypeMapFunctionType(
 				innerValueType,
@@ -198,7 +198,7 @@ func (v *SomeValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Valu
 	panic(errors.NewUnreachableError())
 }
 
-func (v *SomeValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (v *SomeValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	panic(errors.NewUnreachableError())
 }
 
@@ -360,8 +360,8 @@ func (v *SomeValue) Transfer(
 		)
 
 		if remove {
-			context.RemoveReferencedSlab(v.valueStorable)
-			context.RemoveReferencedSlab(storable)
+			RemoveReferencedSlab(context, v.valueStorable)
+			RemoveReferencedSlab(context, storable)
 		}
 	}
 
@@ -398,7 +398,7 @@ func (v *SomeValue) Clone(interpreter *Interpreter) Value {
 func (v *SomeValue) DeepRemove(context ValueRemoveContext, hasNoParentContainer bool) {
 	v.value.DeepRemove(context, hasNoParentContainer)
 	if v.valueStorable != nil {
-		context.RemoveReferencedSlab(v.valueStorable)
+		RemoveReferencedSlab(context, v.valueStorable)
 	}
 }
 

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -354,18 +354,18 @@ func (*StringValue) RemoveKey(_ *Interpreter, _ LocationRange, _ Value) Value {
 	panic(errors.NewUnreachableError())
 }
 
-func (v *StringValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
+func (v *StringValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
 	switch name {
 	case sema.StringTypeLengthFieldName:
 		length := v.Length()
-		return NewIntValueFromInt64(interpreter, int64(length))
+		return NewIntValueFromInt64(context, int64(length))
 
 	case sema.StringTypeUtf8FieldName:
-		return ByteSliceToByteArrayValue(interpreter, []byte(v.Str))
+		return ByteSliceToByteArrayValue(context, []byte(v.Str))
 
 	case sema.StringTypeConcatFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.StringTypeConcatFunctionType,
 			func(v *StringValue, invocation Invocation) Value {
@@ -380,7 +380,7 @@ func (v *StringValue) GetMember(interpreter *Interpreter, locationRange Location
 
 	case sema.StringTypeSliceFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.StringTypeSliceFunctionType,
 			func(v *StringValue, invocation Invocation) Value {
@@ -400,7 +400,7 @@ func (v *StringValue) GetMember(interpreter *Interpreter, locationRange Location
 
 	case sema.StringTypeContainsFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.StringTypeContainsFunctionType,
 			func(v *StringValue, invocation Invocation) Value {
@@ -415,7 +415,7 @@ func (v *StringValue) GetMember(interpreter *Interpreter, locationRange Location
 
 	case sema.StringTypeIndexFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.StringTypeIndexFunctionType,
 			func(v *StringValue, invocation Invocation) Value {
@@ -430,7 +430,7 @@ func (v *StringValue) GetMember(interpreter *Interpreter, locationRange Location
 
 	case sema.StringTypeCountFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.StringTypeIndexFunctionType,
 			func(v *StringValue, invocation Invocation) Value {
@@ -449,7 +449,7 @@ func (v *StringValue) GetMember(interpreter *Interpreter, locationRange Location
 
 	case sema.StringTypeDecodeHexFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.StringTypeDecodeHexFunctionType,
 			func(v *StringValue, invocation Invocation) Value {
@@ -462,7 +462,7 @@ func (v *StringValue) GetMember(interpreter *Interpreter, locationRange Location
 
 	case sema.StringTypeToLowerFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.StringTypeToLowerFunctionType,
 			func(v *StringValue, invocation Invocation) Value {
@@ -472,7 +472,7 @@ func (v *StringValue) GetMember(interpreter *Interpreter, locationRange Location
 
 	case sema.StringTypeSplitFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.StringTypeSplitFunctionType,
 			func(v *StringValue, invocation Invocation) Value {
@@ -491,7 +491,7 @@ func (v *StringValue) GetMember(interpreter *Interpreter, locationRange Location
 
 	case sema.StringTypeReplaceAllFunctionName:
 		return NewBoundHostFunctionValue(
-			interpreter,
+			context,
 			v,
 			sema.StringTypeReplaceAllFunctionType,
 			func(v *StringValue, invocation Invocation) Value {
@@ -523,7 +523,7 @@ func (*StringValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Valu
 	panic(errors.NewUnreachableError())
 }
 
-func (*StringValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (*StringValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Strings have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -750,7 +750,7 @@ func (v *StringValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -169,7 +169,7 @@ func (v TypeValue) GetMember(context MemberAccessibleContext, _ LocationRange, n
 			return FalseValue
 		}
 
-		return BoolValue(context.IsRecovered(location))
+		return BoolValue(context.IsTypeInfoRecovered(location))
 
 	case sema.MetaTypeAddressFieldName:
 		staticType := v.Type

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -440,8 +440,8 @@ func (v UFix64Value) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []
 	return scratch[:9]
 }
 
-func (v UFix64Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.UFix64Type, locationRange)
+func (v UFix64Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.UFix64Type, locationRange)
 }
 
 func (UFix64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -449,7 +449,7 @@ func (UFix64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value
 	panic(errors.NewUnreachableError())
 }
 
-func (UFix64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (UFix64Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -480,7 +480,7 @@ func (v UFix64Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -589,8 +589,8 @@ func (v UIntValue) BitwiseRightShift(context ValueStaticTypeContext, other Integ
 	)
 }
 
-func (v UIntValue) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.UIntType, locationRange)
+func (v UIntValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.UIntType, locationRange)
 }
 
 func (UIntValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -598,7 +598,7 @@ func (UIntValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
 	panic(errors.NewUnreachableError())
 }
 
-func (UIntValue) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (UIntValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -637,7 +637,7 @@ func (v UIntValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -635,8 +635,8 @@ func (v UInt128Value) BitwiseRightShift(context ValueStaticTypeContext, other In
 	)
 }
 
-func (v UInt128Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.UInt128Type, locationRange)
+func (v UInt128Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.UInt128Type, locationRange)
 }
 
 func (UInt128Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -644,7 +644,7 @@ func (UInt128Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Valu
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt128Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (UInt128Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -687,7 +687,7 @@ func (v UInt128Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -496,8 +496,8 @@ func (v UInt16Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 	)
 }
 
-func (v UInt16Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.UInt16Type, locationRange)
+func (v UInt16Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.UInt16Type, locationRange)
 }
 
 func (UInt16Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -505,7 +505,7 @@ func (UInt16Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt16Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (UInt16Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -550,7 +550,7 @@ func (v UInt16Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -635,8 +635,8 @@ func (v UInt256Value) BitwiseRightShift(context ValueStaticTypeContext, other In
 	)
 }
 
-func (v UInt256Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.UInt256Type, locationRange)
+func (v UInt256Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.UInt256Type, locationRange)
 }
 
 func (UInt256Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -644,7 +644,7 @@ func (UInt256Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Valu
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt256Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (UInt256Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -686,7 +686,7 @@ func (v UInt256Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -497,8 +497,8 @@ func (v UInt32Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 	)
 }
 
-func (v UInt32Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.UInt32Type, locationRange)
+func (v UInt32Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.UInt32Type, locationRange)
 }
 
 func (UInt32Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -506,7 +506,7 @@ func (UInt32Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt32Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (UInt32Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -551,7 +551,7 @@ func (v UInt32Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -525,8 +525,8 @@ func (v UInt64Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 	)
 }
 
-func (v UInt64Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.UInt64Type, locationRange)
+func (v UInt64Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.UInt64Type, locationRange)
 }
 
 func (UInt64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -534,7 +534,7 @@ func (UInt64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (UInt64Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -579,7 +579,7 @@ func (v UInt64Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -547,8 +547,8 @@ func (v UInt8Value) BitwiseRightShift(context ValueStaticTypeContext, other Inte
 	)
 }
 
-func (v UInt8Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.UInt8Type, locationRange)
+func (v UInt8Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.UInt8Type, locationRange)
 }
 
 func (UInt8Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -556,7 +556,7 @@ func (UInt8Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value 
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt8Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (UInt8Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -595,7 +595,7 @@ func (v UInt8Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_void.go
+++ b/interpreter/value_void.go
@@ -103,7 +103,7 @@ func (v VoidValue) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -540,8 +540,8 @@ func (v Word128Value) BitwiseRightShift(context ValueStaticTypeContext, other In
 	)
 }
 
-func (v Word128Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.Word128Type, locationRange)
+func (v Word128Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.Word128Type, locationRange)
 }
 
 func (Word128Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -549,7 +549,7 @@ func (Word128Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Valu
 	panic(errors.NewUnreachableError())
 }
 
-func (Word128Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (Word128Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -592,7 +592,7 @@ func (v Word128Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -392,8 +392,8 @@ func (v Word16Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 	return NewWord16Value(context, valueGetter)
 }
 
-func (v Word16Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.Word16Type, locationRange)
+func (v Word16Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.Word16Type, locationRange)
 }
 
 func (Word16Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -401,7 +401,7 @@ func (Word16Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value
 	panic(errors.NewUnreachableError())
 }
 
-func (Word16Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (Word16Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -446,7 +446,7 @@ func (v Word16Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -541,8 +541,8 @@ func (v Word256Value) BitwiseRightShift(context ValueStaticTypeContext, other In
 	)
 }
 
-func (v Word256Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.Word256Type, locationRange)
+func (v Word256Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.Word256Type, locationRange)
 }
 
 func (Word256Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -550,7 +550,7 @@ func (Word256Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Valu
 	panic(errors.NewUnreachableError())
 }
 
-func (Word256Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (Word256Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -593,7 +593,7 @@ func (v Word256Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -393,8 +393,8 @@ func (v Word32Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 	return NewWord32Value(context, valueGetter)
 }
 
-func (v Word32Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.Word32Type, locationRange)
+func (v Word32Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.Word32Type, locationRange)
 }
 
 func (Word32Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -402,7 +402,7 @@ func (Word32Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value
 	panic(errors.NewUnreachableError())
 }
 
-func (Word32Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (Word32Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -447,7 +447,7 @@ func (v Word32Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -421,8 +421,8 @@ func (v Word64Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 	return NewWord64Value(context, valueGetter)
 }
 
-func (v Word64Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.Word64Type, locationRange)
+func (v Word64Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.Word64Type, locationRange)
 }
 
 func (Word64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -430,7 +430,7 @@ func (Word64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value
 	panic(errors.NewUnreachableError())
 }
 
-func (Word64Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (Word64Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -475,7 +475,7 @@ func (v Word64Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -392,8 +392,8 @@ func (v Word8Value) BitwiseRightShift(context ValueStaticTypeContext, other Inte
 	return NewWord8Value(context, valueGetter)
 }
 
-func (v Word8Value) GetMember(interpreter *Interpreter, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(interpreter, v, name, sema.Word8Type, locationRange)
+func (v Word8Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return getNumberValueMember(context, v, name, sema.Word8Type, locationRange)
 }
 
 func (Word8Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
@@ -401,7 +401,7 @@ func (Word8Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value 
 	panic(errors.NewUnreachableError())
 }
 
-func (Word8Value) SetMember(_ *Interpreter, _ LocationRange, _ string, _ Value) bool {
+func (Word8Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
@@ -444,7 +444,7 @@ func (v Word8Value) Transfer(
 	_ bool,
 ) Value {
 	if remove {
-		context.RemoveReferencedSlab(storable)
+		RemoveReferencedSlab(context, storable)
 	}
 	return v
 }

--- a/runtime/account_storage_v2.go
+++ b/runtime/account_storage_v2.go
@@ -54,7 +54,7 @@ func NewAccountStorageV2(
 }
 
 func (s *AccountStorageV2) GetDomainStorageMap(
-	inter *interpreter.Interpreter,
+	storageMutationTracker interpreter.StorageMutationTracker,
 	address common.Address,
 	domain common.StorageDomain,
 	createIfNotExists bool,
@@ -70,7 +70,7 @@ func (s *AccountStorageV2) GetDomainStorageMap(
 	if accountStorageMap != nil {
 		domainStorageMap = accountStorageMap.GetDomain(
 			s.memoryGauge,
-			inter,
+			storageMutationTracker,
 			domain,
 			createIfNotExists,
 		)

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -377,7 +377,7 @@ func exportCompositeValue(
 
 	staticType := v.StaticType(inter)
 
-	semaType, err := inter.ConvertStaticToSemaType(staticType)
+	semaType, err := interpreter.ConvertStaticToSemaType(inter, staticType)
 	if err != nil {
 		return nil, err
 	}
@@ -1204,7 +1204,7 @@ func (i valueImporter) importTypeValue(v cadence.Type) (interpreter.TypeValue, e
 	//
 	// If this fails, the import is invalid
 
-	_, err := inter.ConvertStaticToSemaType(typ)
+	_, err := interpreter.ConvertStaticToSemaType(inter, typ)
 	if err != nil {
 		// unmetered because when err != nil, value should be ignored
 		return interpreter.EmptyTypeValue, err
@@ -1304,7 +1304,7 @@ func (i valueImporter) importArrayValue(
 		types := make([]sema.Type, len(v.Values))
 
 		for i, value := range values {
-			typ, err := inter.ConvertStaticToSemaType(value.StaticType(inter))
+			typ, err := interpreter.ConvertStaticToSemaType(inter, value.StaticType(inter))
 			if err != nil {
 				return nil, err
 			}
@@ -1375,13 +1375,13 @@ func (i valueImporter) importDictionaryValue(
 		valueTypes := make([]sema.Type, size)
 
 		for i := 0; i < size; i++ {
-			keyType, err := inter.ConvertStaticToSemaType(keysAndValues[i*2].StaticType(inter))
+			keyType, err := interpreter.ConvertStaticToSemaType(inter, keysAndValues[i*2].StaticType(inter))
 			if err != nil {
 				return nil, err
 			}
 			keyTypes[i] = keyType
 
-			valueType, err := inter.ConvertStaticToSemaType(keysAndValues[i*2+1].StaticType(inter))
+			valueType, err := interpreter.ConvertStaticToSemaType(inter, keysAndValues[i*2+1].StaticType(inter))
 			if err != nil {
 				return nil, err
 			}
@@ -1460,7 +1460,7 @@ func (i valueImporter) importInclusiveRangeValue(
 	startType := startValue.StaticType(inter)
 
 	if inclusiveRangeType == nil {
-		memberSemaType, err := inter.ConvertStaticToSemaType(startType)
+		memberSemaType, err := interpreter.ConvertStaticToSemaType(inter, startType)
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -75,7 +75,7 @@ type Environment interface {
 		error,
 	)
 	CommitStorage(inter *interpreter.Interpreter) error
-	NewAccountValue(inter *interpreter.Interpreter, address interpreter.AddressValue) interpreter.Value
+	NewAccountValue(context interpreter.FunctionCreationContext, address interpreter.AddressValue) interpreter.Value
 
 	ResolveLocation(identifiers []ast.Identifier, location common.Location) ([]ResolvedLocation, error)
 }
@@ -339,9 +339,9 @@ func (e *interpreterEnvironment) GetAccountAvailableBalance(address common.Addre
 	return e.runtimeInterface.GetAccountAvailableBalance(address)
 }
 
-func (e *interpreterEnvironment) CommitStorageTemporarily(inter *interpreter.Interpreter) error {
+func (e *interpreterEnvironment) CommitStorageTemporarily(context interpreter.ValueTransferContext) error {
 	const commitContractUpdates = false
-	return e.storage.Commit(inter, commitContractUpdates)
+	return e.storage.Commit(context, commitContractUpdates)
 }
 
 func (e *interpreterEnvironment) GetStorageUsed(address common.Address) (uint64, error) {
@@ -870,10 +870,10 @@ func (e *interpreterEnvironment) newOnRecordTraceHandler() interpreter.OnRecordT
 }
 
 func (e *interpreterEnvironment) NewAccountValue(
-	inter *interpreter.Interpreter,
+	context interpreter.FunctionCreationContext,
 	address interpreter.AddressValue,
 ) interpreter.Value {
-	return stdlib.NewAccountValue(inter, e, address)
+	return stdlib.NewAccountValue(context, e, address)
 }
 
 func (e *interpreterEnvironment) ValidatePublicKey(publicKey *stdlib.PublicKey) error {
@@ -995,7 +995,7 @@ func (e *interpreterEnvironment) newOnEventEmittedHandler() interpreter.OnEventE
 
 func (e *interpreterEnvironment) newInjectedCompositeFieldsHandler() interpreter.InjectedCompositeFieldsHandlerFunc {
 	return func(
-		inter *interpreter.Interpreter,
+		context interpreter.FunctionCreationContext,
 		location Location,
 		_ string,
 		compositeKind common.CompositeKind,
@@ -1013,13 +1013,13 @@ func (e *interpreterEnvironment) newInjectedCompositeFieldsHandler() interpreter
 			}
 
 			addressValue := interpreter.NewAddressValue(
-				inter,
+				context,
 				address,
 			)
 
 			return map[string]interpreter.Value{
 				sema.ContractAccountFieldName: stdlib.NewAccountReferenceValue(
-					inter,
+					context,
 					e,
 					addressValue,
 					interpreter.FullyEntitledAccountAccess,

--- a/runtime/migrate_domain_registers.go
+++ b/runtime/migrate_domain_registers.go
@@ -40,7 +40,7 @@ type GetDomainStorageMapFunc func(
 type DomainRegisterMigration struct {
 	ledger              atree.Ledger
 	storage             atree.SlabStorage
-	inter               *interpreter.Interpreter
+	context             interpreter.ValueTransferContext
 	memoryGauge         common.MemoryGauge
 	getDomainStorageMap GetDomainStorageMapFunc
 }
@@ -48,7 +48,7 @@ type DomainRegisterMigration struct {
 func NewDomainRegisterMigration(
 	ledger atree.Ledger,
 	storage atree.SlabStorage,
-	inter *interpreter.Interpreter,
+	context interpreter.ValueTransferContext,
 	memoryGauge common.MemoryGauge,
 	getDomainStorageMap GetDomainStorageMapFunc,
 ) *DomainRegisterMigration {
@@ -58,7 +58,7 @@ func NewDomainRegisterMigration(
 	return &DomainRegisterMigration{
 		ledger:              ledger,
 		storage:             storage,
-		inter:               inter,
+		context:             context,
 		memoryGauge:         memoryGauge,
 		getDomainStorageMap: getDomainStorageMap,
 	}
@@ -144,7 +144,7 @@ func (m *DomainRegisterMigration) migrateDomainRegisters(
 		}
 
 		// Migrate (insert) existing domain storage map to account storage map
-		existed := accountStorageMap.WriteDomain(m.inter, domain, domainStorageMap)
+		existed := accountStorageMap.WriteDomain(m.context, domain, domainStorageMap)
 		if existed {
 			// This shouldn't happen because we are inserting domain storage map into empty account storage map.
 			return nil, errors.NewUnexpectedError(

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -445,7 +445,7 @@ func validateArgumentParams(
 		}
 
 		// Check that decoded value is a subtype of static parameter type
-		if !inter.IsSubTypeOfSemaType(argType, parameterType) {
+		if !interpreter.IsSubTypeOfSemaType(inter, argType, parameterType) {
 			return nil, &InvalidEntryPointArgumentError{
 				Index: parameterIndex,
 				Err: &InvalidValueTypeError{

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -9220,7 +9220,7 @@ func TestRuntimeTypesAndConversions(t *testing.T) {
 					inter, err := interpreter.NewInterpreter(nil, nil, &interpreter.Config{})
 					require.NoError(t, err)
 
-					convertedSemaType, err := inter.ConvertStaticToSemaType(staticType)
+					convertedSemaType, err := interpreter.ConvertStaticToSemaType(inter, staticType)
 					require.NoError(t, err)
 					require.True(t, semaType.Equal(convertedSemaType))
 				})

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -148,7 +148,7 @@ const storageIndexLength = 8
 
 // GetDomainStorageMap returns existing or new domain storage map for the given account and domain.
 func (s *Storage) GetDomainStorageMap(
-	inter *interpreter.Interpreter,
+	storageMutationTracker interpreter.StorageMutationTracker,
 	address common.Address,
 	domain common.StorageDomain,
 	createIfNotExists bool,
@@ -199,7 +199,7 @@ func (s *Storage) GetDomainStorageMap(
 	if known {
 		return s.getDomainStorageMap(
 			cachedFormat,
-			inter,
+			storageMutationTracker,
 			address,
 			domain,
 			createIfNotExists,
@@ -210,7 +210,7 @@ func (s *Storage) GetDomainStorageMap(
 
 	if s.isV2Account(address) {
 		return s.getDomainStorageMapForV2Account(
-			inter,
+			storageMutationTracker,
 			address,
 			domain,
 			createIfNotExists,
@@ -250,7 +250,7 @@ func (s *Storage) GetDomainStorageMap(
 	// New account is treated as v2 account when feature flag is enabled.
 
 	return s.getDomainStorageMapForV2Account(
-		inter,
+		storageMutationTracker,
 		address,
 		domain,
 		createIfNotExists,
@@ -274,13 +274,13 @@ func (s *Storage) getDomainStorageMapForV1Account(
 }
 
 func (s *Storage) getDomainStorageMapForV2Account(
-	inter *interpreter.Interpreter,
+	storageMutationTracker interpreter.StorageMutationTracker,
 	address common.Address,
 	domain common.StorageDomain,
 	createIfNotExists bool,
 ) *interpreter.DomainStorageMap {
 	domainStorageMap := s.AccountStorageV2.GetDomainStorageMap(
-		inter,
+		storageMutationTracker,
 		address,
 		domain,
 		createIfNotExists,
@@ -293,7 +293,7 @@ func (s *Storage) getDomainStorageMapForV2Account(
 
 func (s *Storage) getDomainStorageMap(
 	format StorageFormat,
-	inter *interpreter.Interpreter,
+	storageMutationTracker interpreter.StorageMutationTracker,
 	address common.Address,
 	domain common.StorageDomain,
 	createIfNotExists bool,
@@ -309,7 +309,7 @@ func (s *Storage) getDomainStorageMap(
 
 	case StorageFormatV2:
 		return s.getDomainStorageMapForV2Account(
-			inter,
+			storageMutationTracker,
 			address,
 			domain,
 			createIfNotExists,
@@ -432,34 +432,34 @@ func SortContractUpdates(updates []ContractUpdate) {
 
 // commitContractUpdates writes the contract updates to storage.
 // The contract updates were delayed so they are not observable during execution.
-func (s *Storage) commitContractUpdates(inter *interpreter.Interpreter) {
+func (s *Storage) commitContractUpdates(context interpreter.ValueTransferContext) {
 	if s.contractUpdates == nil {
 		return
 	}
 
 	for pair := s.contractUpdates.Oldest(); pair != nil; pair = pair.Next() {
-		s.writeContractUpdate(inter, pair.Key, pair.Value)
+		s.writeContractUpdate(context, pair.Key, pair.Value)
 	}
 }
 
 func (s *Storage) writeContractUpdate(
-	inter *interpreter.Interpreter,
+	context interpreter.ValueTransferContext,
 	key interpreter.StorageKey,
 	contractValue *interpreter.CompositeValue,
 ) {
-	storageMap := s.GetDomainStorageMap(inter, key.Address, common.StorageDomainContract, true)
+	storageMap := s.GetDomainStorageMap(context, key.Address, common.StorageDomainContract, true)
 	// NOTE: pass nil instead of allocating a Value-typed  interface that points to nil
 	storageMapKey := interpreter.StringStorageMapKey(key.Key)
 	if contractValue == nil {
-		storageMap.WriteValue(inter, storageMapKey, nil)
+		storageMap.WriteValue(context, storageMapKey, nil)
 	} else {
-		storageMap.WriteValue(inter, storageMapKey, contractValue)
+		storageMap.WriteValue(context, storageMapKey, contractValue)
 	}
 }
 
 // Commit serializes/saves all values in the readCache in storage (through the runtime interface).
-func (s *Storage) Commit(inter *interpreter.Interpreter, commitContractUpdates bool) error {
-	return s.commit(inter, commitContractUpdates, true)
+func (s *Storage) Commit(context interpreter.ValueTransferContext, commitContractUpdates bool) error {
+	return s.commit(context, commitContractUpdates, true)
 }
 
 // Deprecated: NondeterministicCommit serializes and commits all values in the deltas storage
@@ -469,10 +469,10 @@ func (s *Storage) NondeterministicCommit(inter *interpreter.Interpreter, commitC
 	return s.commit(inter, commitContractUpdates, false)
 }
 
-func (s *Storage) commit(inter *interpreter.Interpreter, commitContractUpdates bool, deterministic bool) error {
+func (s *Storage) commit(context interpreter.ValueTransferContext, commitContractUpdates bool, deterministic bool) error {
 
 	if commitContractUpdates {
-		s.commitContractUpdates(inter)
+		s.commitContractUpdates(context)
 	}
 
 	err := s.AccountStorageV1.commit()
@@ -486,7 +486,7 @@ func (s *Storage) commit(inter *interpreter.Interpreter, commitContractUpdates b
 			return err
 		}
 
-		err = s.migrateV1AccountsToV2(inter)
+		err = s.migrateV1AccountsToV2(context)
 		if err != nil {
 			return err
 		}
@@ -498,13 +498,13 @@ func (s *Storage) commit(inter *interpreter.Interpreter, commitContractUpdates b
 
 	size := slabStorage.DeltasSizeWithoutTempAddresses()
 	if size > 0 {
-		inter.ReportComputation(common.ComputationKindEncodeValue, uint(size))
+		context.ReportComputation(common.ComputationKindEncodeValue, uint(size))
 		usage := common.NewBytesMemoryUsage(int(size))
-		common.UseMemory(inter, usage)
+		common.UseMemory(context, usage)
 	}
 
 	deltas := slabStorage.DeltasWithoutTempAddresses()
-	common.UseMemory(inter, common.NewAtreeEncodedSlabMemoryUsage(deltas))
+	common.UseMemory(context, common.NewAtreeEncodedSlabMemoryUsage(deltas))
 
 	// TODO: report encoding metric for all encoded slabs
 	if deterministic {
@@ -534,7 +534,7 @@ func (s *Storage) ScheduleV2MigrationForModifiedAccounts() bool {
 	return true
 }
 
-func (s *Storage) migrateV1AccountsToV2(inter *interpreter.Interpreter) error {
+func (s *Storage) migrateV1AccountsToV2(context interpreter.ValueTransferContext) error {
 
 	if !s.Config.StorageFormatV2Enabled {
 		return errors.NewUnexpectedError("cannot migrate to storage format v2, as it is not enabled")
@@ -568,7 +568,7 @@ func (s *Storage) migrateV1AccountsToV2(inter *interpreter.Interpreter) error {
 	migrator := NewDomainRegisterMigration(
 		s.Ledger,
 		s.PersistentSlabStorage,
-		inter,
+		context,
 		s.memoryGauge,
 		getDomainStorageMap,
 	)

--- a/stdlib/bls.go
+++ b/stdlib/bls.go
@@ -52,7 +52,8 @@ func newBLSAggregatePublicKeysFunction(
 			inter := invocation.Interpreter
 			locationRange := invocation.LocationRange
 
-			inter.ExpectType(
+			interpreter.ExpectType(
+				inter,
 				publicKeysValue,
 				sema.PublicKeyArrayType,
 				locationRange,
@@ -129,7 +130,8 @@ func newBLSAggregateSignaturesFunction(
 			inter := invocation.Interpreter
 			locationRange := invocation.LocationRange
 
-			inter.ExpectType(
+			interpreter.ExpectType(
+				inter,
 				signaturesValue,
 				sema.ByteArrayArrayType,
 				locationRange,

--- a/stdlib/publickey.go
+++ b/stdlib/publickey.go
@@ -244,7 +244,8 @@ func newPublicKeyVerifySignatureFunction(
 
 			locationRange := invocation.LocationRange
 
-			inter.ExpectType(
+			interpreter.ExpectType(
+				inter,
 				publicKeyValue,
 				sema.PublicKeyType,
 				locationRange,
@@ -314,7 +315,8 @@ func newPublicKeyVerifyPoPFunction(
 
 			locationRange := invocation.LocationRange
 
-			inter.ExpectType(
+			interpreter.ExpectType(
+				inter,
 				publicKeyValue,
 				sema.PublicKeyType,
 				locationRange,

--- a/stdlib/test.go
+++ b/stdlib/test.go
@@ -439,7 +439,7 @@ func newMatcherWithGenericTestFunction(
 			for _, argument := range invocation.Arguments {
 				argumentStaticType := argument.StaticType(inter)
 
-				if !inter.IsSubTypeOfSemaType(argumentStaticType, parameterType) {
+				if !interpreter.IsSubTypeOfSemaType(inter, argumentStaticType, parameterType) {
 					argumentSemaType := interpreter.MustConvertStaticToSemaType(argumentStaticType, inter)
 
 					panic(interpreter.TypeMismatchError{

--- a/tools/storage-explorer/type.go
+++ b/tools/storage-explorer/type.go
@@ -37,7 +37,7 @@ func prepareType(value interpreter.Value, inter *interpreter.Interpreter) (resul
 		}
 	}()
 
-	semaType, err := inter.ConvertStaticToSemaType(staticType)
+	semaType, err := interpreter.ConvertStaticToSemaType(inter, staticType)
 	if err != nil {
 		typeID := staticType.ID()
 		return typeID, string(typeID)


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3693

Depends on https://github.com/onflow/cadence/pull/3821

## Description

Remove the interpreter dependency for the `GetMember` and `SetMember` methods of `MemberAccessibleValue`.

Instead, accepts a `MemberAccessibleContext`. i.e:

```go
type MemberAccessibleValue struct {
    GetMember(MemberAccessibleContext, LocationRange, string) Value

    SetMember(MemberAccessibleContext, LocationRange, string, Value) bool
}
```

All the other changes are a ripple-effect of this change. They are for refactoring the dependent methods to also remove the usage of interpreter, because the interpreter is no longer available.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
