### PR TITLE
[Compiler] Fix condition compiling

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1013,8 +1013,8 @@ func (c *Compiler[_, _]) VisitEmitStatement(statement *ast.EmitStatement) (_ str
 	c.withConditionExtendedElaboration(
 		statement,
 		func() {
-			eventType := c.ExtendedElaboration.EmitStatementEventType(statement)
 			c.compileExpression(statement.InvocationExpression)
+			eventType := c.ExtendedElaboration.EmitStatementEventType(statement)
 			typeIndex := c.getOrAddType(eventType)
 			c.codeGen.Emit(opcode.InstructionEmitEvent{
 				Type: typeIndex,

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1008,12 +1008,19 @@ func (c *Compiler[_, _]) VisitForStatement(statement *ast.ForStatement) (_ struc
 }
 
 func (c *Compiler[_, _]) VisitEmitStatement(statement *ast.EmitStatement) (_ struct{}) {
-	c.compileExpression(statement.InvocationExpression)
-	eventType := c.ExtendedElaboration.EmitStatementEventType(statement)
-	typeIndex := c.getOrAddType(eventType)
-	c.codeGen.Emit(opcode.InstructionEmitEvent{
-		Type: typeIndex,
-	})
+	// Emit statements can be coming from inherited conditions.
+	// If so, use the corresponding elaboration.
+	c.withConditionExtendedElaboration(
+		statement,
+		func() {
+			eventType := c.ExtendedElaboration.EmitStatementEventType(statement)
+			c.compileExpression(statement.InvocationExpression)
+			typeIndex := c.getOrAddType(eventType)
+			c.codeGen.Emit(opcode.InstructionEmitEvent{
+				Type: typeIndex,
+			})
+		},
+	)
 
 	return
 }

--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -349,7 +349,7 @@ func (d *Desugar) desugarPreConditions(
 		conditions = funcBlock.PreConditions
 
 		for _, condition := range conditions.Conditions {
-			desugaredCondition := d.desugarCondition(condition)
+			desugaredCondition := d.desugarCondition(condition, false)
 			desugaredConditions = append(desugaredConditions, desugaredCondition)
 		}
 	}
@@ -383,7 +383,7 @@ func (d *Desugar) desugarPostConditions(
 		beforeStatements = postConditionsRewrite.BeforeStatements
 
 		for _, condition := range conditionsList {
-			desugaredCondition := d.desugarCondition(condition)
+			desugaredCondition := d.desugarCondition(condition, false)
 			desugaredConditions = append(desugaredConditions, desugaredCondition)
 		}
 	}
@@ -438,7 +438,7 @@ func (d *Desugar) desugarInheritedCondition(condition ast.Condition, inheritedFu
 	prevElaboration := d.elaboration
 	d.elaboration = inheritedFunc.elaboration
 
-	desugaredCondition := d.desugarCondition(condition)
+	desugaredCondition := d.desugarCondition(condition, true)
 	d.elaboration = prevElaboration
 
 	// Elaboration to be used by the condition must be set in the current elaboration.
@@ -464,7 +464,7 @@ var panicFuncInvocationTypes = sema.InvocationExpressionTypes{
 	},
 }
 
-func (d *Desugar) desugarCondition(condition ast.Condition) ast.Statement {
+func (d *Desugar) desugarCondition(condition ast.Condition, isInherited bool) ast.Statement {
 	switch condition := condition.(type) {
 	case *ast.TestCondition:
 
@@ -533,10 +533,113 @@ func (d *Desugar) desugarCondition(condition ast.Condition) ast.Statement {
 		return ifStmt
 	case *ast.EmitCondition:
 		emitStmt := (*ast.EmitStatement)(condition)
-		return emitStmt
+
+		if !isInherited {
+			return emitStmt
+		}
+
+		// If the condition is inherited, then re-write
+		// the emit statement to be type-qualified.
+		// i.e: `emit Event()` will be re-written as `emit Contract.Event()`.
+		// Otherwise, the compiler can't find the symbol.
+
+		eventType := d.elaboration.EmitStatementEventType(emitStmt)
+
+		// Get the contract in which the event was declared.
+		// This is guaranteed, since events can only be declared in contracts.
+		declaredContract := declaredContract(eventType).(sema.CompositeKindedType)
+
+		eventConstructorInvocation := emitStmt.InvocationExpression
+
+		// If the event constructor is already type-qualified, then no need to change anything.
+		if _, ok := eventConstructorInvocation.InvokedExpression.(*ast.MemberExpression); ok {
+			return emitStmt
+		}
+
+		// Otherwise, make it type-qualified
+		invocationTypes := d.elaboration.InvocationExpressionTypes(eventConstructorInvocation)
+
+		pos := eventConstructorInvocation.StartPosition()
+
+		memberExpression := ast.NewMemberExpression(
+			d.memoryGauge,
+			ast.NewIdentifierExpression(
+				d.memoryGauge,
+				ast.NewIdentifier(
+					d.memoryGauge,
+					declaredContract.GetIdentifier(),
+					pos,
+				),
+			),
+			false,
+			pos,
+			ast.NewIdentifier(
+				d.memoryGauge,
+				eventType.Identifier,
+				pos,
+			),
+		)
+
+		newEventConstructorInvocation := ast.NewInvocationExpression(
+			d.memoryGauge,
+			memberExpression,
+			eventConstructorInvocation.TypeArguments,
+			eventConstructorInvocation.Arguments,
+			eventConstructorInvocation.ArgumentsStartPos,
+			eventConstructorInvocation.EndPos,
+		)
+
+		newEmitStmt := ast.NewEmitStatement(
+			d.memoryGauge,
+			newEventConstructorInvocation,
+			emitStmt.StartPos,
+		)
+
+		//Inject a static import so the compiler can link the functions.
+		d.addImport(eventType.Location)
+
+		d.elaboration.SetInvocationExpressionTypes(newEventConstructorInvocation, invocationTypes)
+		d.elaboration.SetEmitStatementEventType(newEmitStmt, eventType)
+
+		// TODO: Is there a way to get the type for the constructor
+		//  from the elaboration, rather than manually constructing it here?
+		eventConstructorFuncType := sema.NewSimpleFunctionType(
+			sema.FunctionPurityImpure,
+			// Parameters are not needed, since they are not used in the compiler
+			nil,
+			sema.NewTypeAnnotation(eventType),
+		)
+		eventConstructorFuncType.IsConstructor = true
+
+		memberAccessInfo := sema.MemberAccessInfo{
+			AccessedType:  declaredContract,
+			ResultingType: eventType,
+			Member: sema.NewPublicFunctionMember(
+				d.memoryGauge,
+				declaredContract,
+				eventType.Identifier,
+				eventConstructorFuncType,
+				"",
+			),
+			IsOptional:      false,
+			ReturnReference: false,
+		}
+
+		d.elaboration.SetMemberExpressionMemberAccessInfo(memberExpression, memberAccessInfo)
+
+		return newEmitStmt
 	default:
 		panic(errors.NewUnreachableError())
 	}
+}
+
+func declaredContract(containedType sema.ContainedType) sema.Type {
+	containerType := containedType.GetContainerType()
+	if containerType == nil {
+		return containedType
+	}
+
+	return declaredContract(containerType.(sema.ContainedType))
 }
 
 func (d *Desugar) VisitSpecialFunctionDeclaration(declaration *ast.SpecialFunctionDeclaration) ast.Declaration {
@@ -921,8 +1024,13 @@ func (d *Desugar) interfaceDelegationMethodCall(
 	// Given these invocations are treated as static calls,
 	// we need to inject a static import as well, so the
 	// compiler can link these functions.
+	d.addImport(interfaceType.Location)
 
-	interfaceLocation, isAddressLocation := interfaceType.Location.(common.AddressLocation)
+	return invocation
+}
+
+func (d *Desugar) addImport(location common.Location) {
+	interfaceLocation, isAddressLocation := location.(common.AddressLocation)
 	if isAddressLocation {
 		if _, exists := d.importsSet[interfaceLocation]; !exists {
 			d.newImports = append(
@@ -940,8 +1048,6 @@ func (d *Desugar) interfaceDelegationMethodCall(
 			d.importsSet[interfaceLocation] = struct{}{}
 		}
 	}
-
-	return invocation
 }
 
 func (d *Desugar) VisitInterfaceDeclaration(declaration *ast.InterfaceDeclaration) ast.Declaration {

--- a/bbq/compiler/extended_elaboration.go
+++ b/bbq/compiler/extended_elaboration.go
@@ -43,6 +43,7 @@ type ExtendedElaboration struct {
 	referenceExpressionBorrowTypes    map[*ast.ReferenceExpression]sema.Type
 	functionDeclarationFunctionTypes  map[*ast.FunctionDeclaration]*sema.FunctionType
 	returnStatementTypes              map[*ast.ReturnStatement]sema.ReturnStatementTypes
+	emitStatementEventTypes           map[*ast.EmitStatement]*sema.CompositeType
 }
 
 func NewExtendedElaboration(elaboration *sema.Elaboration) *ExtendedElaboration {
@@ -240,7 +241,20 @@ func (e *ExtendedElaboration) CastingExpressionTypes(expression *ast.CastingExpr
 }
 
 func (e *ExtendedElaboration) EmitStatementEventType(statement *ast.EmitStatement) *sema.CompositeType {
+	if e.emitStatementEventTypes != nil {
+		types, ok := e.emitStatementEventTypes[statement]
+		if ok {
+			return types
+		}
+	}
 	return e.elaboration.EmitStatementEventType(statement)
+}
+
+func (e *ExtendedElaboration) SetEmitStatementEventType(statement *ast.EmitStatement, compositeType *sema.CompositeType) {
+	if e.emitStatementEventTypes == nil {
+		e.emitStatementEventTypes = map[*ast.EmitStatement]*sema.CompositeType{}
+	}
+	e.emitStatementEventTypes[statement] = compositeType
 }
 
 func (e *ExtendedElaboration) ResultVariableType(enclosingBlock ast.Element) (typ sema.Type, exist bool) {

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -6527,6 +6527,127 @@ func TestCommonBuiltinTypeBoundFunctions(t *testing.T) {
 	})
 }
 
+func TestEmitInContract(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("emit", func(t *testing.T) {
+
+		t.Parallel()
+
+		storage := interpreter.NewInMemoryStorage(nil)
+
+		programs := map[common.Location]*compiledProgram{}
+		contractValues := map[common.Location]*interpreter.CompositeValue{}
+
+		vmConfig := vm.NewConfig(storage)
+		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			program, ok := programs[location]
+			if !ok {
+				assert.FailNow(t, "invalid location")
+			}
+			return program.Program
+		}
+		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+			contractValue, ok := contractValues[location]
+			if !ok {
+				assert.FailNow(t, "invalid location")
+			}
+			return contractValue
+		}
+
+		var uuid uint64 = 42
+		vmConfig.WithInterpreterConfig(&interpreter.Config{
+			UUIDHandler: func() (uint64, error) {
+				uuid++
+				return uuid, nil
+			},
+		})
+
+		contractsAddress := common.MustBytesToAddress([]byte{0x1})
+
+		cLocation := common.NewAddressLocation(nil, contractsAddress, "C")
+
+		// Deploy contract with the implementation
+
+		cContract := `
+            contract C {
+
+                event TestEvent()
+
+                resource Vault {
+                    var balance: Int
+
+                    init(balance: Int) {
+                        self.balance = balance
+                    }
+
+                    fun getBalance(): Int {
+                        pre { emit TestEvent() }
+                        return self.balance
+                    }
+                }
+
+                fun createVault(balance: Int): @Vault {
+                    return <- create Vault(balance: balance)
+                }
+            }
+        `
+
+		cProgram := parseCheckAndCompile(t, cContract, cLocation, programs)
+
+		cVM := vm.NewVM(cLocation, cProgram, vmConfig)
+
+		cContractValue, err := cVM.InitializeContract()
+		require.NoError(t, err)
+		contractValues[cLocation] = cContractValue
+
+		// Run transaction
+
+		tx := fmt.Sprintf(
+			`
+              import C from %[1]s
+
+              fun main(): Int {
+                 var vault <- C.createVault(balance: 10)
+                 var balance = vault.getBalance()
+                 destroy vault
+                 return balance
+              }
+            `,
+			contractsAddress.HexWithPrefix(),
+		)
+
+		txLocation := NewTransactionLocationGenerator()
+
+		eventEmitted := false
+		vmConfig.OnEventEmitted = func(event *interpreter.CompositeValue, eventType *interpreter.CompositeStaticType) error {
+			require.False(t, eventEmitted)
+			eventEmitted = true
+
+			assert.Equal(t,
+				cLocation.TypeID(nil, "C.TestEvent"),
+				eventType.ID(),
+			)
+
+			return nil
+		}
+
+		txProgram := parseCheckAndCompile(t, tx, txLocation(), programs)
+		txVM := vm.NewVM(txLocation(), txProgram, vmConfig)
+
+		require.False(t, eventEmitted)
+
+		result, err := txVM.Invoke("main")
+
+		require.NoError(t, err)
+		require.Equal(t, 0, txVM.StackSize())
+
+		require.True(t, eventEmitted)
+		require.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(10), result)
+	})
+}
+
 func TestInheritedConditions(t *testing.T) {
 
 	t.Parallel()
@@ -6632,7 +6753,7 @@ func TestInheritedConditions(t *testing.T) {
               import C from %[1]s
 
               fun main(): Int {
-                 var vault <- B.createVault(balance: 10)
+                 var vault <- C.createVault(balance: 10)
                  var balance = vault.getBalance()
                  destroy vault
                  return balance
@@ -6643,13 +6764,186 @@ func TestInheritedConditions(t *testing.T) {
 
 		txLocation := NewTransactionLocationGenerator()
 
+		eventEmitted := false
+		vmConfig.OnEventEmitted = func(event *interpreter.CompositeValue, eventType *interpreter.CompositeStaticType) error {
+			require.False(t, eventEmitted)
+			eventEmitted = true
+
+			assert.Equal(t,
+				cLocation.TypeID(nil, "B.TestEvent"),
+				eventType.ID(),
+			)
+
+			return nil
+		}
+
 		txProgram := parseCheckAndCompile(t, tx, txLocation(), programs)
 		txVM := vm.NewVM(txLocation(), txProgram, vmConfig)
+
+		require.False(t, eventEmitted)
 
 		result, err := txVM.Invoke("main")
 
 		require.NoError(t, err)
 		require.Equal(t, 0, txVM.StackSize())
+
+		require.True(t, eventEmitted)
+		require.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(10), result)
+	})
+
+	t.Run("emit in grand parent", func(t *testing.T) {
+
+		t.Parallel()
+
+		storage := interpreter.NewInMemoryStorage(nil)
+
+		programs := map[common.Location]*compiledProgram{}
+		contractValues := map[common.Location]*interpreter.CompositeValue{}
+
+		vmConfig := vm.NewConfig(storage)
+		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			program, ok := programs[location]
+			if !ok {
+				assert.FailNow(t, "invalid location")
+			}
+			return program.Program
+		}
+		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+			contractValue, ok := contractValues[location]
+			if !ok {
+				assert.FailNow(t, "invalid location")
+			}
+			return contractValue
+		}
+
+		var uuid uint64 = 42
+		vmConfig.WithInterpreterConfig(&interpreter.Config{
+			UUIDHandler: func() (uint64, error) {
+				uuid++
+				return uuid, nil
+			},
+		})
+
+		contractsAddress := common.MustBytesToAddress([]byte{0x1})
+
+		aLocation := common.NewAddressLocation(nil, contractsAddress, "A")
+		bLocation := common.NewAddressLocation(nil, contractsAddress, "B")
+		cLocation := common.NewAddressLocation(nil, contractsAddress, "C")
+
+		// Deploy interface contract
+
+		aContract := `
+          contract interface A {
+
+              event TestEvent()
+
+              resource interface VaultSuperInterface {
+                  var balance: Int
+
+                  fun getBalance(): Int {
+                      pre { emit TestEvent() }
+                  }
+              }
+          }
+        `
+
+		// Only need to compile
+		parseCheckAndCompile(t, aContract, aLocation, programs)
+
+		// Deploy interface contract
+
+		bContract := fmt.Sprintf(
+			`
+            import A from %[1]s
+
+            contract interface B: A {
+                resource interface VaultInterface: A.VaultSuperInterface {}
+            }
+            `,
+			contractsAddress.HexWithPrefix(),
+		)
+
+		// Only need to compile
+		parseCheckAndCompile(t, bContract, bLocation, programs)
+
+		// Deploy contract with the implementation
+
+		cContract := fmt.Sprintf(
+			`
+              import B from %[1]s
+
+              contract C {
+
+                  resource Vault: B.VaultInterface {
+                      var balance: Int
+
+                      init(balance: Int) {
+                          self.balance = balance
+                      }
+
+                      fun getBalance(): Int {
+                          return self.balance
+                      }
+                  }
+
+                  fun createVault(balance: Int): @Vault {
+                      return <- create Vault(balance: balance)
+                  }
+              }
+            `,
+			contractsAddress.HexWithPrefix(),
+		)
+
+		cProgram := parseCheckAndCompile(t, cContract, cLocation, programs)
+
+		cVM := vm.NewVM(cLocation, cProgram, vmConfig)
+
+		cContractValue, err := cVM.InitializeContract()
+		require.NoError(t, err)
+		contractValues[cLocation] = cContractValue
+
+		// Run transaction
+
+		tx := fmt.Sprintf(
+			`
+              import C from %[1]s
+
+              fun main(): Int {
+                 var vault <- C.createVault(balance: 10)
+                 var balance = vault.getBalance()
+                 destroy vault
+                 return balance
+              }
+            `,
+			contractsAddress.HexWithPrefix(),
+		)
+
+		txLocation := NewTransactionLocationGenerator()
+
+		eventEmitted := false
+		vmConfig.OnEventEmitted = func(event *interpreter.CompositeValue, eventType *interpreter.CompositeStaticType) error {
+			require.False(t, eventEmitted)
+			eventEmitted = true
+
+			assert.Equal(t,
+				cLocation.TypeID(nil, "A.TestEvent"),
+				eventType.ID(),
+			)
+
+			return nil
+		}
+
+		txProgram := parseCheckAndCompile(t, tx, txLocation(), programs)
+		txVM := vm.NewVM(txLocation(), txProgram, vmConfig)
+
+		require.False(t, eventEmitted)
+
+		result, err := txVM.Invoke("main")
+
+		require.NoError(t, err)
+		require.Equal(t, 0, txVM.StackSize())
+
+		require.True(t, eventEmitted)
 		require.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(10), result)
 	})
 }


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3769

## Description

There were three issues: 
1. Similar to if-statements, emit-statements also could be coming from the inherited interfaces. Thus, when compiling emit-statements, the proper elaboration must be used. (✅ Fixed)
2.  If the inherited condition refers to an unqualified-type (e.g: event, `emit Event()`), then the global lookup fail for the concrete type when compiling this inherited condition. (✅ Fixed). 
    - This is because the event is a local type definition for the interface. Concrete type doesn't have the access.\
    - The fix was to re-write the inherited emit to be type-qualified. i.e: `emit Event()` → `emit Contract.Event()` 
3. Similar to events, if the inherited condition refers to a function/imported symbol that is not available to the concrete type (can happen if the interface calls `A.foo()` inside the condition and interface has an import to `A`. But the concrete type that inherits the same condition does not import `A`. Then `A.foo` cannot be found to the compiler.) (❌ Not fixed yet). 
    - This is not needed for the FT, so we can merge the PR in the current state, and fix this third issue separately.
    - Created https://github.com/onflow/cadence/issues/3878

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
