### PR TITLE
Refactor interpreter environment

### DIFF
--- a/runtime/checking_environment.go
+++ b/runtime/checking_environment.go
@@ -1,0 +1,138 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/stdlib"
+)
+
+type checkingEnvironment struct {
+	// defaultBaseTypeActivation is the base type activation that applies to all locations by default.
+	defaultBaseTypeActivation *sema.VariableActivation
+	// The base type activations for individual locations.
+	// location == nil is the base type activation that applies to all locations,
+	// unless there is a base type activation for the given location.
+	//
+	// Base type activations are lazily / implicitly created
+	// by DeclareType / semaBaseActivationFor
+	baseTypeActivationsByLocation map[common.Location]*sema.VariableActivation
+
+	// defaultBaseValueActivation is the base value activation that applies to all locations by default.
+	defaultBaseValueActivation *sema.VariableActivation
+	// The base value activations for individual locations.
+	// location == nil is the base value activation that applies to all locations,
+	// unless there is a base value activation for the given location.
+	//
+	// Base value activations are lazily / implicitly created
+	// by DeclareValue / semaBaseActivationFor
+	baseValueActivationsByLocation map[common.Location]*sema.VariableActivation
+}
+
+func newCheckingEnvironment() *checkingEnvironment {
+	defaultBaseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+	defaultBaseTypeActivation := sema.NewVariableActivation(sema.BaseTypeActivation)
+	return &checkingEnvironment{
+		defaultBaseValueActivation: defaultBaseValueActivation,
+		defaultBaseTypeActivation:  defaultBaseTypeActivation,
+	}
+}
+
+// getBaseValueActivation returns the base activation for the given location.
+// If a value was declared for the location (using DeclareValue),
+// then the specific base value activation for this location is returned.
+// Otherwise, the default base activation that applies for all locations is returned.
+func (e *checkingEnvironment) getBaseValueActivation(
+	location common.Location,
+) (
+	baseValueActivation *sema.VariableActivation,
+) {
+	baseValueActivationsByLocation := e.baseValueActivationsByLocation
+	// Use the base value activation for the location, if any
+	// (previously implicitly created using DeclareValue)
+	baseValueActivation = baseValueActivationsByLocation[location]
+	if baseValueActivation == nil {
+		// If no base value activation for the location exists
+		// (no value was previously, specifically declared for the location using DeclareValue),
+		// return the base value activation that applies to all locations by default
+		baseValueActivation = e.defaultBaseValueActivation
+	}
+	return
+
+}
+
+// getBaseTypeActivation returns the base activation for the given location.
+// If a type was declared for the location (using DeclareType),
+// then the specific base type activation for this location is returned.
+// Otherwise, the default base activation that applies for all locations is returned.
+func (e *checkingEnvironment) getBaseTypeActivation(
+	location common.Location,
+) (
+	baseTypeActivation *sema.VariableActivation,
+) {
+	// Use the base type activation for the location, if any
+	// (previously implicitly created using DeclareType)
+	baseTypeActivationsByLocation := e.baseTypeActivationsByLocation
+	baseTypeActivation = baseTypeActivationsByLocation[location]
+	if baseTypeActivation == nil {
+		// If no base type activation for the location exists
+		// (no type was previously, specifically declared for the location using DeclareType),
+		// return the base type activation that applies to all locations by default
+		baseTypeActivation = e.defaultBaseTypeActivation
+	}
+	return
+}
+
+func (e *checkingEnvironment) semaBaseActivationFor(
+	location common.Location,
+	baseActivationsByLocation *map[Location]*sema.VariableActivation,
+	defaultBaseActivation *sema.VariableActivation,
+) (baseActivation *sema.VariableActivation) {
+	if location == nil {
+		return defaultBaseActivation
+	}
+
+	if *baseActivationsByLocation == nil {
+		*baseActivationsByLocation = map[Location]*sema.VariableActivation{}
+	} else {
+		baseActivation = (*baseActivationsByLocation)[location]
+	}
+	if baseActivation == nil {
+		baseActivation = sema.NewVariableActivation(defaultBaseActivation)
+		(*baseActivationsByLocation)[location] = baseActivation
+	}
+	return baseActivation
+}
+
+func (e *checkingEnvironment) declareValue(valueDeclaration stdlib.StandardLibraryValue, location common.Location) {
+	e.semaBaseActivationFor(
+		location,
+		&e.baseValueActivationsByLocation,
+		e.defaultBaseValueActivation,
+	).DeclareValue(valueDeclaration)
+}
+
+func (e *checkingEnvironment) declareType(typeDeclaration stdlib.StandardLibraryType, location common.Location) {
+	e.semaBaseActivationFor(
+		location,
+		&e.baseTypeActivationsByLocation,
+		e.defaultBaseTypeActivation,
+	).DeclareType(typeDeclaration)
+}

--- a/runtime/checking_environment.go
+++ b/runtime/checking_environment.go
@@ -19,12 +19,32 @@
 package runtime
 
 import (
+	"time"
+
+	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/interpreter"
+	"github.com/onflow/cadence/old_parser"
+	"github.com/onflow/cadence/parser"
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/stdlib"
 )
 
+// checkingEnvironmentReconfigured is the portion of checkingEnvironment
+// that gets reconfigured by checkingEnvironment.Configure
+type checkingEnvironmentReconfigured struct {
+	runtimeInterface Interface
+	codesAndPrograms CodesAndPrograms
+}
+
 type checkingEnvironment struct {
+	checkingEnvironmentReconfigured
+
+	config *sema.Config
+
+	checkedImports importResolutionResults
+
 	// defaultBaseTypeActivation is the base type activation that applies to all locations by default.
 	defaultBaseTypeActivation *sema.VariableActivation
 	// The base type activations for individual locations.
@@ -49,10 +69,29 @@ type checkingEnvironment struct {
 func newCheckingEnvironment() *checkingEnvironment {
 	defaultBaseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
 	defaultBaseTypeActivation := sema.NewVariableActivation(sema.BaseTypeActivation)
-	return &checkingEnvironment{
+	env := &checkingEnvironment{
 		defaultBaseValueActivation: defaultBaseValueActivation,
 		defaultBaseTypeActivation:  defaultBaseTypeActivation,
 	}
+	env.config = env.newConfig()
+	return env
+}
+
+func (e *checkingEnvironment) newConfig() *sema.Config {
+	return &sema.Config{
+		AccessCheckMode:                  sema.AccessCheckModeStrict,
+		BaseValueActivationHandler:       e.getBaseValueActivation,
+		BaseTypeActivationHandler:        e.getBaseTypeActivation,
+		ValidTopLevelDeclarationsHandler: validTopLevelDeclarations,
+		LocationHandler:                  e.resolveLocation,
+		ImportHandler:                    e.resolveImport,
+		CheckHandler:                     newCheckHandler(&e.runtimeInterface),
+	}
+}
+
+func (e *checkingEnvironment) configure(runtimeInterface Interface, codesAndPrograms CodesAndPrograms) {
+	e.runtimeInterface = runtimeInterface
+	e.codesAndPrograms = codesAndPrograms
 }
 
 // getBaseValueActivation returns the base activation for the given location.
@@ -135,4 +174,338 @@ func (e *checkingEnvironment) declareType(typeDeclaration stdlib.StandardLibrary
 		&e.baseTypeActivationsByLocation,
 		e.defaultBaseTypeActivation,
 	).DeclareType(typeDeclaration)
+}
+
+func (e *checkingEnvironment) resolveLocation(
+	identifiers []Identifier,
+	location Location,
+) (
+	res []ResolvedLocation,
+	err error,
+) {
+	return ResolveLocationWithInterface(
+		e.runtimeInterface,
+		identifiers,
+		location,
+	)
+}
+
+func (e *checkingEnvironment) resolveImport(
+	_ *sema.Checker,
+	importedLocation common.Location,
+	importRange ast.Range,
+) (sema.Import, error) {
+
+	// Check for cyclic imports
+	if e.checkedImports[importedLocation] {
+		return nil, &sema.CyclicImportsError{
+			Location: importedLocation,
+			Range:    importRange,
+		}
+	} else {
+		e.checkedImports[importedLocation] = true
+		defer delete(e.checkedImports, importedLocation)
+	}
+
+	const getAndSetProgram = true
+	program, err := e.GetProgram(
+		importedLocation,
+		getAndSetProgram,
+		e.checkedImports,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return sema.ElaborationImport{
+		Elaboration: program.Elaboration,
+	}, nil
+}
+
+func (e *checkingEnvironment) check(
+	location common.Location,
+	program *ast.Program,
+	checkedImports importResolutionResults,
+) (
+	elaboration *sema.Elaboration,
+	err error,
+) {
+	e.checkedImports = checkedImports
+
+	checker, err := sema.NewChecker(
+		program,
+		location,
+		e,
+		e.config,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	elaboration = checker.Elaboration
+
+	err = checker.Check()
+	if err != nil {
+		return nil, err
+	}
+
+	return elaboration, nil
+}
+
+func (e *checkingEnvironment) MeterMemory(usage common.MemoryUsage) error {
+	return e.runtimeInterface.MeterMemory(usage)
+}
+
+func (e *checkingEnvironment) ParseAndCheckProgram(
+	code []byte,
+	location common.Location,
+	getAndSetProgram bool,
+) (
+	*interpreter.Program,
+	error,
+) {
+	return e.getProgram(
+		location,
+		func() ([]byte, error) {
+			return code, nil
+		},
+		getAndSetProgram,
+		importResolutionResults{
+			// Current program is already in check.
+			// So mark it also as 'already seen'.
+			location: true,
+		},
+	)
+}
+
+// parseAndCheckProgram parses and checks the given program.
+func (e *checkingEnvironment) parseAndCheckProgram(
+	code []byte,
+	location common.Location,
+	checkedImports importResolutionResults,
+) (
+	program *ast.Program,
+	elaboration *sema.Elaboration,
+	err error,
+) {
+	wrapParsingCheckingError := func(err error) error {
+		switch err.(type) {
+		// Wrap only parsing and checking errors.
+		case *sema.CheckerError, parser.Error:
+			return &ParsingCheckingError{
+				Err:      err,
+				Location: location,
+			}
+		default:
+			return err
+		}
+	}
+
+	// Parse
+
+	reportMetric(
+		func() {
+			program, err = parser.ParseProgram(e, code, parser.Config{})
+		},
+		e.runtimeInterface,
+		func(metrics Metrics, duration time.Duration) {
+			metrics.ProgramParsed(location, duration)
+		},
+	)
+	if err != nil {
+		return nil, nil, wrapParsingCheckingError(err)
+	}
+
+	// Check
+
+	elaboration, err = e.check(location, program, checkedImports)
+	if err != nil {
+		return program, nil, wrapParsingCheckingError(err)
+	}
+
+	return program, elaboration, nil
+}
+
+func (e *checkingEnvironment) GetProgram(
+	location Location,
+	storeProgram bool,
+	checkedImports importResolutionResults,
+) (
+	*interpreter.Program,
+	error,
+) {
+	return e.getProgram(
+		location,
+		func() ([]byte, error) {
+			return getLocationCodeFromInterface(e.runtimeInterface, location)
+		},
+		storeProgram,
+		checkedImports,
+	)
+}
+
+// getProgram returns the existing program at the given location, if available.
+// If it is not available, it loads the code, and then parses and checks it.
+func (e *checkingEnvironment) getProgram(
+	location Location,
+	getCode func() ([]byte, error),
+	getAndSetProgram bool,
+	checkedImports importResolutionResults,
+) (
+	program *interpreter.Program,
+	err error,
+) {
+	load := func() (*interpreter.Program, error) {
+		code, err := getCode()
+		if err != nil {
+			return nil, err
+		}
+
+		e.codesAndPrograms.setCode(location, code)
+
+		parsedProgram, elaboration, err := e.parseAndCheckProgramWithRecovery(
+			code,
+			location,
+			checkedImports,
+		)
+		if parsedProgram != nil {
+			e.codesAndPrograms.setProgram(location, parsedProgram)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		return &interpreter.Program{
+			Program:     parsedProgram,
+			Elaboration: elaboration,
+		}, nil
+	}
+
+	if !getAndSetProgram {
+		return load()
+	}
+
+	errors.WrapPanic(func() {
+		program, err = e.runtimeInterface.GetOrLoadProgram(location, func() (program *interpreter.Program, err error) {
+			// Loading is done by Cadence.
+			// If it panics with a user error, e.g. when parsing fails due to a memory metering error,
+			// then do not treat it as an external error (the load callback is called by the embedder)
+			panicErr := UserPanicToError(func() {
+				program, err = load()
+			})
+			if panicErr != nil {
+				return nil, panicErr
+			}
+
+			if err != nil {
+				err = interpreter.WrappedExternalError(err)
+			}
+
+			return
+		})
+	})
+
+	return
+}
+
+// parseAndCheckProgramWithRecovery parses and checks the given program.
+// It first attempts to parse and checks the program as usual.
+// If parsing or checking fails, recovery is attempted.
+//
+// Recovery attempts to parse the contract with the old parser,
+// and if it succeeds, uses the program recovery handler
+// to produce an elaboration for the old program.
+func (e *checkingEnvironment) parseAndCheckProgramWithRecovery(
+	code []byte,
+	location common.Location,
+	checkedImports importResolutionResults,
+) (
+	program *ast.Program,
+	elaboration *sema.Elaboration,
+	err error,
+) {
+	// Attempt to parse and check the program as usual
+	program, elaboration, err = e.parseAndCheckProgram(
+		code,
+		location,
+		checkedImports,
+	)
+	if err == nil {
+		return program, elaboration, nil
+	}
+
+	// If parsing or checking fails, attempt to recover
+
+	recoveredProgram, recoveredElaboration := e.recoverProgram(
+		code,
+		location,
+		checkedImports,
+	)
+
+	// If recovery failed, return the original error
+	if recoveredProgram == nil || recoveredElaboration == nil {
+		return program, elaboration, err
+	}
+
+	recoveredElaboration.IsRecovered = true
+
+	// If recovery succeeded, return the recovered program and elaboration
+	return recoveredProgram, recoveredElaboration, nil
+}
+
+// recoverProgram parses and checks the given program with the old parser,
+// and recovers the elaboration from the old program.
+func (e *checkingEnvironment) recoverProgram(
+	oldCode []byte,
+	location common.Location,
+	checkedImports importResolutionResults,
+) (
+	program *ast.Program,
+	elaboration *sema.Elaboration,
+) {
+	// Parse
+
+	var err error
+	reportMetric(
+		func() {
+			program, err = old_parser.ParseProgram(e, oldCode, old_parser.Config{})
+		},
+		e.runtimeInterface,
+		func(metrics Metrics, duration time.Duration) {
+			metrics.ProgramParsed(location, duration)
+		},
+	)
+	if err != nil {
+		return nil, nil
+	}
+
+	// Recover elaboration from the old program
+
+	var newCode []byte
+	errors.WrapPanic(func() {
+		newCode, err = e.runtimeInterface.RecoverProgram(program, location)
+	})
+	if err != nil || newCode == nil {
+		return nil, nil
+	}
+
+	// Parse and check the recovered program
+
+	program, err = parser.ParseProgram(e, newCode, parser.Config{})
+	if err != nil {
+		return nil, nil
+	}
+
+	elaboration, err = e.check(location, program, checkedImports)
+	if err != nil || elaboration == nil {
+		return nil, nil
+	}
+
+	e.codesAndPrograms.setCode(location, newCode)
+
+	return program, elaboration
+}
+
+func (e *checkingEnvironment) temporarilyRecordCode(location common.AddressLocation, code []byte) {
+	e.codesAndPrograms.setCode(location, code)
 }

--- a/runtime/code.go
+++ b/runtime/code.go
@@ -1,0 +1,47 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/interpreter"
+)
+
+func getLocationCodeFromInterface(
+	i Interface,
+	location common.Location,
+) (
+	code []byte,
+	err error,
+) {
+	if addressLocation, ok := location.(common.AddressLocation); ok {
+		errors.WrapPanic(func() {
+			code, err = i.GetAccountContractCode(addressLocation)
+		})
+	} else {
+		errors.WrapPanic(func() {
+			code, err = i.GetCode(location)
+		})
+	}
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}

--- a/runtime/contract.go
+++ b/runtime/contract.go
@@ -1,0 +1,61 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/interpreter"
+	"github.com/onflow/cadence/sema"
+)
+
+type contractLoader interface {
+	interpreter.StorageMutationTracker
+	common.MemoryGauge
+}
+
+func loadContractValue(
+	loader contractLoader,
+	compositeType *sema.CompositeType,
+	storage *Storage,
+) *interpreter.CompositeValue {
+	var contractValue interpreter.Value
+
+	location := compositeType.Location
+	if addressLocation, ok := location.(common.AddressLocation); ok {
+		storageMap := storage.GetDomainStorageMap(
+			loader,
+			addressLocation.Address,
+			common.StorageDomainContract,
+			false,
+		)
+		if storageMap != nil {
+			contractValue = storageMap.ReadValue(
+				loader,
+				interpreter.StringStorageMapKey(addressLocation.Name),
+			)
+		}
+	}
+
+	if contractValue == nil {
+		panic(errors.NewDefaultUserError("failed to load contract: %s", location))
+	}
+
+	return contractValue.(*interpreter.CompositeValue)
+}

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -220,7 +220,7 @@ func (executor *interpreterContractFunctionExecutor) execute() (val cadence.Valu
 	}
 
 	// Write back all stored values, which were actually just cached, back into storage
-	err = environment.CommitStorage(inter)
+	err = environment.commitStorage(inter)
 	if err != nil {
 		return nil, newError(err, location, codesAndPrograms)
 	}

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -148,7 +148,7 @@ func (executor *interpreterContractFunctionExecutor) execute() (val cadence.Valu
 	)
 
 	// create interpreter
-	_, inter, err := environment.Interpret(
+	_, inter, err := environment.interpret(
 		location,
 		nil,
 		nil,
@@ -253,7 +253,7 @@ func (executor *interpreterContractFunctionExecutor) convertArgument(
 
 			address := interpreter.NewAddressValue(inter, common.Address(addressValue))
 
-			accountValue := environment.NewAccountValue(inter, address)
+			accountValue := environment.newAccountValue(inter, address)
 
 			authorization := interpreter.ConvertSemaAccessToStaticAuthorization(
 				inter,

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -856,12 +856,7 @@ func (e *interpreterEnvironment) newContractValueHandler() interpreter.ContractV
 			}
 		}
 
-		return e.loadContract(
-			inter,
-			compositeType,
-			constructorGenerator,
-			invocationRange,
-		)
+		return loadContractValue(inter, compositeType, e.storage)
 	}
 }
 
@@ -945,38 +940,6 @@ func (e *interpreterEnvironment) newCompositeValueFunctionsHandler() interpreter
 
 		return handler(inter, locationRange, compositeValue)
 	}
-}
-
-func (e *interpreterEnvironment) loadContract(
-	inter *interpreter.Interpreter,
-	compositeType *sema.CompositeType,
-	_ func(common.Address) *interpreter.HostFunctionValue,
-	_ ast.Range,
-) *interpreter.CompositeValue {
-
-	var contractValue interpreter.Value
-
-	location := compositeType.Location
-	if addressLocation, ok := location.(common.AddressLocation); ok {
-		storageMap := e.storage.GetDomainStorageMap(
-			inter,
-			addressLocation.Address,
-			common.StorageDomainContract,
-			false,
-		)
-		if storageMap != nil {
-			contractValue = storageMap.ReadValue(
-				inter,
-				interpreter.StringStorageMapKey(addressLocation.Name),
-			)
-		}
-	}
-
-	if contractValue == nil {
-		panic(errors.NewDefaultUserError("failed to load contract: %s", location))
-	}
-
-	return contractValue.(*interpreter.CompositeValue)
 }
 
 func (e *interpreterEnvironment) newOnFunctionInvocationHandler() func(_ *interpreter.Interpreter) {

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -72,7 +72,7 @@ type Environment interface {
 		*interpreter.Interpreter,
 		error,
 	)
-	CommitStorage(inter *interpreter.Interpreter) error
+	commitStorage(context interpreter.ValueTransferContext) error
 	NewAccountValue(context interpreter.AccountCreationContext, address interpreter.AddressValue) interpreter.Value
 
 	ResolveLocation(identifiers []ast.Identifier, location common.Location) ([]ResolvedLocation, error)
@@ -184,7 +184,7 @@ func (e *interpreterEnvironment) NewInterpreterConfig() *interpreter.Config {
 		// NOTE: ignore e.config.AtreeValidationEnabled here,
 		// and disable storage validation after each value modification.
 		// Instead, storage is validated after commits (if validation is enabled),
-		// see interpreterEnvironment.CommitStorage
+		// see interpreterEnvironment.commitStorage
 		AtreeStorageValidationEnabled:             false,
 		Debugger:                                  e.config.Debugger,
 		OnStatement:                               e.newOnStatementHandler(),
@@ -1137,9 +1137,9 @@ func (e *interpreterEnvironment) newResourceOwnerChangedHandler() interpreter.On
 	return newResourceOwnerChangedHandler(&e.runtimeInterface)
 }
 
-func (e *interpreterEnvironment) CommitStorage(inter *interpreter.Interpreter) error {
+func (e *interpreterEnvironment) commitStorage(context interpreter.ValueTransferContext) error {
 	const commitContractUpdates = true
-	err := e.storage.Commit(inter, commitContractUpdates)
+	err := e.storage.Commit(context, commitContractUpdates)
 	if err != nil {
 		return err
 	}

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -61,7 +61,7 @@ type Environment interface {
 		*interpreter.Program,
 		error,
 	)
-	Interpret(
+	interpret(
 		location common.Location,
 		program *interpreter.Program,
 		f InterpretFunc,
@@ -71,7 +71,7 @@ type Environment interface {
 		error,
 	)
 	commitStorage(context interpreter.ValueTransferContext) error
-	NewAccountValue(context interpreter.AccountCreationContext, address interpreter.AddressValue) interpreter.Value
+	newAccountValue(context interpreter.AccountCreationContext, address interpreter.AddressValue) interpreter.Value
 }
 
 // interpreterEnvironmentReconfigured is the portion of interpreterEnvironment
@@ -147,7 +147,7 @@ func (e *interpreterEnvironment) NewInterpreterConfig() *interpreter.Config {
 		UUIDHandler:                    newUUIDHandler(&e.runtimeInterface),
 		ContractValueHandler:           e.newContractValueHandler(),
 		ImportLocationHandler:          e.newImportLocationHandler(),
-		AccountHandler:                 e.NewAccountValue,
+		AccountHandler:                 e.newAccountValue,
 		OnRecordTrace:                  newOnRecordTraceHandler(&e.runtimeInterface),
 		OnResourceOwnerChange:          e.newResourceOwnerChangedHandler(),
 		CompositeTypeHandler:           e.newCompositeTypeHandler(),
@@ -452,7 +452,7 @@ func (e *interpreterEnvironment) newOnStatementHandler() interpreter.OnStatement
 	}
 }
 
-func (e *interpreterEnvironment) NewAccountValue(
+func (e *interpreterEnvironment) newAccountValue(
 	context interpreter.AccountCreationContext,
 	address interpreter.AddressValue,
 ) interpreter.Value {
@@ -630,7 +630,7 @@ func (e *interpreterEnvironment) InterpretContract(
 		e.deployedContractConstructorInvocation = nil
 	}()
 
-	_, inter, err := e.Interpret(location, program, nil)
+	_, inter, err := e.interpret(location, program, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -648,7 +648,7 @@ func (e *interpreterEnvironment) InterpretContract(
 	return
 }
 
-func (e *interpreterEnvironment) Interpret(
+func (e *interpreterEnvironment) interpret(
 	location common.Location,
 	program *interpreter.Program,
 	f InterpretFunc,

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -72,8 +72,6 @@ type Environment interface {
 	)
 	commitStorage(context interpreter.ValueTransferContext) error
 	NewAccountValue(context interpreter.AccountCreationContext, address interpreter.AddressValue) interpreter.Value
-
-	ResolveLocation(identifiers []ast.Identifier, location common.Location) ([]ResolvedLocation, error)
 }
 
 // interpreterEnvironmentReconfigured is the portion of interpreterEnvironment

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -700,7 +700,7 @@ func (e *interpreterEnvironment) GetProgram(
 	return e.getProgram(
 		location,
 		func() ([]byte, error) {
-			return e.getCode(location)
+			return getLocationCodeFromInterface(e.runtimeInterface, location)
 		},
 		storeProgram,
 		checkedImports,
@@ -767,24 +767,6 @@ func (e *interpreterEnvironment) getProgram(
 			return
 		})
 	})
-
-	return
-}
-
-func (e *interpreterEnvironment) getCode(location common.Location) (code []byte, err error) {
-	if addressLocation, ok := location.(common.AddressLocation); ok {
-		errors.WrapPanic(func() {
-			code, err = e.runtimeInterface.GetAccountContractCode(addressLocation)
-		})
-	} else {
-		errors.WrapPanic(func() {
-			code, err = e.runtimeInterface.GetCode(location)
-		})
-	}
-
-	if err != nil {
-		err = interpreter.WrappedExternalError(err)
-	}
 
 	return
 }

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -650,13 +650,11 @@ func (e *interpreterEnvironment) ResolveLocation(
 	res []ResolvedLocation,
 	err error,
 ) {
-	errors.WrapPanic(func() {
-		res, err = e.runtimeInterface.ResolveLocation(identifiers, location)
-	})
-	if err != nil {
-		err = interpreter.WrappedExternalError(err)
-	}
-	return
+	return ResolveLocationWithInterface(
+		e.runtimeInterface,
+		identifiers,
+		location,
+	)
 }
 
 func (e *interpreterEnvironment) resolveImport(

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -1136,20 +1136,8 @@ func (e *interpreterEnvironment) newResourceOwnerChangedHandler() interpreter.On
 }
 
 func (e *interpreterEnvironment) commitStorage(context interpreter.ValueTransferContext) error {
-	const commitContractUpdates = true
-	err := e.storage.Commit(context, commitContractUpdates)
-	if err != nil {
-		return err
-	}
-
-	if e.config.AtreeValidationEnabled {
-		err = e.storage.CheckHealth()
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	checkStorageHealth := e.config.AtreeValidationEnabled
+	return CommitStorage(context, e.storage, checkStorageHealth)
 }
 
 // getBaseValueActivation returns the base activation for the given location.

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -148,7 +148,7 @@ func (e *interpreterEnvironment) NewInterpreterConfig() *interpreter.Config {
 	return &interpreter.Config{
 		MemoryGauge:                    e,
 		BaseActivationHandler:          e.getBaseActivation,
-		OnEventEmitted:                 e.newOnEventEmittedHandler(),
+		OnEventEmitted:                 newOnEventEmittedHandler(&e.runtimeInterface),
 		InjectedCompositeFieldsHandler: newInjectedCompositeFieldsHandler(e),
 		UUIDHandler:                    newUUIDHandler(&e.runtimeInterface),
 		ContractValueHandler:           e.newContractValueHandler(),
@@ -857,25 +857,6 @@ func (e *interpreterEnvironment) newContractValueHandler() interpreter.ContractV
 		}
 
 		return loadContractValue(inter, compositeType, e.storage)
-	}
-}
-
-func (e *interpreterEnvironment) newOnEventEmittedHandler() interpreter.OnEventEmittedFunc {
-	return func(
-		inter *interpreter.Interpreter,
-		locationRange interpreter.LocationRange,
-		eventValue *interpreter.CompositeValue,
-		eventType *sema.CompositeType,
-	) error {
-		emitEventValue(
-			inter,
-			locationRange,
-			eventType,
-			eventValue,
-			e.runtimeInterface.EmitEvent,
-		)
-
-		return nil
 	}
 }
 

--- a/runtime/handlers.go
+++ b/runtime/handlers.go
@@ -254,3 +254,22 @@ func newOnMeterComputation(i *Interface) interpreter.OnMeterComputationFunc {
 		}
 	}
 }
+
+func newOnEventEmittedHandler(i *Interface) interpreter.OnEventEmittedFunc {
+	return func(
+		inter *interpreter.Interpreter,
+		locationRange interpreter.LocationRange,
+		eventValue *interpreter.CompositeValue,
+		eventType *sema.CompositeType,
+	) error {
+		emitEventValue(
+			inter,
+			locationRange,
+			eventType,
+			eventValue,
+			(*i).EmitEvent,
+		)
+
+		return nil
+	}
+}

--- a/runtime/handlers.go
+++ b/runtime/handlers.go
@@ -1,3 +1,21 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package runtime
 
 import (

--- a/runtime/handlers.go
+++ b/runtime/handlers.go
@@ -1,0 +1,238 @@
+package runtime
+
+import (
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/interpreter"
+	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/stdlib"
+)
+
+func newCheckHandler(i *Interface) sema.CheckHandlerFunc {
+	return func(checker *sema.Checker, check func()) {
+		reportMetric(
+			check,
+			*i,
+			func(metrics Metrics, duration time.Duration) {
+				metrics.ProgramChecked(checker.Location, duration)
+			},
+		)
+	}
+}
+
+func newCapabilityBorrowHandler(handler stdlib.CapabilityControllerHandler) interpreter.CapabilityBorrowHandlerFunc {
+
+	return func(
+		context interpreter.BorrowCapabilityControllerContext,
+		locationRange interpreter.LocationRange,
+		address interpreter.AddressValue,
+		capabilityID interpreter.UInt64Value,
+		wantedBorrowType *sema.ReferenceType,
+		capabilityBorrowType *sema.ReferenceType,
+	) interpreter.ReferenceValue {
+
+		return stdlib.BorrowCapabilityController(
+			context,
+			locationRange,
+			address,
+			capabilityID,
+			wantedBorrowType,
+			capabilityBorrowType,
+			handler,
+		)
+	}
+}
+
+func newCapabilityCheckHandler(handler stdlib.CapabilityControllerHandler) interpreter.CapabilityCheckHandlerFunc {
+	return func(
+		context interpreter.CheckCapabilityControllerContext,
+		locationRange interpreter.LocationRange,
+		address interpreter.AddressValue,
+		capabilityID interpreter.UInt64Value,
+		wantedBorrowType *sema.ReferenceType,
+		capabilityBorrowType *sema.ReferenceType,
+	) interpreter.BoolValue {
+
+		return stdlib.CheckCapabilityController(
+			context,
+			locationRange,
+			address,
+			capabilityID,
+			wantedBorrowType,
+			capabilityBorrowType,
+			handler,
+		)
+	}
+}
+
+func newValidateAccountCapabilitiesGetHandler(i *Interface) interpreter.ValidateAccountCapabilitiesGetHandlerFunc {
+	return func(
+		context interpreter.AccountCapabilityGetValidationContext,
+		locationRange interpreter.LocationRange,
+		address interpreter.AddressValue,
+		path interpreter.PathValue,
+		wantedBorrowType *sema.ReferenceType,
+		capabilityBorrowType *sema.ReferenceType,
+	) (bool, error) {
+		var (
+			ok  bool
+			err error
+		)
+		errors.WrapPanic(func() {
+			ok, err = (*i).ValidateAccountCapabilitiesGet(
+				context,
+				locationRange,
+				address,
+				path,
+				wantedBorrowType,
+				capabilityBorrowType,
+			)
+		})
+		if err != nil {
+			err = interpreter.WrappedExternalError(err)
+		}
+		return ok, err
+	}
+}
+
+func newValidateAccountCapabilitiesPublishHandler(i *Interface) interpreter.ValidateAccountCapabilitiesPublishHandlerFunc {
+	return func(
+		context interpreter.AccountCapabilityPublishValidationContext,
+		locationRange interpreter.LocationRange,
+		address interpreter.AddressValue,
+		path interpreter.PathValue,
+		capabilityBorrowType *interpreter.ReferenceStaticType,
+	) (bool, error) {
+		var (
+			ok  bool
+			err error
+		)
+		errors.WrapPanic(func() {
+			ok, err = (*i).ValidateAccountCapabilitiesPublish(
+				context,
+				locationRange,
+				address,
+				path,
+				capabilityBorrowType,
+			)
+		})
+		if err != nil {
+			err = interpreter.WrappedExternalError(err)
+		}
+		return ok, err
+	}
+}
+
+func configureVersionedFeatures(i Interface) {
+	var (
+		minimumRequiredVersion string
+		err                    error
+	)
+	errors.WrapPanic(func() {
+		minimumRequiredVersion, err = i.MinimumRequiredVersion()
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// No feature flags yet
+	_ = minimumRequiredVersion
+}
+
+func newOnRecordTraceHandler(i *Interface) interpreter.OnRecordTraceFunc {
+	return func(
+		interpreter *interpreter.Interpreter,
+		functionName string,
+		duration time.Duration,
+		attrs []attribute.KeyValue,
+	) {
+		errors.WrapPanic(func() {
+			(*i).RecordTrace(functionName, interpreter.Location, duration, attrs)
+		})
+	}
+}
+
+func newUUIDHandler(i *Interface) interpreter.UUIDHandlerFunc {
+	return func() (uuid uint64, err error) {
+		errors.WrapPanic(func() {
+			uuid, err = (*i).GenerateUUID()
+		})
+		if err != nil {
+			err = interpreter.WrappedExternalError(err)
+		}
+		return
+	}
+}
+
+func newInjectedCompositeFieldsHandler(accountHandler stdlib.AccountHandler) interpreter.InjectedCompositeFieldsHandlerFunc {
+	return func(
+		context interpreter.AccountCreationContext,
+		location Location,
+		_ string,
+		compositeKind common.CompositeKind,
+	) map[string]interpreter.Value {
+
+		switch compositeKind {
+		case common.CompositeKindContract:
+			var address Address
+
+			switch location := location.(type) {
+			case common.AddressLocation:
+				address = location.Address
+			default:
+				return nil
+			}
+
+			addressValue := interpreter.NewAddressValue(
+				context,
+				address,
+			)
+
+			return map[string]interpreter.Value{
+				sema.ContractAccountFieldName: stdlib.NewAccountReferenceValue(
+					context,
+					accountHandler,
+					addressValue,
+					interpreter.FullyEntitledAccountAccess,
+					interpreter.EmptyLocationRange,
+				),
+			}
+		}
+
+		return nil
+	}
+}
+
+func newResourceOwnerChangedHandler(i *Interface) interpreter.OnResourceOwnerChangeFunc {
+	return func(
+		interpreter *interpreter.Interpreter,
+		resource *interpreter.CompositeValue,
+		oldOwner common.Address,
+		newOwner common.Address,
+	) {
+		errors.WrapPanic(func() {
+			(*i).ResourceOwnerChanged(
+				interpreter,
+				resource,
+				oldOwner,
+				newOwner,
+			)
+		})
+	}
+}
+
+func newOnMeterComputation(i *Interface) interpreter.OnMeterComputationFunc {
+	return func(compKind common.ComputationKind, intensity uint) {
+		var err error
+		errors.WrapPanic(func() {
+			err = (*i).MeterComputation(compKind, intensity)
+		})
+		if err != nil {
+			panic(interpreter.WrappedExternalError(err))
+		}
+	}
+}

--- a/runtime/location.go
+++ b/runtime/location.go
@@ -1,0 +1,41 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/interpreter"
+)
+
+func ResolveLocationWithInterface(
+	i Interface,
+	identifiers []Identifier,
+	location Location,
+) (
+	res []ResolvedLocation,
+	err error,
+) {
+	errors.WrapPanic(func() {
+		res, err = i.ResolveLocation(identifiers, location)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -355,9 +355,13 @@ func UserPanicToError(f func()) (returnedError error) {
 	return nil
 }
 
+type LocationResolver interface {
+	ResolveLocation(identifiers []ast.Identifier, location common.Location) ([]ResolvedLocation, error)
+}
+
 type ArgumentDecoder interface {
 	stdlib.StandardLibraryHandler
-	ResolveLocation(identifiers []ast.Identifier, location common.Location) ([]ResolvedLocation, error)
+	LocationResolver
 
 	// DecodeArgument decodes a transaction/script argument against the given type.
 	DecodeArgument(argument []byte, argumentType cadence.Type) (cadence.Value, error)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -582,7 +582,7 @@ func (r *interpreterRuntime) Storage(context Context) (*Storage, *interpreter.In
 		context.CoverageReport,
 	)
 
-	_, inter, err := environment.Interpret(
+	_, inter, err := environment.interpret(
 		location,
 		nil,
 		nil,

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -189,7 +189,7 @@ func (executor *interpreterScriptExecutor) execute() (val cadence.Value, err err
 		codesAndPrograms,
 	)
 
-	value, inter, err := environment.Interpret(
+	value, inter, err := environment.interpret(
 		location,
 		executor.program,
 		executor.interpret,

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -214,7 +214,7 @@ func (executor *interpreterScriptExecutor) execute() (val cadence.Value, err err
 	// Even though this function is `ExecuteScript`, that doesn't imply the changes
 	// to storage will be actually persisted
 
-	err = environment.CommitStorage(inter)
+	err = environment.commitStorage(inter)
 	if err != nil {
 		return nil, newError(err, location, codesAndPrograms)
 	}

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -586,3 +586,20 @@ func (e AccountStorageFormatV1Error) Error() string {
 		e.Address.HexWithPrefix(),
 	)
 }
+
+func CommitStorage(context interpreter.ValueTransferContext, storage *Storage, checkStorageHealth bool) error {
+	const commitContractUpdates = true
+	err := storage.Commit(context, commitContractUpdates)
+	if err != nil {
+		return err
+	}
+
+	if checkStorageHealth {
+		err = storage.CheckHealth()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -210,7 +210,7 @@ func (executor *interpreterTransactionExecutor) authorizerValues(
 
 		addressValue := interpreter.NewAddressValue(inter, address)
 
-		accountValue := executor.environment.NewAccountValue(inter, addressValue)
+		accountValue := executor.environment.newAccountValue(inter, addressValue)
 
 		referenceType, ok := parameter.TypeAnnotation.Type.(*sema.ReferenceType)
 		if !ok || referenceType.Type != sema.AccountType {
@@ -257,7 +257,7 @@ func (executor *interpreterTransactionExecutor) execute() (err error) {
 		codesAndPrograms,
 	)
 
-	_, inter, err := environment.Interpret(
+	_, inter, err := environment.interpret(
 		location,
 		executor.program,
 		executor.interpret,

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -267,7 +267,7 @@ func (executor *interpreterTransactionExecutor) execute() (err error) {
 	}
 
 	// Write back all stored values, which were actually just cached, back into storage
-	err = environment.CommitStorage(inter)
+	err = environment.commitStorage(inter)
 	if err != nil {
 		return newError(err, location, codesAndPrograms)
 	}


### PR DESCRIPTION
Work towards #3849 

## Description

We plan to add a new implementation of `runtime.Environment` which uses the compiler/VM.

Prepare for this work by refactoring the existing interpreter-based implementation, `interpreterEnvironment`, by refactoring code which will be needed in / can be shared with the VM-based environment, and refactoring out all parsing, checking, and program loading related code out of the interpreter environment.

No actual logic was changed, all code was moved. This PR is best viewed commit by commit.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
