### PR TITLE
[Compiler] Complete the implementation of vm function values

### DIFF
--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -60,26 +60,26 @@ func TestCompileRecursionFib(t *testing.T) {
 	assert.Equal(t,
 		[]opcode.Instruction{
 			// if n < 2
-			opcode.InstructionGetLocal{LocalIndex: 0x0},
-			opcode.InstructionGetConstant{ConstantIndex: 0x0},
+			opcode.InstructionGetLocal{LocalIndex: 0},
+			opcode.InstructionGetConstant{ConstantIndex: 0},
 			opcode.InstructionLess{},
 			opcode.InstructionJumpIfFalse{Target: 6},
 			// then return n
-			opcode.InstructionGetLocal{LocalIndex: 0x0},
+			opcode.InstructionGetLocal{LocalIndex: 0},
 			opcode.InstructionReturnValue{},
 			// fib(n - 1)
-			opcode.InstructionGetLocal{LocalIndex: 0x0},
-			opcode.InstructionGetConstant{ConstantIndex: 0x1},
+			opcode.InstructionGetLocal{LocalIndex: 0},
+			opcode.InstructionGetConstant{ConstantIndex: 1},
 			opcode.InstructionSubtract{},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionGetGlobal{GlobalIndex: 0x0},
+			opcode.InstructionTransfer{TypeIndex: 1},
+			opcode.InstructionGetGlobal{GlobalIndex: 0},
 			opcode.InstructionInvoke{},
 			// fib(n - 2)
-			opcode.InstructionGetLocal{LocalIndex: 0x0},
-			opcode.InstructionGetConstant{ConstantIndex: 0x0},
+			opcode.InstructionGetLocal{LocalIndex: 0},
+			opcode.InstructionGetConstant{ConstantIndex: 0},
 			opcode.InstructionSubtract{},
-			opcode.InstructionTransfer{TypeIndex: 0x0},
-			opcode.InstructionGetGlobal{GlobalIndex: 0x0},
+			opcode.InstructionTransfer{TypeIndex: 1},
+			opcode.InstructionGetGlobal{GlobalIndex: 0},
 			opcode.InstructionInvoke{},
 			opcode.InstructionAdd{},
 			// return
@@ -155,22 +155,22 @@ func TestCompileImperativeFib(t *testing.T) {
 		[]opcode.Instruction{
 			// var fib1 = 1
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: fib1Index},
 
 			// var fib2 = 1
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: fib2Index},
 
 			// var fibonacci = fib1
 			opcode.InstructionGetLocal{LocalIndex: fib1Index},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: fibonacciIndex},
 
 			// var i = 2
 			opcode.InstructionGetConstant{ConstantIndex: 1},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: iIndex},
 
 			// while i < n
@@ -183,24 +183,24 @@ func TestCompileImperativeFib(t *testing.T) {
 			opcode.InstructionGetLocal{LocalIndex: fib1Index},
 			opcode.InstructionGetLocal{LocalIndex: fib2Index},
 			opcode.InstructionAdd{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: fibonacciIndex},
 
 			// fib1 = fib2
 			opcode.InstructionGetLocal{LocalIndex: fib2Index},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: fib1Index},
 
 			// fib2 = fibonacci
 			opcode.InstructionGetLocal{LocalIndex: fibonacciIndex},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: fib2Index},
 
 			// i = i + 1
 			opcode.InstructionGetLocal{LocalIndex: iIndex},
 			opcode.InstructionGetConstant{ConstantIndex: 0},
 			opcode.InstructionAdd{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: iIndex},
 
 			// continue loop
@@ -261,7 +261,7 @@ func TestCompileBreak(t *testing.T) {
 		[]opcode.Instruction{
 			// var i = 0
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: iIndex},
 
 			// while true
@@ -281,7 +281,7 @@ func TestCompileBreak(t *testing.T) {
 			opcode.InstructionGetLocal{LocalIndex: iIndex},
 			opcode.InstructionGetConstant{ConstantIndex: 2},
 			opcode.InstructionAdd{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: iIndex},
 
 			// repeat
@@ -347,7 +347,7 @@ func TestCompileContinue(t *testing.T) {
 		[]opcode.Instruction{
 			// var i = 0
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: iIndex},
 
 			// while true
@@ -358,7 +358,7 @@ func TestCompileContinue(t *testing.T) {
 			opcode.InstructionGetLocal{LocalIndex: iIndex},
 			opcode.InstructionGetConstant{ConstantIndex: 1},
 			opcode.InstructionAdd{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: iIndex},
 
 			// if i < 3
@@ -431,13 +431,13 @@ func TestCompileArray(t *testing.T) {
 			opcode.InstructionGetConstant{ConstantIndex: 1},
 			opcode.InstructionGetConstant{ConstantIndex: 2},
 			opcode.InstructionNewArray{
-				TypeIndex:  0,
+				TypeIndex:  1,
 				Size:       3,
 				IsResource: false,
 			},
 
 			// let xs =
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: xsIndex},
 
 			opcode.InstructionReturn{},
@@ -496,12 +496,12 @@ func TestCompileDictionary(t *testing.T) {
 			opcode.InstructionGetConstant{ConstantIndex: 4},
 			opcode.InstructionGetConstant{ConstantIndex: 5},
 			opcode.InstructionNewDictionary{
-				TypeIndex:  0,
+				TypeIndex:  1,
 				Size:       3,
 				IsResource: false,
 			},
 			// let xs =
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: xsIndex},
 
 			opcode.InstructionReturn{},
@@ -581,7 +581,7 @@ func TestCompileIfLet(t *testing.T) {
 			// let y = y'
 			opcode.InstructionGetLocal{LocalIndex: tempYIndex},
 			opcode.InstructionUnwrap{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: yIndex},
 
 			// then { return y }
@@ -652,12 +652,12 @@ func TestCompileIfLetScope(t *testing.T) {
 		[]opcode.Instruction{
 			// let x = 1
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: x1Index},
 
 			// var z = 0
 			opcode.InstructionGetConstant{ConstantIndex: 1},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: zIndex},
 
 			// if let x = y
@@ -670,18 +670,18 @@ func TestCompileIfLetScope(t *testing.T) {
 			// then
 			opcode.InstructionGetLocal{LocalIndex: tempIfLetIndex},
 			opcode.InstructionUnwrap{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: x2Index},
 
 			// z = x
 			opcode.InstructionGetLocal{LocalIndex: x2Index},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: zIndex},
 			opcode.InstructionJump{Target: 21},
 
 			// else { z = x }
 			opcode.InstructionGetLocal{LocalIndex: x1Index},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: zIndex},
 
 			// return x
@@ -747,7 +747,7 @@ func TestCompileSwitch(t *testing.T) {
 		[]opcode.Instruction{
 			// var a = 0
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: aIndex},
 
 			// switch x
@@ -762,7 +762,7 @@ func TestCompileSwitch(t *testing.T) {
 
 			// a = 1
 			opcode.InstructionGetConstant{ConstantIndex: 1},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: aIndex},
 
 			// jump to end
@@ -776,7 +776,7 @@ func TestCompileSwitch(t *testing.T) {
 
 			// a = 2
 			opcode.InstructionGetConstant{ConstantIndex: 2},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: aIndex},
 
 			// jump to end
@@ -785,7 +785,7 @@ func TestCompileSwitch(t *testing.T) {
 			// default:
 			// a = 3
 			opcode.InstructionGetConstant{ConstantIndex: 3},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: aIndex},
 
 			// return a
@@ -939,7 +939,7 @@ func TestWhileSwitchBreak(t *testing.T) {
 		[]opcode.Instruction{
 			// var x = 0
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: xIndex},
 
 			// while true
@@ -965,7 +965,7 @@ func TestWhileSwitchBreak(t *testing.T) {
 			opcode.InstructionGetLocal{LocalIndex: xIndex},
 			opcode.InstructionGetConstant{ConstantIndex: 1},
 			opcode.InstructionAdd{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: xIndex},
 
 			// repeat
@@ -1029,11 +1029,11 @@ func TestCompileEmit(t *testing.T) {
 		[]opcode.Instruction{
 			// Inc(val: x)
 			opcode.InstructionGetLocal{LocalIndex: xIndex},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionGetGlobal{GlobalIndex: 1},
 			opcode.InstructionInvoke{},
 			// emit
-			opcode.InstructionEmitEvent{TypeIndex: 1},
+			opcode.InstructionEmitEvent{TypeIndex: 2},
 
 			opcode.InstructionReturn{},
 		},
@@ -1069,7 +1069,7 @@ func TestCompileSimpleCast(t *testing.T) {
 		[]opcode.Instruction{
 			// x as Int?
 			opcode.InstructionGetLocal{LocalIndex: xIndex},
-			opcode.InstructionSimpleCast{TypeIndex: 0},
+			opcode.InstructionSimpleCast{TypeIndex: 1},
 
 			// return
 			opcode.InstructionReturnValue{},
@@ -1104,7 +1104,7 @@ func TestCompileForceCast(t *testing.T) {
 		[]opcode.Instruction{
 			// x as! Int
 			opcode.InstructionGetLocal{LocalIndex: xIndex},
-			opcode.InstructionForceCast{TypeIndex: 0},
+			opcode.InstructionForceCast{TypeIndex: 1},
 
 			// return
 			opcode.InstructionReturnValue{},
@@ -1139,7 +1139,7 @@ func TestCompileFailableCast(t *testing.T) {
 		[]opcode.Instruction{
 			// x as? Int
 			opcode.InstructionGetLocal{LocalIndex: xIndex},
-			opcode.InstructionFailableCast{TypeIndex: 0},
+			opcode.InstructionFailableCast{TypeIndex: 1},
 
 			// return
 			opcode.InstructionReturnValue{},
@@ -1199,7 +1199,7 @@ func TestCompileNestedLoop(t *testing.T) {
 		[]opcode.Instruction{
 			// var i = 0
 			opcode.InstructionGetConstant{ConstantIndex: zeroIndex},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: iIndex},
 
 			// i < 10
@@ -1211,7 +1211,7 @@ func TestCompileNestedLoop(t *testing.T) {
 
 			// var j = 0
 			opcode.InstructionGetConstant{ConstantIndex: zeroIndex},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: jIndex},
 
 			// j < 10
@@ -1235,7 +1235,7 @@ func TestCompileNestedLoop(t *testing.T) {
 			opcode.InstructionGetLocal{LocalIndex: jIndex},
 			opcode.InstructionGetConstant{ConstantIndex: oneIndex},
 			opcode.InstructionAdd{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: jIndex},
 
 			// continue
@@ -1248,7 +1248,7 @@ func TestCompileNestedLoop(t *testing.T) {
 			opcode.InstructionGetLocal{LocalIndex: iIndex},
 			opcode.InstructionGetConstant{ConstantIndex: oneIndex},
 			opcode.InstructionAdd{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: iIndex},
 
 			// continue
@@ -1310,12 +1310,12 @@ func TestCompileAssignLocal(t *testing.T) {
 		[]opcode.Instruction{
 			// var x = 0
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: xIndex},
 
 			// x = 1
 			opcode.InstructionGetConstant{ConstantIndex: 1},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: xIndex},
 
 			opcode.InstructionReturn{},
@@ -1365,7 +1365,7 @@ func TestCompileAssignGlobal(t *testing.T) {
 		[]opcode.Instruction{
 			// x = 1
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetGlobal{GlobalIndex: 0},
 
 			opcode.InstructionReturn{},
@@ -1457,7 +1457,7 @@ func TestCompileAssignIndex(t *testing.T) {
 			opcode.InstructionGetLocal{LocalIndex: arrayIndex},
 			opcode.InstructionGetLocal{LocalIndex: indexIndex},
 			opcode.InstructionGetLocal{LocalIndex: valueIndex},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetIndex{},
 			opcode.InstructionReturn{},
 		},
@@ -1512,14 +1512,14 @@ func TestCompileMember(t *testing.T) {
 				// let self = Test()
 				opcode.InstructionNew{
 					Kind:      common.CompositeKindStructure,
-					TypeIndex: 0,
+					TypeIndex: 1,
 				},
 				opcode.InstructionSetLocal{LocalIndex: selfIndex},
 
 				// self.x = value
 				opcode.InstructionGetLocal{LocalIndex: selfIndex},
 				opcode.InstructionGetLocal{LocalIndex: valueIndex},
-				opcode.InstructionTransfer{TypeIndex: 1},
+				opcode.InstructionTransfer{TypeIndex: 2},
 				opcode.InstructionSetField{FieldNameIndex: 0},
 
 				// return self
@@ -1628,12 +1628,12 @@ func TestCompileBool(t *testing.T) {
 		[]opcode.Instruction{
 			// let yes = true
 			opcode.InstructionTrue{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: yesIndex},
 
 			// let no = false
 			opcode.InstructionFalse{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: noIndex},
 
 			opcode.InstructionReturn{},
@@ -1720,7 +1720,7 @@ func TestCompileIntegers(t *testing.T) {
 				[]opcode.Instruction{
 					// let yes = true
 					opcode.InstructionGetConstant{ConstantIndex: 0},
-					opcode.InstructionTransfer{TypeIndex: 0},
+					opcode.InstructionTransfer{TypeIndex: 1},
 					opcode.InstructionSetLocal{LocalIndex: vIndex},
 
 					opcode.InstructionReturn{},
@@ -1788,7 +1788,7 @@ func TestCompileFixedPoint(t *testing.T) {
 				[]opcode.Instruction{
 					// let yes = true
 					opcode.InstructionGetConstant{ConstantIndex: 0},
-					opcode.InstructionTransfer{TypeIndex: 0},
+					opcode.InstructionTransfer{TypeIndex: 1},
 					opcode.InstructionSetLocal{LocalIndex: vIndex},
 
 					opcode.InstructionReturn{},
@@ -1855,7 +1855,7 @@ func TestCompileUnaryNot(t *testing.T) {
 			// let no = !true
 			opcode.InstructionTrue{},
 			opcode.InstructionNot{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: noIndex},
 
 			opcode.InstructionReturn{},
@@ -1895,7 +1895,7 @@ func TestCompileUnaryNegate(t *testing.T) {
 			// let v = -x
 			opcode.InstructionGetLocal{LocalIndex: xIndex},
 			opcode.InstructionNegate{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: vIndex},
 
 			opcode.InstructionReturn{},
@@ -1935,7 +1935,7 @@ func TestCompileUnaryDeref(t *testing.T) {
 			// let v = *ref
 			opcode.InstructionGetLocal{LocalIndex: refIndex},
 			opcode.InstructionDeref{},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: vIndex},
 
 			opcode.InstructionReturn{},
@@ -1985,7 +1985,7 @@ func TestCompileBinary(t *testing.T) {
 					opcode.InstructionGetConstant{ConstantIndex: 0},
 					opcode.InstructionGetConstant{ConstantIndex: 1},
 					instruction,
-					opcode.InstructionTransfer{TypeIndex: 0},
+					opcode.InstructionTransfer{TypeIndex: 1},
 					opcode.InstructionSetLocal{LocalIndex: vIndex},
 
 					opcode.InstructionReturn{},
@@ -2126,13 +2126,13 @@ func TestCompileMethodInvocation(t *testing.T) {
 				// let foo = Foo()
 				opcode.InstructionGetGlobal{GlobalIndex: 1},
 				opcode.InstructionInvoke{TypeArgs: nil},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: fooIndex},
 
 				// foo.f(true)
 				opcode.InstructionGetLocal{LocalIndex: fooIndex},
 				opcode.InstructionTrue{},
-				opcode.InstructionTransfer{TypeIndex: 1},
+				opcode.InstructionTransfer{TypeIndex: 2},
 				opcode.InstructionGetGlobal{GlobalIndex: 2},
 				opcode.InstructionInvoke{TypeArgs: nil},
 				opcode.InstructionDrop{},
@@ -2153,7 +2153,7 @@ func TestCompileMethodInvocation(t *testing.T) {
 				// Foo()
 				opcode.InstructionNew{
 					Kind:      common.CompositeKindStructure,
-					TypeIndex: 0,
+					TypeIndex: 1,
 				},
 
 				// assign to self
@@ -2208,7 +2208,7 @@ func TestCompileResourceCreateAndDestroy(t *testing.T) {
 				// let foo <- create Foo()
 				opcode.InstructionGetGlobal{GlobalIndex: 1},
 				opcode.InstructionInvoke{TypeArgs: nil},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: fooIndex},
 
 				// destroy foo
@@ -2231,7 +2231,7 @@ func TestCompileResourceCreateAndDestroy(t *testing.T) {
 				// Foo()
 				opcode.InstructionNew{
 					Kind:      common.CompositeKindResource,
-					TypeIndex: 0,
+					TypeIndex: 1,
 				},
 
 				// assign to self
@@ -2329,7 +2329,7 @@ func TestCompileBlockScope(t *testing.T) {
 		[]opcode.Instruction{
 			// let x = 1
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: x1Index},
 
 			// if y
@@ -2338,14 +2338,14 @@ func TestCompileBlockScope(t *testing.T) {
 
 			// { let x = 2 }
 			opcode.InstructionGetConstant{ConstantIndex: 1},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: x2Index},
 
 			opcode.InstructionJump{Target: 12},
 
 			// else { let x = 3 }
 			opcode.InstructionGetConstant{ConstantIndex: 2},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: x3Index},
 
 			// return x
@@ -2416,7 +2416,7 @@ func TestCompileBlockScope2(t *testing.T) {
 		[]opcode.Instruction{
 			// let x = 1
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: x1Index},
 
 			// if y
@@ -2425,23 +2425,23 @@ func TestCompileBlockScope2(t *testing.T) {
 
 			// var x = x
 			opcode.InstructionGetLocal{LocalIndex: x1Index},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: x2Index},
 
 			// x = 2
 			opcode.InstructionGetConstant{ConstantIndex: 1},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: x2Index},
 
 			opcode.InstructionJump{Target: 18},
 
 			// var x = x
 			opcode.InstructionGetLocal{LocalIndex: x1Index},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: x3Index},
 
 			opcode.InstructionGetConstant{ConstantIndex: 2},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: x3Index},
 
 			// return x
@@ -2622,7 +2622,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 				// panic("pre/post condition failed")
 				opcode.InstructionGetConstant{ConstantIndex: 1}, // error message
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionGetGlobal{GlobalIndex: 1}, // global index 1 is 'panic' function
 				opcode.InstructionInvoke{},
 
@@ -2680,7 +2680,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 				// let result = $_result
 				opcode.InstructionGetLocal{LocalIndex: tempResultIndex},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: resultIndex},
 
 				// x > 0
@@ -2694,7 +2694,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 				// panic("pre/post condition failed")
 				opcode.InstructionGetConstant{ConstantIndex: 2}, // error message
-				opcode.InstructionTransfer{TypeIndex: 1},
+				opcode.InstructionTransfer{TypeIndex: 2},
 				opcode.InstructionGetGlobal{GlobalIndex: 1}, // global index 1 is 'panic' function
 				opcode.InstructionInvoke{},
 
@@ -2753,8 +2753,8 @@ func TestCompileFunctionConditions(t *testing.T) {
 				// Get the reference and assign to `result`.
 				// i.e: `let result = &$_result`
 				opcode.InstructionGetLocal{LocalIndex: tempResultIndex},
-				opcode.InstructionNewRef{TypeIndex: 0},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionNewRef{TypeIndex: 1},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: resultIndex},
 
 				// result != nil
@@ -2768,7 +2768,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 				// panic("pre/post condition failed")
 				opcode.InstructionGetConstant{ConstantIndex: 0}, // error message
-				opcode.InstructionTransfer{TypeIndex: 1},
+				opcode.InstructionTransfer{TypeIndex: 2},
 				opcode.InstructionGetGlobal{GlobalIndex: 1}, // global index 1 is 'panic' function
 				opcode.InstructionInvoke{},
 
@@ -2889,7 +2889,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 				// panic("pre/post condition failed")
 				opcode.InstructionGetConstant{ConstantIndex: constPanicMessageIndex},
-				opcode.InstructionTransfer{TypeIndex: 1},
+				opcode.InstructionTransfer{TypeIndex: 3},
 				opcode.InstructionGetGlobal{GlobalIndex: panicFunctionIndex},
 				opcode.InstructionInvoke{},
 
@@ -2907,7 +2907,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 				// let result = $_result
 				opcode.InstructionGetLocal{LocalIndex: tempResultIndex},
-				opcode.InstructionTransfer{TypeIndex: 2},
+				opcode.InstructionTransfer{TypeIndex: 4},
 				opcode.InstructionSetLocal{LocalIndex: resultIndex},
 
 				// Inherited post condition
@@ -2923,7 +2923,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 				// panic("pre/post condition failed")
 				opcode.InstructionGetConstant{ConstantIndex: constPanicMessageIndex},
-				opcode.InstructionTransfer{TypeIndex: 1},
+				opcode.InstructionTransfer{TypeIndex: 3},
 				opcode.InstructionGetGlobal{GlobalIndex: panicFunctionIndex},
 				opcode.InstructionInvoke{},
 
@@ -3031,7 +3031,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 				// Inherited before function
 				// var $before_0 = x
 				opcode.InstructionGetLocal{LocalIndex: xIndex},
-				opcode.InstructionTransfer{TypeIndex: 1},
+				opcode.InstructionTransfer{TypeIndex: 3},
 				opcode.InstructionSetLocal{LocalIndex: beforeVarIndex},
 
 				// Function body
@@ -3045,7 +3045,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 				// let result = $_result
 				opcode.InstructionGetLocal{LocalIndex: tempResultIndex},
-				opcode.InstructionTransfer{TypeIndex: 1},
+				opcode.InstructionTransfer{TypeIndex: 3},
 				opcode.InstructionSetLocal{LocalIndex: resultIndex},
 
 				// Inherited post condition
@@ -3061,7 +3061,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 				// panic("pre/post condition failed")
 				opcode.InstructionGetConstant{ConstantIndex: constPanicMessageIndex},
-				opcode.InstructionTransfer{TypeIndex: 2},
+				opcode.InstructionTransfer{TypeIndex: 4},
 				opcode.InstructionGetGlobal{GlobalIndex: panicFunctionIndex},
 				opcode.InstructionInvoke{},
 
@@ -3231,7 +3231,7 @@ func TestForLoop(t *testing.T) {
 
 				// x = 5
 				opcode.InstructionGetConstant{ConstantIndex: 0},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: x1Index},
 
 				// Get the iterator and store in local var.
@@ -3255,12 +3255,12 @@ func TestForLoop(t *testing.T) {
 
 				// var e = e
 				opcode.InstructionGetLocal{LocalIndex: e1Index},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: e2Index},
 
 				// var x = 8
 				opcode.InstructionGetConstant{ConstantIndex: 1},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: x2Index},
 
 				// Jump to the beginning (condition) of the loop.
@@ -3310,7 +3310,7 @@ func TestCompileIf(t *testing.T) {
 		[]opcode.Instruction{
 			// var y = 0
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: yIndex},
 
 			// if x
@@ -3319,14 +3319,14 @@ func TestCompileIf(t *testing.T) {
 
 			// then { y = 1 }
 			opcode.InstructionGetConstant{ConstantIndex: 1},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: yIndex},
 
 			opcode.InstructionJump{Target: 12},
 
 			// else { y = 2 }
 			opcode.InstructionGetConstant{ConstantIndex: 2},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: yIndex},
 
 			// return y
@@ -3589,7 +3589,7 @@ func TestCompileTransaction(t *testing.T) {
 			// self.count = 2
 			opcode.InstructionGetLocal{LocalIndex: selfIndex},
 			opcode.InstructionGetConstant{ConstantIndex: const2Index},
-			opcode.InstructionTransfer{TypeIndex: 1},
+			opcode.InstructionTransfer{TypeIndex: 2},
 			opcode.InstructionSetField{FieldNameIndex: constFieldNameIndex},
 
 			// return
@@ -3636,7 +3636,7 @@ func TestCompileTransaction(t *testing.T) {
 
 			// panic("pre/post condition failed")
 			opcode.InstructionGetConstant{ConstantIndex: constErrorMsgIndex},
-			opcode.InstructionTransfer{TypeIndex: 2},
+			opcode.InstructionTransfer{TypeIndex: 3},
 			opcode.InstructionGetGlobal{GlobalIndex: 3}, // global index 3 is 'panic' function
 			opcode.InstructionInvoke{},
 
@@ -3646,7 +3646,7 @@ func TestCompileTransaction(t *testing.T) {
 			// self.count = 10
 			opcode.InstructionGetLocal{LocalIndex: selfIndex},
 			opcode.InstructionGetConstant{ConstantIndex: const10Index},
-			opcode.InstructionTransfer{TypeIndex: 1},
+			opcode.InstructionTransfer{TypeIndex: 2},
 			opcode.InstructionSetField{FieldNameIndex: constFieldNameIndex},
 
 			// Post condition
@@ -3662,7 +3662,7 @@ func TestCompileTransaction(t *testing.T) {
 
 			// panic("pre/post condition failed")
 			opcode.InstructionGetConstant{ConstantIndex: constErrorMsgIndex},
-			opcode.InstructionTransfer{TypeIndex: 2},
+			opcode.InstructionTransfer{TypeIndex: 3},
 			opcode.InstructionGetGlobal{GlobalIndex: 3}, // global index 3 is 'panic' function
 			opcode.InstructionInvoke{},
 
@@ -3834,7 +3834,7 @@ func TestCompileReturns(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 9},
 				opcode.InstructionGetConstant{ConstantIndex: 0},
-				opcode.InstructionTransfer{TypeIndex: 0x0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionGetGlobal{GlobalIndex: 1},
 				opcode.InstructionInvoke{},
 				opcode.InstructionDrop{},
@@ -3875,8 +3875,8 @@ func TestCompileReturns(t *testing.T) {
 		assert.Equal(t,
 			[]opcode.Instruction{
 				// var a = 5
-				opcode.InstructionGetConstant{ConstantIndex: 0x0},
-				opcode.InstructionTransfer{TypeIndex: 0x0},
+				opcode.InstructionGetConstant{ConstantIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: aIndex},
 
 				// $_result = a
@@ -3888,7 +3888,7 @@ func TestCompileReturns(t *testing.T) {
 
 				// result = $_result
 				opcode.InstructionGetLocal{LocalIndex: tempResultIndex},
-				opcode.InstructionTransfer{TypeIndex: 0x0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: resultIndex},
 
 				// Post condition
@@ -3896,7 +3896,7 @@ func TestCompileReturns(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 17},
 				opcode.InstructionGetConstant{ConstantIndex: 1},
-				opcode.InstructionTransfer{TypeIndex: 1},
+				opcode.InstructionTransfer{TypeIndex: 2},
 				opcode.InstructionGetGlobal{GlobalIndex: 1},
 				opcode.InstructionInvoke{},
 				opcode.InstructionDrop{},
@@ -3947,7 +3947,7 @@ func TestCompileReturns(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 12},
 				opcode.InstructionGetConstant{ConstantIndex: 0},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionGetGlobal{GlobalIndex: 2},
 				opcode.InstructionInvoke{},
 				opcode.InstructionDrop{},
@@ -3992,18 +3992,18 @@ func TestCompileFunctionExpression(t *testing.T) {
 		[]opcode.Instruction{
 			// let addOne = fun ...
 			opcode.InstructionNewClosure{FunctionIndex: 1},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: addOneIndex},
 
 			// let x = 2
 			opcode.InstructionGetConstant{ConstantIndex: 1},
-			opcode.InstructionTransfer{TypeIndex: 1},
+			opcode.InstructionTransfer{TypeIndex: 2},
 			opcode.InstructionSetLocal{LocalIndex: xIndex},
 
 			// return x + addOne(3)
 			opcode.InstructionGetLocal{LocalIndex: xIndex},
 			opcode.InstructionGetConstant{ConstantIndex: 2},
-			opcode.InstructionTransfer{TypeIndex: 1},
+			opcode.InstructionTransfer{TypeIndex: 2},
 			opcode.InstructionGetLocal{LocalIndex: addOneIndex},
 			opcode.InstructionInvoke{},
 			opcode.InstructionAdd{},
@@ -4078,13 +4078,13 @@ func TestCompileInnerFunction(t *testing.T) {
 
 			// let x = 2
 			opcode.InstructionGetConstant{ConstantIndex: 1},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 2},
 			opcode.InstructionSetLocal{LocalIndex: xIndex},
 
 			// return x + addOne(3)
 			opcode.InstructionGetLocal{LocalIndex: xIndex},
 			opcode.InstructionGetConstant{ConstantIndex: 2},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 2},
 			opcode.InstructionGetLocal{LocalIndex: addOneIndex},
 			opcode.InstructionInvoke{},
 			opcode.InstructionAdd{},
@@ -4157,7 +4157,7 @@ func TestCompileFunctionExpressionOuterVariableUse(t *testing.T) {
 		[]opcode.Instruction{
 			// let x = 1
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: xLocalIndex},
 
 			// let inner = fun(): Int { ...
@@ -4170,7 +4170,7 @@ func TestCompileFunctionExpressionOuterVariableUse(t *testing.T) {
 					},
 				},
 			},
-			opcode.InstructionTransfer{TypeIndex: 1},
+			opcode.InstructionTransfer{TypeIndex: 2},
 			opcode.InstructionSetLocal{LocalIndex: innerLocalIndex},
 
 			opcode.InstructionReturn{},
@@ -4188,7 +4188,7 @@ func TestCompileFunctionExpressionOuterVariableUse(t *testing.T) {
 		[]opcode.Instruction{
 			// let y = 2
 			opcode.InstructionGetConstant{ConstantIndex: 1},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: yIndex},
 
 			// return x + y
@@ -4235,7 +4235,7 @@ func TestCompileInnerFunctionOuterVariableUse(t *testing.T) {
 		[]opcode.Instruction{
 			// let x = 1
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: xLocalIndex},
 
 			// fun inner(): Int { ...
@@ -4265,7 +4265,7 @@ func TestCompileInnerFunctionOuterVariableUse(t *testing.T) {
 		[]opcode.Instruction{
 			// let y = 2
 			opcode.InstructionGetConstant{ConstantIndex: 1},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: yIndex},
 
 			// return x + y
@@ -4328,7 +4328,7 @@ func TestCompileInnerFunctionOuterOuterVariableUse(t *testing.T) {
 		[]opcode.Instruction{
 			// let x = 1
 			opcode.InstructionGetConstant{ConstantIndex: 0},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: xLocalIndex},
 
 			// fun middle(): Int { ...
@@ -4380,7 +4380,7 @@ func TestCompileInnerFunctionOuterOuterVariableUse(t *testing.T) {
 		[]opcode.Instruction{
 			// let y = 2
 			opcode.InstructionGetConstant{ConstantIndex: 1},
-			opcode.InstructionTransfer{TypeIndex: 0},
+			opcode.InstructionTransfer{TypeIndex: 1},
 			opcode.InstructionSetLocal{LocalIndex: yIndex},
 
 			// return x + y
@@ -4509,12 +4509,12 @@ func TestCompileFunctionExpressionOuterOuterVariableUse(t *testing.T) {
 			[]opcode.Instruction{
 				// let a = 1
 				opcode.InstructionGetConstant{ConstantIndex: 0},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: aLocalIndex},
 
 				// let b = 2
 				opcode.InstructionGetConstant{ConstantIndex: 1},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: bLocalIndex},
 
 				// fun middle(): Int { ...
@@ -4561,12 +4561,12 @@ func TestCompileFunctionExpressionOuterOuterVariableUse(t *testing.T) {
 			[]opcode.Instruction{
 				// let c = 3
 				opcode.InstructionGetConstant{ConstantIndex: 2},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: cLocalIndex},
 
 				// let d = 4
 				opcode.InstructionGetConstant{ConstantIndex: 3},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: dLocalIndex},
 
 				// fun inner(): Int { ...
@@ -4623,12 +4623,12 @@ func TestCompileFunctionExpressionOuterOuterVariableUse(t *testing.T) {
 			[]opcode.Instruction{
 				// let e = 5
 				opcode.InstructionGetConstant{ConstantIndex: 4},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: eLocalIndex},
 
 				// let f = 6
 				opcode.InstructionGetConstant{ConstantIndex: 5},
-				opcode.InstructionTransfer{TypeIndex: 0},
+				opcode.InstructionTransfer{TypeIndex: 1},
 				opcode.InstructionSetLocal{LocalIndex: fLocalIndex},
 
 				// return f + e + d + b + c + a

--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -1249,7 +1249,6 @@ var emptyInitializerFuncType = sema.NewSimpleFunctionType(
 	sema.VoidTypeAnnotation,
 )
 
-
 func simpleFunctionDeclaration(
 	memoryGauge common.MemoryGauge,
 	functionName string,

--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -102,7 +102,7 @@ func (d *Desugar) VisitVariableDeclaration(declaration *ast.VariableDeclaration)
 	return declaration
 }
 
-func (d *Desugar) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration, _ bool) (modifiedDecl ast.Declaration) {
+func (d *Desugar) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration, _ bool) ast.Declaration {
 	funcBlock := declaration.FunctionBlock
 	funcName := declaration.Identifier.Identifier
 
@@ -180,7 +180,7 @@ func (d *Desugar) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration,
 	)
 
 	// TODO: Is the generated function needed to be desugared again?
-	return ast.NewFunctionDeclaration(
+	modifiedDecl := ast.NewFunctionDeclaration(
 		d.memoryGauge,
 		declaration.Access,
 		declaration.Purity,
@@ -194,6 +194,10 @@ func (d *Desugar) VisitFunctionDeclaration(declaration *ast.FunctionDeclaration,
 		declaration.StartPos,
 		declaration.DocString,
 	)
+
+	d.elaboration.SetFunctionDeclarationFunctionType(modifiedDecl, functionType)
+
+	return modifiedDecl
 }
 
 // Declare a `$_result` synthetic variable, to temporarily hold return values.
@@ -998,6 +1002,8 @@ func (d *Desugar) VisitTransactionDeclaration(transaction *ast.TransactionDeclar
 	var varDeclarations []ast.Declaration
 	var initFunction *ast.FunctionDeclaration
 
+	transactionTypes := d.elaboration.TransactionDeclarationType(transaction)
+
 	if transaction.ParameterList != nil {
 		varDeclarations = make([]ast.Declaration, 0, len(transaction.ParameterList.Parameters))
 		statements := make([]ast.Statement, 0, len(transaction.ParameterList.Parameters))
@@ -1064,7 +1070,6 @@ func (d *Desugar) VisitTransactionDeclaration(transaction *ast.TransactionDeclar
 
 			statements = append(statements, assignment)
 
-			transactionTypes := d.elaboration.TransactionDeclarationType(transaction)
 			paramType := transactionTypes.Parameters[index].TypeAnnotation.Type
 			assignmentTypes := sema.AssignmentStatementTypes{
 				ValueType:  paramType,
@@ -1088,6 +1093,14 @@ func (d *Desugar) VisitTransactionDeclaration(transaction *ast.TransactionDeclar
 			transaction.StartPos,
 			transaction.Range,
 		)
+
+		initFunctionType := sema.NewSimpleFunctionType(
+			sema.FunctionPurityImpure,
+			transactionTypes.Parameters,
+			sema.VoidTypeAnnotation,
+		)
+
+		d.elaboration.SetFunctionDeclarationFunctionType(initFunction, initFunctionType)
 	}
 
 	var members []ast.Declaration
@@ -1229,6 +1242,13 @@ var emptyInitializer = func() *ast.SpecialFunctionDeclaration {
 		initializer,
 	)
 }()
+
+var emptyInitializerFuncType = sema.NewSimpleFunctionType(
+	sema.FunctionPurityImpure,
+	nil,
+	sema.VoidTypeAnnotation,
+)
+
 
 func simpleFunctionDeclaration(
 	memoryGauge common.MemoryGauge,

--- a/bbq/compiler/extended_elaboration.go
+++ b/bbq/compiler/extended_elaboration.go
@@ -296,3 +296,7 @@ func (e *ExtendedElaboration) SetFunctionDeclarationFunctionType(
 	}
 	e.functionDeclarationFunctionTypes[declaration] = functionType
 }
+
+func (e *ExtendedElaboration) FunctionExpressionFunctionType(expression *ast.FunctionExpression) *sema.FunctionType {
+	return e.elaboration.FunctionExpressionFunctionType(expression)
+}

--- a/bbq/compiler/function.go
+++ b/bbq/compiler/function.go
@@ -35,18 +35,21 @@ type function[E any] struct {
 	parameterCount uint16
 	upvalues       []opcode.Upvalue
 	upvalueIndices map[opcode.Upvalue]uint16
+	typeIndex      uint16
 }
 
 func newFunction[E any](
 	enclosing *function[E],
 	name string,
 	parameterCount uint16,
+	functionTypeIndex uint16,
 ) *function[E] {
 	return &function[E]{
 		enclosing:      enclosing,
 		name:           name,
 		locals:         activations.NewActivations[*local](nil),
 		parameterCount: parameterCount,
+		typeIndex:      functionTypeIndex,
 	}
 }
 

--- a/bbq/function.go
+++ b/bbq/function.go
@@ -24,4 +24,5 @@ type Function[E any] struct {
 	ParameterCount     uint16
 	TypeParameterCount uint16
 	LocalCount         uint16
+	TypeIndex          uint16
 }

--- a/bbq/vm/executable_program.go
+++ b/bbq/vm/executable_program.go
@@ -21,6 +21,8 @@ package vm
 import (
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/interpreter"
 )
 
 // ExecutableProgram is the 'executable' version of a `bbq.Program`.
@@ -48,4 +50,14 @@ func NewExecutableProgram(
 		Constants:   make([]Value, len(program.Constants)),
 		StaticTypes: program.Types,
 	}
+}
+
+func getTypeFromExecutable[T interpreter.StaticType](executable *ExecutableProgram, index uint16) T {
+	staticType := executable.StaticTypes[index]
+	typedStaticType, ok := staticType.(T)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+
+	return typedStaticType
 }

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
-	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
 )
 
@@ -118,11 +117,7 @@ func LinkGlobals(
 	for i := range program.Functions {
 		function := &program.Functions[i]
 
-		staticType := executable.StaticTypes[function.TypeIndex]
-		funcStaticType, ok := staticType.(interpreter.FunctionStaticType)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
+		funcStaticType := getTypeFromExecutable[interpreter.FunctionStaticType](executable, function.TypeIndex)
 
 		value := FunctionValue{
 			Function:   function,

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -20,6 +20,8 @@ package vm
 
 import (
 	"fmt"
+	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/interpreter"
 
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
@@ -115,9 +117,17 @@ func LinkGlobals(
 	// TODO: include non-function globals
 	for i := range program.Functions {
 		function := &program.Functions[i]
+
+		staticType := executable.StaticTypes[function.TypeIndex]
+		funcStaticType, ok := staticType.(interpreter.FunctionStaticType)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
 		value := FunctionValue{
 			Function:   function,
 			Executable: executable,
+			Type:       funcStaticType,
 		}
 
 		globals = append(globals, value)

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -20,11 +20,11 @@ package vm
 
 import (
 	"fmt"
-	"github.com/onflow/cadence/errors"
-	"github.com/onflow/cadence/interpreter"
 
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/interpreter"
 )
 
 type LinkedGlobals struct {

--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -49,9 +49,8 @@ func NativeFunctions() map[string]Value {
 	return funcs
 }
 
-func RegisterFunction(functionName string, functionValue NativeFunctionValue) {
-	functionValue.Name = functionName
-
+func RegisterFunction(functionValue NativeFunctionValue) {
+	functionName := functionValue.Name
 	_, ok := nativeFunctions[functionName]
 	if ok {
 		panic(errors.NewUnexpectedError("function already exists: %s", functionName))
@@ -60,75 +59,94 @@ func RegisterFunction(functionName string, functionValue NativeFunctionValue) {
 	nativeFunctions[functionName] = functionValue
 }
 
-func RegisterTypeBoundFunction(typeName, functionName string, functionValue NativeFunctionValue) {
+func RegisterTypeBoundFunction(typeName string, functionValue NativeFunctionValue) {
 	// +1 is for the receiver
 	functionValue.ParameterCount++
-	qualifiedName := commons.TypeQualifiedName(typeName, functionName)
-	RegisterFunction(qualifiedName, functionValue)
+
+	// Update the name of the function to be type-qualified
+	qualifiedName := commons.TypeQualifiedName(typeName, functionValue.Name)
+	functionValue.Name = qualifiedName
+
+	RegisterFunction(functionValue)
 }
 
 func init() {
-	RegisterFunction(commons.LogFunctionName, NativeFunctionValue{
-		ParameterCount: len(stdlib.LogFunctionType.Parameters),
-		Function: func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
-			return stdlib.Log(
-				config,
-				config,
-				arguments[0],
-				EmptyLocationRange,
-			)
-		},
-	})
+	RegisterFunction(
+		NewNativeFunctionValue(
+			commons.LogFunctionName,
+			stdlib.LogFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				return stdlib.Log(
+					config,
+					config,
+					arguments[0],
+					EmptyLocationRange,
+				)
+			},
+		),
+	)
 
-	RegisterFunction(commons.PanicFunctionName, NativeFunctionValue{
-		ParameterCount: len(stdlib.PanicFunctionType.Parameters),
-		Function: func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
-			return stdlib.PanicWithError(
-				arguments[0],
-				EmptyLocationRange,
-			)
-		},
-	})
+	RegisterFunction(
+		NewNativeFunctionValue(
+			commons.PanicFunctionName,
+			stdlib.PanicFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				return stdlib.PanicWithError(
+					arguments[0],
+					EmptyLocationRange,
+				)
+			},
+		),
+	)
 
-	RegisterFunction(commons.GetAccountFunctionName, NativeFunctionValue{
-		ParameterCount: len(stdlib.GetAccountFunctionType.Parameters),
-		Function: func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
-			address := arguments[0].(interpreter.AddressValue)
-			return NewAccountReferenceValue(
-				config,
-				config.GetAccountHandler(),
-				common.Address(address),
-			)
-		},
-	})
+	RegisterFunction(
+		NewNativeFunctionValue(
+			commons.GetAccountFunctionName,
+			stdlib.GetAccountFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				address := arguments[0].(interpreter.AddressValue)
+				return NewAccountReferenceValue(
+					config,
+					config.GetAccountHandler(),
+					common.Address(address),
+				)
+			},
+		),
+	)
 
 	// Type constructors
 	// TODO: add the remaining type constructor functions
 
-	RegisterFunction(sema.MetaTypeName, NativeFunctionValue{
-		ParameterCount: len(sema.MetaTypeFunctionType.Parameters),
-		Function: func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
-			return interpreter.NewTypeValue(
-				config.MemoryGauge,
-				typeArguments[0],
-			)
-		},
-	})
+	RegisterFunction(
+		NewNativeFunctionValue(
+			sema.MetaTypeName,
+			sema.MetaTypeFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				return interpreter.NewTypeValue(
+					config.MemoryGauge,
+					typeArguments[0],
+				)
+			},
+		),
+	)
 
 	// Value conversion functions
 	for _, declaration := range interpreter.ConverterDeclarations {
 		// NOTE: declare in loop, as captured in closure below
 		convert := declaration.Convert
 
-		RegisterFunction(declaration.Name, NativeFunctionValue{
-			ParameterCount: len(declaration.FunctionType.Parameters),
-			Function: func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
-				return convert(
-					config.MemoryGauge,
-					arguments[0],
-					EmptyLocationRange,
-				)
-			},
-		})
+		RegisterFunction(
+			NewNativeFunctionValue(
+				declaration.Name,
+				declaration.FunctionType,
+				func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
+					return convert(
+						config.MemoryGauge,
+						arguments[0],
+						EmptyLocationRange,
+					)
+				},
+			),
+		)
 	}
 }

--- a/bbq/vm/value_account_capabilities.go
+++ b/bbq/vm/value_account_capabilities.go
@@ -34,10 +34,10 @@ func init() {
 	// Account.Capabilities.get
 	RegisterTypeBoundFunction(
 		accountCapabilitiesTypeName,
-		sema.Account_CapabilitiesTypeGetFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_CapabilitiesTypeGetFunctionType.Parameters),
-			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_CapabilitiesTypeGetFunctionName,
+			sema.Account_CapabilitiesTypeGetFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.Capabilities)
 				address := getAddressMetaInfoFromValue(args[0])
 
@@ -59,16 +59,16 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.Capabilities.borrow
 	RegisterTypeBoundFunction(
 		accountCapabilitiesTypeName,
-		sema.Account_CapabilitiesTypeBorrowFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_CapabilitiesTypeBorrowFunctionType.Parameters),
-			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_CapabilitiesTypeBorrowFunctionName,
+			sema.Account_CapabilitiesTypeBorrowFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.Capabilities)
 				address := getAddressMetaInfoFromValue(args[0])
 
@@ -91,16 +91,16 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.Capabilities.publish
 	RegisterTypeBoundFunction(
 		accountCapabilitiesTypeName,
-		sema.Account_CapabilitiesTypePublishFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_CapabilitiesTypePublishFunctionType.Parameters),
-			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_CapabilitiesTypePublishFunctionName,
+			sema.Account_CapabilitiesTypePublishFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.Capabilities)
 				accountAddress := getAddressMetaInfoFromValue(args[receiverIndex])
 
@@ -128,16 +128,16 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.Capabilities.unpublish
 	RegisterTypeBoundFunction(
 		accountCapabilitiesTypeName,
-		sema.Account_CapabilitiesTypeUnpublishFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_CapabilitiesTypeUnpublishFunctionType.Parameters),
-			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_CapabilitiesTypeUnpublishFunctionName,
+			sema.Account_CapabilitiesTypeUnpublishFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.Capabilities)
 				accountAddress := getAddressMetaInfoFromValue(args[receiverIndex])
 
@@ -155,16 +155,16 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.Capabilities.exist
 	RegisterTypeBoundFunction(
 		accountCapabilitiesTypeName,
-		sema.Account_CapabilitiesTypeExistsFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_CapabilitiesTypeExistsFunctionType.Parameters),
-			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_CapabilitiesTypeExistsFunctionName,
+			sema.Account_CapabilitiesTypeExistsFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.Capabilities)
 				accountAddress := getAddressMetaInfoFromValue(args[receiverIndex])
 
@@ -180,6 +180,6 @@ func init() {
 					accountAddress.ToAddress(),
 				)
 			},
-		},
+		),
 	)
 }

--- a/bbq/vm/value_account_storage.go
+++ b/bbq/vm/value_account_storage.go
@@ -34,10 +34,10 @@ func init() {
 	// Account.Storage.save
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		sema.Account_StorageTypeSaveFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_StorageTypeSaveFunctionType.Parameters),
-			Function: func(config *Config, typeArs []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_StorageTypeSaveFunctionName,
+			sema.Account_StorageTypeSaveFunctionType,
+			func(config *Config, typeArs []bbq.StaticType, args ...Value) Value {
 
 				address := getAddressMetaInfoFromValue(args[receiverIndex])
 
@@ -51,16 +51,16 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.Storage.borrow
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		sema.Account_StorageTypeBorrowFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_StorageTypeBorrowFunctionType.Parameters),
-			Function: func(config *Config, typeArgs []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_StorageTypeBorrowFunctionName,
+			sema.Account_StorageTypeBorrowFunctionType,
+			func(config *Config, typeArgs []bbq.StaticType, args ...Value) Value {
 				address := getAddressMetaInfoFromValue(args[receiverIndex])
 
 				// arg[0] is the receiver. Actual arguments starts from 1.
@@ -77,16 +77,16 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.Storage.forEachPublic
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		sema.Account_StorageTypeForEachPublicFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_StorageTypeForEachPublicFunctionType.Parameters),
-			Function: func(config *Config, typeArs []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_StorageTypeForEachPublicFunctionName,
+			sema.Account_StorageTypeForEachPublicFunctionType,
+			func(config *Config, typeArs []bbq.StaticType, args ...Value) Value {
 
 				address := getAddressMetaInfoFromValue(args[receiverIndex])
 
@@ -102,16 +102,16 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.Storage.forEachStored
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		sema.Account_StorageTypeForEachStoredFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_StorageTypeForEachPublicFunctionType.Parameters),
-			Function: func(config *Config, typeArs []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_StorageTypeForEachStoredFunctionName,
+			sema.Account_StorageTypeForEachPublicFunctionType,
+			func(config *Config, typeArs []bbq.StaticType, args ...Value) Value {
 
 				address := getAddressMetaInfoFromValue(args[receiverIndex])
 
@@ -127,16 +127,16 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.Storage.type
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		sema.Account_StorageTypeTypeFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_StorageTypeTypeFunctionType.Parameters),
-			Function: func(config *Config, typeArs []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_StorageTypeTypeFunctionName,
+			sema.Account_StorageTypeTypeFunctionType,
+			func(config *Config, typeArs []bbq.StaticType, args ...Value) Value {
 
 				address := getAddressMetaInfoFromValue(args[receiverIndex])
 
@@ -149,16 +149,16 @@ func init() {
 					address.ToAddress(),
 				)
 			},
-		},
+		),
 	)
 
 	// Account.Storage.load
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		sema.Account_StorageTypeLoadFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_StorageTypeLoadFunctionType.Parameters),
-			Function: func(config *Config, typeArgs []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_StorageTypeLoadFunctionName,
+			sema.Account_StorageTypeLoadFunctionType,
+			func(config *Config, typeArgs []bbq.StaticType, args ...Value) Value {
 				address := getAddressMetaInfoFromValue(args[receiverIndex])
 
 				// arg[0] is the receiver. Actual arguments starts from 1.
@@ -176,16 +176,16 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.Storage.copy
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		sema.Account_StorageTypeCopyFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_StorageTypeCopyFunctionType.Parameters),
-			Function: func(config *Config, typeArgs []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_StorageTypeCopyFunctionName,
+			sema.Account_StorageTypeCopyFunctionType,
+			func(config *Config, typeArgs []bbq.StaticType, args ...Value) Value {
 				address := getAddressMetaInfoFromValue(args[receiverIndex]).ToAddress()
 
 				// arg[0] is the receiver. Actual arguments starts from 1.
@@ -203,16 +203,16 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.Storage.check
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		sema.Account_StorageTypeCheckFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_StorageTypeCheckFunctionType.Parameters),
-			Function: func(config *Config, typeArgs []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_StorageTypeCheckFunctionName,
+			sema.Account_StorageTypeCheckFunctionType,
+			func(config *Config, typeArgs []bbq.StaticType, args ...Value) Value {
 				address := getAddressMetaInfoFromValue(args[receiverIndex]).ToAddress()
 
 				// arg[0] is the receiver. Actual arguments starts from 1.
@@ -228,6 +228,6 @@ func init() {
 					semaBorrowType,
 				)
 			},
-		},
+		),
 	)
 }

--- a/bbq/vm/value_account_storagecapabilities.go
+++ b/bbq/vm/value_account_storagecapabilities.go
@@ -34,10 +34,10 @@ func init() {
 	// Account.StorageCapabilities.issue
 	RegisterTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
-		sema.Account_StorageCapabilitiesTypeIssueFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_StorageCapabilitiesTypeIssueFunctionType.Parameters),
-			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_StorageCapabilitiesTypeIssueFunctionName,
+			sema.Account_StorageCapabilitiesTypeIssueFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.StorageCapabilities)
 				accountAddress := getAddressMetaInfoFromValue(args[receiverIndex]).ToAddress()
 
@@ -57,16 +57,16 @@ func init() {
 					semaType,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.StorageCapabilities.issueWithType
 	RegisterTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
-		sema.Account_StorageCapabilitiesTypeIssueWithTypeFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_StorageCapabilitiesTypeIssueWithTypeFunctionType.Parameters),
-			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_StorageCapabilitiesTypeIssueWithTypeFunctionName,
+			sema.Account_StorageCapabilitiesTypeIssueWithTypeFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.StorageCapabilities)
 				accountAddress := getAddressMetaInfoFromValue(args[receiverIndex]).ToAddress()
 
@@ -94,16 +94,16 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.StorageCapabilities.getController
 	RegisterTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
-		sema.Account_StorageCapabilitiesTypeGetControllerFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_StorageCapabilitiesTypeGetControllerFunctionType.Parameters),
-			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_StorageCapabilitiesTypeGetControllerFunctionName,
+			sema.Account_StorageCapabilitiesTypeGetControllerFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.StorageCapabilities)
 				accountAddress := getAddressMetaInfoFromValue(args[receiverIndex]).ToAddress()
 
@@ -121,16 +121,16 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.StorageCapabilities.getControllers
 	RegisterTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
-		sema.Account_StorageCapabilitiesTypeGetControllersFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_StorageCapabilitiesTypeGetControllersFunctionType.Parameters),
-			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_StorageCapabilitiesTypeGetControllersFunctionName,
+			sema.Account_StorageCapabilitiesTypeGetControllersFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.StorageCapabilities)
 				accountAddress := getAddressMetaInfoFromValue(args[receiverIndex]).ToAddress()
 
@@ -148,16 +148,16 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 
 	// Account.StorageCapabilities.forEachController
 	RegisterTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
-		sema.Account_StorageCapabilitiesTypeForEachControllerFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.Account_StorageCapabilitiesTypeForEachControllerFunctionType.Parameters),
-			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.Account_StorageCapabilitiesTypeForEachControllerFunctionName,
+			sema.Account_StorageCapabilitiesTypeForEachControllerFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.StorageCapabilities)
 				accountAddress := getAddressMetaInfoFromValue(args[receiverIndex]).ToAddress()
 
@@ -185,6 +185,6 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		},
+		),
 	)
 }

--- a/bbq/vm/value_capability.go
+++ b/bbq/vm/value_capability.go
@@ -32,10 +32,11 @@ func init() {
 	// Capability.borrow
 	RegisterTypeBoundFunction(
 		typeName,
-		sema.CapabilityTypeBorrowFunctionName,
-		NativeFunctionValue{
-			ParameterCount: len(sema.CapabilityTypeBorrowFunctionType(nil).Parameters),
-			Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
+		NewNativeFunctionValue(
+			sema.CapabilityTypeBorrowFunctionName,
+			// TODO: Should the borrow type need to be changed for each usage?
+			sema.CapabilityTypeBorrowFunctionType(nil),
+			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
 				capabilityValue := getReceiver[*interpreter.IDCapabilityValue](config, args[receiverIndex])
 				capabilityID := capabilityValue.ID
 
@@ -61,5 +62,6 @@ func init() {
 					EmptyLocationRange,
 				)
 			},
-		})
+		),
+	)
 }

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -148,6 +148,19 @@ type NativeFunctionValue struct {
 	Type           interpreter.FunctionStaticType
 }
 
+func NewNativeFunctionValue(
+	name string,
+	funcType *sema.FunctionType,
+	function NativeFunction,
+) NativeFunctionValue {
+	return NativeFunctionValue{
+		Name:           name,
+		ParameterCount: len(funcType.Parameters),
+		Function:       function,
+		Type:           interpreter.NewFunctionStaticType(nil, funcType),
+	}
+}
+
 var _ Value = NativeFunctionValue{}
 var _ interpreter.FunctionValue = NativeFunctionValue{}
 

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -142,7 +142,8 @@ func (v FunctionValue) Invoke(invocation interpreter.Invocation) interpreter.Val
 type NativeFunction func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value
 
 type NativeFunctionValue struct {
-	Name           string
+	Name string
+	// ParameterCount includes actual parameters + receiver for type-bound functions.
 	ParameterCount int
 	Function       NativeFunction
 	Type           interpreter.FunctionStaticType

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -32,6 +32,7 @@ type FunctionValue struct {
 	Function   *bbq.Function[opcode.Instruction]
 	Executable *ExecutableProgram
 	Upvalues   []*Upvalue
+	Type       interpreter.FunctionStaticType
 }
 
 var _ Value = FunctionValue{}
@@ -39,111 +40,103 @@ var _ interpreter.FunctionValue = FunctionValue{}
 
 func (FunctionValue) IsValue() {}
 
-func (FunctionValue) StaticType(interpreter.ValueStaticTypeContext) bbq.StaticType {
-	// TODO:
-	return nil
+func (v FunctionValue) IsFunctionValue() {}
+
+func (v FunctionValue) StaticType(interpreter.ValueStaticTypeContext) bbq.StaticType {
+	return v.Type
 }
 
-func (v FunctionValue) Transfer(_ interpreter.ValueTransferContext,
+func (v FunctionValue) Transfer(
+	context interpreter.ValueTransferContext,
 	_ interpreter.LocationRange,
 	_ atree.Address,
-	_ bool,
-	_ atree.Storable,
+	remove bool,
+	storable atree.Storable,
 	_ map[atree.ValueID]struct{},
 	_ bool,
 ) interpreter.Value {
+	if remove {
+		interpreter.RemoveReferencedSlab(context, storable)
+	}
 	return v
 }
 
 func (v FunctionValue) String() string {
-	//TODO
-	panic(errors.NewUnreachableError())
+	return v.Type.String()
 }
 
-func (v FunctionValue) Storable(storage atree.SlabStorage, address atree.Address, u uint64) (atree.Storable, error) {
-	//TODO
-	panic(errors.NewUnreachableError())
+func (v FunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+	return interpreter.NonStorable{Value: v}, nil
 }
 
 func (v FunctionValue) Accept(
-	context interpreter.ValueVisitContext,
-	visitor interpreter.Visitor,
-	locationRange interpreter.LocationRange,
+	_ interpreter.ValueVisitContext,
+	_ interpreter.Visitor,
+	_ interpreter.LocationRange,
 ) {
-	//TODO
+	// Unused for now
 	panic(errors.NewUnreachableError())
 }
 
 func (v FunctionValue) Walk(
-	interpreter interpreter.ValueWalkContext,
-	walkChild func(interpreter.Value),
-	locationRange interpreter.LocationRange,
+	_ interpreter.ValueWalkContext,
+	_ func(interpreter.Value),
+	_ interpreter.LocationRange,
 ) {
-	//TODO
-	panic(errors.NewUnreachableError())
+	// NO-OP
 }
 
 func (v FunctionValue) ConformsToStaticType(
-	context interpreter.ValueStaticTypeConformanceContext,
-	locationRange interpreter.LocationRange,
-	results interpreter.TypeConformanceResults,
+	_ interpreter.ValueStaticTypeConformanceContext,
+	_ interpreter.LocationRange,
+	_ interpreter.TypeConformanceResults,
 ) bool {
-	//TODO
-	panic(errors.NewUnreachableError())
+	return true
 }
 
-func (v FunctionValue) RecursiveString(seenReferences interpreter.SeenReferences) string {
-	//TODO
-	panic(errors.NewUnreachableError())
+func (v FunctionValue) RecursiveString(_ interpreter.SeenReferences) string {
+	return v.String()
 }
 
 func (v FunctionValue) MeteredString(
 	context interpreter.ValueStringContext,
-	seenReferences interpreter.SeenReferences,
-	locationRange interpreter.LocationRange,
+	_ interpreter.SeenReferences,
+	_ interpreter.LocationRange,
 ) string {
-	//TODO
-	panic(errors.NewUnreachableError())
+	return v.Type.MeteredString(context)
 }
 
-func (v FunctionValue) IsResourceKinded(context interpreter.ValueStaticTypeContext) bool {
-	//TODO
-	panic(errors.NewUnreachableError())
+func (v FunctionValue) IsResourceKinded(_ interpreter.ValueStaticTypeContext) bool {
+	return false
 }
 
-func (v FunctionValue) NeedsStoreTo(address atree.Address) bool {
-	//TODO
-	panic(errors.NewUnreachableError())
+func (v FunctionValue) NeedsStoreTo(_ atree.Address) bool {
+	return false
 }
 
-func (v FunctionValue) DeepRemove(removeContext interpreter.ValueRemoveContext, hasNoParentContainer bool) {
-	//TODO
-	panic(errors.NewUnreachableError())
+func (v FunctionValue) DeepRemove(_ interpreter.ValueRemoveContext, _ bool) {
+	// NO-OP
 }
 
-func (v FunctionValue) Clone(context interpreter.ValueCloneContext) interpreter.Value {
-	//TODO
-	panic(errors.NewUnreachableError())
+func (v FunctionValue) Clone(_ interpreter.ValueCloneContext) interpreter.Value {
+	return v
 }
 
-func (v FunctionValue) IsImportable(context interpreter.ValueImportableContext, locationRange interpreter.LocationRange) bool {
-	//TODO
-	panic(errors.NewUnreachableError())
-}
-
-func (v FunctionValue) IsFunctionValue() {
-	//TODO
-	panic(errors.NewUnreachableError())
+func (v FunctionValue) IsImportable(_ interpreter.ValueImportableContext, _ interpreter.LocationRange) bool {
+	return false
 }
 
 func (v FunctionValue) FunctionType() *sema.FunctionType {
-	//TODO
-	panic(errors.NewUnreachableError())
+	return v.Type.Type
 }
 
 func (v FunctionValue) Invoke(invocation interpreter.Invocation) interpreter.Value {
-	//TODO
-	panic(errors.NewUnreachableError())
+	return invocation.InvocationContext.InvokeFunction(
+		v,
+		invocation.Arguments,
+		invocation.ArgumentTypes,
+		invocation.LocationRange,
+	)
 }
 
 type NativeFunction func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value
@@ -152,12 +145,15 @@ type NativeFunctionValue struct {
 	Name           string
 	ParameterCount int
 	Function       NativeFunction
+	Type           interpreter.FunctionStaticType
 }
 
 var _ Value = NativeFunctionValue{}
 var _ interpreter.FunctionValue = NativeFunctionValue{}
 
 func (NativeFunctionValue) IsValue() {}
+
+func (v NativeFunctionValue) IsFunctionValue() {}
 
 func (NativeFunctionValue) StaticType(interpreter.ValueStaticTypeContext) bbq.StaticType {
 	panic(errors.NewUnreachableError())
@@ -175,95 +171,82 @@ func (v NativeFunctionValue) Transfer(_ interpreter.ValueTransferContext,
 }
 
 func (v NativeFunctionValue) String() string {
-	//TODO
-	panic(errors.NewUnreachableError())
+	return v.Type.String()
 }
 
-func (v NativeFunctionValue) Storable(storage atree.SlabStorage, address atree.Address, u uint64) (atree.Storable, error) {
-	//TODO
-	panic(errors.NewUnreachableError())
+func (v NativeFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+	return interpreter.NonStorable{Value: v}, nil
 }
 
 func (v NativeFunctionValue) Accept(
-	context interpreter.ValueVisitContext,
-	visitor interpreter.Visitor,
-	locationRange interpreter.LocationRange,
+	_ interpreter.ValueVisitContext,
+	_ interpreter.Visitor,
+	_ interpreter.LocationRange,
 ) {
-	//TODO
+	// Unused for now
 	panic(errors.NewUnreachableError())
 }
 
 func (v NativeFunctionValue) Walk(
-	context interpreter.ValueWalkContext,
-	walkChild func(interpreter.Value),
-	locationRange interpreter.LocationRange,
+	_ interpreter.ValueWalkContext,
+	_ func(interpreter.Value),
+	_ interpreter.LocationRange,
 ) {
-	//TODO
-	panic(errors.NewUnreachableError())
+	// NO-OP
 }
 
 func (v NativeFunctionValue) ConformsToStaticType(
-	context interpreter.ValueStaticTypeConformanceContext,
-	locationRange interpreter.LocationRange,
-	results interpreter.TypeConformanceResults,
+	_ interpreter.ValueStaticTypeConformanceContext,
+	_ interpreter.LocationRange,
+	_ interpreter.TypeConformanceResults,
 ) bool {
-	//TODO
-	panic(errors.NewUnreachableError())
+	return true
 }
 
-func (v NativeFunctionValue) RecursiveString(seenReferences interpreter.SeenReferences) string {
-	//TODO
-	panic(errors.NewUnreachableError())
+func (v NativeFunctionValue) RecursiveString(_ interpreter.SeenReferences) string {
+	return v.String()
 }
 
 func (v NativeFunctionValue) MeteredString(
 	context interpreter.ValueStringContext,
-	seenReferences interpreter.SeenReferences,
-	locationRange interpreter.LocationRange,
+	_ interpreter.SeenReferences,
+	_ interpreter.LocationRange,
 ) string {
-	//TODO
-	panic(errors.NewUnreachableError())
+	return v.Type.MeteredString(context)
 }
 
-func (v NativeFunctionValue) IsResourceKinded(context interpreter.ValueStaticTypeContext) bool {
-	//TODO
-	panic(errors.NewUnreachableError())
+func (v NativeFunctionValue) IsResourceKinded(_ interpreter.ValueStaticTypeContext) bool {
+	return false
 }
 
-func (v NativeFunctionValue) NeedsStoreTo(address atree.Address) bool {
-	//TODO
-	panic(errors.NewUnreachableError())
+func (v NativeFunctionValue) NeedsStoreTo(_ atree.Address) bool {
+	return false
 }
 
-func (v NativeFunctionValue) DeepRemove(removeContext interpreter.ValueRemoveContext, hasNoParentContainer bool) {
-	//TODO
-	panic(errors.NewUnreachableError())
+func (v NativeFunctionValue) DeepRemove(_ interpreter.ValueRemoveContext, _ bool) {
+	// NO-OP
 }
 
-func (v NativeFunctionValue) Clone(context interpreter.ValueCloneContext) interpreter.Value {
-	//TODO
-	panic(errors.NewUnreachableError())
+func (v NativeFunctionValue) Clone(_ interpreter.ValueCloneContext) interpreter.Value {
+	return v
 }
 
 func (v NativeFunctionValue) IsImportable(
-	context interpreter.ValueImportableContext,
-	locationRange interpreter.LocationRange,
+	_ interpreter.ValueImportableContext,
+	_ interpreter.LocationRange,
 ) bool {
-	//TODO
-	panic(errors.NewUnreachableError())
-}
-
-func (v NativeFunctionValue) IsFunctionValue() {
-	//TODO
-	panic(errors.NewUnreachableError())
+	return false
 }
 
 func (v NativeFunctionValue) FunctionType() *sema.FunctionType {
-	//TODO
-	panic(errors.NewUnreachableError())
+	return v.Type.Type
 }
 
 func (v NativeFunctionValue) Invoke(invocation interpreter.Invocation) interpreter.Value {
-	//TODO
-	panic(errors.NewUnreachableError())
+	return invocation.InvocationContext.InvokeFunction(
+		v,
+		invocation.Arguments,
+		invocation.ArgumentTypes,
+		invocation.LocationRange,
+	)
 }

--- a/bbq/vm/value_int.go
+++ b/bbq/vm/value_int.go
@@ -30,20 +30,24 @@ import (
 func init() {
 	typeName := interpreter.PrimitiveStaticTypeInt.String()
 
-	RegisterTypeBoundFunction(typeName, sema.ToStringFunctionName, NativeFunctionValue{
-		ParameterCount: len(sema.ToStringFunctionType.Parameters),
-		Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
-			number := args[receiverIndex].(interpreter.IntValue)
+	RegisterTypeBoundFunction(
+		typeName,
+		NewNativeFunctionValue(
+			sema.ToStringFunctionName,
+			sema.ToStringFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
+				number := args[receiverIndex].(interpreter.IntValue)
 
-			// TODO: Refactor and re-use the logic from interpreter.
-			memoryUsage := common.NewStringMemoryUsage(
-				interpreter.OverEstimateNumberStringLength(config.MemoryGauge, number),
-			)
-			return interpreter.NewStringValue(
-				config.MemoryGauge,
-				memoryUsage,
-				number.String,
-			)
-		},
-	})
+				// TODO: Refactor and re-use the logic from interpreter.
+				memoryUsage := common.NewStringMemoryUsage(
+					interpreter.OverEstimateNumberStringLength(config.MemoryGauge, number),
+				)
+				return interpreter.NewStringValue(
+					config.MemoryGauge,
+					memoryUsage,
+					number.String,
+				)
+			},
+		),
+	)
 }

--- a/bbq/vm/value_string.go
+++ b/bbq/vm/value_string.go
@@ -29,17 +29,21 @@ import (
 func init() {
 	typeName := interpreter.PrimitiveStaticTypeString.String()
 
-	RegisterTypeBoundFunction(typeName, sema.StringTypeConcatFunctionName, NativeFunctionValue{
-		ParameterCount: len(sema.StringTypeConcatFunctionType.Parameters),
-		Function: func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
-			first := args[receiverIndex].(*interpreter.StringValue)
+	RegisterTypeBoundFunction(
+		typeName,
+		NewNativeFunctionValue(
+			sema.StringTypeConcatFunctionName,
+			sema.StringTypeConcatFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
+				first := args[receiverIndex].(*interpreter.StringValue)
 
-			return interpreter.StringConcat(
-				config,
-				first,
-				args[typeBoundFunctionArgumentOffset],
-				EmptyLocationRange,
-			)
-		},
-	})
+				return interpreter.StringConcat(
+					config,
+					first,
+					args[typeBoundFunctionArgumentOffset],
+					EmptyLocationRange,
+				)
+			},
+		),
+	)
 }

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -1194,10 +1194,17 @@ func opNewClosure(vm *VM, ins opcode.InstructionNewClosure) {
 		upvalues[upvalueIndex] = upvalue
 	}
 
+	staticType := executable.StaticTypes[function.TypeIndex]
+	funcStaticType, ok := staticType.(interpreter.FunctionStaticType)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+
 	vm.push(FunctionValue{
 		Function:   function,
 		Executable: executable,
 		Upvalues:   upvalues,
+		Type:       funcStaticType,
 	})
 }
 

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -1194,11 +1194,7 @@ func opNewClosure(vm *VM, ins opcode.InstructionNewClosure) {
 		upvalues[upvalueIndex] = upvalue
 	}
 
-	staticType := executable.StaticTypes[function.TypeIndex]
-	funcStaticType, ok := staticType.(interpreter.FunctionStaticType)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
+	funcStaticType := getTypeFromExecutable[interpreter.FunctionStaticType](executable, function.TypeIndex)
 
 	vm.push(FunctionValue{
 		Function:   function,


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3769

## Description

Complete the implementations for function values (user functions and native functions) by:
- Properly implementing all the methods of the `Value` interface
- Include the function type in the function value (needed for runtime subtype checking)
- Update the compiler to put the function types in the type-pool (so the runtime can pick the types from the pool) 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
