### PR TITLE
Refactor interpreter environment – Part 2

### DIFF
--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -73,19 +73,10 @@ type Environment interface {
 	newAccountValue(context interpreter.AccountCreationContext, address interpreter.AddressValue) interpreter.Value
 }
 
-// TODO: improve naming
-type interfaceImpl struct {
-	Interface
-}
-
-func (i interfaceImpl) ProgramLog(message string, _ interpreter.LocationRange) error {
-	return i.Interface.ProgramLog(message)
-}
-
 // interpreterEnvironmentReconfigured is the portion of interpreterEnvironment
 // that gets reconfigured by interpreterEnvironment.Configure
 type interpreterEnvironmentReconfigured struct {
-	interfaceImpl
+	Interface
 	storage        *Storage
 	coverageReport *CoverageReport
 }
@@ -586,4 +577,8 @@ func (e *interpreterEnvironment) getBaseActivation(
 		baseActivation = e.defaultBaseActivation
 	}
 	return
+}
+
+func (e *interpreterEnvironment) ProgramLog(message string, _ interpreter.LocationRange) error {
+	return e.Interface.ProgramLog(message)
 }

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -1404,9 +1404,49 @@ func newAccountContractsBorrowFunction(
 	}
 }
 
+type ContractAdditionTracker interface {
+	// StartContractAddition starts adding a contract.
+	StartContractAddition(location common.AddressLocation)
+
+	// EndContractAddition ends adding the contract
+	EndContractAddition(location common.AddressLocation)
+
+	// IsContractBeingAdded checks whether a contract is being added in the current execution.
+	IsContractBeingAdded(location common.AddressLocation) bool
+}
+
+type SimpleContractAdditionTracker struct {
+	deployedContracts map[common.AddressLocation]struct{}
+}
+
+func NewSimpleContractAdditionTracker() *SimpleContractAdditionTracker {
+	return &SimpleContractAdditionTracker{}
+}
+
+var _ ContractAdditionTracker = &SimpleContractAdditionTracker{}
+
+func (t *SimpleContractAdditionTracker) StartContractAddition(location common.AddressLocation) {
+	if t.deployedContracts == nil {
+		t.deployedContracts = map[common.AddressLocation]struct{}{}
+	}
+
+	t.deployedContracts[location] = struct{}{}
+}
+
+func (t *SimpleContractAdditionTracker) EndContractAddition(location common.AddressLocation) {
+	delete(t.deployedContracts, location)
+}
+
+func (t *SimpleContractAdditionTracker) IsContractBeingAdded(location common.AddressLocation) bool {
+	_, contains := t.deployedContracts[location]
+	return contains
+}
+
 type AccountContractAdditionHandler interface {
 	EventEmitter
 	AccountContractProvider
+	ContractAdditionTracker
+
 	ParseAndCheckProgram(
 		code []byte,
 		location common.Location,
@@ -1429,15 +1469,6 @@ type AccountContractAdditionHandler interface {
 		error,
 	)
 	TemporarilyRecordCode(location common.AddressLocation, code []byte)
-
-	// StartContractAddition starts adding a contract.
-	StartContractAddition(location common.AddressLocation)
-
-	// EndContractAddition ends adding the contract
-	EndContractAddition(location common.AddressLocation)
-
-	// IsContractBeingAdded checks whether a contract is being added in the current execution.
-	IsContractBeingAdded(location common.AddressLocation) bool
 }
 
 // newAccountContractsChangeFunction called when e.g.


### PR DESCRIPTION
Work towards #3849 

## Description

Simplify the interpreter environment a bit more by removing all methods forwarding to the environment's current interface and instead just embedding the interface in the environment, so this is done automatically.

Also, refactor the contract addition tracking out of the environment and provide a new simple stand-alone implementation of it.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
