### PR TITLE
[Compiler] Skip anonymous functions in linker

### DIFF
--- a/bbq/function.go
+++ b/bbq/function.go
@@ -26,3 +26,7 @@ type Function[E any] struct {
 	LocalCount         uint16
 	TypeIndex          uint16
 }
+
+func (f Function[E]) IsAnonymous() bool {
+	return f.Name == ""
+}

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -60,6 +60,8 @@ type Config struct {
 	OnEventEmitted OnEventEmittedFunc
 
 	TypeLoader func(location common.Location, typeID interpreter.TypeID) sema.ContainedType
+
+	debugEnabled bool
 }
 
 var _ interpreter.ReferenceTracker = &Config{}
@@ -96,6 +98,11 @@ func (c *Config) InterpreterConfig() *interpreter.Config {
 
 func (c *Config) WithInterpreterConfig(config *interpreter.Config) *Config {
 	c.interpreterConfig = config
+	return c
+}
+
+func (c *Config) WithDebugEnabled() *Config {
+	c.debugEnabled = true
 	return c
 }
 

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -117,6 +117,12 @@ func LinkGlobals(
 	for i := range program.Functions {
 		function := &program.Functions[i]
 
+		// Anonymous functions are not needed as global variables.
+		// Compiler doesn't reserve global variable for them either.
+		if function.IsAnonymous() {
+			continue
+		}
+
 		funcStaticType := getTypeFromExecutable[interpreter.FunctionStaticType](executable, function.TypeIndex)
 
 		value := FunctionValue{


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3769

## Description

Compiler doesn't reserve global variables for anonymous functions, as they are not needed/looked-up like regular functions. Hence, also skip adding anonymous functions as global variables in the linker.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
