### PR TITLE
[Compiler] Work towards implementing closures

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1075,19 +1075,7 @@ func (c *Compiler[_, _]) VisitAssignmentStatement(statement *ast.AssignmentState
 		assignmentTypes := c.ExtendedElaboration.AssignmentStatementTypes(statement)
 		c.emitTransfer(assignmentTypes.TargetType)
 
-		varName := target.Identifier.Identifier
-		local := c.findLocal(varName)
-		if local != nil {
-			c.codeGen.Emit(opcode.InstructionSetLocal{
-				LocalIndex: local.index,
-			})
-			return
-		}
-
-		global := c.findGlobal(varName)
-		c.codeGen.Emit(opcode.InstructionSetGlobal{
-			GlobalIndex: global.Index,
-		})
+		c.emitVariableStore(target.Identifier.Identifier)
 
 	case *ast.MemberExpression:
 		c.compileExpression(target.Expression)
@@ -1271,12 +1259,31 @@ func (c *Compiler[_, _]) VisitIdentifierExpression(expression *ast.IdentifierExp
 func (c *Compiler[_, _]) emitVariableLoad(name string) {
 	local := c.findLocal(name)
 	if local != nil {
-		c.codeGen.Emit(opcode.InstructionGetLocal{LocalIndex: local.index})
+		c.codeGen.Emit(opcode.InstructionGetLocal{
+			LocalIndex: local.index,
+		})
 		return
 	}
 
 	global := c.findGlobal(name)
-	c.codeGen.Emit(opcode.InstructionGetGlobal{GlobalIndex: global.Index})
+	c.codeGen.Emit(opcode.InstructionGetGlobal{
+		GlobalIndex: global.Index,
+	})
+}
+
+func (c *Compiler[_, _]) emitVariableStore(name string) {
+	local := c.findLocal(name)
+	if local != nil {
+		c.codeGen.Emit(opcode.InstructionSetLocal{
+			LocalIndex: local.index,
+		})
+		return
+	}
+
+	global := c.findGlobal(name)
+	c.codeGen.Emit(opcode.InstructionSetGlobal{
+		GlobalIndex: global.Index,
+	})
 }
 
 func (c *Compiler[_, _]) VisitInvocationExpression(expression *ast.InvocationExpression) (_ struct{}) {

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -863,8 +863,8 @@ func (c *Compiler[_, _]) VisitIfStatement(statement *ast.IfStatement) (_ struct{
 			// in a new scope
 			c.locals.PushNewWithCurrent()
 			additionalThenScope = true
-			localIndex := c.declareLocal(test.Identifier.Identifier)
-			c.codeGen.Emit(opcode.InstructionSetLocal{LocalIndex: localIndex.index})
+			name := test.Identifier.Identifier
+			c.emitDeclareLocal(name)
 
 		default:
 			panic(errors.NewUnreachableError())
@@ -929,11 +929,8 @@ func (c *Compiler[_, _]) VisitForStatement(statement *ast.ForStatement) (_ struc
 		// `var <index> = -1`
 		// Start with -1 and then increment at the start of the loop,
 		// so that we don't have to deal with early exists of the loop.
-		indexLocalVar = c.declareLocal(index.Identifier)
 		c.intConstLoad(constantkind.Int, -1)
-		c.codeGen.Emit(opcode.InstructionSetLocal{
-			LocalIndex: indexLocalVar.index,
-		})
+		indexLocalVar = c.emitDeclareLocal(index.Identifier)
 	}
 
 	testOffset := c.codeGen.Offset()
@@ -973,10 +970,7 @@ func (c *Compiler[_, _]) VisitForStatement(statement *ast.ForStatement) (_ struc
 
 	// Store it (next entry) in a local var.
 	// `<entry> = iterator.next()`
-	elementLocalVar := c.declareLocal(statement.Identifier.Identifier)
-	c.codeGen.Emit(opcode.InstructionSetLocal{
-		LocalIndex: elementLocalVar.index,
-	})
+	c.emitDeclareLocal(statement.Identifier.Identifier)
 
 	// Compile the for-loop body.
 	c.compileBlock(statement.Block, common.DeclarationKindUnknown)
@@ -1062,12 +1056,19 @@ func (c *Compiler[_, _]) VisitVariableDeclaration(declaration *ast.VariableDecla
 			c.emitTransfer(varDeclTypes.TargetType)
 
 			// Declare the variable *after* compiling the value expression
-			local := c.declareLocal(name)
-			c.codeGen.Emit(opcode.InstructionSetLocal{LocalIndex: local.index})
+			c.emitDeclareLocal(name)
 		}
 	})
 
 	return
+}
+
+func (c *Compiler[_, _]) emitDeclareLocal(name string) *local {
+	local := c.declareLocal(name)
+	c.codeGen.Emit(opcode.InstructionSetLocal{
+		LocalIndex: local.index,
+	})
+	return local
 }
 
 func (c *Compiler[_, _]) VisitAssignmentStatement(statement *ast.AssignmentStatement) (_ struct{}) {
@@ -2112,9 +2113,8 @@ func (c *Compiler[_, _]) withConditionExtendedElaboration(statement ast.Statemen
 
 func (c *Compiler[_, _]) declareLocal(name string) *local {
 	f := c.currentFunction
-	index := f.generateLocalIndex()
 	local := &local{
-		index: index,
+		index: f.generateLocalIndex(),
 		depth: c.locals.Depth(),
 	}
 	c.locals.Set(name, local)

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -4122,3 +4122,110 @@ func TestCompileInnerFunction(t *testing.T) {
 		program.Constants,
 	)
 }
+
+func TestCompileFunctionExpressionOuterVariableUse(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+        fun test() {
+            let x = 1
+            let inner = fun(): Int {
+                return x
+            }
+        }
+    `)
+	require.NoError(t, err)
+
+	comp := compiler.NewInstructionCompiler(checker)
+	program := comp.Compile()
+
+	require.Len(t, program.Functions, 2)
+
+	functions := comp.ExportFunctions()
+	require.Equal(t, len(program.Functions), len(functions))
+
+	const (
+		// xIndex is the index of the local variable `x`, which is the first local variable
+		xIndex = iota
+	)
+
+	assert.Equal(t,
+		[]opcode.Instruction{
+			// let x = 1
+			opcode.InstructionGetConstant{ConstantIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: xIndex},
+
+			// let inner = fun(): Int { ...
+			opcode.InstructionNewClosure{FunctionIndex: 1},
+			opcode.InstructionTransfer{TypeIndex: 1},
+			opcode.InstructionSetLocal{LocalIndex: 1},
+
+			opcode.InstructionReturn{},
+		},
+		functions[0].Code,
+	)
+
+	assert.Equal(t,
+		[]opcode.Instruction{
+			// return x
+			opcode.InstructionGetLocal{LocalIndex: xIndex},
+			opcode.InstructionReturnValue{},
+		},
+		functions[1].Code,
+	)
+}
+
+func TestCompileInnerFunctionOuterVariableUse(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+        fun test() {
+            let x = 1
+            fun inner(): Int {
+                return x
+            }
+        }
+    `)
+	require.NoError(t, err)
+
+	comp := compiler.NewInstructionCompiler(checker)
+	program := comp.Compile()
+
+	require.Len(t, program.Functions, 2)
+
+	functions := comp.ExportFunctions()
+	require.Equal(t, len(program.Functions), len(functions))
+
+	const (
+		// xIndex is the index of the local variable `x`, which is the first local variable
+		xIndex = iota
+	)
+
+	assert.Equal(t,
+		[]opcode.Instruction{
+			// let x = 1
+			opcode.InstructionGetConstant{ConstantIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionSetLocal{LocalIndex: xIndex},
+
+			// fun inner(): Int { ...
+			opcode.InstructionNewClosure{FunctionIndex: 1},
+			opcode.InstructionSetLocal{LocalIndex: 1},
+
+			opcode.InstructionReturn{},
+		},
+		functions[0].Code,
+	)
+
+	assert.Equal(t,
+		[]opcode.Instruction{
+			// return x
+			opcode.InstructionGetLocal{LocalIndex: xIndex},
+			opcode.InstructionReturnValue{},
+		},
+		functions[1].Code,
+	)
+}

--- a/bbq/compiler/function.go
+++ b/bbq/compiler/function.go
@@ -25,18 +25,22 @@ import (
 )
 
 type function[E any] struct {
-	name                string
-	code                []E
-	localCount          uint16
-	parameterCount      uint16
-	isCompositeFunction bool
+	name           string
+	code           []E
+	localCount     uint16
+	parameterCount uint16
+	localsDepth    int
 }
 
-func newFunction[E any](name string, parameterCount uint16, isCompositeFunction bool) *function[E] {
+func newFunction[E any](
+	name string,
+	parameterCount uint16,
+	localsDepth int,
+) *function[E] {
 	return &function[E]{
-		name:                name,
-		parameterCount:      parameterCount,
-		isCompositeFunction: isCompositeFunction,
+		name:           name,
+		parameterCount: parameterCount,
+		localsDepth:    localsDepth,
 	}
 }
 

--- a/bbq/compiler/function.go
+++ b/bbq/compiler/function.go
@@ -21,7 +21,6 @@ package compiler
 import (
 	"math"
 
-	"github.com/onflow/cadence/activations"
 	"github.com/onflow/cadence/errors"
 )
 
@@ -29,7 +28,6 @@ type function[E any] struct {
 	name                string
 	code                []E
 	localCount          uint16
-	locals              *activations.Activations[*local]
 	parameterCount      uint16
 	isCompositeFunction bool
 }
@@ -38,27 +36,15 @@ func newFunction[E any](name string, parameterCount uint16, isCompositeFunction 
 	return &function[E]{
 		name:                name,
 		parameterCount:      parameterCount,
-		locals:              activations.NewActivations[*local](nil),
 		isCompositeFunction: isCompositeFunction,
 	}
 }
 
 func (f *function[E]) generateLocalIndex() uint16 {
-	index := f.localCount
-	f.localCount++
-	return index
-}
-
-func (f *function[E]) declareLocal(name string) *local {
 	if f.localCount == math.MaxUint16 {
 		panic(errors.NewDefaultUserError("invalid local declaration"))
 	}
-	index := f.generateLocalIndex()
-	local := &local{index: index}
-	f.locals.Set(name, local)
-	return local
-}
-
-func (f *function[E]) findLocal(name string) *local {
-	return f.locals.Find(name)
+	index := f.localCount
+	f.localCount++
+	return index
 }

--- a/bbq/compiler/local.go
+++ b/bbq/compiler/local.go
@@ -20,4 +20,5 @@ package compiler
 
 type local struct {
 	index uint16
+	depth int
 }

--- a/bbq/function.go
+++ b/bbq/function.go
@@ -24,6 +24,4 @@ type Function[E any] struct {
 	ParameterCount     uint16
 	TypeParameterCount uint16
 	LocalCount         uint16
-
-	IsCompositeFunction bool
 }


### PR DESCRIPTION
Work towards #3769 
Depends on #3839 

## Description

Start implementing closures.

- Allow referring to outer locals in nested functions (inner functions and functions expressions), by keeping a stack of locals across all nested functions, instead of per function
- Centralize the code generation of storing to variables (`emitVariableStore`), just how it already was for loading variables (`emitVariableLoad`)
- Centralize the code generation for declaring locals
- Keep track of local and function depth. This is needed later for determining if loading/storing locals or cells
- Clean up: Remove the unused `isCompositeFunction` field of functions

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
