### PR TITLE
[Compiler] Separate methods from fields for `SimpleCompositeValue`

### DIFF
--- a/interpreter/composite_value_test.go
+++ b/interpreter/composite_value_test.go
@@ -119,6 +119,7 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 		},
 		nil,
 		nil,
+		nil,
 	)
 
 	valueDeclaration := stdlib.StandardLibraryValue{

--- a/interpreter/interpreter_transaction.go
+++ b/interpreter/interpreter_transaction.go
@@ -63,6 +63,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	self.isTransaction = true

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -29,10 +29,11 @@ import (
 // SimpleCompositeValue
 
 type SimpleCompositeValue struct {
-	staticType      StaticType
-	Fields          map[string]Value
-	ComputeField    func(name string, context MemberAccessibleContext, locationRange LocationRange) Value
-	fieldFormatters map[string]func(common.MemoryGauge, Value, SeenReferences) string
+	staticType           StaticType
+	Fields               map[string]Value
+	ComputeField         func(name string, context MemberAccessibleContext, locationRange LocationRange) Value
+	FunctionMemberGetter func(name string, context MemberAccessibleContext) FunctionValue
+	fieldFormatters      map[string]func(common.MemoryGauge, Value, SeenReferences) string
 	// stringer is an optional function that is used to produce the string representation of the value.
 	// If nil, the FieldNames are used.
 	stringer func(ValueStringContext, SeenReferences, LocationRange) string
@@ -60,6 +61,7 @@ func NewSimpleCompositeValue(
 	fieldNames []string,
 	fields map[string]Value,
 	computeField func(name string, context MemberAccessibleContext, locationRange LocationRange) Value,
+	functionMemberGetter func(name string, context MemberAccessibleContext) FunctionValue,
 	fieldFormatters map[string]func(common.MemoryGauge, Value, SeenReferences) string,
 	stringer func(ValueStringContext, SeenReferences, LocationRange) string,
 ) *SimpleCompositeValue {
@@ -68,13 +70,14 @@ func NewSimpleCompositeValue(
 	common.UseMemory(gauge, common.NewSimpleCompositeMemoryUsage(len(fields)))
 
 	return &SimpleCompositeValue{
-		TypeID:          typeID,
-		staticType:      staticType,
-		FieldNames:      fieldNames,
-		Fields:          fields,
-		ComputeField:    computeField,
-		fieldFormatters: fieldFormatters,
-		stringer:        stringer,
+		TypeID:               typeID,
+		staticType:           staticType,
+		FieldNames:           fieldNames,
+		Fields:               fields,
+		ComputeField:         computeField,
+		FunctionMemberGetter: functionMemberGetter,
+		fieldFormatters:      fieldFormatters,
+		stringer:             stringer,
 	}
 }
 
@@ -137,7 +140,6 @@ func (v *SimpleCompositeValue) IsImportable(context ValueImportableContext, loca
 }
 
 func (v *SimpleCompositeValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-
 	value, ok := v.Fields[name]
 	if ok {
 		return value
@@ -145,10 +147,13 @@ func (v *SimpleCompositeValue) GetMember(context MemberAccessibleContext, locati
 
 	computeField := v.ComputeField
 	if computeField != nil {
-		return computeField(name, context, locationRange)
+		value = computeField(name, context, locationRange)
+		if value != nil {
+			return value
+		}
 	}
 
-	return nil
+	return context.GetMethod(v, name, locationRange)
 }
 
 func (v *SimpleCompositeValue) GetMethod(
@@ -156,8 +161,11 @@ func (v *SimpleCompositeValue) GetMethod(
 	locationRange LocationRange,
 	name string,
 ) FunctionValue {
-	// TODO:
-	return nil
+	if v.FunctionMemberGetter == nil {
+		return nil
+	}
+
+	return v.FunctionMemberGetter(name, context)
 }
 
 func (v *SimpleCompositeValue) RemoveMember(_ ValueTransferContext, _ LocationRange, name string) Value {

--- a/interpreter/value_account.go
+++ b/interpreter/value_account.go
@@ -109,8 +109,10 @@ func NewAccountValue(
 		accountTypeID,
 		accountStaticType,
 		accountFieldNames,
+		// Only fields, no methods
 		fields,
 		computeField,
+		nil,
 		nil,
 		stringer,
 	)

--- a/interpreter/value_account_accountcapabilities.go
+++ b/interpreter/value_account_accountcapabilities.go
@@ -43,9 +43,9 @@ func NewAccountAccountCapabilitiesValue(
 
 	var accountCapabilities *SimpleCompositeValue
 
-	fields := map[string]Value{}
+	methods := map[string]FunctionValue{}
 
-	computeLazyStoredField := func(name string) Value {
+	computeLazyStoredMethod := func(name string) FunctionValue {
 		switch name {
 		case sema.Account_AccountCapabilitiesTypeGetControllerFunctionName:
 			return getControllerFunction(accountCapabilities)
@@ -62,12 +62,16 @@ func NewAccountAccountCapabilitiesValue(
 		return nil
 	}
 
-	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
-		field := computeLazyStoredField(name)
-		if field != nil {
-			fields[name] = field
+	methodGetter := func(name string, _ MemberAccessibleContext) FunctionValue {
+		method, ok := methods[name]
+		if !ok {
+			method = computeLazyStoredMethod(name)
+			if method != nil {
+				methods[name] = method
+			}
 		}
-		return field
+
+		return method
 	}
 
 	var str string
@@ -85,8 +89,10 @@ func NewAccountAccountCapabilitiesValue(
 		account_AccountCapabilitiesTypeID,
 		account_AccountCapabilitiesStaticType,
 		account_AccountCapabilitiesFieldNames,
-		fields,
-		computeField,
+		// No fields, only methods.
+		nil,
+		nil,
+		methodGetter,
 		nil,
 		stringer,
 	).WithPrivateField(AccountTypePrivateAddressFieldName, address)

--- a/interpreter/value_account_capabilities.go
+++ b/interpreter/value_account_capabilities.go
@@ -56,6 +56,23 @@ func NewAccountCapabilitiesValue(
 			return storageCapabilitiesConstructor()
 		case sema.Account_CapabilitiesTypeAccountFieldName:
 			return accountCapabilitiesConstructor()
+		}
+
+		return nil
+	}
+
+	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
+		field := computeLazyStoredField(name)
+		if field != nil {
+			fields[name] = field
+		}
+		return field
+	}
+
+	methods := map[string]FunctionValue{}
+
+	computeLazyStoredMethod := func(name string) FunctionValue {
+		switch name {
 		case sema.Account_CapabilitiesTypeGetFunctionName:
 			return getFunction(capabilities)
 		case sema.Account_CapabilitiesTypeBorrowFunctionName:
@@ -71,12 +88,16 @@ func NewAccountCapabilitiesValue(
 		return nil
 	}
 
-	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
-		field := computeLazyStoredField(name)
-		if field != nil {
-			fields[name] = field
+	methodGetter := func(name string, _ MemberAccessibleContext) FunctionValue {
+		method, ok := methods[name]
+		if !ok {
+			method = computeLazyStoredMethod(name)
+			if method != nil {
+				methods[name] = method
+			}
 		}
-		return field
+
+		return method
 	}
 
 	var str string
@@ -96,6 +117,7 @@ func NewAccountCapabilitiesValue(
 		account_CapabilitiesFieldNames,
 		fields,
 		computeField,
+		methodGetter,
 		nil,
 		stringer,
 	).WithPrivateField(AccountTypePrivateAddressFieldName, address)

--- a/interpreter/value_account_contracts.go
+++ b/interpreter/value_account_contracts.go
@@ -47,9 +47,9 @@ func NewAccountContractsValue(
 
 	var accountContracts *SimpleCompositeValue
 
-	fields := map[string]Value{}
+	methods := map[string]FunctionValue{}
 
-	computeLazyStoredField := func(name string) Value {
+	computeLazyStoredMethod := func(name string) FunctionValue {
 		switch name {
 		case sema.Account_ContractsTypeAddFunctionName:
 			return addFunction(accountContracts)
@@ -74,11 +74,19 @@ func NewAccountContractsValue(
 			return namesGetter(context, locationRange)
 		}
 
-		field := computeLazyStoredField(name)
-		if field != nil {
-			fields[name] = field
+		return nil
+	}
+
+	methodGetter := func(name string, _ MemberAccessibleContext) FunctionValue {
+		method, ok := methods[name]
+		if !ok {
+			method = computeLazyStoredMethod(name)
+			if method != nil {
+				methods[name] = method
+			}
 		}
-		return field
+
+		return method
 	}
 
 	var str string
@@ -96,8 +104,10 @@ func NewAccountContractsValue(
 		account_ContractsTypeID,
 		account_ContractsStaticType,
 		account_ContractsFieldNames,
-		fields,
+		// No fields, only computed fields, and methods.
+		nil,
 		computeField,
+		methodGetter,
 		nil,
 		stringer,
 	)

--- a/interpreter/value_account_inbox.go
+++ b/interpreter/value_account_inbox.go
@@ -42,9 +42,9 @@ func NewAccountInboxValue(
 
 	var accountInbox *SimpleCompositeValue
 
-	fields := map[string]Value{}
+	methods := map[string]FunctionValue{}
 
-	computeLazyStoredField := func(name string) Value {
+	computeLazyStoredMethod := func(name string) FunctionValue {
 		switch name {
 		case sema.Account_InboxTypePublishFunctionName:
 			return publishFunction(accountInbox)
@@ -57,12 +57,16 @@ func NewAccountInboxValue(
 		return nil
 	}
 
-	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
-		field := computeLazyStoredField(name)
-		if field != nil {
-			fields[name] = field
+	methodGetter := func(name string, _ MemberAccessibleContext) FunctionValue {
+		method, ok := methods[name]
+		if !ok {
+			method = computeLazyStoredMethod(name)
+			if method != nil {
+				methods[name] = method
+			}
 		}
-		return field
+
+		return method
 	}
 
 	var str string
@@ -80,8 +84,10 @@ func NewAccountInboxValue(
 		account_InboxTypeID,
 		account_InboxStaticType,
 		account_InboxFieldNames,
-		fields,
-		computeField,
+		// No fields, only methods.
+		nil,
+		nil,
+		methodGetter,
 		nil,
 		stringer,
 	)

--- a/interpreter/value_account_storagecapabilities.go
+++ b/interpreter/value_account_storagecapabilities.go
@@ -43,9 +43,9 @@ func NewAccountStorageCapabilitiesValue(
 
 	var storageCapabilities *SimpleCompositeValue
 
-	fields := map[string]Value{}
+	methods := map[string]FunctionValue{}
 
-	computeLazyStoredField := func(name string) Value {
+	computeLazyStoredMethod := func(name string) FunctionValue {
 		switch name {
 		case sema.Account_StorageCapabilitiesTypeGetControllerFunctionName:
 			return getControllerFunction(storageCapabilities)
@@ -62,12 +62,16 @@ func NewAccountStorageCapabilitiesValue(
 		return nil
 	}
 
-	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
-		field := computeLazyStoredField(name)
-		if field != nil {
-			fields[name] = field
+	methodsGetter := func(name string, _ MemberAccessibleContext) FunctionValue {
+		method, ok := methods[name]
+		if !ok {
+			method = computeLazyStoredMethod(name)
+			if method != nil {
+				methods[name] = method
+			}
 		}
-		return field
+
+		return method
 	}
 
 	var str string
@@ -85,8 +89,10 @@ func NewAccountStorageCapabilitiesValue(
 		account_StorageCapabilitiesTypeID,
 		account_StorageCapabilitiesStaticType,
 		account_StorageCapabilitiesFieldNames,
-		fields,
-		computeField,
+		// No fields, only methods.
+		nil,
+		nil,
+		methodsGetter,
 		nil,
 		stringer,
 	).WithPrivateField(AccountTypePrivateAddressFieldName, address)

--- a/interpreter/value_accountkey.go
+++ b/interpreter/value_accountkey.go
@@ -59,5 +59,6 @@ func NewAccountKeyValue(
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 }

--- a/interpreter/value_authaccount_keys.go
+++ b/interpreter/value_authaccount_keys.go
@@ -44,9 +44,9 @@ func NewAccountKeysValue(
 
 	var accountKeys *SimpleCompositeValue
 
-	fields := map[string]Value{}
+	methods := map[string]FunctionValue{}
 
-	computeLazyStoredField := func(name string) Value {
+	computeLazyStoredMethod := func(name string) FunctionValue {
 		switch name {
 		case sema.Account_KeysTypeAddFunctionName:
 			return addFunction(accountKeys)
@@ -66,12 +66,19 @@ func NewAccountKeysValue(
 		case sema.Account_KeysTypeCountFieldName:
 			return getKeysCount()
 		}
+		return nil
+	}
 
-		field := computeLazyStoredField(name)
-		if field != nil {
-			fields[name] = field
+	methodsGetter := func(name string, _ MemberAccessibleContext) FunctionValue {
+		method, ok := methods[name]
+		if !ok {
+			method = computeLazyStoredMethod(name)
+			if method != nil {
+				methods[name] = method
+			}
 		}
-		return field
+
+		return method
 	}
 
 	var str string
@@ -89,8 +96,10 @@ func NewAccountKeysValue(
 		account_KeysTypeID,
 		account_KeysStaticType,
 		account_KeysFieldNames,
-		fields,
+		// No fields, only computed fields, and methods.
+		nil,
 		computeField,
+		methodsGetter,
 		nil,
 		stringer,
 	)

--- a/interpreter/value_block.go
+++ b/interpreter/value_block.go
@@ -67,6 +67,7 @@ func NewBlockValue(
 			sema.BlockTypeTimestampFieldName: timestamp,
 		},
 		nil,
+		nil,
 		blockFieldFormatters(context),
 		nil,
 	)

--- a/interpreter/value_deployedcontract.go
+++ b/interpreter/value_deployedcontract.go
@@ -52,6 +52,7 @@ func NewDeployedContractValue(
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	publicTypesFuncValue := newPublicTypesFunctionValue(

--- a/interpreter/value_deployment_result.go
+++ b/interpreter/value_deployment_result.go
@@ -45,5 +45,6 @@ func NewDeploymentResultValue(
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 }

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -269,11 +269,10 @@ func (f *HostFunctionValue) GetMember(context MemberAccessibleContext, _ Locatio
 }
 
 func (v *HostFunctionValue) GetMethod(
-	context MemberAccessibleContext,
-	locationRange LocationRange,
-	name string,
+	_ MemberAccessibleContext,
+	_ LocationRange,
+	_ string,
 ) FunctionValue {
-	// TODO:
 	return nil
 }
 

--- a/interpreter/value_test.go
+++ b/interpreter/value_test.go
@@ -4373,6 +4373,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				)
 			},
 			true,
@@ -4388,6 +4389,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 					map[string]Value{
 						"foo": newInvalidCompositeValue(inter),
 					},
+					nil,
 					nil,
 					nil,
 					nil,

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -340,6 +340,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 				nil,
 				nil,
 				nil,
+				nil,
 			),
 		}
 
@@ -417,6 +418,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 				nil,
 				nil,
 				nil,
+				nil,
 			),
 		}
 
@@ -482,6 +484,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 			Value: interpreter.NewSimpleCompositeValue(nil,
 				yType.ID(),
 				interpreter.ConvertSemaCompositeTypeToStaticCompositeType(nil, yType),
+				nil,
 				nil,
 				nil,
 				nil,
@@ -567,6 +570,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 			Value: interpreter.NewSimpleCompositeValue(nil,
 				yType.ID(),
 				interpreter.ConvertSemaCompositeTypeToStaticCompositeType(nil, yType),
+				nil,
 				nil,
 				nil,
 				nil,

--- a/stdlib/hashalgorithm.go
+++ b/stdlib/hashalgorithm.go
@@ -58,6 +58,7 @@ func NewHashAlgorithmCase(
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	value.Fields = map[string]interpreter.Value{
 		sema.EnumRawValueFieldName:                    rawValue,

--- a/stdlib/rlp.go
+++ b/stdlib/rlp.go
@@ -165,6 +165,7 @@ var rlpContractValue = interpreter.NewSimpleCompositeValue(
 	nil,
 	nil,
 	nil,
+	nil,
 )
 
 var RLPContract = StandardLibraryValue{

--- a/stdlib/signaturealgorithm.go
+++ b/stdlib/signaturealgorithm.go
@@ -44,6 +44,7 @@ func NewSignatureAlgorithmCase(rawValue interpreter.UInt8Value) interpreter.Memb
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 }
 


### PR DESCRIPTION
Depends on https://github.com/onflow/cadence/pull/3886

## Description

Implementing the tech-debt discussed in https://github.com/onflow/cadence/pull/3886#discussion_r2052960139

Once this and #3886 are merged, I'll port the changes done to interpreter values to master as well, to minimize any future conflicts.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
