### PR TITLE
Decouple remaining methods of `Value` interface from the interpreter

### DIFF
--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -170,6 +170,12 @@ type ValueCloneContext interface {
 
 var _ ValueCloneContext = &Interpreter{}
 
+type ValueImportableContext interface {
+	ContainerMutationContext
+}
+
+var _ ValueImportableContext = &Interpreter{}
+
 type ReferenceCreationContext interface {
 	common.MemoryGauge
 	ReferenceTracker

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -78,6 +78,13 @@ type ValueStaticTypeContext interface {
 
 var _ ValueStaticTypeContext = &Interpreter{}
 
+type ValueStaticTypeConformanceContext interface {
+	ValueStaticTypeContext
+	ContainerMutationContext
+}
+
+var _ ValueStaticTypeConformanceContext = &Interpreter{}
+
 type StorageContext interface {
 	ValueStaticTypeContext
 	common.MemoryGauge
@@ -551,11 +558,11 @@ func (ctx NoOpStringContext) MaybeTrackReferencedResourceKindedValue(_ *Ephemera
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) ClearReferencedResourceKindedValues(valueID atree.ValueID) {
+func (ctx NoOpStringContext) ClearReferencedResourceKindedValues(_ atree.ValueID) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) ReferencedResourceKindedValues(valueID atree.ValueID) map[*EphemeralReferenceValue]struct{} {
+func (ctx NoOpStringContext) ReferencedResourceKindedValues(_ atree.ValueID) map[*EphemeralReferenceValue]struct{} {
 	panic(errors.NewUnreachableError())
 }
 
@@ -587,6 +594,10 @@ func (ctx NoOpStringContext) ReportDictionaryValueTransferTrace(_ string, _ int,
 	panic(errors.NewUnreachableError())
 }
 
+func (ctx NoOpStringContext) ReportArrayValueConformsToStaticTypeTrace(_ string, _ int, _ time.Duration) {
+	panic(errors.NewUnreachableError())
+}
+
 func (ctx NoOpStringContext) ReportDictionaryValueDestroyTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
@@ -604,6 +615,10 @@ func (ctx NoOpStringContext) ReportDictionaryValueGetMemberTrace(_ string, _ int
 }
 
 func (ctx NoOpStringContext) ReportDictionaryValueConstructTrace(_ string, _ int, _ time.Duration) {
+	panic(errors.NewUnreachableError())
+}
+
+func (ctx NoOpStringContext) ReportDictionaryValueConformsToStaticTypeTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
@@ -627,6 +642,10 @@ func (ctx NoOpStringContext) ReportCompositeValueConstructTrace(_ string, _ stri
 	panic(errors.NewUnreachableError())
 }
 
+func (ctx NoOpStringContext) ReportCompositeValueConformsToStaticTypeTrace(_ string, _ string, _ string, _ time.Duration) {
+	panic(errors.NewUnreachableError())
+}
+
 func (ctx NoOpStringContext) ReportDomainStorageMapDeepRemoveTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
@@ -647,7 +666,7 @@ func (ctx NoOpStringContext) InStorageIteration() bool {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) SetInStorageIteration(b bool) {
+func (ctx NoOpStringContext) SetInStorageIteration(_ bool) {
 	panic(errors.NewUnreachableError())
 }
 

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -163,6 +163,13 @@ type ValueStringContext interface {
 
 var _ ValueStringContext = &Interpreter{}
 
+type ValueCloneContext interface {
+	StorageContext
+	ReferenceTracker
+}
+
+var _ ValueCloneContext = &Interpreter{}
+
 type ReferenceCreationContext interface {
 	common.MemoryGauge
 	ReferenceTracker

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -176,6 +176,12 @@ type ValueImportableContext interface {
 
 var _ ValueImportableContext = &Interpreter{}
 
+type ValueVisitContext interface {
+	ValueWalkContext
+}
+
+var _ ValueVisitContext = &Interpreter{}
+
 type ReferenceCreationContext interface {
 	common.MemoryGauge
 	ReferenceTracker

--- a/interpreter/interpreter_tracing.go
+++ b/interpreter/interpreter_tracing.go
@@ -55,12 +55,14 @@ type Tracer interface {
 	ReportArrayValueTransferTrace(info string, count int, since time.Duration)
 	ReportArrayValueConstructTrace(typeInfo string, count int, duration time.Duration)
 	ReportArrayValueDestroyTrace(info string, count int, since time.Duration)
+	ReportArrayValueConformsToStaticTypeTrace(info string, count int, since time.Duration)
 
 	ReportDictionaryValueTransferTrace(info string, count int, since time.Duration)
 	ReportDictionaryValueDeepRemoveTrace(info string, count int, since time.Duration)
 	ReportDictionaryValueGetMemberTrace(info string, count int, name string, since time.Duration)
 	ReportDictionaryValueConstructTrace(info string, count int, since time.Duration)
 	ReportDictionaryValueDestroyTrace(info string, count int, since time.Duration)
+	ReportDictionaryValueConformsToStaticTypeTrace(info string, count int, since time.Duration)
 
 	ReportCompositeValueDeepRemoveTrace(owner string, id string, kind string, since time.Duration)
 	ReportCompositeValueTransferTrace(owner string, id string, kind string, since time.Duration)
@@ -68,6 +70,7 @@ type Tracer interface {
 	ReportCompositeValueGetMemberTrace(owner string, typeID string, kind string, name string, duration time.Duration)
 	ReportCompositeValueConstructTrace(owner string, id string, kind string, since time.Duration)
 	ReportCompositeValueDestroyTrace(owner string, id string, kind string, since time.Duration)
+	ReportCompositeValueConformsToStaticTypeTrace(owner string, id string, kind string, since time.Duration)
 
 	ReportDomainStorageMapDeepRemoveTrace(info string, i int, since time.Duration)
 }
@@ -145,7 +148,7 @@ func (interpreter *Interpreter) ReportArrayValueTransferTrace(
 	)
 }
 
-func (interpreter *Interpreter) reportArrayValueConformsToStaticTypeTrace(
+func (interpreter *Interpreter) ReportArrayValueConformsToStaticTypeTrace(
 	typeInfo string,
 	count int,
 	duration time.Duration,
@@ -229,7 +232,7 @@ func (interpreter *Interpreter) ReportDictionaryValueTransferTrace(
 	)
 }
 
-func (interpreter *Interpreter) reportDictionaryValueConformsToStaticTypeTrace(
+func (interpreter *Interpreter) ReportDictionaryValueConformsToStaticTypeTrace(
 	typeInfo string,
 	count int,
 	duration time.Duration,
@@ -326,7 +329,7 @@ func (interpreter *Interpreter) ReportCompositeValueTransferTrace(
 	)
 }
 
-func (interpreter *Interpreter) reportCompositeValueConformsToStaticTypeTrace(
+func (interpreter *Interpreter) ReportCompositeValueConformsToStaticTypeTrace(
 	owner string,
 	typeID string,
 	kind string,

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -226,7 +226,7 @@ func (v *SimpleCompositeValue) MeteredString(context ValueStringContext, seenRef
 }
 
 func (v *SimpleCompositeValue) ConformsToStaticType(
-	interpreter *Interpreter,
+	context ValueStaticTypeConformanceContext,
 	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
@@ -237,7 +237,7 @@ func (v *SimpleCompositeValue) ConformsToStaticType(
 			continue
 		}
 		if !value.ConformsToStaticType(
-			interpreter,
+			context,
 			locationRange,
 			results,
 		) {

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -80,8 +80,8 @@ func NewSimpleCompositeValue(
 
 func (*SimpleCompositeValue) IsValue() {}
 
-func (v *SimpleCompositeValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitSimpleCompositeValue(interpreter, v)
+func (v *SimpleCompositeValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitSimpleCompositeValue(context, v)
 }
 
 // ForEachField iterates over all field-name field-value pairs of the composite value.

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -256,7 +256,7 @@ func (*SimpleCompositeValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (v *SimpleCompositeValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (v *SimpleCompositeValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -283,14 +283,14 @@ func (v *SimpleCompositeValue) Transfer(
 	return v
 }
 
-func (v *SimpleCompositeValue) Clone(interpreter *Interpreter) Value {
+func (v *SimpleCompositeValue) Clone(context ValueCloneContext) Value {
 
 	clonedFields := make(map[string]Value, len(v.Fields))
 
 	for _, fieldName := range v.FieldNames {
 		fieldValue := v.Fields[fieldName]
 
-		clonedFields[fieldName] = fieldValue.Clone(interpreter)
+		clonedFields[fieldName] = fieldValue.Clone(context)
 	}
 
 	return &SimpleCompositeValue{

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -112,10 +112,10 @@ func (v *SimpleCompositeValue) StaticType(_ ValueStaticTypeContext) StaticType {
 	return v.staticType
 }
 
-func (v *SimpleCompositeValue) IsImportable(inter *Interpreter, locationRange LocationRange) bool {
+func (v *SimpleCompositeValue) IsImportable(context ValueImportableContext, locationRange LocationRange) bool {
 	// Check type is importable
-	staticType := v.StaticType(inter)
-	semaType := MustConvertStaticToSemaType(staticType, inter)
+	staticType := v.StaticType(context)
+	semaType := MustConvertStaticToSemaType(staticType, context)
 	if !semaType.IsImportable(map[*sema.Member]bool{}) {
 		return false
 	}
@@ -123,7 +123,7 @@ func (v *SimpleCompositeValue) IsImportable(inter *Interpreter, locationRange Lo
 	// Check all field values are importable
 	importable := true
 	v.ForEachField(func(_ string, value Value) (resume bool) {
-		if !value.IsImportable(inter, locationRange) {
+		if !value.IsImportable(context, locationRange) {
 			importable = false
 			// stop iteration
 			return false

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -128,7 +128,7 @@ type Value interface {
 	// Clone returns a new value that is equal to this value.
 	// NOTE: not used by interpreter, but used externally (e.g. state migration)
 	// NOTE: memory metering is unnecessary for Clone methods
-	Clone(interpreter *Interpreter) Value
+	Clone(context ValueCloneContext) Value
 	IsImportable(interpreter *Interpreter, locationRange LocationRange) bool
 }
 

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -93,7 +93,7 @@ type Value interface {
 	fmt.Stringer
 	IsValue()
 	Accept(interpreter *Interpreter, visitor Visitor, locationRange LocationRange)
-	Walk(interpreter ValueWalkContext, walkChild func(Value), locationRange LocationRange)
+	Walk(walkContext ValueWalkContext, walkChild func(Value), locationRange LocationRange)
 	StaticType(context ValueStaticTypeContext) StaticType
 	// ConformsToStaticType returns true if the value (i.e. its dynamic type)
 	// conforms to its own static type.
@@ -128,8 +128,8 @@ type Value interface {
 	// Clone returns a new value that is equal to this value.
 	// NOTE: not used by interpreter, but used externally (e.g. state migration)
 	// NOTE: memory metering is unnecessary for Clone methods
-	Clone(context ValueCloneContext) Value
-	IsImportable(interpreter *Interpreter, locationRange LocationRange) bool
+	Clone(cloneContext ValueCloneContext) Value
+	IsImportable(context ValueImportableContext, locationRange LocationRange) bool
 }
 
 // ValueIndexableValue

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -104,7 +104,7 @@ type Value interface {
 	// e.g. the element type of an array, it also ensures the nested values'
 	// static types are subtypes.
 	ConformsToStaticType(
-		interpreter *Interpreter,
+		context ValueStaticTypeConformanceContext,
 		locationRange LocationRange,
 		results TypeConformanceResults,
 	) bool

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -92,7 +92,7 @@ type Value interface {
 	// NOTE: important, error messages rely on values to implement String
 	fmt.Stringer
 	IsValue()
-	Accept(interpreter *Interpreter, visitor Visitor, locationRange LocationRange)
+	Accept(context ValueVisitContext, visitor Visitor, locationRange LocationRange)
 	Walk(walkContext ValueWalkContext, walkChild func(Value), locationRange LocationRange)
 	StaticType(context ValueStaticTypeContext) StaticType
 	// ConformsToStaticType returns true if the value (i.e. its dynamic type)

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -89,8 +89,8 @@ func (v *AccountCapabilityControllerValue) CapabilityControllerBorrowType() *Ref
 	return v.BorrowType
 }
 
-func (v *AccountCapabilityControllerValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitAccountCapabilityControllerValue(interpreter, v)
+func (v *AccountCapabilityControllerValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitAccountCapabilityControllerValue(context, v)
 }
 
 func (v *AccountCapabilityControllerValue) Walk(_ ValueWalkContext, walkChild func(Value), _ LocationRange) {

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -162,7 +162,7 @@ func (*AccountCapabilityControllerValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*AccountCapabilityControllerValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (*AccountCapabilityControllerValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -181,7 +181,7 @@ func (v *AccountCapabilityControllerValue) Transfer(
 	return v
 }
 
-func (v *AccountCapabilityControllerValue) Clone(_ *Interpreter) Value {
+func (v *AccountCapabilityControllerValue) Clone(_ ValueCloneContext) Value {
 	return &AccountCapabilityControllerValue{
 		BorrowType:   v.BorrowType,
 		CapabilityID: v.CapabilityID,

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -101,7 +101,7 @@ func (v *AccountCapabilityControllerValue) StaticType(_ ValueStaticTypeContext) 
 	return PrimitiveStaticTypeAccountCapabilityController
 }
 
-func (*AccountCapabilityControllerValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (*AccountCapabilityControllerValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return false
 }
 

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -126,7 +126,7 @@ func (v *AccountCapabilityControllerValue) MeteredString(context ValueStringCont
 }
 
 func (v *AccountCapabilityControllerValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -209,7 +209,7 @@ func (AddressValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ stri
 }
 
 func (v AddressValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -106,7 +106,7 @@ func (AddressValue) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeAddress)
 }
 
-func (AddressValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (AddressValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -94,8 +94,8 @@ var _ MemberAccessibleValue = AddressValue{}
 
 func (AddressValue) IsValue() {}
 
-func (v AddressValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitAddressValue(interpreter, v)
+func (v AddressValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitAddressValue(context, v)
 }
 
 func (AddressValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -156,7 +156,7 @@ func (v AddressValue) ToAddress() common.Address {
 	return common.Address(v)
 }
 
-func (v AddressValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+func (v AddressValue) GetMember(context MemberAccessibleContext, _ LocationRange, name string) Value {
 	switch name {
 
 	case sema.ToStringFunctionName:
@@ -228,7 +228,7 @@ func (AddressValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (AddressValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (AddressValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -247,7 +247,7 @@ func (v AddressValue) Transfer(
 	return v
 }
 
-func (v AddressValue) Clone(_ *Interpreter) Value {
+func (v AddressValue) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -1423,11 +1423,9 @@ func (v *ArrayValue) Transfer(
 	return res
 }
 
-func (v *ArrayValue) Clone(interpreter *Interpreter) Value {
-	config := interpreter.SharedState.Config
-
+func (v *ArrayValue) Clone(context ValueCloneContext) Value {
 	array := newArrayValueFromConstructor(
-		interpreter,
+		context,
 		v.Type,
 		v.array.Count(),
 		func() *atree.Array {
@@ -1437,7 +1435,7 @@ func (v *ArrayValue) Clone(interpreter *Interpreter) Value {
 			}
 
 			array, err := atree.NewArrayFromBatchData(
-				config.Storage,
+				context.Storage(),
 				v.StorageAddress(),
 				v.array.Type(),
 				func() (atree.Value, error) {
@@ -1449,8 +1447,8 @@ func (v *ArrayValue) Clone(interpreter *Interpreter) Value {
 						return nil, nil
 					}
 
-					element := MustConvertStoredValue(interpreter, value).
-						Clone(interpreter)
+					element := MustConvertStoredValue(context, value).
+						Clone(context)
 
 					return element, nil
 				},

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -310,12 +310,12 @@ func (v *ArrayValue) StaticType(_ ValueStaticTypeContext) StaticType {
 	return v.Type
 }
 
-func (v *ArrayValue) IsImportable(inter *Interpreter, locationRange LocationRange) bool {
+func (v *ArrayValue) IsImportable(context ValueImportableContext, locationRange LocationRange) bool {
 	importable := true
 	v.Iterate(
-		inter,
+		context,
 		func(element Value) (resume bool) {
-			if !element.IsImportable(inter, locationRange) {
+			if !element.IsImportable(context, locationRange) {
 				importable = false
 				// stop iteration
 				return false

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -192,16 +192,16 @@ func (*ArrayValue) IsValue() {}
 
 func (*ArrayValue) isAtreeContainerBackedValue() {}
 
-func (v *ArrayValue) Accept(interpreter *Interpreter, visitor Visitor, locationRange LocationRange) {
-	descend := visitor.VisitArrayValue(interpreter, v)
+func (v *ArrayValue) Accept(context ValueVisitContext, visitor Visitor, locationRange LocationRange) {
+	descend := visitor.VisitArrayValue(context, v)
 	if !descend {
 		return
 	}
 
 	v.Walk(
-		interpreter,
+		context,
 		func(element Value) {
-			element.Accept(interpreter, visitor, locationRange)
+			element.Accept(context, visitor, locationRange)
 		},
 		locationRange,
 	)

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -183,7 +183,7 @@ func (v BoolValue) Transfer(
 	return v
 }
 
-func (v BoolValue) Clone(_ *Interpreter) Value {
+func (v BoolValue) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -52,7 +52,7 @@ func (BoolValue) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeBool)
 }
 
-func (BoolValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (BoolValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return sema.BoolType.Importable
 }
 

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -40,8 +40,8 @@ const FalseValue = BoolValue(false)
 
 func (BoolValue) IsValue() {}
 
-func (v BoolValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitBoolValue(interpreter, v)
+func (v BoolValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitBoolValue(context, v)
 }
 
 func (BoolValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -149,7 +149,7 @@ func (v BoolValue) MeteredString(context ValueStringContext, _ SeenReferences, _
 }
 
 func (v BoolValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -100,8 +100,8 @@ func (v *IDCapabilityValue) isInvalid() bool {
 	return v.ID == InvalidCapabilityID
 }
 
-func (v *IDCapabilityValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitCapabilityValue(interpreter, v)
+func (v *IDCapabilityValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitCapabilityValue(context, v)
 }
 
 func (v *IDCapabilityValue) Walk(_ ValueWalkContext, walkChild func(Value), _ LocationRange) {

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -116,7 +116,7 @@ func (v *IDCapabilityValue) StaticType(context ValueStaticTypeContext) StaticTyp
 	)
 }
 
-func (v *IDCapabilityValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (v *IDCapabilityValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return false
 }
 

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -218,7 +218,7 @@ func (*IDCapabilityValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*IDCapabilityValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (*IDCapabilityValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -238,10 +238,10 @@ func (v *IDCapabilityValue) Transfer(
 	return v
 }
 
-func (v *IDCapabilityValue) Clone(interpreter *Interpreter) Value {
+func (v *IDCapabilityValue) Clone(context ValueCloneContext) Value {
 	return NewUnmeteredCapabilityValue(
 		v.ID,
-		v.address.Clone(interpreter).(AddressValue),
+		v.address.Clone(context).(AddressValue),
 		v.BorrowType,
 	)
 }

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -175,7 +175,7 @@ func (*IDCapabilityValue) SetMember(_ MemberAccessibleContext, _ LocationRange, 
 }
 
 func (v *IDCapabilityValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -91,7 +91,7 @@ func (CharacterValue) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeCharacter)
 }
 
-func (CharacterValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (CharacterValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return sema.CharacterType.Importable
 }
 

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -165,7 +165,7 @@ func (v CharacterValue) HashInput(_ common.MemoryGauge, _ LocationRange, scratch
 }
 
 func (v CharacterValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -180,7 +180,7 @@ func (CharacterValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (CharacterValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (CharacterValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -199,7 +199,7 @@ func (v CharacterValue) Transfer(
 	return v
 }
 
-func (v CharacterValue) Clone(_ *Interpreter) Value {
+func (v CharacterValue) Clone(_ ValueCloneContext) Value {
 	return v
 }
 
@@ -219,7 +219,7 @@ func (CharacterValue) ChildStorables() []atree.Storable {
 	return nil
 }
 
-func (v CharacterValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+func (v CharacterValue) GetMember(context MemberAccessibleContext, _ LocationRange, name string) Value {
 	switch name {
 	case sema.ToStringFunctionName:
 		return NewBoundHostFunctionValue(

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -79,8 +79,8 @@ var _ MemberAccessibleValue = CharacterValue{}
 
 func (CharacterValue) IsValue() {}
 
-func (v CharacterValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitCharacterValue(interpreter, v)
+func (v CharacterValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitCharacterValue(context, v)
 }
 
 func (CharacterValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -1342,17 +1342,15 @@ func (v *CompositeValue) ResourceUUID(interpreter *Interpreter) *UInt64Value {
 	return &uuid
 }
 
-func (v *CompositeValue) Clone(interpreter *Interpreter) Value {
+func (v *CompositeValue) Clone(context ValueCloneContext) Value {
 
 	iterator, err := v.dictionary.ReadOnlyIterator()
 	if err != nil {
 		panic(errors.NewExternalError(err))
 	}
 
-	config := interpreter.SharedState.Config
-
 	dictionary, err := atree.NewMapFromBatchData(
-		config.Storage,
+		context.Storage(),
 		v.StorageAddress(),
 		atree.NewDefaultDigesterBuilder(),
 		v.dictionary.Type(),
@@ -1373,7 +1371,7 @@ func (v *CompositeValue) Clone(interpreter *Interpreter) Value {
 			// an "atree-level string", not an interpreter.Value.
 			// Thus, we do not, and cannot, convert.
 			key := atreeKey
-			value := MustConvertStoredValue(interpreter, atreeValue).Clone(interpreter)
+			value := MustConvertStoredValue(context, atreeValue).Clone(context)
 
 			return key, value, nil
 		},

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -281,18 +281,18 @@ func (v *CompositeValue) StaticType(context ValueStaticTypeContext) StaticType {
 	return v.staticType
 }
 
-func (v *CompositeValue) IsImportable(inter *Interpreter, locationRange LocationRange) bool {
+func (v *CompositeValue) IsImportable(context ValueImportableContext, locationRange LocationRange) bool {
 	// Check type is importable
-	staticType := v.StaticType(inter)
-	semaType := MustConvertStaticToSemaType(staticType, inter)
+	staticType := v.StaticType(context)
+	semaType := MustConvertStaticToSemaType(staticType, context)
 	if !semaType.IsImportable(map[*sema.Member]bool{}) {
 		return false
 	}
 
 	// Check all field values are importable
 	importable := true
-	v.ForEachField(inter, func(_ string, value Value) (resume bool) {
-		if !value.IsImportable(inter, locationRange) {
+	v.ForEachField(context, func(_ string, value Value) (resume bool) {
+		if !value.IsImportable(context, locationRange) {
 			importable = false
 			// stop iteration
 			return false

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -242,14 +242,14 @@ func (*CompositeValue) IsValue() {}
 
 func (*CompositeValue) isAtreeContainerBackedValue() {}
 
-func (v *CompositeValue) Accept(interpreter *Interpreter, visitor Visitor, locationRange LocationRange) {
-	descend := visitor.VisitCompositeValue(interpreter, v)
+func (v *CompositeValue) Accept(context ValueVisitContext, visitor Visitor, locationRange LocationRange) {
+	descend := visitor.VisitCompositeValue(context, v)
 	if !descend {
 		return
 	}
 
-	v.ForEachField(interpreter, func(_ string, value Value) (resume bool) {
-		value.Accept(interpreter, visitor, locationRange)
+	v.ForEachField(context, func(_ string, value Value) (resume bool) {
+		value.Accept(context, visitor, locationRange)
 
 		// continue iteration
 		return true

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -496,7 +496,7 @@ func compositeMember(context FunctionCreationContext, compositeValue Value, memb
 	return memberValue
 }
 
-func (v *CompositeValue) isInvalidatedResource(context ValueStaticTypeContext) bool {
+func (v *CompositeValue) isInvalidatedResource(_ ValueStaticTypeContext) bool {
 	return v.isDestroyed || (v.dictionary == nil && v.Kind == common.CompositeKindResource)
 }
 
@@ -937,13 +937,11 @@ func (v *CompositeValue) TypeID() TypeID {
 }
 
 func (v *CompositeValue) ConformsToStaticType(
-	interpreter *Interpreter,
+	context ValueStaticTypeConformanceContext,
 	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
-	config := interpreter.SharedState.Config
-
-	if config.TracingEnabled {
+	if context.TracingEnabled() {
 		startTime := time.Now()
 
 		owner := v.GetOwner().String()
@@ -951,7 +949,7 @@ func (v *CompositeValue) ConformsToStaticType(
 		kind := v.Kind.String()
 
 		defer func() {
-			interpreter.reportCompositeValueConformsToStaticTypeTrace(
+			context.ReportCompositeValueConformsToStaticTypeTrace(
 				owner,
 				typeID,
 				kind,
@@ -960,17 +958,17 @@ func (v *CompositeValue) ConformsToStaticType(
 		}()
 	}
 
-	staticType := v.StaticType(interpreter)
-	semaType := MustConvertStaticToSemaType(staticType, interpreter)
+	staticType := v.StaticType(context)
+	semaType := MustConvertStaticToSemaType(staticType, context)
 
 	switch staticType.(type) {
 	case *CompositeStaticType:
-		return v.CompositeStaticTypeConformsToStaticType(interpreter, locationRange, results, semaType)
+		return v.CompositeStaticTypeConformsToStaticType(context, locationRange, results, semaType)
 
 	// CompositeValue is also used for storing types which aren't CompositeStaticType.
 	// E.g. InclusiveRange.
 	case InclusiveRangeStaticType:
-		return v.InclusiveRangeStaticTypeConformsToStaticType(interpreter, locationRange, results, semaType)
+		return v.InclusiveRangeStaticTypeConformsToStaticType(context, locationRange, results, semaType)
 
 	default:
 		return false
@@ -978,7 +976,7 @@ func (v *CompositeValue) ConformsToStaticType(
 }
 
 func (v *CompositeValue) CompositeStaticTypeConformsToStaticType(
-	interpreter *Interpreter,
+	context ValueStaticTypeConformanceContext,
 	locationRange LocationRange,
 	results TypeConformanceResults,
 	semaType sema.Type,
@@ -992,8 +990,8 @@ func (v *CompositeValue) CompositeStaticTypeConformsToStaticType(
 	}
 
 	if compositeType.Kind == common.CompositeKindAttachment {
-		base := v.getBaseValue(interpreter, UnauthorizedAccess, locationRange).Value
-		if base == nil || !base.ConformsToStaticType(interpreter, locationRange, results) {
+		base := v.getBaseValue(context, UnauthorizedAccess, locationRange).Value
+		if base == nil || !base.ConformsToStaticType(context, locationRange, results) {
 			return false
 		}
 	}
@@ -1012,7 +1010,7 @@ func (v *CompositeValue) CompositeStaticTypeConformsToStaticType(
 	}
 
 	for _, fieldName := range compositeType.Fields {
-		value := v.GetField(interpreter, fieldName)
+		value := v.GetField(context, fieldName)
 		if value == nil {
 			if computedFields == nil {
 				return false
@@ -1023,7 +1021,7 @@ func (v *CompositeValue) CompositeStaticTypeConformsToStaticType(
 				return false
 			}
 
-			value = fieldGetter(interpreter, locationRange, v)
+			value = fieldGetter(context, locationRange, v)
 		}
 
 		member, ok := compositeType.Members.Get(fieldName)
@@ -1031,14 +1029,14 @@ func (v *CompositeValue) CompositeStaticTypeConformsToStaticType(
 			return false
 		}
 
-		fieldStaticType := value.StaticType(interpreter)
+		fieldStaticType := value.StaticType(context)
 
-		if !IsSubTypeOfSemaType(interpreter, fieldStaticType, member.TypeAnnotation.Type) {
+		if !IsSubTypeOfSemaType(context, fieldStaticType, member.TypeAnnotation.Type) {
 			return false
 		}
 
 		if !value.ConformsToStaticType(
-			interpreter,
+			context,
 			locationRange,
 			results,
 		) {
@@ -1050,7 +1048,7 @@ func (v *CompositeValue) CompositeStaticTypeConformsToStaticType(
 }
 
 func (v *CompositeValue) InclusiveRangeStaticTypeConformsToStaticType(
-	interpreter *Interpreter,
+	context ValueStaticTypeConformanceContext,
 	locationRange LocationRange,
 	results TypeConformanceResults,
 	semaType sema.Type,
@@ -1060,21 +1058,21 @@ func (v *CompositeValue) InclusiveRangeStaticTypeConformsToStaticType(
 		return false
 	}
 
-	expectedMemberStaticType := ConvertSemaToStaticType(interpreter, inclusiveRangeType.MemberType)
+	expectedMemberStaticType := ConvertSemaToStaticType(context, inclusiveRangeType.MemberType)
 	for _, fieldName := range sema.InclusiveRangeTypeFieldNames {
-		value := v.GetField(interpreter, fieldName)
+		value := v.GetField(context, fieldName)
 
-		fieldStaticType := value.StaticType(interpreter)
+		fieldStaticType := value.StaticType(context)
 
 		// InclusiveRange is non-covariant.
 		// For e.g. we disallow assigning InclusiveRange<Int> to an InclusiveRange<Integer>.
-		// Hence we do an exact equality check instead of a sub-type check.
+		// Hence, we do an exact equality check instead of a subtype check.
 		if !fieldStaticType.Equal(expectedMemberStaticType) {
 			return false
 		}
 
 		if !value.ConformsToStaticType(
-			interpreter,
+			context,
 			locationRange,
 			results,
 		) {

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -250,16 +250,16 @@ func (*DictionaryValue) IsValue() {}
 
 func (*DictionaryValue) isAtreeContainerBackedValue() {}
 
-func (v *DictionaryValue) Accept(interpreter *Interpreter, visitor Visitor, locationRange LocationRange) {
-	descend := visitor.VisitDictionaryValue(interpreter, v)
+func (v *DictionaryValue) Accept(context ValueVisitContext, visitor Visitor, locationRange LocationRange) {
+	descend := visitor.VisitDictionaryValue(context, v)
 	if !descend {
 		return
 	}
 
 	v.Walk(
-		interpreter,
+		context,
 		func(value Value) {
-			value.Accept(interpreter, visitor, locationRange)
+			value.Accept(context, visitor, locationRange)
 		},
 		locationRange,
 	)

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -446,13 +446,13 @@ func (v *DictionaryValue) StaticType(_ ValueStaticTypeContext) StaticType {
 	return v.Type
 }
 
-func (v *DictionaryValue) IsImportable(inter *Interpreter, locationRange LocationRange) bool {
+func (v *DictionaryValue) IsImportable(context ValueImportableContext, locationRange LocationRange) bool {
 	importable := true
 	v.Iterate(
-		inter,
+		context,
 		locationRange,
 		func(key, value Value) (resume bool) {
-			if !key.IsImportable(inter, locationRange) || !value.IsImportable(inter, locationRange) {
+			if !key.IsImportable(context, locationRange) || !value.IsImportable(context, locationRange) {
 				importable = false
 				// stop iteration
 				return false

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -1429,11 +1429,9 @@ func (v *DictionaryValue) Transfer(
 	return res
 }
 
-func (v *DictionaryValue) Clone(interpreter *Interpreter) Value {
-	config := interpreter.SharedState.Config
-
-	valueComparator := newValueComparator(interpreter, EmptyLocationRange)
-	hashInputProvider := newHashInputProvider(interpreter, EmptyLocationRange)
+func (v *DictionaryValue) Clone(context ValueCloneContext) Value {
+	valueComparator := newValueComparator(context, EmptyLocationRange)
+	hashInputProvider := newHashInputProvider(context, EmptyLocationRange)
 
 	iterator, err := v.dictionary.ReadOnlyIterator()
 	if err != nil {
@@ -1441,7 +1439,7 @@ func (v *DictionaryValue) Clone(interpreter *Interpreter) Value {
 	}
 
 	orderedMap, err := atree.NewMapFromBatchData(
-		config.Storage,
+		context.Storage(),
 		v.StorageAddress(),
 		atree.NewDefaultDigesterBuilder(),
 		v.dictionary.Type(),
@@ -1458,11 +1456,11 @@ func (v *DictionaryValue) Clone(interpreter *Interpreter) Value {
 				return nil, nil, nil
 			}
 
-			key := MustConvertStoredValue(interpreter, atreeKey).
-				Clone(interpreter)
+			key := MustConvertStoredValue(context, atreeKey).
+				Clone(context)
 
-			value := MustConvertStoredValue(interpreter, atreeValue).
-				Clone(interpreter)
+			value := MustConvertStoredValue(context, atreeValue).
+				Clone(context)
 
 			return key, value, nil
 		},
@@ -1472,7 +1470,7 @@ func (v *DictionaryValue) Clone(interpreter *Interpreter) Value {
 	}
 
 	dictionary := newDictionaryValueFromAtreeMap(
-		interpreter,
+		context,
 		v.Type,
 		v.elementSize,
 		orderedMap,

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -1112,22 +1112,20 @@ type DictionaryEntryValues struct {
 }
 
 func (v *DictionaryValue) ConformsToStaticType(
-	interpreter *Interpreter,
+	context ValueStaticTypeConformanceContext,
 	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
 
 	count := v.Count()
 
-	config := interpreter.SharedState.Config
-
-	if config.TracingEnabled {
+	if context.TracingEnabled() {
 		startTime := time.Now()
 
 		typeInfo := v.Type.String()
 
 		defer func() {
-			interpreter.reportDictionaryValueConformsToStaticTypeTrace(
+			context.ReportDictionaryValueConformsToStaticTypeTrace(
 				typeInfo,
 				count,
 				time.Since(startTime),
@@ -1135,7 +1133,7 @@ func (v *DictionaryValue) ConformsToStaticType(
 		}()
 	}
 
-	staticType, ok := v.StaticType(interpreter).(*DictionaryStaticType)
+	staticType, ok := v.StaticType(context).(*DictionaryStaticType)
 	if !ok {
 		return false
 	}
@@ -1161,14 +1159,14 @@ func (v *DictionaryValue) ConformsToStaticType(
 
 		// atree.OrderedMap iteration provides low-level atree.Value,
 		// convert to high-level interpreter.Value
-		entryKey := MustConvertStoredValue(interpreter, key)
+		entryKey := MustConvertStoredValue(context, key)
 
-		if !IsSubType(interpreter, entryKey.StaticType(interpreter), keyType) {
+		if !IsSubType(context, entryKey.StaticType(context), keyType) {
 			return false
 		}
 
 		if !entryKey.ConformsToStaticType(
-			interpreter,
+			context,
 			locationRange,
 			results,
 		) {
@@ -1179,14 +1177,14 @@ func (v *DictionaryValue) ConformsToStaticType(
 
 		// atree.OrderedMap iteration provides low-level atree.Value,
 		// convert to high-level interpreter.Value
-		entryValue := MustConvertStoredValue(interpreter, value)
+		entryValue := MustConvertStoredValue(context, value)
 
-		if !IsSubType(interpreter, entryValue.StaticType(interpreter), valueType) {
+		if !IsSubType(context, entryValue.StaticType(context), valueType) {
 			return false
 		}
 
 		if !entryValue.ConformsToStaticType(
-			interpreter,
+			context,
 			locationRange,
 			results,
 		) {

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -274,7 +274,7 @@ func (*EphemeralReferenceValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*EphemeralReferenceValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (*EphemeralReferenceValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -293,8 +293,8 @@ func (v *EphemeralReferenceValue) Transfer(
 	return v
 }
 
-func (v *EphemeralReferenceValue) Clone(inter *Interpreter) Value {
-	return NewUnmeteredEphemeralReferenceValue(inter, v.Authorization, v.Value, v.BorrowedType, EmptyLocationRange)
+func (v *EphemeralReferenceValue) Clone(context ValueCloneContext) Value {
+	return NewUnmeteredEphemeralReferenceValue(context, v.Authorization, v.Value, v.BorrowedType, EmptyLocationRange)
 }
 
 func (*EphemeralReferenceValue) DeepRemove(_ ValueRemoveContext, _ bool) {

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -122,7 +122,7 @@ func (v *EphemeralReferenceValue) GetAuthorization() Authorization {
 	return v.Authorization
 }
 
-func (*EphemeralReferenceValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (*EphemeralReferenceValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return false
 }
 

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -229,16 +229,12 @@ func (v *EphemeralReferenceValue) Equal(_ ValueComparisonContext, _ LocationRang
 	}
 }
 
-func (v *EphemeralReferenceValue) ConformsToStaticType(
-	interpreter *Interpreter,
-	locationRange LocationRange,
-	results TypeConformanceResults,
-) bool {
+func (v *EphemeralReferenceValue) ConformsToStaticType(context ValueStaticTypeConformanceContext, locationRange LocationRange, results TypeConformanceResults, ) bool {
 	self := v.Value
 
-	staticType := v.Value.StaticType(interpreter)
+	staticType := v.Value.StaticType(context)
 
-	if !IsSubTypeOfSemaType(interpreter, staticType, v.BorrowedType) {
+	if !IsSubTypeOfSemaType(context, staticType, v.BorrowedType) {
 		return false
 	}
 
@@ -256,7 +252,7 @@ func (v *EphemeralReferenceValue) ConformsToStaticType(
 	results[entry] = true
 
 	result := self.ConformsToStaticType(
-		interpreter,
+		context,
 		locationRange,
 		results,
 	)

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -81,8 +81,8 @@ func NewEphemeralReferenceValue(
 
 func (*EphemeralReferenceValue) IsValue() {}
 
-func (v *EphemeralReferenceValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitEphemeralReferenceValue(interpreter, v)
+func (v *EphemeralReferenceValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitEphemeralReferenceValue(context, v)
 }
 
 func (*EphemeralReferenceValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -86,8 +86,8 @@ var _ MemberAccessibleValue = Fix64Value(0)
 
 func (Fix64Value) IsValue() {}
 
-func (v Fix64Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitFix64Value(interpreter, v)
+func (v Fix64Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitFix64Value(context, v)
 }
 
 func (Fix64Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -567,7 +567,7 @@ func (Fix64Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Fix64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (Fix64Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -586,7 +586,7 @@ func (v Fix64Value) Transfer(
 	return v
 }
 
-func (v Fix64Value) Clone(_ *Interpreter) Value {
+func (v Fix64Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -548,7 +548,7 @@ func (v Fix64Value) ToBigEndianBytes() []byte {
 }
 
 func (v Fix64Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -98,7 +98,7 @@ func (Fix64Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeFix64)
 }
 
-func (Fix64Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (Fix64Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -95,8 +95,8 @@ func (f *InterpretedFunctionValue) MeteredString(context ValueStringContext, _ S
 	return f.String()
 }
 
-func (f *InterpretedFunctionValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitInterpretedFunctionValue(interpreter, f)
+func (f *InterpretedFunctionValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitInterpretedFunctionValue(context, f)
 }
 
 func (f *InterpretedFunctionValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
@@ -229,8 +229,8 @@ var _ ContractValue = &HostFunctionValue{}
 
 func (*HostFunctionValue) IsValue() {}
 
-func (f *HostFunctionValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitHostFunctionValue(interpreter, f)
+func (f *HostFunctionValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitHostFunctionValue(context, f)
 }
 
 func (f *HostFunctionValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {
@@ -405,8 +405,8 @@ func (f BoundFunctionValue) MeteredString(context ValueStringContext, seenRefere
 	return f.Function.MeteredString(context, seenReferences, locationRange)
 }
 
-func (f BoundFunctionValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitBoundFunctionValue(interpreter, f)
+func (f BoundFunctionValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitBoundFunctionValue(context, f)
 }
 
 func (f BoundFunctionValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -126,7 +126,7 @@ func (f *InterpretedFunctionValue) Invoke(invocation Invocation) Value {
 }
 
 func (f *InterpretedFunctionValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
@@ -279,7 +279,7 @@ func (*HostFunctionValue) SetMember(_ MemberAccessibleContext, _ LocationRange, 
 }
 
 func (f *HostFunctionValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
@@ -466,12 +466,12 @@ func (f BoundFunctionValue) Invoke(invocation Invocation) Value {
 }
 
 func (f BoundFunctionValue) ConformsToStaticType(
-	interpreter *Interpreter,
+	context ValueStaticTypeConformanceContext,
 	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
 	return f.Function.ConformsToStaticType(
-		interpreter,
+		context,
 		locationRange,
 		results,
 	)

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -107,7 +107,7 @@ func (f *InterpretedFunctionValue) StaticType(context ValueStaticTypeContext) St
 	return ConvertSemaToStaticType(context, f.Type)
 }
 
-func (*InterpretedFunctionValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (*InterpretedFunctionValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return false
 }
 
@@ -241,7 +241,7 @@ func (f *HostFunctionValue) StaticType(context ValueStaticTypeContext) StaticTyp
 	return ConvertSemaToStaticType(context, f.Type)
 }
 
-func (*HostFunctionValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (*HostFunctionValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return false
 }
 
@@ -417,7 +417,7 @@ func (f BoundFunctionValue) StaticType(context ValueStaticTypeContext) StaticTyp
 	return f.Function.StaticType(context)
 }
 
-func (BoundFunctionValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (BoundFunctionValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return false
 }
 

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -141,7 +141,7 @@ func (*InterpretedFunctionValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*InterpretedFunctionValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (*InterpretedFunctionValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -161,7 +161,7 @@ func (f *InterpretedFunctionValue) Transfer(
 	return f
 }
 
-func (f *InterpretedFunctionValue) Clone(_ *Interpreter) Value {
+func (f *InterpretedFunctionValue) Clone(_ ValueCloneContext) Value {
 	return f
 }
 
@@ -294,7 +294,7 @@ func (*HostFunctionValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*HostFunctionValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (*HostFunctionValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -314,7 +314,7 @@ func (f *HostFunctionValue) Transfer(
 	return f
 }
 
-func (f *HostFunctionValue) Clone(_ *Interpreter) Value {
+func (f *HostFunctionValue) Clone(_ ValueCloneContext) Value {
 	return f
 }
 
@@ -485,7 +485,7 @@ func (BoundFunctionValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (BoundFunctionValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (BoundFunctionValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -505,7 +505,7 @@ func (f BoundFunctionValue) Transfer(
 	return f
 }
 
-func (f BoundFunctionValue) Clone(_ *Interpreter) Value {
+func (f BoundFunctionValue) Clone(_ ValueCloneContext) Value {
 	return f
 }
 

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -108,7 +108,7 @@ func (IntValue) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeInt)
 }
 
-func (IntValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (IntValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -566,7 +566,7 @@ func (v IntValue) Transfer(
 	return v
 }
 
-func (v IntValue) Clone(_ *Interpreter) Value {
+func (v IntValue) Clone(_ ValueCloneContext) Value {
 	return NewUnmeteredIntValueFromBigInt(v.BigInt)
 }
 

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -536,7 +536,7 @@ func (IntValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, 
 }
 
 func (v IntValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -96,8 +96,8 @@ var _ MemberAccessibleValue = IntValue{}
 
 func (IntValue) IsValue() {}
 
-func (v IntValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitIntValue(interpreter, v)
+func (v IntValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitIntValue(context, v)
 }
 
 func (IntValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -107,8 +107,8 @@ var _ MemberAccessibleValue = Int128Value{}
 
 func (Int128Value) IsValue() {}
 
-func (v Int128Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitInt128Value(interpreter, v)
+func (v Int128Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitInt128Value(context, v)
 }
 
 func (Int128Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -772,7 +772,7 @@ func (Int128Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Int128Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (Int128Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -791,7 +791,7 @@ func (v Int128Value) Transfer(
 	return v
 }
 
-func (v Int128Value) Clone(_ *Interpreter) Value {
+func (v Int128Value) Clone(_ ValueCloneContext) Value {
 	return NewUnmeteredInt128ValueFromBigInt(v.BigInt)
 }
 

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -119,7 +119,7 @@ func (Int128Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeInt128)
 }
 
-func (Int128Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (Int128Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -757,7 +757,7 @@ func (v Int128Value) ToBigEndianBytes() []byte {
 }
 
 func (v Int128Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -62,8 +62,8 @@ var _ MemberAccessibleValue = Int16Value(0)
 
 func (Int16Value) IsValue() {}
 
-func (v Int16Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitInt16Value(interpreter, v)
+func (v Int16Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitInt16Value(context, v)
 }
 
 func (Int16Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -649,7 +649,7 @@ func (Int16Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Int16Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (Int16Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -668,7 +668,7 @@ func (v Int16Value) Transfer(
 	return v
 }
 
-func (v Int16Value) Clone(_ *Interpreter) Value {
+func (v Int16Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -634,7 +634,7 @@ func (v Int16Value) ToBigEndianBytes() []byte {
 }
 
 func (v Int16Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -74,7 +74,7 @@ func (Int16Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeInt16)
 }
 
-func (Int16Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (Int16Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -88,7 +88,7 @@ func (Int256Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeInt256)
 }
 
-func (Int256Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (Int256Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -739,7 +739,7 @@ func (Int256Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Int256Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (Int256Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -758,7 +758,7 @@ func (v Int256Value) Transfer(
 	return v
 }
 
-func (v Int256Value) Clone(_ *Interpreter) Value {
+func (v Int256Value) Clone(_ ValueCloneContext) Value {
 	return NewUnmeteredInt256ValueFromBigInt(v.BigInt)
 }
 

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -76,8 +76,8 @@ var _ MemberAccessibleValue = Int256Value{}
 
 func (Int256Value) IsValue() {}
 
-func (v Int256Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitInt256Value(interpreter, v)
+func (v Int256Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitInt256Value(context, v)
 }
 
 func (Int256Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -724,7 +724,7 @@ func (v Int256Value) ToBigEndianBytes() []byte {
 }
 
 func (v Int256Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -74,7 +74,7 @@ func (Int32Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeInt32)
 }
 
-func (Int32Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (Int32Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -634,7 +634,7 @@ func (v Int32Value) ToBigEndianBytes() []byte {
 }
 
 func (v Int32Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -62,8 +62,8 @@ var _ MemberAccessibleValue = Int32Value(0)
 
 func (Int32Value) IsValue() {}
 
-func (v Int32Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitInt32Value(interpreter, v)
+func (v Int32Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitInt32Value(context, v)
 }
 
 func (Int32Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -649,7 +649,7 @@ func (Int32Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Int32Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (Int32Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -668,7 +668,7 @@ func (v Int32Value) Transfer(
 	return v
 }
 
-func (v Int32Value) Clone(_ *Interpreter) Value {
+func (v Int32Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -628,7 +628,7 @@ func (v Int64Value) ToBigEndianBytes() []byte {
 }
 
 func (v Int64Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -74,7 +74,7 @@ func (Int64Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeInt64)
 }
 
-func (Int64Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (Int64Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -643,7 +643,7 @@ func (Int64Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Int64Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (Int64Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -662,7 +662,7 @@ func (v Int64Value) Transfer(
 	return v
 }
 
-func (v Int64Value) Clone(_ *Interpreter) Value {
+func (v Int64Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -62,8 +62,8 @@ var _ MemberAccessibleValue = Int64Value(0)
 
 func (Int64Value) IsValue() {}
 
-func (v Int64Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitInt64Value(interpreter, v)
+func (v Int64Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitInt64Value(context, v)
 }
 
 func (Int64Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -60,8 +60,8 @@ var _ HashableValue = Int8Value(0)
 
 func (Int8Value) IsValue() {}
 
-func (v Int8Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitInt8Value(interpreter, v)
+func (v Int8Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitInt8Value(context, v)
 }
 
 func (Int8Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -631,7 +631,7 @@ func (v Int8Value) ToBigEndianBytes() []byte {
 }
 
 func (v Int8Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -646,7 +646,7 @@ func (Int8Value) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (Int8Value) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (Int8Value) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -665,7 +665,7 @@ func (v Int8Value) Transfer(
 	return v
 }
 
-func (v Int8Value) Clone(_ *Interpreter) Value {
+func (v Int8Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -72,7 +72,7 @@ func (Int8Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeInt8)
 }
 
-func (Int8Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (Int8Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_link.go
+++ b/interpreter/value_link.go
@@ -52,7 +52,7 @@ func (PathLinkValue) IsValue() {}
 
 func (PathLinkValue) isLinkValue() {}
 
-func (v PathLinkValue) Accept(_ *Interpreter, _ Visitor, _ LocationRange) {
+func (v PathLinkValue) Accept(context ValueVisitContext, visitor Visitor, locationRange LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 
@@ -177,7 +177,7 @@ func (AccountLinkValue) IsValue() {}
 
 func (AccountLinkValue) isLinkValue() {}
 
-func (v AccountLinkValue) Accept(_ *Interpreter, _ Visitor, _ LocationRange) {
+func (v AccountLinkValue) Accept(context ValueVisitContext, visitor Visitor, locationRange LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 

--- a/interpreter/value_link.go
+++ b/interpreter/value_link.go
@@ -92,7 +92,7 @@ func (v PathLinkValue) MeteredString(_ ValueStringContext, _ SeenReferences, _ L
 }
 
 func (v PathLinkValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {
@@ -215,12 +215,12 @@ func (v AccountLinkValue) RecursiveString(_ SeenReferences) string {
 	panic(errors.NewUnreachableError())
 }
 
-func (v AccountLinkValue) MeteredString(context ValueStringContext, seenReferences SeenReferences, locationRange LocationRange) string {
+func (v AccountLinkValue) MeteredString(_ ValueStringContext, _ SeenReferences, _ LocationRange) string {
 	panic(errors.NewUnreachableError())
 }
 
 func (v AccountLinkValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_link.go
+++ b/interpreter/value_link.go
@@ -140,10 +140,10 @@ func (v PathLinkValue) Transfer(
 	return v
 }
 
-func (v PathLinkValue) Clone(inter *Interpreter) Value {
+func (v PathLinkValue) Clone(context ValueCloneContext) Value {
 	return PathLinkValue{
 		Type:       v.Type,
-		TargetPath: v.TargetPath.Clone(inter).(PathValue),
+		TargetPath: v.TargetPath.Clone(context).(PathValue),
 	}
 }
 
@@ -263,7 +263,7 @@ func (v AccountLinkValue) Transfer(
 	return v
 }
 
-func (AccountLinkValue) Clone(_ *Interpreter) Value {
+func (AccountLinkValue) Clone(_ ValueCloneContext) Value {
 	return AccountLinkValue{}
 }
 

--- a/interpreter/value_link.go
+++ b/interpreter/value_link.go
@@ -71,7 +71,7 @@ func (v PathLinkValue) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewCapabilityStaticType(context, v.Type)
 }
 
-func (PathLinkValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (PathLinkValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	panic(errors.NewUnreachableError())
 }
 
@@ -203,7 +203,7 @@ func (v AccountLinkValue) StaticType(context ValueStaticTypeContext) StaticType 
 	)
 }
 
-func (AccountLinkValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (AccountLinkValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	panic(errors.NewUnreachableError())
 }
 

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -118,7 +118,7 @@ func (NilValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, 
 }
 
 func (v NilValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -43,8 +43,8 @@ var _ OptionalValue = NilValue{}
 
 func (NilValue) IsValue() {}
 
-func (v NilValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitNilValue(interpreter, v)
+func (v NilValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitNilValue(context, v)
 }
 
 func (NilValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -58,7 +58,7 @@ func (NilValue) StaticType(context ValueStaticTypeContext) StaticType {
 	)
 }
 
-func (NilValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (NilValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -142,7 +142,7 @@ func (NilValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (NilValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (NilValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -161,7 +161,7 @@ func (v NilValue) Transfer(
 	return v
 }
 
-func (v NilValue) Clone(_ *Interpreter) Value {
+func (v NilValue) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -58,8 +58,8 @@ var _ MemberAccessibleValue = PathValue{}
 
 func (PathValue) IsValue() {}
 
-func (v PathValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitPathValue(interpreter, v)
+func (v PathValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitPathValue(context, v)
 }
 
 func (PathValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -151,7 +151,7 @@ func (PathValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string,
 }
 
 func (v PathValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -245,7 +245,7 @@ func (v PathValue) Transfer(
 	return v
 }
 
-func (v PathValue) Clone(_ *Interpreter) Value {
+func (v PathValue) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -79,7 +79,7 @@ func (v PathValue) StaticType(context ValueStaticTypeContext) StaticType {
 	}
 }
 
-func (v PathValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (v PathValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	switch v.Domain {
 	case common.PathDomainStorage:
 		return sema.StoragePathType.Importable

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -61,7 +61,7 @@ func (*PathCapabilityValue) IsValue() {}
 
 func (*PathCapabilityValue) isCapabilityValue() {}
 
-func (v *PathCapabilityValue) Accept(_ *Interpreter, _ Visitor, _ LocationRange) {
+func (v *PathCapabilityValue) Accept(context ValueVisitContext, visitor Visitor, locationRange LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -189,7 +189,7 @@ func (*PathCapabilityValue) SetMember(_ MemberAccessibleContext, _ LocationRange
 }
 
 func (v *PathCapabilityValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -237,7 +237,7 @@ func (*PathCapabilityValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*PathCapabilityValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (*PathCapabilityValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -257,11 +257,11 @@ func (v *PathCapabilityValue) Transfer(
 	return v
 }
 
-func (v *PathCapabilityValue) Clone(interpreter *Interpreter) Value {
+func (v *PathCapabilityValue) Clone(context ValueCloneContext) Value {
 	return &PathCapabilityValue{
 		BorrowType: v.BorrowType,
-		Path:       v.Path.Clone(interpreter).(PathValue),
-		address:    v.address.Clone(interpreter).(AddressValue),
+		Path:       v.Path.Clone(context).(PathValue),
+		address:    v.address.Clone(context).(AddressValue),
 	}
 }
 

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -77,7 +77,7 @@ func (v *PathCapabilityValue) StaticType(context ValueStaticTypeContext) StaticT
 	)
 }
 
-func (v *PathCapabilityValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (v *PathCapabilityValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return false
 }
 func (v *PathCapabilityValue) String() string {

--- a/interpreter/value_placeholder.go
+++ b/interpreter/value_placeholder.go
@@ -43,7 +43,7 @@ func (f placeholderValue) MeteredString(context ValueStringContext, _ SeenRefere
 	return ""
 }
 
-func (f placeholderValue) Accept(_ *Interpreter, _ Visitor, _ LocationRange) {
+func (f placeholderValue) Accept(context ValueVisitContext, visitor Visitor, locationRange LocationRange) {
 	// NO-OP
 }
 

--- a/interpreter/value_placeholder.go
+++ b/interpreter/value_placeholder.go
@@ -60,7 +60,7 @@ func (placeholderValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
 }
 
 func (f placeholderValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_placeholder.go
+++ b/interpreter/value_placeholder.go
@@ -55,7 +55,7 @@ func (f placeholderValue) StaticType(_ ValueStaticTypeContext) StaticType {
 	return PrimitiveStaticTypeNever
 }
 
-func (placeholderValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (placeholderValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return false
 }
 

--- a/interpreter/value_placeholder.go
+++ b/interpreter/value_placeholder.go
@@ -95,7 +95,7 @@ func (f placeholderValue) Transfer(
 	return f
 }
 
-func (f placeholderValue) Clone(_ *Interpreter) Value {
+func (f placeholderValue) Clone(_ ValueCloneContext) Value {
 	return f
 }
 

--- a/interpreter/value_published.go
+++ b/interpreter/value_published.go
@@ -50,8 +50,8 @@ var _ EquatableValue = &PublishedValue{}
 
 func (*PublishedValue) IsValue() {}
 
-func (v *PublishedValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitPublishedValue(interpreter, v)
+func (v *PublishedValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitPublishedValue(context, v)
 }
 
 func (v *PublishedValue) StaticType(context ValueStaticTypeContext) StaticType {

--- a/interpreter/value_published.go
+++ b/interpreter/value_published.go
@@ -60,7 +60,7 @@ func (v *PublishedValue) StaticType(context ValueStaticTypeContext) StaticType {
 	return v.Value.StaticType(context)
 }
 
-func (*PublishedValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (*PublishedValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return false
 }
 

--- a/interpreter/value_published.go
+++ b/interpreter/value_published.go
@@ -171,10 +171,10 @@ func (v *PublishedValue) Transfer(
 
 }
 
-func (v *PublishedValue) Clone(interpreter *Interpreter) Value {
+func (v *PublishedValue) Clone(context ValueCloneContext) Value {
 	return &PublishedValue{
 		Recipient: v.Recipient,
-		Value:     v.Value.Clone(interpreter).(*IDCapabilityValue),
+		Value:     v.Value.Clone(context).(*IDCapabilityValue),
 	}
 }
 

--- a/interpreter/value_published.go
+++ b/interpreter/value_published.go
@@ -92,7 +92,7 @@ func (v *PublishedValue) Walk(_ ValueWalkContext, walkChild func(Value), _ Locat
 }
 
 func (v *PublishedValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -391,8 +391,8 @@ func (v *SomeValue) Transfer(
 	return res
 }
 
-func (v *SomeValue) Clone(interpreter *Interpreter) Value {
-	innerValue := v.value.Clone(interpreter)
+func (v *SomeValue) Clone(context ValueCloneContext) Value {
+	innerValue := v.value.Clone(context)
 	return NewUnmeteredSomeValueNonCopying(innerValue)
 }
 

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -204,7 +204,7 @@ func (v *SomeValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ stri
 }
 
 func (v *SomeValue) ConformsToStaticType(
-	interpreter *Interpreter,
+	context ValueStaticTypeConformanceContext,
 	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
@@ -216,7 +216,7 @@ func (v *SomeValue) ConformsToStaticType(
 	innerValue := v.InnerValue()
 
 	return innerValue.ConformsToStaticType(
-		interpreter,
+		context,
 		locationRange,
 		results,
 	)

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -107,8 +107,8 @@ func (v *SomeValue) StaticType(context ValueStaticTypeContext) StaticType {
 	)
 }
 
-func (v *SomeValue) IsImportable(inter *Interpreter, locationRange LocationRange) bool {
-	return v.value.IsImportable(inter, locationRange)
+func (v *SomeValue) IsImportable(context ValueImportableContext, locationRange LocationRange) bool {
+	return v.value.IsImportable(context, locationRange)
 }
 
 func (*SomeValue) isOptionalValue() {}

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -80,12 +80,12 @@ func (v *SomeValue) UnwrapAtreeValue() (atree.Value, uint64) {
 
 func (*SomeValue) IsValue() {}
 
-func (v *SomeValue) Accept(interpreter *Interpreter, visitor Visitor, locationRange LocationRange) {
-	descend := visitor.VisitSomeValue(interpreter, v)
+func (v *SomeValue) Accept(context ValueVisitContext, visitor Visitor, locationRange LocationRange) {
+	descend := visitor.VisitSomeValue(context, v)
 	if !descend {
 		return
 	}
-	v.value.Accept(interpreter, visitor, locationRange)
+	v.value.Accept(context, visitor, locationRange)
 }
 
 func (v *SomeValue) Walk(_ ValueWalkContext, walkChild func(Value), _ LocationRange) {

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -385,7 +385,7 @@ func (v *StorageReferenceValue) Transfer(
 	return v
 }
 
-func (v *StorageReferenceValue) Clone(_ *Interpreter) Value {
+func (v *StorageReferenceValue) Clone(_ ValueCloneContext) Value {
 	return NewUnmeteredStorageReferenceValue(
 		v.Authorization,
 		v.TargetStorageAddress,

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -117,7 +117,7 @@ func (v *StorageReferenceValue) GetAuthorization() Authorization {
 	return v.Authorization
 }
 
-func (*StorageReferenceValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (*StorageReferenceValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return false
 }
 

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -330,25 +330,25 @@ func (v *StorageReferenceValue) Equal(_ ValueComparisonContext, _ LocationRange,
 }
 
 func (v *StorageReferenceValue) ConformsToStaticType(
-	interpreter *Interpreter,
+	context ValueStaticTypeConformanceContext,
 	locationRange LocationRange,
 	results TypeConformanceResults,
 ) bool {
-	referencedValue, err := v.dereference(interpreter, locationRange)
+	referencedValue, err := v.dereference(context, locationRange)
 	if referencedValue == nil || err != nil {
 		return false
 	}
 
 	self := *referencedValue
 
-	staticType := self.StaticType(interpreter)
+	staticType := self.StaticType(context)
 
-	if !IsSubTypeOfSemaType(interpreter, staticType, v.BorrowedType) {
+	if !IsSubTypeOfSemaType(context, staticType, v.BorrowedType) {
 		return false
 	}
 
 	return self.ConformsToStaticType(
-		interpreter,
+		context,
 		locationRange,
 		results,
 	)

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -76,8 +76,8 @@ func NewStorageReferenceValue(
 
 func (*StorageReferenceValue) IsValue() {}
 
-func (v *StorageReferenceValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitStorageReferenceValue(interpreter, v)
+func (v *StorageReferenceValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitStorageReferenceValue(context, v)
 }
 
 func (*StorageReferenceValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -206,9 +206,9 @@ func (v *StorageCapabilityControllerValue) Transfer(
 	return v
 }
 
-func (v *StorageCapabilityControllerValue) Clone(interpreter *Interpreter) Value {
+func (v *StorageCapabilityControllerValue) Clone(context ValueCloneContext) Value {
 	return &StorageCapabilityControllerValue{
-		TargetPath:   v.TargetPath.Clone(interpreter).(PathValue),
+		TargetPath:   v.TargetPath.Clone(context).(PathValue),
 		BorrowType:   v.BorrowType,
 		CapabilityID: v.CapabilityID,
 	}

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -150,7 +150,7 @@ func (v *StorageCapabilityControllerValue) MeteredString(context ValueStringCont
 }
 
 func (v *StorageCapabilityControllerValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -110,8 +110,8 @@ func (v *StorageCapabilityControllerValue) CapabilityControllerBorrowType() *Ref
 	return v.BorrowType
 }
 
-func (v *StorageCapabilityControllerValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitStorageCapabilityControllerValue(interpreter, v)
+func (v *StorageCapabilityControllerValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitStorageCapabilityControllerValue(context, v)
 }
 
 func (v *StorageCapabilityControllerValue) Walk(_ ValueWalkContext, walkChild func(Value), _ LocationRange) {

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -123,7 +123,7 @@ func (v *StorageCapabilityControllerValue) StaticType(_ ValueStaticTypeContext) 
 	return PrimitiveStaticTypeStorageCapabilityController
 }
 
-func (*StorageCapabilityControllerValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (*StorageCapabilityControllerValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return false
 }
 

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -840,7 +840,7 @@ func (v *StringValue) DecodeHex(context ArrayCreationContext, locationRange Loca
 }
 
 func (v *StringValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -750,7 +750,7 @@ func (*StringValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (*StringValue) IsResourceKinded(context ValueStaticTypeContext) bool {
+func (*StringValue) IsResourceKinded(_ ValueStaticTypeContext) bool {
 	return false
 }
 
@@ -770,7 +770,7 @@ func (v *StringValue) Transfer(
 	return v
 }
 
-func (v *StringValue) Clone(_ *Interpreter) Value {
+func (v *StringValue) Clone(_ ValueCloneContext) Value {
 	return NewUnmeteredStringValue(v.Str)
 }
 

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -114,8 +114,8 @@ func (v *StringValue) prepareGraphemes() {
 
 func (*StringValue) IsValue() {}
 
-func (v *StringValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitStringValue(interpreter, v)
+func (v *StringValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitStringValue(context, v)
 }
 
 func (*StringValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -126,7 +126,7 @@ func (*StringValue) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeString)
 }
 
-func (*StringValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (*StringValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return sema.StringType.Importable
 }
 

--- a/interpreter/value_test.go
+++ b/interpreter/value_test.go
@@ -1370,10 +1370,10 @@ func TestVisitor(t *testing.T) {
 	var intVisits, stringVisits int
 
 	visitor := EmptyVisitor{
-		IntValueVisitor: func(interpreter *Interpreter, value IntValue) {
+		IntValueVisitor: func(_ ValueVisitContext, _ IntValue) {
 			intVisits++
 		},
-		StringValueVisitor: func(interpreter *Interpreter, value *StringValue) {
+		StringValueVisitor: func(_ ValueVisitContext, _ *StringValue) {
 			stringVisits++
 		},
 	}

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -266,7 +266,7 @@ func (TypeValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string,
 }
 
 func (v TypeValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -309,7 +309,7 @@ func (v TypeValue) Transfer(
 	return v
 }
 
-func (v TypeValue) Clone(_ *Interpreter) Value {
+func (v TypeValue) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -70,7 +70,7 @@ func (TypeValue) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeMetaType)
 }
 
-func (TypeValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (TypeValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return sema.MetaType.Importable
 }
 

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -58,8 +58,8 @@ func NewTypeValue(
 
 func (TypeValue) IsValue() {}
 
-func (v TypeValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitTypeValue(interpreter, v)
+func (v TypeValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitTypeValue(context, v)
 }
 
 func (TypeValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -455,7 +455,7 @@ func (UFix64Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ strin
 }
 
 func (v UFix64Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -177,7 +177,7 @@ func (UFix64Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeUFix64)
 }
 
-func (UFix64Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (UFix64Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -165,8 +165,8 @@ var _ MemberAccessibleValue = UFix64Value{}
 
 func (UFix64Value) IsValue() {}
 
-func (v UFix64Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitUFix64Value(interpreter, v)
+func (v UFix64Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitUFix64Value(context, v)
 }
 
 func (UFix64Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -485,7 +485,7 @@ func (v UFix64Value) Transfer(
 	return v
 }
 
-func (v UFix64Value) Clone(_ *Interpreter) Value {
+func (v UFix64Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -608,7 +608,7 @@ func (v UIntValue) ToBigEndianBytes() []byte {
 }
 
 func (v UIntValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -129,7 +129,7 @@ func (UIntValue) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeUInt)
 }
 
-func (v UIntValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (v UIntValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -642,7 +642,7 @@ func (v UIntValue) Transfer(
 	return v
 }
 
-func (v UIntValue) Clone(_ *Interpreter) Value {
+func (v UIntValue) Clone(_ ValueCloneContext) Value {
 	return NewUnmeteredUIntValueFromBigInt(v.BigInt)
 }
 

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -117,8 +117,8 @@ var _ MemberAccessibleValue = UIntValue{}
 
 func (UIntValue) IsValue() {}
 
-func (v UIntValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitUIntValue(interpreter, v)
+func (v UIntValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitUIntValue(context, v)
 }
 
 func (UIntValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -654,7 +654,7 @@ func (v UInt128Value) ToBigEndianBytes() []byte {
 }
 
 func (v UInt128Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -88,7 +88,7 @@ func (UInt128Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeUInt128)
 }
 
-func (UInt128Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (UInt128Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -692,7 +692,7 @@ func (v UInt128Value) Transfer(
 	return v
 }
 
-func (v UInt128Value) Clone(_ *Interpreter) Value {
+func (v UInt128Value) Clone(_ ValueCloneContext) Value {
 	return NewUnmeteredUInt128ValueFromBigInt(v.BigInt)
 }
 

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -76,8 +76,8 @@ var _ MemberAccessibleValue = UInt128Value{}
 
 func (UInt128Value) IsValue() {}
 
-func (v UInt128Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitUInt128Value(interpreter, v)
+func (v UInt128Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitUInt128Value(context, v)
 }
 
 func (UInt128Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -555,7 +555,7 @@ func (v UInt16Value) Transfer(
 	return v
 }
 
-func (v UInt16Value) Clone(_ *Interpreter) Value {
+func (v UInt16Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -517,7 +517,7 @@ func (v UInt16Value) ToBigEndianBytes() []byte {
 }
 
 func (v UInt16Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -72,7 +72,7 @@ func (UInt16Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeUInt16)
 }
 
-func (UInt16Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (UInt16Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -60,8 +60,8 @@ func NewUnmeteredUInt16Value(value uint16) UInt16Value {
 
 func (UInt16Value) IsValue() {}
 
-func (v UInt16Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitUInt16Value(interpreter, v)
+func (v UInt16Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitUInt16Value(context, v)
 }
 
 func (UInt16Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -654,7 +654,7 @@ func (v UInt256Value) ToBigEndianBytes() []byte {
 }
 
 func (v UInt256Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -88,7 +88,7 @@ func (UInt256Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeUInt256)
 }
 
-func (UInt256Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (UInt256Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -76,8 +76,8 @@ var _ MemberAccessibleValue = UInt256Value{}
 
 func (UInt256Value) IsValue() {}
 
-func (v UInt256Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitUInt256Value(interpreter, v)
+func (v UInt256Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitUInt256Value(context, v)
 }
 
 func (UInt256Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -691,7 +691,7 @@ func (v UInt256Value) Transfer(
 	return v
 }
 
-func (v UInt256Value) Clone(_ *Interpreter) Value {
+func (v UInt256Value) Clone(_ ValueCloneContext) Value {
 	return NewUnmeteredUInt256ValueFromBigInt(v.BigInt)
 }
 

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -72,7 +72,7 @@ func (UInt32Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeUInt32)
 }
 
-func (UInt32Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (UInt32Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -518,7 +518,7 @@ func (v UInt32Value) ToBigEndianBytes() []byte {
 }
 
 func (v UInt32Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -60,8 +60,8 @@ var _ MemberAccessibleValue = UInt32Value(0)
 
 func (UInt32Value) IsValue() {}
 
-func (v UInt32Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitUInt32Value(interpreter, v)
+func (v UInt32Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitUInt32Value(context, v)
 }
 
 func (UInt32Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -556,7 +556,7 @@ func (v UInt32Value) Transfer(
 	return v
 }
 
-func (v UInt32Value) Clone(_ *Interpreter) Value {
+func (v UInt32Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -546,7 +546,7 @@ func (v UInt64Value) ToBigEndianBytes() []byte {
 }
 
 func (v UInt64Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -79,7 +79,7 @@ func (UInt64Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeUInt64)
 }
 
-func (UInt64Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (UInt64Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -67,8 +67,8 @@ func NewUnmeteredUInt64Value(value uint64) UInt64Value {
 
 func (UInt64Value) IsValue() {}
 
-func (v UInt64Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitUInt64Value(interpreter, v)
+func (v UInt64Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitUInt64Value(context, v)
 }
 
 func (UInt64Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -584,7 +584,7 @@ func (v UInt64Value) Transfer(
 	return v
 }
 
-func (v UInt64Value) Clone(_ *Interpreter) Value {
+func (v UInt64Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -566,7 +566,7 @@ func (v UInt8Value) ToBigEndianBytes() []byte {
 }
 
 func (v UInt8Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -72,7 +72,7 @@ func (UInt8Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeUInt8)
 }
 
-func (UInt8Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (UInt8Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -600,7 +600,7 @@ func (v UInt8Value) Transfer(
 	return v
 }
 
-func (v UInt8Value) Clone(_ *Interpreter) Value {
+func (v UInt8Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -60,8 +60,8 @@ func NewUnmeteredUInt8Value(value uint8) UInt8Value {
 
 func (UInt8Value) IsValue() {}
 
-func (v UInt8Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitUInt8Value(interpreter, v)
+func (v UInt8Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitUInt8Value(context, v)
 }
 
 func (UInt8Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_void.go
+++ b/interpreter/value_void.go
@@ -51,7 +51,7 @@ func (VoidValue) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeVoid)
 }
 
-func (VoidValue) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (VoidValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return sema.VoidType.Importable
 }
 

--- a/interpreter/value_void.go
+++ b/interpreter/value_void.go
@@ -108,7 +108,7 @@ func (v VoidValue) Transfer(
 	return v
 }
 
-func (v VoidValue) Clone(_ *Interpreter) Value {
+func (v VoidValue) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_void.go
+++ b/interpreter/value_void.go
@@ -39,8 +39,8 @@ var _ EquatableValue = VoidValue{}
 
 func (VoidValue) IsValue() {}
 
-func (v VoidValue) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitVoidValue(interpreter, v)
+func (v VoidValue) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitVoidValue(context, v)
 }
 
 func (VoidValue) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_void.go
+++ b/interpreter/value_void.go
@@ -69,7 +69,7 @@ func (v VoidValue) MeteredString(context ValueStringContext, _ SeenReferences, _
 }
 
 func (v VoidValue) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -76,8 +76,8 @@ var _ MemberAccessibleValue = Word128Value{}
 
 func (Word128Value) IsValue() {}
 
-func (v Word128Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitWord128Value(interpreter, v)
+func (v Word128Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitWord128Value(context, v)
 }
 
 func (Word128Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -88,7 +88,7 @@ func (Word128Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeWord128)
 }
 
-func (Word128Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (Word128Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -597,7 +597,7 @@ func (v Word128Value) Transfer(
 	return v
 }
 
-func (v Word128Value) Clone(_ *Interpreter) Value {
+func (v Word128Value) Clone(_ ValueCloneContext) Value {
 	return NewUnmeteredWord128ValueFromBigInt(v.BigInt)
 }
 

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -559,7 +559,7 @@ func (v Word128Value) ToBigEndianBytes() []byte {
 }
 
 func (v Word128Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -413,7 +413,7 @@ func (v Word16Value) ToBigEndianBytes() []byte {
 }
 
 func (v Word16Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -61,8 +61,8 @@ func NewUnmeteredWord16Value(value uint16) Word16Value {
 
 func (Word16Value) IsValue() {}
 
-func (v Word16Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitWord16Value(interpreter, v)
+func (v Word16Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitWord16Value(context, v)
 }
 
 func (Word16Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -73,7 +73,7 @@ func (Word16Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeWord16)
 }
 
-func (Word16Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (Word16Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -451,7 +451,7 @@ func (v Word16Value) Transfer(
 	return v
 }
 
-func (v Word16Value) Clone(_ *Interpreter) Value {
+func (v Word16Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -76,8 +76,8 @@ var _ MemberAccessibleValue = Word256Value{}
 
 func (Word256Value) IsValue() {}
 
-func (v Word256Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitWord256Value(interpreter, v)
+func (v Word256Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitWord256Value(context, v)
 }
 
 func (Word256Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -560,7 +560,7 @@ func (v Word256Value) ToBigEndianBytes() []byte {
 }
 
 func (v Word256Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -88,7 +88,7 @@ func (Word256Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeWord256)
 }
 
-func (Word256Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (Word256Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -598,7 +598,7 @@ func (v Word256Value) Transfer(
 	return v
 }
 
-func (v Word256Value) Clone(_ *Interpreter) Value {
+func (v Word256Value) Clone(_ ValueCloneContext) Value {
 	return NewUnmeteredWord256ValueFromBigInt(v.BigInt)
 }
 

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -73,7 +73,7 @@ func (Word32Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeWord32)
 }
 
-func (Word32Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (Word32Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -452,7 +452,7 @@ func (v Word32Value) Transfer(
 	return v
 }
 
-func (v Word32Value) Clone(_ *Interpreter) Value {
+func (v Word32Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -414,7 +414,7 @@ func (v Word32Value) ToBigEndianBytes() []byte {
 }
 
 func (v Word32Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -61,8 +61,8 @@ func NewUnmeteredWord32Value(value uint32) Word32Value {
 
 func (Word32Value) IsValue() {}
 
-func (v Word32Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitWord32Value(interpreter, v)
+func (v Word32Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitWord32Value(context, v)
 }
 
 func (Word32Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -81,7 +81,7 @@ func (Word64Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeWord64)
 }
 
-func (Word64Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (Word64Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -69,8 +69,8 @@ var _ BigNumberValue = Word64Value(0)
 
 func (Word64Value) IsValue() {}
 
-func (v Word64Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitWord64Value(interpreter, v)
+func (v Word64Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitWord64Value(context, v)
 }
 
 func (Word64Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -442,7 +442,7 @@ func (v Word64Value) ToBigEndianBytes() []byte {
 }
 
 func (v Word64Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -480,7 +480,7 @@ func (v Word64Value) Transfer(
 	return v
 }
 
-func (v Word64Value) Clone(_ *Interpreter) Value {
+func (v Word64Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -60,8 +60,8 @@ func NewUnmeteredWord8Value(value uint8) Word8Value {
 
 func (Word8Value) IsValue() {}
 
-func (v Word8Value) Accept(interpreter *Interpreter, visitor Visitor, _ LocationRange) {
-	visitor.VisitWord8Value(interpreter, v)
+func (v Word8Value) Accept(context ValueVisitContext, visitor Visitor, _ LocationRange) {
+	visitor.VisitWord8Value(context, v)
 }
 
 func (Word8Value) Walk(_ ValueWalkContext, _ func(Value), _ LocationRange) {

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -72,7 +72,7 @@ func (Word8Value) StaticType(context ValueStaticTypeContext) StaticType {
 	return NewPrimitiveStaticType(context, PrimitiveStaticTypeWord8)
 }
 
-func (Word8Value) IsImportable(_ *Interpreter, _ LocationRange) bool {
+func (Word8Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 	return true
 }
 

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -449,7 +449,7 @@ func (v Word8Value) Transfer(
 	return v
 }
 
-func (v Word8Value) Clone(_ *Interpreter) Value {
+func (v Word8Value) Clone(_ ValueCloneContext) Value {
 	return v
 }
 

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -411,7 +411,7 @@ func (v Word8Value) ToBigEndianBytes() []byte {
 }
 
 func (v Word8Value) ConformsToStaticType(
-	_ *Interpreter,
+	_ ValueStaticTypeConformanceContext,
 	_ LocationRange,
 	_ TypeConformanceResults,
 ) bool {

--- a/interpreter/visitor.go
+++ b/interpreter/visitor.go
@@ -19,405 +19,405 @@
 package interpreter
 
 type Visitor interface {
-	VisitSimpleCompositeValue(interpreter *Interpreter, value *SimpleCompositeValue)
-	VisitTypeValue(interpreter *Interpreter, value TypeValue)
-	VisitVoidValue(interpreter *Interpreter, value VoidValue)
-	VisitBoolValue(interpreter *Interpreter, value BoolValue)
-	VisitStringValue(interpreter *Interpreter, value *StringValue)
-	VisitCharacterValue(interpreter *Interpreter, value CharacterValue)
-	VisitArrayValue(interpreter *Interpreter, value *ArrayValue) bool
-	VisitIntValue(interpreter *Interpreter, value IntValue)
-	VisitInt8Value(interpreter *Interpreter, value Int8Value)
-	VisitInt16Value(interpreter *Interpreter, value Int16Value)
-	VisitInt32Value(interpreter *Interpreter, value Int32Value)
-	VisitInt64Value(interpreter *Interpreter, value Int64Value)
-	VisitInt128Value(interpreter *Interpreter, value Int128Value)
-	VisitInt256Value(interpreter *Interpreter, value Int256Value)
-	VisitUIntValue(interpreter *Interpreter, value UIntValue)
-	VisitUInt8Value(interpreter *Interpreter, value UInt8Value)
-	VisitUInt16Value(interpreter *Interpreter, value UInt16Value)
-	VisitUInt32Value(interpreter *Interpreter, value UInt32Value)
-	VisitUInt64Value(interpreter *Interpreter, value UInt64Value)
-	VisitUInt128Value(interpreter *Interpreter, value UInt128Value)
-	VisitUInt256Value(interpreter *Interpreter, value UInt256Value)
-	VisitWord8Value(interpreter *Interpreter, value Word8Value)
-	VisitWord16Value(interpreter *Interpreter, value Word16Value)
-	VisitWord32Value(interpreter *Interpreter, value Word32Value)
-	VisitWord64Value(interpreter *Interpreter, value Word64Value)
-	VisitWord128Value(interpreter *Interpreter, value Word128Value)
-	VisitWord256Value(interpreter *Interpreter, value Word256Value)
-	VisitFix64Value(interpreter *Interpreter, value Fix64Value)
-	VisitUFix64Value(interpreter *Interpreter, value UFix64Value)
-	VisitCompositeValue(interpreter *Interpreter, value *CompositeValue) bool
-	VisitDictionaryValue(interpreter *Interpreter, value *DictionaryValue) bool
-	VisitNilValue(interpreter *Interpreter, value NilValue)
-	VisitSomeValue(interpreter *Interpreter, value *SomeValue) bool
-	VisitStorageReferenceValue(interpreter *Interpreter, value *StorageReferenceValue)
-	VisitEphemeralReferenceValue(interpreter *Interpreter, value *EphemeralReferenceValue)
-	VisitAddressValue(interpreter *Interpreter, value AddressValue)
-	VisitPathValue(interpreter *Interpreter, value PathValue)
-	VisitCapabilityValue(interpreter *Interpreter, value *IDCapabilityValue)
-	VisitPublishedValue(interpreter *Interpreter, value *PublishedValue)
-	VisitInterpretedFunctionValue(interpreter *Interpreter, value *InterpretedFunctionValue)
-	VisitHostFunctionValue(interpreter *Interpreter, value *HostFunctionValue)
-	VisitBoundFunctionValue(interpreter *Interpreter, value BoundFunctionValue)
-	VisitStorageCapabilityControllerValue(interpreter *Interpreter, v *StorageCapabilityControllerValue)
-	VisitAccountCapabilityControllerValue(interpreter *Interpreter, v *AccountCapabilityControllerValue)
+	VisitSimpleCompositeValue(context ValueVisitContext, value *SimpleCompositeValue)
+	VisitTypeValue(context ValueVisitContext, value TypeValue)
+	VisitVoidValue(context ValueVisitContext, value VoidValue)
+	VisitBoolValue(context ValueVisitContext, value BoolValue)
+	VisitStringValue(context ValueVisitContext, value *StringValue)
+	VisitCharacterValue(context ValueVisitContext, value CharacterValue)
+	VisitArrayValue(context ValueVisitContext, value *ArrayValue) bool
+	VisitIntValue(context ValueVisitContext, value IntValue)
+	VisitInt8Value(context ValueVisitContext, value Int8Value)
+	VisitInt16Value(context ValueVisitContext, value Int16Value)
+	VisitInt32Value(context ValueVisitContext, value Int32Value)
+	VisitInt64Value(context ValueVisitContext, value Int64Value)
+	VisitInt128Value(context ValueVisitContext, value Int128Value)
+	VisitInt256Value(context ValueVisitContext, value Int256Value)
+	VisitUIntValue(context ValueVisitContext, value UIntValue)
+	VisitUInt8Value(context ValueVisitContext, value UInt8Value)
+	VisitUInt16Value(context ValueVisitContext, value UInt16Value)
+	VisitUInt32Value(context ValueVisitContext, value UInt32Value)
+	VisitUInt64Value(context ValueVisitContext, value UInt64Value)
+	VisitUInt128Value(context ValueVisitContext, value UInt128Value)
+	VisitUInt256Value(context ValueVisitContext, value UInt256Value)
+	VisitWord8Value(context ValueVisitContext, value Word8Value)
+	VisitWord16Value(context ValueVisitContext, value Word16Value)
+	VisitWord32Value(context ValueVisitContext, value Word32Value)
+	VisitWord64Value(context ValueVisitContext, value Word64Value)
+	VisitWord128Value(context ValueVisitContext, value Word128Value)
+	VisitWord256Value(context ValueVisitContext, value Word256Value)
+	VisitFix64Value(context ValueVisitContext, value Fix64Value)
+	VisitUFix64Value(context ValueVisitContext, value UFix64Value)
+	VisitCompositeValue(context ValueVisitContext, value *CompositeValue) bool
+	VisitDictionaryValue(context ValueVisitContext, value *DictionaryValue) bool
+	VisitNilValue(context ValueVisitContext, value NilValue)
+	VisitSomeValue(context ValueVisitContext, value *SomeValue) bool
+	VisitStorageReferenceValue(context ValueVisitContext, value *StorageReferenceValue)
+	VisitEphemeralReferenceValue(context ValueVisitContext, value *EphemeralReferenceValue)
+	VisitAddressValue(context ValueVisitContext, value AddressValue)
+	VisitPathValue(context ValueVisitContext, value PathValue)
+	VisitCapabilityValue(context ValueVisitContext, value *IDCapabilityValue)
+	VisitPublishedValue(context ValueVisitContext, value *PublishedValue)
+	VisitInterpretedFunctionValue(context ValueVisitContext, value *InterpretedFunctionValue)
+	VisitHostFunctionValue(context ValueVisitContext, value *HostFunctionValue)
+	VisitBoundFunctionValue(context ValueVisitContext, value BoundFunctionValue)
+	VisitStorageCapabilityControllerValue(context ValueVisitContext, v *StorageCapabilityControllerValue)
+	VisitAccountCapabilityControllerValue(context ValueVisitContext, v *AccountCapabilityControllerValue)
 }
 
 type EmptyVisitor struct {
-	SimpleCompositeValueVisitor             func(interpreter *Interpreter, value *SimpleCompositeValue)
-	TypeValueVisitor                        func(interpreter *Interpreter, value TypeValue)
-	VoidValueVisitor                        func(interpreter *Interpreter, value VoidValue)
-	BoolValueVisitor                        func(interpreter *Interpreter, value BoolValue)
-	CharacterValueVisitor                   func(interpreter *Interpreter, value CharacterValue)
-	StringValueVisitor                      func(interpreter *Interpreter, value *StringValue)
-	ArrayValueVisitor                       func(interpreter *Interpreter, value *ArrayValue) bool
-	IntValueVisitor                         func(interpreter *Interpreter, value IntValue)
-	Int8ValueVisitor                        func(interpreter *Interpreter, value Int8Value)
-	Int16ValueVisitor                       func(interpreter *Interpreter, value Int16Value)
-	Int32ValueVisitor                       func(interpreter *Interpreter, value Int32Value)
-	Int64ValueVisitor                       func(interpreter *Interpreter, value Int64Value)
-	Int128ValueVisitor                      func(interpreter *Interpreter, value Int128Value)
-	Int256ValueVisitor                      func(interpreter *Interpreter, value Int256Value)
-	UIntValueVisitor                        func(interpreter *Interpreter, value UIntValue)
-	UInt8ValueVisitor                       func(interpreter *Interpreter, value UInt8Value)
-	UInt16ValueVisitor                      func(interpreter *Interpreter, value UInt16Value)
-	UInt32ValueVisitor                      func(interpreter *Interpreter, value UInt32Value)
-	UInt64ValueVisitor                      func(interpreter *Interpreter, value UInt64Value)
-	UInt128ValueVisitor                     func(interpreter *Interpreter, value UInt128Value)
-	UInt256ValueVisitor                     func(interpreter *Interpreter, value UInt256Value)
-	Word8ValueVisitor                       func(interpreter *Interpreter, value Word8Value)
-	Word16ValueVisitor                      func(interpreter *Interpreter, value Word16Value)
-	Word32ValueVisitor                      func(interpreter *Interpreter, value Word32Value)
-	Word64ValueVisitor                      func(interpreter *Interpreter, value Word64Value)
-	Word128ValueVisitor                     func(interpreter *Interpreter, value Word128Value)
-	Word256ValueVisitor                     func(interpreter *Interpreter, value Word256Value)
-	Fix64ValueVisitor                       func(interpreter *Interpreter, value Fix64Value)
-	UFix64ValueVisitor                      func(interpreter *Interpreter, value UFix64Value)
-	CompositeValueVisitor                   func(interpreter *Interpreter, value *CompositeValue) bool
-	DictionaryValueVisitor                  func(interpreter *Interpreter, value *DictionaryValue) bool
-	NilValueVisitor                         func(interpreter *Interpreter, value NilValue)
-	SomeValueVisitor                        func(interpreter *Interpreter, value *SomeValue) bool
-	StorageReferenceValueVisitor            func(interpreter *Interpreter, value *StorageReferenceValue)
-	EphemeralReferenceValueVisitor          func(interpreter *Interpreter, value *EphemeralReferenceValue)
-	AddressValueVisitor                     func(interpreter *Interpreter, value AddressValue)
-	PathValueVisitor                        func(interpreter *Interpreter, value PathValue)
-	CapabilityValueVisitor                  func(interpreter *Interpreter, value *IDCapabilityValue)
-	PublishedValueVisitor                   func(interpreter *Interpreter, value *PublishedValue)
-	InterpretedFunctionValueVisitor         func(interpreter *Interpreter, value *InterpretedFunctionValue)
-	HostFunctionValueVisitor                func(interpreter *Interpreter, value *HostFunctionValue)
-	BoundFunctionValueVisitor               func(interpreter *Interpreter, value BoundFunctionValue)
-	StorageCapabilityControllerValueVisitor func(interpreter *Interpreter, value *StorageCapabilityControllerValue)
-	AccountCapabilityControllerValueVisitor func(interpreter *Interpreter, value *AccountCapabilityControllerValue)
+	SimpleCompositeValueVisitor             func(context ValueVisitContext, value *SimpleCompositeValue)
+	TypeValueVisitor                        func(context ValueVisitContext, value TypeValue)
+	VoidValueVisitor                        func(context ValueVisitContext, value VoidValue)
+	BoolValueVisitor                        func(context ValueVisitContext, value BoolValue)
+	CharacterValueVisitor                   func(context ValueVisitContext, value CharacterValue)
+	StringValueVisitor                      func(context ValueVisitContext, value *StringValue)
+	ArrayValueVisitor                       func(context ValueVisitContext, value *ArrayValue) bool
+	IntValueVisitor                         func(context ValueVisitContext, value IntValue)
+	Int8ValueVisitor                        func(context ValueVisitContext, value Int8Value)
+	Int16ValueVisitor                       func(context ValueVisitContext, value Int16Value)
+	Int32ValueVisitor                       func(context ValueVisitContext, value Int32Value)
+	Int64ValueVisitor                       func(context ValueVisitContext, value Int64Value)
+	Int128ValueVisitor                      func(context ValueVisitContext, value Int128Value)
+	Int256ValueVisitor                      func(context ValueVisitContext, value Int256Value)
+	UIntValueVisitor                        func(context ValueVisitContext, value UIntValue)
+	UInt8ValueVisitor                       func(context ValueVisitContext, value UInt8Value)
+	UInt16ValueVisitor                      func(context ValueVisitContext, value UInt16Value)
+	UInt32ValueVisitor                      func(context ValueVisitContext, value UInt32Value)
+	UInt64ValueVisitor                      func(context ValueVisitContext, value UInt64Value)
+	UInt128ValueVisitor                     func(context ValueVisitContext, value UInt128Value)
+	UInt256ValueVisitor                     func(context ValueVisitContext, value UInt256Value)
+	Word8ValueVisitor                       func(context ValueVisitContext, value Word8Value)
+	Word16ValueVisitor                      func(context ValueVisitContext, value Word16Value)
+	Word32ValueVisitor                      func(context ValueVisitContext, value Word32Value)
+	Word64ValueVisitor                      func(context ValueVisitContext, value Word64Value)
+	Word128ValueVisitor                     func(context ValueVisitContext, value Word128Value)
+	Word256ValueVisitor                     func(context ValueVisitContext, value Word256Value)
+	Fix64ValueVisitor                       func(context ValueVisitContext, value Fix64Value)
+	UFix64ValueVisitor                      func(context ValueVisitContext, value UFix64Value)
+	CompositeValueVisitor                   func(context ValueVisitContext, value *CompositeValue) bool
+	DictionaryValueVisitor                  func(context ValueVisitContext, value *DictionaryValue) bool
+	NilValueVisitor                         func(context ValueVisitContext, value NilValue)
+	SomeValueVisitor                        func(context ValueVisitContext, value *SomeValue) bool
+	StorageReferenceValueVisitor            func(context ValueVisitContext, value *StorageReferenceValue)
+	EphemeralReferenceValueVisitor          func(context ValueVisitContext, value *EphemeralReferenceValue)
+	AddressValueVisitor                     func(context ValueVisitContext, value AddressValue)
+	PathValueVisitor                        func(context ValueVisitContext, value PathValue)
+	CapabilityValueVisitor                  func(context ValueVisitContext, value *IDCapabilityValue)
+	PublishedValueVisitor                   func(context ValueVisitContext, value *PublishedValue)
+	InterpretedFunctionValueVisitor         func(context ValueVisitContext, value *InterpretedFunctionValue)
+	HostFunctionValueVisitor                func(context ValueVisitContext, value *HostFunctionValue)
+	BoundFunctionValueVisitor               func(context ValueVisitContext, value BoundFunctionValue)
+	StorageCapabilityControllerValueVisitor func(context ValueVisitContext, value *StorageCapabilityControllerValue)
+	AccountCapabilityControllerValueVisitor func(context ValueVisitContext, value *AccountCapabilityControllerValue)
 }
 
 var _ Visitor = &EmptyVisitor{}
 
-func (v EmptyVisitor) VisitSimpleCompositeValue(interpreter *Interpreter, value *SimpleCompositeValue) {
+func (v EmptyVisitor) VisitSimpleCompositeValue(context ValueVisitContext, value *SimpleCompositeValue) {
 	if v.SimpleCompositeValueVisitor == nil {
 		return
 	}
-	v.SimpleCompositeValueVisitor(interpreter, value)
+	v.SimpleCompositeValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitTypeValue(interpreter *Interpreter, value TypeValue) {
+func (v EmptyVisitor) VisitTypeValue(context ValueVisitContext, value TypeValue) {
 	if v.TypeValueVisitor == nil {
 		return
 	}
-	v.TypeValueVisitor(interpreter, value)
+	v.TypeValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitVoidValue(interpreter *Interpreter, value VoidValue) {
+func (v EmptyVisitor) VisitVoidValue(context ValueVisitContext, value VoidValue) {
 	if v.VoidValueVisitor == nil {
 		return
 	}
-	v.VoidValueVisitor(interpreter, value)
+	v.VoidValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitBoolValue(interpreter *Interpreter, value BoolValue) {
+func (v EmptyVisitor) VisitBoolValue(context ValueVisitContext, value BoolValue) {
 	if v.BoolValueVisitor == nil {
 		return
 	}
-	v.BoolValueVisitor(interpreter, value)
+	v.BoolValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitStringValue(interpreter *Interpreter, value *StringValue) {
+func (v EmptyVisitor) VisitStringValue(context ValueVisitContext, value *StringValue) {
 	if v.StringValueVisitor == nil {
 		return
 	}
-	v.StringValueVisitor(interpreter, value)
+	v.StringValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitCharacterValue(interpreter *Interpreter, value CharacterValue) {
+func (v EmptyVisitor) VisitCharacterValue(context ValueVisitContext, value CharacterValue) {
 	if v.StringValueVisitor == nil {
 		return
 	}
-	v.CharacterValueVisitor(interpreter, value)
+	v.CharacterValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitArrayValue(interpreter *Interpreter, value *ArrayValue) bool {
+func (v EmptyVisitor) VisitArrayValue(context ValueVisitContext, value *ArrayValue) bool {
 	if v.ArrayValueVisitor == nil {
 		return true
 	}
-	return v.ArrayValueVisitor(interpreter, value)
+	return v.ArrayValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitIntValue(interpreter *Interpreter, value IntValue) {
+func (v EmptyVisitor) VisitIntValue(context ValueVisitContext, value IntValue) {
 	if v.IntValueVisitor == nil {
 		return
 	}
-	v.IntValueVisitor(interpreter, value)
+	v.IntValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitInt8Value(interpreter *Interpreter, value Int8Value) {
+func (v EmptyVisitor) VisitInt8Value(context ValueVisitContext, value Int8Value) {
 	if v.Int8ValueVisitor == nil {
 		return
 	}
-	v.Int8ValueVisitor(interpreter, value)
+	v.Int8ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitInt16Value(interpreter *Interpreter, value Int16Value) {
+func (v EmptyVisitor) VisitInt16Value(context ValueVisitContext, value Int16Value) {
 	if v.Int16ValueVisitor == nil {
 		return
 	}
-	v.Int16ValueVisitor(interpreter, value)
+	v.Int16ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitInt32Value(interpreter *Interpreter, value Int32Value) {
+func (v EmptyVisitor) VisitInt32Value(context ValueVisitContext, value Int32Value) {
 	if v.Int32ValueVisitor == nil {
 		return
 	}
-	v.Int32ValueVisitor(interpreter, value)
+	v.Int32ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitInt64Value(interpreter *Interpreter, value Int64Value) {
+func (v EmptyVisitor) VisitInt64Value(context ValueVisitContext, value Int64Value) {
 	if v.Int64ValueVisitor == nil {
 		return
 	}
-	v.Int64ValueVisitor(interpreter, value)
+	v.Int64ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitInt128Value(interpreter *Interpreter, value Int128Value) {
+func (v EmptyVisitor) VisitInt128Value(context ValueVisitContext, value Int128Value) {
 	if v.Int128ValueVisitor == nil {
 		return
 	}
-	v.Int128ValueVisitor(interpreter, value)
+	v.Int128ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitInt256Value(interpreter *Interpreter, value Int256Value) {
+func (v EmptyVisitor) VisitInt256Value(context ValueVisitContext, value Int256Value) {
 	if v.Int256ValueVisitor == nil {
 		return
 	}
-	v.Int256ValueVisitor(interpreter, value)
+	v.Int256ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitUIntValue(interpreter *Interpreter, value UIntValue) {
+func (v EmptyVisitor) VisitUIntValue(context ValueVisitContext, value UIntValue) {
 	if v.UIntValueVisitor == nil {
 		return
 	}
-	v.UIntValueVisitor(interpreter, value)
+	v.UIntValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitUInt8Value(interpreter *Interpreter, value UInt8Value) {
+func (v EmptyVisitor) VisitUInt8Value(context ValueVisitContext, value UInt8Value) {
 	if v.UInt8ValueVisitor == nil {
 		return
 	}
-	v.UInt8ValueVisitor(interpreter, value)
+	v.UInt8ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitUInt16Value(interpreter *Interpreter, value UInt16Value) {
+func (v EmptyVisitor) VisitUInt16Value(context ValueVisitContext, value UInt16Value) {
 	if v.UInt16ValueVisitor == nil {
 		return
 	}
-	v.UInt16ValueVisitor(interpreter, value)
+	v.UInt16ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitUInt32Value(interpreter *Interpreter, value UInt32Value) {
+func (v EmptyVisitor) VisitUInt32Value(context ValueVisitContext, value UInt32Value) {
 	if v.UInt32ValueVisitor == nil {
 		return
 	}
-	v.UInt32ValueVisitor(interpreter, value)
+	v.UInt32ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitUInt64Value(interpreter *Interpreter, value UInt64Value) {
+func (v EmptyVisitor) VisitUInt64Value(context ValueVisitContext, value UInt64Value) {
 	if v.UInt64ValueVisitor == nil {
 		return
 	}
-	v.UInt64ValueVisitor(interpreter, value)
+	v.UInt64ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitUInt128Value(interpreter *Interpreter, value UInt128Value) {
+func (v EmptyVisitor) VisitUInt128Value(context ValueVisitContext, value UInt128Value) {
 	if v.UInt128ValueVisitor == nil {
 		return
 	}
-	v.UInt128ValueVisitor(interpreter, value)
+	v.UInt128ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitUInt256Value(interpreter *Interpreter, value UInt256Value) {
+func (v EmptyVisitor) VisitUInt256Value(context ValueVisitContext, value UInt256Value) {
 	if v.UInt256ValueVisitor == nil {
 		return
 	}
-	v.UInt256ValueVisitor(interpreter, value)
+	v.UInt256ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitWord8Value(interpreter *Interpreter, value Word8Value) {
+func (v EmptyVisitor) VisitWord8Value(context ValueVisitContext, value Word8Value) {
 	if v.Word8ValueVisitor == nil {
 		return
 	}
-	v.Word8ValueVisitor(interpreter, value)
+	v.Word8ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitWord16Value(interpreter *Interpreter, value Word16Value) {
+func (v EmptyVisitor) VisitWord16Value(context ValueVisitContext, value Word16Value) {
 	if v.Word16ValueVisitor == nil {
 		return
 	}
-	v.Word16ValueVisitor(interpreter, value)
+	v.Word16ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitWord32Value(interpreter *Interpreter, value Word32Value) {
+func (v EmptyVisitor) VisitWord32Value(context ValueVisitContext, value Word32Value) {
 	if v.Word32ValueVisitor == nil {
 		return
 	}
-	v.Word32ValueVisitor(interpreter, value)
+	v.Word32ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitWord64Value(interpreter *Interpreter, value Word64Value) {
+func (v EmptyVisitor) VisitWord64Value(context ValueVisitContext, value Word64Value) {
 	if v.Word64ValueVisitor == nil {
 		return
 	}
-	v.Word64ValueVisitor(interpreter, value)
+	v.Word64ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitWord128Value(interpreter *Interpreter, value Word128Value) {
+func (v EmptyVisitor) VisitWord128Value(context ValueVisitContext, value Word128Value) {
 	if v.Word128ValueVisitor == nil {
 		return
 	}
-	v.Word128ValueVisitor(interpreter, value)
+	v.Word128ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitWord256Value(interpreter *Interpreter, value Word256Value) {
+func (v EmptyVisitor) VisitWord256Value(context ValueVisitContext, value Word256Value) {
 	if v.Word256ValueVisitor == nil {
 		return
 	}
-	v.Word256ValueVisitor(interpreter, value)
+	v.Word256ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitFix64Value(interpreter *Interpreter, value Fix64Value) {
+func (v EmptyVisitor) VisitFix64Value(context ValueVisitContext, value Fix64Value) {
 	if v.Fix64ValueVisitor == nil {
 		return
 	}
-	v.Fix64ValueVisitor(interpreter, value)
+	v.Fix64ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitUFix64Value(interpreter *Interpreter, value UFix64Value) {
+func (v EmptyVisitor) VisitUFix64Value(context ValueVisitContext, value UFix64Value) {
 	if v.UFix64ValueVisitor == nil {
 		return
 	}
-	v.UFix64ValueVisitor(interpreter, value)
+	v.UFix64ValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitCompositeValue(interpreter *Interpreter, value *CompositeValue) bool {
+func (v EmptyVisitor) VisitCompositeValue(context ValueVisitContext, value *CompositeValue) bool {
 	if v.CompositeValueVisitor == nil {
 		return true
 	}
-	return v.CompositeValueVisitor(interpreter, value)
+	return v.CompositeValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitDictionaryValue(interpreter *Interpreter, value *DictionaryValue) bool {
+func (v EmptyVisitor) VisitDictionaryValue(context ValueVisitContext, value *DictionaryValue) bool {
 	if v.DictionaryValueVisitor == nil {
 		return true
 	}
-	return v.DictionaryValueVisitor(interpreter, value)
+	return v.DictionaryValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitNilValue(interpreter *Interpreter, value NilValue) {
+func (v EmptyVisitor) VisitNilValue(context ValueVisitContext, value NilValue) {
 	if v.NilValueVisitor == nil {
 		return
 	}
-	v.NilValueVisitor(interpreter, value)
+	v.NilValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitSomeValue(interpreter *Interpreter, value *SomeValue) bool {
+func (v EmptyVisitor) VisitSomeValue(context ValueVisitContext, value *SomeValue) bool {
 	if v.SomeValueVisitor == nil {
 		return true
 	}
-	return v.SomeValueVisitor(interpreter, value)
+	return v.SomeValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitStorageReferenceValue(interpreter *Interpreter, value *StorageReferenceValue) {
+func (v EmptyVisitor) VisitStorageReferenceValue(context ValueVisitContext, value *StorageReferenceValue) {
 	if v.StorageReferenceValueVisitor == nil {
 		return
 	}
-	v.StorageReferenceValueVisitor(interpreter, value)
+	v.StorageReferenceValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitEphemeralReferenceValue(interpreter *Interpreter, value *EphemeralReferenceValue) {
+func (v EmptyVisitor) VisitEphemeralReferenceValue(context ValueVisitContext, value *EphemeralReferenceValue) {
 	if v.EphemeralReferenceValueVisitor == nil {
 		return
 	}
-	v.EphemeralReferenceValueVisitor(interpreter, value)
+	v.EphemeralReferenceValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitAddressValue(interpreter *Interpreter, value AddressValue) {
+func (v EmptyVisitor) VisitAddressValue(context ValueVisitContext, value AddressValue) {
 	if v.AddressValueVisitor == nil {
 		return
 	}
-	v.AddressValueVisitor(interpreter, value)
+	v.AddressValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitPathValue(interpreter *Interpreter, value PathValue) {
+func (v EmptyVisitor) VisitPathValue(context ValueVisitContext, value PathValue) {
 	if v.PathValueVisitor == nil {
 		return
 	}
-	v.PathValueVisitor(interpreter, value)
+	v.PathValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitCapabilityValue(interpreter *Interpreter, value *IDCapabilityValue) {
+func (v EmptyVisitor) VisitCapabilityValue(context ValueVisitContext, value *IDCapabilityValue) {
 	if v.CapabilityValueVisitor == nil {
 		return
 	}
-	v.CapabilityValueVisitor(interpreter, value)
+	v.CapabilityValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitPublishedValue(interpreter *Interpreter, value *PublishedValue) {
+func (v EmptyVisitor) VisitPublishedValue(context ValueVisitContext, value *PublishedValue) {
 	if v.PublishedValueVisitor == nil {
 		return
 	}
-	v.PublishedValueVisitor(interpreter, value)
+	v.PublishedValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitInterpretedFunctionValue(interpreter *Interpreter, value *InterpretedFunctionValue) {
+func (v EmptyVisitor) VisitInterpretedFunctionValue(context ValueVisitContext, value *InterpretedFunctionValue) {
 	if v.InterpretedFunctionValueVisitor == nil {
 		return
 	}
-	v.InterpretedFunctionValueVisitor(interpreter, value)
+	v.InterpretedFunctionValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitHostFunctionValue(interpreter *Interpreter, value *HostFunctionValue) {
+func (v EmptyVisitor) VisitHostFunctionValue(context ValueVisitContext, value *HostFunctionValue) {
 	if v.HostFunctionValueVisitor == nil {
 		return
 	}
-	v.HostFunctionValueVisitor(interpreter, value)
+	v.HostFunctionValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitBoundFunctionValue(interpreter *Interpreter, value BoundFunctionValue) {
+func (v EmptyVisitor) VisitBoundFunctionValue(context ValueVisitContext, value BoundFunctionValue) {
 	if v.BoundFunctionValueVisitor == nil {
 		return
 	}
-	v.BoundFunctionValueVisitor(interpreter, value)
+	v.BoundFunctionValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitStorageCapabilityControllerValue(interpreter *Interpreter, value *StorageCapabilityControllerValue) {
+func (v EmptyVisitor) VisitStorageCapabilityControllerValue(context ValueVisitContext, value *StorageCapabilityControllerValue) {
 	if v.StorageCapabilityControllerValueVisitor == nil {
 		return
 	}
-	v.StorageCapabilityControllerValueVisitor(interpreter, value)
+	v.StorageCapabilityControllerValueVisitor(context, value)
 }
 
-func (v EmptyVisitor) VisitAccountCapabilityControllerValue(interpreter *Interpreter, value *AccountCapabilityControllerValue) {
+func (v EmptyVisitor) VisitAccountCapabilityControllerValue(context ValueVisitContext, value *AccountCapabilityControllerValue) {
 	if v.AccountCapabilityControllerValueVisitor == nil {
 		return
 	}
-	v.AccountCapabilityControllerValueVisitor(interpreter, value)
+	v.AccountCapabilityControllerValueVisitor(context, value)
 }


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3693

## Description

Refactors the remaining methods:
- `ConformsToStaticType`
- `Clone`
- `IsImportable`
- `Accept`

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
