### PR TITLE
[Compiler] Compile upvalues

### DIFF
--- a/bbq/compiler/function.go
+++ b/bbq/compiler/function.go
@@ -21,26 +21,30 @@ package compiler
 import (
 	"math"
 
+	"github.com/onflow/cadence/activations"
 	"github.com/onflow/cadence/errors"
 )
 
 type function[E any] struct {
+	enclosing      *function[E]
 	name           string
 	code           []E
+	locals         *activations.Activations[*local]
 	localCount     uint16
 	parameterCount uint16
-	localsDepth    int
+	upvalues       map[upvalue]uint16
 }
 
 func newFunction[E any](
+	enclosing *function[E],
 	name string,
 	parameterCount uint16,
-	localsDepth int,
 ) *function[E] {
 	return &function[E]{
+		enclosing:      enclosing,
 		name:           name,
+		locals:         activations.NewActivations[*local](nil),
 		parameterCount: parameterCount,
-		localsDepth:    localsDepth,
 	}
 }
 
@@ -48,7 +52,65 @@ func (f *function[E]) generateLocalIndex() uint16 {
 	if f.localCount == math.MaxUint16 {
 		panic(errors.NewDefaultUserError("invalid local declaration"))
 	}
-	index := f.localCount
+	localIndex := f.localCount
 	f.localCount++
-	return index
+	return localIndex
+}
+
+func (f *function[E]) declareLocal(name string) *local {
+	local := &local{
+		index: f.generateLocalIndex(),
+	}
+	f.locals.Set(name, local)
+	return local
+}
+
+func (f *function[E]) findLocal(name string) *local {
+	return f.locals.Find(name)
+}
+
+func (f *function[E]) addUpvalue(targetIndex uint16, targetIsLocal bool) uint16 {
+	upval := upvalue{
+		targetIndex:   targetIndex,
+		targetIsLocal: targetIsLocal,
+	}
+
+	if upvalueIndex, ok := f.upvalues[upval]; ok {
+		return upvalueIndex
+	}
+
+	count := len(f.upvalues)
+	if count == math.MaxUint16 {
+		panic(errors.NewDefaultUserError("invalid upvalue declaration"))
+	}
+
+	upvalueIndex := uint16(count)
+	if f.upvalues == nil {
+		f.upvalues = make(map[upvalue]uint16)
+	}
+	f.upvalues[upval] = upvalueIndex
+	return upvalueIndex
+}
+
+func (f *function[E]) findOrAddUpvalue(name string) (upvalueIndex uint16, ok bool) {
+	if f.enclosing == nil {
+		return 0, false
+	}
+
+	enclosingLocal := f.enclosing.findLocal(name)
+	if enclosingLocal != nil {
+		targetIndex := enclosingLocal.index
+		const targetIsLocal = true
+		return f.addUpvalue(targetIndex, targetIsLocal), true
+	}
+
+	enclosingUpvalueIndex, ok := f.enclosing.findOrAddUpvalue(name)
+	if ok {
+		targetIndex := enclosingUpvalueIndex
+		// target is upvalue
+		const targetIsLocal = false
+		return f.addUpvalue(targetIndex, targetIsLocal), true
+	}
+
+	return 0, false
 }

--- a/bbq/compiler/local.go
+++ b/bbq/compiler/local.go
@@ -20,5 +20,4 @@ package compiler
 
 type local struct {
 	index uint16
-	depth int
 }

--- a/bbq/opcode/gen/instructions.schema.json
+++ b/bbq/opcode/gen/instructions.schema.json
@@ -28,7 +28,6 @@
             "index",
             "indices",
             "size",
-            "string",
             "castKind",
             "pathDomain",
             "compositeKind"

--- a/bbq/opcode/gen/instructions.schema.json
+++ b/bbq/opcode/gen/instructions.schema.json
@@ -30,7 +30,8 @@
             "size",
             "castKind",
             "pathDomain",
-            "compositeKind"
+            "compositeKind",
+            "upvalues"
           ]
         },
         "description": { "type": "string" }

--- a/bbq/opcode/gen/main.go
+++ b/bbq/opcode/gen/main.go
@@ -40,6 +40,7 @@ const (
 	operandTypeCastKind      = "castKind"
 	operandTypePathDomain    = "pathDomain"
 	operandTypeCompositeKind = "compositeKind"
+	operandTypeUpvalues      = "upvalues"
 )
 
 type instruction struct {
@@ -316,6 +317,14 @@ func instructionOperandsFields(ins instruction) *dst.FieldList {
 				Path: commonPackagePath,
 			}
 
+		case operandTypeUpvalues:
+			typeExpr = &dst.ArrayType{
+				Elt: &dst.Ident{
+					Name: "Upvalue",
+					Path: opcodePackagePath,
+				},
+			}
+
 		default:
 			panic(fmt.Sprintf("unsupported operand type: %s", operand.Type))
 		}
@@ -473,6 +482,8 @@ func instructionStringFuncDecl(ins instruction) *dst.FuncDecl {
 			switch operand.Type {
 			case operandTypeIndices:
 				funcName = "printfUInt16ArrayArgument"
+			case operandTypeUpvalues:
+				funcName = "printfUpvalueArrayArgument"
 			default:
 				funcName = "printfArgument"
 			}
@@ -604,6 +615,9 @@ func instructionEncodeFuncDecl(ins instruction) *dst.FuncDecl {
 		case operandTypeCompositeKind:
 			funcName = "emitCompositeKind"
 
+		case operandTypeUpvalues:
+			funcName = "emitUpvalueArray"
+
 		default:
 			panic(fmt.Sprintf("unsupported operand type: %s", operand.Type))
 		}
@@ -696,6 +710,9 @@ func instructionDecodeFuncDecl(ins instruction) *dst.FuncDecl {
 
 		case operandTypeCompositeKind:
 			funcName = "decodeCompositeKind"
+
+		case operandTypeUpvalues:
+			funcName = "decodeUpvalueArray"
 
 		default:
 			panic(fmt.Sprintf("unsupported operand type: %s", operand.Type))

--- a/bbq/opcode/gen/main.go
+++ b/bbq/opcode/gen/main.go
@@ -37,7 +37,6 @@ const (
 	operandTypeIndex         = "index"
 	operandTypeIndices       = "indices"
 	operandTypeSize          = "size"
-	operandTypeString        = "string"
 	operandTypeCastKind      = "castKind"
 	operandTypePathDomain    = "pathDomain"
 	operandTypeCompositeKind = "compositeKind"
@@ -298,9 +297,6 @@ func instructionOperandsFields(ins instruction) *dst.FieldList {
 			typeExpr = &dst.ArrayType{
 				Elt: dst.NewIdent("uint16"),
 			}
-
-		case operandTypeString:
-			typeExpr = dst.NewIdent("string")
 
 		case operandTypeCastKind:
 			typeExpr = &dst.Ident{
@@ -599,9 +595,6 @@ func instructionEncodeFuncDecl(ins instruction) *dst.FuncDecl {
 		case operandTypeSize:
 			funcName = "emitUint16"
 
-		case operandTypeString:
-			funcName = "emitString"
-
 		case operandTypeCastKind:
 			funcName = "emitCastKind"
 
@@ -694,9 +687,6 @@ func instructionDecodeFuncDecl(ins instruction) *dst.FuncDecl {
 
 		case operandTypeSize:
 			funcName = "decodeUint16"
-
-		case operandTypeString:
-			funcName = "decodeString"
 
 		case operandTypeCastKind:
 			funcName = "decodeCastKind"

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -89,6 +89,66 @@ func DecodeSetLocal(ip *uint16, code []byte) (i InstructionSetLocal) {
 	return i
 }
 
+// InstructionGetUpvalue
+//
+// Pushes the value of the upvalue at the given index onto the stack.
+type InstructionGetUpvalue struct {
+	UpvalueIndex uint16
+}
+
+var _ Instruction = InstructionGetUpvalue{}
+
+func (InstructionGetUpvalue) Opcode() Opcode {
+	return GetUpvalue
+}
+
+func (i InstructionGetUpvalue) String() string {
+	var sb strings.Builder
+	sb.WriteString(i.Opcode().String())
+	printfArgument(&sb, "upvalueIndex", i.UpvalueIndex)
+	return sb.String()
+}
+
+func (i InstructionGetUpvalue) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+	emitUint16(code, i.UpvalueIndex)
+}
+
+func DecodeGetUpvalue(ip *uint16, code []byte) (i InstructionGetUpvalue) {
+	i.UpvalueIndex = decodeUint16(ip, code)
+	return i
+}
+
+// InstructionSetUpvalue
+//
+// Pops a value off the stack and then sets the upvalue at the given index to that value.
+type InstructionSetUpvalue struct {
+	UpvalueIndex uint16
+}
+
+var _ Instruction = InstructionSetUpvalue{}
+
+func (InstructionSetUpvalue) Opcode() Opcode {
+	return SetUpvalue
+}
+
+func (i InstructionSetUpvalue) String() string {
+	var sb strings.Builder
+	sb.WriteString(i.Opcode().String())
+	printfArgument(&sb, "upvalueIndex", i.UpvalueIndex)
+	return sb.String()
+}
+
+func (i InstructionSetUpvalue) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+	emitUint16(code, i.UpvalueIndex)
+}
+
+func DecodeSetUpvalue(ip *uint16, code []byte) (i InstructionSetUpvalue) {
+	i.UpvalueIndex = decodeUint16(ip, code)
+	return i
+}
+
 // InstructionGetGlobal
 //
 // Pushes the value of the global at the given index onto the stack.
@@ -1449,6 +1509,10 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 		return DecodeGetLocal(ip, code)
 	case SetLocal:
 		return DecodeSetLocal(ip, code)
+	case GetUpvalue:
+		return DecodeGetUpvalue(ip, code)
+	case SetUpvalue:
+		return DecodeSetUpvalue(ip, code)
 	case GetGlobal:
 		return DecodeGetGlobal(ip, code)
 	case SetGlobal:

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -578,6 +578,7 @@ func DecodeGetConstant(ip *uint16, code []byte) (i InstructionGetConstant) {
 // Creates a new closure with the function at the given index and pushes it onto the stack.
 type InstructionNewClosure struct {
 	FunctionIndex uint16
+	Upvalues      []Upvalue
 }
 
 var _ Instruction = InstructionNewClosure{}
@@ -590,16 +591,19 @@ func (i InstructionNewClosure) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
 	printfArgument(&sb, "functionIndex", i.FunctionIndex)
+	printfUpvalueArrayArgument(&sb, "upvalues", i.Upvalues)
 	return sb.String()
 }
 
 func (i InstructionNewClosure) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
 	emitUint16(code, i.FunctionIndex)
+	emitUpvalueArray(code, i.Upvalues)
 }
 
 func DecodeNewClosure(ip *uint16, code []byte) (i InstructionNewClosure) {
 	i.FunctionIndex = decodeUint16(ip, code)
+	i.Upvalues = decodeUpvalueArray(ip, code)
 	return i
 }
 

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -256,6 +256,8 @@
   operands:
     - name: "functionIndex"
       type: "index"
+    - name: "upvalues"
+      type: "upvalues"
   valueEffects:
     push:
       - name: "value"

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -27,6 +27,30 @@
       - name: "value"
         type: "value"
 
+# Upvalue instructions
+
+- name: "getUpvalue"
+  description:
+    Pushes the value of the upvalue at the given index onto the stack.
+  operands:
+    - name: "upvalueIndex"
+      type: "index"
+  valueEffects:
+    push:
+      - name: "value"
+        type: "value"
+
+- name: "setUpvalue"
+  description:
+    Pops a value off the stack and then sets the upvalue at the given index to that value.
+  operands:
+    - name: "upvalueIndex"
+      type: "index"
+  valueEffects:
+    pop:
+      - name: "value"
+        type: "value"
+
 # Global instructions
 
 - name: "getGlobal"

--- a/bbq/opcode/opcode.go
+++ b/bbq/opcode/opcode.go
@@ -117,14 +117,14 @@ const (
 	GetConstant
 	GetLocal
 	SetLocal
+	GetUpvalue
+	SetUpvalue
 	GetGlobal
 	SetGlobal
 	GetField
 	SetField
 	SetIndex
 	GetIndex
-	_
-	_
 	_
 	_
 	_

--- a/bbq/opcode/opcode_string.go
+++ b/bbq/opcode/opcode_string.go
@@ -52,12 +52,14 @@ func _() {
 	_ = x[GetConstant-69]
 	_ = x[GetLocal-70]
 	_ = x[SetLocal-71]
-	_ = x[GetGlobal-72]
-	_ = x[SetGlobal-73]
-	_ = x[GetField-74]
-	_ = x[SetField-75]
-	_ = x[SetIndex-76]
-	_ = x[GetIndex-77]
+	_ = x[GetUpvalue-72]
+	_ = x[SetUpvalue-73]
+	_ = x[GetGlobal-74]
+	_ = x[SetGlobal-75]
+	_ = x[GetField-76]
+	_ = x[SetField-77]
+	_ = x[SetIndex-78]
+	_ = x[GetIndex-79]
 	_ = x[Invoke-89]
 	_ = x[InvokeDynamic-90]
 	_ = x[Drop-99]
@@ -76,7 +78,7 @@ const (
 	_Opcode_name_3 = "LessGreaterLessOrEqualGreaterOrEqualEqualNotEqualNot"
 	_Opcode_name_4 = "UnwrapDestroyTransferSimpleCastFailableCastForceCastDeref"
 	_Opcode_name_5 = "TrueFalseNewPathNilNewArrayNewDictionaryNewRefNewClosure"
-	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetGlobalSetGlobalGetFieldSetFieldSetIndexGetIndex"
+	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetUpvalueSetUpvalueGetGlobalSetGlobalGetFieldSetFieldSetIndexGetIndex"
 	_Opcode_name_7 = "InvokeInvokeDynamic"
 	_Opcode_name_8 = "DropDup"
 	_Opcode_name_9 = "IteratorIteratorHasNextIteratorNextEmitEventOpcodeMax"
@@ -89,7 +91,7 @@ var (
 	_Opcode_index_3 = [...]uint8{0, 4, 11, 22, 36, 41, 49, 52}
 	_Opcode_index_4 = [...]uint8{0, 6, 13, 21, 31, 43, 52, 57}
 	_Opcode_index_5 = [...]uint8{0, 4, 9, 12, 16, 19, 27, 40, 46, 56}
-	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 36, 45, 53, 61, 69, 77}
+	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 37, 47, 56, 65, 73, 81, 89, 97}
 	_Opcode_index_7 = [...]uint8{0, 6, 19}
 	_Opcode_index_8 = [...]uint8{0, 4, 7}
 	_Opcode_index_9 = [...]uint8{0, 8, 23, 35, 44, 53}
@@ -114,7 +116,7 @@ func (i Opcode) String() string {
 	case 49 <= i && i <= 57:
 		i -= 49
 		return _Opcode_name_5[_Opcode_index_5[i]:_Opcode_index_5[i+1]]
-	case 69 <= i && i <= 77:
+	case 69 <= i && i <= 79:
 		i -= 69
 		return _Opcode_name_6[_Opcode_index_6[i]:_Opcode_index_6[i+1]]
 	case 89 <= i && i <= 90:

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -127,7 +127,9 @@ func TestPrintInstruction(t *testing.T) {
 		"NewArray typeIndex:258 size:772 isResource:true":      {byte(NewArray), 1, 2, 3, 4, 1},
 		"NewDictionary typeIndex:258 size:772 isResource:true": {byte(NewDictionary), 1, 2, 3, 4, 1},
 
-		"NewClosure functionIndex:258": {byte(NewClosure), 1, 2},
+		"NewClosure functionIndex:258 upvalues:[targetIndex:772 isLocal:false, targetIndex:1543 isLocal:true]": {
+			byte(NewClosure), 1, 2, 0, 2, 3, 4, 0, 6, 7, 1,
+		},
 
 		"Unknown":     {byte(Unknown)},
 		"Return":      {byte(Return)},

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -93,6 +93,8 @@ func TestPrintInstruction(t *testing.T) {
 		"GetConstant constantIndex:258": {byte(GetConstant), 1, 2},
 		"GetLocal localIndex:258":       {byte(GetLocal), 1, 2},
 		"SetLocal localIndex:258":       {byte(SetLocal), 1, 2},
+		"GetUpvalue upvalueIndex:258":   {byte(GetUpvalue), 1, 2},
+		"SetUpvalue upvalueIndex:258":   {byte(SetUpvalue), 1, 2},
 		"GetGlobal globalIndex:258":     {byte(GetGlobal), 1, 2},
 		"SetGlobal globalIndex:258":     {byte(SetGlobal), 1, 2},
 

--- a/bbq/opcode/upvalue.go
+++ b/bbq/opcode/upvalue.go
@@ -1,0 +1,24 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opcode
+
+type Upvalue struct {
+	TargetIndex uint16
+	IsLocal     bool
+}

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -1162,6 +1162,11 @@ func opNewClosure(vm *VM, ins opcode.InstructionNewClosure) {
 	executable := vm.callFrame.executable
 	function := &executable.Program.Functions[ins.FunctionIndex]
 
+	// TODO: implement upvalues
+	if len(ins.Upvalues) > 0 {
+		panic(errors.NewUnreachableError())
+	}
+
 	vm.push(FunctionValue{
 		Function:   function,
 		Executable: executable,


### PR DESCRIPTION
Work towards #3769 

## Description

Continue implementing closures, by completing the compilation part. 

References to outer variables (free variables) are compiled to upvalues, like in Lua. See e.g. 
- https://www.cs.tufts.edu/~nr/cs257/archive/roberto-ierusalimschy/closures-draft.pdf
- https://www.jucs.org/jucs_11_7/the_implementation_of_lua/jucs_11_7_1159_1176_defigueiredo.html#sec5
- https://craftinginterpreters.com/closures.html


The main benefit compared to the previously planned approach similar to CPython is that we do not need an additional pass to detect free variables in the compiler or checker (last point):

> - [...] no impact on the performance of programs that do not use non-local variables.
> - [...] provide[s] acceptable performance for imperative programs, where side effects (e.g., assignments) are the norm.
> - [...] compatible with the standard execution model for procedural languages, where variables live in activation records allocated in an array-based stack.
> - [...] amenable to a one-pass compiler that generates code on the fly, without intermediate representations.

Changes of this PR:
- Revert part of #3840, parts of [7f340f8](https://github.com/onflow/cadence/pull/3840/commits/7f340f871c30c211f4e70662daf599cdcfc8aa10) and [3109d7d](https://github.com/onflow/cadence/pull/3840/commits/3109d7da06b59b34209a38b3c4f3554a783ba920), as they were unnecessary
- Add new instructions `GetUpvalue` and `SetUpvalue`
- Add upvalue array operand to `NewClosure` instruction
- Until implemented in the VM, abort VM when a closure has upvalues. i.e. this work has no impact on simple inner functions and function expressions which do not refer to outer variables

Unrelated cleanup: remove support for string operands from instruction code generator. All instructions which used to use string operands were previously refactored to refer to a constant index instead.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
