### PR TITLE
[Compiler] Decouple `interpreter.Invocation` from the `Interpreter` instance

### DIFF
--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -20,7 +20,6 @@ package vm
 
 import (
 	"github.com/onflow/atree"
-
 	"github.com/onflow/cadence/bbq/commons"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
@@ -48,8 +47,8 @@ type Config struct {
 
 	// TODO: Move these to a 'shared state'?
 	storage                                     interpreter.Storage
-	CapabilityControllerIterations              map[AddressPath]int
-	MutationDuringCapabilityControllerIteration bool
+	CapabilityControllerIterations              map[interpreter.AddressPath]int
+	mutationDuringCapabilityControllerIteration bool
 	referencedResourceKindedValues              ReferencedResourceKindedValues
 
 	// OnEventEmitted is triggered when an event is emitted by the program
@@ -75,8 +74,8 @@ func NewConfig(storage interpreter.Storage) *Config {
 		ContractValueHandler: nil,
 		accountHandler:       nil,
 
-		CapabilityControllerIterations:              make(map[AddressPath]int),
-		MutationDuringCapabilityControllerIteration: false,
+		CapabilityControllerIterations:              make(map[interpreter.AddressPath]int),
+		mutationDuringCapabilityControllerIteration: false,
 		referencedResourceKindedValues:              ReferencedResourceKindedValues{},
 	}
 }
@@ -290,9 +289,44 @@ func (c *Config) GetAccountHandler() stdlib.AccountHandler {
 	return c.accountHandler
 }
 
-type ContractValueHandler func(conf *Config, location common.Location) *interpreter.CompositeValue
-
-type AddressPath struct {
-	Address common.Address
-	Path    interpreter.PathValue
+func (c *Config) StorageMutatedDuringIteration() bool {
+	//TODO
+	return false
 }
+
+func (c *Config) InStorageIteration() bool {
+	//TODO
+	return false
+}
+
+func (c *Config) SetInStorageIteration(b bool) {
+	//TODO
+}
+
+func (c *Config) WithResourceDestruction(valueID atree.ValueID, locationRange interpreter.LocationRange, f func()) {
+	//TODO
+}
+
+func (c *Config) GetCapabilityControllerIterations() map[interpreter.AddressPath]int {
+	return c.CapabilityControllerIterations
+}
+
+func (c *Config) SetMutationDuringCapabilityControllerIteration() {
+	c.mutationDuringCapabilityControllerIteration = true
+}
+
+func (c *Config) MutationDuringCapabilityControllerIteration() bool {
+	return c.mutationDuringCapabilityControllerIteration
+}
+
+func (c *Config) GetContractValue(contractLocation common.AddressLocation) (*interpreter.CompositeValue, error) {
+	//TODO
+	return nil, nil
+}
+
+func (c *Config) SetAttachmentIteration(composite *interpreter.CompositeValue, state bool) bool {
+	//TODO
+	return false
+}
+
+type ContractValueHandler func(conf *Config, location common.Location) *interpreter.CompositeValue

--- a/bbq/vm/test/interpreter_test.go
+++ b/bbq/vm/test/interpreter_test.go
@@ -204,7 +204,7 @@ func TestInterpreterFTTransfer(t *testing.T) {
 		temporarilyRecordCode: func(location common.AddressLocation, code []byte) {
 			// do nothing
 		},
-		emitEvent: func(*interpreter.Interpreter, interpreter.LocationRange, *sema.CompositeType, []interpreter.Value) {
+		emitEvent: func(interpreter.ValueExportContext, interpreter.LocationRange, *sema.CompositeType, []interpreter.Value) {
 			// do nothing
 		},
 		recordContractUpdate: func(location common.AddressLocation, value *interpreter.CompositeValue) {
@@ -574,7 +574,7 @@ func BenchmarkInterpreterFTTransfer(b *testing.B) {
 		temporarilyRecordCode: func(location common.AddressLocation, code []byte) {
 			// do nothing
 		},
-		emitEvent: func(*interpreter.Interpreter, interpreter.LocationRange, *sema.CompositeType, []interpreter.Value) {
+		emitEvent: func(interpreter.ValueExportContext, interpreter.LocationRange, *sema.CompositeType, []interpreter.Value) {
 			// do nothing
 		},
 		recordContractUpdate: func(location common.AddressLocation, value *interpreter.CompositeValue) {

--- a/bbq/vm/test/interpreter_test.go
+++ b/bbq/vm/test/interpreter_test.go
@@ -255,7 +255,8 @@ func TestInterpreterFTTransfer(t *testing.T) {
 
 			constructor := constructorGenerator(common.ZeroAddress)
 
-			value, err := inter.InvokeFunctionValue(
+			value, err := interpreter.InvokeFunctionValue(
+				inter,
 				constructor,
 				[]interpreter.Value{signer},
 				[]sema.Type{
@@ -275,7 +276,7 @@ func TestInterpreterFTTransfer(t *testing.T) {
 			return flowTokenContractValue
 		},
 		CapabilityBorrowHandler: func(
-			inter *interpreter.Interpreter,
+			context interpreter.BorrowCapabilityControllerContext,
 			locationRange interpreter.LocationRange,
 			address interpreter.AddressValue,
 			capabilityID interpreter.UInt64Value,
@@ -283,7 +284,7 @@ func TestInterpreterFTTransfer(t *testing.T) {
 			capabilityBorrowType *sema.ReferenceType,
 		) interpreter.ReferenceValue {
 			return stdlib.BorrowCapabilityController(
-				inter,
+				context,
 				locationRange,
 				address,
 				capabilityID,
@@ -625,7 +626,8 @@ func BenchmarkInterpreterFTTransfer(b *testing.B) {
 
 			constructor := constructorGenerator(common.ZeroAddress)
 
-			value, err := inter.InvokeFunctionValue(
+			value, err := interpreter.InvokeFunctionValue(
+				inter,
 				constructor,
 				[]interpreter.Value{signer},
 				[]sema.Type{
@@ -645,7 +647,7 @@ func BenchmarkInterpreterFTTransfer(b *testing.B) {
 			return flowTokenContractValue
 		},
 		CapabilityBorrowHandler: func(
-			inter *interpreter.Interpreter,
+			context interpreter.BorrowCapabilityControllerContext,
 			locationRange interpreter.LocationRange,
 			address interpreter.AddressValue,
 			capabilityID interpreter.UInt64Value,
@@ -653,7 +655,7 @@ func BenchmarkInterpreterFTTransfer(b *testing.B) {
 			capabilityBorrowType *sema.ReferenceType,
 		) interpreter.ReferenceValue {
 			return stdlib.BorrowCapabilityController(
-				inter,
+				context,
 				locationRange,
 				address,
 				capabilityID,

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -64,7 +64,7 @@ type testAccountHandler struct {
 	getAccountKey    func(address common.Address, index uint32) (*stdlib.AccountKey, error)
 	accountKeysCount func(address common.Address) (uint32, error)
 	emitEvent        func(
-		inter *interpreter.Interpreter,
+		context interpreter.ValueExportContext,
 		locationRange interpreter.LocationRange,
 		eventType *sema.CompositeType,
 		values []interpreter.Value,
@@ -214,7 +214,7 @@ func (t *testAccountHandler) AccountKeysCount(address common.Address) (uint32, e
 }
 
 func (t *testAccountHandler) EmitEvent(
-	inter *interpreter.Interpreter,
+	context interpreter.ValueExportContext,
 	locationRange interpreter.LocationRange,
 	eventType *sema.CompositeType,
 	values []interpreter.Value,
@@ -223,7 +223,7 @@ func (t *testAccountHandler) EmitEvent(
 		panic(errors.NewUnexpectedError("unexpected call to EmitEvent"))
 	}
 	t.emitEvent(
-		inter,
+		context,
 		locationRange,
 		eventType,
 		values,

--- a/bbq/vm/tracer.go
+++ b/bbq/vm/tracer.go
@@ -44,6 +44,10 @@ func (ctx Tracer) ReportArrayValueConstructTrace(_ string, _ int, _ time.Duratio
 	panic(errors.NewUnreachableError())
 }
 
+func (c *Config) ReportArrayValueDestroyTrace(info string, count int, since time.Duration) {
+	panic(errors.NewUnreachableError())
+}
+
 func (ctx Tracer) ReportDictionaryValueTransferTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
@@ -64,6 +68,9 @@ func (c *Config) ReportDictionaryValueConstructTrace(_ string, _ int, _ time.Dur
 	panic(errors.NewUnreachableError())
 }
 
+func (c *Config) ReportDictionaryValueDestroyTrace(info string, count int, since time.Duration) {
+	panic(errors.NewUnreachableError())
+}
 func (ctx Tracer) ReportCompositeValueTransferTrace(_ string, _ string, _ string, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
@@ -77,6 +84,10 @@ func (ctx Tracer) ReportCompositeValueGetMemberTrace(_ string, _ string, _ strin
 }
 
 func (ctx Tracer) ReportCompositeValueConstructTrace(_ string, _ string, _ string, _ time.Duration) {
+	panic(errors.NewUnreachableError())
+}
+
+func (c *Config) ReportCompositeValueDestroyTrace(owner string, id string, kind string, since time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 

--- a/bbq/vm/value_account.go
+++ b/bbq/vm/value_account.go
@@ -334,12 +334,12 @@ func recordStorageCapabilityController(
 		panic(errors.NewUnreachableError())
 	}
 
-	addressPath := AddressPath{
+	addressPath := interpreter.AddressPath{
 		Address: address,
 		Path:    targetPathValue,
 	}
 	if config.CapabilityControllerIterations[addressPath] > 0 {
-		config.MutationDuringCapabilityControllerIteration = true
+		config.mutationDuringCapabilityControllerIteration = true
 	}
 
 	identifier := targetPathValue.Identifier

--- a/bbq/vm/value_capability.go
+++ b/bbq/vm/value_capability.go
@@ -85,7 +85,7 @@ func init() {
 }
 
 func GetCheckedCapabilityControllerReference(
-	context interpreter.CapConReferenceValueContext,
+	context interpreter.ValueCapabilityControllerReferenceValueContext,
 	capabilityAddressValue interpreter.AddressValue,
 	capabilityIDValue interpreter.UInt64Value,
 	wantedBorrowType *interpreter.ReferenceStaticType,

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -66,7 +66,7 @@ func (v FunctionValue) Accept(interpreter *interpreter.Interpreter, visitor inte
 	panic(errors.NewUnreachableError())
 }
 
-func (v FunctionValue) Walk(interpreter *interpreter.Interpreter, walkChild func(interpreter.Value), locationRange interpreter.LocationRange) {
+func (v FunctionValue) Walk(interpreter interpreter.ValueWalkContext, walkChild func(interpreter.Value), locationRange interpreter.LocationRange) {
 	//TODO
 	panic(errors.NewUnreachableError())
 }
@@ -153,7 +153,7 @@ func (v NativeFunctionValue) Accept(interpreter *interpreter.Interpreter, visito
 	panic(errors.NewUnreachableError())
 }
 
-func (v NativeFunctionValue) Walk(interpreter *interpreter.Interpreter, walkChild func(interpreter.Value), locationRange interpreter.LocationRange) {
+func (v NativeFunctionValue) Walk(interpreter interpreter.ValueWalkContext, walkChild func(interpreter.Value), locationRange interpreter.LocationRange) {
 	//TODO
 	panic(errors.NewUnreachableError())
 }

--- a/bbq/vm/value_iterator.go
+++ b/bbq/vm/value_iterator.go
@@ -55,7 +55,7 @@ func (v IteratorWrapperValue) Accept(interpreter *interpreter.Interpreter, visit
 	panic(errors.NewUnreachableError())
 }
 
-func (v IteratorWrapperValue) Walk(interpreter *interpreter.Interpreter, walkChild func(interpreter.Value), locationRange interpreter.LocationRange) {
+func (v IteratorWrapperValue) Walk(interpreter interpreter.ValueWalkContext, walkChild func(interpreter.Value), locationRange interpreter.LocationRange) {
 	// Iterator is an internal-only value.
 	// Hence, this should never be called.
 	panic(errors.NewUnreachableError())

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -317,7 +317,7 @@ func (*StandardLibraryHandler) GetAccountContractCode(_ common.AddressLocation) 
 }
 
 func (*StandardLibraryHandler) EmitEvent(
-	_ *interpreter.Interpreter,
+	_ interpreter.ValueExportContext,
 	_ interpreter.LocationRange,
 	_ *sema.CompositeType,
 	_ []interpreter.Value,

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -20,9 +20,8 @@ package interpreter_test
 
 import (
 	"fmt"
-	"testing"
-
 	"github.com/onflow/atree"
+	"testing"
 
 	"github.com/onflow/cadence/activations"
 	"github.com/onflow/cadence/errors"
@@ -415,39 +414,28 @@ func (n NoOpReferenceCreationContext) MeterMemory(usage common.MemoryUsage) erro
 
 type NoOpFunctionCreationContext struct {
 	NoOpReferenceCreationContext
+	//Just to make the compiler happy
+	interpreter.ResourceDestructionContext
 }
 
-func (n NoOpFunctionCreationContext) ReadStored(storageAddress common.Address, domain common.StorageDomain, identifier interpreter.StorageMapKey) interpreter.Value {
+func (n NoOpFunctionCreationContext) ClearReferencedResourceKindedValues(valueID atree.ValueID) {
+	// NO-OP
+}
+
+func (n NoOpFunctionCreationContext) ReferencedResourceKindedValues(valueID atree.ValueID) map[*interpreter.EphemeralReferenceValue]struct{} {
 	// NO-OP
 	return nil
 }
 
-func (n NoOpFunctionCreationContext) GetEntitlementType(typeID interpreter.TypeID) (*sema.EntitlementType, error) {
+func (n NoOpFunctionCreationContext) CheckInvalidatedResourceOrResourceReference(value interpreter.Value, locationRange interpreter.LocationRange) {
 	// NO-OP
-	return nil, nil
 }
 
-func (n NoOpFunctionCreationContext) GetEntitlementMapType(typeID interpreter.TypeID) (*sema.EntitlementMapType, error) {
+func (n NoOpFunctionCreationContext) MaybeTrackReferencedResourceKindedValue(ref *interpreter.EphemeralReferenceValue) {
 	// NO-OP
-	return nil, nil
 }
 
-func (n NoOpFunctionCreationContext) GetInterfaceType(location common.Location, qualifiedIdentifier string, typeID interpreter.TypeID) (*sema.InterfaceType, error) {
-	// NO-OP
-	return nil, nil
-}
-
-func (n NoOpFunctionCreationContext) GetCompositeType(location common.Location, qualifiedIdentifier string, typeID interpreter.TypeID) (*sema.CompositeType, error) {
-	// NO-OP
-	return nil, nil
-}
-
-func (n NoOpFunctionCreationContext) IsRecovered(location common.Location) bool {
-	// NO-OP
-	return false
-}
-
-func (n NoOpFunctionCreationContext) GetCompositeValueFunctions(v *interpreter.CompositeValue, locationRange interpreter.LocationRange) *interpreter.FunctionOrderedMap {
+func (n NoOpFunctionCreationContext) MeterMemory(usage common.MemoryUsage) error {
 	// NO-OP
 	return nil
 }
@@ -538,7 +526,7 @@ func testAccountWithErrorHandler(
 					return baseActivation
 				},
 				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
-				AccountHandler: func(context interpreter.FunctionCreationContext, address interpreter.AddressValue) interpreter.Value {
+				AccountHandler: func(context interpreter.AccountCreationContext, address interpreter.AddressValue) interpreter.Value {
 					return stdlib.NewAccountValue(context, nil, address)
 				},
 			},

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -91,7 +91,7 @@ type testAccountHandler struct {
 	getAccountKey    func(address common.Address, index uint32) (*stdlib.AccountKey, error)
 	accountKeysCount func(address common.Address) (uint32, error)
 	emitEvent        func(
-		inter *interpreter.Interpreter,
+		context interpreter.ValueExportContext,
 		locationRange interpreter.LocationRange,
 		eventType *sema.CompositeType,
 		values []interpreter.Value,
@@ -241,7 +241,7 @@ func (t *testAccountHandler) AccountKeysCount(address common.Address) (uint32, e
 }
 
 func (t *testAccountHandler) EmitEvent(
-	inter *interpreter.Interpreter,
+	context interpreter.ValueExportContext,
 	locationRange interpreter.LocationRange,
 	eventType *sema.CompositeType,
 	values []interpreter.Value,
@@ -250,7 +250,7 @@ func (t *testAccountHandler) EmitEvent(
 		panic(errors.NewUnexpectedError("unexpected call to EmitEvent"))
 	}
 	t.emitEvent(
-		inter,
+		context,
 		locationRange,
 		eventType,
 		values,

--- a/interpreter/conversion.go
+++ b/interpreter/conversion.go
@@ -118,9 +118,9 @@ func ByteSliceToByteArrayValue(context ArrayCreationContext, buf []byte) *ArrayV
 	)
 }
 
-func ByteSliceToConstantSizedByteArrayValue(interpreter *Interpreter, buf []byte) *ArrayValue {
+func ByteSliceToConstantSizedByteArrayValue(context ArrayCreationContext, buf []byte) *ArrayValue {
 
-	common.UseMemory(interpreter, common.NewBytesMemoryUsage(len(buf)))
+	common.UseMemory(context, common.NewBytesMemoryUsage(len(buf)))
 
 	var values []Value
 
@@ -133,13 +133,13 @@ func ByteSliceToConstantSizedByteArrayValue(interpreter *Interpreter, buf []byte
 	}
 
 	constantSizedByteArrayStaticType := NewConstantSizedStaticType(
-		interpreter,
+		context,
 		PrimitiveStaticTypeUInt8,
 		int64(len(buf)),
 	)
 
 	return NewArrayValue(
-		interpreter,
+		context,
 		EmptyLocationRange,
 		constantSizedByteArrayStaticType,
 		common.ZeroAddress,

--- a/interpreter/conversion.go
+++ b/interpreter/conversion.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-func ByteArrayValueToByteSlice(interpreter *Interpreter, value Value, locationRange LocationRange) ([]byte, error) {
+func ByteArrayValueToByteSlice(context ContainerMutationContext, value Value, locationRange LocationRange) ([]byte, error) {
 	array, ok := value.(*ArrayValue)
 	if !ok {
 		return nil, errors.NewDefaultUserError("value is not an array")
@@ -39,10 +39,10 @@ func ByteArrayValueToByteSlice(interpreter *Interpreter, value Value, locationRa
 
 		var err error
 		array.Iterate(
-			interpreter,
+			context,
 			func(element Value) (resume bool) {
 				var b byte
-				b, err = ByteValueToByte(interpreter, element, locationRange)
+				b, err = ByteValueToByte(context, element, locationRange)
 				if err != nil {
 					return false
 				}

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -220,13 +220,82 @@ type ResourceDestructionHandler interface {
 
 var _ ResourceDestructionHandler = &Interpreter{}
 
-type CapConReferenceValueContext interface {
+type AccountCapabilityCreationContext interface {
+	StorageCapabilityCreationContext
+}
+
+var _ AccountCapabilityCreationContext = &Interpreter{}
+
+type ValueCapabilityControllerReferenceValueContext interface {
 	FunctionCreationContext
 	ValueStaticTypeContext
 	AccountHandlerContextContext
 }
 
-var _ CapConReferenceValueContext = &Interpreter{}
+var _ ValueCapabilityControllerReferenceValueContext = &Interpreter{}
+
+type StorageCapabilityCreationContext interface {
+	FunctionCreationContext
+	CapabilityControllerContext
+}
+
+var _ StorageCapabilityCreationContext = &Interpreter{}
+
+type CapabilityControllerReferenceContext interface {
+	StorageReader
+	ReferenceCreationContext
+}
+
+var _ CapabilityControllerReferenceContext = &Interpreter{}
+
+type CapabilityControllerContext interface {
+	StorageContext
+	DictionaryCreationContext
+	ValueExportContext
+	GetCapabilityControllerIterations() map[AddressPath]int
+	SetMutationDuringCapabilityControllerIteration()
+	MutationDuringCapabilityControllerIteration() bool
+}
+
+var _ CapabilityControllerContext = &Interpreter{}
+
+type GetCapabilityControllerContext interface {
+	TypeConverter
+	EntitlementMappingsSubstitutionHandler
+	StorageReader
+}
+
+var _ GetCapabilityControllerContext = &Interpreter{}
+
+type GetCapabilityControllerReferenceContext interface {
+	GetCapabilityControllerContext
+	ValueCapabilityControllerReferenceValueContext
+}
+
+var _ GetCapabilityControllerReferenceContext = &Interpreter{}
+
+
+type CheckCapabilityControllerContext interface {
+	GetCapabilityControllerReferenceContext
+}
+
+var _ CheckCapabilityControllerContext = &Interpreter{}
+
+
+type BorrowCapabilityControllerContext interface {
+	GetCapabilityControllerReferenceContext
+	ValidateAccountCapabilitiesGetHandler() ValidateAccountCapabilitiesGetHandlerFunc
+}
+
+var _ BorrowCapabilityControllerContext = &Interpreter{}
+
+// TODO: This is used by the FVM.
+//   Check and the functionalities needed.
+type AccountCapabilityValidationContext interface {
+}
+
+var _ AccountCapabilityValidationContext = &Interpreter{}
+
 
 type ResourceDestructionContext interface {
 	ValueWalkContext
@@ -274,6 +343,11 @@ type InvocationContext interface {
 	ValueStringContext
 	MemberAccessibleContext
 	AttachmentContext
+	ErrorHandler
+	ArrayCreationContext
+	AccountCreationContext
+	BorrowCapabilityControllerContext
+	AccountCapabilityValidationContext
 	GetLocation() common.Location
 }
 
@@ -291,7 +365,52 @@ type CompositeValueExportContext interface {
 	AttachmentContext
 }
 
-var _ ValueExportContext = &Interpreter{}
+var _ CompositeValueExportContext = &Interpreter{}
+
+type PublicKeyCreationContext interface {
+	MemberAccessibleContext
+}
+
+var _ PublicKeyCreationContext = &Interpreter{}
+
+type PublicKeyValidationContext interface {
+	PublicKeyCreationContext
+}
+
+var _ PublicKeyValidationContext = &Interpreter{}
+
+type AccountKeyCreationContext interface {
+	PublicKeyCreationContext
+	AccountCapabilityCreationContext
+}
+
+var _ AccountKeyCreationContext = &Interpreter{}
+
+type AccountCreationContext interface {
+	AccountKeyCreationContext
+	AccountContractCreationContext
+}
+
+var _ AccountCreationContext = &Interpreter{}
+
+type AccountContractCreationContext interface {
+	AccountContractBorrowContext
+}
+
+var _ AccountContractCreationContext = &Interpreter{}
+
+type AccountContractBorrowContext interface {
+	FunctionCreationContext
+	GetContractValue(contractLocation common.AddressLocation) (*CompositeValue, error)
+}
+
+var _ AccountContractBorrowContext = &Interpreter{}
+
+type ErrorHandler interface {
+	RecoverErrors(onError func(error))
+}
+
+var _ ErrorHandler = &Interpreter{}
 
 // NoOpStringContext is the ValueStringContext implementation used in Value.RecursiveString method.
 // Since Value.RecursiveString is a non-mutating operation, it should only need the no-op memory metering

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -251,6 +251,16 @@ type EventContext interface {
 
 var _ EventContext = &Interpreter{}
 
+// InvocationContext is a composite of all contexts, since function invocations
+// can perform various operations, and hence need to provide all possible contexts to it.
+type InvocationContext interface {
+	StorageContext
+	ValueStringContext
+	MemberAccessibleContext
+}
+
+var _ InvocationContext = &Interpreter{}
+
 // NoOpStringContext is the ValueStringContext implementation used in Value.RecursiveString method.
 // Since Value.RecursiveString is a non-mutating operation, it should only need the no-op memory metering
 // and a WithMutationPrevention implementation.

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -233,6 +233,7 @@ type ResourceDestructionContext interface {
 	ResourceDestructionHandler
 	CompositeFunctionContext
 	EventContext
+	InvocationContext
 
 	GetResourceDestructionContextForLocation(location common.Location) ResourceDestructionContext
 }
@@ -251,15 +252,46 @@ type EventContext interface {
 
 var _ EventContext = &Interpreter{}
 
+type AttachmentContext interface {
+	ValueStaticTypeContext
+	ReferenceCreationContext
+	SetAttachmentIteration(composite *CompositeValue, state bool) bool
+}
+
+var _ AttachmentContext = &Interpreter{}
+
+type StoreValueCheckContext interface {
+	TypeConverter
+	GetCapabilityCheckHandler() CapabilityCheckHandlerFunc
+}
+
+var _ StoreValueCheckContext = &Interpreter{}
+
 // InvocationContext is a composite of all contexts, since function invocations
 // can perform various operations, and hence need to provide all possible contexts to it.
 type InvocationContext interface {
 	StorageContext
 	ValueStringContext
 	MemberAccessibleContext
+	AttachmentContext
+	GetLocation() common.Location
 }
 
 var _ InvocationContext = &Interpreter{}
+
+type ValueExportContext interface {
+	ContainerMutationContext // needed for container iteration
+	CompositeValueExportContext
+}
+
+var _ ValueExportContext = &Interpreter{}
+
+type CompositeValueExportContext interface {
+	MemberAccessibleContext
+	AttachmentContext
+}
+
+var _ ValueExportContext = &Interpreter{}
 
 // NoOpStringContext is the ValueStringContext implementation used in Value.RecursiveString method.
 // Since Value.RecursiveString is a non-mutating operation, it should only need the no-op memory metering

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -120,6 +120,21 @@ type ValueTransferContext interface {
 
 var _ ValueTransferContext = &Interpreter{}
 
+
+type ValueConversionContext interface {
+	ValueTransferContext
+	EntitlementMappingsSubstitutionHandler
+}
+
+var _ ValueTransferContext = &Interpreter{}
+
+type ValueCreationContext interface {
+	ArrayCreationContext
+	DictionaryCreationContext
+}
+
+var _ ValueCreationContext = &Interpreter{}
+
 type ValueRemoveContext = ValueTransferContext
 
 var _ ValueRemoveContext = &Interpreter{}

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -405,7 +405,9 @@ type InvocationContext interface {
 	CapabilityHandlers
 	StoredValueCheckContext
 	VariableResolver
+
 	GetLocation() common.Location
+	CallStack() []Invocation
 }
 
 var _ InvocationContext = &Interpreter{}

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -120,7 +120,6 @@ type ValueTransferContext interface {
 
 var _ ValueTransferContext = &Interpreter{}
 
-
 type ValueConversionContext interface {
 	ValueTransferContext
 	EntitlementMappingsSubstitutionHandler
@@ -405,6 +404,7 @@ type InvocationContext interface {
 	AccountCapabilityGetValidationContext
 	CapabilityHandlers
 	StoredValueCheckContext
+	VariableResolver
 	GetLocation() common.Location
 }
 
@@ -468,6 +468,12 @@ type ErrorHandler interface {
 }
 
 var _ ErrorHandler = &Interpreter{}
+
+type VariableResolver interface {
+	GetValueOfVariable(name string) Value
+}
+
+var _ VariableResolver = &Interpreter{}
 
 // NoOpStringContext is the ValueStringContext implementation used in Value.RecursiveString method.
 // Since Value.RecursiveString is a non-mutating operation, it should only need the no-op memory metering

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -328,6 +328,13 @@ type CapabilityHandlers interface {
 
 var _ CapabilityHandlers = &Interpreter{}
 
+type StringValueFunctionContext interface {
+	common.MemoryGauge
+	ComputationReporter
+}
+
+var _ StringValueFunctionContext = &Interpreter{}
+
 // TODO: This is used by the FVM.
 //
 //	Check and the functionalities needed.

--- a/interpreter/interface_test.go
+++ b/interpreter/interface_test.go
@@ -1131,7 +1131,7 @@ func TestInterpretInterfaceFunctionConditionsInheritance(t *testing.T) {
 			``,
 			func(invocation interpreter.Invocation) interpreter.Value {
 				message := invocation.Arguments[0].MeteredString(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					interpreter.SeenReferences{},
 					invocation.LocationRange,
 				)

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5763,7 +5763,7 @@ func (interpreter *Interpreter) EnforceNotResourceDestruction(
 	}
 }
 
-func (interpreter *Interpreter) withResourceDestruction(
+func (interpreter *Interpreter) WithResourceDestruction(
 	valueID atree.ValueID,
 	locationRange LocationRange,
 	f func(),
@@ -5844,6 +5844,14 @@ func (interpreter *Interpreter) MaybeSetMutationDuringCapConIteration(addressPat
 }
 
 func (interpreter *Interpreter) GetMemberAccessContextForLocation(location common.Location) MemberAccessibleContext {
+	return interpreter.ensureLoaded(location)
+}
+
+func (interpreter *Interpreter) GetResourceDestructionContextForLocation(location common.Location) ResourceDestructionContext {
+	return interpreter.ensureLoaded(location)
+}
+
+func (interpreter *Interpreter) ensureLoaded(location common.Location) *Interpreter {
 	if location == nil || interpreter.Location == location {
 		return interpreter
 	}

--- a/interpreter/interpreter_expression.go
+++ b/interpreter/interpreter_expression.go
@@ -153,7 +153,8 @@ func (interpreter *Interpreter) valueIndexExpressionGetterSetter(
 	indexedType := indexExpressionTypes.IndexedType
 	indexingType := indexExpressionTypes.IndexingType
 
-	transferredIndexingValue := interpreter.transferAndConvert(
+	transferredIndexingValue := transferAndConvert(
+		interpreter,
 		interpreter.evalExpression(indexExpression.IndexingExpression),
 		indexingType,
 		indexedType.IndexingType(),
@@ -653,7 +654,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 		resultType := binaryExpressionTypes.ResultType
 
 		// NOTE: important to convert both any and optional
-		return interpreter.ConvertAndBox(locationRange, value, rightType, resultType)
+		return ConvertAndBox(interpreter, locationRange, value, rightType, resultType)
 	}
 
 	panic(&unsupportedOperation{
@@ -1002,7 +1003,7 @@ func (interpreter *Interpreter) VisitArrayExpression(expression *ast.ArrayExpres
 				Location:    interpreter.Location,
 				HasPosition: argumentExpression,
 			}
-			copies[i] = interpreter.transferAndConvert(argument, argumentType, elementType, locationRange)
+			copies[i] = transferAndConvert(interpreter, argument, argumentType, elementType, locationRange)
 		}
 	}
 
@@ -1036,7 +1037,8 @@ func (interpreter *Interpreter) VisitDictionaryExpression(expression *ast.Dictio
 		entryType := entryTypes[i]
 		entry := expression.Entries[i]
 
-		key := interpreter.transferAndConvert(
+		key := transferAndConvert(
+			interpreter,
 			dictionaryEntryValues.Key,
 			entryType.KeyType,
 			dictionaryType.KeyType,
@@ -1046,7 +1048,8 @@ func (interpreter *Interpreter) VisitDictionaryExpression(expression *ast.Dictio
 			},
 		)
 
-		value := interpreter.transferAndConvert(
+		value := transferAndConvert(
+			interpreter,
 			dictionaryEntryValues.Value,
 			entryType.ValueType,
 			dictionaryType.ValueType,
@@ -1415,7 +1418,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 		}
 
 		// The failable cast may upcast to an optional type, e.g. `1 as? Int?`, so box
-		value = interpreter.ConvertAndBox(locationRange, value, valueSemaType, expectedType)
+		value = ConvertAndBox(interpreter, locationRange, value, valueSemaType, expectedType)
 
 		if expression.Operation == ast.OperationFailableCast {
 			// Failable casting is a resource invalidation
@@ -1429,7 +1432,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 	case ast.OperationCast:
 		staticValueType := castingExpressionTypes.StaticValueType
 		// The cast may upcast to an optional type, e.g. `1 as Int?`, so box
-		return interpreter.ConvertAndBox(locationRange, value, staticValueType, expectedType)
+		return ConvertAndBox(interpreter, locationRange, value, staticValueType, expectedType)
 
 	default:
 		panic(errors.NewUnreachableError())

--- a/interpreter/interpreter_expression.go
+++ b/interpreter/interpreter_expression.go
@@ -1237,7 +1237,8 @@ func (interpreter *Interpreter) visitInvocationExpressionWithImplicitArgument(in
 
 	interpreter.reportFunctionInvocation()
 
-	resultValue := interpreter.invokeFunctionValue(
+	resultValue := invokeFunctionValue(
+		interpreter,
 		function,
 		arguments,
 		argumentExpressions,

--- a/interpreter/interpreter_expression.go
+++ b/interpreter/interpreter_expression.go
@@ -1366,7 +1366,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 	}
 
 	castingExpressionTypes := interpreter.Program.Elaboration.CastingExpressionTypes(expression)
-	expectedType := interpreter.SubstituteMappedEntitlements(castingExpressionTypes.TargetType)
+	expectedType := SubstituteMappedEntitlements(interpreter, castingExpressionTypes.TargetType)
 
 	switch expression.Operation {
 	case ast.OperationFailableCast, ast.OperationForceCast:
@@ -1386,7 +1386,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 			// otherwise dynamic cast now always unboxes optionals
 			value = interpreter.Unbox(value)
 		}
-		valueSemaType := interpreter.SubstituteMappedEntitlements(MustSemaTypeOfValue(value, interpreter))
+		valueSemaType := SubstituteMappedEntitlements(interpreter, MustSemaTypeOfValue(value, interpreter))
 		valueStaticType := ConvertSemaToStaticType(interpreter, valueSemaType)
 		isSubType := IsSubTypeOfSemaType(interpreter, valueStaticType, expectedType)
 

--- a/interpreter/interpreter_invocation.go
+++ b/interpreter/interpreter_invocation.go
@@ -25,7 +25,8 @@ import (
 	"github.com/onflow/cadence/sema"
 )
 
-func (interpreter *Interpreter) InvokeFunctionValue(
+func InvokeFunctionValue(
+	context InvocationContext,
 	function FunctionValue,
 	arguments []Value,
 	argumentTypes []sema.Type,
@@ -38,12 +39,12 @@ func (interpreter *Interpreter) InvokeFunctionValue(
 ) {
 
 	// recover internal panics and return them as an error
-	defer interpreter.RecoverErrors(func(internalErr error) {
+	defer context.RecoverErrors(func(internalErr error) {
 		err = internalErr
 	})
 
 	return invokeFunctionValue(
-		interpreter,
+		context,
 		function,
 		arguments,
 		nil,

--- a/interpreter/interpreter_invocation.go
+++ b/interpreter/interpreter_invocation.go
@@ -42,7 +42,8 @@ func (interpreter *Interpreter) InvokeFunctionValue(
 		err = internalErr
 	})
 
-	return interpreter.invokeFunctionValue(
+	return invokeFunctionValue(
+		interpreter,
 		function,
 		arguments,
 		nil,
@@ -54,7 +55,8 @@ func (interpreter *Interpreter) InvokeFunctionValue(
 	), nil
 }
 
-func (interpreter *Interpreter) invokeFunctionValue(
+func invokeFunctionValue(
+	context InvocationContext,
 	function FunctionValue,
 	arguments []Value,
 	expressions []ast.Expression,
@@ -68,6 +70,8 @@ func (interpreter *Interpreter) invokeFunctionValue(
 	parameterTypeCount := len(parameterTypes)
 
 	var transferredArguments []Value
+
+	location := context.GetLocation()
 
 	argumentCount := len(arguments)
 	if argumentCount > 0 {
@@ -84,7 +88,7 @@ func (interpreter *Interpreter) invokeFunctionValue(
 			}
 
 			locationRange := LocationRange{
-				Location:    interpreter.Location,
+				Location:    location,
 				HasPosition: locationPos,
 			}
 
@@ -98,7 +102,7 @@ func (interpreter *Interpreter) invokeFunctionValue(
 				)
 			} else {
 				transferredArguments[i] = argument.Transfer(
-					interpreter,
+					context,
 					locationRange,
 					atree.Address{},
 					false,
@@ -111,12 +115,12 @@ func (interpreter *Interpreter) invokeFunctionValue(
 	}
 
 	locationRange := LocationRange{
-		Location:    interpreter.Location,
+		Location:    location,
 		HasPosition: invocationPosition,
 	}
 
 	invocation := NewInvocation(
-		interpreter,
+		context,
 		nil,
 		nil,
 		nil,

--- a/interpreter/interpreter_invocation.go
+++ b/interpreter/interpreter_invocation.go
@@ -95,7 +95,8 @@ func invokeFunctionValue(
 
 			if i < parameterTypeCount {
 				parameterType := parameterTypes[i]
-				transferredArguments[i] = interpreter.transferAndConvert(
+				transferredArguments[i] = transferAndConvert(
+					context,
 					argument,
 					argumentType,
 					parameterType,
@@ -154,7 +155,8 @@ func invokeFunctionValue(
 	//
 	// Here runtime function's return type is `T`, but invocation's return type is `T?`.
 
-	return interpreter.ConvertAndBox(
+	return ConvertAndBox(
+		context,
 		locationRange,
 		resultValue,
 		functionReturnType,

--- a/interpreter/interpreter_statement.go
+++ b/interpreter/interpreter_statement.go
@@ -87,7 +87,7 @@ func (interpreter *Interpreter) VisitReturnStatement(statement *ast.ReturnStatem
 		}
 
 		// NOTE: copy on return
-		value = interpreter.transferAndConvert(value, valueType, returnType, locationRange)
+		value = transferAndConvert(interpreter, value, valueType, returnType, locationRange)
 	}
 
 	return ReturnResult{Value: value}
@@ -509,7 +509,8 @@ func (interpreter *Interpreter) visitVariableDeclaration(
 		}
 	}
 
-	transferredValue := interpreter.transferAndConvert(
+	transferredValue := transferAndConvert(
+		interpreter,
 		result,
 		valueType,
 		targetType,
@@ -598,10 +599,10 @@ func (interpreter *Interpreter) VisitSwapStatement(swap *ast.SwapStatement) Stat
 	// and left value to right target
 
 	checkInvalidatedResourceOrResourceReference(rightValue, rightLocationRange, interpreter)
-	transferredRightValue := interpreter.transferAndConvert(rightValue, rightType, leftType, rightLocationRange)
+	transferredRightValue := transferAndConvert(interpreter, rightValue, rightType, leftType, rightLocationRange)
 
 	checkInvalidatedResourceOrResourceReference(leftValue, leftLocationRange, interpreter)
-	transferredLeftValue := interpreter.transferAndConvert(leftValue, leftType, rightType, leftLocationRange)
+	transferredLeftValue := transferAndConvert(interpreter, leftValue, leftType, rightType, leftLocationRange)
 
 	leftGetterSetter.set(transferredRightValue)
 	rightGetterSetter.set(transferredLeftValue)

--- a/interpreter/interpreter_statement.go
+++ b/interpreter/interpreter_statement.go
@@ -362,7 +362,7 @@ func (interpreter *Interpreter) visitForStatementBody(
 	return nil, false
 }
 
-func (interpreter *Interpreter) emitEvent(event *CompositeValue, eventType *sema.CompositeType, locationRange LocationRange) {
+func (interpreter *Interpreter) EmitEvent(event *CompositeValue, eventType *sema.CompositeType, locationRange LocationRange) {
 
 	config := interpreter.SharedState.Config
 
@@ -393,7 +393,7 @@ func (interpreter *Interpreter) VisitEmitStatement(statement *ast.EmitStatement)
 		HasPosition: statement,
 	}
 
-	interpreter.emitEvent(event, eventType, locationRange)
+	interpreter.EmitEvent(event, eventType, locationRange)
 
 	return nil
 }

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -45,7 +45,8 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	t.Run("Bool to Bool?", func(t *testing.T) {
 		inter := newTestInterpreter(t)
 
-		value := inter.BoxOptional(
+		value := BoxOptional(
+			inter,
 			TrueValue,
 			&sema.OptionalType{Type: sema.BoolType},
 		)
@@ -58,7 +59,8 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	t.Run("Bool? to Bool?", func(t *testing.T) {
 		inter := newTestInterpreter(t)
 
-		value := inter.BoxOptional(
+		value := BoxOptional(
+			inter,
 			NewUnmeteredSomeValueNonCopying(TrueValue),
 			&sema.OptionalType{Type: sema.BoolType},
 		)
@@ -71,7 +73,8 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 	t.Run("Bool? to Bool??", func(t *testing.T) {
 		inter := newTestInterpreter(t)
 
-		value := inter.BoxOptional(
+		value := BoxOptional(
+			inter,
 			NewUnmeteredSomeValueNonCopying(TrueValue),
 			&sema.OptionalType{
 				Type: &sema.OptionalType{
@@ -91,7 +94,8 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 		inter := newTestInterpreter(t)
 
 		// NOTE:
-		value := inter.BoxOptional(
+		value := BoxOptional(
+			inter,
 			Nil,
 			&sema.OptionalType{
 				Type: &sema.OptionalType{
@@ -109,7 +113,8 @@ func TestInterpreterOptionalBoxing(t *testing.T) {
 		inter := newTestInterpreter(t)
 
 		// NOTE:
-		value := inter.BoxOptional(
+		value := BoxOptional(
+			inter,
 			NewUnmeteredSomeValueNonCopying(Nil),
 			&sema.OptionalType{
 				Type: &sema.OptionalType{
@@ -142,7 +147,8 @@ func TestInterpreterBoxing(t *testing.T) {
 					NewUnmeteredSomeValueNonCopying(
 						TrueValue,
 					),
-					inter.ConvertAndBox(
+					ConvertAndBox(
+						inter,
 						EmptyLocationRange,
 						TrueValue,
 						sema.BoolType,
@@ -159,7 +165,8 @@ func TestInterpreterBoxing(t *testing.T) {
 					NewUnmeteredSomeValueNonCopying(
 						TrueValue,
 					),
-					inter.ConvertAndBox(
+					ConvertAndBox(
+						inter,
 						EmptyLocationRange,
 						NewUnmeteredSomeValueNonCopying(TrueValue),
 						&sema.OptionalType{Type: sema.BoolType},

--- a/interpreter/interpreter_tracing.go
+++ b/interpreter/interpreter_tracing.go
@@ -54,17 +54,20 @@ type Tracer interface {
 	ReportArrayValueDeepRemoveTrace(typeInfo string, count int, duration time.Duration)
 	ReportArrayValueTransferTrace(info string, count int, since time.Duration)
 	ReportArrayValueConstructTrace(typeInfo string, count int, duration time.Duration)
+	ReportArrayValueDestroyTrace(info string, count int, since time.Duration)
 
 	ReportDictionaryValueTransferTrace(info string, count int, since time.Duration)
 	ReportDictionaryValueDeepRemoveTrace(info string, count int, since time.Duration)
 	ReportDictionaryValueGetMemberTrace(info string, count int, name string, since time.Duration)
 	ReportDictionaryValueConstructTrace(info string, count int, since time.Duration)
+	ReportDictionaryValueDestroyTrace(info string, count int, since time.Duration)
 
 	ReportCompositeValueDeepRemoveTrace(owner string, id string, kind string, since time.Duration)
 	ReportCompositeValueTransferTrace(owner string, id string, kind string, since time.Duration)
 	ReportCompositeValueSetMemberTrace(owner string, id string, kind string, name string, since time.Duration)
 	ReportCompositeValueGetMemberTrace(owner string, typeID string, kind string, name string, duration time.Duration)
 	ReportCompositeValueConstructTrace(owner string, id string, kind string, since time.Duration)
+	ReportCompositeValueDestroyTrace(owner string, id string, kind string, since time.Duration)
 
 	ReportDomainStorageMapDeepRemoveTrace(info string, i int, since time.Duration)
 }
@@ -114,7 +117,7 @@ func (interpreter *Interpreter) ReportArrayValueDeepRemoveTrace(
 	)
 }
 
-func (interpreter *Interpreter) reportArrayValueDestroyTrace(
+func (interpreter *Interpreter) ReportArrayValueDestroyTrace(
 	typeInfo string,
 	count int,
 	duration time.Duration,
@@ -198,7 +201,7 @@ func (interpreter *Interpreter) ReportDomainStorageMapDeepRemoveTrace(
 	)
 }
 
-func (interpreter *Interpreter) reportDictionaryValueDestroyTrace(
+func (interpreter *Interpreter) ReportDictionaryValueDestroyTrace(
 	typeInfo string,
 	count int,
 	duration time.Duration,
@@ -293,7 +296,7 @@ func (interpreter *Interpreter) ReportCompositeValueDeepRemoveTrace(
 	)
 }
 
-func (interpreter *Interpreter) reportCompositeValueDestroyTrace(
+func (interpreter *Interpreter) ReportCompositeValueDestroyTrace(
 	owner string,
 	typeID string,
 	kind string,

--- a/interpreter/invocation.go
+++ b/interpreter/invocation.go
@@ -30,13 +30,13 @@ type Invocation struct {
 	Base               *EphemeralReferenceValue
 	BoundAuthorization Authorization
 	TypeParameterTypes *sema.TypeParameterTypeOrderedMap
-	Interpreter        *Interpreter
+	InvocationContext  InvocationContext
 	Arguments          []Value
 	ArgumentTypes      []sema.Type
 }
 
 func NewInvocation(
-	interpreter *Interpreter,
+	invocationContext InvocationContext,
 	self *Value,
 	base *EphemeralReferenceValue,
 	boundAuth Authorization,
@@ -45,7 +45,7 @@ func NewInvocation(
 	typeParameterTypes *sema.TypeParameterTypeOrderedMap,
 	locationRange LocationRange,
 ) Invocation {
-	common.UseMemory(interpreter, common.InvocationMemoryUsage)
+	common.UseMemory(invocationContext, common.InvocationMemoryUsage)
 
 	return Invocation{
 		Self:               self,
@@ -55,7 +55,7 @@ func NewInvocation(
 		ArgumentTypes:      argumentTypes,
 		TypeParameterTypes: typeParameterTypes,
 		LocationRange:      locationRange,
-		Interpreter:        interpreter,
+		InvocationContext:  invocationContext,
 	}
 }
 

--- a/interpreter/invocation_test.go
+++ b/interpreter/invocation_test.go
@@ -163,7 +163,8 @@ func TestInterpretRejectUnboxedInvocation(t *testing.T) {
 		interpreter.EmptyLocationRange,
 	)
 
-	_, err := inter.InvokeFunction(
+	_, err := interpreter.InvokeFunction(
+		inter,
 		test,
 		invocation,
 	)

--- a/interpreter/invocation_test.go
+++ b/interpreter/invocation_test.go
@@ -62,7 +62,7 @@ func TestInterpretSelfDeclaration(t *testing.T) {
 			func(invocation interpreter.Invocation) interpreter.Value {
 				// Check that the *caller's* self
 
-				callStack := invocation.Interpreter.CallStack()
+				callStack := invocation.InvocationContext.CallStack()
 				parentInvocation := callStack[len(callStack)-1]
 
 				if expectSelf {

--- a/interpreter/memory_metering_test.go
+++ b/interpreter/memory_metering_test.go
@@ -8659,7 +8659,7 @@ func TestInterpretValueStringConversion(t *testing.T) {
 				meter.meter = make(map[common.MemoryKind]uint64)
 
 				loggedString = invocation.Arguments[0].MeteredString(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					interpreter.SeenReferences{},
 					invocation.LocationRange,
 				)
@@ -9003,7 +9003,7 @@ func TestInterpretStaticTypeStringConversion(t *testing.T) {
 				meter.meter = make(map[common.MemoryKind]uint64)
 
 				loggedString = invocation.Arguments[0].MeteredString(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					interpreter.SeenReferences{},
 					invocation.LocationRange,
 				)

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -369,7 +369,8 @@ func makeContractValueHandler(
 
 		constructor := constructorGenerator(common.ZeroAddress)
 
-		value, err := inter.InvokeFunctionValue(
+		value, err := interpreter.InvokeFunctionValue(
+			inter,
 			constructor,
 			arguments,
 			argumentTypes,
@@ -5506,7 +5507,8 @@ func TestInterpretStructureFunctionBindingInside(t *testing.T) {
 	functionValue, err := inter.Invoke("test")
 	require.NoError(t, err)
 
-	value, err := inter.InvokeFunctionValue(
+	value, err := interpreter.InvokeFunctionValue(
+		inter,
 		functionValue.(interpreter.FunctionValue),
 		nil,
 		nil,
@@ -8805,7 +8807,7 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 				Config: &interpreter.Config{
 					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 					InjectedCompositeFieldsHandler: func(
-						context interpreter.FunctionCreationContext,
+						context interpreter.AccountCreationContext,
 						_ common.Location,
 						_ string,
 						_ common.CompositeKind,
@@ -9398,7 +9400,7 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 					return baseActivation
 				},
-				AccountHandler: func(context interpreter.FunctionCreationContext, address interpreter.AddressValue) interpreter.Value {
+				AccountHandler: func(context interpreter.AccountCreationContext, address interpreter.AddressValue) interpreter.Value {
 					return stdlib.NewAccountValue(context, nil, address)
 				},
 			},

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -112,7 +112,7 @@ func parseCheckAndInterpretWithLogs(
 		``,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			message := invocation.Arguments[0].MeteredString(
-				invocation.Interpreter,
+				invocation.InvocationContext,
 				interpreter.SeenReferences{},
 				invocation.LocationRange,
 			)
@@ -2155,7 +2155,7 @@ func TestInterpretHostFunctionWithVariableArguments(t *testing.T) {
 
 			require.Len(t, invocation.Arguments, 3)
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			AssertValuesEqual(
 				t,
@@ -2263,7 +2263,7 @@ func TestInterpretHostFunctionWithOptionalArguments(t *testing.T) {
 
 			require.Len(t, invocation.Arguments, 3)
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			AssertValuesEqual(
 				t,
@@ -5308,7 +5308,7 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 				var auth = interpreter.UnauthorizedAccess
 				if authorized {
 					auth = interpreter.ConvertSemaAccessToStaticAuthorization(
-						invocation.Interpreter,
+						invocation.InvocationContext,
 						sema.NewEntitlementSetAccess(
 							[]*sema.EntitlementType{getType("E").(*sema.EntitlementType)},
 							sema.Conjunction,

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -94,7 +94,7 @@ func (v *SimpleCompositeValue) ForEachField(
 
 // Walk iterates over all field values of the composite value.
 // It does NOT walk the computed fields and functions!
-func (v *SimpleCompositeValue) Walk(_ *Interpreter, walkChild func(Value), _ LocationRange) {
+func (v *SimpleCompositeValue) Walk(_ ValueWalkContext, walkChild func(Value), _ LocationRange) {
 	v.ForEachField(func(_ string, fieldValue Value) (resume bool) {
 		walkChild(fieldValue)
 

--- a/interpreter/statictype.go
+++ b/interpreter/statictype.go
@@ -1208,6 +1208,12 @@ type StaticAuthorizationConversionHandler interface {
 	GetEntitlementMapType(typeID TypeID) (*sema.EntitlementMapType, error)
 }
 
+type EntitlementMappingsSubstitutionHandler interface {
+	common.MemoryGauge
+	StaticAuthorizationConversionHandler
+	CurrentEntitlementMappedValue() Authorization
+}
+
 type StaticTypeConversionHandler interface {
 	StaticAuthorizationConversionHandler
 	GetInterfaceType(location common.Location, qualifiedIdentifier string, typeID TypeID) (*sema.InterfaceType, error)

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -93,7 +93,7 @@ type Value interface {
 	fmt.Stringer
 	//isValue()
 	Accept(interpreter *Interpreter, visitor Visitor, locationRange LocationRange)
-	Walk(interpreter *Interpreter, walkChild func(Value), locationRange LocationRange)
+	Walk(interpreter ValueWalkContext, walkChild func(Value), locationRange LocationRange)
 	StaticType(context ValueStaticTypeContext) StaticType
 	// ConformsToStaticType returns true if the value (i.e. its dynamic type)
 	// conforms to its own static type.
@@ -196,18 +196,18 @@ type ComparableValue interface {
 
 type ResourceKindedValue interface {
 	Value
-	Destroy(interpreter *Interpreter, locationRange LocationRange)
+	Destroy(context ResourceDestructionContext, locationRange LocationRange)
 	IsDestroyed() bool
 	isInvalidatedResource(context ValueStaticTypeContext) bool
 }
 
-func maybeDestroy(interpreter *Interpreter, locationRange LocationRange, value Value) {
+func maybeDestroy(context ResourceDestructionContext, locationRange LocationRange, value Value) {
 	resourceKindedValue, ok := value.(ResourceKindedValue)
 	if !ok {
 		return
 	}
 
-	resourceKindedValue.Destroy(interpreter, locationRange)
+	resourceKindedValue.Destroy(context, locationRange)
 }
 
 // ReferenceTrackedResourceKindedValue is a resource-kinded value

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -93,7 +93,7 @@ func (v *AccountCapabilityControllerValue) Accept(interpreter *Interpreter, visi
 	visitor.VisitAccountCapabilityControllerValue(interpreter, v)
 }
 
-func (v *AccountCapabilityControllerValue) Walk(_ *Interpreter, walkChild func(Value), _ LocationRange) {
+func (v *AccountCapabilityControllerValue) Walk(_ ValueWalkContext, walkChild func(Value), _ LocationRange) {
 	walkChild(v.CapabilityID)
 }
 

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -49,7 +49,7 @@ type AccountCapabilityControllerValue struct {
 	GetCapability func(common.MemoryGauge) *IDCapabilityValue
 	GetTag        func(StorageReader) *StringValue
 	SetTag        func(storageWriter StorageWriter, tag *StringValue)
-	Delete        func(inter *Interpreter, locationRange LocationRange)
+	Delete        func(context CapabilityControllerContext, locationRange LocationRange)
 }
 
 func NewUnmeteredAccountCapabilityControllerValue(
@@ -293,7 +293,8 @@ func (v *AccountCapabilityControllerValue) ReferenceValue(
 	locationRange LocationRange,
 ) ReferenceValue {
 
-	account := context.AccountHandler()(context, AddressValue(capabilityAddress))
+	accountHandler := context.AccountHandler()
+	account := accountHandler(context, AddressValue(capabilityAddress))
 
 	// Account must be of `Account` type.
 	ExpectType(
@@ -351,10 +352,10 @@ func (v *AccountCapabilityControllerValue) newDeleteFunction(
 		context,
 		sema.AccountCapabilityControllerTypeDeleteFunctionType,
 		func(invocation Invocation) Value {
-			inter := invocation.InvocationContext
+			invocationContext := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
-			v.Delete(inter, locationRange)
+			v.Delete(invocationContext, locationRange)
 
 			v.deleted = true
 

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -287,7 +287,7 @@ func (v *AccountCapabilityControllerValue) ControllerCapabilityID() UInt64Value 
 }
 
 func (v *AccountCapabilityControllerValue) ReferenceValue(
-	context CapConReferenceValueContext,
+	context ValueCapabilityControllerReferenceValueContext,
 	capabilityAddress common.Address,
 	resultBorrowType *sema.ReferenceType,
 	locationRange LocationRange,

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -351,7 +351,7 @@ func (v *AccountCapabilityControllerValue) newDeleteFunction(
 		context,
 		sema.AccountCapabilityControllerTypeDeleteFunctionType,
 		func(invocation Invocation) Value {
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			v.Delete(inter, locationRange)
@@ -370,7 +370,7 @@ func (v *AccountCapabilityControllerValue) newSetTagFunction(
 		context,
 		sema.AccountCapabilityControllerTypeSetTagFunctionType,
 		func(invocation Invocation) Value {
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			newTagValue, ok := invocation.Arguments[0].(*StringValue)
 			if !ok {

--- a/interpreter/value_accountkey.go
+++ b/interpreter/value_accountkey.go
@@ -19,6 +19,7 @@
 package interpreter
 
 import (
+	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/sema"
 )
 
@@ -34,7 +35,7 @@ var accountKeyFieldNames = []string{
 
 // NewAccountKeyValue constructs an AccountKey value.
 func NewAccountKeyValue(
-	inter *Interpreter,
+	gauge common.MemoryGauge,
 	keyIndex IntValue,
 	publicKey *CompositeValue,
 	hashAlgo Value,
@@ -50,7 +51,7 @@ func NewAccountKeyValue(
 	}
 
 	return NewSimpleCompositeValue(
-		inter,
+		gauge,
 		accountKeyTypeID,
 		AccountKeyStaticType,
 		accountKeyFieldNames,

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -165,7 +165,7 @@ func (v AddressValue) GetMember(context MemberAccessibleContext, locationRange L
 			v,
 			sema.ToStringFunctionType,
 			func(v AddressValue, invocation Invocation) Value {
-				interpreter := invocation.Interpreter
+				interpreter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				memoryUsage := common.NewStringMemoryUsage(
@@ -188,7 +188,7 @@ func (v AddressValue) GetMember(context MemberAccessibleContext, locationRange L
 			v,
 			sema.AddressTypeToBytesFunctionType,
 			func(v AddressValue, invocation Invocation) Value {
-				interpreter := invocation.Interpreter
+				interpreter := invocation.InvocationContext
 				address := common.Address(v)
 				return ByteSliceToByteArrayValue(interpreter, address[:])
 			},
@@ -273,14 +273,14 @@ func AddressFromBytes(invocation Invocation) Value {
 		panic(errors.NewUnreachableError())
 	}
 
-	inter := invocation.Interpreter
+	inter := invocation.InvocationContext
 
 	bytes, err := ByteArrayValueToByteSlice(inter, argument, invocation.LocationRange)
 	if err != nil {
 		panic(err)
 	}
 
-	return NewAddressValue(invocation.Interpreter, common.MustBytesToAddress(bytes))
+	return NewAddressValue(invocation.InvocationContext, common.MustBytesToAddress(bytes))
 }
 
 func AddressFromString(invocation Invocation) Value {
@@ -294,6 +294,6 @@ func AddressFromString(invocation Invocation) Value {
 		return Nil
 	}
 
-	inter := invocation.Interpreter
+	inter := invocation.InvocationContext
 	return NewSomeValueNonCopying(inter, NewAddressValue(inter, addr))
 }

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -98,7 +98,7 @@ func (v AddressValue) Accept(interpreter *Interpreter, visitor Visitor, _ Locati
 	visitor.VisitAddressValue(interpreter, v)
 }
 
-func (AddressValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (AddressValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -843,7 +843,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 			),
 			func(v *ArrayValue, invocation Invocation) Value {
 				v.Append(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 					invocation.Arguments[0],
 				)
@@ -864,7 +864,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 					panic(errors.NewUnreachableError())
 				}
 				v.AppendAll(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 					otherArray,
 				)
@@ -885,7 +885,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 					panic(errors.NewUnreachableError())
 				}
 				return v.Concat(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 					otherArray,
 				)
@@ -900,7 +900,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 				v.SemaType(context).ElementType(false),
 			),
 			func(v *ArrayValue, invocation Invocation) Value {
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				indexValue, ok := invocation.Arguments[0].(NumberValue)
@@ -929,7 +929,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 				v.SemaType(context).ElementType(false),
 			),
 			func(v *ArrayValue, invocation Invocation) Value {
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				indexValue, ok := invocation.Arguments[0].(NumberValue)
@@ -955,7 +955,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 			),
 			func(v *ArrayValue, invocation Invocation) Value {
 				return v.RemoveFirst(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 				)
 			},
@@ -970,7 +970,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 			),
 			func(v *ArrayValue, invocation Invocation) Value {
 				return v.RemoveLast(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 				)
 			},
@@ -985,7 +985,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 			),
 			func(v *ArrayValue, invocation Invocation) Value {
 				return v.FirstIndex(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 					invocation.Arguments[0],
 				)
@@ -1001,7 +1001,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 			),
 			func(v *ArrayValue, invocation Invocation) Value {
 				return v.Contains(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 					invocation.Arguments[0],
 				)
@@ -1027,7 +1027,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 				}
 
 				return v.Slice(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					from,
 					to,
 					invocation.LocationRange,
@@ -1044,7 +1044,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 			),
 			func(v *ArrayValue, invocation Invocation) Value {
 				return v.Reverse(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 				)
 			},
@@ -1059,7 +1059,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 				v.SemaType(context).ElementType(false),
 			),
 			func(v *ArrayValue, invocation Invocation) Value {
-				interpreter := invocation.Interpreter
+				interpreter := invocation.InvocationContext
 
 				funcArgument, ok := invocation.Arguments[0].(FunctionValue)
 				if !ok {
@@ -1083,7 +1083,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 				v.SemaType(context),
 			),
 			func(v *ArrayValue, invocation Invocation) Value {
-				interpreter := invocation.Interpreter
+				interpreter := invocation.InvocationContext
 
 				funcArgument, ok := invocation.Arguments[0].(FunctionValue)
 				if !ok {
@@ -1106,7 +1106,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 				v.SemaType(context).ElementType(false),
 			),
 			func(v *ArrayValue, invocation Invocation) Value {
-				interpreter := invocation.Interpreter
+				interpreter := invocation.InvocationContext
 
 				return v.ToVariableSized(
 					interpreter,
@@ -1123,7 +1123,7 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 				v.SemaType(context).ElementType(false),
 			),
 			func(v *ArrayValue, invocation Invocation) Value {
-				interpreter := invocation.Interpreter
+				interpreter := invocation.InvocationContext
 
 				typeParameterPair := invocation.TypeParameterTypes.Oldest()
 				if typeParameterPair == nil {

--- a/interpreter/value_block.go
+++ b/interpreter/value_block.go
@@ -34,10 +34,10 @@ var blockFieldNames = []string{
 	sema.BlockTypeIdFieldName,
 	sema.BlockTypeTimestampFieldName,
 }
-var blockFieldFormatters = func(inter *Interpreter) map[string]func(common.MemoryGauge, Value, SeenReferences) string {
+var blockFieldFormatters = func(context ContainerMutationContext) map[string]func(common.MemoryGauge, Value, SeenReferences) string {
 	return map[string]func(common.MemoryGauge, Value, SeenReferences) string{
 		sema.BlockTypeIdFieldName: func(memoryGauge common.MemoryGauge, value Value, references SeenReferences) string {
-			bytes, err := ByteArrayValueToByteSlice(inter, value, EmptyLocationRange)
+			bytes, err := ByteArrayValueToByteSlice(context, value, EmptyLocationRange)
 			if err != nil {
 				panic(err)
 			}
@@ -49,14 +49,14 @@ var blockFieldFormatters = func(inter *Interpreter) map[string]func(common.Memor
 }
 
 func NewBlockValue(
-	inter *Interpreter,
+	context ContainerMutationContext,
 	height UInt64Value,
 	view UInt64Value,
 	id *ArrayValue,
 	timestamp UFix64Value,
 ) *SimpleCompositeValue {
 	return NewSimpleCompositeValue(
-		inter,
+		context,
 		sema.BlockType.TypeID,
 		blockStaticType,
 		blockFieldNames,
@@ -67,7 +67,7 @@ func NewBlockValue(
 			sema.BlockTypeTimestampFieldName: timestamp,
 		},
 		nil,
-		blockFieldFormatters(inter),
+		blockFieldFormatters(context),
 		nil,
 	)
 }

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -44,7 +44,7 @@ func (v BoolValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationR
 	visitor.VisitBoolValue(interpreter, v)
 }
 
-func (BoolValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (BoolValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -104,7 +104,7 @@ func (v *IDCapabilityValue) Accept(interpreter *Interpreter, visitor Visitor, _ 
 	visitor.VisitCapabilityValue(interpreter, v)
 }
 
-func (v *IDCapabilityValue) Walk(_ *Interpreter, walkChild func(Value), _ LocationRange) {
+func (v *IDCapabilityValue) Walk(_ ValueWalkContext, walkChild func(Value), _ LocationRange) {
 	walkChild(v.ID)
 	walkChild(v.address)
 }

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -83,7 +83,7 @@ func (v CharacterValue) Accept(interpreter *Interpreter, visitor Visitor, _ Loca
 	visitor.VisitCharacterValue(interpreter, v)
 }
 
-func (CharacterValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (CharacterValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -227,7 +227,7 @@ func (v CharacterValue) GetMember(context MemberAccessibleContext, locationRange
 			v,
 			sema.ToStringFunctionType,
 			func(v CharacterValue, invocation Invocation) Value {
-				interpreter := invocation.Interpreter
+				interpreter := invocation.InvocationContext
 
 				memoryUsage := common.NewStringMemoryUsage(len(v.Str))
 

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -94,7 +94,7 @@ func NewUnmeteredCompositeField(name string, value Value) CompositeField {
 // for a type which isn't CompositeType.
 // For e.g. InclusiveRangeType
 func NewCompositeValueWithStaticType(
-	interpreter *Interpreter,
+	context MemberAccessibleContext,
 	locationRange LocationRange,
 	location common.Location,
 	qualifiedIdentifier string,
@@ -104,7 +104,7 @@ func NewCompositeValueWithStaticType(
 	staticType StaticType,
 ) *CompositeValue {
 	value := NewCompositeValue(
-		interpreter,
+		context,
 		locationRange,
 		location,
 		qualifiedIdentifier,

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -1678,7 +1678,7 @@ func (v *CompositeValue) forEachAttachmentFunction(context FunctionCreationConte
 			compositeType.GetCompositeKind(),
 		),
 		func(v *CompositeValue, invocation Invocation) Value {
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			functionValue, ok := invocation.Arguments[0].(FunctionValue)
 			if !ok {

--- a/interpreter/value_deployedcontract.go
+++ b/interpreter/value_deployedcontract.go
@@ -34,13 +34,13 @@ var deployedContractFieldNames = []string{
 }
 
 func NewDeployedContractValue(
-	inter *Interpreter,
+	context FunctionCreationContext,
 	address AddressValue,
 	name *StringValue,
 	code *ArrayValue,
 ) *SimpleCompositeValue {
 	deployedContract := NewSimpleCompositeValue(
-		inter,
+		context,
 		sema.DeployedContractType.TypeID,
 		deployedContractStaticType,
 		deployedContractFieldNames,
@@ -55,7 +55,7 @@ func NewDeployedContractValue(
 	)
 
 	publicTypesFuncValue := newPublicTypesFunctionValue(
-		inter,
+		context,
 		deployedContract,
 		address,
 		name,
@@ -66,7 +66,7 @@ func NewDeployedContractValue(
 }
 
 func newPublicTypesFunctionValue(
-	inter *Interpreter,
+	context FunctionCreationContext,
 	self MemberAccessibleValue,
 	addressValue AddressValue,
 	name *StringValue,
@@ -76,7 +76,7 @@ func newPublicTypesFunctionValue(
 
 	address := addressValue.ToAddress()
 	return NewBoundHostFunctionValue(
-		inter,
+		context,
 		self,
 		sema.DeployedContractTypePublicTypesFunctionType,
 		func(_ MemberAccessibleValue, inv Invocation) Value {

--- a/interpreter/value_deployedcontract.go
+++ b/interpreter/value_deployedcontract.go
@@ -81,7 +81,7 @@ func newPublicTypesFunctionValue(
 		sema.DeployedContractTypePublicTypesFunctionType,
 		func(_ MemberAccessibleValue, inv Invocation) Value {
 			if publicTypes == nil {
-				innerInter := inv.Interpreter
+				innerInter := inv.InvocationContext
 				contractLocation := common.NewAddressLocation(innerInter, address, name.Str)
 				// we're only looking at the contract as a whole, so no need to construct a nested path
 				qualifiedIdent := name.Str

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -813,7 +813,7 @@ func (v *DictionaryValue) GetMember(context MemberAccessibleContext, locationRan
 				keyValue := invocation.Arguments[0]
 
 				return v.Remove(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 					keyValue,
 				)
@@ -832,7 +832,7 @@ func (v *DictionaryValue) GetMember(context MemberAccessibleContext, locationRan
 				newValue := invocation.Arguments[1]
 
 				return v.Insert(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 					keyValue,
 					newValue,
@@ -849,7 +849,7 @@ func (v *DictionaryValue) GetMember(context MemberAccessibleContext, locationRan
 			),
 			func(v *DictionaryValue, invocation Invocation) Value {
 				return v.ContainsKey(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 					invocation.Arguments[0],
 				)
@@ -863,7 +863,7 @@ func (v *DictionaryValue) GetMember(context MemberAccessibleContext, locationRan
 				v.SemaType(context),
 			),
 			func(v *DictionaryValue, invocation Invocation) Value {
-				interpreter := invocation.Interpreter
+				interpreter := invocation.InvocationContext
 
 				funcArgument, ok := invocation.Arguments[0].(FunctionValue)
 				if !ok {

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -85,7 +85,7 @@ func (v *EphemeralReferenceValue) Accept(interpreter *Interpreter, visitor Visit
 	visitor.VisitEphemeralReferenceValue(interpreter, v)
 }
 
-func (*EphemeralReferenceValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (*EphemeralReferenceValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 	// NOTE: *not* walking referenced value!
 }

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -90,7 +90,7 @@ func (v Fix64Value) Accept(interpreter *Interpreter, visitor Visitor, _ Location
 	visitor.VisitFix64Value(interpreter, v)
 }
 
-func (Fix64Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (Fix64Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -433,7 +433,7 @@ func (f BoundFunctionValue) invoke(invocation Invocation) Value {
 	invocation.BoundAuthorization = f.BoundAuthorization
 
 	locationRange := invocation.LocationRange
-	inter := invocation.Interpreter
+	inter := invocation.InvocationContext
 
 	// If the `self` is already a reference to begin with (e.g: attachments),
 	// then pass the reference as-is to the invocation.

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -99,7 +99,7 @@ func (f *InterpretedFunctionValue) Accept(interpreter *Interpreter, visitor Visi
 	visitor.VisitInterpretedFunctionValue(interpreter, f)
 }
 
-func (f *InterpretedFunctionValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (f *InterpretedFunctionValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 
@@ -233,7 +233,7 @@ func (f *HostFunctionValue) Accept(interpreter *Interpreter, visitor Visitor, _ 
 	visitor.VisitHostFunctionValue(interpreter, f)
 }
 
-func (f *HostFunctionValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (f *HostFunctionValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 
@@ -409,7 +409,7 @@ func (f BoundFunctionValue) Accept(interpreter *Interpreter, visitor Visitor, _ 
 	visitor.VisitBoundFunctionValue(interpreter, f)
 }
 
-func (f BoundFunctionValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (f BoundFunctionValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -542,7 +542,7 @@ func NewBoundHostFunctionValue[T Value](
 
 // NewUnmeteredBoundHostFunctionValue creates a bound-function value for a host-function.
 func NewUnmeteredBoundHostFunctionValue(
-	interpreter *Interpreter,
+	context FunctionCreationContext,
 	self Value,
 	funcType *sema.FunctionType,
 	function HostFunction,
@@ -551,7 +551,7 @@ func NewUnmeteredBoundHostFunctionValue(
 	hostFunc := NewUnmeteredStaticHostFunctionValue(funcType, function)
 
 	return NewBoundFunctionValue(
-		interpreter,
+		context,
 		hostFunc,
 		&self,
 		nil,

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -100,7 +100,7 @@ func (v IntValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRa
 	visitor.VisitIntValue(interpreter, v)
 }
 
-func (IntValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (IntValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -111,7 +111,7 @@ func (v Int128Value) Accept(interpreter *Interpreter, visitor Visitor, _ Locatio
 	visitor.VisitInt128Value(interpreter, v)
 }
 
-func (Int128Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (Int128Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -66,7 +66,7 @@ func (v Int16Value) Accept(interpreter *Interpreter, visitor Visitor, _ Location
 	visitor.VisitInt16Value(interpreter, v)
 }
 
-func (Int16Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (Int16Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -80,7 +80,7 @@ func (v Int256Value) Accept(interpreter *Interpreter, visitor Visitor, _ Locatio
 	visitor.VisitInt256Value(interpreter, v)
 }
 
-func (Int256Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (Int256Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -66,7 +66,7 @@ func (v Int32Value) Accept(interpreter *Interpreter, visitor Visitor, _ Location
 	visitor.VisitInt32Value(interpreter, v)
 }
 
-func (Int32Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (Int32Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -66,7 +66,7 @@ func (v Int64Value) Accept(interpreter *Interpreter, visitor Visitor, _ Location
 	visitor.VisitInt64Value(interpreter, v)
 }
 
-func (Int64Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (Int64Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -64,7 +64,7 @@ func (v Int8Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationR
 	visitor.VisitInt8Value(interpreter, v)
 }
 
-func (Int8Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (Int8Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_link.go
+++ b/interpreter/value_link.go
@@ -56,7 +56,7 @@ func (v PathLinkValue) Accept(_ *Interpreter, _ Visitor, _ LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 
-func (v PathLinkValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (v PathLinkValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 
@@ -181,7 +181,7 @@ func (v AccountLinkValue) Accept(_ *Interpreter, _ Visitor, _ LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 
-func (AccountLinkValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (AccountLinkValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -47,7 +47,7 @@ func (v NilValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRa
 	visitor.VisitNilValue(interpreter, v)
 }
 
-func (NilValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (NilValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 
@@ -74,7 +74,7 @@ func (NilValue) IsDestroyed() bool {
 	return false
 }
 
-func (v NilValue) Destroy(_ *Interpreter, _ LocationRange) {}
+func (v NilValue) Destroy(context ResourceDestructionContext, locationRange LocationRange) {}
 
 func (NilValue) String() string {
 	return format.Nil

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -66,7 +66,7 @@ func (NilValue) isOptionalValue() {}
 
 func (NilValue) forEach(_ func(Value)) {}
 
-func (v NilValue) fmap(_ *Interpreter, _ func(Value) Value) OptionalValue {
+func (v NilValue) fmap(_ common.MemoryGauge, _ func(Value) Value) OptionalValue {
 	return v
 }
 

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -58,7 +58,7 @@ func getNumberValueMember(context MemberAccessibleContext, v NumberValue, name s
 			v,
 			sema.ToStringFunctionType,
 			func(v NumberValue, invocation Invocation) Value {
-				interpreter := invocation.Interpreter
+				interpreter := invocation.InvocationContext
 
 				memoryUsage := common.NewStringMemoryUsage(
 					OverEstimateNumberStringLength(interpreter, v),
@@ -80,7 +80,7 @@ func getNumberValueMember(context MemberAccessibleContext, v NumberValue, name s
 			sema.ToBigEndianBytesFunctionType,
 			func(v NumberValue, invocation Invocation) Value {
 				return ByteSliceToByteArrayValue(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					v.ToBigEndianBytes(),
 				)
 			},
@@ -98,7 +98,7 @@ func getNumberValueMember(context MemberAccessibleContext, v NumberValue, name s
 				}
 
 				return v.SaturatingPlus(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					other,
 					locationRange,
 				)
@@ -117,7 +117,7 @@ func getNumberValueMember(context MemberAccessibleContext, v NumberValue, name s
 				}
 
 				return v.SaturatingMinus(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					other,
 					locationRange,
 				)
@@ -136,7 +136,7 @@ func getNumberValueMember(context MemberAccessibleContext, v NumberValue, name s
 				}
 
 				return v.SaturatingMul(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					other,
 					locationRange,
 				)
@@ -155,7 +155,7 @@ func getNumberValueMember(context MemberAccessibleContext, v NumberValue, name s
 				}
 
 				return v.SaturatingDiv(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					other,
 					locationRange,
 				)

--- a/interpreter/value_optional.go
+++ b/interpreter/value_optional.go
@@ -18,11 +18,13 @@
 
 package interpreter
 
+import "github.com/onflow/cadence/common"
+
 // OptionalValue
 
 type OptionalValue interface {
 	Value
 	isOptionalValue()
 	forEach(f func(Value))
-	fmap(inter *Interpreter, f func(Value) Value) OptionalValue
+	fmap(memoryGauge common.MemoryGauge, f func(Value) Value) OptionalValue
 }

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -62,7 +62,7 @@ func (v PathValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationR
 	visitor.VisitPathValue(interpreter, v)
 }
 
-func (PathValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (PathValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -191,7 +191,7 @@ func (PathValue) IsStorable() bool {
 	return true
 }
 
-func newPathFromStringValue(interpreter *Interpreter, domain common.PathDomain, value Value) Value {
+func newPathFromStringValue(gauge common.MemoryGauge, domain common.PathDomain, value Value) Value {
 	stringValue, ok := value.(*StringValue)
 	if !ok {
 		return Nil
@@ -200,9 +200,9 @@ func newPathFromStringValue(interpreter *Interpreter, domain common.PathDomain, 
 	// NOTE: any identifier is allowed, it does not have to match the syntax for path literals
 
 	return NewSomeValueNonCopying(
-		interpreter,
+		gauge,
 		NewPathValue(
-			interpreter,
+			gauge,
 			domain,
 			stringValue.Str,
 		),

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -119,7 +119,7 @@ func (v PathValue) GetMember(context MemberAccessibleContext, locationRange Loca
 			v,
 			sema.ToStringFunctionType,
 			func(v PathValue, invocation Invocation) Value {
-				interpreter := invocation.Interpreter
+				interpreter := invocation.InvocationContext
 
 				domainLength := len(v.Domain.Identifier())
 				identifierLength := len(v.Identifier)

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -65,7 +65,7 @@ func (v *PathCapabilityValue) Accept(_ *Interpreter, _ Visitor, _ LocationRange)
 	panic(errors.NewUnreachableError())
 }
 
-func (v *PathCapabilityValue) Walk(_ *Interpreter, walkChild func(Value), _ LocationRange) {
+func (v *PathCapabilityValue) Walk(_ ValueWalkContext, walkChild func(Value), _ LocationRange) {
 	walkChild(v.address)
 	walkChild(v.Path)
 }

--- a/interpreter/value_placeholder.go
+++ b/interpreter/value_placeholder.go
@@ -47,7 +47,7 @@ func (f placeholderValue) Accept(_ *Interpreter, _ Visitor, _ LocationRange) {
 	// NO-OP
 }
 
-func (f placeholderValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (f placeholderValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_publickey.go
+++ b/interpreter/value_publickey.go
@@ -27,14 +27,14 @@ import (
 // Parameter types:
 // - publicKey: PublicKey
 type PublicKeyValidationHandlerFunc func(
-	interpreter *Interpreter,
+	context PublicKeyValidationContext,
 	locationRange LocationRange,
 	publicKey *CompositeValue,
 ) error
 
 // NewPublicKeyValue constructs a PublicKey value.
 func NewPublicKeyValue(
-	interpreter *Interpreter,
+	context PublicKeyCreationContext,
 	locationRange LocationRange,
 	publicKey *ArrayValue,
 	signAlgo Value,
@@ -53,7 +53,7 @@ func NewPublicKeyValue(
 	}
 
 	publicKeyValue := NewCompositeValue(
-		interpreter,
+		context,
 		locationRange,
 		sema.PublicKeyType.Location,
 		sema.PublicKeyType.QualifiedIdentifier(),
@@ -62,7 +62,7 @@ func NewPublicKeyValue(
 		common.ZeroAddress,
 	)
 
-	err := validatePublicKey(interpreter, locationRange, publicKeyValue)
+	err := validatePublicKey(context, locationRange, publicKeyValue)
 	if err != nil {
 		panic(InvalidPublicKeyError{
 			PublicKey:     publicKey,

--- a/interpreter/value_published.go
+++ b/interpreter/value_published.go
@@ -86,7 +86,7 @@ func (v *PublishedValue) MeteredString(context ValueStringContext, seenReference
 	)
 }
 
-func (v *PublishedValue) Walk(_ *Interpreter, walkChild func(Value), _ LocationRange) {
+func (v *PublishedValue) Walk(_ ValueWalkContext, walkChild func(Value), _ LocationRange) {
 	walkChild(v.Recipient)
 	walkChild(v.Value)
 }

--- a/interpreter/value_range.go
+++ b/interpreter/value_range.go
@@ -176,7 +176,7 @@ func createInclusiveRange(
 				return rangeContains(
 					rangeValue,
 					rangeType,
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 					needleInteger,
 				)

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -146,7 +146,7 @@ func (v *SomeValue) MeteredString(context ValueStringContext, seenReferences See
 	return v.value.MeteredString(context, seenReferences, locationRange)
 }
 
-func (v *SomeValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+func (v *SomeValue) GetMember(context MemberAccessibleContext, _ LocationRange, name string) Value {
 	switch name {
 	case sema.OptionalTypeMapFunctionName:
 		innerValueType := MustConvertStaticToSemaType(
@@ -160,7 +160,7 @@ func (v *SomeValue) GetMember(context MemberAccessibleContext, locationRange Loc
 				innerValueType,
 			),
 			func(v *SomeValue, invocation Invocation) Value {
-				inter := invocation.InvocationContext
+				invocationContext := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				transformFunction, ok := invocation.Arguments[0].(FunctionValue)
@@ -173,9 +173,10 @@ func (v *SomeValue) GetMember(context MemberAccessibleContext, locationRange Loc
 				returnType := transformFunctionType.ReturnTypeAnnotation.Type
 
 				return v.fmap(
-					inter,
+					invocationContext,
 					func(v Value) Value {
-						return inter.invokeFunctionValue(
+						return invokeFunctionValue(
+							invocationContext,
 							transformFunction,
 							[]Value{v},
 							nil,

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -160,7 +160,7 @@ func (v *SomeValue) GetMember(context MemberAccessibleContext, locationRange Loc
 				innerValueType,
 			),
 			func(v *SomeValue, invocation Invocation) Value {
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				transformFunction, ok := invocation.Arguments[0].(FunctionValue)

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -88,7 +88,7 @@ func (v *SomeValue) Accept(interpreter *Interpreter, visitor Visitor, locationRa
 	v.value.Accept(interpreter, visitor, locationRange)
 }
 
-func (v *SomeValue) Walk(_ *Interpreter, walkChild func(Value), _ LocationRange) {
+func (v *SomeValue) Walk(_ ValueWalkContext, walkChild func(Value), _ LocationRange) {
 	walkChild(v.value)
 }
 
@@ -126,9 +126,9 @@ func (v *SomeValue) IsDestroyed() bool {
 	return v.isDestroyed
 }
 
-func (v *SomeValue) Destroy(interpreter *Interpreter, locationRange LocationRange) {
+func (v *SomeValue) Destroy(context ResourceDestructionContext, locationRange LocationRange) {
 	innerValue := v.InnerValue()
-	maybeDestroy(interpreter, locationRange, innerValue)
+	maybeDestroy(context, locationRange, innerValue)
 
 	v.isDestroyed = true
 	v.value = nil

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -117,9 +117,9 @@ func (v *SomeValue) forEach(f func(Value)) {
 	f(v.value)
 }
 
-func (v *SomeValue) fmap(inter *Interpreter, f func(Value) Value) OptionalValue {
+func (v *SomeValue) fmap(memoryGauge common.MemoryGauge, f func(Value) Value) OptionalValue {
 	newValue := f(v.value)
-	return NewSomeValueNonCopying(inter, newValue)
+	return NewSomeValueNonCopying(memoryGauge, newValue)
 }
 
 func (v *SomeValue) IsDestroyed() bool {

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -80,7 +80,7 @@ func (v *StorageReferenceValue) Accept(interpreter *Interpreter, visitor Visitor
 	visitor.VisitStorageReferenceValue(interpreter, v)
 }
 
-func (*StorageReferenceValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (*StorageReferenceValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 	// NOTE: *not* walking referenced value!
 }

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -114,7 +114,7 @@ func (v *StorageCapabilityControllerValue) Accept(interpreter *Interpreter, visi
 	visitor.VisitStorageCapabilityControllerValue(interpreter, v)
 }
 
-func (v *StorageCapabilityControllerValue) Walk(_ *Interpreter, walkChild func(Value), _ LocationRange) {
+func (v *StorageCapabilityControllerValue) Walk(_ ValueWalkContext, walkChild func(Value), _ LocationRange) {
 	walkChild(v.TargetPath)
 	walkChild(v.CapabilityID)
 }

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -33,7 +33,7 @@ type CapabilityControllerValue interface {
 	isCapabilityControllerValue()
 	CapabilityControllerBorrowType() *ReferenceStaticType
 	ReferenceValue(
-		context CapConReferenceValueContext,
+		context ValueCapabilityControllerReferenceValueContext,
 		capabilityAddress common.Address,
 		resultBorrowType *sema.ReferenceType,
 		locationRange LocationRange,
@@ -322,7 +322,7 @@ func (v *StorageCapabilityControllerValue) ControllerCapabilityID() UInt64Value 
 }
 
 func (v *StorageCapabilityControllerValue) ReferenceValue(
-	context CapConReferenceValueContext,
+	context ValueCapabilityControllerReferenceValueContext,
 	capabilityAddress common.Address,
 	resultBorrowType *sema.ReferenceType,
 	_ LocationRange,

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -375,7 +375,7 @@ func (v *StorageCapabilityControllerValue) newDeleteFunction(
 		context,
 		sema.StorageCapabilityControllerTypeDeleteFunctionType,
 		func(invocation Invocation) Value {
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			v.Delete(inter, locationRange)
@@ -406,7 +406,7 @@ func (v *StorageCapabilityControllerValue) newRetargetFunction(
 		context,
 		sema.StorageCapabilityControllerTypeRetargetFunctionType,
 		func(invocation Invocation) Value {
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			// Get path argument
@@ -431,7 +431,7 @@ func (v *StorageCapabilityControllerValue) newSetTagFunction(
 		context,
 		sema.StorageCapabilityControllerTypeSetTagFunctionType,
 		func(invocation Invocation) Value {
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			newTagValue, ok := invocation.Arguments[0].(*StringValue)
 			if !ok {

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -65,8 +65,8 @@ type StorageCapabilityControllerValue struct {
 	GetCapability func(common.MemoryGauge) *IDCapabilityValue
 	GetTag        func(storageReader StorageReader) *StringValue
 	SetTag        func(storageWriter StorageWriter, tag *StringValue)
-	Delete        func(inter *Interpreter, locationRange LocationRange)
-	SetTarget     func(inter *Interpreter, locationRange LocationRange, target PathValue)
+	Delete        func(context CapabilityControllerContext, locationRange LocationRange)
+	SetTarget     func(context CapabilityControllerContext, locationRange LocationRange, target PathValue)
 }
 
 func NewUnmeteredStorageCapabilityControllerValue(

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -118,7 +118,7 @@ func (v *StringValue) Accept(interpreter *Interpreter, visitor Visitor, _ Locati
 	visitor.VisitStringValue(interpreter, v)
 }
 
-func (*StringValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (*StringValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -225,7 +225,7 @@ func (v *StringValue) HashInput(_ common.MemoryGauge, _ LocationRange, scratch [
 	return buffer
 }
 
-func (v *StringValue) Concat(interpreter *Interpreter, other *StringValue, locationRange LocationRange) Value {
+func (v *StringValue) Concat(context StringValueFunctionContext, other *StringValue, locationRange LocationRange) Value {
 
 	firstLength := len(v.Str)
 	secondLength := len(other.Str)
@@ -235,10 +235,10 @@ func (v *StringValue) Concat(interpreter *Interpreter, other *StringValue, locat
 	memoryUsage := common.NewStringMemoryUsage(newLength)
 
 	// Meter computation as if the two strings were iterated.
-	interpreter.ReportComputation(common.ComputationKindLoop, uint(newLength))
+	context.ReportComputation(common.ComputationKindLoop, uint(newLength))
 
 	return NewStringValue(
-		interpreter,
+		context,
 		memoryUsage,
 		func() string {
 			var sb strings.Builder
@@ -369,12 +369,12 @@ func (v *StringValue) GetMember(context MemberAccessibleContext, locationRange L
 			v,
 			sema.StringTypeConcatFunctionType,
 			func(v *StringValue, invocation Invocation) Value {
-				interpreter := invocation.InvocationContext
+				invocationContext := invocation.InvocationContext
 				otherArray, ok := invocation.Arguments[0].(*StringValue)
 				if !ok {
 					panic(errors.NewUnreachableError())
 				}
-				return v.Concat(interpreter, otherArray, locationRange)
+				return v.Concat(invocationContext, otherArray, locationRange)
 			},
 		)
 
@@ -549,7 +549,7 @@ func (v *StringValue) Length() int {
 	return v.length
 }
 
-func (v *StringValue) ToLower(interpreter *Interpreter) *StringValue {
+func (v *StringValue) ToLower(interpreter StringValueFunctionContext) *StringValue {
 
 	// Meter computation as if the string was iterated.
 	interpreter.ReportComputation(common.ComputationKindLoop, uint(len(v.Str)))
@@ -578,26 +578,26 @@ func (v *StringValue) ToLower(interpreter *Interpreter) *StringValue {
 	)
 }
 
-func (v *StringValue) Split(inter *Interpreter, locationRange LocationRange, separator *StringValue) *ArrayValue {
+func (v *StringValue) Split(context ArrayCreationContext, locationRange LocationRange, separator *StringValue) *ArrayValue {
 
 	if len(separator.Str) == 0 {
-		return v.Explode(inter, locationRange)
+		return v.Explode(context, locationRange)
 	}
 
-	count := v.count(inter, locationRange, separator) + 1
+	count := v.count(context, locationRange, separator) + 1
 
 	partIndex := 0
 
 	remaining := v
 
 	return NewArrayValueWithIterator(
-		inter,
+		context,
 		VarSizedArrayOfStringType,
 		common.ZeroAddress,
 		uint64(count),
 		func() Value {
 
-			inter.ReportComputation(common.ComputationKindLoop, 1)
+			context.ReportComputation(common.ComputationKindLoop, 1)
 
 			if partIndex >= count {
 				return nil
@@ -609,7 +609,7 @@ func (v *StringValue) Split(inter *Interpreter, locationRange LocationRange, sep
 				return remaining
 			}
 
-			separatorCharacterIndex, _ := remaining.indexOf(inter, separator)
+			separatorCharacterIndex, _ := remaining.indexOf(context, separator)
 			if separatorCharacterIndex < 0 {
 				return nil
 			}
@@ -634,17 +634,17 @@ func (v *StringValue) Split(inter *Interpreter, locationRange LocationRange, sep
 }
 
 // Explode returns a Cadence array of type [String], where each element is a single character of the string
-func (v *StringValue) Explode(inter *Interpreter, locationRange LocationRange) *ArrayValue {
+func (v *StringValue) Explode(context ArrayCreationContext, locationRange LocationRange) *ArrayValue {
 
-	iterator := v.Iterator(inter, locationRange)
+	iterator := v.Iterator(context, locationRange)
 
 	return NewArrayValueWithIterator(
-		inter,
+		context,
 		VarSizedArrayOfStringType,
 		common.ZeroAddress,
 		uint64(v.Length()),
 		func() Value {
-			value := iterator.Next(inter, locationRange)
+			value := iterator.Next(context, locationRange)
 			if value == nil {
 				return nil
 			}
@@ -657,7 +657,7 @@ func (v *StringValue) Explode(inter *Interpreter, locationRange LocationRange) *
 			str := character.Str
 
 			return NewStringValue(
-				inter,
+				context,
 				common.NewStringMemoryUsage(len(str)),
 				func() string {
 					return str
@@ -668,13 +668,13 @@ func (v *StringValue) Explode(inter *Interpreter, locationRange LocationRange) *
 }
 
 func (v *StringValue) ReplaceAll(
-	inter *Interpreter,
+	context StringValueFunctionContext,
 	locationRange LocationRange,
 	original *StringValue,
 	replacement *StringValue,
 ) *StringValue {
 
-	count := v.count(inter, locationRange, original)
+	count := v.count(context, locationRange, original)
 	if count == 0 {
 		return v
 	}
@@ -684,12 +684,12 @@ func (v *StringValue) ReplaceAll(
 	memoryUsage := common.NewStringMemoryUsage(newByteLength)
 
 	// Meter computation as if the string was iterated.
-	inter.ReportComputation(common.ComputationKindLoop, uint(len(v.Str)))
+	context.ReportComputation(common.ComputationKindLoop, uint(len(v.Str)))
 
 	remaining := v
 
 	return NewStringValue(
-		inter,
+		context,
 		memoryUsage,
 		func() string {
 			var b strings.Builder
@@ -706,7 +706,7 @@ func (v *StringValue) ReplaceAll(
 						_, originalByteOffset = remaining.graphemes.Positions()
 					}
 				} else {
-					originalCharacterIndex, originalByteOffset = remaining.indexOf(inter, original)
+					originalCharacterIndex, originalByteOffset = remaining.indexOf(context, original)
 					if originalCharacterIndex < 0 {
 						panic(errors.NewUnreachableError())
 					}
@@ -779,7 +779,7 @@ func (*StringValue) ChildStorables() []atree.Storable {
 var ByteArrayStaticType = ConvertSemaArrayTypeToStaticArrayType(nil, sema.ByteArrayType)
 
 // DecodeHex hex-decodes this string and returns an array of UInt8 values
-func (v *StringValue) DecodeHex(interpreter *Interpreter, locationRange LocationRange) *ArrayValue {
+func (v *StringValue) DecodeHex(context ArrayCreationContext, locationRange LocationRange) *ArrayValue {
 	bs, err := hex.DecodeString(v.Str)
 	if err != nil {
 		if err, ok := err.(hex.InvalidByteError); ok {
@@ -801,7 +801,7 @@ func (v *StringValue) DecodeHex(interpreter *Interpreter, locationRange Location
 	i := 0
 
 	return NewArrayValueWithIterator(
-		interpreter,
+		context,
 		ByteArrayStaticType,
 		common.ZeroAddress,
 		uint64(len(bs)),
@@ -811,7 +811,7 @@ func (v *StringValue) DecodeHex(interpreter *Interpreter, locationRange Location
 			}
 
 			value := NewUInt8Value(
-				interpreter,
+				context,
 				func() uint8 {
 					return bs[i]
 				},
@@ -951,12 +951,12 @@ func (v *StringValue) isGraphemeBoundaryEndPrepared(end int) bool {
 	}
 }
 
-func (v *StringValue) IndexOf(inter *Interpreter, other *StringValue) IntValue {
-	index, _ := v.indexOf(inter, other)
-	return NewIntValueFromInt64(inter, int64(index))
+func (v *StringValue) IndexOf(context StringValueFunctionContext, other *StringValue) IntValue {
+	index, _ := v.indexOf(context, other)
+	return NewIntValueFromInt64(context, int64(index))
 }
 
-func (v *StringValue) indexOf(inter *Interpreter, other *StringValue) (characterIndex int, byteOffset int) {
+func (v *StringValue) indexOf(reporter ComputationReporter, other *StringValue) (characterIndex int, byteOffset int) {
 
 	if len(other.Str) == 0 {
 		return 0, 0
@@ -973,7 +973,7 @@ func (v *StringValue) indexOf(inter *Interpreter, other *StringValue) (character
 
 	// Meter computation as if the string was iterated.
 	// This is a conservative over-estimation.
-	inter.ReportComputation(common.ComputationKindLoop, uint(len(v.Str)*len(other.Str)))
+	reporter.ReportComputation(common.ComputationKindLoop, uint(len(v.Str)*len(other.Str)))
 
 	v.prepareGraphemes()
 
@@ -1027,29 +1027,29 @@ func (v *StringValue) indexOf(inter *Interpreter, other *StringValue) (character
 	return -1, -1
 }
 
-func (v *StringValue) Contains(inter *Interpreter, other *StringValue) BoolValue {
-	characterIndex, _ := v.indexOf(inter, other)
+func (v *StringValue) Contains(context StringValueFunctionContext, other *StringValue) BoolValue {
+	characterIndex, _ := v.indexOf(context, other)
 	return characterIndex >= 0
 }
 
-func (v *StringValue) Count(inter *Interpreter, locationRange LocationRange, other *StringValue) IntValue {
-	index := v.count(inter, locationRange, other)
-	return NewIntValueFromInt64(inter, int64(index))
+func (v *StringValue) Count(context StringValueFunctionContext, locationRange LocationRange, other *StringValue) IntValue {
+	index := v.count(context, locationRange, other)
+	return NewIntValueFromInt64(context, int64(index))
 }
 
-func (v *StringValue) count(inter *Interpreter, locationRange LocationRange, other *StringValue) int {
+func (v *StringValue) count(reporter ComputationReporter, locationRange LocationRange, other *StringValue) int {
 	if other.Length() == 0 {
 		return 1 + v.Length()
 	}
 
 	// Meter computation as if the string was iterated.
-	inter.ReportComputation(common.ComputationKindLoop, uint(len(v.Str)))
+	reporter.ReportComputation(common.ComputationKindLoop, uint(len(v.Str)))
 
 	remaining := v
 	count := 0
 
 	for {
-		index, _ := remaining.indexOf(inter, other)
+		index, _ := remaining.indexOf(reporter, other)
 		if index == -1 {
 			return count
 		}

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -369,7 +369,7 @@ func (v *StringValue) GetMember(context MemberAccessibleContext, locationRange L
 			v,
 			sema.StringTypeConcatFunctionType,
 			func(v *StringValue, invocation Invocation) Value {
-				interpreter := invocation.Interpreter
+				interpreter := invocation.InvocationContext
 				otherArray, ok := invocation.Arguments[0].(*StringValue)
 				if !ok {
 					panic(errors.NewUnreachableError())
@@ -409,7 +409,7 @@ func (v *StringValue) GetMember(context MemberAccessibleContext, locationRange L
 					panic(errors.NewUnreachableError())
 				}
 
-				return v.Contains(invocation.Interpreter, other)
+				return v.Contains(invocation.InvocationContext, other)
 			},
 		)
 
@@ -424,7 +424,7 @@ func (v *StringValue) GetMember(context MemberAccessibleContext, locationRange L
 					panic(errors.NewUnreachableError())
 				}
 
-				return v.IndexOf(invocation.Interpreter, other)
+				return v.IndexOf(invocation.InvocationContext, other)
 			},
 		)
 
@@ -440,7 +440,7 @@ func (v *StringValue) GetMember(context MemberAccessibleContext, locationRange L
 				}
 
 				return v.Count(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 					other,
 				)
@@ -454,7 +454,7 @@ func (v *StringValue) GetMember(context MemberAccessibleContext, locationRange L
 			sema.StringTypeDecodeHexFunctionType,
 			func(v *StringValue, invocation Invocation) Value {
 				return v.DecodeHex(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 				)
 			},
@@ -466,7 +466,7 @@ func (v *StringValue) GetMember(context MemberAccessibleContext, locationRange L
 			v,
 			sema.StringTypeToLowerFunctionType,
 			func(v *StringValue, invocation Invocation) Value {
-				return v.ToLower(invocation.Interpreter)
+				return v.ToLower(invocation.InvocationContext)
 			},
 		)
 
@@ -482,7 +482,7 @@ func (v *StringValue) GetMember(context MemberAccessibleContext, locationRange L
 				}
 
 				return v.Split(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 					separator,
 				)
@@ -506,7 +506,7 @@ func (v *StringValue) GetMember(context MemberAccessibleContext, locationRange L
 				}
 
 				return v.ReplaceAll(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 					original,
 					replacement,
@@ -1088,7 +1088,7 @@ func stringFunctionEncodeHex(invocation Invocation) Value {
 		panic(errors.NewUnreachableError())
 	}
 
-	inter := invocation.Interpreter
+	inter := invocation.InvocationContext
 	memoryUsage := common.NewStringMemoryUsage(
 		safeMul(argument.Count(), 2, invocation.LocationRange),
 	)
@@ -1108,7 +1108,7 @@ func stringFunctionFromUtf8(invocation Invocation) Value {
 		panic(errors.NewUnreachableError())
 	}
 
-	inter := invocation.Interpreter
+	inter := invocation.InvocationContext
 	// naively read the entire byte array before validating
 	buf, err := ByteArrayValueToByteSlice(inter, argument, invocation.LocationRange)
 
@@ -1136,7 +1136,7 @@ func stringFunctionFromCharacters(invocation Invocation) Value {
 		panic(errors.NewUnreachableError())
 	}
 
-	inter := invocation.Interpreter
+	inter := invocation.InvocationContext
 
 	// NewStringMemoryUsage already accounts for empty string.
 	common.UseMemory(inter, common.NewStringMemoryUsage(0))
@@ -1171,7 +1171,7 @@ func stringFunctionJoin(invocation Invocation) Value {
 		panic(errors.NewUnreachableError())
 	}
 
-	inter := invocation.Interpreter
+	inter := invocation.InvocationContext
 
 	switch stringArray.Count() {
 	case 0:

--- a/interpreter/value_test.go
+++ b/interpreter/value_test.go
@@ -3415,7 +3415,7 @@ func TestPublicKeyValue(t *testing.T) {
 			EmptyLocationRange,
 			publicKey,
 			sigAlgo,
-			func(interpreter *Interpreter, locationRange LocationRange, publicKey *CompositeValue) error {
+			func(context PublicKeyValidationContext, locationRange LocationRange, publicKey *CompositeValue) error {
 				return nil
 			},
 		)
@@ -3469,7 +3469,7 @@ func TestPublicKeyValue(t *testing.T) {
 					EmptyLocationRange,
 					publicKey,
 					sigAlgo,
-					func(interpreter *Interpreter, locationRange LocationRange, publicKey *CompositeValue) error {
+					func(context PublicKeyValidationContext, locationRange LocationRange, publicKey *CompositeValue) error {
 						return fakeError
 					},
 				)

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -136,7 +136,7 @@ func (v TypeValue) GetMember(context MemberAccessibleContext, _ LocationRange, n
 			v,
 			sema.MetaTypeIsSubtypeFunctionType,
 			func(v TypeValue, invocation Invocation) Value {
-				interpreter := invocation.Interpreter
+				interpreter := invocation.InvocationContext
 
 				staticType := v.Type
 				otherTypeValue, ok := invocation.Arguments[0].(TypeValue)

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -62,7 +62,7 @@ func (v TypeValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationR
 	visitor.VisitTypeValue(interpreter, v)
 }
 
-func (TypeValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (TypeValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -169,7 +169,7 @@ func (v UFix64Value) Accept(interpreter *Interpreter, visitor Visitor, _ Locatio
 	visitor.VisitUFix64Value(interpreter, v)
 }
 
-func (UFix64Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (UFix64Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -121,7 +121,7 @@ func (v UIntValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationR
 	visitor.VisitUIntValue(interpreter, v)
 }
 
-func (UIntValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (UIntValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -80,7 +80,7 @@ func (v UInt128Value) Accept(interpreter *Interpreter, visitor Visitor, _ Locati
 	visitor.VisitUInt128Value(interpreter, v)
 }
 
-func (UInt128Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (UInt128Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -64,7 +64,7 @@ func (v UInt16Value) Accept(interpreter *Interpreter, visitor Visitor, _ Locatio
 	visitor.VisitUInt16Value(interpreter, v)
 }
 
-func (UInt16Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (UInt16Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -80,7 +80,7 @@ func (v UInt256Value) Accept(interpreter *Interpreter, visitor Visitor, _ Locati
 	visitor.VisitUInt256Value(interpreter, v)
 }
 
-func (UInt256Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (UInt256Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -64,7 +64,7 @@ func (v UInt32Value) Accept(interpreter *Interpreter, visitor Visitor, _ Locatio
 	visitor.VisitUInt32Value(interpreter, v)
 }
 
-func (UInt32Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (UInt32Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -71,7 +71,7 @@ func (v UInt64Value) Accept(interpreter *Interpreter, visitor Visitor, _ Locatio
 	visitor.VisitUInt64Value(interpreter, v)
 }
 
-func (UInt64Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (UInt64Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -64,7 +64,7 @@ func (v UInt8Value) Accept(interpreter *Interpreter, visitor Visitor, _ Location
 	visitor.VisitUInt8Value(interpreter, v)
 }
 
-func (UInt8Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (UInt8Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_void.go
+++ b/interpreter/value_void.go
@@ -43,7 +43,7 @@ func (v VoidValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationR
 	visitor.VisitVoidValue(interpreter, v)
 }
 
-func (VoidValue) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (VoidValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -80,7 +80,7 @@ func (v Word128Value) Accept(interpreter *Interpreter, visitor Visitor, _ Locati
 	visitor.VisitWord128Value(interpreter, v)
 }
 
-func (Word128Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (Word128Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -65,7 +65,7 @@ func (v Word16Value) Accept(interpreter *Interpreter, visitor Visitor, _ Locatio
 	visitor.VisitWord16Value(interpreter, v)
 }
 
-func (Word16Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (Word16Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -80,7 +80,7 @@ func (v Word256Value) Accept(interpreter *Interpreter, visitor Visitor, _ Locati
 	visitor.VisitWord256Value(interpreter, v)
 }
 
-func (Word256Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (Word256Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -65,7 +65,7 @@ func (v Word32Value) Accept(interpreter *Interpreter, visitor Visitor, _ Locatio
 	visitor.VisitWord32Value(interpreter, v)
 }
 
-func (Word32Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (Word32Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -73,7 +73,7 @@ func (v Word64Value) Accept(interpreter *Interpreter, visitor Visitor, _ Locatio
 	visitor.VisitWord64Value(interpreter, v)
 }
 
-func (Word64Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (Word64Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -64,7 +64,7 @@ func (v Word8Value) Accept(interpreter *Interpreter, visitor Visitor, _ Location
 	visitor.VisitWord8Value(interpreter, v)
 }
 
-func (Word8Value) Walk(_ *Interpreter, _ func(Value), _ LocationRange) {
+func (Word8Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
 	// NO-OP
 }
 

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -217,7 +217,7 @@ func (executor *interpreterContractFunctionExecutor) execute() (val cadence.Valu
 		return nil, newError(err, location, codesAndPrograms)
 	}
 
-	value, err := inter.InvokeFunction(contractFunction, invocation)
+	value, err := interpreter.InvokeFunction(inter, contractFunction, invocation)
 	if err != nil {
 		return nil, newError(err, location, codesAndPrograms)
 	}

--- a/runtime/convertValues.go
+++ b/runtime/convertValues.go
@@ -32,29 +32,13 @@ import (
 	"github.com/onflow/cadence/stdlib"
 )
 
-// exportValue converts a runtime value to its native Go representation.
-func exportValue(
-	value exportableValue,
-	locationRange interpreter.LocationRange,
-) (
-	cadence.Value,
-	error,
-) {
-	return exportValueWithInterpreter(
-		value.Value,
-		value.Interpreter(),
-		locationRange,
-		seenReferences{},
-	)
-}
-
 // ExportValue converts a runtime value to its native Go representation.
 func ExportValue(
 	value interpreter.Value,
 	inter *interpreter.Interpreter,
 	locationRange interpreter.LocationRange,
 ) (cadence.Value, error) {
-	return exportValueWithInterpreter(
+	return exportValue(
 		value,
 		inter,
 		locationRange,
@@ -66,14 +50,14 @@ func ExportValue(
 // as not all values are Go hashable, i.e. this might lead to run-time panics
 type seenReferences map[interpreter.ReferenceValue]struct{}
 
-// exportValueWithInterpreter exports the given internal (interpreter) value to an external value.
+// exportValue exports the given internal (interpreter) value to an external value.
 //
 // The export is recursive, the results parameter prevents cycles:
 // it is checked at the start of the recursively called function,
 // and pre-set before a recursive call.
-func exportValueWithInterpreter(
+func exportValue(
 	value interpreter.Value,
-	inter *interpreter.Interpreter,
+	context interpreter.ValueExportContext,
 	locationRange interpreter.LocationRange,
 	seenReferences seenReferences,
 ) (
@@ -83,16 +67,16 @@ func exportValueWithInterpreter(
 
 	switch v := value.(type) {
 	case interpreter.VoidValue:
-		return cadence.NewMeteredVoid(inter), nil
+		return cadence.NewMeteredVoid(context), nil
 	case interpreter.NilValue:
-		return cadence.NewMeteredOptional(inter, nil), nil
+		return cadence.NewMeteredOptional(context, nil), nil
 	case *interpreter.SomeValue:
-		return exportSomeValue(v, inter, locationRange, seenReferences)
+		return exportSomeValue(v, context, locationRange, seenReferences)
 	case interpreter.BoolValue:
-		return cadence.NewMeteredBool(inter, bool(v)), nil
+		return cadence.NewMeteredBool(context, bool(v)), nil
 	case *interpreter.StringValue:
 		return cadence.NewMeteredString(
-			inter,
+			context,
 			common.NewCadenceStringMemoryUsage(len(v.Str)),
 			func() string {
 				return v.Str
@@ -100,7 +84,7 @@ func exportValueWithInterpreter(
 		)
 	case interpreter.CharacterValue:
 		return cadence.NewMeteredCharacter(
-			inter,
+			context,
 			common.NewCadenceCharacterMemoryUsage(len(v.Str)),
 			func() string {
 				return v.Str
@@ -109,14 +93,14 @@ func exportValueWithInterpreter(
 	case *interpreter.ArrayValue:
 		return exportArrayValue(
 			v,
-			inter,
+			context,
 			locationRange,
 			seenReferences,
 		)
 	case interpreter.IntValue:
-		bigInt := v.ToBigInt(inter)
+		bigInt := v.ToBigInt(context)
 		return cadence.NewMeteredIntFromBig(
-			inter,
+			context,
 			common.NewCadenceIntMemoryUsage(
 				common.BigIntByteLength(bigInt),
 			),
@@ -125,31 +109,31 @@ func exportValueWithInterpreter(
 			},
 		), nil
 	case interpreter.Int8Value:
-		return cadence.NewMeteredInt8(inter, int8(v)), nil
+		return cadence.NewMeteredInt8(context, int8(v)), nil
 	case interpreter.Int16Value:
-		return cadence.NewMeteredInt16(inter, int16(v)), nil
+		return cadence.NewMeteredInt16(context, int16(v)), nil
 	case interpreter.Int32Value:
-		return cadence.NewMeteredInt32(inter, int32(v)), nil
+		return cadence.NewMeteredInt32(context, int32(v)), nil
 	case interpreter.Int64Value:
-		return cadence.NewMeteredInt64(inter, int64(v)), nil
+		return cadence.NewMeteredInt64(context, int64(v)), nil
 	case interpreter.Int128Value:
 		return cadence.NewMeteredInt128FromBig(
-			inter,
+			context,
 			func() *big.Int {
-				return v.ToBigInt(inter)
+				return v.ToBigInt(context)
 			},
 		)
 	case interpreter.Int256Value:
 		return cadence.NewMeteredInt256FromBig(
-			inter,
+			context,
 			func() *big.Int {
-				return v.ToBigInt(inter)
+				return v.ToBigInt(context)
 			},
 		)
 	case interpreter.UIntValue:
-		bigInt := v.ToBigInt(inter)
+		bigInt := v.ToBigInt(context)
 		return cadence.NewMeteredUIntFromBig(
-			inter,
+			context,
 			common.NewCadenceIntMemoryUsage(
 				common.BigIntByteLength(bigInt),
 			),
@@ -158,47 +142,47 @@ func exportValueWithInterpreter(
 			},
 		)
 	case interpreter.UInt8Value:
-		return cadence.NewMeteredUInt8(inter, uint8(v)), nil
+		return cadence.NewMeteredUInt8(context, uint8(v)), nil
 	case interpreter.UInt16Value:
-		return cadence.NewMeteredUInt16(inter, uint16(v)), nil
+		return cadence.NewMeteredUInt16(context, uint16(v)), nil
 	case interpreter.UInt32Value:
-		return cadence.NewMeteredUInt32(inter, uint32(v)), nil
+		return cadence.NewMeteredUInt32(context, uint32(v)), nil
 	case interpreter.UInt64Value:
-		return cadence.NewMeteredUInt64(inter, uint64(v)), nil
+		return cadence.NewMeteredUInt64(context, uint64(v)), nil
 	case interpreter.UInt128Value:
 		return cadence.NewMeteredUInt128FromBig(
-			inter,
+			context,
 			func() *big.Int {
-				return v.ToBigInt(inter)
+				return v.ToBigInt(context)
 			},
 		)
 	case interpreter.UInt256Value:
 		return cadence.NewMeteredUInt256FromBig(
-			inter,
+			context,
 			func() *big.Int {
-				return v.ToBigInt(inter)
+				return v.ToBigInt(context)
 			},
 		)
 	case interpreter.Word8Value:
-		return cadence.NewMeteredWord8(inter, uint8(v)), nil
+		return cadence.NewMeteredWord8(context, uint8(v)), nil
 	case interpreter.Word16Value:
-		return cadence.NewMeteredWord16(inter, uint16(v)), nil
+		return cadence.NewMeteredWord16(context, uint16(v)), nil
 	case interpreter.Word32Value:
-		return cadence.NewMeteredWord32(inter, uint32(v)), nil
+		return cadence.NewMeteredWord32(context, uint32(v)), nil
 	case interpreter.Word64Value:
-		return cadence.NewMeteredWord64(inter, uint64(v)), nil
+		return cadence.NewMeteredWord64(context, uint64(v)), nil
 	case interpreter.Word128Value:
 		return cadence.NewMeteredWord128FromBig(
-			inter,
+			context,
 			func() *big.Int {
-				return v.ToBigInt(inter)
+				return v.ToBigInt(context)
 			},
 		)
 	case interpreter.Word256Value:
 		return cadence.NewMeteredWord256FromBig(
-			inter,
+			context,
 			func() *big.Int {
-				return v.ToBigInt(inter)
+				return v.ToBigInt(context)
 			},
 		)
 	case interpreter.Fix64Value:
@@ -208,34 +192,34 @@ func exportValueWithInterpreter(
 	case *interpreter.CompositeValue:
 		return exportCompositeValue(
 			v,
-			inter,
+			context,
 			locationRange,
 			seenReferences,
 		)
 	case *interpreter.SimpleCompositeValue:
 		return exportCompositeValue(
 			v,
-			inter,
+			context,
 			locationRange,
 			seenReferences,
 		)
 	case *interpreter.DictionaryValue:
 		return exportDictionaryValue(
 			v,
-			inter,
+			context,
 			locationRange,
 			seenReferences,
 		)
 	case interpreter.AddressValue:
-		return cadence.NewMeteredAddress(inter, v), nil
+		return cadence.NewMeteredAddress(context, v), nil
 	case interpreter.PathValue:
-		return exportPathValue(inter, v)
+		return exportPathValue(context, v)
 	case interpreter.TypeValue:
-		return exportTypeValue(v, inter), nil
+		return exportTypeValue(v, context), nil
 	case *interpreter.IDCapabilityValue:
-		return exportCapabilityValue(v, inter)
+		return exportCapabilityValue(v, context)
 	case *interpreter.PathCapabilityValue: //nolint:staticcheck
-		return exportPathCapabilityValue(v, inter)
+		return exportPathCapabilityValue(v, context)
 	case *interpreter.EphemeralReferenceValue:
 		if v.Value == nil {
 			return nil, nil
@@ -248,9 +232,9 @@ func exportValueWithInterpreter(
 		defer delete(seenReferences, v)
 		seenReferences[v] = struct{}{}
 
-		return exportValueWithInterpreter(
+		return exportValue(
 			v.Value,
-			inter,
+			context,
 			locationRange,
 			seenReferences,
 		)
@@ -262,30 +246,30 @@ func exportValueWithInterpreter(
 		defer delete(seenReferences, v)
 		seenReferences[v] = struct{}{}
 
-		referencedValue := v.ReferencedValue(inter, interpreter.EmptyLocationRange, true)
+		referencedValue := v.ReferencedValue(context, interpreter.EmptyLocationRange, true)
 		if referencedValue == nil {
 			return nil, nil
 		}
 
-		return exportValueWithInterpreter(
+		return exportValue(
 			*referencedValue,
-			inter,
+			context,
 			locationRange,
 			seenReferences,
 		)
 	case interpreter.FunctionValue:
-		return exportFunctionValue(v, inter), nil
+		return exportFunctionValue(v, context), nil
 	case nil:
 		return nil, nil
 	}
 	return nil, &ValueNotExportableError{
-		Type: value.StaticType(inter),
+		Type: value.StaticType(context),
 	}
 }
 
 func exportSomeValue(
 	v *interpreter.SomeValue,
-	inter *interpreter.Interpreter,
+	context interpreter.ValueExportContext,
 	locationRange interpreter.LocationRange,
 	seenReferences seenReferences,
 ) (
@@ -295,12 +279,12 @@ func exportSomeValue(
 	innerValue := v.InnerValue()
 
 	if innerValue == nil {
-		return cadence.NewMeteredOptional(inter, nil), nil
+		return cadence.NewMeteredOptional(context, nil), nil
 	}
 
-	value, err := exportValueWithInterpreter(
+	value, err := exportValue(
 		innerValue,
-		inter,
+		context,
 		locationRange,
 		seenReferences,
 	)
@@ -308,12 +292,12 @@ func exportSomeValue(
 		return cadence.Optional{}, err
 	}
 
-	return cadence.NewMeteredOptional(inter, value), nil
+	return cadence.NewMeteredOptional(context, value), nil
 }
 
 func exportArrayValue(
 	v *interpreter.ArrayValue,
-	inter *interpreter.Interpreter,
+	context interpreter.ValueExportContext,
 	locationRange interpreter.LocationRange,
 	seenReferences seenReferences,
 ) (
@@ -321,19 +305,19 @@ func exportArrayValue(
 	error,
 ) {
 	array, err := cadence.NewMeteredArray(
-		inter,
+		context,
 		v.Count(),
 		func() ([]cadence.Value, error) {
 			values := make([]cadence.Value, 0, v.Count())
 
 			var err error
 			v.Iterate(
-				inter,
+				context,
 				func(value interpreter.Value) (resume bool) {
 					var exportedValue cadence.Value
-					exportedValue, err = exportValueWithInterpreter(
+					exportedValue, err = exportValue(
 						value,
-						inter,
+						context,
 						locationRange,
 						seenReferences,
 					)
@@ -360,14 +344,14 @@ func exportArrayValue(
 		return cadence.Array{}, err
 	}
 
-	exportType := ExportType(v.SemaType(inter), map[sema.TypeID]cadence.Type{}).(cadence.ArrayType)
+	exportType := ExportType(v.SemaType(context), map[sema.TypeID]cadence.Type{}).(cadence.ArrayType)
 
 	return array.WithType(exportType), err
 }
 
 func exportCompositeValue(
 	v interpreter.Value,
-	inter *interpreter.Interpreter,
+	context interpreter.CompositeValueExportContext,
 	locationRange interpreter.LocationRange,
 	seenReferences seenReferences,
 ) (
@@ -375,9 +359,9 @@ func exportCompositeValue(
 	error,
 ) {
 
-	staticType := v.StaticType(inter)
+	staticType := v.StaticType(context)
 
-	semaType, err := interpreter.ConvertStaticToSemaType(inter, staticType)
+	semaType, err := interpreter.ConvertStaticToSemaType(context, staticType)
 	if err != nil {
 		return nil, err
 	}
@@ -393,7 +377,7 @@ func exportCompositeValue(
 		// Continue.
 	case *sema.InclusiveRangeType:
 		// InclusiveRange is stored as a CompositeValue but isn't a CompositeType.
-		return exportCompositeValueAsInclusiveRange(v, semaType, inter, locationRange, seenReferences)
+		return exportCompositeValueAsInclusiveRange(v, semaType, context, locationRange, seenReferences)
 	default:
 		panic(errors.NewUnreachableError())
 	}
@@ -403,8 +387,8 @@ func exportCompositeValue(
 		panic(errors.NewUnreachableError())
 	}
 
-	// TODO: consider making the results map "global", by moving it up to exportValueWithInterpreter
-	t := exportCompositeType(inter, compositeType, map[sema.TypeID]cadence.Type{})
+	// TODO: consider making the results map "global", by moving it up to exportValue
+	t := exportCompositeType(context, compositeType, map[sema.TypeID]cadence.Type{})
 
 	// NOTE: use the exported type's fields to ensure fields in type
 	// and value are in sync
@@ -425,19 +409,19 @@ func exportCompositeValue(
 				computeField := v.ComputeField
 
 				if fieldValue == nil && computeField != nil {
-					fieldValue = computeField(fieldName, inter, locationRange)
+					fieldValue = computeField(fieldName, context, locationRange)
 				}
 
 			case *interpreter.CompositeValue:
-				fieldValue = v.GetField(inter, fieldName)
+				fieldValue = v.GetField(context, fieldName)
 				if fieldValue == nil {
-					fieldValue = v.GetComputedField(inter, locationRange, fieldName)
+					fieldValue = v.GetComputedField(context, locationRange, fieldName)
 				}
 			}
 
-			exportedFieldValue, err := exportValueWithInterpreter(
+			exportedFieldValue, err := exportValue(
 				fieldValue,
-				inter,
+				context,
 				locationRange,
 				seenReferences,
 			)
@@ -448,10 +432,10 @@ func exportCompositeValue(
 		}
 
 		if composite, ok := v.(*interpreter.CompositeValue); ok {
-			for _, attachment := range composite.GetAttachments(inter, locationRange) {
-				exportedAttachmentValue, err := exportValueWithInterpreter(
+			for _, attachment := range composite.GetAttachments(context, locationRange) {
+				exportedAttachmentValue, err := exportValue(
 					attachment,
-					inter,
+					context,
 					locationRange,
 					seenReferences,
 				)
@@ -473,7 +457,7 @@ func exportCompositeValue(
 	switch compositeKind {
 	case common.CompositeKindStructure:
 		structure, err := cadence.NewMeteredStruct(
-			inter,
+			context,
 			len(fields),
 			makeFieldsValues,
 		)
@@ -484,7 +468,7 @@ func exportCompositeValue(
 
 	case common.CompositeKindResource:
 		resource, err := cadence.NewMeteredResource(
-			inter,
+			context,
 			len(fields),
 			makeFieldsValues,
 		)
@@ -495,7 +479,7 @@ func exportCompositeValue(
 
 	case common.CompositeKindAttachment:
 		attachment, err := cadence.NewMeteredAttachment(
-			inter,
+			context,
 			len(fields),
 			makeFieldsValues,
 		)
@@ -506,7 +490,7 @@ func exportCompositeValue(
 
 	case common.CompositeKindEvent:
 		event, err := cadence.NewMeteredEvent(
-			inter,
+			context,
 			len(fields),
 			makeFieldsValues,
 		)
@@ -517,7 +501,7 @@ func exportCompositeValue(
 
 	case common.CompositeKindContract:
 		contract, err := cadence.NewMeteredContract(
-			inter,
+			context,
 			len(fields),
 			makeFieldsValues,
 		)
@@ -528,7 +512,7 @@ func exportCompositeValue(
 
 	case common.CompositeKindEnum:
 		enum, err := cadence.NewMeteredEnum(
-			inter,
+			context,
 			len(fields),
 			makeFieldsValues,
 		)
@@ -557,7 +541,7 @@ func exportCompositeValue(
 
 func exportDictionaryValue(
 	v *interpreter.DictionaryValue,
-	inter *interpreter.Interpreter,
+	context interpreter.ValueExportContext,
 	locationRange interpreter.LocationRange,
 	seenReferences seenReferences,
 ) (
@@ -565,21 +549,21 @@ func exportDictionaryValue(
 	error,
 ) {
 	dictionary, err := cadence.NewMeteredDictionary(
-		inter,
+		context,
 		v.Count(),
 		func() ([]cadence.KeyValuePair, error) {
 			var err error
 			pairs := make([]cadence.KeyValuePair, 0, v.Count())
 
 			v.Iterate(
-				inter,
+				context,
 				locationRange,
 				func(key, value interpreter.Value) (resume bool) {
 
 					var convertedKey cadence.Value
-					convertedKey, err = exportValueWithInterpreter(
+					convertedKey, err = exportValue(
 						key,
-						inter,
+						context,
 						locationRange,
 						seenReferences,
 					)
@@ -588,9 +572,9 @@ func exportDictionaryValue(
 					}
 
 					var convertedValue cadence.Value
-					convertedValue, err = exportValueWithInterpreter(
+					convertedValue, err = exportValue(
 						value,
-						inter,
+						context,
 						locationRange,
 						seenReferences,
 					)
@@ -621,7 +605,7 @@ func exportDictionaryValue(
 		return cadence.Dictionary{}, err
 	}
 
-	exportType := ExportType(v.SemaType(inter), map[sema.TypeID]cadence.Type{}).(*cadence.DictionaryType)
+	exportType := ExportType(v.SemaType(context), map[sema.TypeID]cadence.Type{}).(*cadence.DictionaryType)
 
 	return dictionary.WithType(exportType), err
 }
@@ -629,7 +613,7 @@ func exportDictionaryValue(
 func exportCompositeValueAsInclusiveRange(
 	v interpreter.Value,
 	inclusiveRangeType *sema.InclusiveRangeType,
-	inter *interpreter.Interpreter,
+	context interpreter.ValueExportContext,
 	locationRange interpreter.LocationRange,
 	seenReferences seenReferences,
 ) (
@@ -643,15 +627,15 @@ func exportCompositeValueAsInclusiveRange(
 	}
 
 	getNonComputedField := func(fieldName string) (cadence.Value, error) {
-		fieldValue := compositeValue.GetField(inter, fieldName)
+		fieldValue := compositeValue.GetField(context, fieldName)
 		if fieldValue == nil {
 			// Bug if the field is absent.
 			panic(errors.NewUnreachableError())
 		}
 
-		return exportValueWithInterpreter(
+		return exportValue(
 			fieldValue,
-			inter,
+			context,
 			locationRange,
 			seenReferences,
 		)
@@ -673,13 +657,13 @@ func exportCompositeValueAsInclusiveRange(
 	}
 
 	inclusiveRange := cadence.NewMeteredInclusiveRange(
-		inter,
+		context,
 		startValue,
 		endValue,
 		stepValue,
 	)
 
-	t := exportInclusiveRangeType(inter, inclusiveRangeType, map[sema.TypeID]cadence.Type{})
+	t := exportInclusiveRangeType(context, inclusiveRangeType, map[sema.TypeID]cadence.Type{})
 	return inclusiveRange.WithType(t), err
 }
 
@@ -691,51 +675,51 @@ func exportPathValue(gauge common.MemoryGauge, v interpreter.PathValue) (cadence
 	)
 }
 
-func exportTypeValue(v interpreter.TypeValue, inter *interpreter.Interpreter) cadence.TypeValue {
+func exportTypeValue(v interpreter.TypeValue, converter interpreter.TypeConverter) cadence.TypeValue {
 	var typ sema.Type
 	if v.Type != nil {
-		typ = interpreter.MustConvertStaticToSemaType(v.Type, inter)
+		typ = interpreter.MustConvertStaticToSemaType(v.Type, converter)
 	}
 	return cadence.NewMeteredTypeValue(
-		inter,
-		ExportMeteredType(inter, typ, map[sema.TypeID]cadence.Type{}),
+		converter,
+		ExportMeteredType(converter, typ, map[sema.TypeID]cadence.Type{}),
 	)
 }
 
 func exportCapabilityValue(
 	v *interpreter.IDCapabilityValue,
-	inter *interpreter.Interpreter,
+	typeConverter interpreter.TypeConverter,
 ) (cadence.Capability, error) {
-	borrowType := interpreter.MustConvertStaticToSemaType(v.BorrowType, inter)
-	exportedBorrowType := ExportMeteredType(inter, borrowType, map[sema.TypeID]cadence.Type{})
+	borrowType := interpreter.MustConvertStaticToSemaType(v.BorrowType, typeConverter)
+	exportedBorrowType := ExportMeteredType(typeConverter, borrowType, map[sema.TypeID]cadence.Type{})
 
 	return cadence.NewMeteredCapability(
-		inter,
-		cadence.NewMeteredUInt64(inter, uint64(v.ID)),
-		cadence.NewMeteredAddress(inter, v.Address()),
+		typeConverter,
+		cadence.NewMeteredUInt64(typeConverter, uint64(v.ID)),
+		cadence.NewMeteredAddress(typeConverter, v.Address()),
 		exportedBorrowType,
 	), nil
 }
 
 func exportPathCapabilityValue(
 	v *interpreter.PathCapabilityValue, //nolint:staticcheck
-	inter *interpreter.Interpreter,
+	typeConverter interpreter.TypeConverter,
 ) (cadence.Capability, error) {
 	var exportedBorrowType cadence.Type
 
 	if v.BorrowType != nil {
-		borrowType := interpreter.MustConvertStaticToSemaType(v.BorrowType, inter)
-		exportedBorrowType = ExportMeteredType(inter, borrowType, map[sema.TypeID]cadence.Type{})
+		borrowType := interpreter.MustConvertStaticToSemaType(v.BorrowType, typeConverter)
+		exportedBorrowType = ExportMeteredType(typeConverter, borrowType, map[sema.TypeID]cadence.Type{})
 	}
 
 	capability := cadence.NewMeteredCapability(
-		inter,
-		cadence.NewMeteredUInt64(inter, uint64(interpreter.InvalidCapabilityID)),
-		cadence.NewMeteredAddress(inter, v.Address()),
+		typeConverter,
+		cadence.NewMeteredUInt64(typeConverter, uint64(interpreter.InvalidCapabilityID)),
+		cadence.NewMeteredAddress(typeConverter, v.Address()),
 		exportedBorrowType,
 	)
 
-	path, err := exportPathValue(inter, v.Path)
+	path, err := exportPathValue(typeConverter, v.Path)
 	if err != nil {
 		return cadence.Capability{}, err
 	}
@@ -746,7 +730,7 @@ func exportPathCapabilityValue(
 
 // exportEvent converts a runtime event to its native Go representation.
 func exportEvent(
-	gauge common.MemoryGauge,
+	context interpreter.ValueExportContext,
 	event exportableEvent,
 	locationRange interpreter.LocationRange,
 	seenReferences seenReferences,
@@ -755,15 +739,15 @@ func exportEvent(
 	error,
 ) {
 	exported, err := cadence.NewMeteredEvent(
-		gauge,
+		context,
 		len(event.Fields),
 		func() ([]cadence.Value, error) {
 			fields := make([]cadence.Value, len(event.Fields))
 
 			for i, field := range event.Fields {
-				value, err := exportValueWithInterpreter(
-					field.Value,
-					field.Interpreter(),
+				value, err := exportValue(
+					field,
+					context,
 					locationRange,
 					seenReferences,
 				)
@@ -781,18 +765,18 @@ func exportEvent(
 		return cadence.Event{}, err
 	}
 
-	eventType := ExportMeteredType(gauge, event.Type, map[sema.TypeID]cadence.Type{}).(*cadence.EventType)
+	eventType := ExportMeteredType(context, event.Type, map[sema.TypeID]cadence.Type{}).(*cadence.EventType)
 
 	return exported.WithType(eventType), nil
 }
 
 func exportFunctionValue(
 	v interpreter.FunctionValue,
-	inter *interpreter.Interpreter,
+	gauge common.MemoryGauge,
 ) cadence.Function {
 	return cadence.NewMeteredFunction(
-		inter,
-		ExportMeteredType(inter, v.FunctionType(), map[sema.TypeID]cadence.Type{}).(*cadence.FunctionType),
+		gauge,
+		ExportMeteredType(gauge, v.FunctionType(), map[sema.TypeID]cadence.Type{}).(*cadence.FunctionType),
 	)
 }
 

--- a/runtime/empty.go
+++ b/runtime/empty.go
@@ -241,7 +241,7 @@ func (EmptyRuntimeInterface) RecoverProgram(_ *ast.Program, _ common.Location) (
 }
 
 func (EmptyRuntimeInterface) ValidateAccountCapabilitiesGet(
-	_ *interpreter.Interpreter,
+	_ interpreter.AccountCapabilityGetValidationContext,
 	_ interpreter.LocationRange,
 	_ interpreter.AddressValue,
 	_ interpreter.PathValue,
@@ -252,7 +252,7 @@ func (EmptyRuntimeInterface) ValidateAccountCapabilitiesGet(
 }
 
 func (EmptyRuntimeInterface) ValidateAccountCapabilitiesPublish(
-	_ *interpreter.Interpreter,
+	_ interpreter.AccountCapabilityPublishValidationContext,
 	_ interpreter.LocationRange,
 	_ interpreter.AddressValue,
 	_ interpreter.PathValue,

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -1329,7 +1329,7 @@ func (e *interpreterEnvironment) getBaseActivation(
 func (e *interpreterEnvironment) newCapabilityBorrowHandler() interpreter.CapabilityBorrowHandlerFunc {
 
 	return func(
-		inter *interpreter.Interpreter,
+		context interpreter.BorrowCapabilityControllerContext,
 		locationRange interpreter.LocationRange,
 		address interpreter.AddressValue,
 		capabilityID interpreter.UInt64Value,
@@ -1338,7 +1338,7 @@ func (e *interpreterEnvironment) newCapabilityBorrowHandler() interpreter.Capabi
 	) interpreter.ReferenceValue {
 
 		return stdlib.BorrowCapabilityController(
-			inter,
+			context,
 			locationRange,
 			address,
 			capabilityID,
@@ -1373,7 +1373,7 @@ func (e *interpreterEnvironment) newCapabilityCheckHandler() interpreter.Capabil
 
 func (e *interpreterEnvironment) newValidateAccountCapabilitiesGetHandler() interpreter.ValidateAccountCapabilitiesGetHandlerFunc {
 	return func(
-		context interpreter.AccountCapabilityValidationContext,
+		context interpreter.AccountCapabilityGetValidationContext,
 		locationRange interpreter.LocationRange,
 		address interpreter.AddressValue,
 		path interpreter.PathValue,
@@ -1403,7 +1403,7 @@ func (e *interpreterEnvironment) newValidateAccountCapabilitiesGetHandler() inte
 
 func (e *interpreterEnvironment) newValidateAccountCapabilitiesPublishHandler() interpreter.ValidateAccountCapabilitiesPublishHandlerFunc {
 	return func(
-		inter *interpreter.Interpreter,
+		context interpreter.AccountCapabilityPublishValidationContext,
 		locationRange interpreter.LocationRange,
 		address interpreter.AddressValue,
 		path interpreter.PathValue,
@@ -1415,7 +1415,7 @@ func (e *interpreterEnvironment) newValidateAccountCapabilitiesPublishHandler() 
 		)
 		errors.WrapPanic(func() {
 			ok, err = e.runtimeInterface.ValidateAccountCapabilitiesPublish(
-				inter,
+				context,
 				locationRange,
 				address,
 				path,

--- a/runtime/events.go
+++ b/runtime/events.go
@@ -67,14 +67,9 @@ func EmitEventFields(
 		))
 	}
 
-	exportableEventFields := make([]exportableValue, len(eventFields))
-	for i, field := range eventFields {
-		exportableEventFields[i] = newExportableValue(field, inter)
-	}
-
 	eventValue := exportableEvent{
 		Type:   eventType,
-		Fields: exportableEventFields,
+		Fields: eventFields,
 	}
 
 	exportedEvent, err := exportEvent(

--- a/runtime/events.go
+++ b/runtime/events.go
@@ -49,7 +49,7 @@ func emitEventValue(
 }
 
 func EmitEventFields(
-	inter *interpreter.Interpreter,
+	context interpreter.ValueExportContext,
 	locationRange interpreter.LocationRange,
 	eventType *sema.CompositeType,
 	eventFields []interpreter.Value,
@@ -73,7 +73,7 @@ func EmitEventFields(
 	}
 
 	exportedEvent, err := exportEvent(
-		inter,
+		context,
 		eventValue,
 		locationRange,
 		seenReferences{},

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -147,7 +147,7 @@ type Interface interface {
 	GenerateAccountID(address common.Address) (uint64, error)
 	RecoverProgram(program *ast.Program, location common.Location) ([]byte, error)
 	ValidateAccountCapabilitiesGet(
-		inter *interpreter.Interpreter,
+		context interpreter.AccountCapabilityValidationContext,
 		locationRange interpreter.LocationRange,
 		address interpreter.AddressValue,
 		path interpreter.PathValue,

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -147,7 +147,7 @@ type Interface interface {
 	GenerateAccountID(address common.Address) (uint64, error)
 	RecoverProgram(program *ast.Program, location common.Location) ([]byte, error)
 	ValidateAccountCapabilitiesGet(
-		context interpreter.AccountCapabilityValidationContext,
+		context interpreter.AccountCapabilityGetValidationContext,
 		locationRange interpreter.LocationRange,
 		address interpreter.AddressValue,
 		path interpreter.PathValue,
@@ -155,7 +155,7 @@ type Interface interface {
 		capabilityBorrowType *sema.ReferenceType,
 	) (bool, error)
 	ValidateAccountCapabilitiesPublish(
-		inter *interpreter.Interpreter,
+		context interpreter.AccountCapabilityPublishValidationContext,
 		locationRange interpreter.LocationRange,
 		address interpreter.AddressValue,
 		path interpreter.PathValue,

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -658,7 +658,7 @@ func TestRuntimePredeclaredTypeWithInjectedFunctions(t *testing.T) {
 			xConstructorType,
 			func(invocation interpreter.Invocation) interpreter.Value {
 				return interpreter.NewCompositeValue(
-					invocation.Interpreter,
+					invocation.InvocationContext,
 					invocation.LocationRange,
 					xType.Location,
 					xType.QualifiedIdentifier(),

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -202,9 +202,9 @@ func (executor *interpreterScriptExecutor) execute() (val cadence.Value, err err
 
 	// Export before committing storage
 
-	exportableValue := newExportableValue(value, inter)
-	result, err := exportValue(
-		exportableValue,
+	result, err := ExportValue(
+		value,
+		inter,
 		interpreter.EmptyLocationRange,
 	)
 	if err != nil {

--- a/runtime/value.go
+++ b/runtime/value.go
@@ -46,7 +46,7 @@ func (v exportableValue) Interpreter() *interpreter.Interpreter {
 
 type exportableEvent struct {
 	Type   sema.Type
-	Fields []exportableValue
+	Fields []interpreter.Value
 }
 
 type Address = common.Address

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -122,7 +122,7 @@ func NewAccountConstructor(creator AccountCreator) StandardLibraryValue {
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			interpreter.ExpectType(
@@ -230,7 +230,7 @@ func NewGetAuthAccountFunction(handler AccountHandler) StandardLibraryValue {
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			typeParameterPair := invocation.TypeParameterTypes.Oldest()
@@ -616,7 +616,7 @@ func newAccountKeysAddFunction(
 					panic(errors.NewUnreachableError())
 				}
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				publicKey, err := NewPublicKeyFromValue(inter, locationRange, publicKeyValue)
@@ -724,7 +724,7 @@ func newAccountKeysGetFunction(
 					return interpreter.Nil
 				}
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 
 				return interpreter.NewSomeValueNonCopying(
 					inter,
@@ -768,7 +768,7 @@ func newAccountKeysForEachFunction(
 					panic(errors.NewUnreachableError())
 				}
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				liftKeyToValue := func(key *AccountKey) interpreter.Value {
@@ -913,7 +913,7 @@ func newAccountKeysRevokeFunction(
 					return interpreter.Nil
 				}
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 
 				handler.EmitEvent(
 					inter,
@@ -966,7 +966,7 @@ func newAccountInboxPublishFunction(
 					panic(errors.NewUnreachableError())
 				}
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				handler.EmitEvent(
@@ -1023,7 +1023,7 @@ func newAccountInboxUnpublishFunction(
 					panic(errors.NewUnreachableError())
 				}
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				storageMapKey := interpreter.StringStorageMapKey(nameValue.Str)
@@ -1043,7 +1043,7 @@ func newAccountInboxUnpublishFunction(
 				}
 
 				ty := sema.NewCapabilityType(inter, typeParameterPair.Value)
-				publishedType := publishedValue.Value.StaticType(invocation.Interpreter)
+				publishedType := publishedValue.Value.StaticType(invocation.InvocationContext)
 				if !interpreter.IsSubTypeOfSemaType(inter, publishedType, ty) {
 					panic(interpreter.ForceCastTypeMismatchError{
 						ExpectedType:  ty,
@@ -1106,7 +1106,7 @@ func newAccountInboxClaimFunction(
 					panic(errors.NewUnreachableError())
 				}
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				providerAddress := providerValue.ToAddress()
@@ -1133,7 +1133,7 @@ func newAccountInboxClaimFunction(
 				}
 
 				ty := sema.NewCapabilityType(inter, typeParameterPair.Value)
-				publishedType := publishedValue.Value.StaticType(invocation.Interpreter)
+				publishedType := publishedValue.Value.StaticType(invocation.InvocationContext)
 				if !interpreter.IsSubTypeOfSemaType(inter, publishedType, ty) {
 					panic(interpreter.ForceCastTypeMismatchError{
 						ExpectedType:  ty,
@@ -1275,7 +1275,7 @@ func newAccountContractsGetFunction(
 					panic(errors.NewUnreachableError())
 				}
 				name := nameValue.Str
-				location := common.NewAddressLocation(invocation.Interpreter, address, name)
+				location := common.NewAddressLocation(invocation.InvocationContext, address, name)
 
 				var code []byte
 				var err error
@@ -1288,13 +1288,13 @@ func newAccountContractsGetFunction(
 
 				if len(code) > 0 {
 					return interpreter.NewSomeValueNonCopying(
-						invocation.Interpreter,
+						invocation.InvocationContext,
 						interpreter.NewDeployedContractValue(
-							invocation.Interpreter,
+							invocation.InvocationContext,
 							addressValue,
 							nameValue,
 							interpreter.ByteSliceToByteArrayValue(
-								invocation.Interpreter,
+								invocation.InvocationContext,
 								code,
 							),
 						),
@@ -1324,7 +1324,7 @@ func newAccountContractsBorrowFunction(
 			functionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				nameValue, ok := invocation.Arguments[0].(*interpreter.StringValue)
@@ -1332,7 +1332,7 @@ func newAccountContractsBorrowFunction(
 					panic(errors.NewUnreachableError())
 				}
 				name := nameValue.Str
-				location := common.NewAddressLocation(invocation.Interpreter, address, name)
+				location := common.NewAddressLocation(invocation.InvocationContext, address, name)
 
 				typeParameterPair := invocation.TypeParameterTypes.Oldest()
 				if typeParameterPair == nil {
@@ -1514,7 +1514,7 @@ func changeAccountContracts(
 	constructorArguments := invocation.Arguments[requiredArgumentCount:]
 	constructorArgumentTypes := invocation.ArgumentTypes[requiredArgumentCount:]
 
-	newCode, err := interpreter.ByteArrayValueToByteSlice(invocation.Interpreter, newCodeValue, locationRange)
+	newCode, err := interpreter.ByteArrayValueToByteSlice(invocation.InvocationContext, newCodeValue, locationRange)
 	if err != nil {
 		panic(errors.NewDefaultUserError("add requires the second argument to be an array"))
 	}
@@ -1531,7 +1531,7 @@ func changeAccountContracts(
 	}
 
 	address := addressValue.ToAddress()
-	location := common.NewAddressLocation(invocation.Interpreter, address, contractName)
+	location := common.NewAddressLocation(invocation.InvocationContext, address, contractName)
 
 	existingCode, err := handler.GetAccountContractCode(location)
 	if err != nil {
@@ -1669,14 +1669,14 @@ func changeAccountContracts(
 
 	// Validate the contract update
 
-	inter := invocation.Interpreter
+	inter := invocation.InvocationContext
 
 	if isUpdate {
 		oldCode, err := handler.GetAccountContractCode(location)
 		handleContractUpdateError(err, newCode)
 
-		memoryGauge := invocation.Interpreter.SharedState.Config.MemoryGauge
-		legacyUpgradeEnabled := invocation.Interpreter.SharedState.Config.LegacyContractUpgradeEnabled
+		memoryGauge := invocation.InvocationContext.SharedState.Config.MemoryGauge
+		legacyUpgradeEnabled := invocation.InvocationContext.SharedState.Config.LegacyContractUpgradeEnabled
 
 		var oldProgram *ast.Program
 
@@ -1820,7 +1820,7 @@ func newAccountContractsTryUpdateFunction(
 					if deployedContract == nil {
 						optionalDeployedContract = interpreter.NilOptionalValue
 					} else {
-						optionalDeployedContract = interpreter.NewSomeValueNonCopying(invocation.Interpreter, deployedContract)
+						optionalDeployedContract = interpreter.NewSomeValueNonCopying(invocation.InvocationContext, deployedContract)
 					}
 
 					deploymentResult = interpreter.NewDeploymentResultValue(context, optionalDeployedContract)
@@ -2100,13 +2100,13 @@ func newAccountContractsRemoveFunction(
 			sema.Account_ContractsTypeRemoveFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				nameValue, ok := invocation.Arguments[0].(*interpreter.StringValue)
 				if !ok {
 					panic(errors.NewUnreachableError())
 				}
 				name := nameValue.Str
-				location := common.NewAddressLocation(invocation.Interpreter, address, name)
+				location := common.NewAddressLocation(invocation.InvocationContext, address, name)
 
 				// Get the current code
 
@@ -2222,7 +2222,7 @@ func NewGetAccountFunction(handler AccountHandler) StandardLibraryValue {
 		getAccountFunctionDocString,
 		func(invocation interpreter.Invocation) interpreter.Value {
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			accountAddress, ok := invocation.Arguments[0].(interpreter.AddressValue)
@@ -2377,7 +2377,7 @@ func newAccountStorageCapabilitiesGetControllerFunction(
 			sema.Account_StorageCapabilitiesTypeGetControllerFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				// Get capability ID argument
@@ -2426,7 +2426,7 @@ func newAccountStorageCapabilitiesGetControllersFunction(
 			sema.Account_StorageCapabilitiesTypeGetControllersFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				// Get path argument
@@ -2501,7 +2501,7 @@ func newAccountStorageCapabilitiesForEachControllerFunction(
 			sema.Account_StorageCapabilitiesTypeForEachControllerFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				// Get path argument
@@ -2616,7 +2616,7 @@ func newAccountStorageCapabilitiesIssueFunction(
 			sema.Account_StorageCapabilitiesTypeIssueFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				// Get path argument
@@ -2659,7 +2659,7 @@ func newAccountStorageCapabilitiesIssueWithTypeFunction(
 			sema.Account_StorageCapabilitiesTypeIssueFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				// Get path argument
@@ -2813,7 +2813,7 @@ func newAccountAccountCapabilitiesIssueFunction(
 			sema.Account_AccountCapabilitiesTypeIssueFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				// Get borrow type type argument
@@ -2848,7 +2848,7 @@ func newAccountAccountCapabilitiesIssueWithTypeFunction(
 			sema.Account_AccountCapabilitiesTypeIssueFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				// Get type argument
@@ -3496,7 +3496,7 @@ func newAccountCapabilitiesPublishFunction(
 			accountCapabilities,
 			sema.Account_CapabilitiesTypePublishFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				// Get capability argument
@@ -3632,7 +3632,7 @@ func newAccountCapabilitiesUnpublishFunction(
 			sema.Account_CapabilitiesTypeUnpublishFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				// Get path argument
@@ -3906,7 +3906,7 @@ func newAccountCapabilitiesGetFunction(
 			funcType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				// Get path argument
@@ -4092,7 +4092,7 @@ func newAccountCapabilitiesExistsFunction(
 			sema.Account_CapabilitiesTypeExistsFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 
 				// Get path argument
 
@@ -4161,7 +4161,7 @@ func newAccountAccountCapabilitiesGetControllerFunction(
 			sema.Account_AccountCapabilitiesTypeGetControllerFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				// Get capability ID argument
@@ -4210,7 +4210,7 @@ func newAccountAccountCapabilitiesGetControllersFunction(
 			sema.Account_AccountCapabilitiesTypeGetControllersFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				// Get capability controllers iterator
@@ -4291,7 +4291,7 @@ func newAccountAccountCapabilitiesForEachControllerFunction(
 			sema.Account_AccountCapabilitiesTypeForEachControllerFunctionType,
 			func(_ interpreter.MemberAccessibleValue, invocation interpreter.Invocation) interpreter.Value {
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				// Get function argument

--- a/stdlib/block.go
+++ b/stdlib/block.go
@@ -112,14 +112,14 @@ var blockIDMemoryUsage = common.NewNumberMemoryUsage(
 )
 
 func NewBlockValue(
-	inter *interpreter.Interpreter,
+	context interpreter.ArrayCreationContext,
 	locationRange interpreter.LocationRange,
 	block Block,
 ) interpreter.Value {
 
 	// height
 	heightValue := interpreter.NewUInt64Value(
-		inter,
+		context,
 		func() uint64 {
 			return block.Height
 		},
@@ -127,21 +127,21 @@ func NewBlockValue(
 
 	// view
 	viewValue := interpreter.NewUInt64Value(
-		inter,
+		context,
 		func() uint64 {
 			return block.View
 		},
 	)
 
 	// ID
-	common.UseMemory(inter, blockIDMemoryUsage)
+	common.UseMemory(context, blockIDMemoryUsage)
 	var values = make([]interpreter.Value, sema.BlockTypeIdFieldType.Size)
 	for i, b := range block.Hash {
 		values[i] = interpreter.NewUnmeteredUInt8Value(b)
 	}
 
 	idValue := interpreter.NewArrayValue(
-		inter,
+		context,
 		locationRange,
 		BlockIDStaticType,
 		common.ZeroAddress,
@@ -151,7 +151,7 @@ func NewBlockValue(
 	// timestamp
 	// TODO: verify
 	timestampValue := interpreter.NewUFix64ValueWithInteger(
-		inter,
+		context,
 		func() uint64 {
 			return uint64(time.Unix(0, block.Timestamp).Unix())
 		},
@@ -159,7 +159,7 @@ func NewBlockValue(
 	)
 
 	return interpreter.NewBlockValue(
-		inter,
+		context,
 		heightValue,
 		viewValue,
 		idValue,

--- a/stdlib/block.go
+++ b/stdlib/block.go
@@ -85,7 +85,7 @@ func NewGetBlockFunction(provider BlockAtHeightProvider) StandardLibraryValue {
 				panic(errors.NewUnreachableError())
 			}
 
-			memoryGauge := invocation.Interpreter
+			memoryGauge := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			block, exists := getBlockAtHeight(
@@ -215,7 +215,7 @@ func NewGetCurrentBlockFunction(provider CurrentBlockProvider) StandardLibraryVa
 				panic(errors.NewUnexpectedError("cannot get current block"))
 			}
 
-			memoryGauge := invocation.Interpreter
+			memoryGauge := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			return NewBlockValue(memoryGauge, locationRange, block)

--- a/stdlib/bls.go
+++ b/stdlib/bls.go
@@ -49,7 +49,7 @@ func newBLSAggregatePublicKeysFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			interpreter.ExpectType(
@@ -127,7 +127,7 @@ func newBLSAggregateSignaturesFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			interpreter.ExpectType(

--- a/stdlib/hashalgorithm.go
+++ b/stdlib/hashalgorithm.go
@@ -81,12 +81,12 @@ func newHashAlgorithmHashFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.InvocationContext
+			context := invocation.InvocationContext
 
 			locationRange := invocation.LocationRange
 
 			return hash(
-				inter,
+				context,
 				locationRange,
 				hasher,
 				dataValue,
@@ -134,14 +134,14 @@ func newHashAlgorithmHashWithTagFunction(
 }
 
 func hash(
-	inter *interpreter.Interpreter,
+	context interpreter.MemberAccessibleContext,
 	locationRange interpreter.LocationRange,
 	hasher Hasher,
 	dataValue *interpreter.ArrayValue,
 	tagValue *interpreter.StringValue,
 	hashAlgorithmValue interpreter.MemberAccessibleValue,
 ) interpreter.Value {
-	data, err := interpreter.ByteArrayValueToByteSlice(inter, dataValue, locationRange)
+	data, err := interpreter.ByteArrayValueToByteSlice(context, dataValue, locationRange)
 	if err != nil {
 		panic(errors.NewUnexpectedError("failed to get data. %w", err))
 	}
@@ -151,7 +151,7 @@ func hash(
 		tag = tagValue.Str
 	}
 
-	hashAlgorithm := NewHashAlgorithmFromValue(inter, locationRange, hashAlgorithmValue)
+	hashAlgorithm := NewHashAlgorithmFromValue(context, locationRange, hashAlgorithmValue)
 
 	var result []byte
 	errors.WrapPanic(func() {
@@ -160,7 +160,7 @@ func hash(
 	if err != nil {
 		panic(interpreter.WrappedExternalError(err))
 	}
-	return interpreter.ByteSliceToByteArrayValue(inter, result)
+	return interpreter.ByteSliceToByteArrayValue(context, result)
 }
 
 func NewHashAlgorithmConstructor(hasher Hasher) StandardLibraryValue {

--- a/stdlib/hashalgorithm.go
+++ b/stdlib/hashalgorithm.go
@@ -81,7 +81,7 @@ func newHashAlgorithmHashFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			locationRange := invocation.LocationRange
 
@@ -117,7 +117,7 @@ func newHashAlgorithmHashWithTagFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			locationRange := invocation.LocationRange
 

--- a/stdlib/log.go
+++ b/stdlib/log.go
@@ -54,7 +54,7 @@ func NewLogFunction(logger Logger) StandardLibraryValue {
 			value := invocation.Arguments[0]
 			locationRange := invocation.LocationRange
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 			message := value.MeteredString(inter, interpreter.SeenReferences{}, locationRange)
 
 			var err error

--- a/stdlib/publickey.go
+++ b/stdlib/publickey.go
@@ -94,7 +94,7 @@ func NewPublicKeyConstructor(
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			return NewPublicKeyFromFields(
@@ -240,7 +240,7 @@ func newPublicKeyVerifySignatureFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			locationRange := invocation.LocationRange
 
@@ -311,7 +311,7 @@ func newPublicKeyVerifyPoPFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			locationRange := invocation.LocationRange
 

--- a/stdlib/publickey.go
+++ b/stdlib/publickey.go
@@ -94,11 +94,11 @@ func NewPublicKeyConstructor(
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.InvocationContext
+			context := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			return NewPublicKeyFromFields(
-				inter,
+				context,
 				locationRange,
 				publicKey,
 				signAlgo,
@@ -109,14 +109,14 @@ func NewPublicKeyConstructor(
 }
 
 func NewPublicKeyFromFields(
-	inter *interpreter.Interpreter,
+	context interpreter.PublicKeyCreationContext,
 	locationRange interpreter.LocationRange,
 	publicKey *interpreter.ArrayValue,
 	signAlgo *interpreter.SimpleCompositeValue,
 	publicKeyValidator PublicKeyValidator,
 ) *interpreter.CompositeValue {
 	return interpreter.NewPublicKeyValue(
-		inter,
+		context,
 		locationRange,
 		publicKey,
 		signAlgo,

--- a/stdlib/publickey.go
+++ b/stdlib/publickey.go
@@ -56,11 +56,11 @@ type PublicKeyValidator interface {
 
 func newPublicKeyValidationHandler(validator PublicKeyValidator) interpreter.PublicKeyValidationHandlerFunc {
 	return func(
-		inter *interpreter.Interpreter,
+		context interpreter.PublicKeyValidationContext,
 		locationRange interpreter.LocationRange,
 		publicKeyValue *interpreter.CompositeValue,
 	) error {
-		publicKey, err := NewPublicKeyFromValue(inter, locationRange, publicKeyValue)
+		publicKey, err := NewPublicKeyFromValue(context, locationRange, publicKeyValue)
 		if err != nil {
 			return err
 		}
@@ -124,20 +124,20 @@ func NewPublicKeyFromFields(
 	)
 }
 
-func assumePublicKeyIsValid(_ *interpreter.Interpreter, _ interpreter.LocationRange, _ *interpreter.CompositeValue) error {
+func assumePublicKeyIsValid(_ interpreter.PublicKeyValidationContext, _ interpreter.LocationRange, _ *interpreter.CompositeValue) error {
 	return nil
 }
 
 func NewPublicKeyValue(
-	inter *interpreter.Interpreter,
+	context interpreter.PublicKeyCreationContext,
 	locationRange interpreter.LocationRange,
 	publicKey *PublicKey,
 ) *interpreter.CompositeValue {
 	return interpreter.NewPublicKeyValue(
-		inter,
+		context,
 		locationRange,
 		interpreter.ByteSliceToByteArrayValue(
-			inter,
+			context,
 			publicKey.PublicKey,
 		),
 		NewSignatureAlgorithmCase(
@@ -149,7 +149,7 @@ func NewPublicKeyValue(
 }
 
 func NewPublicKeyFromValue(
-	inter *interpreter.Interpreter,
+	context interpreter.PublicKeyCreationContext,
 	locationRange interpreter.LocationRange,
 	publicKey interpreter.MemberAccessibleValue,
 ) (
@@ -157,15 +157,15 @@ func NewPublicKeyFromValue(
 	error,
 ) {
 	// publicKey field
-	key := publicKey.GetMember(inter, locationRange, sema.PublicKeyTypePublicKeyFieldName)
+	key := publicKey.GetMember(context, locationRange, sema.PublicKeyTypePublicKeyFieldName)
 
-	byteArray, err := interpreter.ByteArrayValueToByteSlice(inter, key, locationRange)
+	byteArray, err := interpreter.ByteArrayValueToByteSlice(context, key, locationRange)
 	if err != nil {
 		return nil, errors.NewUnexpectedError("public key needs to be a byte array. %w", err)
 	}
 
 	// sign algo field
-	signAlgoField := publicKey.GetMember(inter, locationRange, sema.PublicKeyTypeSignAlgoFieldName)
+	signAlgoField := publicKey.GetMember(context, locationRange, sema.PublicKeyTypeSignAlgoFieldName)
 	if signAlgoField == nil {
 		return nil, errors.NewUnexpectedError("sign algorithm is not set")
 	}
@@ -178,7 +178,7 @@ func NewPublicKeyFromValue(
 		)
 	}
 
-	rawValue := signAlgoValue.GetMember(inter, locationRange, sema.EnumRawValueFieldName)
+	rawValue := signAlgoValue.GetMember(context, locationRange, sema.EnumRawValueFieldName)
 	if rawValue == nil {
 		return nil, errors.NewDefaultUserError("sign algorithm raw value is not set")
 	}

--- a/stdlib/random.go
+++ b/stdlib/random.go
@@ -115,7 +115,7 @@ func NewRevertibleRandomFunction(generator RandomGenerator) StandardLibraryValue
 		revertibleRandomFunctionType,
 		revertibleRandomFunctionDocString,
 		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			returnIntegerType := invocation.TypeParameterTypes.Oldest().Value
 

--- a/stdlib/random_test.go
+++ b/stdlib/random_test.go
@@ -72,7 +72,8 @@ func TestRandomBasicUniformityWithModulo(t *testing.T) {
 			// make sure modulo fits in 8 bits
 			require.Less(t, modulo, 1<<8)
 
-			moduloValue := inter.ConvertAndBox(
+			moduloValue := interpreter.ConvertAndBox(
+				inter,
 				interpreter.EmptyLocationRange,
 				interpreter.NewUnmeteredUIntValueFromUint64(uint64(modulo)),
 				sema.UIntType,

--- a/stdlib/range.go
+++ b/stdlib/range.go
@@ -126,11 +126,11 @@ var InclusiveRangeConstructorFunction = NewStandardLibraryStaticFunction(
 			panic(errors.NewUnreachableError())
 		}
 
-		inter := invocation.InvocationContext
+		invocationContext := invocation.InvocationContext
 		locationRange := invocation.LocationRange
 
-		startStaticType := start.StaticType(inter)
-		endStaticType := end.StaticType(inter)
+		startStaticType := start.StaticType(invocationContext)
+		endStaticType := end.StaticType(invocationContext)
 		if !startStaticType.Equal(endStaticType) {
 			panic(interpreter.InclusiveRangeConstructionError{
 				LocationRange: locationRange,
@@ -151,7 +151,7 @@ var InclusiveRangeConstructorFunction = NewStandardLibraryStaticFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			stepStaticType := step.StaticType(inter)
+			stepStaticType := step.StaticType(invocationContext)
 			if stepStaticType != startStaticType {
 				panic(interpreter.InclusiveRangeConstructionError{
 					LocationRange: locationRange,
@@ -164,7 +164,7 @@ var InclusiveRangeConstructorFunction = NewStandardLibraryStaticFunction(
 			}
 
 			return interpreter.NewInclusiveRangeValueWithStep(
-				inter,
+				invocationContext,
 				locationRange,
 				start,
 				end,
@@ -175,7 +175,7 @@ var InclusiveRangeConstructorFunction = NewStandardLibraryStaticFunction(
 		}
 
 		return interpreter.NewInclusiveRangeValue(
-			inter,
+			invocationContext,
 			locationRange,
 			start,
 			end,

--- a/stdlib/range.go
+++ b/stdlib/range.go
@@ -126,7 +126,7 @@ var InclusiveRangeConstructorFunction = NewStandardLibraryStaticFunction(
 			panic(errors.NewUnreachableError())
 		}
 
-		inter := invocation.Interpreter
+		inter := invocation.InvocationContext
 		locationRange := invocation.LocationRange
 
 		startStaticType := start.StaticType(inter)
@@ -142,8 +142,8 @@ var InclusiveRangeConstructorFunction = NewStandardLibraryStaticFunction(
 			})
 		}
 
-		rangeStaticType := interpreter.NewInclusiveRangeStaticType(invocation.Interpreter, startStaticType)
-		rangeSemaType := sema.NewInclusiveRangeType(invocation.Interpreter, invocation.ArgumentTypes[0])
+		rangeStaticType := interpreter.NewInclusiveRangeStaticType(invocation.InvocationContext, startStaticType)
+		rangeSemaType := sema.NewInclusiveRangeType(invocation.InvocationContext, invocation.ArgumentTypes[0])
 
 		if len(invocation.Arguments) > 2 {
 			step, ok := invocation.Arguments[2].(interpreter.IntegerValue)

--- a/stdlib/rlp.go
+++ b/stdlib/rlp.go
@@ -53,11 +53,11 @@ var rlpDecodeStringFunction = interpreter.NewUnmeteredStaticHostFunctionValue(
 			panic(errors.NewUnreachableError())
 		}
 
-		invocation.Interpreter.ReportComputation(common.ComputationKindSTDLIBRLPDecodeString, uint(input.Count()))
+		invocation.InvocationContext.ReportComputation(common.ComputationKindSTDLIBRLPDecodeString, uint(input.Count()))
 
 		locationRange := invocation.LocationRange
 
-		convertedInput, err := interpreter.ByteArrayValueToByteSlice(invocation.Interpreter, input, locationRange)
+		convertedInput, err := interpreter.ByteArrayValueToByteSlice(invocation.InvocationContext, input, locationRange)
 		if err != nil {
 			panic(RLPDecodeStringError{
 				Msg:           err.Error(),
@@ -77,7 +77,7 @@ var rlpDecodeStringFunction = interpreter.NewUnmeteredStaticHostFunctionValue(
 				LocationRange: locationRange,
 			})
 		}
-		return interpreter.ByteSliceToByteArrayValue(invocation.Interpreter, output)
+		return interpreter.ByteSliceToByteArrayValue(invocation.InvocationContext, output)
 	},
 )
 
@@ -103,11 +103,11 @@ var rlpDecodeListFunction = interpreter.NewUnmeteredStaticHostFunctionValue(
 			panic(errors.NewUnreachableError())
 		}
 
-		invocation.Interpreter.ReportComputation(common.ComputationKindSTDLIBRLPDecodeList, uint(input.Count()))
+		invocation.InvocationContext.ReportComputation(common.ComputationKindSTDLIBRLPDecodeList, uint(input.Count()))
 
 		locationRange := invocation.LocationRange
 
-		convertedInput, err := interpreter.ByteArrayValueToByteSlice(invocation.Interpreter, input, locationRange)
+		convertedInput, err := interpreter.ByteArrayValueToByteSlice(invocation.InvocationContext, input, locationRange)
 		if err != nil {
 			panic(RLPDecodeListError{
 				Msg:           err.Error(),
@@ -133,14 +133,14 @@ var rlpDecodeListFunction = interpreter.NewUnmeteredStaticHostFunctionValue(
 
 		values := make([]interpreter.Value, len(output))
 		for i, b := range output {
-			values[i] = interpreter.ByteSliceToByteArrayValue(invocation.Interpreter, b)
+			values[i] = interpreter.ByteSliceToByteArrayValue(invocation.InvocationContext, b)
 		}
 
 		return interpreter.NewArrayValue(
-			invocation.Interpreter,
+			invocation.InvocationContext,
 			locationRange,
 			interpreter.NewVariableSizedStaticType(
-				invocation.Interpreter,
+				invocation.InvocationContext,
 				interpreter.ByteArrayStaticType,
 			),
 			common.ZeroAddress,

--- a/stdlib/test-framework.go
+++ b/stdlib/test-framework.go
@@ -37,7 +37,7 @@ type TestFramework interface {
 
 type Blockchain interface {
 	RunScript(
-		inter *interpreter.Interpreter,
+		context TestFrameworkScriptExecutionContext,
 		code string, arguments []interpreter.Value,
 	) *ScriptResult
 
@@ -46,7 +46,7 @@ type Blockchain interface {
 	GetAccount(interpreter.AddressValue) (*Account, error)
 
 	AddTransaction(
-		inter *interpreter.Interpreter,
+		context TestFrameworkAddTransactionContext,
 		code string,
 		authorizers []common.Address,
 		signers []*Account,
@@ -58,7 +58,7 @@ type Blockchain interface {
 	CommitBlock() error
 
 	DeployContract(
-		inter *interpreter.Interpreter,
+		context TestFrameworkContractDeploymentContext,
 		name string,
 		path string,
 		arguments []interpreter.Value,
@@ -69,7 +69,7 @@ type Blockchain interface {
 	ServiceAccount() (*Account, error)
 
 	Events(
-		inter *interpreter.Interpreter,
+		context TestFrameworkEventsContext,
 		eventType interpreter.StaticType,
 	) interpreter.Value
 
@@ -95,3 +95,36 @@ type Account struct {
 	PublicKey *PublicKey
 	Address   common.Address
 }
+
+// TODO: This is used by the test-framework.
+//
+//	Check and the functionalities needed.
+type TestFrameworkScriptExecutionContext interface {
+}
+
+var _ TestFrameworkScriptExecutionContext = &interpreter.Interpreter{}
+
+// TODO: This is used by the test-framework.
+//
+//	Check and the functionalities needed.
+type TestFrameworkAddTransactionContext interface {
+}
+
+var _ TestFrameworkAddTransactionContext = &interpreter.Interpreter{}
+
+// TODO: This is used by the test-framework.
+//
+//	Check and the functionalities needed.
+type TestFrameworkContractDeploymentContext interface {
+}
+
+var _ TestFrameworkContractDeploymentContext = &interpreter.Interpreter{}
+
+// TODO: This is used by the test-framework.
+//
+//	Check and the functionalities needed.
+type TestFrameworkEventsContext interface {
+	interpreter.ArrayCreationContext
+}
+
+var _ TestFrameworkEventsContext = &interpreter.Interpreter{}

--- a/stdlib/test.go
+++ b/stdlib/test.go
@@ -101,7 +101,7 @@ func getFunctionTypeFromMember(funcMember *sema.Member, funcName string) *sema.F
 }
 
 func getNestedTypeConstructorValue(
-	inter *interpreter.Interpreter,
+	context interpreter.ValueStaticTypeContext,
 	parent interpreter.Value,
 	typeName string,
 ) *interpreter.HostFunctionValue {
@@ -111,7 +111,7 @@ func getNestedTypeConstructorValue(
 	}
 
 	constructorVar := compositeValue.NestedVariables[typeName]
-	constructor, ok := constructorVar.GetValue(inter).(*interpreter.HostFunctionValue)
+	constructor, ok := constructorVar.GetValue(context).(*interpreter.HostFunctionValue)
 	if !ok {
 		panic(errors.NewUnexpectedError("invalid type for constructor"))
 	}
@@ -119,7 +119,7 @@ func getNestedTypeConstructorValue(
 }
 
 func arrayValueToSlice(
-	inter *interpreter.Interpreter,
+	context interpreter.ContainerMutationContext,
 	value interpreter.Value,
 	locationRange interpreter.LocationRange,
 ) ([]interpreter.Value, error) {
@@ -131,7 +131,7 @@ func arrayValueToSlice(
 	result := make([]interpreter.Value, 0, array.Count())
 
 	array.Iterate(
-		inter,
+		context,
 		func(element interpreter.Value) (resume bool) {
 			result = append(result, element)
 			return true
@@ -145,7 +145,7 @@ func arrayValueToSlice(
 
 // newScriptResult Creates a "ScriptResult" using the return value of the executed script.
 func newScriptResult(
-	inter *interpreter.Interpreter,
+	context interpreter.InvocationContext,
 	returnValue interpreter.Value,
 	result *ScriptResult,
 ) interpreter.Value {
@@ -155,21 +155,22 @@ func newScriptResult(
 	}
 
 	// Lookup and get 'ResultStatus' enum value.
-	resultStatusConstructor := getConstructor(inter, testResultStatusTypeName)
+	resultStatusConstructor := getConstructor(context, testResultStatusTypeName)
 	var status interpreter.Value
 	if result.Error == nil {
 		succeededVar := resultStatusConstructor.NestedVariables[testResultStatusTypeSucceededCaseName]
-		status = succeededVar.GetValue(inter)
+		status = succeededVar.GetValue(context)
 	} else {
 		failedVar := resultStatusConstructor.NestedVariables[testResultStatusTypeFailedCaseName]
-		status = failedVar.GetValue(inter)
+		status = failedVar.GetValue(context)
 	}
 
-	errValue := newErrorValue(inter, result.Error)
+	errValue := newErrorValue(context, result.Error)
 
 	// Create a 'ScriptResult' by calling its constructor.
-	scriptResultConstructor := getConstructor(inter, testScriptResultTypeName)
-	scriptResult, err := inter.InvokeExternally(
+	scriptResultConstructor := getConstructor(context, testScriptResultTypeName)
+	scriptResult, err := interpreter.InvokeExternally(
+		context,
 		scriptResultConstructor,
 		scriptResultConstructor.Type,
 		[]interpreter.Value{
@@ -186,9 +187,8 @@ func newScriptResult(
 	return scriptResult
 }
 
-func getConstructor(inter *interpreter.Interpreter, typeName string) *interpreter.HostFunctionValue {
-	resultStatusConstructorVar := inter.FindVariable(typeName)
-	resultStatusConstructor, ok := resultStatusConstructorVar.GetValue(inter).(*interpreter.HostFunctionValue)
+func getConstructor(variableResolver interpreter.VariableResolver, typeName string) *interpreter.HostFunctionValue {
+	resultStatusConstructor, ok := variableResolver.GetValueOfVariable(typeName).(*interpreter.HostFunctionValue)
 	if !ok {
 		panic(errors.NewUnexpectedError("invalid type for constructor of '%s'", typeName))
 	}
@@ -197,7 +197,7 @@ func getConstructor(inter *interpreter.Interpreter, typeName string) *interprete
 }
 
 func addressArrayValueToSlice(
-	inter *interpreter.Interpreter,
+	context interpreter.ContainerMutationContext,
 	accountsValue interpreter.Value,
 	locationRange interpreter.LocationRange,
 ) []common.Address {
@@ -209,7 +209,7 @@ func addressArrayValueToSlice(
 	addresses := make([]common.Address, 0)
 
 	accountsArray.Iterate(
-		inter,
+		context,
 		func(element interpreter.Value) (resume bool) {
 			address, ok := element.(interpreter.AddressValue)
 			if !ok {
@@ -228,7 +228,7 @@ func addressArrayValueToSlice(
 }
 
 func accountsArrayValueToSlice(
-	inter *interpreter.Interpreter,
+	context interpreter.PublicKeyCreationContext,
 	accountsValue interpreter.Value,
 	locationRange interpreter.LocationRange,
 ) []*Account {
@@ -241,14 +241,14 @@ func accountsArrayValueToSlice(
 	accounts := make([]*Account, 0)
 
 	accountsArray.Iterate(
-		inter,
+		context,
 		func(element interpreter.Value) (resume bool) {
 			accountValue, ok := element.(interpreter.MemberAccessibleValue)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}
 
-			account := accountFromValue(inter, accountValue, locationRange)
+			account := accountFromValue(context, accountValue, locationRange)
 
 			accounts = append(accounts, account)
 
@@ -262,14 +262,14 @@ func accountsArrayValueToSlice(
 }
 
 func accountFromValue(
-	inter *interpreter.Interpreter,
+	context interpreter.PublicKeyCreationContext,
 	accountValue interpreter.MemberAccessibleValue,
 	locationRange interpreter.LocationRange,
 ) *Account {
 
 	// Get address
 	addressValue := accountValue.GetMember(
-		inter,
+		context,
 		locationRange,
 		accountAddressFieldName,
 	)
@@ -280,7 +280,7 @@ func accountFromValue(
 
 	// Get public key
 	publicKeyVal, ok := accountValue.GetMember(
-		inter,
+		context,
 		locationRange,
 		sema.AccountKeyPublicKeyFieldName,
 	).(interpreter.MemberAccessibleValue)
@@ -289,7 +289,7 @@ func accountFromValue(
 		panic(errors.NewUnreachableError())
 	}
 
-	publicKey, err := NewPublicKeyFromValue(inter, locationRange, publicKeyVal)
+	publicKey, err := NewPublicKeyFromValue(context, locationRange, publicKeyVal)
 	if err != nil {
 		panic(err)
 	}
@@ -301,24 +301,25 @@ func accountFromValue(
 }
 
 // newTransactionResult Creates a "TransactionResult" indicating the status of the transaction execution.
-func newTransactionResult(inter *interpreter.Interpreter, result *TransactionResult) interpreter.Value {
+func newTransactionResult(context interpreter.InvocationContext, result *TransactionResult) interpreter.Value {
 	// Lookup and get 'ResultStatus' enum value.
-	resultStatusConstructor := getConstructor(inter, testResultStatusTypeName)
+	resultStatusConstructor := getConstructor(context, testResultStatusTypeName)
 	var status interpreter.Value
 	if result.Error == nil {
 		succeededVar := resultStatusConstructor.NestedVariables[testResultStatusTypeSucceededCaseName]
-		status = succeededVar.GetValue(inter)
+		status = succeededVar.GetValue(context)
 	} else {
 		failedVar := resultStatusConstructor.NestedVariables[testResultStatusTypeFailedCaseName]
-		status = failedVar.GetValue(inter)
+		status = failedVar.GetValue(context)
 	}
 
 	// Create a 'TransactionResult' by calling its constructor.
-	transactionResultConstructor := getConstructor(inter, testTransactionResultTypeName)
+	transactionResultConstructor := getConstructor(context, testTransactionResultTypeName)
 
-	errValue := newErrorValue(inter, result.Error)
+	errValue := newErrorValue(context, result.Error)
 
-	transactionResult, err := inter.InvokeExternally(
+	transactionResult, err := interpreter.InvokeExternally(
+		context,
 		transactionResultConstructor,
 		transactionResultConstructor.Type,
 		[]interpreter.Value{
@@ -334,15 +335,16 @@ func newTransactionResult(inter *interpreter.Interpreter, result *TransactionRes
 	return transactionResult
 }
 
-func newErrorValue(inter *interpreter.Interpreter, err error) interpreter.Value {
+func newErrorValue(context interpreter.InvocationContext, err error) interpreter.Value {
 	if err == nil {
 		return interpreter.Nil
 	}
 
 	// Create a 'Error' by calling its constructor.
-	errorConstructor := getConstructor(inter, testErrorTypeName)
+	errorConstructor := getConstructor(context, testErrorTypeName)
 
-	errorValue, invocationErr := inter.InvokeExternally(
+	errorValue, invocationErr := interpreter.InvokeExternally(
+		context,
 		errorConstructor,
 		errorConstructor.Type,
 		[]interpreter.Value{
@@ -382,14 +384,15 @@ func newMatcherWithAnyStructTestFunction(
 	testFunc interpreter.FunctionValue,
 ) interpreter.Value {
 
-	inter := invocation.InvocationContext
+	context := invocation.InvocationContext
 
 	matcherConstructor := getNestedTypeConstructorValue(
-		inter,
+		context,
 		*invocation.Self,
 		testMatcherTypeName,
 	)
-	matcher, err := inter.InvokeExternally(
+	matcher, err := interpreter.InvokeExternally(
+		context,
 		matcherConstructor,
 		matcherConstructor.Type,
 		[]interpreter.Value{
@@ -434,13 +437,13 @@ func newMatcherWithGenericTestFunction(
 	matcherTestFunction := interpreter.NewUnmeteredStaticHostFunctionValue(
 		matcherTestFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.InvocationContext
+			invocationContext := invocation.InvocationContext
 
 			for _, argument := range invocation.Arguments {
-				argumentStaticType := argument.StaticType(inter)
+				argumentStaticType := argument.StaticType(invocationContext)
 
-				if !interpreter.IsSubTypeOfSemaType(inter, argumentStaticType, parameterType) {
-					argumentSemaType := interpreter.MustConvertStaticToSemaType(argumentStaticType, inter)
+				if !interpreter.IsSubTypeOfSemaType(invocationContext, argumentStaticType, parameterType) {
+					argumentSemaType := interpreter.MustConvertStaticToSemaType(argumentStaticType, invocationContext)
 
 					panic(interpreter.TypeMismatchError{
 						ExpectedType:  parameterType,
@@ -450,7 +453,7 @@ func newMatcherWithGenericTestFunction(
 				}
 			}
 
-			value, err := inter.InvokeFunction(testFunc, invocation)
+			value, err := interpreter.InvokeFunction(invocationContext, testFunc, invocation)
 			if err != nil {
 				panic(err)
 			}

--- a/stdlib/test.go
+++ b/stdlib/test.go
@@ -382,7 +382,7 @@ func newMatcherWithAnyStructTestFunction(
 	testFunc interpreter.FunctionValue,
 ) interpreter.Value {
 
-	inter := invocation.Interpreter
+	inter := invocation.InvocationContext
 
 	matcherConstructor := getNestedTypeConstructorValue(
 		inter,
@@ -434,7 +434,7 @@ func newMatcherWithGenericTestFunction(
 	matcherTestFunction := interpreter.NewUnmeteredStaticHostFunctionValue(
 		matcherTestFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			for _, argument := range invocation.Arguments {
 				argumentStaticType := argument.StaticType(inter)

--- a/stdlib/test_contract.go
+++ b/stdlib/test_contract.go
@@ -163,7 +163,7 @@ func testTypeAssertEqualFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			expectedType := expected.StaticType(inter)
 			actualType := actual.StaticType(inter)
@@ -302,7 +302,7 @@ func newTestTypeExpectFunction(functionType *sema.FunctionType) testContractBoun
 					panic(errors.NewUnreachableError())
 				}
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				result := invokeMatcherTest(
@@ -547,7 +547,7 @@ func newTestTypeEqualFunction(
 					panic(errors.NewUnreachableError())
 				}
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 
 				// This is a static function.
 				equalTestFunc := interpreter.NewStaticHostFunctionValue(
@@ -740,7 +740,7 @@ func newTestTypeContainFunction(
 					panic(errors.NewUnreachableError())
 				}
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 
 				// This is a static function.
 				containTestFunc := interpreter.NewStaticHostFunctionValue(
@@ -816,7 +816,7 @@ func newTestTypeBeGreaterThanFunction(
 					panic(errors.NewUnreachableError())
 				}
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 
 				// This is a static function.
 				beGreaterThanTestFunc := interpreter.NewStaticHostFunctionValue(
@@ -909,7 +909,7 @@ func newTestTypeExpectFailureFunction(
 			testContractValue,
 			testExpectFailureFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 				functionValue, ok := invocation.Arguments[0].(interpreter.FunctionValue)
 				if !ok {
 					panic(errors.NewUnreachableError())
@@ -965,7 +965,7 @@ func newTestTypeBeLessThanFunction(
 					panic(errors.NewUnreachableError())
 				}
 
-				inter := invocation.Interpreter
+				inter := invocation.InvocationContext
 
 				// This is a static function.
 				beLessThanTestFunc := interpreter.NewStaticHostFunctionValue(

--- a/stdlib/test_contract.go
+++ b/stdlib/test_contract.go
@@ -48,7 +48,7 @@ type TestContractType struct {
 }
 
 type testContractBoundFunctionGenerator func(
-	*interpreter.Interpreter,
+	interpreter.FunctionCreationContext,
 	*interpreter.CompositeValue,
 ) interpreter.BoundFunctionValue
 
@@ -289,9 +289,9 @@ func newTestTypeExpectFunctionType(matcherType *sema.CompositeType) *sema.Functi
 }
 
 func newTestTypeExpectFunction(functionType *sema.FunctionType) testContractBoundFunctionGenerator {
-	return func(inter *interpreter.Interpreter, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
+	return func(context interpreter.FunctionCreationContext, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
 		return interpreter.NewUnmeteredBoundHostFunctionValue(
-			inter,
+			context,
 			testContractValue,
 			functionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
@@ -302,11 +302,11 @@ func newTestTypeExpectFunction(functionType *sema.FunctionType) testContractBoun
 					panic(errors.NewUnreachableError())
 				}
 
-				inter := invocation.InvocationContext
+				invocationContext := invocation.InvocationContext
 				locationRange := invocation.LocationRange
 
 				result := invokeMatcherTest(
-					inter,
+					invocationContext,
 					matcher,
 					value,
 					locationRange,
@@ -330,13 +330,13 @@ func newTestTypeExpectFunction(functionType *sema.FunctionType) testContractBoun
 }
 
 func invokeMatcherTest(
-	inter *interpreter.Interpreter,
+	context interpreter.InvocationContext,
 	matcher interpreter.MemberAccessibleValue,
 	value interpreter.Value,
 	locationRange interpreter.LocationRange,
 ) bool {
 	testFunc := matcher.GetMember(
-		inter,
+		context,
 		locationRange,
 		matcherTestFieldName,
 	)
@@ -351,7 +351,8 @@ func invokeMatcherTest(
 
 	functionType := funcValue.FunctionType()
 
-	testResult, err := inter.InvokeExternally(
+	testResult, err := interpreter.InvokeExternally(
+		context,
 		funcValue,
 		functionType,
 		[]interpreter.Value{
@@ -392,11 +393,11 @@ var testTypeReadFileFunctionType = &sema.FunctionType{
 
 func newTestTypeReadFileFunction(
 	testFramework TestFramework,
-	inter *interpreter.Interpreter,
+	context interpreter.FunctionCreationContext,
 	testContractValue *interpreter.CompositeValue,
 ) interpreter.BoundFunctionValue {
 	return interpreter.NewUnmeteredBoundHostFunctionValue(
-		inter,
+		context,
 		testContractValue,
 		testTypeReadFileFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -476,9 +477,9 @@ func newTestTypeNewMatcherFunction(
 	newMatcherFunctionType *sema.FunctionType,
 	matcherTestFunctionType *sema.FunctionType,
 ) testContractBoundFunctionGenerator {
-	return func(inter *interpreter.Interpreter, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
+	return func(context interpreter.FunctionCreationContext, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
 		return interpreter.NewUnmeteredBoundHostFunctionValue(
-			inter,
+			context,
 			testContractValue,
 			newMatcherFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
@@ -536,9 +537,9 @@ func newTestTypeEqualFunction(
 	equalFunctionType *sema.FunctionType,
 	matcherTestFunctionType *sema.FunctionType,
 ) testContractBoundFunctionGenerator {
-	return func(inter *interpreter.Interpreter, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
+	return func(context interpreter.FunctionCreationContext, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
 		return interpreter.NewUnmeteredBoundHostFunctionValue(
-			inter,
+			context,
 			testContractValue,
 			equalFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
@@ -600,9 +601,9 @@ func newTestTypeBeEmptyFunction(
 	beEmptyFunctionType *sema.FunctionType,
 	matcherTestFunctionType *sema.FunctionType,
 ) testContractBoundFunctionGenerator {
-	return func(inter *interpreter.Interpreter, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
+	return func(context interpreter.FunctionCreationContext, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
 		return interpreter.NewUnmeteredBoundHostFunctionValue(
-			inter,
+			context,
 			testContractValue,
 			beEmptyFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
@@ -662,9 +663,9 @@ func newTestTypeHaveElementCountFunction(
 	haveElementCountFunctionType *sema.FunctionType,
 	matcherTestFunctionType *sema.FunctionType,
 ) testContractBoundFunctionGenerator {
-	return func(inter *interpreter.Interpreter, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
+	return func(context interpreter.FunctionCreationContext, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
 		return interpreter.NewUnmeteredBoundHostFunctionValue(
-			inter,
+			context,
 			testContractValue,
 			haveElementCountFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
@@ -729,9 +730,9 @@ func newTestTypeContainFunction(
 	containFunctionType *sema.FunctionType,
 	matcherTestFunctionType *sema.FunctionType,
 ) testContractBoundFunctionGenerator {
-	return func(inter *interpreter.Interpreter, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
+	return func(context interpreter.FunctionCreationContext, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
 		return interpreter.NewUnmeteredBoundHostFunctionValue(
-			inter,
+			context,
 			testContractValue,
 			containFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
@@ -805,9 +806,9 @@ func newTestTypeBeGreaterThanFunction(
 	beGreaterThanFunctionType *sema.FunctionType,
 	matcherTestFunctionType *sema.FunctionType,
 ) testContractBoundFunctionGenerator {
-	return func(inter *interpreter.Interpreter, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
+	return func(context interpreter.FunctionCreationContext, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
 		return interpreter.NewUnmeteredBoundHostFunctionValue(
-			inter,
+			context,
 			testContractValue,
 			beGreaterThanFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
@@ -903,13 +904,13 @@ func newTestTypeExpectFailureFunctionType() *sema.FunctionType {
 func newTestTypeExpectFailureFunction(
 	testExpectFailureFunctionType *sema.FunctionType,
 ) testContractBoundFunctionGenerator {
-	return func(inter *interpreter.Interpreter, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
+	return func(context interpreter.FunctionCreationContext, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
 		return interpreter.NewUnmeteredBoundHostFunctionValue(
-			inter,
+			context,
 			testContractValue,
 			testExpectFailureFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
-				inter := invocation.InvocationContext
+				invocationContext := invocation.InvocationContext
 				functionValue, ok := invocation.Arguments[0].(interpreter.FunctionValue)
 				if !ok {
 					panic(errors.NewUnreachableError())
@@ -923,7 +924,7 @@ func newTestTypeExpectFailureFunction(
 
 				failedAsExpected := true
 
-				defer inter.RecoverErrors(func(internalErr error) {
+				defer invocationContext.RecoverErrors(func(internalErr error) {
 					if !failedAsExpected {
 						panic(internalErr)
 					} else if !strings.Contains(internalErr.Error(), errorMessage.Str) {
@@ -934,7 +935,8 @@ func newTestTypeExpectFailureFunction(
 					}
 				})
 
-				_, err := inter.InvokeExternally(
+				_, err := interpreter.InvokeExternally(
+					invocationContext,
 					functionValue,
 					functionType,
 					nil,
@@ -954,9 +956,9 @@ func newTestTypeBeLessThanFunction(
 	beLessThanFunctionType *sema.FunctionType,
 	matcherTestFunctionType *sema.FunctionType,
 ) testContractBoundFunctionGenerator {
-	return func(inter *interpreter.Interpreter, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
+	return func(context interpreter.FunctionCreationContext, testContractValue *interpreter.CompositeValue) interpreter.BoundFunctionValue {
 		return interpreter.NewUnmeteredBoundHostFunctionValue(
-			inter,
+			context,
 			testContractValue,
 			beLessThanFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
@@ -1303,7 +1305,8 @@ func (t *TestContractType) NewTestContract(
 		interpreter.EmptyLocationRange,
 	)
 	returnType := constructor.FunctionType().ReturnTypeAnnotation.Type
-	value, err := inter.InvokeFunctionValue(
+	value, err := interpreter.InvokeFunctionValue(
+		inter,
 		constructor,
 		[]interpreter.Value{emulatorBackend},
 		initializerTypes,

--- a/stdlib/test_emulatorbackend.go
+++ b/stdlib/test_emulatorbackend.go
@@ -263,7 +263,7 @@ func (t *testEmulatorBackendType) newExecuteScriptFunction(
 		emulatorBackend,
 		t.executeScriptFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			script, ok := invocation.Arguments[0].(*interpreter.StringValue)
 			if !ok {
@@ -311,7 +311,7 @@ func (t *testEmulatorBackendType) newCreateAccountFunction(
 				panic(err)
 			}
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			return newTestAccountValue(
@@ -388,7 +388,7 @@ func (t *testEmulatorBackendType) newGetAccountFunction(
 				})
 			}
 
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			return newTestAccountValue(
@@ -423,7 +423,7 @@ func (t *testEmulatorBackendType) newAddTransactionFunction(
 		emulatorBackend,
 		t.addTransactionFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 			locationRange := invocation.LocationRange
 
 			transactionValue, ok := invocation.Arguments[0].(interpreter.MemberAccessibleValue)
@@ -518,7 +518,7 @@ func (t *testEmulatorBackendType) newExecuteNextTransactionFunction(
 				return interpreter.Nil
 			}
 
-			return newTransactionResult(invocation.Interpreter, result)
+			return newTransactionResult(invocation.InvocationContext, result)
 		},
 	)
 }
@@ -569,7 +569,7 @@ func (t *testEmulatorBackendType) newDeployContractFunction(
 		emulatorBackend,
 		t.deployContractFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			// Contract name
 			name, ok := invocation.Arguments[0].(*interpreter.StringValue)
@@ -624,7 +624,7 @@ func (t *testEmulatorBackendType) newLogsFunction(
 		t.logsFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			logs := blockchain.Logs()
-			inter := invocation.Interpreter
+			inter := invocation.InvocationContext
 
 			arrayType := interpreter.NewVariableSizedStaticType(
 				inter,
@@ -682,7 +682,7 @@ func (t *testEmulatorBackendType) newServiceAccountFunction(
 			}
 
 			return newTestAccountValue(
-				invocation.Interpreter,
+				invocation.InvocationContext,
 				invocation.LocationRange,
 				serviceAccount,
 			)
@@ -726,7 +726,7 @@ func (t *testEmulatorBackendType) newEventsFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			return blockchain.Events(invocation.Interpreter, eventType)
+			return blockchain.Events(invocation.InvocationContext, eventType)
 		},
 	)
 }
@@ -813,7 +813,7 @@ func (t *testEmulatorBackendType) newCreateSnapshotFunction(
 			}
 
 			err := blockchain.CreateSnapshot(name.Str)
-			return newErrorValue(invocation.Interpreter, err)
+			return newErrorValue(invocation.InvocationContext, err)
 		},
 	)
 }
@@ -843,7 +843,7 @@ func (t *testEmulatorBackendType) newLoadSnapshotFunction(
 			}
 
 			err := blockchain.LoadSnapshot(name.Str)
-			return newErrorValue(invocation.Interpreter, err)
+			return newErrorValue(invocation.InvocationContext, err)
 		},
 	)
 }

--- a/stdlib/test_emulatorbackend.go
+++ b/stdlib/test_emulatorbackend.go
@@ -263,7 +263,7 @@ func (t *testEmulatorBackendType) newExecuteScriptFunction(
 		emulatorBackend,
 		t.executeScriptFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.InvocationContext
+			invocationContext := invocation.InvocationContext
 
 			script, ok := invocation.Arguments[0].(*interpreter.StringValue)
 			if !ok {
@@ -271,7 +271,7 @@ func (t *testEmulatorBackendType) newExecuteScriptFunction(
 			}
 
 			args, err := arrayValueToSlice(
-				inter,
+				invocationContext,
 				invocation.Arguments[1],
 				invocation.LocationRange,
 			)
@@ -279,9 +279,9 @@ func (t *testEmulatorBackendType) newExecuteScriptFunction(
 				panic(errors.NewUnexpectedErrorFromCause(err))
 			}
 
-			result := blockchain.RunScript(inter, script.Str, args)
+			result := blockchain.RunScript(invocationContext, script.Str, args)
 
-			return newScriptResult(inter, result.Value, result)
+			return newScriptResult(invocationContext, result.Value, result)
 		},
 	)
 }
@@ -324,7 +324,7 @@ func (t *testEmulatorBackendType) newCreateAccountFunction(
 }
 
 func newTestAccountValue(
-	inter *interpreter.Interpreter,
+	context interpreter.InvocationContext,
 	locationRange interpreter.LocationRange,
 	account *Account,
 ) interpreter.Value {
@@ -333,14 +333,15 @@ func newTestAccountValue(
 	address := interpreter.NewAddressValue(nil, account.Address)
 
 	publicKey := NewPublicKeyValue(
-		inter,
+		context,
 		locationRange,
 		account.PublicKey,
 	)
 
 	// Create an 'Account' by calling its constructor.
-	accountConstructor := getConstructor(inter, testAccountTypeName)
-	accountValue, err := inter.InvokeExternally(
+	accountConstructor := getConstructor(context, testAccountTypeName)
+	accountValue, err := interpreter.InvokeExternally(
+		context,
 		accountConstructor,
 		accountConstructor.Type,
 		[]interpreter.Value{

--- a/stdlib/test_test.go
+++ b/stdlib/test_test.go
@@ -2241,13 +2241,13 @@ func TestBlockchain(t *testing.T) {
 		testFramework := &mockedTestFramework{
 			emulatorBackend: func() Blockchain {
 				return &mockedBlockchain{
-					events: func(inter *interpreter.Interpreter, eventType interpreter.StaticType) interpreter.Value {
+					events: func(context TestFrameworkEventsContext, eventType interpreter.StaticType) interpreter.Value {
 						eventsInvoked = true
 						assert.Nil(t, eventType)
 						return interpreter.NewArrayValue(
-							inter,
+							context,
 							interpreter.EmptyLocationRange,
-							interpreter.NewVariableSizedStaticType(inter, interpreter.PrimitiveStaticTypeAnyStruct),
+							interpreter.NewVariableSizedStaticType(context, interpreter.PrimitiveStaticTypeAnyStruct),
 							common.Address{},
 						)
 					},
@@ -2290,7 +2290,7 @@ func TestBlockchain(t *testing.T) {
 		testFramework := &mockedTestFramework{
 			emulatorBackend: func() Blockchain {
 				return &mockedBlockchain{
-					events: func(inter *interpreter.Interpreter, eventType interpreter.StaticType) interpreter.Value {
+					events: func(context TestFrameworkEventsContext, eventType interpreter.StaticType) interpreter.Value {
 						eventsInvoked = true
 						assert.NotNil(t, eventType)
 
@@ -2299,9 +2299,9 @@ func TestBlockchain(t *testing.T) {
 						assert.Equal(t, "Foo", compositeType.QualifiedIdentifier)
 
 						return interpreter.NewArrayValue(
-							inter,
+							context,
 							interpreter.EmptyLocationRange,
-							interpreter.NewVariableSizedStaticType(inter, interpreter.PrimitiveStaticTypeAnyStruct),
+							interpreter.NewVariableSizedStaticType(context, interpreter.PrimitiveStaticTypeAnyStruct),
 							common.Address{},
 						)
 					},
@@ -2666,7 +2666,7 @@ func TestBlockchain(t *testing.T) {
 			emulatorBackend: func() Blockchain {
 				return &mockedBlockchain{
 					deployContract: func(
-						inter *interpreter.Interpreter,
+						_ TestFrameworkContractDeploymentContext,
 						name string,
 						path string,
 						arguments []interpreter.Value,
@@ -2720,7 +2720,7 @@ func TestBlockchain(t *testing.T) {
 			emulatorBackend: func() Blockchain {
 				return &mockedBlockchain{
 					deployContract: func(
-						inter *interpreter.Interpreter,
+						inter TestFrameworkContractDeploymentContext,
 						name string,
 						path string,
 						arguments []interpreter.Value,
@@ -2892,16 +2892,16 @@ func (m mockedTestFramework) ReadFile(fileName string) (string, error) {
 
 // mockedBlockchain is the implementation of `Blockchain` for testing purposes.
 type mockedBlockchain struct {
-	runScript          func(inter *interpreter.Interpreter, code string, arguments []interpreter.Value)
+	runScript          func(context TestFrameworkScriptExecutionContext, code string, arguments []interpreter.Value)
 	createAccount      func() (*Account, error)
 	getAccount         func(interpreter.AddressValue) (*Account, error)
-	addTransaction     func(inter *interpreter.Interpreter, code string, authorizers []common.Address, signers []*Account, arguments []interpreter.Value) error
+	addTransaction     func(context TestFrameworkAddTransactionContext, code string, authorizers []common.Address, signers []*Account, arguments []interpreter.Value) error
 	executeTransaction func() *TransactionResult
 	commitBlock        func() error
-	deployContract     func(inter *interpreter.Interpreter, name string, path string, arguments []interpreter.Value) error
+	deployContract     func(context TestFrameworkContractDeploymentContext, name string, path string, arguments []interpreter.Value) error
 	logs               func() []string
 	serviceAccount     func() (*Account, error)
-	events             func(inter *interpreter.Interpreter, eventType interpreter.StaticType) interpreter.Value
+	events             func(context TestFrameworkEventsContext, eventType interpreter.StaticType) interpreter.Value
 	reset              func(uint64)
 	moveTime           func(int64)
 	createSnapshot     func(string) error
@@ -2911,7 +2911,7 @@ type mockedBlockchain struct {
 var _ Blockchain = &mockedBlockchain{}
 
 func (m mockedBlockchain) RunScript(
-	inter *interpreter.Interpreter,
+	context TestFrameworkScriptExecutionContext,
 	code string,
 	arguments []interpreter.Value,
 ) *ScriptResult {
@@ -2919,7 +2919,7 @@ func (m mockedBlockchain) RunScript(
 		panic("'RunScript' is not implemented")
 	}
 
-	return m.RunScript(inter, code, arguments)
+	return m.RunScript(context, code, arguments)
 }
 
 func (m mockedBlockchain) CreateAccount() (*Account, error) {
@@ -2939,7 +2939,7 @@ func (m mockedBlockchain) GetAccount(address interpreter.AddressValue) (*Account
 }
 
 func (m mockedBlockchain) AddTransaction(
-	inter *interpreter.Interpreter,
+	context TestFrameworkAddTransactionContext,
 	code string,
 	authorizers []common.Address,
 	signers []*Account,
@@ -2949,7 +2949,7 @@ func (m mockedBlockchain) AddTransaction(
 		panic("'AddTransaction' is not implemented")
 	}
 
-	return m.addTransaction(inter, code, authorizers, signers, arguments)
+	return m.addTransaction(context, code, authorizers, signers, arguments)
 }
 
 func (m mockedBlockchain) ExecuteNextTransaction() *TransactionResult {
@@ -2969,7 +2969,7 @@ func (m mockedBlockchain) CommitBlock() error {
 }
 
 func (m mockedBlockchain) DeployContract(
-	inter *interpreter.Interpreter,
+	context TestFrameworkContractDeploymentContext,
 	name string,
 	path string,
 	arguments []interpreter.Value,
@@ -2978,7 +2978,7 @@ func (m mockedBlockchain) DeployContract(
 		panic("'DeployContract' is not implemented")
 	}
 
-	return m.deployContract(inter, name, path, arguments)
+	return m.deployContract(context, name, path, arguments)
 }
 
 func (m mockedBlockchain) Logs() []string {
@@ -2998,14 +2998,14 @@ func (m mockedBlockchain) ServiceAccount() (*Account, error) {
 }
 
 func (m mockedBlockchain) Events(
-	inter *interpreter.Interpreter,
+	context TestFrameworkEventsContext,
 	eventType interpreter.StaticType,
 ) interpreter.Value {
 	if m.events == nil {
 		panic("'Events' is not implemented")
 	}
 
-	return m.events(inter, eventType)
+	return m.events(context, eventType)
 }
 
 func (m mockedBlockchain) Reset(height uint64) {

--- a/test_utils/runtime_utils/testinterface.go
+++ b/test_utils/runtime_utils/testinterface.go
@@ -117,7 +117,7 @@ type TestRuntimeInterface struct {
 	OnGenerateAccountID              func(address common.Address) (uint64, error)
 	OnRecoverProgram                 func(program *ast.Program, location common.Location) ([]byte, error)
 	OnValidateAccountCapabilitiesGet func(
-		inter *interpreter.Interpreter,
+		context interpreter.AccountCapabilityGetValidationContext,
 		locationRange interpreter.LocationRange,
 		address interpreter.AddressValue,
 		path interpreter.PathValue,
@@ -125,7 +125,7 @@ type TestRuntimeInterface struct {
 		capabilityBorrowType *sema.ReferenceType,
 	) (bool, error)
 	OnValidateAccountCapabilitiesPublish func(
-		inter *interpreter.Interpreter,
+		context interpreter.AccountCapabilityPublishValidationContext,
 		locationRange interpreter.LocationRange,
 		address interpreter.AddressValue,
 		path interpreter.PathValue,
@@ -626,7 +626,7 @@ func (i *TestRuntimeInterface) RecoverProgram(program *ast.Program, location com
 }
 
 func (i *TestRuntimeInterface) ValidateAccountCapabilitiesGet(
-	inter *interpreter.Interpreter,
+	context interpreter.AccountCapabilityGetValidationContext,
 	locationRange interpreter.LocationRange,
 	address interpreter.AddressValue,
 	path interpreter.PathValue,
@@ -637,7 +637,7 @@ func (i *TestRuntimeInterface) ValidateAccountCapabilitiesGet(
 		return true, nil
 	}
 	return i.OnValidateAccountCapabilitiesGet(
-		inter,
+		context,
 		locationRange,
 		address,
 		path,
@@ -647,7 +647,7 @@ func (i *TestRuntimeInterface) ValidateAccountCapabilitiesGet(
 }
 
 func (i *TestRuntimeInterface) ValidateAccountCapabilitiesPublish(
-	inter *interpreter.Interpreter,
+	context interpreter.AccountCapabilityPublishValidationContext,
 	locationRange interpreter.LocationRange,
 	address interpreter.AddressValue,
 	path interpreter.PathValue,
@@ -657,7 +657,7 @@ func (i *TestRuntimeInterface) ValidateAccountCapabilitiesPublish(
 		return true, nil
 	}
 	return i.OnValidateAccountCapabilitiesPublish(
-		inter,
+		context,
 		locationRange,
 		address,
 		path,

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -149,7 +149,7 @@ func parseCheckAndInterpretWithLogs( // nolint:unused
 		``,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			message := invocation.Arguments[0].MeteredString(
-				invocation.Interpreter,
+				invocation.InvocationContext,
 				interpreter.SeenReferences{},
 				invocation.LocationRange,
 			)


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3693

Depends on https://github.com/onflow/cadence/pull/3825

## Description

Removes the reference to `interpreter.Interpreter` from the `interpreter.Invocation`. This would allow us to re-use the standard library functions in the VM.

Unfortunately the refactoring exploded all over the code, and ended-up having to refactor other functions including:
- Refactoring `Destroy` and `Walk` methods of `Value` interface to remove the interpreter parameter.
- Refactoring `exportValue` and (and all it's dependent methods) to remove the interpreter parameter.
- Refactoring `Transfer` and `convert` methods for values to remove the interpreter parameter.
- Refactoring test-framework remove the interpreter dependencies.
- Refactoring account-related functions (i.e: `stdlib/account.go`) to remove the interpreter dependencies.

All tests are passing for both interpreter and vm.

Next-up, we can start refactoring and re-using the standard-library functions.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
