### PR TITLE
[Compiler] Support entitlements in compiler/vm

### DIFF
--- a/bbq/commons/utils.go
+++ b/bbq/commons/utils.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
+	"github.com/onflow/cadence/sema"
 )
 
 func TypeQualifiedName(typeName, functionName string) string {
@@ -31,6 +32,33 @@ func TypeQualifiedName(typeName, functionName string) string {
 	}
 
 	return typeName + "." + functionName
+}
+
+// TypeQualifier returns the prefix to be appended to an identifier
+// (e.g: to a function name), to make it type-qualified.
+// For primitive types, the type-qualifier is the typeID itself.
+// For derived types (e.g: arrays, dictionaries, capabilities, etc.) the type-qualifier
+// is a predefined identifier.
+// TODO: Add other types
+// TODO: Maybe make this a method on the type
+func TypeQualifier(typ sema.Type) string {
+	switch typ := typ.(type) {
+	case sema.ArrayType:
+		return TypeQualifierArray
+	case *sema.DictionaryType:
+		return TypeQualifierDictionary
+	case *sema.OptionalType:
+		return TypeQualifier(typ.Type)
+	case *sema.ReferenceType:
+		return TypeQualifier(typ.Type)
+	case *sema.IntersectionType:
+		// TODO: Revisit. Probably this is not needed here?
+		return TypeQualifier(typ.Types[0])
+	case *sema.CapabilityType:
+		return interpreter.PrimitiveStaticTypeCapability.String()
+	default:
+		return typ.QualifiedString()
+	}
 }
 
 func LocationToBytes(location common.Location) ([]byte, error) {

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1341,7 +1341,7 @@ func (c *Compiler[_, _]) VisitInvocationExpression(expression *ast.InvocationExp
 			panic(errors.NewUnreachableError())
 		}
 
-		typeName := TypeName(memberInfo.AccessedType)
+		typeName := commons.TypeQualifier(memberInfo.AccessedType)
 		var funcName string
 
 		invocationType := memberInfo.Member.TypeAnnotation.Type.(*sema.FunctionType)
@@ -1419,20 +1419,6 @@ func isDynamicMethodInvocation(accessedType sema.Type) bool {
 		return true
 	default:
 		return false
-	}
-}
-
-func TypeName(typ sema.Type) string {
-	switch typ := typ.(type) {
-	case *sema.ReferenceType:
-		return TypeName(typ.Type)
-	case *sema.IntersectionType:
-		// TODO: Revisit. Probably this is not needed here?
-		return TypeName(typ.Types[0])
-	case *sema.CapabilityType:
-		return interpreter.PrimitiveStaticTypeCapability.String()
-	default:
-		return typ.QualifiedString()
 	}
 }
 

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1465,6 +1465,8 @@ func (c *Compiler[_, _]) VisitMemberExpression(expression *ast.MemberExpression)
 	}
 
 	if memberAccessInfo.IsOptional {
+		// TODO: Complete the optional-chaining implementations.
+		//  e.g: Need a nil check, since unwrap panics on nil
 		c.codeGen.Emit(opcode.InstructionUnwrap{})
 	}
 

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1469,6 +1469,9 @@ func (c *Compiler[_, _]) VisitMemberExpression(expression *ast.MemberExpression)
 	}
 
 	constant := c.addStringConst(expression.Identifier.Identifier)
+
+	// TODO: remove member if `isNestedResourceMove`
+	//  See `Interpreter.memberExpressionGetterSetter` for the reference implementation.
 	c.codeGen.Emit(opcode.InstructionGetField{
 		FieldNameIndex: constant.index,
 	})
@@ -1479,6 +1482,8 @@ func (c *Compiler[_, _]) VisitMemberExpression(expression *ast.MemberExpression)
 		index := c.getOrAddType(memberAccessInfo.ResultingType)
 		c.codeGen.Emit(opcode.InstructionNewRef{TypeIndex: index})
 	}
+
+	// TODO: Need to wrap the result back with an optional, if `memberAccessInfo.IsOptional`
 
 	return
 }

--- a/bbq/compiler/extended_elaboration.go
+++ b/bbq/compiler/extended_elaboration.go
@@ -300,3 +300,7 @@ func (e *ExtendedElaboration) SetFunctionDeclarationFunctionType(
 func (e *ExtendedElaboration) FunctionExpressionFunctionType(expression *ast.FunctionExpression) *sema.FunctionType {
 	return e.elaboration.FunctionExpressionFunctionType(expression)
 }
+
+func (e *ExtendedElaboration) IndexExpressionTypes(expression *ast.IndexExpression) (types sema.IndexExpressionTypes, contains bool) {
+	return e.elaboration.IndexExpressionTypes(expression)
+}

--- a/bbq/compiler/native_functions.go
+++ b/bbq/compiler/native_functions.go
@@ -47,7 +47,11 @@ var builtinTypes = []sema.Type{
 	sema.StringType,
 	sema.AccountType,
 	sema.IntType,
+	sema.MetaType,
+
 	&sema.CapabilityType{},
+	&sema.ConstantSizedType{},
+	&sema.VariableSizedType{},
 }
 
 var stdlibFunctions = []string{
@@ -85,7 +89,8 @@ func init() {
 
 func registerBoundFunctions(typ sema.Type) {
 	for name := range typ.GetMembers() { //nolint:maprange
-		funcName := commons.TypeQualifiedName(typ.QualifiedString(), name)
+		typeQualifier := commons.TypeQualifier(typ)
+		funcName := commons.TypeQualifiedName(typeQualifier, name)
 		addNativeFunction(funcName)
 	}
 

--- a/bbq/compiler/native_functions.go
+++ b/bbq/compiler/native_functions.go
@@ -58,9 +58,6 @@ var stdlibFunctions = []string{
 	commons.LogFunctionName,
 	commons.PanicFunctionName,
 	commons.GetAccountFunctionName,
-
-	// TODO: Remove after https://github.com/onflow/cadence-internal/pull/320
-	sema.MetaTypeName,
 }
 
 func init() {

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -517,7 +517,8 @@ func DecodeNewDictionary(ip *uint16, code []byte) (i InstructionNewDictionary) {
 //
 // Pops a value off the stack, creates a new reference with the given type, and then pushes it onto the stack.
 type InstructionNewRef struct {
-	TypeIndex uint16
+	TypeIndex  uint16
+	IsImplicit bool
 }
 
 var _ Instruction = InstructionNewRef{}
@@ -530,16 +531,19 @@ func (i InstructionNewRef) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
 	printfArgument(&sb, "typeIndex", i.TypeIndex)
+	printfArgument(&sb, "isImplicit", i.IsImplicit)
 	return sb.String()
 }
 
 func (i InstructionNewRef) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
 	emitUint16(code, i.TypeIndex)
+	emitBool(code, i.IsImplicit)
 }
 
 func DecodeNewRef(ip *uint16, code []byte) (i InstructionNewRef) {
 	i.TypeIndex = decodeUint16(ip, code)
+	i.IsImplicit = decodeBool(ip, code)
 	return i
 }
 

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -233,6 +233,8 @@
   operands:
     - name: "typeIndex"
       type: "index"
+    - name: "isImplicit"
+      type: "bool"
   valueEffects:
     pop:
       - name: "value"

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -121,8 +121,8 @@ func TestPrintInstruction(t *testing.T) {
 			byte(Invoke), 0, 2, 3, 4, 5, 6,
 		},
 
-		"NewRef typeIndex:258": {byte(NewRef), 1, 2},
-		"Deref":                {byte(Deref)},
+		"NewRef typeIndex:258 isImplicit:true": {byte(NewRef), 1, 2, 1},
+		"Deref":                                {byte(Deref)},
 
 		"NewArray typeIndex:258 size:772 isResource:true":      {byte(NewArray), 1, 2, 3, 4, 1},
 		"NewDictionary typeIndex:258 size:772 isResource:true": {byte(NewDictionary), 1, 2, 3, 4, 1},

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -269,6 +269,7 @@ func (c *Config) OnResourceOwnerChange(resource *interpreter.CompositeValue, old
 }
 
 func (c *Config) WithMutationPrevention(valueID atree.ValueID, f func()) {
+	f()
 	//TODO
 }
 
@@ -320,6 +321,7 @@ func (c *Config) SetInStorageIteration(b bool) {
 }
 
 func (c *Config) WithResourceDestruction(valueID atree.ValueID, locationRange interpreter.LocationRange, f func()) {
+	f()
 	//TODO
 }
 

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -146,11 +146,16 @@ func (c *Config) IsSubType(subType interpreter.StaticType, superType interpreter
 
 func (c *Config) GetInterfaceType(
 	location common.Location,
-	_ string,
+	qualifiedIdentifier string,
 	typeID interpreter.TypeID,
 ) (*sema.InterfaceType, error) {
 
-	// TODO: Lookup in built-in types
+	if location == nil {
+		interfaceType := sema.NativeInterfaceTypes[qualifiedIdentifier]
+		if interfaceType != nil {
+			return interfaceType, nil
+		}
+	}
 
 	compositeKindedType := c.TypeLoader(location, typeID)
 	if compositeKindedType != nil {
@@ -170,11 +175,16 @@ func (c *Config) GetInterfaceType(
 
 func (c *Config) GetCompositeType(
 	location common.Location,
-	_ string,
+	qualifiedIdentifier string,
 	typeID interpreter.TypeID,
 ) (*sema.CompositeType, error) {
 
-	// TODO: Lookup in built-in types
+	if location == nil {
+		compositeType := sema.NativeCompositeTypes[qualifiedIdentifier]
+		if compositeType != nil {
+			return compositeType, nil
+		}
+	}
 
 	compositeKindedType := c.TypeLoader(location, typeID)
 	if compositeKindedType != nil {
@@ -193,12 +203,21 @@ func (c *Config) GetCompositeType(
 }
 
 func (c *Config) GetEntitlementType(typeID interpreter.TypeID) (*sema.EntitlementType, error) {
-	location, _, err := common.DecodeTypeID(c, string(typeID))
+	location, qualifiedIdentifier, err := common.DecodeTypeID(c, string(typeID))
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: Lookup in built-in types
+	if location == nil {
+		ty := sema.BuiltinEntitlements[qualifiedIdentifier]
+		if ty == nil {
+			return nil, interpreter.TypeLoadingError{
+				TypeID: typeID,
+			}
+		}
+
+		return ty, nil
+	}
 
 	typ := c.TypeLoader(location, typeID)
 	if typ != nil {
@@ -217,12 +236,21 @@ func (c *Config) GetEntitlementType(typeID interpreter.TypeID) (*sema.Entitlemen
 }
 
 func (c *Config) GetEntitlementMapType(typeID interpreter.TypeID) (*sema.EntitlementMapType, error) {
-	location, _, err := common.DecodeTypeID(c, string(typeID))
+	location, qualifiedIdentifier, err := common.DecodeTypeID(c, string(typeID))
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: Lookup in built-in types
+	if location == nil {
+		ty := sema.BuiltinEntitlementMappings[qualifiedIdentifier]
+		if ty == nil {
+			return nil, interpreter.TypeLoadingError{
+				TypeID: typeID,
+			}
+		}
+
+		return ty, nil
+	}
 
 	typ := c.TypeLoader(location, typeID)
 	if typ != nil {

--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -130,6 +130,23 @@ func init() {
 		),
 	)
 
+	RegisterFunction(
+		NewNativeFunctionValue(
+			sema.ReferenceTypeFunctionName,
+			sema.ReferenceTypeFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				entitlementValues := arguments[0].(*interpreter.ArrayValue)
+				typeValue := arguments[1].(interpreter.TypeValue)
+				return interpreter.ConstructReferenceStaticType(
+					config,
+					entitlementValues,
+					EmptyLocationRange,
+					typeValue,
+				)
+			},
+		),
+	)
+
 	// Value conversion functions
 	for _, declaration := range interpreter.ConverterDeclarations {
 		// NOTE: declare in loop, as captured in closure below

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/stdlib"
+	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/runtime_utils"
 	. "github.com/onflow/cadence/test_utils/sema_utils"
 
@@ -439,7 +440,7 @@ func parseCheckAndCompileCodeWithOptions(
 		options.ParseAndCheckOptions,
 		programs,
 	)
-	programs[checker.Location] = &compiledProgram{
+	programs[location] = &compiledProgram{
 		Elaboration: checker.Elaboration,
 	}
 
@@ -449,7 +450,7 @@ func parseCheckAndCompileCodeWithOptions(
 		checker,
 		programs,
 	)
-	programs[checker.Location].Program = program
+	programs[location].Program = program
 
 	return program
 }
@@ -641,8 +642,9 @@ func CompileAndPrepareToInvoke(t testing.TB, code string, options CompilerAndVMO
 	if parseAndCheckOptions != nil {
 		location = parseAndCheckOptions.Location
 	}
+
 	if location == nil {
-		location = common.ScriptLocation{0x1}
+		location = TestLocation
 	}
 
 	program := parseCheckAndCompileCodeWithOptions(
@@ -664,6 +666,16 @@ func CompileAndPrepareToInvoke(t testing.TB, code string, options CompilerAndVMO
 			compositeType := elaboration.CompositeType(typeID)
 			if compositeType != nil {
 				return compositeType
+			}
+
+			entitlementType := elaboration.EntitlementType(typeID)
+			if entitlementType != nil {
+				return entitlementType
+			}
+
+			entitlementMapType := elaboration.EntitlementMapType(typeID)
+			if entitlementMapType != nil {
+				return entitlementMapType
 			}
 
 			return elaboration.InterfaceType(typeID)

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -4541,7 +4541,7 @@ func TestEmit(t *testing.T) {
 		eventEmitted = true
 
 		assert.Equal(t,
-			common.ScriptLocation{0x1}.TypeID(nil, "Inc"),
+			TestLocation.TypeID(nil, "Inc"),
 			eventType.ID(),
 		)
 
@@ -5437,7 +5437,7 @@ func TestTypeConstructor(t *testing.T) {
 				nil,
 				interpreter.NewCompositeStaticTypeComputeTypeID(
 					nil,
-					common.ScriptLocation{0x1},
+					TestLocation,
 					"Foo",
 				),
 			),

--- a/bbq/vm/value_account.go
+++ b/bbq/vm/value_account.go
@@ -65,8 +65,14 @@ func init() {
 }
 
 func getAddressMetaInfoFromValue(value Value) interpreter.AddressValue {
-	simpleCompositeValue, ok := value.(*interpreter.SimpleCompositeValue)
-	if !ok {
+	var simpleCompositeValue *interpreter.SimpleCompositeValue
+	switch typedValue := value.(type) {
+	case *interpreter.SimpleCompositeValue:
+		simpleCompositeValue = typedValue
+	case *interpreter.EphemeralReferenceValue:
+		// Account values are references of simple composites.
+		simpleCompositeValue = typedValue.Value.(*interpreter.SimpleCompositeValue)
+	default:
 		panic(errors.NewUnreachableError())
 	}
 

--- a/bbq/vm/value_array.go
+++ b/bbq/vm/value_array.go
@@ -16,25 +16,27 @@
  * limitations under the License.
  */
 
-package commons
+package vm
 
-const (
-	InitFunctionName                = "init"
-	ExecuteFunctionName             = "execute"
-	TransactionWrapperCompositeName = "transaction"
-	TransactionExecuteFunctionName  = "transaction.execute"
-	TransactionPrepareFunctionName  = "transaction.prepare"
-	LogFunctionName                 = "log"
-	PanicFunctionName               = "panic"
-	GetAccountFunctionName          = "getAccount"
-
-	// Names used by generated constructs
-
-	ProgramInitFunctionName         = "$_init_"
-	TransactionGeneratedParamPrefix = "$_param_"
-
-	// Type qualifiers for built-in member functions
-
-	TypeQualifierArray      = "$Array"
-	TypeQualifierDictionary = "$Dictionary"
+import (
+	"github.com/onflow/cadence/bbq"
+	"github.com/onflow/cadence/bbq/commons"
+	"github.com/onflow/cadence/interpreter"
+	"github.com/onflow/cadence/sema"
 )
+
+// members
+
+func init() {
+	RegisterTypeBoundFunction(
+		commons.TypeQualifierArray,
+		NewNativeFunctionValue(
+			sema.GetTypeFunctionName,
+			sema.GetTypeFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				value := arguments[receiverIndex]
+				return interpreter.ValueGetType(config, value)
+			},
+		),
+	)
+}

--- a/bbq/vm/value_type.go
+++ b/bbq/vm/value_type.go
@@ -1,0 +1,54 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vm
+
+import (
+	"github.com/onflow/cadence/bbq"
+	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/interpreter"
+	"github.com/onflow/cadence/sema"
+)
+
+// members
+
+func init() {
+	typeName := string(interpreter.PrimitiveStaticTypeMetaType.ID())
+
+	RegisterTypeBoundFunction(
+		typeName,
+		NewNativeFunctionValue(
+			sema.MetaTypeIsSubtypeFunctionName,
+			sema.MetaTypeIsSubtypeFunctionType,
+			func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				typeValue := arguments[receiverIndex].(interpreter.TypeValue)
+
+				otherTypeValue, ok := arguments[typeBoundFunctionArgumentOffset].(interpreter.TypeValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				return interpreter.MetaTypeIsSubType(
+					config,
+					typeValue,
+					otherTypeValue,
+				)
+			},
+		),
+	)
+}

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -957,18 +957,19 @@ func opNewDictionary(vm *VM, ins opcode.InstructionNewDictionary) {
 }
 
 func opNewRef(vm *VM, ins opcode.InstructionNewRef) {
-	borrowedType := vm.loadType(ins.TypeIndex).(*interpreter.ReferenceStaticType)
+	borrowedType := vm.loadType(ins.TypeIndex)
 	value := vm.pop()
 
-	semaBorrowedType := interpreter.MustConvertStaticToSemaType(borrowedType.ReferencedType, vm.config)
+	semaBorrowedType := interpreter.MustConvertStaticToSemaType(borrowedType, vm.config)
 
-	ref := interpreter.NewEphemeralReferenceValue(
+	ref := interpreter.CreateReferenceValue(
 		vm.config,
-		borrowedType.Authorization,
-		value,
 		semaBorrowedType,
+		value,
 		EmptyLocationRange,
+		false,
 	)
+
 	vm.push(ref)
 }
 

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -583,25 +583,23 @@ func opSetGlobal(vm *VM, ins opcode.InstructionSetGlobal) {
 }
 
 func opSetIndex(vm *VM) {
-	array, index, element := vm.pop3()
-	arrayValue := array.(*interpreter.ArrayValue)
-	indexValue := index.(interpreter.IntValue)
-	arrayValue.SetKey(
+	container, index, value := vm.pop3()
+	containerValue := container.(interpreter.ValueIndexableValue)
+	containerValue.SetKey(
 		vm.config,
 		EmptyLocationRange,
-		indexValue,
-		element,
+		index,
+		value,
 	)
 }
 
 func opGetIndex(vm *VM) {
-	array, index := vm.pop2()
-	arrayValue := array.(*interpreter.ArrayValue)
-	indexValue := index.(interpreter.IntValue)
-	element := arrayValue.GetKey(
+	container, index := vm.pop2()
+	containerValue := container.(interpreter.ValueIndexableValue)
+	element := containerValue.GetKey(
 		vm.config,
 		EmptyLocationRange,
-		indexValue,
+		index,
 	)
 	vm.push(element)
 }

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -967,7 +967,7 @@ func opNewRef(vm *VM, ins opcode.InstructionNewRef) {
 		semaBorrowedType,
 		value,
 		EmptyLocationRange,
-		false,
+		ins.IsImplicit,
 	)
 
 	vm.push(ref)

--- a/interpreter/entitlements_test.go
+++ b/interpreter/entitlements_test.go
@@ -27,8 +27,9 @@ import (
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/stdlib"
+	"github.com/onflow/cadence/test_utils"
 	. "github.com/onflow/cadence/test_utils/common_utils"
-
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
 )
 
@@ -40,7 +41,7 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             resource R {}
 
             fun test(): Bool {
@@ -63,7 +64,7 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             resource R {}
@@ -88,7 +89,7 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             resource R {}
@@ -113,7 +114,7 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           entitlement X
 
           resource R {}
@@ -138,7 +139,7 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -163,7 +164,7 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             resource R {}
@@ -188,7 +189,7 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -214,7 +215,7 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -244,7 +245,7 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -272,7 +273,7 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -302,7 +303,7 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -332,7 +333,7 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -362,7 +363,7 @@ func TestInterpretEntitledReferenceRuntimeTypes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -395,7 +396,7 @@ func TestInterpretEntitledReferences(t *testing.T) {
 
 		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
-		inter, _ := testAccount(t, address, true, nil,
+		inter, _ := testAccountWithCompilerEnabled(t, address, true, nil,
 			`
               entitlement X
               entitlement Y
@@ -429,7 +430,7 @@ func TestInterpretEntitledReferences(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             access(all) fun test(): Bool {
@@ -459,7 +460,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -486,7 +487,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -513,7 +514,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -540,7 +541,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -567,7 +568,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -593,7 +594,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -620,7 +621,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -647,7 +648,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -675,7 +676,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             resource interface RI {}
 
             resource R: RI {}
@@ -707,7 +708,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement E
             entitlement F
 
@@ -736,7 +737,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
             entitlement Y
 
@@ -779,7 +780,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             fun test(capX: Capability<auth(X) &Int>): Capability {
@@ -817,7 +818,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             fun test(): Bool {
@@ -842,7 +843,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             fun test(): Bool {
@@ -868,7 +869,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             fun test(): Bool {
@@ -893,7 +894,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             fun test(): Bool {
@@ -918,7 +919,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             fun test(): Bool {
@@ -943,7 +944,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             fun test(): Bool {
@@ -968,7 +969,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             fun test(): Bool {
@@ -993,7 +994,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             fun test(): Bool {
@@ -1018,7 +1019,7 @@ func TestInterpretEntitledReferenceCasting(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement X
 
             fun test(): Bool {
@@ -1048,7 +1049,7 @@ func TestInterpretEntitledResult(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           entitlement X
           entitlement Y
 
@@ -1085,7 +1086,7 @@ func TestInterpretEntitledResult(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		invokable := parseCheckAndPrepare(t, `
           entitlement X
           entitlement Y
 
@@ -1107,11 +1108,16 @@ func TestInterpretEntitledResult(t *testing.T) {
           }
         `)
 
-		_, err := inter.Invoke("test")
+		_, err := invokable.Invoke("test")
 		RequireError(t, err)
 
-		var conditionError interpreter.ConditionError
-		require.ErrorAs(t, err, &conditionError)
+		if _, compiled := invokable.(*test_utils.VMInvokable); compiled {
+			var panicError stdlib.PanicError
+			require.ErrorAs(t, err, &panicError)
+		} else {
+			var conditionError interpreter.ConditionError
+			require.ErrorAs(t, err, &conditionError)
+		}
 	})
 }
 
@@ -1122,7 +1128,7 @@ func TestInterpretEntitlementMappingFields(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           entitlement X
           entitlement Y
 
@@ -1169,7 +1175,7 @@ func TestInterpretEntitlementMappingFields(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           entitlement X
           entitlement Y
           entitlement E
@@ -1220,7 +1226,7 @@ func TestInterpretEntitlementMappingFields(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           entitlement X
           entitlement Y
           entitlement E
@@ -1270,7 +1276,7 @@ func TestInterpretEntitlementMappingFields(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           entitlement X
           entitlement Y
           entitlement E
@@ -1305,7 +1311,7 @@ func TestInterpretEntitlementMappingFields(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
         entitlement X
         entitlement Y
         entitlement E
@@ -2128,7 +2134,7 @@ func TestInterpretBuiltinEntitlements(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
         struct S {
             access(Mutate) fun foo() {}
             access(Insert) fun bar() {}

--- a/interpreter/entitlements_test.go
+++ b/interpreter/entitlements_test.go
@@ -1363,7 +1363,7 @@ func TestInterpretEntitlementMappingFields(t *testing.T) {
 
 		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
 
-		inter, _ := testAccount(t, address, true, nil,
+		inter, _ := testAccountWithCompilerEnabled(t, address, true, nil,
 			`
               entitlement X
               entitlement Y

--- a/interpreter/interpreter_expression.go
+++ b/interpreter/interpreter_expression.go
@@ -316,7 +316,7 @@ func getReferenceValue(
 	resultType sema.Type,
 	locationRange LocationRange,
 ) Value {
-	return createReference(context, resultType, value, locationRange, true)
+	return CreateReferenceValue(context, resultType, value, locationRange, true)
 }
 
 func (interpreter *Interpreter) checkMemberAccess(
@@ -1440,10 +1440,16 @@ func (interpreter *Interpreter) VisitReferenceExpression(referenceExpression *as
 		HasPosition: referenceExpression,
 	}
 
-	return createReference(interpreter, borrowType, result, locationRange, false)
+	return CreateReferenceValue(
+		interpreter,
+		borrowType,
+		result,
+		locationRange,
+		false,
+	)
 }
 
-func createReference(
+func CreateReferenceValue(
 	context ReferenceCreationContext,
 	borrowType sema.Type,
 	value Value,
@@ -1476,7 +1482,7 @@ func createReference(
 
 			innerValue := value.InnerValue()
 
-			referenceValue := createReference(context, innerType, innerValue, locationRange, false)
+			referenceValue := CreateReferenceValue(context, innerType, innerValue, locationRange, false)
 
 			// Wrap the reference with an optional (since an optional is expected).
 			return NewSomeValueNonCopying(context, referenceValue)
@@ -1490,7 +1496,7 @@ func createReference(
 			// Case (2):
 			// If the referenced value is non-optional,
 			// but the target type is optional.
-			referenceValue := createReference(context, innerType, value, locationRange, false)
+			referenceValue := CreateReferenceValue(context, innerType, value, locationRange, false)
 
 			// Wrap the reference with an optional (since an optional is expected).
 			return NewSomeValueNonCopying(context, referenceValue)
@@ -1503,7 +1509,7 @@ func createReference(
 			// Case (3.a): target type is non-optional, actual value is optional.
 			innerValue := value.InnerValue()
 
-			return createReference(context, typ, innerValue, locationRange, false)
+			return CreateReferenceValue(context, typ, innerValue, locationRange, false)
 
 		case NilValue:
 			// Case (3.b) value is nil.

--- a/interpreter/member_test.go
+++ b/interpreter/member_test.go
@@ -1210,7 +1210,7 @@ func TestInterpretNestedReferenceMemberAccess(t *testing.T) {
 	t.Run("indexing", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             resource R {}
 
             fun test() {
@@ -1228,7 +1228,7 @@ func TestInterpretNestedReferenceMemberAccess(t *testing.T) {
 	t.Run("field", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             resource R {}
 
             struct Container {
@@ -1254,7 +1254,7 @@ func TestInterpretNestedReferenceMemberAccess(t *testing.T) {
 	t.Run("referenceArray", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
 
             entitlement E
 


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3769

## Description

Entitlements in static-types is already working, since the `interpreter.Value`s and `interpreter.StaticType`s are re-used in the vm.

The only new functionality needed was to support entitlement mappings in fields/field-access, particularly for references.

While at it, also add the support for returning references for member-access/index-access, via references.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
