### PR TITLE
Decouple remaining methods of value-related interfaces from the interpreter

### DIFF
--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -123,6 +123,11 @@ type ValueTransferContext interface {
 
 	WithMutationPrevention(valueID atree.ValueID, f func())
 	ValidateMutation(valueID atree.ValueID, locationRange LocationRange)
+
+	EnforceNotResourceDestruction(
+		valueID atree.ValueID,
+		locationRange LocationRange,
+	)
 }
 
 var _ ValueTransferContext = &Interpreter{}
@@ -258,11 +263,6 @@ type StorageIterationTracker interface {
 var _ StorageIterationTracker = &Interpreter{}
 
 type ResourceDestructionHandler interface {
-	EnforceNotResourceDestruction(
-		valueID atree.ValueID,
-		locationRange LocationRange,
-	)
-
 	WithResourceDestruction(
 		valueID atree.ValueID,
 		locationRange LocationRange,
@@ -533,6 +533,10 @@ func (ctx NoOpStringContext) ValidateMutation(_ atree.ValueID, _ LocationRange) 
 	panic(errors.NewUnreachableError())
 }
 
+func (ctx NoOpStringContext) EnforceNotResourceDestruction(_ atree.ValueID, _ LocationRange) {
+	panic(errors.NewUnreachableError())
+}
+
 func (ctx NoOpStringContext) ReadStored(_ common.Address, _ common.StorageDomain, _ StorageMapKey) Value {
 	panic(errors.NewUnreachableError())
 }
@@ -662,6 +666,10 @@ func (ctx NoOpStringContext) ReportCompositeValueConstructTrace(_ string, _ stri
 }
 
 func (ctx NoOpStringContext) ReportCompositeValueConformsToStaticTypeTrace(_ string, _ string, _ string, _ time.Duration) {
+	panic(errors.NewUnreachableError())
+}
+
+func (ctx NoOpStringContext) ReportCompositeValueRemoveMemberTrace(_ string, _ string, _ string, _ string, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -194,6 +194,21 @@ type ReferenceCreationContext interface {
 
 var _ ReferenceCreationContext = &Interpreter{}
 
+type GetReferenceContext interface {
+	ReferenceCreationContext
+	ValueStaticTypeContext
+	EntitlementMappingsSubstitutionHandler
+}
+
+var _ GetReferenceContext = &Interpreter{}
+
+type IterableValueForeachContext interface {
+	ValueTransferContext
+	EntitlementMappingsSubstitutionHandler
+}
+
+var _ IterableValueForeachContext = &Interpreter{}
+
 type AccountHandlerContext interface {
 	AccountHandler() AccountHandlerFunc
 }

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5334,7 +5334,7 @@ func getTypeFunction(context FunctionCreationContext, self Value) FunctionValue 
 }
 
 func setMember(
-	context MemberAccessibleContext,
+	context ValueTransferContext,
 	self Value,
 	locationRange LocationRange,
 	identifier string,

--- a/interpreter/interpreter_tracing.go
+++ b/interpreter/interpreter_tracing.go
@@ -71,6 +71,7 @@ type Tracer interface {
 	ReportCompositeValueConstructTrace(owner string, id string, kind string, since time.Duration)
 	ReportCompositeValueDestroyTrace(owner string, id string, kind string, since time.Duration)
 	ReportCompositeValueConformsToStaticTypeTrace(owner string, id string, kind string, since time.Duration)
+	ReportCompositeValueRemoveMemberTrace(owner string, id string, kind string, name string, since time.Duration)
 
 	ReportDomainStorageMapDeepRemoveTrace(info string, i int, since time.Duration)
 }
@@ -376,7 +377,7 @@ func (interpreter *Interpreter) ReportCompositeValueSetMemberTrace(
 	)
 }
 
-func (interpreter *Interpreter) reportCompositeValueRemoveMemberTrace(
+func (interpreter *Interpreter) ReportCompositeValueRemoveMemberTrace(
 	owner string,
 	typeID string,
 	kind string,

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -151,13 +151,13 @@ func (v *SimpleCompositeValue) GetMember(context MemberAccessibleContext, locati
 	return nil
 }
 
-func (v *SimpleCompositeValue) RemoveMember(_ *Interpreter, _ LocationRange, name string) Value {
+func (v *SimpleCompositeValue) RemoveMember(_ ValueTransferContext, _ LocationRange, name string) Value {
 	value := v.Fields[name]
 	delete(v.Fields, name)
 	return value
 }
 
-func (v *SimpleCompositeValue) SetMember(_ MemberAccessibleContext, _ LocationRange, name string, value Value) bool {
+func (v *SimpleCompositeValue) SetMember(_ ValueTransferContext, _ LocationRange, name string, value Value) bool {
 	_, hasField := v.Fields[name]
 	v.Fields[name] = value
 	return hasField

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -232,7 +232,7 @@ type ContractValue interface {
 type IterableValue interface {
 	Value
 	ForEach(
-		interpreter *Interpreter,
+		context IterableValueForeachContext,
 		elementType sema.Type,
 		function func(value Value) (resume bool),
 		transferElements bool,

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -144,9 +144,9 @@ type ValueIndexableValue interface {
 
 type TypeIndexableValue interface {
 	Value
-	GetTypeKey(interpreter *Interpreter, locationRange LocationRange, ty sema.Type) Value
-	SetTypeKey(interpreter *Interpreter, locationRange LocationRange, ty sema.Type, value Value)
-	RemoveTypeKey(interpreter *Interpreter, locationRange LocationRange, ty sema.Type) Value
+	GetTypeKey(context MemberAccessibleContext, locationRange LocationRange, ty sema.Type) Value
+	SetTypeKey(context ValueTransferContext, locationRange LocationRange, ty sema.Type, value Value)
+	RemoveTypeKey(context ValueTransferContext, locationRange LocationRange, ty sema.Type) Value
 }
 
 // MemberAccessibleValue

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -216,7 +216,7 @@ type ReferenceTrackedResourceKindedValue interface {
 	ResourceKindedValue
 	IsReferenceTrackedResourceKindedValue()
 	ValueID() atree.ValueID
-	IsStaleResource(*Interpreter) bool
+	IsStaleResource(ValueStaticTypeContext) bool
 }
 
 // ContractValue is the value of a contract.

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -154,9 +154,9 @@ type TypeIndexableValue interface {
 type MemberAccessibleValue interface {
 	Value
 	GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value
-	RemoveMember(interpreter *Interpreter, locationRange LocationRange, name string) Value
-	// returns whether a value previously existed with this name
-	SetMember(context MemberAccessibleContext, locationRange LocationRange, name string, value Value) bool
+	RemoveMember(context ValueTransferContext, locationRange LocationRange, name string) Value
+	// SetMember returns whether a value previously existed with this name.
+	SetMember(context ValueTransferContext, locationRange LocationRange, name string, value Value) bool
 }
 
 type ValueComparisonContext interface {

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -255,13 +255,13 @@ func (v *AccountCapabilityControllerValue) GetMember(context MemberAccessibleCon
 	return nil
 }
 
-func (*AccountCapabilityControllerValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (*AccountCapabilityControllerValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Account capability controllers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
 func (v *AccountCapabilityControllerValue) SetMember(
-	context MemberAccessibleContext,
+	context ValueTransferContext,
 	_ LocationRange,
 	identifier string,
 	value Value,

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -198,12 +198,12 @@ func (v AddressValue) GetMember(context MemberAccessibleContext, _ LocationRange
 	return nil
 }
 
-func (AddressValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (AddressValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Addresses have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (AddressValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (AddressValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Addresses have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -1149,12 +1149,12 @@ func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange,
 	return nil
 }
 
-func (v *ArrayValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (v *ArrayValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Arrays have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (v *ArrayValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (v *ArrayValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Arrays have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -335,8 +335,8 @@ func (v *ArrayValue) isInvalidatedResource(context ValueStaticTypeContext) bool 
 	return v.isDestroyed || (v.array == nil && v.IsResourceKinded(context))
 }
 
-func (v *ArrayValue) IsStaleResource(interpreter *Interpreter) bool {
-	return v.array == nil && v.IsResourceKinded(interpreter)
+func (v *ArrayValue) IsStaleResource(context ValueStaticTypeContext) bool {
+	return v.array == nil && v.IsResourceKinded(context)
 }
 
 func (v *ArrayValue) Destroy(context ResourceDestructionContext, locationRange LocationRange) {

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -208,7 +208,7 @@ func (v *ArrayValue) Accept(context ValueVisitContext, visitor Visitor, location
 }
 
 func (v *ArrayValue) Iterate(
-	context ContainerMutationContext,
+	context ValueTransferContext,
 	f func(element Value) (resume bool),
 	transferElements bool,
 	locationRange LocationRange,
@@ -225,7 +225,7 @@ func (v *ArrayValue) Iterate(
 // IterateReadOnlyLoaded iterates over all LOADED elements of the array.
 // DO NOT perform storage mutations in the callback!
 func (v *ArrayValue) IterateReadOnlyLoaded(
-	context ContainerMutationContext,
+	context ValueTransferContext,
 	f func(element Value) (resume bool),
 	locationRange LocationRange,
 ) {
@@ -241,7 +241,7 @@ func (v *ArrayValue) IterateReadOnlyLoaded(
 }
 
 func (v *ArrayValue) iterate(
-	context ContainerMutationContext,
+	context ValueTransferContext,
 	atreeIterate func(fn atree.ArrayIterationFunc) error,
 	f func(element Value) (resume bool),
 	transferElements bool,
@@ -1829,13 +1829,13 @@ func (v *ArrayValue) Map(
 }
 
 func (v *ArrayValue) ForEach(
-	interpreter *Interpreter,
+	context IterableValueForeachContext,
 	_ sema.Type,
 	function func(value Value) (resume bool),
 	transferElements bool,
 	locationRange LocationRange,
 ) {
-	v.Iterate(interpreter, function, transferElements, locationRange)
+	v.Iterate(context, function, transferElements, locationRange)
 }
 
 func (v *ArrayValue) ToVariableSized(

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -164,12 +164,12 @@ func (v *IDCapabilityValue) GetMember(context MemberAccessibleContext, _ Locatio
 	return nil
 }
 
-func (*IDCapabilityValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (*IDCapabilityValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Capabilities have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (*IDCapabilityValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (*IDCapabilityValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Capabilities have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -248,12 +248,12 @@ func (v CharacterValue) GetMember(context MemberAccessibleContext, _ LocationRan
 	return nil
 }
 
-func (CharacterValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (CharacterValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Characters have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (CharacterValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (CharacterValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Characters have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -1887,15 +1887,15 @@ func (v *CompositeValue) Iterator(context ValueStaticTypeContext, locationRange 
 }
 
 func (v *CompositeValue) ForEach(
-	interpreter *Interpreter,
+	context IterableValueForeachContext,
 	_ sema.Type,
 	function func(value Value) (resume bool),
 	transferElements bool,
 	locationRange LocationRange,
 ) {
-	iterator := v.Iterator(interpreter, locationRange)
+	iterator := v.Iterator(context, locationRange)
 	for {
-		value := iterator.Next(interpreter, locationRange)
+		value := iterator.Next(context, locationRange)
 		if value == nil {
 			return
 		}
@@ -1903,7 +1903,7 @@ func (v *CompositeValue) ForEach(
 		if transferElements {
 			// Each element must be transferred before passing onto the function.
 			value = value.Transfer(
-				interpreter,
+				context,
 				locationRange,
 				atree.Address{},
 				false,

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -500,8 +500,8 @@ func (v *CompositeValue) isInvalidatedResource(_ ValueStaticTypeContext) bool {
 	return v.isDestroyed || (v.dictionary == nil && v.Kind == common.CompositeKindResource)
 }
 
-func (v *CompositeValue) IsStaleResource(inter *Interpreter) bool {
-	return v.dictionary == nil && v.IsResourceKinded(inter)
+func (v *CompositeValue) IsStaleResource(context ValueStaticTypeContext) bool {
+	return v.dictionary == nil && v.IsResourceKinded(context)
 }
 
 func (v *CompositeValue) GetComputedFields() map[string]ComputedField {

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -474,8 +474,8 @@ func (v *DictionaryValue) isInvalidatedResource(context ValueStaticTypeContext) 
 	return v.isDestroyed || (v.dictionary == nil && v.IsResourceKinded(context))
 }
 
-func (v *DictionaryValue) IsStaleResource(interpreter *Interpreter) bool {
-	return v.dictionary == nil && v.IsResourceKinded(interpreter)
+func (v *DictionaryValue) IsStaleResource(context ValueStaticTypeContext) bool {
+	return v.dictionary == nil && v.IsResourceKinded(context)
 }
 
 func (v *DictionaryValue) Destroy(context ResourceDestructionContext, locationRange LocationRange) {

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -883,12 +883,12 @@ func (v *DictionaryValue) GetMember(context MemberAccessibleContext, locationRan
 	return nil
 }
 
-func (v *DictionaryValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (v *DictionaryValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Dictionaries have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (v *DictionaryValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (v *DictionaryValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Dictionaries have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -308,14 +308,14 @@ func (*EphemeralReferenceValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 func (*EphemeralReferenceValue) isReference() {}
 
 func (v *EphemeralReferenceValue) ForEach(
-	interpreter *Interpreter,
+	context IterableValueForeachContext,
 	elementType sema.Type,
 	function func(value Value) (resume bool),
 	_ bool,
 	locationRange LocationRange,
 ) {
 	forEachReference(
-		interpreter,
+		context,
 		v,
 		v.Value,
 		elementType,

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -139,18 +139,18 @@ func (v *EphemeralReferenceValue) GetMember(context MemberAccessibleContext, loc
 }
 
 func (v *EphemeralReferenceValue) RemoveMember(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	locationRange LocationRange,
 	identifier string,
 ) Value {
 	if memberAccessibleValue, ok := v.Value.(MemberAccessibleValue); ok {
-		return memberAccessibleValue.RemoveMember(interpreter, locationRange, identifier)
+		return memberAccessibleValue.RemoveMember(context, locationRange, identifier)
 	}
 
 	return nil
 }
 
-func (v *EphemeralReferenceValue) SetMember(context MemberAccessibleContext, locationRange LocationRange, name string, value Value) bool {
+func (v *EphemeralReferenceValue) SetMember(context ValueTransferContext, locationRange LocationRange, name string, value Value) bool {
 	return setMember(context, v.Value, locationRange, name, value)
 }
 

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -175,7 +175,7 @@ func (v *EphemeralReferenceValue) RemoveKey(context ContainerMutationContext, lo
 }
 
 func (v *EphemeralReferenceValue) GetTypeKey(
-	interpreter *Interpreter,
+	context MemberAccessibleContext,
 	locationRange LocationRange,
 	key sema.Type,
 ) Value {
@@ -183,34 +183,34 @@ func (v *EphemeralReferenceValue) GetTypeKey(
 
 	if selfComposite, isComposite := self.(*CompositeValue); isComposite {
 		return selfComposite.getTypeKey(
-			interpreter,
+			context,
 			locationRange,
 			key,
-			MustConvertStaticAuthorizationToSemaAccess(interpreter, v.Authorization),
+			MustConvertStaticAuthorizationToSemaAccess(context, v.Authorization),
 		)
 	}
 
 	return self.(TypeIndexableValue).
-		GetTypeKey(interpreter, locationRange, key)
+		GetTypeKey(context, locationRange, key)
 }
 
 func (v *EphemeralReferenceValue) SetTypeKey(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	locationRange LocationRange,
 	key sema.Type,
 	value Value,
 ) {
 	v.Value.(TypeIndexableValue).
-		SetTypeKey(interpreter, locationRange, key, value)
+		SetTypeKey(context, locationRange, key, value)
 }
 
 func (v *EphemeralReferenceValue) RemoveTypeKey(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	locationRange LocationRange,
 	key sema.Type,
 ) Value {
 	return v.Value.(TypeIndexableValue).
-		RemoveTypeKey(interpreter, locationRange, key)
+		RemoveTypeKey(context, locationRange, key)
 }
 
 func (v *EphemeralReferenceValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -531,12 +531,12 @@ func (v Fix64Value) GetMember(context MemberAccessibleContext, locationRange Loc
 	return getNumberValueMember(context, v, name, sema.Fix64Type, locationRange)
 }
 
-func (Fix64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (Fix64Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Fix64Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (Fix64Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -268,12 +268,12 @@ func (f *HostFunctionValue) GetMember(context MemberAccessibleContext, _ Locatio
 	return nil
 }
 
-func (*HostFunctionValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (*HostFunctionValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Host functions have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (*HostFunctionValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (*HostFunctionValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Host functions have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -525,12 +525,12 @@ func (v IntValue) GetMember(context MemberAccessibleContext, locationRange Locat
 	return getNumberValueMember(context, v, name, sema.IntType, locationRange)
 }
 
-func (IntValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (IntValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (IntValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (IntValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -742,12 +742,12 @@ func (v Int128Value) GetMember(context MemberAccessibleContext, locationRange Lo
 	return getNumberValueMember(context, v, name, sema.Int128Type, locationRange)
 }
 
-func (Int128Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (Int128Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Int128Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (Int128Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -617,12 +617,12 @@ func (v Int16Value) GetMember(context MemberAccessibleContext, locationRange Loc
 	return getNumberValueMember(context, v, name, sema.Int16Type, locationRange)
 }
 
-func (Int16Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (Int16Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Int16Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (Int16Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -709,12 +709,12 @@ func (v Int256Value) GetMember(context MemberAccessibleContext, locationRange Lo
 	return getNumberValueMember(context, v, name, sema.Int256Type, locationRange)
 }
 
-func (Int256Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (Int256Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Int256Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (Int256Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -617,12 +617,12 @@ func (v Int32Value) GetMember(context MemberAccessibleContext, locationRange Loc
 	return getNumberValueMember(context, v, name, sema.Int32Type, locationRange)
 }
 
-func (Int32Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (Int32Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Int32Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (Int32Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -611,12 +611,12 @@ func (v Int64Value) GetMember(context MemberAccessibleContext, locationRange Loc
 	return getNumberValueMember(context, v, name, sema.Int64Type, locationRange)
 }
 
-func (Int64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (Int64Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Int64Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (Int64Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -616,12 +616,12 @@ func (v Int8Value) GetMember(context MemberAccessibleContext, locationRange Loca
 	return getNumberValueMember(context, v, name, sema.Int8Type, locationRange)
 }
 
-func (Int8Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (Int8Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Int8Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (Int8Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -107,12 +107,12 @@ func (v NilValue) GetMember(context MemberAccessibleContext, locationRange Locat
 	return nil
 }
 
-func (NilValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (NilValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Nil has no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (NilValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (NilValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Nil has no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -140,12 +140,12 @@ func (v PathValue) GetMember(context MemberAccessibleContext, locationRange Loca
 	return nil
 }
 
-func (PathValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (PathValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Paths have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (PathValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (PathValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Paths have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -180,11 +180,11 @@ func (v *PathCapabilityValue) GetMember(context MemberAccessibleContext, locatio
 	return nil
 }
 
-func (*PathCapabilityValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (*PathCapabilityValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	panic(errors.NewUnreachableError())
 }
 
-func (*PathCapabilityValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (*PathCapabilityValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	panic(errors.NewUnreachableError())
 }
 

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -195,11 +195,11 @@ func (v *SomeValue) GetMember(context MemberAccessibleContext, _ LocationRange, 
 	return nil
 }
 
-func (v *SomeValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (v *SomeValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	panic(errors.NewUnreachableError())
 }
 
-func (v *SomeValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (v *SomeValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	panic(errors.NewUnreachableError())
 }
 

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -220,16 +220,16 @@ func (v *StorageReferenceValue) GetMember(context MemberAccessibleContext, locat
 }
 
 func (v *StorageReferenceValue) RemoveMember(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	locationRange LocationRange,
 	name string,
 ) Value {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.mustReferencedValue(context, locationRange)
 
-	return self.(MemberAccessibleValue).RemoveMember(interpreter, locationRange, name)
+	return self.(MemberAccessibleValue).RemoveMember(context, locationRange, name)
 }
 
-func (v *StorageReferenceValue) SetMember(context MemberAccessibleContext, locationRange LocationRange, name string, value Value) bool {
+func (v *StorageReferenceValue) SetMember(context ValueTransferContext, locationRange LocationRange, name string, value Value) bool {
 	self := v.mustReferencedValue(context, locationRange)
 
 	return setMember(

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -401,15 +401,15 @@ func (*StorageReferenceValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 func (*StorageReferenceValue) isReference() {}
 
 func (v *StorageReferenceValue) ForEach(
-	interpreter *Interpreter,
+	context IterableValueForeachContext,
 	elementType sema.Type,
 	function func(value Value) (resume bool),
 	_ bool,
 	locationRange LocationRange,
 ) {
-	referencedValue := v.mustReferencedValue(interpreter, locationRange)
+	referencedValue := v.mustReferencedValue(context, locationRange)
 	forEachReference(
-		interpreter,
+		context,
 		v,
 		referencedValue,
 		elementType,
@@ -419,7 +419,7 @@ func (v *StorageReferenceValue) ForEach(
 }
 
 func forEachReference(
-	interpreter *Interpreter,
+	context IterableValueForeachContext,
 	reference ReferenceValue,
 	referencedValue Value,
 	elementType sema.Type,
@@ -437,10 +437,15 @@ func forEachReference(
 		// The loop dereference the reference once, and hold onto that referenced-value.
 		// But the reference could get invalidated during the iteration, making that referenced-value invalid.
 		// So check the validity of the reference, before each iteration.
-		checkInvalidatedResourceOrResourceReference(reference, locationRange, interpreter)
+		checkInvalidatedResourceOrResourceReference(reference, locationRange, context)
 
 		if isResultReference {
-			value = interpreter.getReferenceValue(value, elementType, locationRange)
+			value = getReferenceValue(
+				context,
+				value,
+				elementType,
+				locationRange,
+			)
 		}
 
 		return function(value)
@@ -456,7 +461,7 @@ func forEachReference(
 	const transferElements = false
 
 	referencedIterable.ForEach(
-		interpreter,
+		context,
 		referencedElementType,
 		updatedFunction,
 		transferElements,

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -270,46 +270,46 @@ func (v *StorageReferenceValue) RemoveKey(context ContainerMutationContext, loca
 }
 
 func (v *StorageReferenceValue) GetTypeKey(
-	interpreter *Interpreter,
+	context MemberAccessibleContext,
 	locationRange LocationRange,
 	key sema.Type,
 ) Value {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.mustReferencedValue(context, locationRange)
 
 	if selfComposite, isComposite := self.(*CompositeValue); isComposite {
 		return selfComposite.getTypeKey(
-			interpreter,
+			context,
 			locationRange,
 			key,
-			MustConvertStaticAuthorizationToSemaAccess(interpreter, v.Authorization),
+			MustConvertStaticAuthorizationToSemaAccess(context, v.Authorization),
 		)
 	}
 
 	return self.(TypeIndexableValue).
-		GetTypeKey(interpreter, locationRange, key)
+		GetTypeKey(context, locationRange, key)
 }
 
 func (v *StorageReferenceValue) SetTypeKey(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	locationRange LocationRange,
 	key sema.Type,
 	value Value,
 ) {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.mustReferencedValue(context, locationRange)
 
 	self.(TypeIndexableValue).
-		SetTypeKey(interpreter, locationRange, key, value)
+		SetTypeKey(context, locationRange, key, value)
 }
 
 func (v *StorageReferenceValue) RemoveTypeKey(
-	interpreter *Interpreter,
+	context ValueTransferContext,
 	locationRange LocationRange,
 	key sema.Type,
 ) Value {
-	self := v.mustReferencedValue(interpreter, locationRange)
+	self := v.mustReferencedValue(context, locationRange)
 
 	return self.(TypeIndexableValue).
-		RemoveTypeKey(interpreter, locationRange, key)
+		RemoveTypeKey(context, locationRange, key)
 }
 
 func (v *StorageReferenceValue) Equal(_ ValueComparisonContext, _ LocationRange, other Value) bool {

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -290,13 +290,13 @@ func (v *StorageCapabilityControllerValue) GetMember(context MemberAccessibleCon
 	return nil
 }
 
-func (*StorageCapabilityControllerValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (*StorageCapabilityControllerValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Storage capability controllers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
 func (v *StorageCapabilityControllerValue) SetMember(
-	context MemberAccessibleContext,
+	context ValueTransferContext,
 	_ LocationRange,
 	identifier string,
 	value Value,

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -854,22 +854,22 @@ func (v *StringValue) Iterator(_ ValueStaticTypeContext, _ LocationRange) ValueI
 }
 
 func (v *StringValue) ForEach(
-	interpreter *Interpreter,
+	context IterableValueForeachContext,
 	_ sema.Type,
 	function func(value Value) (resume bool),
 	transferElements bool,
 	locationRange LocationRange,
 ) {
-	iterator := v.Iterator(interpreter, locationRange)
+	iterator := v.Iterator(context, locationRange)
 	for {
-		value := iterator.Next(interpreter, locationRange)
+		value := iterator.Next(context, locationRange)
 		if value == nil {
 			return
 		}
 
 		if transferElements {
 			value = value.Transfer(
-				interpreter,
+				context,
 				locationRange,
 				atree.Address{},
 				false,

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -533,12 +533,12 @@ func StringConcat(
 	return this.Concat(context, otherArray, locationRange)
 }
 
-func (*StringValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (*StringValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Strings have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (*StringValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (*StringValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Strings have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -255,12 +255,12 @@ func (v TypeValue) GetMember(context MemberAccessibleContext, _ LocationRange, n
 	return nil
 }
 
-func (TypeValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (TypeValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Types have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (TypeValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (TypeValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Types have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -444,12 +444,12 @@ func (v UFix64Value) GetMember(context MemberAccessibleContext, locationRange Lo
 	return getNumberValueMember(context, v, name, sema.UFix64Type, locationRange)
 }
 
-func (UFix64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (UFix64Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UFix64Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (UFix64Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -593,12 +593,12 @@ func (v UIntValue) GetMember(context MemberAccessibleContext, locationRange Loca
 	return getNumberValueMember(context, v, name, sema.UIntType, locationRange)
 }
 
-func (UIntValue) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (UIntValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UIntValue) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (UIntValue) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -639,12 +639,12 @@ func (v UInt128Value) GetMember(context MemberAccessibleContext, locationRange L
 	return getNumberValueMember(context, v, name, sema.UInt128Type, locationRange)
 }
 
-func (UInt128Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (UInt128Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt128Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (UInt128Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -500,12 +500,12 @@ func (v UInt16Value) GetMember(context MemberAccessibleContext, locationRange Lo
 	return getNumberValueMember(context, v, name, sema.UInt16Type, locationRange)
 }
 
-func (UInt16Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (UInt16Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt16Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (UInt16Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -639,12 +639,12 @@ func (v UInt256Value) GetMember(context MemberAccessibleContext, locationRange L
 	return getNumberValueMember(context, v, name, sema.UInt256Type, locationRange)
 }
 
-func (UInt256Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (UInt256Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt256Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (UInt256Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -501,12 +501,12 @@ func (v UInt32Value) GetMember(context MemberAccessibleContext, locationRange Lo
 	return getNumberValueMember(context, v, name, sema.UInt32Type, locationRange)
 }
 
-func (UInt32Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (UInt32Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt32Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (UInt32Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -529,12 +529,12 @@ func (v UInt64Value) GetMember(context MemberAccessibleContext, locationRange Lo
 	return getNumberValueMember(context, v, name, sema.UInt64Type, locationRange)
 }
 
-func (UInt64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (UInt64Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt64Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (UInt64Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -551,12 +551,12 @@ func (v UInt8Value) GetMember(context MemberAccessibleContext, locationRange Loc
 	return getNumberValueMember(context, v, name, sema.UInt8Type, locationRange)
 }
 
-func (UInt8Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (UInt8Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (UInt8Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (UInt8Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -544,12 +544,12 @@ func (v Word128Value) GetMember(context MemberAccessibleContext, locationRange L
 	return getNumberValueMember(context, v, name, sema.Word128Type, locationRange)
 }
 
-func (Word128Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (Word128Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Word128Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (Word128Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -396,12 +396,12 @@ func (v Word16Value) GetMember(context MemberAccessibleContext, locationRange Lo
 	return getNumberValueMember(context, v, name, sema.Word16Type, locationRange)
 }
 
-func (Word16Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (Word16Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Word16Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (Word16Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -545,12 +545,12 @@ func (v Word256Value) GetMember(context MemberAccessibleContext, locationRange L
 	return getNumberValueMember(context, v, name, sema.Word256Type, locationRange)
 }
 
-func (Word256Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (Word256Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Word256Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (Word256Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -397,12 +397,12 @@ func (v Word32Value) GetMember(context MemberAccessibleContext, locationRange Lo
 	return getNumberValueMember(context, v, name, sema.Word32Type, locationRange)
 }
 
-func (Word32Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (Word32Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Word32Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (Word32Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -425,12 +425,12 @@ func (v Word64Value) GetMember(context MemberAccessibleContext, locationRange Lo
 	return getNumberValueMember(context, v, name, sema.Word64Type, locationRange)
 }
 
-func (Word64Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (Word64Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Word64Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (Word64Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -396,12 +396,12 @@ func (v Word8Value) GetMember(context MemberAccessibleContext, locationRange Loc
 	return getNumberValueMember(context, v, name, sema.Word8Type, locationRange)
 }
 
-func (Word8Value) RemoveMember(_ *Interpreter, _ LocationRange, _ string) Value {
+func (Word8Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Numbers have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }
 
-func (Word8Value) SetMember(_ MemberAccessibleContext, _ LocationRange, _ string, _ Value) bool {
+func (Word8Value) SetMember(_ ValueTransferContext, _ LocationRange, _ string, _ Value) bool {
 	// Numbers have no settable members (fields / functions)
 	panic(errors.NewUnreachableError())
 }


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/3693

## Description

Refactor the remaining methods of below interfaces:
- `MemberAccessibleValue`
- `TypeIndexableValue`
- `ReferenceTrackedResourceKindedValue`
- `IterableValue`


With this, all the interfaces defined in [interpreter/value.go](https://github.com/onflow/cadence/blob/113aaa4a115d391a5cd775b514999cee02f33d90/interpreter/value.go), and their implementations are now independent from the interpreter.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
