### PR TITLE
[Compiler] Improve program printing

### DIFF
--- a/bbq/opcode/gen/instructions.schema.json
+++ b/bbq/opcode/gen/instructions.schema.json
@@ -32,7 +32,7 @@
             "functionIndex",
             "upvalueIndex",
             "offset",
-            "indices",
+            "typeIndices",
             "size",
             "castKind",
             "pathDomain",

--- a/bbq/opcode/gen/main.go
+++ b/bbq/opcode/gen/main.go
@@ -502,6 +502,7 @@ func instructionStringFuncDecl(ins instruction) *dst.FuncDecl {
 							Op: token.AND,
 							X:  dst.NewIdent("sb"),
 						},
+						dst.NewIdent("false"),
 					},
 				},
 			},
@@ -583,6 +584,7 @@ func instructionOperandsStringFuncDecl(ins instruction) *dst.FuncDecl {
 							X:   dst.NewIdent("i"),
 							Sel: operandIdent(operand),
 						},
+						dst.NewIdent("colorize"),
 					},
 				},
 			},
@@ -614,6 +616,12 @@ func instructionOperandsStringFuncDecl(ins instruction) *dst.FuncDecl {
 								Name: "Builder",
 							},
 						},
+					},
+					{
+						Names: []*dst.Ident{
+							dst.NewIdent("colorize"),
+						},
+						Type: dst.NewIdent("bool"),
 					},
 				},
 			},
@@ -697,6 +705,7 @@ func instructionResolvedOperandsStringFuncDecl(ins instruction) *dst.FuncDecl {
 							Value: fmt.Sprintf(`"%s"`, operand.Name),
 						},
 						arg,
+						dst.NewIdent("colorize"),
 					},
 				},
 			},
@@ -744,6 +753,12 @@ func instructionResolvedOperandsStringFuncDecl(ins instruction) *dst.FuncDecl {
 			Type: &dst.ArrayType{
 				Elt: dst.NewIdent("string"),
 			},
+		},
+		{
+			Names: []*dst.Ident{
+				dst.NewIdent("colorize"),
+			},
+			Type: dst.NewIdent("bool"),
 		},
 	}
 

--- a/bbq/opcode/gen/main.go
+++ b/bbq/opcode/gen/main.go
@@ -567,8 +567,23 @@ func instructionOperandsStringFuncDecl(ins instruction) *dst.FuncDecl {
 		default:
 			funcName = "printfArgument"
 		}
+
 		stmts = append(
 			stmts,
+			&dst.ExprStmt{
+				X: &dst.CallExpr{
+					Fun: &dst.SelectorExpr{
+						X:   dst.NewIdent("sb"),
+						Sel: dst.NewIdent("WriteByte"),
+					},
+					Args: []dst.Expr{
+						&dst.BasicLit{
+							Kind:  token.CHAR,
+							Value: "' '",
+						},
+					},
+				},
+			},
 			&dst.ExprStmt{
 				X: &dst.CallExpr{
 					Fun: &dst.Ident{
@@ -697,6 +712,20 @@ func instructionResolvedOperandsStringFuncDecl(ins instruction) *dst.FuncDecl {
 
 		stmts = append(
 			stmts,
+			&dst.ExprStmt{
+				X: &dst.CallExpr{
+					Fun: &dst.SelectorExpr{
+						X:   dst.NewIdent("sb"),
+						Sel: dst.NewIdent("WriteByte"),
+					},
+					Args: []dst.Expr{
+						&dst.BasicLit{
+							Kind:  token.CHAR,
+							Value: "' '",
+						},
+					},
+				},
+			},
 			&dst.ExprStmt{
 				X: &dst.CallExpr{
 					Fun: &dst.Ident{

--- a/bbq/opcode/instruction.go
+++ b/bbq/opcode/instruction.go
@@ -23,6 +23,7 @@ package opcode
 import (
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 
 	"github.com/onflow/cadence/bbq/constant"
@@ -224,8 +225,15 @@ func printfArgument(sb *strings.Builder, fieldName string, v any) {
 	_, _ = fmt.Fprintf(sb, " %s:%v", fieldName, v)
 }
 
-func printfConstantArgument(sb *strings.Builder, fieldName string, constant constant.Constant) {
-	_, _ = fmt.Fprintf(sb, " %s:%s", fieldName, constant)
+func printfConstantArgument(sb *strings.Builder, fieldName string, c constant.Constant) {
+	formattedConstant := c.String()
+	switch c.Kind {
+	case constant.String:
+		formattedConstant = strconv.Quote(formattedConstant)
+	default:
+		formattedConstant = fmt.Sprintf("%s(%s)", formattedConstant, c.Kind)
+	}
+	_, _ = fmt.Fprintf(sb, " %s:%s", fieldName, formattedConstant)
 }
 
 func printfTypeArgument(sb *strings.Builder, fieldName string, typ interpreter.StaticType) {

--- a/bbq/opcode/instruction.go
+++ b/bbq/opcode/instruction.go
@@ -210,7 +210,7 @@ func printfUInt16ArrayArgument(
 		argumentName = colorizeArgumentName(argumentName)
 	}
 
-	_, _ = fmt.Fprintf(sb, " %s:[", argumentName)
+	_, _ = fmt.Fprintf(sb, "%s:[", argumentName)
 	for i, value := range values {
 		if i > 0 {
 			sb.WriteString(", ")
@@ -235,13 +235,14 @@ func printfUpvalueArrayArgument(
 		argumentName = colorizeArgumentName(argumentName)
 	}
 
-	_, _ = fmt.Fprintf(sb, " %s:[", argumentName)
+	_, _ = fmt.Fprintf(sb, "%s:[", argumentName)
 
 	for i, upvalue := range upvalues {
 		if i > 0 {
-			sb.WriteByte(',')
+			sb.WriteString(", ")
 		}
 		printfArgument(sb, "targetIndex", upvalue.TargetIndex, colorize)
+		sb.WriteByte(' ')
 		printfArgument(sb, "isLocal", upvalue.IsLocal, colorize)
 	}
 
@@ -260,7 +261,7 @@ func printfArgument(
 		formattedValue = colorizeArgumentValue(formattedValue)
 	}
 
-	_, _ = fmt.Fprintf(sb, " %s:%s", argumentName, formattedValue)
+	_, _ = fmt.Fprintf(sb, "%s:%s", argumentName, formattedValue)
 }
 
 func printfConstantArgument(
@@ -282,7 +283,7 @@ func printfConstantArgument(
 		formattedConstant = colorizeArgumentValue(formattedConstant)
 	}
 
-	_, _ = fmt.Fprintf(sb, " %s:%s", argumentName, formattedConstant)
+	_, _ = fmt.Fprintf(sb, "%s:%s", argumentName, formattedConstant)
 }
 
 func printfTypeArgument(
@@ -296,7 +297,7 @@ func printfTypeArgument(
 		argumentName = colorizeArgumentName(argumentName)
 		formattedType = colorizeArgumentValue(formattedType)
 	}
-	_, _ = fmt.Fprintf(sb, " %s:%s", argumentName, formattedType)
+	_, _ = fmt.Fprintf(sb, "%s:%s", argumentName, formattedType)
 }
 
 func printfTypeArrayArgument(
@@ -310,7 +311,7 @@ func printfTypeArrayArgument(
 		argumentName = colorizeArgumentName(argumentName)
 	}
 
-	_, _ = fmt.Fprintf(sb, " %s:[", argumentName)
+	_, _ = fmt.Fprintf(sb, "%s:[", argumentName)
 
 	for i, typeIndex := range typeIndices {
 		if i > 0 {
@@ -340,7 +341,7 @@ func printfFunctionNameArgument(
 		argumentName = colorizeArgumentName(argumentName)
 		functionName = colorizeArgumentValue(functionName)
 	}
-	_, _ = fmt.Fprintf(sb, " %s:%s", argumentName, functionName)
+	_, _ = fmt.Fprintf(sb, "%s:%s", argumentName, functionName)
 }
 
 func colorizeArgumentName(argumentName string) string {

--- a/bbq/opcode/instruction.go
+++ b/bbq/opcode/instruction.go
@@ -265,7 +265,7 @@ func printfArgument(
 
 func printfConstantArgument(
 	sb *strings.Builder,
-	fieldName string,
+	argumentName string,
 	c constant.Constant,
 	colorize bool,
 ) {
@@ -278,25 +278,56 @@ func printfConstantArgument(
 	}
 
 	if colorize {
-		fieldName = colorizeArgumentName(fieldName)
+		argumentName = colorizeArgumentName(argumentName)
 		formattedConstant = colorizeArgumentValue(formattedConstant)
 	}
 
-	_, _ = fmt.Fprintf(sb, " %s:%s", fieldName, formattedConstant)
+	_, _ = fmt.Fprintf(sb, " %s:%s", argumentName, formattedConstant)
 }
 
 func printfTypeArgument(
 	sb *strings.Builder,
-	fieldName string,
+	argumentName string,
 	typ interpreter.StaticType,
 	colorize bool,
 ) {
 	formattedType := strconv.Quote(typ.String())
 	if colorize {
-		fieldName = colorizeArgumentName(fieldName)
+		argumentName = colorizeArgumentName(argumentName)
 		formattedType = colorizeArgumentValue(formattedType)
 	}
-	_, _ = fmt.Fprintf(sb, " %s:%s", fieldName, formattedType)
+	_, _ = fmt.Fprintf(sb, " %s:%s", argumentName, formattedType)
+}
+
+func printfTypeArrayArgument(
+	sb *strings.Builder,
+	argumentName string,
+	typeIndices []uint16,
+	colorize bool,
+	types []interpreter.StaticType,
+) {
+	if colorize {
+		argumentName = colorizeArgumentName(argumentName)
+	}
+
+	_, _ = fmt.Fprintf(sb, " %s:[", argumentName)
+
+	for i, typeIndex := range typeIndices {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+
+		typ := types[typeIndex]
+
+		formattedType := strconv.Quote(typ.String())
+		if colorize {
+			formattedType = colorizeArgumentValue(formattedType)
+		}
+
+		sb.WriteString(formattedType)
+	}
+
+	sb.WriteByte(']')
 }
 
 func printfFunctionNameArgument(

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -27,12 +27,13 @@ func (i InstructionUnknown) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionUnknown) OperandsString(sb *strings.Builder) {}
+func (i InstructionUnknown) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionUnknown) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionUnknown) Encode(code *[]byte) {
@@ -55,19 +56,20 @@ func (InstructionGetLocal) Opcode() Opcode {
 func (i InstructionGetLocal) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionGetLocal) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "local", i.Local)
+func (i InstructionGetLocal) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "local", i.Local, colorize)
 }
 
 func (i InstructionGetLocal) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfArgument(sb, "local", i.Local)
+	functionNames []string,
+	colorize bool) {
+	printfArgument(sb, "local", i.Local, colorize)
 }
 
 func (i InstructionGetLocal) Encode(code *[]byte) {
@@ -96,19 +98,20 @@ func (InstructionSetLocal) Opcode() Opcode {
 func (i InstructionSetLocal) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionSetLocal) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "local", i.Local)
+func (i InstructionSetLocal) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "local", i.Local, colorize)
 }
 
 func (i InstructionSetLocal) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfArgument(sb, "local", i.Local)
+	functionNames []string,
+	colorize bool) {
+	printfArgument(sb, "local", i.Local, colorize)
 }
 
 func (i InstructionSetLocal) Encode(code *[]byte) {
@@ -137,19 +140,20 @@ func (InstructionGetUpvalue) Opcode() Opcode {
 func (i InstructionGetUpvalue) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionGetUpvalue) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "upvalue", i.Upvalue)
+func (i InstructionGetUpvalue) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "upvalue", i.Upvalue, colorize)
 }
 
 func (i InstructionGetUpvalue) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfArgument(sb, "upvalue", i.Upvalue)
+	functionNames []string,
+	colorize bool) {
+	printfArgument(sb, "upvalue", i.Upvalue, colorize)
 }
 
 func (i InstructionGetUpvalue) Encode(code *[]byte) {
@@ -178,19 +182,20 @@ func (InstructionSetUpvalue) Opcode() Opcode {
 func (i InstructionSetUpvalue) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionSetUpvalue) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "upvalue", i.Upvalue)
+func (i InstructionSetUpvalue) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "upvalue", i.Upvalue, colorize)
 }
 
 func (i InstructionSetUpvalue) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfArgument(sb, "upvalue", i.Upvalue)
+	functionNames []string,
+	colorize bool) {
+	printfArgument(sb, "upvalue", i.Upvalue, colorize)
 }
 
 func (i InstructionSetUpvalue) Encode(code *[]byte) {
@@ -219,19 +224,20 @@ func (InstructionGetGlobal) Opcode() Opcode {
 func (i InstructionGetGlobal) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionGetGlobal) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "global", i.Global)
+func (i InstructionGetGlobal) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "global", i.Global, colorize)
 }
 
 func (i InstructionGetGlobal) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfArgument(sb, "global", i.Global)
+	functionNames []string,
+	colorize bool) {
+	printfArgument(sb, "global", i.Global, colorize)
 }
 
 func (i InstructionGetGlobal) Encode(code *[]byte) {
@@ -260,19 +266,20 @@ func (InstructionSetGlobal) Opcode() Opcode {
 func (i InstructionSetGlobal) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionSetGlobal) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "global", i.Global)
+func (i InstructionSetGlobal) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "global", i.Global, colorize)
 }
 
 func (i InstructionSetGlobal) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfArgument(sb, "global", i.Global)
+	functionNames []string,
+	colorize bool) {
+	printfArgument(sb, "global", i.Global, colorize)
 }
 
 func (i InstructionSetGlobal) Encode(code *[]byte) {
@@ -301,19 +308,20 @@ func (InstructionGetField) Opcode() Opcode {
 func (i InstructionGetField) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionGetField) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "fieldName", i.FieldName)
+func (i InstructionGetField) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "fieldName", i.FieldName, colorize)
 }
 
 func (i InstructionGetField) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfConstantArgument(sb, "fieldName", constants[i.FieldName])
+	functionNames []string,
+	colorize bool) {
+	printfConstantArgument(sb, "fieldName", constants[i.FieldName], colorize)
 }
 
 func (i InstructionGetField) Encode(code *[]byte) {
@@ -342,19 +350,20 @@ func (InstructionSetField) Opcode() Opcode {
 func (i InstructionSetField) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionSetField) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "fieldName", i.FieldName)
+func (i InstructionSetField) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "fieldName", i.FieldName, colorize)
 }
 
 func (i InstructionSetField) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfConstantArgument(sb, "fieldName", constants[i.FieldName])
+	functionNames []string,
+	colorize bool) {
+	printfConstantArgument(sb, "fieldName", constants[i.FieldName], colorize)
 }
 
 func (i InstructionSetField) Encode(code *[]byte) {
@@ -383,12 +392,13 @@ func (i InstructionGetIndex) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionGetIndex) OperandsString(sb *strings.Builder) {}
+func (i InstructionGetIndex) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionGetIndex) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionGetIndex) Encode(code *[]byte) {
@@ -411,12 +421,13 @@ func (i InstructionSetIndex) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionSetIndex) OperandsString(sb *strings.Builder) {}
+func (i InstructionSetIndex) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionSetIndex) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionSetIndex) Encode(code *[]byte) {
@@ -439,12 +450,13 @@ func (i InstructionTrue) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionTrue) OperandsString(sb *strings.Builder) {}
+func (i InstructionTrue) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionTrue) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionTrue) Encode(code *[]byte) {
@@ -467,12 +479,13 @@ func (i InstructionFalse) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionFalse) OperandsString(sb *strings.Builder) {}
+func (i InstructionFalse) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionFalse) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionFalse) Encode(code *[]byte) {
@@ -495,12 +508,13 @@ func (i InstructionNil) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionNil) OperandsString(sb *strings.Builder) {}
+func (i InstructionNil) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionNil) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionNil) Encode(code *[]byte) {
@@ -524,21 +538,22 @@ func (InstructionPath) Opcode() Opcode {
 func (i InstructionPath) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionPath) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "domain", i.Domain)
-	printfArgument(sb, "identifier", i.Identifier)
+func (i InstructionPath) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "domain", i.Domain, colorize)
+	printfArgument(sb, "identifier", i.Identifier, colorize)
 }
 
 func (i InstructionPath) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfArgument(sb, "domain", i.Domain)
-	printfConstantArgument(sb, "identifier", constants[i.Identifier])
+	functionNames []string,
+	colorize bool) {
+	printfArgument(sb, "domain", i.Domain, colorize)
+	printfConstantArgument(sb, "identifier", constants[i.Identifier], colorize)
 }
 
 func (i InstructionPath) Encode(code *[]byte) {
@@ -570,21 +585,22 @@ func (InstructionNew) Opcode() Opcode {
 func (i InstructionNew) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionNew) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "kind", i.Kind)
-	printfArgument(sb, "type", i.Type)
+func (i InstructionNew) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "kind", i.Kind, colorize)
+	printfArgument(sb, "type", i.Type, colorize)
 }
 
 func (i InstructionNew) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfArgument(sb, "kind", i.Kind)
-	printfTypeArgument(sb, "type", types[i.Type])
+	functionNames []string,
+	colorize bool) {
+	printfArgument(sb, "kind", i.Kind, colorize)
+	printfTypeArgument(sb, "type", types[i.Type], colorize)
 }
 
 func (i InstructionNew) Encode(code *[]byte) {
@@ -617,23 +633,24 @@ func (InstructionNewArray) Opcode() Opcode {
 func (i InstructionNewArray) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionNewArray) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "type", i.Type)
-	printfArgument(sb, "size", i.Size)
-	printfArgument(sb, "isResource", i.IsResource)
+func (i InstructionNewArray) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "type", i.Type, colorize)
+	printfArgument(sb, "size", i.Size, colorize)
+	printfArgument(sb, "isResource", i.IsResource, colorize)
 }
 
 func (i InstructionNewArray) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfTypeArgument(sb, "type", types[i.Type])
-	printfArgument(sb, "size", i.Size)
-	printfArgument(sb, "isResource", i.IsResource)
+	functionNames []string,
+	colorize bool) {
+	printfTypeArgument(sb, "type", types[i.Type], colorize)
+	printfArgument(sb, "size", i.Size, colorize)
+	printfArgument(sb, "isResource", i.IsResource, colorize)
 }
 
 func (i InstructionNewArray) Encode(code *[]byte) {
@@ -668,23 +685,24 @@ func (InstructionNewDictionary) Opcode() Opcode {
 func (i InstructionNewDictionary) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionNewDictionary) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "type", i.Type)
-	printfArgument(sb, "size", i.Size)
-	printfArgument(sb, "isResource", i.IsResource)
+func (i InstructionNewDictionary) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "type", i.Type, colorize)
+	printfArgument(sb, "size", i.Size, colorize)
+	printfArgument(sb, "isResource", i.IsResource, colorize)
 }
 
 func (i InstructionNewDictionary) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfTypeArgument(sb, "type", types[i.Type])
-	printfArgument(sb, "size", i.Size)
-	printfArgument(sb, "isResource", i.IsResource)
+	functionNames []string,
+	colorize bool) {
+	printfTypeArgument(sb, "type", types[i.Type], colorize)
+	printfArgument(sb, "size", i.Size, colorize)
+	printfArgument(sb, "isResource", i.IsResource, colorize)
 }
 
 func (i InstructionNewDictionary) Encode(code *[]byte) {
@@ -718,21 +736,22 @@ func (InstructionNewRef) Opcode() Opcode {
 func (i InstructionNewRef) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionNewRef) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "type", i.Type)
-	printfArgument(sb, "isImplicit", i.IsImplicit)
+func (i InstructionNewRef) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "type", i.Type, colorize)
+	printfArgument(sb, "isImplicit", i.IsImplicit, colorize)
 }
 
 func (i InstructionNewRef) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfTypeArgument(sb, "type", types[i.Type])
-	printfArgument(sb, "isImplicit", i.IsImplicit)
+	functionNames []string,
+	colorize bool) {
+	printfTypeArgument(sb, "type", types[i.Type], colorize)
+	printfArgument(sb, "isImplicit", i.IsImplicit, colorize)
 }
 
 func (i InstructionNewRef) Encode(code *[]byte) {
@@ -763,19 +782,20 @@ func (InstructionGetConstant) Opcode() Opcode {
 func (i InstructionGetConstant) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionGetConstant) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "constant", i.Constant)
+func (i InstructionGetConstant) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "constant", i.Constant, colorize)
 }
 
 func (i InstructionGetConstant) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfConstantArgument(sb, "constant", constants[i.Constant])
+	functionNames []string,
+	colorize bool) {
+	printfConstantArgument(sb, "constant", constants[i.Constant], colorize)
 }
 
 func (i InstructionGetConstant) Encode(code *[]byte) {
@@ -805,21 +825,22 @@ func (InstructionNewClosure) Opcode() Opcode {
 func (i InstructionNewClosure) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionNewClosure) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "function", i.Function)
-	printfUpvalueArrayArgument(sb, "upvalues", i.Upvalues)
+func (i InstructionNewClosure) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "function", i.Function, colorize)
+	printfUpvalueArrayArgument(sb, "upvalues", i.Upvalues, colorize)
 }
 
 func (i InstructionNewClosure) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfFunctionNameArgument(sb, "function", functionNames[i.Function])
-	printfUpvalueArrayArgument(sb, "upvalues", i.Upvalues)
+	functionNames []string,
+	colorize bool) {
+	printfFunctionNameArgument(sb, "function", functionNames[i.Function], colorize)
+	printfUpvalueArrayArgument(sb, "upvalues", i.Upvalues, colorize)
 }
 
 func (i InstructionNewClosure) Encode(code *[]byte) {
@@ -850,19 +871,20 @@ func (InstructionInvoke) Opcode() Opcode {
 func (i InstructionInvoke) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionInvoke) OperandsString(sb *strings.Builder) {
-	printfUInt16ArrayArgument(sb, "typeArgs", i.TypeArgs)
+func (i InstructionInvoke) OperandsString(sb *strings.Builder, colorize bool) {
+	printfUInt16ArrayArgument(sb, "typeArgs", i.TypeArgs, colorize)
 }
 
 func (i InstructionInvoke) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfUInt16ArrayArgument(sb, "typeArgs", i.TypeArgs)
+	functionNames []string,
+	colorize bool) {
+	printfUInt16ArrayArgument(sb, "typeArgs", i.TypeArgs, colorize)
 }
 
 func (i InstructionInvoke) Encode(code *[]byte) {
@@ -893,23 +915,24 @@ func (InstructionInvokeDynamic) Opcode() Opcode {
 func (i InstructionInvokeDynamic) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionInvokeDynamic) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "name", i.Name)
-	printfUInt16ArrayArgument(sb, "typeArgs", i.TypeArgs)
-	printfArgument(sb, "argCount", i.ArgCount)
+func (i InstructionInvokeDynamic) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "name", i.Name, colorize)
+	printfUInt16ArrayArgument(sb, "typeArgs", i.TypeArgs, colorize)
+	printfArgument(sb, "argCount", i.ArgCount, colorize)
 }
 
 func (i InstructionInvokeDynamic) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfConstantArgument(sb, "name", constants[i.Name])
-	printfUInt16ArrayArgument(sb, "typeArgs", i.TypeArgs)
-	printfArgument(sb, "argCount", i.ArgCount)
+	functionNames []string,
+	colorize bool) {
+	printfConstantArgument(sb, "name", constants[i.Name], colorize)
+	printfUInt16ArrayArgument(sb, "typeArgs", i.TypeArgs, colorize)
+	printfArgument(sb, "argCount", i.ArgCount, colorize)
 }
 
 func (i InstructionInvokeDynamic) Encode(code *[]byte) {
@@ -942,12 +965,13 @@ func (i InstructionDup) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionDup) OperandsString(sb *strings.Builder) {}
+func (i InstructionDup) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionDup) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionDup) Encode(code *[]byte) {
@@ -970,12 +994,13 @@ func (i InstructionDrop) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionDrop) OperandsString(sb *strings.Builder) {}
+func (i InstructionDrop) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionDrop) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionDrop) Encode(code *[]byte) {
@@ -998,12 +1023,13 @@ func (i InstructionDestroy) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionDestroy) OperandsString(sb *strings.Builder) {}
+func (i InstructionDestroy) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionDestroy) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionDestroy) Encode(code *[]byte) {
@@ -1026,12 +1052,13 @@ func (i InstructionUnwrap) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionUnwrap) OperandsString(sb *strings.Builder) {}
+func (i InstructionUnwrap) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionUnwrap) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionUnwrap) Encode(code *[]byte) {
@@ -1054,17 +1081,20 @@ func (InstructionTransfer) Opcode() Opcode {
 func (i InstructionTransfer) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionTransfer) OperandsString(sb *strings.Builder) { printfArgument(sb, "type", i.Type) }
+func (i InstructionTransfer) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "type", i.Type, colorize)
+}
 
 func (i InstructionTransfer) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfTypeArgument(sb, "type", types[i.Type])
+	functionNames []string,
+	colorize bool) {
+	printfTypeArgument(sb, "type", types[i.Type], colorize)
 }
 
 func (i InstructionTransfer) Encode(code *[]byte) {
@@ -1093,19 +1123,20 @@ func (InstructionSimpleCast) Opcode() Opcode {
 func (i InstructionSimpleCast) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionSimpleCast) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "type", i.Type)
+func (i InstructionSimpleCast) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "type", i.Type, colorize)
 }
 
 func (i InstructionSimpleCast) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfTypeArgument(sb, "type", types[i.Type])
+	functionNames []string,
+	colorize bool) {
+	printfTypeArgument(sb, "type", types[i.Type], colorize)
 }
 
 func (i InstructionSimpleCast) Encode(code *[]byte) {
@@ -1134,19 +1165,20 @@ func (InstructionFailableCast) Opcode() Opcode {
 func (i InstructionFailableCast) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionFailableCast) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "type", i.Type)
+func (i InstructionFailableCast) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "type", i.Type, colorize)
 }
 
 func (i InstructionFailableCast) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfTypeArgument(sb, "type", types[i.Type])
+	functionNames []string,
+	colorize bool) {
+	printfTypeArgument(sb, "type", types[i.Type], colorize)
 }
 
 func (i InstructionFailableCast) Encode(code *[]byte) {
@@ -1175,17 +1207,20 @@ func (InstructionForceCast) Opcode() Opcode {
 func (i InstructionForceCast) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionForceCast) OperandsString(sb *strings.Builder) { printfArgument(sb, "type", i.Type) }
+func (i InstructionForceCast) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "type", i.Type, colorize)
+}
 
 func (i InstructionForceCast) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfTypeArgument(sb, "type", types[i.Type])
+	functionNames []string,
+	colorize bool) {
+	printfTypeArgument(sb, "type", types[i.Type], colorize)
 }
 
 func (i InstructionForceCast) Encode(code *[]byte) {
@@ -1214,12 +1249,13 @@ func (i InstructionDeref) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionDeref) OperandsString(sb *strings.Builder) {}
+func (i InstructionDeref) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionDeref) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionDeref) Encode(code *[]byte) {
@@ -1242,17 +1278,20 @@ func (InstructionJump) Opcode() Opcode {
 func (i InstructionJump) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionJump) OperandsString(sb *strings.Builder) { printfArgument(sb, "target", i.Target) }
+func (i InstructionJump) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "target", i.Target, colorize)
+}
 
 func (i InstructionJump) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfArgument(sb, "target", i.Target)
+	functionNames []string,
+	colorize bool) {
+	printfArgument(sb, "target", i.Target, colorize)
 }
 
 func (i InstructionJump) Encode(code *[]byte) {
@@ -1281,19 +1320,20 @@ func (InstructionJumpIfFalse) Opcode() Opcode {
 func (i InstructionJumpIfFalse) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionJumpIfFalse) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "target", i.Target)
+func (i InstructionJumpIfFalse) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "target", i.Target, colorize)
 }
 
 func (i InstructionJumpIfFalse) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfArgument(sb, "target", i.Target)
+	functionNames []string,
+	colorize bool) {
+	printfArgument(sb, "target", i.Target, colorize)
 }
 
 func (i InstructionJumpIfFalse) Encode(code *[]byte) {
@@ -1322,19 +1362,20 @@ func (InstructionJumpIfTrue) Opcode() Opcode {
 func (i InstructionJumpIfTrue) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionJumpIfTrue) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "target", i.Target)
+func (i InstructionJumpIfTrue) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "target", i.Target, colorize)
 }
 
 func (i InstructionJumpIfTrue) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfArgument(sb, "target", i.Target)
+	functionNames []string,
+	colorize bool) {
+	printfArgument(sb, "target", i.Target, colorize)
 }
 
 func (i InstructionJumpIfTrue) Encode(code *[]byte) {
@@ -1363,19 +1404,20 @@ func (InstructionJumpIfNil) Opcode() Opcode {
 func (i InstructionJumpIfNil) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionJumpIfNil) OperandsString(sb *strings.Builder) {
-	printfArgument(sb, "target", i.Target)
+func (i InstructionJumpIfNil) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "target", i.Target, colorize)
 }
 
 func (i InstructionJumpIfNil) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfArgument(sb, "target", i.Target)
+	functionNames []string,
+	colorize bool) {
+	printfArgument(sb, "target", i.Target, colorize)
 }
 
 func (i InstructionJumpIfNil) Encode(code *[]byte) {
@@ -1404,12 +1446,13 @@ func (i InstructionReturn) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionReturn) OperandsString(sb *strings.Builder) {}
+func (i InstructionReturn) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionReturn) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionReturn) Encode(code *[]byte) {
@@ -1432,12 +1475,13 @@ func (i InstructionReturnValue) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionReturnValue) OperandsString(sb *strings.Builder) {}
+func (i InstructionReturnValue) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionReturnValue) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionReturnValue) Encode(code *[]byte) {
@@ -1460,12 +1504,13 @@ func (i InstructionEqual) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionEqual) OperandsString(sb *strings.Builder) {}
+func (i InstructionEqual) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionEqual) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionEqual) Encode(code *[]byte) {
@@ -1488,12 +1533,13 @@ func (i InstructionNotEqual) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionNotEqual) OperandsString(sb *strings.Builder) {}
+func (i InstructionNotEqual) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionNotEqual) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionNotEqual) Encode(code *[]byte) {
@@ -1516,12 +1562,13 @@ func (i InstructionNot) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionNot) OperandsString(sb *strings.Builder) {}
+func (i InstructionNot) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionNot) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionNot) Encode(code *[]byte) {
@@ -1544,12 +1591,13 @@ func (i InstructionAdd) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionAdd) OperandsString(sb *strings.Builder) {}
+func (i InstructionAdd) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionAdd) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionAdd) Encode(code *[]byte) {
@@ -1572,12 +1620,13 @@ func (i InstructionSubtract) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionSubtract) OperandsString(sb *strings.Builder) {}
+func (i InstructionSubtract) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionSubtract) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionSubtract) Encode(code *[]byte) {
@@ -1600,12 +1649,13 @@ func (i InstructionMultiply) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionMultiply) OperandsString(sb *strings.Builder) {}
+func (i InstructionMultiply) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionMultiply) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionMultiply) Encode(code *[]byte) {
@@ -1628,12 +1678,13 @@ func (i InstructionDivide) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionDivide) OperandsString(sb *strings.Builder) {}
+func (i InstructionDivide) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionDivide) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionDivide) Encode(code *[]byte) {
@@ -1656,12 +1707,13 @@ func (i InstructionMod) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionMod) OperandsString(sb *strings.Builder) {}
+func (i InstructionMod) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionMod) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionMod) Encode(code *[]byte) {
@@ -1684,12 +1736,13 @@ func (i InstructionNegate) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionNegate) OperandsString(sb *strings.Builder) {}
+func (i InstructionNegate) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionNegate) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionNegate) Encode(code *[]byte) {
@@ -1712,12 +1765,13 @@ func (i InstructionLess) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionLess) OperandsString(sb *strings.Builder) {}
+func (i InstructionLess) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionLess) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionLess) Encode(code *[]byte) {
@@ -1740,12 +1794,13 @@ func (i InstructionLessOrEqual) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionLessOrEqual) OperandsString(sb *strings.Builder) {}
+func (i InstructionLessOrEqual) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionLessOrEqual) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionLessOrEqual) Encode(code *[]byte) {
@@ -1768,12 +1823,13 @@ func (i InstructionGreater) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionGreater) OperandsString(sb *strings.Builder) {}
+func (i InstructionGreater) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionGreater) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionGreater) Encode(code *[]byte) {
@@ -1796,12 +1852,13 @@ func (i InstructionGreaterOrEqual) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionGreaterOrEqual) OperandsString(sb *strings.Builder) {}
+func (i InstructionGreaterOrEqual) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionGreaterOrEqual) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionGreaterOrEqual) Encode(code *[]byte) {
@@ -1824,12 +1881,13 @@ func (i InstructionBitwiseOr) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionBitwiseOr) OperandsString(sb *strings.Builder) {}
+func (i InstructionBitwiseOr) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionBitwiseOr) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionBitwiseOr) Encode(code *[]byte) {
@@ -1852,12 +1910,13 @@ func (i InstructionBitwiseXor) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionBitwiseXor) OperandsString(sb *strings.Builder) {}
+func (i InstructionBitwiseXor) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionBitwiseXor) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionBitwiseXor) Encode(code *[]byte) {
@@ -1880,12 +1939,13 @@ func (i InstructionBitwiseAnd) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionBitwiseAnd) OperandsString(sb *strings.Builder) {}
+func (i InstructionBitwiseAnd) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionBitwiseAnd) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionBitwiseAnd) Encode(code *[]byte) {
@@ -1908,12 +1968,13 @@ func (i InstructionBitwiseLeftShift) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionBitwiseLeftShift) OperandsString(sb *strings.Builder) {}
+func (i InstructionBitwiseLeftShift) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionBitwiseLeftShift) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionBitwiseLeftShift) Encode(code *[]byte) {
@@ -1936,12 +1997,13 @@ func (i InstructionBitwiseRightShift) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionBitwiseRightShift) OperandsString(sb *strings.Builder) {}
+func (i InstructionBitwiseRightShift) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionBitwiseRightShift) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionBitwiseRightShift) Encode(code *[]byte) {
@@ -1964,12 +2026,13 @@ func (i InstructionIterator) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionIterator) OperandsString(sb *strings.Builder) {}
+func (i InstructionIterator) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionIterator) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionIterator) Encode(code *[]byte) {
@@ -1992,12 +2055,13 @@ func (i InstructionIteratorHasNext) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionIteratorHasNext) OperandsString(sb *strings.Builder) {}
+func (i InstructionIteratorHasNext) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionIteratorHasNext) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionIteratorHasNext) Encode(code *[]byte) {
@@ -2020,12 +2084,13 @@ func (i InstructionIteratorNext) String() string {
 	return i.Opcode().String()
 }
 
-func (i InstructionIteratorNext) OperandsString(sb *strings.Builder) {}
+func (i InstructionIteratorNext) OperandsString(sb *strings.Builder, colorize bool) {}
 
 func (i InstructionIteratorNext) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
+	functionNames []string,
+	colorize bool) {
 }
 
 func (i InstructionIteratorNext) Encode(code *[]byte) {
@@ -2048,17 +2113,20 @@ func (InstructionEmitEvent) Opcode() Opcode {
 func (i InstructionEmitEvent) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb)
+	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionEmitEvent) OperandsString(sb *strings.Builder) { printfArgument(sb, "type", i.Type) }
+func (i InstructionEmitEvent) OperandsString(sb *strings.Builder, colorize bool) {
+	printfArgument(sb, "type", i.Type, colorize)
+}
 
 func (i InstructionEmitEvent) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
-	functionNames []string) {
-	printfTypeArgument(sb, "type", types[i.Type])
+	functionNames []string,
+	colorize bool) {
+	printfTypeArgument(sb, "type", types[i.Type], colorize)
 }
 
 func (i InstructionEmitEvent) Encode(code *[]byte) {

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -61,6 +61,7 @@ func (i InstructionGetLocal) String() string {
 }
 
 func (i InstructionGetLocal) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "local", i.Local, colorize)
 }
 
@@ -69,6 +70,7 @@ func (i InstructionGetLocal) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "local", i.Local, colorize)
 }
 
@@ -103,6 +105,7 @@ func (i InstructionSetLocal) String() string {
 }
 
 func (i InstructionSetLocal) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "local", i.Local, colorize)
 }
 
@@ -111,6 +114,7 @@ func (i InstructionSetLocal) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "local", i.Local, colorize)
 }
 
@@ -145,6 +149,7 @@ func (i InstructionGetUpvalue) String() string {
 }
 
 func (i InstructionGetUpvalue) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "upvalue", i.Upvalue, colorize)
 }
 
@@ -153,6 +158,7 @@ func (i InstructionGetUpvalue) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "upvalue", i.Upvalue, colorize)
 }
 
@@ -187,6 +193,7 @@ func (i InstructionSetUpvalue) String() string {
 }
 
 func (i InstructionSetUpvalue) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "upvalue", i.Upvalue, colorize)
 }
 
@@ -195,6 +202,7 @@ func (i InstructionSetUpvalue) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "upvalue", i.Upvalue, colorize)
 }
 
@@ -229,6 +237,7 @@ func (i InstructionGetGlobal) String() string {
 }
 
 func (i InstructionGetGlobal) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "global", i.Global, colorize)
 }
 
@@ -237,6 +246,7 @@ func (i InstructionGetGlobal) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "global", i.Global, colorize)
 }
 
@@ -271,6 +281,7 @@ func (i InstructionSetGlobal) String() string {
 }
 
 func (i InstructionSetGlobal) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "global", i.Global, colorize)
 }
 
@@ -279,6 +290,7 @@ func (i InstructionSetGlobal) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "global", i.Global, colorize)
 }
 
@@ -313,6 +325,7 @@ func (i InstructionGetField) String() string {
 }
 
 func (i InstructionGetField) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "fieldName", i.FieldName, colorize)
 }
 
@@ -321,6 +334,7 @@ func (i InstructionGetField) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfConstantArgument(sb, "fieldName", constants[i.FieldName], colorize)
 }
 
@@ -355,6 +369,7 @@ func (i InstructionSetField) String() string {
 }
 
 func (i InstructionSetField) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "fieldName", i.FieldName, colorize)
 }
 
@@ -363,6 +378,7 @@ func (i InstructionSetField) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfConstantArgument(sb, "fieldName", constants[i.FieldName], colorize)
 }
 
@@ -543,7 +559,9 @@ func (i InstructionPath) String() string {
 }
 
 func (i InstructionPath) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "domain", i.Domain, colorize)
+	sb.WriteByte(' ')
 	printfArgument(sb, "identifier", i.Identifier, colorize)
 }
 
@@ -552,7 +570,9 @@ func (i InstructionPath) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "domain", i.Domain, colorize)
+	sb.WriteByte(' ')
 	printfConstantArgument(sb, "identifier", constants[i.Identifier], colorize)
 }
 
@@ -590,7 +610,9 @@ func (i InstructionNew) String() string {
 }
 
 func (i InstructionNew) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "kind", i.Kind, colorize)
+	sb.WriteByte(' ')
 	printfArgument(sb, "type", i.Type, colorize)
 }
 
@@ -599,7 +621,9 @@ func (i InstructionNew) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "kind", i.Kind, colorize)
+	sb.WriteByte(' ')
 	printfTypeArgument(sb, "type", types[i.Type], colorize)
 }
 
@@ -638,8 +662,11 @@ func (i InstructionNewArray) String() string {
 }
 
 func (i InstructionNewArray) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "type", i.Type, colorize)
+	sb.WriteByte(' ')
 	printfArgument(sb, "size", i.Size, colorize)
+	sb.WriteByte(' ')
 	printfArgument(sb, "isResource", i.IsResource, colorize)
 }
 
@@ -648,8 +675,11 @@ func (i InstructionNewArray) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfTypeArgument(sb, "type", types[i.Type], colorize)
+	sb.WriteByte(' ')
 	printfArgument(sb, "size", i.Size, colorize)
+	sb.WriteByte(' ')
 	printfArgument(sb, "isResource", i.IsResource, colorize)
 }
 
@@ -690,8 +720,11 @@ func (i InstructionNewDictionary) String() string {
 }
 
 func (i InstructionNewDictionary) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "type", i.Type, colorize)
+	sb.WriteByte(' ')
 	printfArgument(sb, "size", i.Size, colorize)
+	sb.WriteByte(' ')
 	printfArgument(sb, "isResource", i.IsResource, colorize)
 }
 
@@ -700,8 +733,11 @@ func (i InstructionNewDictionary) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfTypeArgument(sb, "type", types[i.Type], colorize)
+	sb.WriteByte(' ')
 	printfArgument(sb, "size", i.Size, colorize)
+	sb.WriteByte(' ')
 	printfArgument(sb, "isResource", i.IsResource, colorize)
 }
 
@@ -741,7 +777,9 @@ func (i InstructionNewRef) String() string {
 }
 
 func (i InstructionNewRef) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "type", i.Type, colorize)
+	sb.WriteByte(' ')
 	printfArgument(sb, "isImplicit", i.IsImplicit, colorize)
 }
 
@@ -750,7 +788,9 @@ func (i InstructionNewRef) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfTypeArgument(sb, "type", types[i.Type], colorize)
+	sb.WriteByte(' ')
 	printfArgument(sb, "isImplicit", i.IsImplicit, colorize)
 }
 
@@ -787,6 +827,7 @@ func (i InstructionGetConstant) String() string {
 }
 
 func (i InstructionGetConstant) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "constant", i.Constant, colorize)
 }
 
@@ -795,6 +836,7 @@ func (i InstructionGetConstant) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfConstantArgument(sb, "constant", constants[i.Constant], colorize)
 }
 
@@ -830,7 +872,9 @@ func (i InstructionNewClosure) String() string {
 }
 
 func (i InstructionNewClosure) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "function", i.Function, colorize)
+	sb.WriteByte(' ')
 	printfUpvalueArrayArgument(sb, "upvalues", i.Upvalues, colorize)
 }
 
@@ -839,7 +883,9 @@ func (i InstructionNewClosure) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfFunctionNameArgument(sb, "function", functionNames[i.Function], colorize)
+	sb.WriteByte(' ')
 	printfUpvalueArrayArgument(sb, "upvalues", i.Upvalues, colorize)
 }
 
@@ -876,6 +922,7 @@ func (i InstructionInvoke) String() string {
 }
 
 func (i InstructionInvoke) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfUInt16ArrayArgument(sb, "typeArgs", i.TypeArgs, colorize)
 }
 
@@ -884,6 +931,7 @@ func (i InstructionInvoke) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfTypeArrayArgument(sb, "typeArgs", i.TypeArgs, colorize, types)
 }
 
@@ -920,8 +968,11 @@ func (i InstructionInvokeDynamic) String() string {
 }
 
 func (i InstructionInvokeDynamic) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "name", i.Name, colorize)
+	sb.WriteByte(' ')
 	printfUInt16ArrayArgument(sb, "typeArgs", i.TypeArgs, colorize)
+	sb.WriteByte(' ')
 	printfArgument(sb, "argCount", i.ArgCount, colorize)
 }
 
@@ -930,8 +981,11 @@ func (i InstructionInvokeDynamic) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfConstantArgument(sb, "name", constants[i.Name], colorize)
+	sb.WriteByte(' ')
 	printfTypeArrayArgument(sb, "typeArgs", i.TypeArgs, colorize, types)
+	sb.WriteByte(' ')
 	printfArgument(sb, "argCount", i.ArgCount, colorize)
 }
 
@@ -1086,6 +1140,7 @@ func (i InstructionTransfer) String() string {
 }
 
 func (i InstructionTransfer) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "type", i.Type, colorize)
 }
 
@@ -1094,6 +1149,7 @@ func (i InstructionTransfer) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfTypeArgument(sb, "type", types[i.Type], colorize)
 }
 
@@ -1128,6 +1184,7 @@ func (i InstructionSimpleCast) String() string {
 }
 
 func (i InstructionSimpleCast) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "type", i.Type, colorize)
 }
 
@@ -1136,6 +1193,7 @@ func (i InstructionSimpleCast) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfTypeArgument(sb, "type", types[i.Type], colorize)
 }
 
@@ -1170,6 +1228,7 @@ func (i InstructionFailableCast) String() string {
 }
 
 func (i InstructionFailableCast) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "type", i.Type, colorize)
 }
 
@@ -1178,6 +1237,7 @@ func (i InstructionFailableCast) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfTypeArgument(sb, "type", types[i.Type], colorize)
 }
 
@@ -1212,6 +1272,7 @@ func (i InstructionForceCast) String() string {
 }
 
 func (i InstructionForceCast) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "type", i.Type, colorize)
 }
 
@@ -1220,6 +1281,7 @@ func (i InstructionForceCast) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfTypeArgument(sb, "type", types[i.Type], colorize)
 }
 
@@ -1283,6 +1345,7 @@ func (i InstructionJump) String() string {
 }
 
 func (i InstructionJump) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "target", i.Target, colorize)
 }
 
@@ -1291,6 +1354,7 @@ func (i InstructionJump) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "target", i.Target, colorize)
 }
 
@@ -1325,6 +1389,7 @@ func (i InstructionJumpIfFalse) String() string {
 }
 
 func (i InstructionJumpIfFalse) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "target", i.Target, colorize)
 }
 
@@ -1333,6 +1398,7 @@ func (i InstructionJumpIfFalse) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "target", i.Target, colorize)
 }
 
@@ -1367,6 +1433,7 @@ func (i InstructionJumpIfTrue) String() string {
 }
 
 func (i InstructionJumpIfTrue) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "target", i.Target, colorize)
 }
 
@@ -1375,6 +1442,7 @@ func (i InstructionJumpIfTrue) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "target", i.Target, colorize)
 }
 
@@ -1409,6 +1477,7 @@ func (i InstructionJumpIfNil) String() string {
 }
 
 func (i InstructionJumpIfNil) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "target", i.Target, colorize)
 }
 
@@ -1417,6 +1486,7 @@ func (i InstructionJumpIfNil) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "target", i.Target, colorize)
 }
 
@@ -2118,6 +2188,7 @@ func (i InstructionEmitEvent) String() string {
 }
 
 func (i InstructionEmitEvent) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
 	printfArgument(sb, "type", i.Type, colorize)
 }
 
@@ -2126,6 +2197,7 @@ func (i InstructionEmitEvent) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
+	sb.WriteByte(' ')
 	printfTypeArgument(sb, "type", types[i.Type], colorize)
 }
 

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -884,7 +884,7 @@ func (i InstructionInvoke) ResolvedOperandsString(sb *strings.Builder,
 	types []interpreter.StaticType,
 	functionNames []string,
 	colorize bool) {
-	printfUInt16ArrayArgument(sb, "typeArgs", i.TypeArgs, colorize)
+	printfTypeArrayArgument(sb, "typeArgs", i.TypeArgs, colorize, types)
 }
 
 func (i InstructionInvoke) Encode(code *[]byte) {
@@ -931,7 +931,7 @@ func (i InstructionInvokeDynamic) ResolvedOperandsString(sb *strings.Builder,
 	functionNames []string,
 	colorize bool) {
 	printfConstantArgument(sb, "name", constants[i.Name], colorize)
-	printfUInt16ArrayArgument(sb, "typeArgs", i.TypeArgs, colorize)
+	printfTypeArrayArgument(sb, "typeArgs", i.TypeArgs, colorize, types)
 	printfArgument(sb, "argCount", i.ArgCount, colorize)
 }
 

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -273,7 +273,7 @@
     and then pushes the result back on to the stack.
   operands:
     - name: "typeArgs"
-      type: "indices"
+      type: "typeIndices"
   valueEffects:
     pop:
       - name: "arguments"
@@ -294,7 +294,7 @@
     - name: "name"
       type: "constantIndex"
     - name: "typeArgs"
-      type: "indices"
+      type: "typeIndices"
     - name: "argCount"
       type: "size"
   valueEffects:

--- a/bbq/opcode/print.go
+++ b/bbq/opcode/print.go
@@ -82,9 +82,15 @@ func PrintInstructions(
 
 		var operandsBuilder strings.Builder
 		if resolve {
-			instruction.ResolvedOperandsString(&operandsBuilder, constants, types, functionNames)
+			instruction.ResolvedOperandsString(
+				&operandsBuilder,
+				constants,
+				types,
+				functionNames,
+				colorize,
+			)
 		} else {
-			instruction.OperandsString(&operandsBuilder)
+			instruction.OperandsString(&operandsBuilder, colorize)
 		}
 
 		var formattedOffset string

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -112,10 +112,10 @@ func TestPrintResolved(t *testing.T) {
 		},
 	}
 
-	const expected = ` 0 | GetConstant | constant:foo
- 1 | GetConstant | constant:1
- 2 |   EmitEvent | type:Int
- 3 |   EmitEvent | type:[String]
+	const expected = ` 0 | GetConstant | constant:"foo"
+ 1 | GetConstant | constant:1(Int)
+ 2 |   EmitEvent | type:"Int"
+ 3 |   EmitEvent | type:"[String]"
  4 |  NewClosure | function:bar upvalues:[]
  5 |  NewClosure | function:baz upvalues:[]
 


### PR DESCRIPTION
Work towards #3769 

### Description

- Improve printing of constants
- Colorize instruction operands
- Resolve type indices (e.g. type arguments of invocation instructions)

Example:

<img width="1164" alt="Screenshot 2025-04-15 at 11 07 10 AM" src="https://github.com/user-attachments/assets/cbf4de18-a368-4acf-ae29-42dd1ad53567" />



______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
