### PR TITLE
[Compiler] Implement closed upvalues in VM

### DIFF
--- a/bbq/vm/callframe.go
+++ b/bbq/vm/callframe.go
@@ -22,4 +22,5 @@ type callFrame struct {
 	localsOffset uint16
 	localsCount  uint16
 	function     FunctionValue
+	openUpvalues map[int]*Upvalue
 }

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -1176,7 +1176,7 @@ func TestContractField(t *testing.T) {
       }
         `,
 			ParseAndCheckOptions{
-				Location: common.NewAddressLocation(nil, common.Address{0x1}, "MyContract"),
+				Location: importLocation,
 			},
 		)
 		require.NoError(t, err)
@@ -1249,7 +1249,7 @@ func TestContractField(t *testing.T) {
       }
         `,
 			ParseAndCheckOptions{
-				Location: common.NewAddressLocation(nil, common.Address{0x1}, "MyContract"),
+				Location: importLocation,
 			},
 		)
 		require.NoError(t, err)
@@ -5564,6 +5564,28 @@ func TestUnclosedUpvalueAssignment(t *testing.T) {
 	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(3), actual)
 }
 
+func TestUnclosedUpvalueAssignment2(t *testing.T) {
+
+	t.Parallel()
+
+	actual, err := compileAndInvoke(t,
+		`
+          fun test(): Int {
+              var x = 1
+              fun addToX(_ y: Int) {
+                  x = x + y
+              }
+              addToX(2)
+              addToX(2)
+              return x
+          }
+        `,
+		"test",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(5), actual)
+}
+
 func TestClosedUpvalue(t *testing.T) {
 
 	t.Parallel()
@@ -5587,6 +5609,32 @@ func TestClosedUpvalue(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(5), actual)
+}
+
+func TestClosedUpvalueVariableAssignmentBeforeReturn(t *testing.T) {
+
+	t.Parallel()
+
+	actual, err := compileAndInvoke(t,
+		`
+          fun new(): fun(Int): Int {
+              var x = 1
+              fun addToX(_ y: Int): Int {
+                  return x + y
+              }
+              x = 10
+              return addToX
+          }
+
+          fun test(): Int {
+              let f = new()
+              return f(1) + f(2)
+          }
+        `,
+		"test",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(23), actual)
 }
 
 func TestClosedUpvalueAssignment(t *testing.T) {
@@ -5692,4 +5740,96 @@ func TestCounterWithInitialization(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(4), actual)
+}
+
+func TestContractClosure(t *testing.T) {
+
+	t.Parallel()
+
+	importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "Counter")
+
+	importedChecker, err := ParseAndCheckWithOptions(t,
+		`
+          contract Counter {
+              fun newCounter(): fun(): Int {
+                  var count = 0
+                  return fun(): Int {
+                      count = count + 1
+                      return count
+                  }
+              }
+          }
+        `,
+		ParseAndCheckOptions{
+			Location: importLocation,
+		},
+	)
+	require.NoError(t, err)
+
+	importCompiler := compiler.NewInstructionCompiler(importedChecker)
+	importedProgram := importCompiler.Compile()
+
+	vmInstance := vm.NewVM(importLocation, importedProgram, nil)
+	importedContractValue, err := vmInstance.InitializeContract()
+	require.NoError(t, err)
+
+	activation := sema.NewVariableActivation(sema.BaseValueActivation)
+	activation.DeclareValue(stdlib.PanicFunction)
+
+	checker, err := ParseAndCheckWithOptions(t,
+		`
+          import Counter from 0x1
+
+          fun test(): Int {
+              let counter1 = Counter.newCounter()
+              let counter2 = Counter.newCounter()
+
+              if counter1() != 1 { panic("first count wrong") }
+              if counter1() != 2 { panic("second count wrong") } 
+              if counter2() != 1 { panic("third count wrong") }
+              if counter2() != 2 { panic("fourth count wrong") }
+              if counter1() != 3 { panic("fifth count wrong") } 
+              if counter2() != 3 { panic("sixth count wrong") }
+              if counter2() != 4 { panic("seventh count wrong") }
+
+              return counter1() + counter2()
+          }
+        `,
+		ParseAndCheckOptions{
+			Config: &sema.Config{
+				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
+				BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
+					return activation
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	comp := compiler.NewInstructionCompiler(checker)
+	comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		return importedProgram
+	}
+
+	program := comp.Compile()
+
+	vmConfig := &vm.Config{
+		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
+			return importedProgram
+		},
+		ContractValueHandler: func(vmConfig *vm.Config, location common.Location) *interpreter.CompositeValue {
+			return importedContractValue
+		},
+	}
+
+	vmInstance = vm.NewVM(scriptLocation(), program, vmConfig)
+
+	result, err := vmInstance.Invoke("test")
+	require.NoError(t, err)
+	require.Equal(t, 0, vmInstance.StackSize())
+	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(9), result)
 }

--- a/bbq/vm/upvalue.go
+++ b/bbq/vm/upvalue.go
@@ -19,5 +19,6 @@
 package vm
 
 type Upvalue struct {
-	stackOffset int
+	absoluteLocalsIndex int
+	closed              Value
 }

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -215,8 +215,9 @@ func (vm *VM) pushCallFrame(functionValue FunctionValue, arguments []Value) {
 }
 
 func (vm *VM) popCallFrame() {
-	// Close all open upvalues before popping the locals
-	for absoluteLocalsIndex, upvalue := range vm.callFrame.openUpvalues {
+	// Close all open upvalues before popping the locals.
+	// The order of the closing does not matter
+	for absoluteLocalsIndex, upvalue := range vm.callFrame.openUpvalues { //nolint:maprange
 		upvalue.closed = vm.locals[absoluteLocalsIndex]
 	}
 

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -37,7 +37,7 @@ type VM struct {
 	locals []Value
 
 	callstack []callFrame
-	callFrame callFrame
+	callFrame *callFrame
 
 	ipStack []uint16
 	ip      uint16
@@ -211,10 +211,15 @@ func (vm *VM) pushCallFrame(functionValue FunctionValue, arguments []Value) {
 	vm.ip = 0
 
 	vm.callstack = append(vm.callstack, callFrame)
-	vm.callFrame = callFrame
+	vm.callFrame = &vm.callstack[len(vm.callstack)-1]
 }
 
 func (vm *VM) popCallFrame() {
+	// Close all open upvalues before popping the locals
+	for absoluteLocalsIndex, upvalue := range vm.callFrame.openUpvalues {
+		upvalue.closed = vm.locals[absoluteLocalsIndex]
+	}
+
 	vm.locals = vm.locals[:vm.callFrame.localsOffset]
 
 	newIpStackDepth := len(vm.ipStack) - 1
@@ -227,7 +232,7 @@ func (vm *VM) popCallFrame() {
 		vm.ip = 0
 	} else {
 		vm.ip = vm.ipStack[newIpStackDepth-1]
-		vm.callFrame = vm.callstack[newStackDepth-1]
+		vm.callFrame = &vm.callstack[newStackDepth-1]
 	}
 }
 
@@ -550,12 +555,21 @@ func opSetLocal(vm *VM, ins opcode.InstructionSetLocal) {
 
 func opGetUpvalue(vm *VM, ins opcode.InstructionGetUpvalue) {
 	upvalue := vm.callFrame.function.Upvalues[ins.UpvalueIndex]
-	vm.push(vm.locals[upvalue.stackOffset])
+	value := upvalue.closed
+	if value == nil {
+		value = vm.locals[upvalue.absoluteLocalsIndex]
+	}
+	vm.push(value)
 }
 
 func opSetUpvalue(vm *VM, ins opcode.InstructionSetUpvalue) {
 	upvalue := vm.callFrame.function.Upvalues[ins.UpvalueIndex]
-	vm.locals[upvalue.stackOffset] = vm.pop()
+	value := vm.pop()
+	if upvalue.closed == nil {
+		vm.locals[upvalue.absoluteLocalsIndex] = value
+	} else {
+		upvalue.closed = value
+	}
 }
 
 func opGetGlobal(vm *VM, ins opcode.InstructionGetGlobal) {
@@ -1186,8 +1200,8 @@ func opNewClosure(vm *VM, ins opcode.InstructionNewClosure) {
 		targetIndex := upvalueDescriptor.TargetIndex
 		var upvalue *Upvalue
 		if upvalueDescriptor.IsLocal {
-			stackOffset := int(vm.callFrame.localsOffset) + int(targetIndex)
-			upvalue = vm.captureUpvalue(stackOffset)
+			absoluteLocalsIndex := int(vm.callFrame.localsOffset) + int(targetIndex)
+			upvalue = vm.captureUpvalue(absoluteLocalsIndex)
 		} else {
 			upvalue = vm.callFrame.function.Upvalues[targetIndex]
 		}
@@ -1201,10 +1215,21 @@ func opNewClosure(vm *VM, ins opcode.InstructionNewClosure) {
 	})
 }
 
-func (vm *VM) captureUpvalue(stackOffset int) *Upvalue {
-	return &Upvalue{
-		stackOffset: stackOffset,
+func (vm *VM) captureUpvalue(absoluteLocalsIndex int) *Upvalue {
+	// Check if the upvalue already exists and reuse it
+	if upvalue, ok := vm.callFrame.openUpvalues[absoluteLocalsIndex]; ok {
+		return upvalue
 	}
+
+	// Create a new upvalue and record it as open
+	upvalue := &Upvalue{
+		absoluteLocalsIndex: absoluteLocalsIndex,
+	}
+	if vm.callFrame.openUpvalues == nil {
+		vm.callFrame.openUpvalues = make(map[int]*Upvalue)
+	}
+	vm.callFrame.openUpvalues[absoluteLocalsIndex] = upvalue
+	return upvalue
 }
 
 func (vm *VM) initializeConstant(index uint16) (value Value) {


### PR DESCRIPTION
Work towards #3769 

## Description

Finish the implementation of closures by closing open upvalues in the VM.

The implementation differs slightly from Lua / what is described in https://craftinginterpreters.com/closures.html#tracking-open-upvalues and https://craftinginterpreters.com/closures.html#closing-upvalues-at-runtime. 

This is because unlike in Lua / the VM described in Crafting Interpreters, our compiler/VM currently keeps all locals of all scopes of the function in the call frame, i.e. it does not pop locals on block scope end, but pops all locals at function scope end / when the call frame is popped. 

That means we do not need to emit instructions to pop locals or close upvalues, but can just implicitly (without instructions in the code) close all open values when the call frame is popped, which pops all locals.

It would be great to come up with or find more test case scenarios.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
