### PR TITLE
[Compiler] Optimize transfers

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -55,7 +55,9 @@ type Compiler[E, T any] struct {
 	currentControlFlow  *controlFlow
 	returns             []returns
 	currentReturn       *returns
-	staticTypes         []T
+
+	types         []sema.Type
+	compiledTypes []T
 
 	// postConditionsIndices keeps track of where the post conditions start (i.e: index of the statement in the block),
 	// for each function.
@@ -67,7 +69,7 @@ type Compiler[E, T any] struct {
 	// postConditionsIndex is the statement-index of the post-conditions for the current function.
 	postConditionsIndex int
 
-	// Cache alike for staticTypes and constants in the pool.
+	// Cache alike for compiledTypes and constants in the pool.
 	typesInPool     map[sema.TypeID]uint16
 	constantsInPool map[constantsCacheKey]*Constant
 
@@ -553,7 +555,7 @@ func (c *Compiler[_, _]) exportConstants() []constant.Constant {
 }
 
 func (c *Compiler[_, T]) exportTypes() []T {
-	return c.staticTypes
+	return c.compiledTypes
 }
 
 func (c *Compiler[_, _]) exportImports() []bbq.Import {
@@ -2233,6 +2235,22 @@ func (c *Compiler[_, _]) emitTransfer(targetType sema.Type) {
 				return
 			}
 		}
+
+	case opcode.InstructionNewClosure:
+		// If the last instruction is a closure creation of the same type,
+		// then the transfer is not needed.
+		function := c.functions[lastInstruction.Function]
+		functionSourceType := c.types[function.typeIndex].(*sema.FunctionType)
+		if functionTargetType, ok := targetType.(*sema.FunctionType); ok {
+			if functionSourceType.Equal(functionTargetType) {
+				return
+			}
+		}
+
+	case opcode.InstructionNil:
+		// If the last instruction is a nil load,
+		// then the transfer is not needed.
+		return
 	}
 
 	typeIndex := c.getOrAddType(targetType)
@@ -2241,29 +2259,30 @@ func (c *Compiler[_, _]) emitTransfer(targetType sema.Type) {
 	})
 }
 
-func (c *Compiler[_, T]) getOrAddType(targetType sema.Type) uint16 {
-	typeID := targetType.ID()
+func (c *Compiler[_, T]) getOrAddType(ty sema.Type) uint16 {
+	typeID := ty.ID()
 
 	// Optimization: Re-use types in the pool.
 	index, ok := c.typesInPool[typeID]
 
 	if !ok {
-		staticType := interpreter.ConvertSemaToStaticType(c.memoryGauge, targetType)
-		typ := c.typeGen.CompileType(staticType)
-		index = c.addType(typ)
+		staticType := interpreter.ConvertSemaToStaticType(c.memoryGauge, ty)
+		data := c.typeGen.CompileType(staticType)
+		index = c.addCompiledType(ty, data)
 		c.typesInPool[typeID] = index
 	}
 
 	return index
 }
 
-func (c *Compiler[_, T]) addType(data T) uint16 {
-	count := len(c.staticTypes)
+func (c *Compiler[_, T]) addCompiledType(ty sema.Type, data T) uint16 {
+	count := len(c.compiledTypes)
 	if count >= math.MaxUint16 {
 		panic(errors.NewDefaultUserError("invalid type declaration"))
 	}
 
-	c.staticTypes = append(c.staticTypes, data)
+	c.compiledTypes = append(c.compiledTypes, data)
+	c.types = append(c.types, ty)
 	return uint16(count)
 }
 

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -4118,7 +4118,6 @@ func TestCompileFunctionExpression(t *testing.T) {
 		[]opcode.Instruction{
 			// let addOne = fun ...
 			opcode.InstructionNewClosure{Function: 1},
-			opcode.InstructionTransfer{Type: 1},
 			opcode.InstructionSetLocal{Local: addOneIndex},
 
 			// let x = 2
@@ -4291,7 +4290,6 @@ func TestCompileFunctionExpressionOuterVariableUse(t *testing.T) {
 					},
 				},
 			},
-			opcode.InstructionTransfer{Type: 1},
 			opcode.InstructionSetLocal{Local: innerLocalIndex},
 
 			opcode.InstructionReturn{},
@@ -4975,4 +4973,70 @@ func TestCompileTransferNewPath(t *testing.T) {
 			program.Constants,
 		)
 	})
+}
+
+func TestCompileTransferClosure(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+      fun test() {
+          let x = fun() {}
+      }
+    `)
+	require.NoError(t, err)
+
+	comp := compiler.NewInstructionCompiler(checker)
+	program := comp.Compile()
+
+	require.Len(t, program.Functions, 2)
+
+	functions := comp.ExportFunctions()
+	require.Equal(t, len(program.Functions), len(functions))
+
+	assert.Equal(t,
+		[]opcode.Instruction{
+			// let x = fun() {}
+			opcode.InstructionNewClosure{
+				Function: 1,
+			},
+			// NOTE: *no* transfer
+			opcode.InstructionSetLocal{Local: 0},
+			// return
+			opcode.InstructionReturn{},
+		},
+		functions[0].Code,
+	)
+}
+
+func TestCompileTransferNil(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+      fun test() {
+          let x: Int? = nil
+      }
+    `)
+	require.NoError(t, err)
+
+	comp := compiler.NewInstructionCompiler(checker)
+	program := comp.Compile()
+
+	require.Len(t, program.Functions, 1)
+
+	functions := comp.ExportFunctions()
+	require.Equal(t, len(program.Functions), len(functions))
+
+	assert.Equal(t,
+		[]opcode.Instruction{
+			// let x: Int? = nil
+			opcode.InstructionNil{},
+			// NOTE: *no* transfer
+			opcode.InstructionSetLocal{Local: 0},
+			// return
+			opcode.InstructionReturn{},
+		},
+		functions[0].Code,
+	)
 }


### PR DESCRIPTION
Work towards #3769 

## Description

Avoid emitting `Transfer` instructions after:
- `NewClosure` instruction which has the target type
- `Nil`

Improves the FT benchmark by ~5%.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
