### PR TITLE
[Compiler] Rename path instruction

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1828,13 +1828,15 @@ func (c *Compiler[_, _]) VisitPathExpression(expression *ast.PathExpression) (_ 
 	}
 
 	identifierConst := c.addStringConst(identifier)
+	identifierIndex := identifierConst.index
 
 	c.codeGen.Emit(
-		opcode.InstructionPath{
+		opcode.InstructionNewPath{
 			Domain:     domain,
-			Identifier: identifierConst.index,
+			Identifier: identifierIndex,
 		},
 	)
+
 	return
 }
 

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -2322,7 +2322,7 @@ func TestCompilePath(t *testing.T) {
 
 	assert.Equal(t,
 		[]opcode.Instruction{
-			opcode.InstructionPath{
+			opcode.InstructionNewPath{
 				Domain:     common.PathDomainStorage,
 				Identifier: 0,
 			},

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -507,52 +507,6 @@ func (i InstructionNil) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
 }
 
-// InstructionPath
-//
-// Creates a new path with the given domain and identifier and then pushes it onto the stack.
-type InstructionPath struct {
-	Domain     common.PathDomain
-	Identifier uint16
-}
-
-var _ Instruction = InstructionPath{}
-
-func (InstructionPath) Opcode() Opcode {
-	return Path
-}
-
-func (i InstructionPath) String() string {
-	var sb strings.Builder
-	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
-	return sb.String()
-}
-
-func (i InstructionPath) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "domain", i.Domain)
-	printfArgument(sb, "identifier", i.Identifier)
-}
-
-func (i InstructionPath) ResolvedOperandsString(sb *strings.Builder,
-	constants []constant.Constant,
-	types []interpreter.StaticType,
-	functionNames []string) {
-	printfArgument(sb, "domain", i.Domain)
-	printfConstantArgument(sb, "identifier", constants[i.Identifier])
-}
-
-func (i InstructionPath) Encode(code *[]byte) {
-	emitOpcode(code, i.Opcode())
-	emitPathDomain(code, i.Domain)
-	emitUint16(code, i.Identifier)
-}
-
-func DecodePath(ip *uint16, code []byte) (i InstructionPath) {
-	i.Domain = decodePathDomain(ip, code)
-	i.Identifier = decodeUint16(ip, code)
-	return i
-}
-
 // InstructionNew
 //
 // Creates a new instance of the given kind and type and then pushes it onto the stack.
@@ -596,6 +550,52 @@ func (i InstructionNew) Encode(code *[]byte) {
 func DecodeNew(ip *uint16, code []byte) (i InstructionNew) {
 	i.Kind = decodeCompositeKind(ip, code)
 	i.Type = decodeUint16(ip, code)
+	return i
+}
+
+// InstructionNewPath
+//
+// Creates a new path with the given domain and identifier and then pushes it onto the stack.
+type InstructionNewPath struct {
+	Domain     common.PathDomain
+	Identifier uint16
+}
+
+var _ Instruction = InstructionNewPath{}
+
+func (InstructionNewPath) Opcode() Opcode {
+	return NewPath
+}
+
+func (i InstructionNewPath) String() string {
+	var sb strings.Builder
+	sb.WriteString(i.Opcode().String())
+	i.OperandsString(&sb)
+	return sb.String()
+}
+
+func (i InstructionNewPath) OperandsString(sb *strings.Builder) {
+	printfArgument(sb, "domain", i.Domain)
+	printfArgument(sb, "identifier", i.Identifier)
+}
+
+func (i InstructionNewPath) ResolvedOperandsString(sb *strings.Builder,
+	constants []constant.Constant,
+	types []interpreter.StaticType,
+	functionNames []string) {
+	printfArgument(sb, "domain", i.Domain)
+	printfConstantArgument(sb, "identifier", constants[i.Identifier])
+}
+
+func (i InstructionNewPath) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+	emitPathDomain(code, i.Domain)
+	emitUint16(code, i.Identifier)
+}
+
+func DecodeNewPath(ip *uint16, code []byte) (i InstructionNewPath) {
+	i.Domain = decodePathDomain(ip, code)
+	i.Identifier = decodeUint16(ip, code)
 	return i
 }
 
@@ -2101,10 +2101,10 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 		return InstructionFalse{}
 	case Nil:
 		return InstructionNil{}
-	case Path:
-		return DecodePath(ip, code)
 	case New:
 		return DecodeNew(ip, code)
+	case NewPath:
+		return DecodeNewPath(ip, code)
 	case NewArray:
 		return DecodeNewArray(ip, code)
 	case NewDictionary:

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -158,18 +158,6 @@
       - name: "value"
         type: "value"
 
-- name: "path"
-  description: Creates a new path with the given domain and identifier and then pushes it onto the stack.
-  operands:
-    - name: "domain"
-      type: "pathDomain"
-    - name: "identifier"
-      type: "constantIndex"
-  valueEffects:
-    push:
-      - name: "value"
-        type: "path"
-
 - name: "new"
   description: Creates a new instance of the given kind and type and then pushes it onto the stack.
   operands:
@@ -181,6 +169,18 @@
     push:
       - name: "value"
         type: "value"
+
+- name: "newPath"
+  description: Creates a new path with the given domain and identifier and then pushes it onto the stack.
+  operands:
+    - name: "domain"
+      type: "pathDomain"
+    - name: "identifier"
+      type: "constantIndex"
+  valueEffects:
+    push:
+      - name: "value"
+        type: "path"
 
 - name: "newArray"
   description:

--- a/bbq/opcode/opcode.go
+++ b/bbq/opcode/opcode.go
@@ -95,9 +95,9 @@ const (
 
 	True
 	False
-	New
-	Path
 	Nil
+	New
+	NewPath
 	NewArray
 	NewDictionary
 	NewRef

--- a/bbq/opcode/opcode_string.go
+++ b/bbq/opcode/opcode_string.go
@@ -42,9 +42,9 @@ func _() {
 	_ = x[Deref-42]
 	_ = x[True-49]
 	_ = x[False-50]
-	_ = x[New-51]
-	_ = x[Path-52]
-	_ = x[Nil-53]
+	_ = x[Nil-51]
+	_ = x[New-52]
+	_ = x[NewPath-53]
 	_ = x[NewArray-54]
 	_ = x[NewDictionary-55]
 	_ = x[NewRef-56]
@@ -77,7 +77,7 @@ const (
 	_Opcode_name_2 = "BitwiseOrBitwiseAndBitwiseXorBitwiseLeftShiftBitwiseRightShift"
 	_Opcode_name_3 = "LessGreaterLessOrEqualGreaterOrEqualEqualNotEqualNot"
 	_Opcode_name_4 = "UnwrapDestroyTransferSimpleCastFailableCastForceCastDeref"
-	_Opcode_name_5 = "TrueFalseNewPathNilNewArrayNewDictionaryNewRefNewClosure"
+	_Opcode_name_5 = "TrueFalseNilNewNewPathNewArrayNewDictionaryNewRefNewClosure"
 	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetUpvalueSetUpvalueGetGlobalSetGlobalGetFieldSetFieldSetIndexGetIndex"
 	_Opcode_name_7 = "InvokeInvokeDynamic"
 	_Opcode_name_8 = "DropDup"
@@ -90,7 +90,7 @@ var (
 	_Opcode_index_2 = [...]uint8{0, 9, 19, 29, 45, 62}
 	_Opcode_index_3 = [...]uint8{0, 4, 11, 22, 36, 41, 49, 52}
 	_Opcode_index_4 = [...]uint8{0, 6, 13, 21, 31, 43, 52, 57}
-	_Opcode_index_5 = [...]uint8{0, 4, 9, 12, 16, 19, 27, 40, 46, 56}
+	_Opcode_index_5 = [...]uint8{0, 4, 9, 12, 15, 22, 30, 43, 49, 59}
 	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 37, 47, 56, 65, 73, 81, 89, 97}
 	_Opcode_index_7 = [...]uint8{0, 6, 19}
 	_Opcode_index_8 = [...]uint8{0, 4, 7}

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -181,7 +181,7 @@ func TestPrintInstruction(t *testing.T) {
 		"FailableCast type:258": {byte(FailableCast), 1, 2, 3},
 		"ForceCast type:258":    {byte(ForceCast), 1, 2, 3},
 
-		`Path domain:PathDomainStorage identifier:5`: {byte(Path), 1, 0, 5},
+		`NewPath domain:PathDomainStorage identifier:5`: {byte(NewPath), 1, 0, 5},
 
 		`InvokeDynamic name:1 typeArgs:[772, 1286] argCount:1800`: {
 			byte(InvokeDynamic), 0, 1, 0, 2, 3, 4, 5, 6, 7, 8,

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -797,7 +797,7 @@ func opDestroy(vm *VM) {
 	value.Destroy(vm.config, EmptyLocationRange)
 }
 
-func opPath(vm *VM, ins opcode.InstructionPath) {
+func opNewPath(vm *VM, ins opcode.InstructionNewPath) {
 	identifierIndex := ins.Identifier
 	identifier := getStringConstant(vm, identifierIndex)
 	value := interpreter.NewPathValue(
@@ -1180,8 +1180,8 @@ func (vm *VM) run() {
 			opTransfer(vm, ins)
 		case opcode.InstructionDestroy:
 			opDestroy(vm)
-		case opcode.InstructionPath:
-			opPath(vm, ins)
+		case opcode.InstructionNewPath:
+			opNewPath(vm, ins)
 		case opcode.InstructionSimpleCast:
 			opSimpleCast(vm, ins)
 		case opcode.InstructionFailableCast:


### PR DESCRIPTION
Work towards #3769 

## Description

Minor: Align the naming of the instruction which creates a new path with the other instructions which create new values by adding a `new` prefix.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
