### PR TITLE
[Compiler] Test contract `account` and resource `owner` fields

### DIFF
--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -282,8 +282,10 @@ func (c *Config) EnforceNotResourceDestruction(valueID atree.ValueID, locationRa
 }
 
 func (c *Config) InjectedCompositeFieldsHandler() interpreter.InjectedCompositeFieldsHandlerFunc {
-	//TODO
-	return nil
+	if c.interpreterConfig == nil {
+		return nil
+	}
+	return c.interpreterConfig.InjectedCompositeFieldsHandler
 }
 
 func (c *Config) GetMemberAccessContextForLocation(_ common.Location) interpreter.MemberAccessibleContext {
@@ -292,8 +294,7 @@ func (c *Config) GetMemberAccessContextForLocation(_ common.Location) interprete
 }
 
 func (c *Config) AccountHandler() interpreter.AccountHandlerFunc {
-	// TODO:
-	return nil
+	return c.interpreterConfig.AccountHandler
 }
 
 func (c *Config) GetAccountHandler() stdlib.AccountHandler {

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -638,7 +638,15 @@ func compileAndInvokeWithOptions(
 func CompileAndPrepareToInvoke(t testing.TB, code string, options CompilerAndVMOptions) *vm.VM {
 	programs := map[common.Location]*compiledProgram{}
 
-	location := common.ScriptLocation{0x1}
+	var location common.Location
+	parseAndCheckOptions := options.ParseAndCheckOptions
+	if parseAndCheckOptions != nil {
+		location = parseAndCheckOptions.Location
+	}
+	if location == nil {
+		location = common.ScriptLocation{0x1}
+	}
+
 	program := parseCheckAndCompileCodeWithOptions(
 		t,
 		code,
@@ -669,10 +677,8 @@ func CompileAndPrepareToInvoke(t testing.TB, code string, options CompilerAndVMO
 		}
 	}
 
-	scriptLocation := runtime_utils.NewScriptLocationGenerator()
-
 	programVM := vm.NewVM(
-		scriptLocation(),
+		location,
 		program,
 		vmConfig,
 	)

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -5470,3 +5470,216 @@ func TestInnerFunction(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(6), actual)
 }
+
+func TestContractContractAccount(t *testing.T) {
+	t.Parallel()
+
+	importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "C")
+
+	importedChecker, err := ParseAndCheckWithOptions(t,
+		`
+          contract C {
+              fun test(): Address {
+                  return self.account.address
+              }
+          }
+        `,
+		ParseAndCheckOptions{
+			Location: importLocation,
+		},
+	)
+	require.NoError(t, err)
+
+	importCompiler := compiler.NewInstructionCompiler(importedChecker)
+	importedProgram := importCompiler.Compile()
+
+	vmInstance := vm.NewVM(importLocation, importedProgram, nil)
+	importedContractValue, err := vmInstance.InitializeContract()
+	require.NoError(t, err)
+
+	checker, err := ParseAndCheckWithOptions(t,
+		`
+          import C from 0x1
+
+          fun test(): Address {
+              return C.test()
+          }
+        `,
+		ParseAndCheckOptions{
+			Config: &sema.Config{
+				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	comp := compiler.NewInstructionCompiler(checker)
+	comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		return importedProgram
+	}
+
+	program := comp.Compile()
+
+	addressValue := interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1})
+
+	vmConfig := (&vm.Config{
+		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
+			return importedProgram
+		},
+		ContractValueHandler: func(*vm.Config, common.Location) *interpreter.CompositeValue {
+			return importedContractValue
+		},
+	}).WithInterpreterConfig(&interpreter.Config{
+		InjectedCompositeFieldsHandler: func(
+			context interpreter.AccountCreationContext,
+			_ common.Location,
+			_ string,
+			_ common.CompositeKind,
+		) map[string]interpreter.Value {
+
+			accountRef := stdlib.NewAccountReferenceValue(
+				context,
+				nil,
+				addressValue,
+				interpreter.FullyEntitledAccountAccess,
+				interpreter.EmptyLocationRange,
+			)
+
+			return map[string]interpreter.Value{
+				sema.ContractAccountFieldName: accountRef,
+			}
+		},
+	})
+
+	vmInstance = vm.NewVM(scriptLocation(), program, vmConfig)
+
+	result, err := vmInstance.Invoke("test")
+	require.NoError(t, err)
+	require.Equal(t, 0, vmInstance.StackSize())
+
+	require.Equal(
+		t,
+		interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
+		result,
+	)
+}
+
+func TestResourceOwner(t *testing.T) {
+	t.Parallel()
+
+	importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "C")
+
+	importedChecker, err := ParseAndCheckWithOptions(t,
+		`
+          contract C {
+
+              resource R {}
+
+              fun test(): Address {
+                  let r <- create R()
+                  let path = /storage/r
+                  self.account.storage.save(<- r, to: path)
+                  let rRef = self.account.storage.borrow<&R>(from: path)!
+                  return rRef.owner!.address
+              }
+          }
+        `,
+		ParseAndCheckOptions{
+			Location: importLocation,
+		},
+	)
+	require.NoError(t, err)
+
+	importCompiler := compiler.NewInstructionCompiler(importedChecker)
+	importedProgram := importCompiler.Compile()
+
+	vmInstance := vm.NewVM(importLocation, importedProgram, nil)
+	importedContractValue, err := vmInstance.InitializeContract()
+	require.NoError(t, err)
+
+	checker, err := ParseAndCheckWithOptions(t,
+		`
+          import C from 0x1
+
+          fun test(): Address {
+              return C.test()
+          }
+        `,
+		ParseAndCheckOptions{
+			Config: &sema.Config{
+				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	comp := compiler.NewInstructionCompiler(checker)
+	comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		return importedProgram
+	}
+
+	program := comp.Compile()
+
+	addressValue := interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1})
+
+	vmConfig := (&vm.Config{
+		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
+			return importedProgram
+		},
+		ContractValueHandler: func(*vm.Config, common.Location) *interpreter.CompositeValue {
+			return importedContractValue
+		},
+		TypeLoader: func(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
+			elaboration := importedChecker.Elaboration
+			compositeType := elaboration.CompositeType(typeID)
+			if compositeType != nil {
+				return compositeType
+			}
+
+			return elaboration.InterfaceType(typeID)
+		},
+	}).WithInterpreterConfig(&interpreter.Config{
+		InjectedCompositeFieldsHandler: func(
+			context interpreter.AccountCreationContext,
+			_ common.Location,
+			_ string,
+			_ common.CompositeKind,
+		) map[string]interpreter.Value {
+
+			accountRef := stdlib.NewAccountReferenceValue(
+				context,
+				nil,
+				addressValue,
+				interpreter.FullyEntitledAccountAccess,
+				interpreter.EmptyLocationRange,
+			)
+
+			return map[string]interpreter.Value{
+				sema.ContractAccountFieldName: accountRef,
+			}
+		},
+		AccountHandler: func(context interpreter.AccountCreationContext, address interpreter.AddressValue) interpreter.Value {
+			return stdlib.NewAccountValue(context, nil, address)
+		},
+	})
+
+	vmInstance = vm.NewVM(scriptLocation(), program, vmConfig)
+
+	result, err := vmInstance.Invoke("test")
+	require.NoError(t, err)
+	require.Equal(t, 0, vmInstance.StackSize())
+
+	require.Equal(
+		t,
+		interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x1}),
+		result,
+	)
+}


### PR DESCRIPTION
Work towards #3769 

## Description

Given that the VM uses the interpreter composite value, the field lookup just works, after configuring the environment correctly.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
