### PR TITLE
[Compiler] Decouple `ValueIndexableValue` interface from the interpreter

### DIFF
--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -125,15 +125,16 @@ type ComputationReporter interface {
 
 var _ ComputationReporter = &Interpreter{}
 
-type ValueIterationContext interface {
+type ContainerMutationContext interface {
 	ValueTransferContext
 	WithMutationPrevention(valueID atree.ValueID, f func())
+	ValidateMutation(valueID atree.ValueID, locationRange LocationRange)
 }
 
-var _ ValueIterationContext = &Interpreter{}
+var _ ContainerMutationContext = &Interpreter{}
 
 type ValueStringContext interface {
-	ValueIterationContext
+	ContainerMutationContext
 }
 
 var _ ValueStringContext = &Interpreter{}
@@ -217,6 +218,10 @@ func (n NoOpStringContext) MeterMemory(_ common.MemoryUsage) error {
 func (n NoOpStringContext) WithMutationPrevention(_ atree.ValueID, f func()) {
 	f()
 	return
+}
+
+func (n NoOpStringContext) ValidateMutation(_ atree.ValueID, _ LocationRange) {
+	panic(errors.NewUnreachableError())
 }
 
 func (n NoOpStringContext) ReadStored(_ common.Address, _ common.StorageDomain, _ StorageMapKey) Value {

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5221,17 +5221,18 @@ func ExpectType(
 	}
 }
 
-func (interpreter *Interpreter) checkContainerMutation(
+func checkContainerMutation(
+	context ValueStaticTypeContext,
 	elementType StaticType,
 	element Value,
 	locationRange LocationRange,
 ) {
-	actualElementType := element.StaticType(interpreter)
+	actualElementType := element.StaticType(context)
 
-	if !IsSubType(interpreter, actualElementType, elementType) {
+	if !IsSubType(context, actualElementType, elementType) {
 		panic(ContainerMutationError{
-			ExpectedType:  MustConvertStaticToSemaType(elementType, interpreter),
-			ActualType:    MustSemaTypeOfValue(element, interpreter),
+			ExpectedType:  MustConvertStaticToSemaType(elementType, context),
+			ActualType:    MustSemaTypeOfValue(element, context),
 			LocationRange: locationRange,
 		})
 	}
@@ -5712,7 +5713,7 @@ func capabilityCheckFunction(
 	)
 }
 
-func (interpreter *Interpreter) validateMutation(valueID atree.ValueID, locationRange LocationRange) {
+func (interpreter *Interpreter) ValidateMutation(valueID atree.ValueID, locationRange LocationRange) {
 	_, present := interpreter.SharedState.containerValueIteration[valueID]
 	if !present {
 		return

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -136,10 +136,10 @@ type Value interface {
 
 type ValueIndexableValue interface {
 	Value
-	GetKey(interpreter *Interpreter, locationRange LocationRange, key Value) Value
-	SetKey(interpreter *Interpreter, locationRange LocationRange, key Value, value Value)
-	RemoveKey(interpreter *Interpreter, locationRange LocationRange, key Value) Value
-	InsertKey(interpreter *Interpreter, locationRange LocationRange, key Value, value Value)
+	GetKey(context ValueComparisonContext, locationRange LocationRange, key Value) Value
+	SetKey(context ContainerMutationContext, locationRange LocationRange, key Value, value Value)
+	RemoveKey(context ContainerMutationContext, locationRange LocationRange, key Value) Value
+	InsertKey(context ContainerMutationContext, locationRange LocationRange, key Value, value Value)
 }
 
 type TypeIndexableValue interface {

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -1500,7 +1500,7 @@ func (v *CompositeValue) forEachFieldName(
 // ForEachField iterates over all field-name field-value pairs of the composite value.
 // It does NOT iterate over computed fields and functions!
 func (v *CompositeValue) ForEachField(
-	context ValueIterationContext,
+	context ContainerMutationContext,
 	f func(fieldName string, fieldValue Value) (resume bool),
 	locationRange LocationRange,
 ) {
@@ -1523,7 +1523,7 @@ func (v *CompositeValue) ForEachField(
 // It does NOT iterate over computed fields and functions!
 // DO NOT perform storage mutations in the callback!
 func (v *CompositeValue) ForEachReadOnlyLoadedField(
-	context ValueIterationContext,
+	context ContainerMutationContext,
 	f func(fieldName string, fieldValue Value) (resume bool),
 	locationRange LocationRange,
 ) {
@@ -1536,7 +1536,7 @@ func (v *CompositeValue) ForEachReadOnlyLoadedField(
 }
 
 func (v *CompositeValue) forEachField(
-	context ValueIterationContext,
+	context ContainerMutationContext,
 	atreeIterate func(fn atree.MapEntryIterationFunc) error,
 	f func(fieldName string, fieldValue Value) (resume bool),
 	locationRange LocationRange,

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -154,42 +154,24 @@ func (v *EphemeralReferenceValue) SetMember(context MemberAccessibleContext, loc
 	return setMember(context, v.Value, locationRange, name, value)
 }
 
-func (v *EphemeralReferenceValue) GetKey(
-	interpreter *Interpreter,
-	locationRange LocationRange,
-	key Value,
-) Value {
+func (v *EphemeralReferenceValue) GetKey(context ValueComparisonContext, locationRange LocationRange, key Value) Value {
 	return v.Value.(ValueIndexableValue).
-		GetKey(interpreter, locationRange, key)
+		GetKey(context, locationRange, key)
 }
 
-func (v *EphemeralReferenceValue) SetKey(
-	interpreter *Interpreter,
-	locationRange LocationRange,
-	key Value,
-	value Value,
-) {
+func (v *EphemeralReferenceValue) SetKey(context ContainerMutationContext, locationRange LocationRange, key Value, value Value) {
 	v.Value.(ValueIndexableValue).
-		SetKey(interpreter, locationRange, key, value)
+		SetKey(context, locationRange, key, value)
 }
 
-func (v *EphemeralReferenceValue) InsertKey(
-	interpreter *Interpreter,
-	locationRange LocationRange,
-	key Value,
-	value Value,
-) {
+func (v *EphemeralReferenceValue) InsertKey(context ContainerMutationContext, locationRange LocationRange, key Value, value Value) {
 	v.Value.(ValueIndexableValue).
-		InsertKey(interpreter, locationRange, key, value)
+		InsertKey(context, locationRange, key, value)
 }
 
-func (v *EphemeralReferenceValue) RemoveKey(
-	interpreter *Interpreter,
-	locationRange LocationRange,
-	key Value,
-) Value {
+func (v *EphemeralReferenceValue) RemoveKey(context ContainerMutationContext, locationRange LocationRange, key Value) Value {
 	return v.Value.(ValueIndexableValue).
-		RemoveKey(interpreter, locationRange, key)
+		RemoveKey(context, locationRange, key)
 }
 
 func (v *EphemeralReferenceValue) GetTypeKey(

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -241,50 +241,32 @@ func (v *StorageReferenceValue) SetMember(context MemberAccessibleContext, locat
 	)
 }
 
-func (v *StorageReferenceValue) GetKey(
-	interpreter *Interpreter,
-	locationRange LocationRange,
-	key Value,
-) Value {
-	self := v.mustReferencedValue(interpreter, locationRange)
+func (v *StorageReferenceValue) GetKey(context ValueComparisonContext, locationRange LocationRange, key Value) Value {
+	self := v.mustReferencedValue(context, locationRange)
 
 	return self.(ValueIndexableValue).
-		GetKey(interpreter, locationRange, key)
+		GetKey(context, locationRange, key)
 }
 
-func (v *StorageReferenceValue) SetKey(
-	interpreter *Interpreter,
-	locationRange LocationRange,
-	key Value,
-	value Value,
-) {
-	self := v.mustReferencedValue(interpreter, locationRange)
+func (v *StorageReferenceValue) SetKey(context ContainerMutationContext, locationRange LocationRange, key Value, value Value) {
+	self := v.mustReferencedValue(context, locationRange)
 
 	self.(ValueIndexableValue).
-		SetKey(interpreter, locationRange, key, value)
+		SetKey(context, locationRange, key, value)
 }
 
-func (v *StorageReferenceValue) InsertKey(
-	interpreter *Interpreter,
-	locationRange LocationRange,
-	key Value,
-	value Value,
-) {
-	self := v.mustReferencedValue(interpreter, locationRange)
+func (v *StorageReferenceValue) InsertKey(context ContainerMutationContext, locationRange LocationRange, key Value, value Value) {
+	self := v.mustReferencedValue(context, locationRange)
 
 	self.(ValueIndexableValue).
-		InsertKey(interpreter, locationRange, key, value)
+		InsertKey(context, locationRange, key, value)
 }
 
-func (v *StorageReferenceValue) RemoveKey(
-	interpreter *Interpreter,
-	locationRange LocationRange,
-	key Value,
-) Value {
-	self := v.mustReferencedValue(interpreter, locationRange)
+func (v *StorageReferenceValue) RemoveKey(context ContainerMutationContext, locationRange LocationRange, key Value) Value {
+	self := v.mustReferencedValue(context, locationRange)
 
 	return self.(ValueIndexableValue).
-		RemoveKey(interpreter, locationRange, key)
+		RemoveKey(context, locationRange, key)
 }
 
 func (v *StorageReferenceValue) GetTypeKey(

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -322,7 +322,7 @@ func (v *StringValue) checkBounds(index int, locationRange LocationRange) {
 	}
 }
 
-func (v *StringValue) GetKey(interpreter *Interpreter, locationRange LocationRange, key Value) Value {
+func (v *StringValue) GetKey(context ValueComparisonContext, locationRange LocationRange, key Value) Value {
 	index := key.(NumberValue).ToInt(locationRange)
 	v.checkBounds(index, locationRange)
 
@@ -334,7 +334,7 @@ func (v *StringValue) GetKey(interpreter *Interpreter, locationRange LocationRan
 
 	char := v.graphemes.Str()
 	return NewCharacterValue(
-		interpreter,
+		context,
 		common.NewCharacterMemoryUsage(len(char)),
 		func() string {
 			return char
@@ -342,15 +342,15 @@ func (v *StringValue) GetKey(interpreter *Interpreter, locationRange LocationRan
 	)
 }
 
-func (*StringValue) SetKey(_ *Interpreter, _ LocationRange, _ Value, _ Value) {
+func (*StringValue) SetKey(_ ContainerMutationContext, _ LocationRange, _ Value, _ Value) {
 	panic(errors.NewUnreachableError())
 }
 
-func (*StringValue) InsertKey(_ *Interpreter, _ LocationRange, _ Value, _ Value) {
+func (*StringValue) InsertKey(_ ContainerMutationContext, _ LocationRange, _ Value, _ Value) {
 	panic(errors.NewUnreachableError())
 }
 
-func (*StringValue) RemoveKey(_ *Interpreter, _ LocationRange, _ Value) Value {
+func (*StringValue) RemoveKey(_ ContainerMutationContext, _ LocationRange, _ Value) Value {
 	panic(errors.NewUnreachableError())
 }
 


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3693

Depends on https://github.com/onflow/cadence/pull/3822

## Description

Decouple all methods of `ValueIndexableValue` interface from the interpreter

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
