### PR TITLE
[Compiler] Register common type-bound functions for all builtin types

### DIFF
--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -1655,7 +1655,7 @@ func TestTransaction(t *testing.T) {
 		activation := sema.NewVariableActivation(sema.BaseValueActivation)
 		activation.DeclareValue(stdlib.PanicFunction)
 		activation.DeclareValue(stdlib.NewStandardLibraryStaticFunction(
-			"log",
+			commons.LogFunctionName,
 			sema.NewSimpleFunctionType(
 				sema.FunctionPurityView,
 				[]sema.Parameter{
@@ -1745,7 +1745,7 @@ func TestTransaction(t *testing.T) {
 		activation := sema.NewVariableActivation(sema.BaseValueActivation)
 		activation.DeclareValue(stdlib.PanicFunction)
 		activation.DeclareValue(stdlib.NewStandardLibraryStaticFunction(
-			"log",
+			commons.LogFunctionName,
 			sema.NewSimpleFunctionType(
 				sema.FunctionPurityView,
 				[]sema.Parameter{
@@ -1840,7 +1840,7 @@ func TestTransaction(t *testing.T) {
 		activation := sema.NewVariableActivation(sema.BaseValueActivation)
 		activation.DeclareValue(stdlib.PanicFunction)
 		activation.DeclareValue(stdlib.NewStandardLibraryStaticFunction(
-			"log",
+			commons.LogFunctionName,
 			sema.NewSimpleFunctionType(
 				sema.FunctionPurityView,
 				[]sema.Parameter{
@@ -3259,7 +3259,7 @@ func TestFunctionPreConditions(t *testing.T) {
 		activation := sema.NewVariableActivation(sema.BaseValueActivation)
 		activation.DeclareValue(stdlib.PanicFunction)
 		activation.DeclareValue(stdlib.NewStandardLibraryStaticFunction(
-			"log",
+			commons.LogFunctionName,
 			sema.NewSimpleFunctionType(
 				sema.FunctionPurityView,
 				[]sema.Parameter{
@@ -3369,7 +3369,7 @@ func TestFunctionPreConditions(t *testing.T) {
 		activation := sema.NewVariableActivation(sema.BaseValueActivation)
 		activation.DeclareValue(stdlib.PanicFunction)
 		activation.DeclareValue(stdlib.NewStandardLibraryStaticFunction(
-			"log",
+			commons.LogFunctionName,
 			sema.NewSimpleFunctionType(
 				sema.FunctionPurityView,
 				[]sema.Parameter{
@@ -3717,7 +3717,7 @@ func TestFunctionPostConditions(t *testing.T) {
 		activation := sema.NewVariableActivation(sema.BaseValueActivation)
 		activation.DeclareValue(stdlib.PanicFunction)
 		activation.DeclareValue(stdlib.NewStandardLibraryStaticFunction(
-			"log",
+			commons.LogFunctionName,
 			sema.NewSimpleFunctionType(
 				sema.FunctionPurityView,
 				[]sema.Parameter{
@@ -4201,7 +4201,7 @@ func TestBeforeFunctionInPostConditions(t *testing.T) {
 		activation := sema.NewVariableActivation(sema.BaseValueActivation)
 		activation.DeclareValue(stdlib.PanicFunction)
 		activation.DeclareValue(stdlib.NewStandardLibraryStaticFunction(
-			"log",
+			commons.LogFunctionName,
 			sema.NewSimpleFunctionType(
 				sema.FunctionPurityView,
 				[]sema.Parameter{
@@ -4293,7 +4293,7 @@ func TestBeforeFunctionInPostConditions(t *testing.T) {
 		activation := sema.NewVariableActivation(sema.BaseValueActivation)
 		activation.DeclareValue(stdlib.PanicFunction)
 		activation.DeclareValue(stdlib.NewStandardLibraryStaticFunction(
-			"log",
+			commons.LogFunctionName,
 			sema.NewSimpleFunctionType(
 				sema.FunctionPurityView,
 				[]sema.Parameter{
@@ -4389,7 +4389,7 @@ func TestBeforeFunctionInPostConditions(t *testing.T) {
 		activation := sema.NewVariableActivation(sema.BaseValueActivation)
 		activation.DeclareValue(stdlib.PanicFunction)
 		activation.DeclareValue(stdlib.NewStandardLibraryStaticFunction(
-			"log",
+			commons.LogFunctionName,
 			sema.NewSimpleFunctionType(
 				sema.FunctionPurityView,
 				[]sema.Parameter{

--- a/bbq/vm/value_account_capabilities.go
+++ b/bbq/vm/value_account_capabilities.go
@@ -34,7 +34,7 @@ func init() {
 	// Account.Capabilities.get
 	RegisterTypeBoundFunction(
 		accountCapabilitiesTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_CapabilitiesTypeGetFunctionName,
 			sema.Account_CapabilitiesTypeGetFunctionType,
 			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
@@ -65,7 +65,7 @@ func init() {
 	// Account.Capabilities.borrow
 	RegisterTypeBoundFunction(
 		accountCapabilitiesTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_CapabilitiesTypeBorrowFunctionName,
 			sema.Account_CapabilitiesTypeBorrowFunctionType,
 			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
@@ -97,7 +97,7 @@ func init() {
 	// Account.Capabilities.publish
 	RegisterTypeBoundFunction(
 		accountCapabilitiesTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_CapabilitiesTypePublishFunctionName,
 			sema.Account_CapabilitiesTypePublishFunctionType,
 			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
@@ -134,7 +134,7 @@ func init() {
 	// Account.Capabilities.unpublish
 	RegisterTypeBoundFunction(
 		accountCapabilitiesTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_CapabilitiesTypeUnpublishFunctionName,
 			sema.Account_CapabilitiesTypeUnpublishFunctionType,
 			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
@@ -161,7 +161,7 @@ func init() {
 	// Account.Capabilities.exist
 	RegisterTypeBoundFunction(
 		accountCapabilitiesTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_CapabilitiesTypeExistsFunctionName,
 			sema.Account_CapabilitiesTypeExistsFunctionType,
 			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {

--- a/bbq/vm/value_account_storage.go
+++ b/bbq/vm/value_account_storage.go
@@ -34,7 +34,7 @@ func init() {
 	// Account.Storage.save
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_StorageTypeSaveFunctionName,
 			sema.Account_StorageTypeSaveFunctionType,
 			func(config *Config, typeArs []bbq.StaticType, args ...Value) Value {
@@ -57,7 +57,7 @@ func init() {
 	// Account.Storage.borrow
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_StorageTypeBorrowFunctionName,
 			sema.Account_StorageTypeBorrowFunctionType,
 			func(config *Config, typeArgs []bbq.StaticType, args ...Value) Value {
@@ -83,7 +83,7 @@ func init() {
 	// Account.Storage.forEachPublic
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_StorageTypeForEachPublicFunctionName,
 			sema.Account_StorageTypeForEachPublicFunctionType,
 			func(config *Config, typeArs []bbq.StaticType, args ...Value) Value {
@@ -108,7 +108,7 @@ func init() {
 	// Account.Storage.forEachStored
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_StorageTypeForEachStoredFunctionName,
 			sema.Account_StorageTypeForEachPublicFunctionType,
 			func(config *Config, typeArs []bbq.StaticType, args ...Value) Value {
@@ -133,7 +133,7 @@ func init() {
 	// Account.Storage.type
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_StorageTypeTypeFunctionName,
 			sema.Account_StorageTypeTypeFunctionType,
 			func(config *Config, typeArs []bbq.StaticType, args ...Value) Value {
@@ -155,7 +155,7 @@ func init() {
 	// Account.Storage.load
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_StorageTypeLoadFunctionName,
 			sema.Account_StorageTypeLoadFunctionType,
 			func(config *Config, typeArgs []bbq.StaticType, args ...Value) Value {
@@ -182,7 +182,7 @@ func init() {
 	// Account.Storage.copy
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_StorageTypeCopyFunctionName,
 			sema.Account_StorageTypeCopyFunctionType,
 			func(config *Config, typeArgs []bbq.StaticType, args ...Value) Value {
@@ -209,7 +209,7 @@ func init() {
 	// Account.Storage.check
 	RegisterTypeBoundFunction(
 		accountStorageTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_StorageTypeCheckFunctionName,
 			sema.Account_StorageTypeCheckFunctionType,
 			func(config *Config, typeArgs []bbq.StaticType, args ...Value) Value {

--- a/bbq/vm/value_account_storagecapabilities.go
+++ b/bbq/vm/value_account_storagecapabilities.go
@@ -34,7 +34,7 @@ func init() {
 	// Account.StorageCapabilities.issue
 	RegisterTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_StorageCapabilitiesTypeIssueFunctionName,
 			sema.Account_StorageCapabilitiesTypeIssueFunctionType,
 			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
@@ -63,7 +63,7 @@ func init() {
 	// Account.StorageCapabilities.issueWithType
 	RegisterTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_StorageCapabilitiesTypeIssueWithTypeFunctionName,
 			sema.Account_StorageCapabilitiesTypeIssueWithTypeFunctionType,
 			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
@@ -100,7 +100,7 @@ func init() {
 	// Account.StorageCapabilities.getController
 	RegisterTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_StorageCapabilitiesTypeGetControllerFunctionName,
 			sema.Account_StorageCapabilitiesTypeGetControllerFunctionType,
 			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
@@ -127,7 +127,7 @@ func init() {
 	// Account.StorageCapabilities.getControllers
 	RegisterTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_StorageCapabilitiesTypeGetControllersFunctionName,
 			sema.Account_StorageCapabilitiesTypeGetControllersFunctionType,
 			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
@@ -154,7 +154,7 @@ func init() {
 	// Account.StorageCapabilities.forEachController
 	RegisterTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.Account_StorageCapabilitiesTypeForEachControllerFunctionName,
 			sema.Account_StorageCapabilitiesTypeForEachControllerFunctionType,
 			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {

--- a/bbq/vm/value_array.go
+++ b/bbq/vm/value_array.go
@@ -30,19 +30,7 @@ import (
 func init() {
 	RegisterTypeBoundFunction(
 		commons.TypeQualifierArray,
-		NewNativeFunctionValue(
-			sema.GetTypeFunctionName,
-			sema.GetTypeFunctionType,
-			func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {
-				value := arguments[receiverIndex]
-				return interpreter.ValueGetType(config, value)
-			},
-		),
-	)
-
-	RegisterTypeBoundFunction(
-		commons.TypeQualifierArray,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.ArrayTypeAppendFunctionName,
 			// TODO:
 			sema.ArrayAppendFunctionType(sema.AnyType),

--- a/bbq/vm/value_capability.go
+++ b/bbq/vm/value_capability.go
@@ -32,7 +32,7 @@ func init() {
 	// Capability.borrow
 	RegisterTypeBoundFunction(
 		typeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.CapabilityTypeBorrowFunctionName,
 			// TODO: Should the borrow type need to be changed for each usage?
 			sema.CapabilityTypeBorrowFunctionType(nil),

--- a/bbq/vm/value_dictionary.go
+++ b/bbq/vm/value_dictionary.go
@@ -31,7 +31,7 @@ func init() {
 
 	RegisterTypeBoundFunction(
 		commons.TypeQualifierDictionary,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.DictionaryTypeRemoveFunctionName,
 			// TODO:
 			sema.DictionaryRemoveFunctionType(&sema.DictionaryType{

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -162,6 +162,19 @@ func NewNativeFunctionValue(
 	}
 }
 
+func NewBoundNativeFunctionValue(
+	name string,
+	funcType *sema.FunctionType,
+	function NativeFunction,
+) NativeFunctionValue {
+	return NativeFunctionValue{
+		Name:           name,
+		ParameterCount: len(funcType.Parameters) + 1, // +1 is for the receiver
+		Function:       function,
+		Type:           interpreter.NewFunctionStaticType(nil, funcType),
+	}
+}
+
 var _ Value = NativeFunctionValue{}
 var _ interpreter.FunctionValue = NativeFunctionValue{}
 

--- a/bbq/vm/value_int.go
+++ b/bbq/vm/value_int.go
@@ -18,34 +18,7 @@
 
 package vm
 
-import (
-	"github.com/onflow/cadence/bbq"
-	"github.com/onflow/cadence/common"
-	"github.com/onflow/cadence/interpreter"
-	"github.com/onflow/cadence/sema"
-)
-
 // members
 
 func init() {
-	RegisterTypeBoundFunction(
-		sema.IntTypeName,
-		NewNativeFunctionValue(
-			sema.ToStringFunctionName,
-			sema.ToStringFunctionType,
-			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
-				number := args[receiverIndex].(interpreter.IntValue)
-
-				// TODO: Refactor and re-use the logic from interpreter.
-				memoryUsage := common.NewStringMemoryUsage(
-					interpreter.OverEstimateNumberStringLength(config.MemoryGauge, number),
-				)
-				return interpreter.NewStringValue(
-					config.MemoryGauge,
-					memoryUsage,
-					number.String,
-				)
-			},
-		),
-	)
 }

--- a/bbq/vm/value_string.go
+++ b/bbq/vm/value_string.go
@@ -31,7 +31,7 @@ func init() {
 
 	RegisterTypeBoundFunction(
 		typeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.StringTypeConcatFunctionName,
 			sema.StringTypeConcatFunctionType,
 			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {

--- a/bbq/vm/value_type.go
+++ b/bbq/vm/value_type.go
@@ -32,7 +32,7 @@ func init() {
 
 	RegisterTypeBoundFunction(
 		typeName,
-		NewNativeFunctionValue(
+		NewBoundNativeFunctionValue(
 			sema.MetaTypeIsSubtypeFunctionName,
 			sema.MetaTypeIsSubtypeFunctionType,
 			func(config *Config, typeArguments []bbq.StaticType, arguments ...Value) Value {

--- a/bbq/vm/value_ufix64.go
+++ b/bbq/vm/value_ufix64.go
@@ -18,26 +18,7 @@
 
 package vm
 
-import (
-	"github.com/onflow/cadence/bbq"
-	"github.com/onflow/cadence/interpreter"
-	"github.com/onflow/cadence/sema"
-)
-
 // members
 
 func init() {
-	RegisterTypeBoundFunction(
-		sema.UFix64TypeName,
-		NewNativeFunctionValue(
-			sema.ToStringFunctionName,
-			sema.ToStringFunctionType,
-			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
-				number := args[receiverIndex].(interpreter.UFix64Value)
-
-				// TODO: memory metering
-				return interpreter.NewUnmeteredStringValue(number.String())
-			},
-		),
-	)
 }

--- a/bbq/vm/value_uint64.go
+++ b/bbq/vm/value_uint64.go
@@ -18,26 +18,7 @@
 
 package vm
 
-import (
-	"github.com/onflow/cadence/bbq"
-	"github.com/onflow/cadence/interpreter"
-	"github.com/onflow/cadence/sema"
-)
-
 // members
 
 func init() {
-	RegisterTypeBoundFunction(
-		sema.UInt64TypeName,
-		NewNativeFunctionValue(
-			sema.ToStringFunctionName,
-			sema.ToStringFunctionType,
-			func(config *Config, typeArguments []bbq.StaticType, args ...Value) Value {
-				number := args[receiverIndex].(interpreter.UInt64Value)
-
-				// TODO: memory metering
-				return interpreter.NewUnmeteredStringValue(number.String())
-			},
-		),
-	)
 }

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5219,28 +5219,31 @@ func isInstanceFunction(context FunctionCreationContext, self Value) FunctionVal
 		self,
 		sema.IsInstanceFunctionType,
 		func(self Value, invocation Invocation) Value {
-			interpreter := invocation.InvocationContext
+			invocationContext := invocation.InvocationContext
 
 			firstArgument := invocation.Arguments[0]
 			typeValue, ok := firstArgument.(TypeValue)
-
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}
 
-			staticType := typeValue.Type
-
-			// Values are never instances of unknown types
-			if staticType == nil {
-				return FalseValue
-			}
-
-			// NOTE: not invocation.Self, as that is only set for composite values
-			selfType := self.StaticType(interpreter)
-			return BoolValue(
-				IsSubType(interpreter, selfType, staticType),
-			)
+			return IsInstance(invocationContext, self, typeValue)
 		},
+	)
+}
+
+func IsInstance(invocationContext InvocationContext, self Value, typeValue TypeValue) Value {
+	staticType := typeValue.Type
+
+	// Values are never instances of unknown types
+	if staticType == nil {
+		return FalseValue
+	}
+
+	// NOTE: not invocation.Self, as that is only set for composite values
+	selfType := self.StaticType(invocationContext)
+	return BoolValue(
+		IsSubType(invocationContext, selfType, staticType),
 	)
 }
 

--- a/sema/type.go
+++ b/sema/type.go
@@ -623,7 +623,7 @@ func withBuiltinMembers(ty Type, members map[string]MemberResolver) map[string]M
 
 	// All number types, addresses, and path types have a `toString` function
 
-	if IsSubType(ty, NumberType) || IsSubType(ty, TheAddressType) || IsSubType(ty, PathType) {
+	if HasToStringFunction(ty) {
 
 		members[ToStringFunctionName] = MemberResolver{
 			Kind: common.DeclarationKindFunction,
@@ -661,6 +661,10 @@ func withBuiltinMembers(ty Type, members map[string]MemberResolver) map[string]M
 	}
 
 	return members
+}
+
+func HasToStringFunction(ty Type) bool {
+	return IsSubType(ty, NumberType) || IsSubType(ty, TheAddressType) || IsSubType(ty, PathType)
 }
 
 // OptionalType represents the optional variant of another type

--- a/sema/type.go
+++ b/sema/type.go
@@ -4142,45 +4142,45 @@ type TypeArgumentsCheck func(
 // the types available in programs
 var BaseTypeActivation = NewVariableActivation(nil)
 
+var AllBuiltinTypes = common.Concat(
+	AllNumberTypes,
+	[]Type{
+		MetaType,
+		VoidType,
+		AnyStructType,
+		AnyStructAttachmentType,
+		AnyResourceType,
+		AnyResourceAttachmentType,
+		NeverType,
+		BoolType,
+		CharacterType,
+		StringType,
+		TheAddressType,
+		AccountType,
+		PathType,
+		StoragePathType,
+		CapabilityPathType,
+		PrivatePathType,
+		PublicPathType,
+		&CapabilityType{},
+		DeployedContractType,
+		BlockType,
+		AccountKeyType,
+		PublicKeyType,
+		SignatureAlgorithmType,
+		HashAlgorithmType,
+		StorageCapabilityControllerType,
+		AccountCapabilityControllerType,
+		DeploymentResultType,
+		HashableStructType,
+		&InclusiveRangeType{},
+		StructStringerType,
+	},
+)
+
 func init() {
 
-	types := common.Concat(
-		AllNumberTypes,
-		[]Type{
-			MetaType,
-			VoidType,
-			AnyStructType,
-			AnyStructAttachmentType,
-			AnyResourceType,
-			AnyResourceAttachmentType,
-			NeverType,
-			BoolType,
-			CharacterType,
-			StringType,
-			TheAddressType,
-			AccountType,
-			PathType,
-			StoragePathType,
-			CapabilityPathType,
-			PrivatePathType,
-			PublicPathType,
-			&CapabilityType{},
-			DeployedContractType,
-			BlockType,
-			AccountKeyType,
-			PublicKeyType,
-			SignatureAlgorithmType,
-			HashAlgorithmType,
-			StorageCapabilityControllerType,
-			AccountCapabilityControllerType,
-			DeploymentResultType,
-			HashableStructType,
-			&InclusiveRangeType{},
-			StructStringerType,
-		},
-	)
-
-	for _, ty := range types {
+	for _, ty := range AllBuiltinTypes {
 		addToBaseActivation(ty)
 	}
 


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3769

## Description

Register the native functions that are common to all types (e.g: `toString`, `getType`, etc.) in one place. This only register the functions for built-in types for now.

Next step would be to do the same for user-defined types.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
