### PR TITLE
[Compiler] Compile simple function expressions

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1604,10 +1604,17 @@ func (c *Compiler[_, _]) VisitFunctionExpression(expression *ast.FunctionExpress
 		FunctionIndex: uint16(functionIndex),
 	})
 
+	parameterCount := 0
 	parameterList := expression.ParameterList
-	parameterCount := uint16(len(parameterList.Parameters))
+	if parameterList != nil {
+		parameterCount = len(parameterList.Parameters)
+	}
 
-	function := c.addFunction("", parameterCount)
+	if parameterCount > math.MaxUint16 {
+		panic(errors.NewDefaultUserError("invalid parameter count"))
+	}
+
+	function := c.addFunction("", uint16(parameterCount))
 
 	previousFunction := c.currentFunction
 	c.targetFunction(function)

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -3959,3 +3959,85 @@ func TestCompileReturns(t *testing.T) {
 		)
 	})
 }
+
+func TestCompileFunctionExpression(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+      fun test(): Int {
+          let addOne = fun(_ x: Int): Int {
+              return x + 1
+          }
+          let x = 2
+          return x + addOne(3)
+      }
+    `)
+	require.NoError(t, err)
+
+	comp := compiler.NewInstructionCompiler(checker)
+	program := comp.Compile()
+
+	require.Len(t, program.Functions, 2)
+
+	functions := comp.ExportFunctions()
+	require.Equal(t, len(program.Functions), len(functions))
+
+	const (
+		addOneIndex = iota
+		xIndex
+	)
+
+	assert.Equal(t,
+		[]opcode.Instruction{
+			// let addOne = fun ...
+			opcode.InstructionNewClosure{FunctionIndex: 1},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: addOneIndex},
+
+			// let x = 2
+			opcode.InstructionGetConstant{ConstantIndex: 1},
+			opcode.InstructionTransfer{TypeIndex: 1},
+			opcode.InstructionSetLocal{LocalIndex: xIndex},
+
+			// return x + addOne(3)
+			opcode.InstructionGetLocal{LocalIndex: xIndex},
+			opcode.InstructionGetConstant{ConstantIndex: 2},
+			opcode.InstructionTransfer{TypeIndex: 1},
+			opcode.InstructionGetLocal{LocalIndex: addOneIndex},
+			opcode.InstructionInvoke{},
+			opcode.InstructionAdd{},
+			opcode.InstructionReturnValue{},
+		},
+		functions[0].Code,
+	)
+
+	assert.Equal(t,
+		[]opcode.Instruction{
+			// return x + 1
+			opcode.InstructionGetLocal{LocalIndex: 0},
+			opcode.InstructionGetConstant{ConstantIndex: 0},
+			opcode.InstructionAdd{},
+			opcode.InstructionReturnValue{},
+		},
+		functions[1].Code,
+	)
+
+	assert.Equal(t,
+		[]bbq.Constant{
+			{
+				Data: []byte{0x1},
+				Kind: constantkind.Int,
+			},
+			{
+				Data: []byte{0x2},
+				Kind: constantkind.Int,
+			},
+			{
+				Data: []byte{0x3},
+				Kind: constantkind.Int,
+			},
+		},
+		program.Constants,
+	)
+}

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -513,6 +513,36 @@ func DecodeGetConstant(ip *uint16, code []byte) (i InstructionGetConstant) {
 	return i
 }
 
+// InstructionNewClosure
+//
+// Creates a new closure with the function at the given index and pushes it onto the stack.
+type InstructionNewClosure struct {
+	FunctionIndex uint16
+}
+
+var _ Instruction = InstructionNewClosure{}
+
+func (InstructionNewClosure) Opcode() Opcode {
+	return NewClosure
+}
+
+func (i InstructionNewClosure) String() string {
+	var sb strings.Builder
+	sb.WriteString(i.Opcode().String())
+	printfArgument(&sb, "functionIndex", i.FunctionIndex)
+	return sb.String()
+}
+
+func (i InstructionNewClosure) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+	emitUint16(code, i.FunctionIndex)
+}
+
+func DecodeNewClosure(ip *uint16, code []byte) (i InstructionNewClosure) {
+	i.FunctionIndex = decodeUint16(ip, code)
+	return i
+}
+
 // InstructionInvoke
 //
 // Pops the function and arguments off the stack, invokes the function with the arguments, and then pushes the result back on to the stack.
@@ -1449,6 +1479,8 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 		return DecodeNewRef(ip, code)
 	case GetConstant:
 		return DecodeGetConstant(ip, code)
+	case NewClosure:
+		return DecodeNewClosure(ip, code)
 	case Invoke:
 		return DecodeInvoke(ip, code)
 	case InvokeDynamic:

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -227,6 +227,16 @@
       - name: "value"
         type: "value"
 
+- name: "newClosure"
+  description: Creates a new closure with the function at the given index and pushes it onto the stack.
+  operands:
+    - name: "functionIndex"
+      type: "index"
+  valueEffects:
+    push:
+      - name: "value"
+        type: "value"
+
 # Invocation instructions
 
 - name: "invoke"

--- a/bbq/opcode/opcode.go
+++ b/bbq/opcode/opcode.go
@@ -101,7 +101,7 @@ const (
 	NewArray
 	NewDictionary
 	NewRef
-	_
+	NewClosure
 	_
 	_
 	_

--- a/bbq/opcode/opcode_string.go
+++ b/bbq/opcode/opcode_string.go
@@ -48,6 +48,7 @@ func _() {
 	_ = x[NewArray-54]
 	_ = x[NewDictionary-55]
 	_ = x[NewRef-56]
+	_ = x[NewClosure-57]
 	_ = x[GetConstant-69]
 	_ = x[GetLocal-70]
 	_ = x[SetLocal-71]
@@ -74,7 +75,7 @@ const (
 	_Opcode_name_2 = "BitwiseOrBitwiseAndBitwiseXorBitwiseLeftShiftBitwiseRightShift"
 	_Opcode_name_3 = "LessGreaterLessOrEqualGreaterOrEqualEqualNotEqualNot"
 	_Opcode_name_4 = "UnwrapDestroyTransferSimpleCastFailableCastForceCastDeref"
-	_Opcode_name_5 = "TrueFalseNewPathNilNewArrayNewDictionaryNewRef"
+	_Opcode_name_5 = "TrueFalseNewPathNilNewArrayNewDictionaryNewRefNewClosure"
 	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetGlobalSetGlobalGetFieldSetFieldSetIndexGetIndex"
 	_Opcode_name_7 = "InvokeInvokeDynamic"
 	_Opcode_name_8 = "DropDup"
@@ -87,7 +88,7 @@ var (
 	_Opcode_index_2 = [...]uint8{0, 9, 19, 29, 45, 62}
 	_Opcode_index_3 = [...]uint8{0, 4, 11, 22, 36, 41, 49, 52}
 	_Opcode_index_4 = [...]uint8{0, 6, 13, 21, 31, 43, 52, 57}
-	_Opcode_index_5 = [...]uint8{0, 4, 9, 12, 16, 19, 27, 40, 46}
+	_Opcode_index_5 = [...]uint8{0, 4, 9, 12, 16, 19, 27, 40, 46, 56}
 	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 36, 45, 53, 61, 69, 77}
 	_Opcode_index_7 = [...]uint8{0, 6, 19}
 	_Opcode_index_8 = [...]uint8{0, 4, 7}
@@ -110,7 +111,7 @@ func (i Opcode) String() string {
 	case 36 <= i && i <= 42:
 		i -= 36
 		return _Opcode_name_4[_Opcode_index_4[i]:_Opcode_index_4[i+1]]
-	case 49 <= i && i <= 56:
+	case 49 <= i && i <= 57:
 		i -= 49
 		return _Opcode_name_5[_Opcode_index_5[i]:_Opcode_index_5[i+1]]
 	case 69 <= i && i <= 77:

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -125,6 +125,8 @@ func TestPrintInstruction(t *testing.T) {
 		"NewArray typeIndex:258 size:772 isResource:true":      {byte(NewArray), 1, 2, 3, 4, 1},
 		"NewDictionary typeIndex:258 size:772 isResource:true": {byte(NewDictionary), 1, 2, 3, 4, 1},
 
+		"NewClosure functionIndex:258": {byte(NewClosure), 1, 2},
+
 		"Unknown":     {byte(Unknown)},
 		"Return":      {byte(Return)},
 		"ReturnValue": {byte(ReturnValue)},

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -5427,3 +5427,26 @@ func TestReturnStatements(t *testing.T) {
 		)
 	})
 }
+
+func TestFunctionExpression(t *testing.T) {
+
+	t.Parallel()
+
+	actual, err := compileAndInvoke(t,
+		`
+          fun test(): Int {
+              let addOne = fun(_ x: Int): Int {
+                  return x + 1
+              }
+              let x = 2
+              return x + addOne(3)
+          }
+        `,
+		"test",
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, err)
+	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(6), actual)
+
+}

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -39,7 +39,8 @@ var _ interpreter.FunctionValue = FunctionValue{}
 func (FunctionValue) IsValue() {}
 
 func (FunctionValue) StaticType(interpreter.ValueStaticTypeContext) bbq.StaticType {
-	panic(errors.NewUnreachableError())
+	// TODO:
+	return nil
 }
 
 func (v FunctionValue) Transfer(_ interpreter.ValueTransferContext,


### PR DESCRIPTION
Work towards #3769

## Description

Add support for simple function expressions that do not close over variables.

- Add new instruction `NewClosure` which pushes a function value for the given function index onto the stack
- Compile function expressions by compiling function and emitting `NewClosure` instruction

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
