### PR TITLE
Reuse value-conversions of interpreter in vm

### DIFF
--- a/bbq/vm/value.go
+++ b/bbq/vm/value.go
@@ -20,137 +20,25 @@ package vm
 
 import (
 	"github.com/onflow/cadence/bbq"
-	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 )
 
 type Value = interpreter.Value
 
-//type MemberAccessibleValue interface {
-//	// TODO: See whether `Config` parameter can be removed from the below functions.
-//	// Currently it's unknown because `AccountCapabilityControllerValue` members
-//	// are not yet implemented.
-//
-//	GetMember(config *Config, name string) Value
-//	SetMember(config *Config, name string, value Value)
-//}
-
-//type ResourceKindedValue interface {
-//	Value
-//	// TODO:
-//	//Destroy(interpreter *Interpreter, locationRange LocationRange)
-//	//IsDestroyed() bool
-//	//isInvalidatedResource(*Interpreter) bool
-//	IsResourceKinded() bool
-//}
-//
-//// ReferenceTrackedResourceKindedValue is a resource-kinded value
-//// that must be tracked when a reference of it is taken.
-//type ReferenceTrackedResourceKindedValue interface {
-//	ResourceKindedValue
-//	IsReferenceTrackedResourceKindedValue()
-//	ValueID() atree.ValueID
-//	IsStaleResource() bool
-//}
-
-//// IterableValue is a value which can be iterated over, e.g. with a for-loop
-//type IterableValue interface {
-//	Value
-//	Iterator() ValueIterator
-//}
-
-//type ValueIterator interface {
-//	interpreter.ValueIterator
-//	Value
-//}
-
 // ConvertAndBox converts a value to a target type, and boxes in optionals and any value, if necessary
-// TODO: Remove this and re-use interpreter's method
 func ConvertAndBox(
-	gauge common.MemoryGauge,
+	config *Config,
 	value Value,
 	valueType, targetType bbq.StaticType,
 ) Value {
-	value = convert(gauge, value, valueType, targetType)
-	return BoxOptional(gauge, value, targetType)
-}
+	valueSemaType := interpreter.MustConvertStaticToSemaType(valueType, config)
+	targetSemaType := interpreter.MustConvertStaticToSemaType(targetType, config)
 
-// TODO: Remove this and re-use interpreter's method
-func convert(gauge common.MemoryGauge, value Value, valueType, targetType bbq.StaticType) Value {
-	if valueType == nil {
-		return value
-	}
-
-	unwrappedTargetType := UnwrapOptionalType(targetType)
-
-	// if the value is optional, convert the inner value to the unwrapped target type
-	if optionalValueType, valueIsOptional := valueType.(*interpreter.OptionalStaticType); valueIsOptional {
-		switch value := value.(type) {
-		case interpreter.NilValue:
-			return value
-
-		case *interpreter.SomeValue:
-			if !optionalValueType.Type.Equal(unwrappedTargetType) {
-				innerValue := convert(
-					gauge,
-					value.InnerValue(),
-					optionalValueType.Type,
-					unwrappedTargetType,
-				)
-				return interpreter.NewSomeValueNonCopying(gauge, innerValue)
-			}
-			return value
-		}
-	}
-
-	switch unwrappedTargetType {
-	// TODO: add other cases
-	default:
-		return value
-	}
-}
-
-// TODO: Remove this and re-use interpreter's method
-func Unbox(value Value) Value {
-	for {
-		some, ok := value.(*interpreter.SomeValue)
-		if !ok {
-			return value
-		}
-
-		value = some.InnerValue()
-	}
-}
-
-// BoxOptional boxes a value in optionals, if necessary
-// TODO: Remove this and re-use interpreter's method
-func BoxOptional(
-	gauge common.MemoryGauge,
-	value Value,
-	targetType bbq.StaticType,
-) Value {
-
-	inner := value
-
-	for {
-		optionalType, ok := targetType.(*interpreter.OptionalStaticType)
-		if !ok {
-			break
-		}
-
-		switch typedInner := inner.(type) {
-		case *interpreter.SomeValue:
-			inner = typedInner.InnerValue()
-
-		case interpreter.NilValue:
-			// NOTE: nested nil will be unboxed!
-			return inner
-
-		default:
-			value = interpreter.NewSomeValueNonCopying(gauge, value)
-		}
-
-		targetType = optionalType.Type
-	}
-	return value
+	return interpreter.ConvertAndBox(
+		config,
+		EmptyLocationRange,
+		value,
+		valueSemaType,
+		targetSemaType,
+	)
 }

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -843,7 +843,7 @@ func castValueAndValueType(config *Config, targetType bbq.StaticType, value Valu
 	if !(unboxedExpectedType == interpreter.PrimitiveStaticTypeAnyStruct ||
 		unboxedExpectedType == interpreter.PrimitiveStaticTypeAnyResource) {
 		// otherwise dynamic cast now always unboxes optionals
-		value = Unbox(value)
+		value = interpreter.Unbox(value)
 	}
 
 	return value, valueType

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -2402,7 +2402,7 @@ func BoxOptional(gauge common.MemoryGauge, value Value, targetType sema.Type) Va
 	return value
 }
 
-func (interpreter *Interpreter) Unbox(value Value) Value {
+func Unbox(value Value) Value {
 	for {
 		some, ok := value.(*SomeValue)
 		if !ok {

--- a/interpreter/interpreter_expression.go
+++ b/interpreter/interpreter_expression.go
@@ -665,9 +665,9 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 }
 
 func (interpreter *Interpreter) testEqual(left, right Value, expression *ast.BinaryExpression) BoolValue {
-	left = interpreter.Unbox(left)
+	left = Unbox(left)
 
-	right = interpreter.Unbox(right)
+	right = Unbox(right)
 
 	leftEquatable, ok := left.(EquatableValue)
 	if !ok {
@@ -1387,7 +1387,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 		unboxedExpectedType := sema.UnwrapOptionalType(expectedType)
 		if !(unboxedExpectedType == sema.AnyStructType || unboxedExpectedType == sema.AnyResourceType) {
 			// otherwise dynamic cast now always unboxes optionals
-			value = interpreter.Unbox(value)
+			value = Unbox(value)
 		}
 		valueSemaType := SubstituteMappedEntitlements(interpreter, MustSemaTypeOfValue(value, interpreter))
 		valueStaticType := ConvertSemaToStaticType(interpreter, valueSemaType)

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -49,9 +49,8 @@ type Invokable interface {
 }
 
 type VMInvokable struct {
-	*interpreter.Interpreter
 	vmInstance *vm.VM
-	config     *vm.Config
+	*vm.Config
 }
 
 var _ Invokable = &VMInvokable{}
@@ -78,8 +77,7 @@ func ParseCheckAndPrepare(t testing.TB, code string, compile bool) Invokable {
 
 	return &VMInvokable{
 		vmInstance:  vmInstance,
-		config:      vmConfig,
-		Interpreter: vmConfig.Interpreter(),
+		Config:      vmConfig,
 	}
 
 }


### PR DESCRIPTION
Closes #3770

## Description

While at it, also remove the `Interpreter` usages in the vm. It was previously used for value conversions (vm-value to/from interpreter-value), which is no longer needed.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
