### PR TITLE
[Compiler] Add UUID to resources

### DIFF
--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -90,6 +90,10 @@ func (c *Config) WithAccountHandler(handler stdlib.AccountHandler) *Config {
 	return c
 }
 
+func (c *Config) InterpreterConfig() *interpreter.Config {
+	return c.interpreterConfig
+}
+
 func (c *Config) WithInterpreterConfig(config *interpreter.Config) *Config {
 	c.interpreterConfig = config
 	return c

--- a/bbq/vm/value_composite.go
+++ b/bbq/vm/value_composite.go
@@ -1,0 +1,60 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vm
+
+import (
+	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/interpreter"
+	"github.com/onflow/cadence/sema"
+)
+
+func newCompositeValueFields(config *Config, compositeKind common.CompositeKind) (fields []interpreter.CompositeField) {
+
+	if compositeKind == common.CompositeKindResource {
+
+		uuidHandler := config.interpreterConfig.UUIDHandler
+		if uuidHandler == nil {
+			panic(interpreter.UUIDUnavailableError{
+				// TODO:
+				LocationRange: EmptyLocationRange,
+			})
+		}
+
+		uuid, err := uuidHandler()
+		if err != nil {
+			panic(err)
+		}
+
+		fields = append(
+			fields,
+			interpreter.NewCompositeField(
+				nil,
+				sema.ResourceUUIDFieldName,
+				interpreter.NewUInt64Value(
+					nil,
+					func() uint64 {
+						return uuid
+					},
+				),
+			),
+		)
+	}
+
+	return
+}

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -39,8 +39,8 @@ import (
 	"github.com/onflow/cadence/test_utils"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
-	"github.com/onflow/cadence/test_utils/runtime_utils"
-	"github.com/onflow/cadence/test_utils/sema_utils"
+	. "github.com/onflow/cadence/test_utils/runtime_utils"
+	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
 type storageKey struct {
@@ -585,9 +585,9 @@ func testAccountWithErrorHandlerWithCompiler(
 			t,
 			code,
 			compilerUtils.CompilerAndVMOptions{
-				ParseAndCheckOptions: &sema_utils.ParseAndCheckOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
 					Config: &sema.Config{
-						LocationHandler: runtime_utils.NewSingleIdentifierLocationResolver(t),
+						LocationHandler: NewSingleIdentifierLocationResolver(t),
 						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 							return baseValueActivation
 						},
@@ -608,6 +608,16 @@ func testAccountWithErrorHandlerWithCompiler(
 				},
 			},
 		)
+
+		var uuid uint64
+		uuidHandler := func() (uint64, error) {
+			uuid++
+			return uuid, nil
+		}
+
+		vmConfig.WithInterpreterConfig(&interpreter.Config{
+			UUIDHandler: uuidHandler,
+		})
 
 		invokable = test_utils.NewVMInvokable(vmInstance, vmConfig)
 		storage = vmConfig.Storage()


### PR DESCRIPTION
Work towards #3769 

## Description

When creating a new resource, generate a UUID using the config's UUID handler, and inject it into the resource as a field.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
