### PR TITLE
[Compiler] Implement unclosed upvalues in VM

### DIFF
--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -4484,7 +4484,7 @@ func TestCompileFunctionExpressionOuterOuterVariableUse(t *testing.T) {
               }
           }
       }
-  `)
+    `)
 	require.NoError(t, err)
 
 	comp := compiler.NewInstructionCompiler(checker)

--- a/bbq/opcode/instruction.go
+++ b/bbq/opcode/instruction.go
@@ -196,7 +196,7 @@ func printfUInt16ArrayArgument(sb *strings.Builder, argName string, values []uin
 		_, _ = fmt.Fprintf(sb, "%d", value)
 	}
 
-	sb.WriteString("]")
+	sb.WriteByte(']')
 }
 
 func printfUpvalueArrayArgument(sb *strings.Builder, argName string, upvalues []Upvalue) {
@@ -208,7 +208,7 @@ func printfUpvalueArrayArgument(sb *strings.Builder, argName string, upvalues []
 		_, _ = fmt.Fprintf(sb, "targetIndex:%d isLocal:%v", upvalue.TargetIndex, upvalue.IsLocal)
 	}
 
-	sb.WriteString("]")
+	sb.WriteByte(']')
 }
 
 func printfArgument(sb *strings.Builder, fieldName string, v any) {

--- a/bbq/vm/callframe.go
+++ b/bbq/vm/callframe.go
@@ -18,14 +18,8 @@
 
 package vm
 
-import (
-	"github.com/onflow/cadence/bbq"
-	"github.com/onflow/cadence/bbq/opcode"
-)
-
 type callFrame struct {
-	executable   *ExecutableProgram
 	localsOffset uint16
 	localsCount  uint16
-	function     *bbq.Function[opcode.Instruction]
+	function     FunctionValue
 }

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -5470,3 +5470,96 @@ func TestInnerFunction(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(6), actual)
 }
+
+func TestUnclosedUpvalue(t *testing.T) {
+
+	t.Parallel()
+
+	actual, err := compileAndInvoke(t,
+		`
+          fun test(): Int {
+              let x = 1
+              fun addToX(_ y: Int): Int {
+                  return x + y
+              }
+              return addToX(2)
+          }
+        `,
+		"test",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(3), actual)
+}
+
+func TestUnclosedUpvalueNested(t *testing.T) {
+
+	t.Parallel()
+
+	actual, err := compileAndInvoke(t,
+		`
+          fun test(): Int {
+              let x = 1
+              fun middle(): Int {
+                  fun inner(): Int {
+                      let y = 2
+                      return x + y
+                  }
+                  return inner()
+              }
+              return middle()
+          }
+        `,
+		"test",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(3), actual)
+}
+
+func TestUnclosedUpvalueDeeplyNested(t *testing.T) {
+
+	t.Parallel()
+
+	actual, err := compileAndInvoke(t,
+		`
+          fun test(): Int {
+              let a = 1
+              let b = 2
+              fun middle(): Int {
+                  let c = 3
+                  let d = 4
+                  fun inner(): Int {
+                      let e = 5
+                      let f = 6
+                      return f + e + d + b + c + a
+                  }
+                  return inner()
+              }
+              return middle()
+          }
+        `,
+		"test",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(21), actual)
+}
+
+func TestUnclosedUpvalueAssignment(t *testing.T) {
+
+	t.Parallel()
+
+	actual, err := compileAndInvoke(t,
+		`
+          fun test(): Int {
+              var x = 1
+              fun addToX(_ y: Int) {
+                  x = x + y
+              }
+              addToX(2)
+              return x
+          }
+        `,
+		"test",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(3), actual)
+}

--- a/bbq/vm/upvalue.go
+++ b/bbq/vm/upvalue.go
@@ -1,0 +1,23 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vm
+
+type Upvalue struct {
+	absoluteLocalIndex uint16
+}

--- a/bbq/vm/upvalue.go
+++ b/bbq/vm/upvalue.go
@@ -19,5 +19,5 @@
 package vm
 
 type Upvalue struct {
-	absoluteLocalIndex uint16
+	stackOffset int
 }

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -31,6 +31,7 @@ import (
 type FunctionValue struct {
 	Function   *bbq.Function[opcode.Instruction]
 	Executable *ExecutableProgram
+	Upvalues   []*Upvalue
 }
 
 var _ Value = FunctionValue{}

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -548,6 +548,16 @@ func opSetLocal(vm *VM, ins opcode.InstructionSetLocal) {
 	vm.locals[absoluteIndex] = vm.pop()
 }
 
+func opGetUpvalue(vm *VM, ins opcode.InstructionGetUpvalue) {
+	upvalue := vm.callFrame.function.Upvalues[ins.UpvalueIndex]
+	vm.push(vm.locals[upvalue.absoluteLocalIndex])
+}
+
+func opSetUpvalue(vm *VM, ins opcode.InstructionSetUpvalue) {
+	upvalue := vm.callFrame.function.Upvalues[ins.UpvalueIndex]
+	vm.locals[upvalue.absoluteLocalIndex] = vm.pop()
+}
+
 func opGetGlobal(vm *VM, ins opcode.InstructionGetGlobal) {
 	value := vm.callFrame.function.Executable.Globals[ins.GlobalIndex]
 	vm.push(value)
@@ -1073,6 +1083,10 @@ func (vm *VM) run() {
 			opGetLocal(vm, ins)
 		case opcode.InstructionSetLocal:
 			opSetLocal(vm, ins)
+		case opcode.InstructionGetUpvalue:
+			opGetUpvalue(vm, ins)
+		case opcode.InstructionSetUpvalue:
+			opSetUpvalue(vm, ins)
 		case opcode.InstructionGetGlobal:
 			opGetGlobal(vm, ins)
 		case opcode.InstructionSetGlobal:

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -550,12 +550,12 @@ func opSetLocal(vm *VM, ins opcode.InstructionSetLocal) {
 
 func opGetUpvalue(vm *VM, ins opcode.InstructionGetUpvalue) {
 	upvalue := vm.callFrame.function.Upvalues[ins.UpvalueIndex]
-	vm.push(vm.locals[upvalue.absoluteLocalIndex])
+	vm.push(vm.locals[upvalue.stackOffset])
 }
 
 func opSetUpvalue(vm *VM, ins opcode.InstructionSetUpvalue) {
 	upvalue := vm.callFrame.function.Upvalues[ins.UpvalueIndex]
-	vm.locals[upvalue.absoluteLocalIndex] = vm.pop()
+	vm.locals[upvalue.stackOffset] = vm.pop()
 }
 
 func opGetGlobal(vm *VM, ins opcode.InstructionGetGlobal) {
@@ -1186,8 +1186,8 @@ func opNewClosure(vm *VM, ins opcode.InstructionNewClosure) {
 		targetIndex := upvalueDescriptor.TargetIndex
 		var upvalue *Upvalue
 		if upvalueDescriptor.IsLocal {
-			absoluteLocalIndex := vm.callFrame.localsOffset + targetIndex
-			upvalue = vm.captureUpvalue(absoluteLocalIndex)
+			stackOffset := int(vm.callFrame.localsOffset) + int(targetIndex)
+			upvalue = vm.captureUpvalue(stackOffset)
 		} else {
 			upvalue = vm.callFrame.function.Upvalues[targetIndex]
 		}
@@ -1201,9 +1201,9 @@ func opNewClosure(vm *VM, ins opcode.InstructionNewClosure) {
 	})
 }
 
-func (vm *VM) captureUpvalue(absoluteLocalIndex uint16) *Upvalue {
+func (vm *VM) captureUpvalue(stackOffset int) *Upvalue {
 	return &Upvalue{
-		absoluteLocalIndex: absoluteLocalIndex,
+		stackOffset: stackOffset,
 	}
 }
 


### PR DESCRIPTION
Work towards #3769
Depends on #3842

## Description

Implement support for _unclosed_ upvalues, i.e. variables that are closed over and used before the function that declares the variable has returned. A follow-up PR will add support for _closed_ upvalues.

This PR:
- Changes VM call frames to use function values. They both already contained function code + executable
- Implements upvalues of the `newClosure` instruction by creating upvalues that point to the locals on the stack / enclosing function upvalues
- Implements the `GetUpvalue` and `SetUpvalue` instructions

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
