### PR TITLE
Port changes to the `interpreter` package from the `feature/compiler` branch

### DIFF
--- a/interpreter/composite_value_test.go
+++ b/interpreter/composite_value_test.go
@@ -119,6 +119,7 @@ func testCompositeValue(t *testing.T, code string) *interpreter.Interpreter {
 		},
 		nil,
 		nil,
+		nil,
 	)
 
 	valueDeclaration := stdlib.StandardLibraryValue{

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -223,6 +223,8 @@ type MemberAccessibleContext interface {
 
 	InjectedCompositeFieldsHandler() InjectedCompositeFieldsHandlerFunc
 	GetMemberAccessContextForLocation(location common.Location) MemberAccessibleContext
+
+	GetMethod(value MemberAccessibleValue, name string, locationRange LocationRange) FunctionValue
 }
 
 var _ MemberAccessibleContext = &Interpreter{}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5983,3 +5983,7 @@ func (interpreter *Interpreter) SetInStorageIteration(inStorageIteration bool) {
 func (interpreter *Interpreter) StorageMutatedDuringIteration() bool {
 	return interpreter.SharedState.storageMutatedDuringIteration
 }
+
+func (interpreter *Interpreter) GetMethod(value MemberAccessibleValue, name string, locationRange LocationRange) FunctionValue {
+	return value.GetMethod(interpreter, locationRange, name)
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5184,18 +5184,24 @@ func getMember(context MemberAccessibleContext, self Value, locationRange Locati
 		result = memberAccessibleValue.GetMember(context, locationRange, identifier)
 	}
 	if result == nil {
-		switch identifier {
-		case sema.IsInstanceFunctionName:
-			return isInstanceFunction(context, self)
-		case sema.GetTypeFunctionName:
-			return getTypeFunction(context, self)
-		}
+		result = getBuiltinFunctionMember(context, self, identifier)
 	}
 
 	// NOTE: do not panic if the member is nil. This is a valid state.
 	// For example, when a composite field is initialized with a force-assignment, the field's value is read.
 
 	return result
+}
+
+func getBuiltinFunctionMember(context MemberAccessibleContext, self Value, identifier string) FunctionValue {
+	switch identifier {
+	case sema.IsInstanceFunctionName:
+		return isInstanceFunction(context, self)
+	case sema.GetTypeFunctionName:
+		return getTypeFunction(context, self)
+	default:
+		return nil
+	}
 }
 
 func isInstanceFunction(context FunctionCreationContext, self Value) FunctionValue {

--- a/interpreter/interpreter_transaction.go
+++ b/interpreter/interpreter_transaction.go
@@ -63,6 +63,7 @@ func (interpreter *Interpreter) declareTransactionEntryPoint(declaration *ast.Tr
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	self.isTransaction = true

--- a/interpreter/member_test.go
+++ b/interpreter/member_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/interpreter"
@@ -595,14 +596,16 @@ func TestInterpretMemberAccess(t *testing.T) {
                 }
             }
 
-            fun test() {
+            fun test(): Int {
                 let test = Test()
                 var foo: (fun(): Int) = test.foo
+                return foo()
             }
         `)
 
-		_, err := inter.Invoke("test")
+		result, err := inter.Invoke("test")
 		require.NoError(t, err)
+		assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(1), result)
 	})
 
 	t.Run("composite reference, field", func(t *testing.T) {

--- a/interpreter/member_test.go
+++ b/interpreter/member_test.go
@@ -736,15 +736,17 @@ func TestInterpretMemberAccess(t *testing.T) {
                 }
             }
 
-            fun test() {
+            fun test(): Int {
                 let test = Test()
                 let testRef = &test as &Test
                 var foo: (fun(): Int) = testRef.foo
+                return foo()
             }
         `)
 
-		_, err := inter.Invoke("test")
+		result, err := inter.Invoke("test")
 		require.NoError(t, err)
+		assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(1), result)
 	})
 
 	t.Run("resource reference, nested", func(t *testing.T) {

--- a/interpreter/member_test.go
+++ b/interpreter/member_test.go
@@ -42,7 +42,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				t.Parallel()
 
-				inter := parseCheckAndInterpret(t, `
+				inter := parseCheckAndPrepare(t, `
                     struct S {
                         var foo: Int
 
@@ -127,7 +127,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				t.Parallel()
 
-				inter := parseCheckAndInterpret(t, `
+				inter := parseCheckAndPrepare(t, `
                     struct S {
                         var foo: Int
 
@@ -205,7 +205,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				t.Parallel()
 
-				inter := parseCheckAndInterpret(t, `
+				inter := parseCheckAndPrepare(t, `
                     struct interface SI {
                         var foo: Int
                     }
@@ -298,7 +298,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				t.Parallel()
 
-				inter := parseCheckAndInterpret(t, `
+				inter := parseCheckAndPrepare(t, `
                     struct interface SI {
                         let foo: Int
                     }
@@ -567,7 +567,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("composite, field", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             struct Test {
                 var x: [Int]
                 init() {
@@ -588,7 +588,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("composite, function", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             struct Test {
                 access(all) fun foo(): Int {
                     return 1
@@ -608,7 +608,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("composite reference, field", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             struct Test {
                 var x: [Int]
                 init() {
@@ -630,7 +630,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("composite reference, optional field", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             struct Test {
                 var x: [Int]?
                 init() {
@@ -652,7 +652,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("composite reference, nil in optional field", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             struct Test {
                 var x: [Int]?
                 init() {
@@ -681,7 +681,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("composite reference, nil in anystruct field", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             struct Test {
                 var x: AnyStruct
                 init() {
@@ -704,7 +704,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("composite reference, primitive field", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             struct Test {
                 var x: Int
                 init() {
@@ -726,7 +726,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("composite reference, function", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             struct Test {
                 access(all) fun foo(): Int {
                     return 1
@@ -747,7 +747,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("resource reference, nested", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             resource Foo {
                 var bar: @Bar
                 init() {
@@ -791,7 +791,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("composite reference, anystruct typed field, with reference value", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             struct Test {
                 var x: AnyStruct
                 init() {
@@ -820,7 +820,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("array, element", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test() {
                 let array: [[Int]] = [[1, 2]]
                 var x: [Int] = array[0]
@@ -834,7 +834,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("array reference, element", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test() {
                 let array: [[Int]] = [[1, 2]]
                 let arrayRef = &array as &[[Int]]
@@ -849,7 +849,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("array authorized reference, element", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement A
 
             fun test() {
@@ -868,7 +868,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("array reference, element, in assignment", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test() {
                 let array: [[Int]] = [[1, 2]]
                 let arrayRef = &array as &[[Int]]
@@ -884,7 +884,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("array reference, optional typed element", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test() {
                 let array: [[Int]?] = [[1, 2]]
                 let arrayRef = &array as &[[Int]?]
@@ -899,7 +899,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("array reference, primitive typed element", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test() {
                 let array: [Int] = [1, 2]
                 let arrayRef = &array as &[Int]
@@ -914,7 +914,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("array reference, anystruct typed element, with reference value", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test(): &AnyStruct {
                 var s = "hello"
                 let array: [AnyStruct] = [&s as &String]
@@ -936,7 +936,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("dictionary, value", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test() {
                 let dict: {String: {String: Int}} = {"one": {"two": 2}}
                 var x: {String: Int}? = dict["one"]
@@ -950,7 +950,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("dictionary reference, value", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test() {
                 let dict: {String: {String: Int} } = {"one": {"two": 2}}
                 let dictRef = &dict as &{String: {String: Int}}
@@ -965,7 +965,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("dictionary authorized reference, value", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement A
 
             fun test() {
@@ -984,7 +984,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("dictionary reference, value, in assignment", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test() {
                 let dict: {String: {String: Int} } = {"one": {"two": 2}}
                 let dictRef = &dict as &{String: {String: Int}}
@@ -1000,7 +1000,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("dictionary reference, optional typed value", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test() {
                 let dict: {String: {String: Int}?} = {"one": {"two": 2}}
                 let dictRef = &dict as &{String: {String: Int}?}
@@ -1015,7 +1015,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("dictionary reference, primitive typed value", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test() {
                 let dict: {String: Int} = {"one": 1}
                 let dictRef = &dict as &{String: Int}
@@ -1114,7 +1114,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("entitlement map access on field", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             entitlement A
             entitlement B
             entitlement mapping M {
@@ -1165,7 +1165,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 				typeName,
 			)
 
-			inter := parseCheckAndInterpret(t, code)
+			inter := parseCheckAndPrepare(t, code)
 
 			_, err := inter.Invoke("test")
 			require.NoError(t, err)

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -151,6 +151,15 @@ func (v *SimpleCompositeValue) GetMember(context MemberAccessibleContext, locati
 	return nil
 }
 
+func (v *SimpleCompositeValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	// TODO:
+	return nil
+}
+
 func (v *SimpleCompositeValue) RemoveMember(_ ValueTransferContext, _ LocationRange, name string) Value {
 	value := v.Fields[name]
 	delete(v.Fields, name)

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -29,10 +29,11 @@ import (
 // SimpleCompositeValue
 
 type SimpleCompositeValue struct {
-	staticType      StaticType
-	Fields          map[string]Value
-	ComputeField    func(name string, context MemberAccessibleContext, locationRange LocationRange) Value
-	fieldFormatters map[string]func(common.MemoryGauge, Value, SeenReferences) string
+	staticType           StaticType
+	Fields               map[string]Value
+	ComputeField         func(name string, context MemberAccessibleContext, locationRange LocationRange) Value
+	FunctionMemberGetter func(name string, context MemberAccessibleContext) FunctionValue
+	fieldFormatters      map[string]func(common.MemoryGauge, Value, SeenReferences) string
 	// stringer is an optional function that is used to produce the string representation of the value.
 	// If nil, the FieldNames are used.
 	stringer func(ValueStringContext, SeenReferences, LocationRange) string
@@ -60,6 +61,7 @@ func NewSimpleCompositeValue(
 	fieldNames []string,
 	fields map[string]Value,
 	computeField func(name string, context MemberAccessibleContext, locationRange LocationRange) Value,
+	functionMemberGetter func(name string, context MemberAccessibleContext) FunctionValue,
 	fieldFormatters map[string]func(common.MemoryGauge, Value, SeenReferences) string,
 	stringer func(ValueStringContext, SeenReferences, LocationRange) string,
 ) *SimpleCompositeValue {
@@ -68,13 +70,14 @@ func NewSimpleCompositeValue(
 	common.UseMemory(gauge, common.NewSimpleCompositeMemoryUsage(len(fields)))
 
 	return &SimpleCompositeValue{
-		TypeID:          typeID,
-		staticType:      staticType,
-		FieldNames:      fieldNames,
-		Fields:          fields,
-		ComputeField:    computeField,
-		fieldFormatters: fieldFormatters,
-		stringer:        stringer,
+		TypeID:               typeID,
+		staticType:           staticType,
+		FieldNames:           fieldNames,
+		Fields:               fields,
+		ComputeField:         computeField,
+		FunctionMemberGetter: functionMemberGetter,
+		fieldFormatters:      fieldFormatters,
+		stringer:             stringer,
 	}
 }
 
@@ -137,7 +140,6 @@ func (v *SimpleCompositeValue) IsImportable(context ValueImportableContext, loca
 }
 
 func (v *SimpleCompositeValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-
 	value, ok := v.Fields[name]
 	if ok {
 		return value
@@ -145,10 +147,13 @@ func (v *SimpleCompositeValue) GetMember(context MemberAccessibleContext, locati
 
 	computeField := v.ComputeField
 	if computeField != nil {
-		return computeField(name, context, locationRange)
+		value = computeField(name, context, locationRange)
+		if value != nil {
+			return value
+		}
 	}
 
-	return nil
+	return context.GetMethod(v, name, locationRange)
 }
 
 func (v *SimpleCompositeValue) GetMethod(
@@ -156,8 +161,11 @@ func (v *SimpleCompositeValue) GetMethod(
 	locationRange LocationRange,
 	name string,
 ) FunctionValue {
-	// TODO:
-	return nil
+	if v.FunctionMemberGetter == nil {
+		return nil
+	}
+
+	return v.FunctionMemberGetter(name, context)
 }
 
 func (v *SimpleCompositeValue) RemoveMember(_ ValueTransferContext, _ LocationRange, name string) Value {

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -157,6 +157,7 @@ type MemberAccessibleValue interface {
 	RemoveMember(context ValueTransferContext, locationRange LocationRange, name string) Value
 	// SetMember returns whether a value previously existed with this name.
 	SetMember(context ValueTransferContext, locationRange LocationRange, name string, value Value) bool
+	GetMethod(context MemberAccessibleContext, locationRange LocationRange, name string) FunctionValue
 }
 
 type ValueComparisonContext interface {

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -157,6 +157,8 @@ type MemberAccessibleValue interface {
 	RemoveMember(context ValueTransferContext, locationRange LocationRange, name string) Value
 	// SetMember returns whether a value previously existed with this name.
 	SetMember(context ValueTransferContext, locationRange LocationRange, name string, value Value) bool
+	// GetMethod returns member functions of this value.
+	// IMPORTANT: This method is for internal use only. Always use `GetMember` to retrieve a member of any kind.
 	GetMethod(context MemberAccessibleContext, locationRange LocationRange, name string) FunctionValue
 }
 

--- a/interpreter/value_account.go
+++ b/interpreter/value_account.go
@@ -109,8 +109,10 @@ func NewAccountValue(
 		accountTypeID,
 		accountStaticType,
 		accountFieldNames,
+		// Only fields, no methods
 		fields,
 		computeField,
+		nil,
 		nil,
 		stringer,
 	)

--- a/interpreter/value_account_accountcapabilities.go
+++ b/interpreter/value_account_accountcapabilities.go
@@ -43,9 +43,9 @@ func NewAccountAccountCapabilitiesValue(
 
 	var accountCapabilities *SimpleCompositeValue
 
-	fields := map[string]Value{}
+	methods := map[string]FunctionValue{}
 
-	computeLazyStoredField := func(name string) Value {
+	computeLazyStoredMethod := func(name string) FunctionValue {
 		switch name {
 		case sema.Account_AccountCapabilitiesTypeGetControllerFunctionName:
 			return getControllerFunction(accountCapabilities)
@@ -62,12 +62,16 @@ func NewAccountAccountCapabilitiesValue(
 		return nil
 	}
 
-	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
-		field := computeLazyStoredField(name)
-		if field != nil {
-			fields[name] = field
+	methodGetter := func(name string, _ MemberAccessibleContext) FunctionValue {
+		method, ok := methods[name]
+		if !ok {
+			method = computeLazyStoredMethod(name)
+			if method != nil {
+				methods[name] = method
+			}
 		}
-		return field
+
+		return method
 	}
 
 	var str string
@@ -85,8 +89,10 @@ func NewAccountAccountCapabilitiesValue(
 		account_AccountCapabilitiesTypeID,
 		account_AccountCapabilitiesStaticType,
 		account_AccountCapabilitiesFieldNames,
-		fields,
-		computeField,
+		// No fields, only methods.
+		nil,
+		nil,
+		methodGetter,
 		nil,
 		stringer,
 	).WithPrivateField(accountTypePrivateAddressFieldName, address)

--- a/interpreter/value_account_contracts.go
+++ b/interpreter/value_account_contracts.go
@@ -47,9 +47,9 @@ func NewAccountContractsValue(
 
 	var accountContracts *SimpleCompositeValue
 
-	fields := map[string]Value{}
+	methods := map[string]FunctionValue{}
 
-	computeLazyStoredField := func(name string) Value {
+	computeLazyStoredMethod := func(name string) FunctionValue {
 		switch name {
 		case sema.Account_ContractsTypeAddFunctionName:
 			return addFunction(accountContracts)
@@ -74,11 +74,19 @@ func NewAccountContractsValue(
 			return namesGetter(context, locationRange)
 		}
 
-		field := computeLazyStoredField(name)
-		if field != nil {
-			fields[name] = field
+		return nil
+	}
+
+	methodGetter := func(name string, _ MemberAccessibleContext) FunctionValue {
+		method, ok := methods[name]
+		if !ok {
+			method = computeLazyStoredMethod(name)
+			if method != nil {
+				methods[name] = method
+			}
 		}
-		return field
+
+		return method
 	}
 
 	var str string
@@ -96,8 +104,10 @@ func NewAccountContractsValue(
 		account_ContractsTypeID,
 		account_ContractsStaticType,
 		account_ContractsFieldNames,
-		fields,
+		// No fields, only computed fields, and methods.
+		nil,
 		computeField,
+		methodGetter,
 		nil,
 		stringer,
 	)

--- a/interpreter/value_account_inbox.go
+++ b/interpreter/value_account_inbox.go
@@ -42,9 +42,9 @@ func NewAccountInboxValue(
 
 	var accountInbox *SimpleCompositeValue
 
-	fields := map[string]Value{}
+	methods := map[string]FunctionValue{}
 
-	computeLazyStoredField := func(name string) Value {
+	computeLazyStoredMethod := func(name string) FunctionValue {
 		switch name {
 		case sema.Account_InboxTypePublishFunctionName:
 			return publishFunction(accountInbox)
@@ -57,12 +57,16 @@ func NewAccountInboxValue(
 		return nil
 	}
 
-	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
-		field := computeLazyStoredField(name)
-		if field != nil {
-			fields[name] = field
+	methodGetter := func(name string, _ MemberAccessibleContext) FunctionValue {
+		method, ok := methods[name]
+		if !ok {
+			method = computeLazyStoredMethod(name)
+			if method != nil {
+				methods[name] = method
+			}
 		}
-		return field
+
+		return method
 	}
 
 	var str string
@@ -80,8 +84,10 @@ func NewAccountInboxValue(
 		account_InboxTypeID,
 		account_InboxStaticType,
 		account_InboxFieldNames,
-		fields,
-		computeField,
+		// No fields, only methods.
+		nil,
+		nil,
+		methodGetter,
 		nil,
 		stringer,
 	)

--- a/interpreter/value_account_storage.go
+++ b/interpreter/value_account_storage.go
@@ -41,9 +41,9 @@ func NewAccountStorageValue(
 
 	var storageValue *SimpleCompositeValue
 
-	fields := map[string]Value{}
+	methods := map[string]FunctionValue{}
 
-	computeLazyStoredField := func(name string, context MemberAccessibleContext) Value {
+	computeLazyStoredMethod := func(name string, context MemberAccessibleContext) FunctionValue {
 		switch name {
 		case sema.Account_StorageTypeForEachPublicFunctionName:
 			return newStorageIterationFunction(
@@ -102,11 +102,19 @@ func NewAccountStorageValue(
 			return storageCapacityGet(context)
 		}
 
-		field := computeLazyStoredField(name, context)
-		if field != nil {
-			fields[name] = field
+		return nil
+	}
+
+	methodsGetter := func(name string, context MemberAccessibleContext) FunctionValue {
+		method, ok := methods[name]
+		if !ok {
+			method = computeLazyStoredMethod(name, context)
+			if method != nil {
+				methods[name] = method
+			}
 		}
-		return field
+
+		return method
 	}
 
 	var str string
@@ -124,8 +132,10 @@ func NewAccountStorageValue(
 		account_StorageTypeID,
 		account_StorageStaticType,
 		account_StorageFieldNames,
-		fields,
+		// No fields, only computed fields, and methods.
+		nil,
 		computeField,
+		methodsGetter,
 		nil,
 		stringer,
 	).WithPrivateField(accountTypePrivateAddressFieldName, address)

--- a/interpreter/value_account_storagecapabilities.go
+++ b/interpreter/value_account_storagecapabilities.go
@@ -43,9 +43,9 @@ func NewAccountStorageCapabilitiesValue(
 
 	var storageCapabilities *SimpleCompositeValue
 
-	fields := map[string]Value{}
+	methods := map[string]FunctionValue{}
 
-	computeLazyStoredField := func(name string) Value {
+	computeLazyStoredMethod := func(name string) FunctionValue {
 		switch name {
 		case sema.Account_StorageCapabilitiesTypeGetControllerFunctionName:
 			return getControllerFunction(storageCapabilities)
@@ -62,12 +62,16 @@ func NewAccountStorageCapabilitiesValue(
 		return nil
 	}
 
-	computeField := func(name string, _ MemberAccessibleContext, _ LocationRange) Value {
-		field := computeLazyStoredField(name)
-		if field != nil {
-			fields[name] = field
+	methodsGetter := func(name string, _ MemberAccessibleContext) FunctionValue {
+		method, ok := methods[name]
+		if !ok {
+			method = computeLazyStoredMethod(name)
+			if method != nil {
+				methods[name] = method
+			}
 		}
-		return field
+
+		return method
 	}
 
 	var str string
@@ -85,8 +89,10 @@ func NewAccountStorageCapabilitiesValue(
 		account_StorageCapabilitiesTypeID,
 		account_StorageCapabilitiesStaticType,
 		account_StorageCapabilitiesFieldNames,
-		fields,
-		computeField,
+		// No fields, only methods.
+		nil,
+		nil,
+		methodsGetter,
 		nil,
 		stringer,
 	).WithPrivateField(accountTypePrivateAddressFieldName, address)

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -242,9 +242,12 @@ func (v *AccountCapabilityControllerValue) GetMember(context MemberAccessibleCon
 
 func (v *AccountCapabilityControllerValue) GetMethod(
 	context MemberAccessibleContext,
-	locationRange LocationRange,
+	_ LocationRange,
 	name string,
 ) FunctionValue {
+	// NOTE: check if controller is already deleted
+	v.checkDeleted()
+
 	switch name {
 	case sema.AccountCapabilityControllerTypeSetTagFunctionName:
 		if v.setTagFunction == nil {

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -210,7 +210,7 @@ type deletionCheckedFunctionValue struct {
 	FunctionValue
 }
 
-func (v *AccountCapabilityControllerValue) GetMember(context MemberAccessibleContext, _ LocationRange, name string) (result Value) {
+func (v *AccountCapabilityControllerValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) (result Value) {
 	defer func() {
 		switch typedResult := result.(type) {
 		case deletionCheckedFunctionValue:
@@ -227,12 +227,6 @@ func (v *AccountCapabilityControllerValue) GetMember(context MemberAccessibleCon
 	case sema.AccountCapabilityControllerTypeTagFieldName:
 		return v.GetTag(context)
 
-	case sema.AccountCapabilityControllerTypeSetTagFunctionName:
-		if v.setTagFunction == nil {
-			v.setTagFunction = v.newSetTagFunction(context)
-		}
-		return v.setTagFunction
-
 	case sema.AccountCapabilityControllerTypeCapabilityIDFieldName:
 		return v.CapabilityID
 
@@ -241,6 +235,22 @@ func (v *AccountCapabilityControllerValue) GetMember(context MemberAccessibleCon
 
 	case sema.AccountCapabilityControllerTypeCapabilityFieldName:
 		return v.GetCapability(context)
+	}
+
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v *AccountCapabilityControllerValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	switch name {
+	case sema.AccountCapabilityControllerTypeSetTagFunctionName:
+		if v.setTagFunction == nil {
+			v.setTagFunction = v.newSetTagFunction(context)
+		}
+		return v.setTagFunction
 
 	case sema.AccountCapabilityControllerTypeDeleteFunctionName:
 		if v.deleteFunction == nil {

--- a/interpreter/value_accountkey.go
+++ b/interpreter/value_accountkey.go
@@ -59,5 +59,6 @@ func NewAccountKeyValue(
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 }

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -156,7 +156,15 @@ func (v AddressValue) ToAddress() common.Address {
 	return common.Address(v)
 }
 
-func (v AddressValue) GetMember(context MemberAccessibleContext, _ LocationRange, name string) Value {
+func (v AddressValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v AddressValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
 	switch name {
 
 	case sema.ToStringFunctionName:

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -829,11 +829,21 @@ func (v *ArrayValue) Contains(
 	return BoolValue(result)
 }
 
-func (v *ArrayValue) GetMember(context MemberAccessibleContext, _ LocationRange, name string) Value {
+func (v *ArrayValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
 	switch name {
 	case "length":
 		return NewIntValueFromInt64(context, int64(v.Count()))
+	}
 
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v *ArrayValue) GetMethod(
+	context MemberAccessibleContext,
+	_ LocationRange,
+	name string,
+) FunctionValue {
+	switch name {
 	case "append":
 		return NewBoundHostFunctionValue(
 			context,

--- a/interpreter/value_authaccount_keys.go
+++ b/interpreter/value_authaccount_keys.go
@@ -44,9 +44,9 @@ func NewAccountKeysValue(
 
 	var accountKeys *SimpleCompositeValue
 
-	fields := map[string]Value{}
+	methods := map[string]FunctionValue{}
 
-	computeLazyStoredField := func(name string) Value {
+	computeLazyStoredMethod := func(name string) FunctionValue {
 		switch name {
 		case sema.Account_KeysTypeAddFunctionName:
 			return addFunction(accountKeys)
@@ -66,12 +66,19 @@ func NewAccountKeysValue(
 		case sema.Account_KeysTypeCountFieldName:
 			return getKeysCount()
 		}
+		return nil
+	}
 
-		field := computeLazyStoredField(name)
-		if field != nil {
-			fields[name] = field
+	methodsGetter := func(name string, _ MemberAccessibleContext) FunctionValue {
+		method, ok := methods[name]
+		if !ok {
+			method = computeLazyStoredMethod(name)
+			if method != nil {
+				methods[name] = method
+			}
 		}
-		return field
+
+		return method
 	}
 
 	var str string
@@ -89,8 +96,10 @@ func NewAccountKeysValue(
 		account_KeysTypeID,
 		account_KeysStaticType,
 		account_KeysFieldNames,
-		fields,
+		// No fields, only computed fields, and methods.
+		nil,
 		computeField,
+		methodsGetter,
 		nil,
 		stringer,
 	)

--- a/interpreter/value_block.go
+++ b/interpreter/value_block.go
@@ -67,6 +67,7 @@ func NewBlockValue(
 			sema.BlockTypeTimestampFieldName: timestamp,
 		},
 		nil,
+		nil,
 		blockFieldFormatters(context),
 		nil,
 	)

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -142,7 +142,23 @@ func (v *IDCapabilityValue) MeteredString(context ValueStringContext, seenRefere
 	)
 }
 
-func (v *IDCapabilityValue) GetMember(context MemberAccessibleContext, _ LocationRange, name string) Value {
+func (v *IDCapabilityValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	switch name {
+	case sema.CapabilityTypeAddressFieldName:
+		return v.address
+
+	case sema.CapabilityTypeIDFieldName:
+		return v.ID
+	}
+
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v *IDCapabilityValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
 	switch name {
 	case sema.CapabilityTypeBorrowFunctionName:
 		// this function will panic already if this conversion fails
@@ -153,12 +169,6 @@ func (v *IDCapabilityValue) GetMember(context MemberAccessibleContext, _ Locatio
 		// this function will panic already if this conversion fails
 		borrowType, _ := MustConvertStaticToSemaType(v.BorrowType, context).(*sema.ReferenceType)
 		return capabilityCheckFunction(context, v, v.address, v.ID, borrowType)
-
-	case sema.CapabilityTypeAddressFieldName:
-		return v.address
-
-	case sema.CapabilityTypeIDFieldName:
-		return v.ID
 	}
 
 	return nil

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -219,7 +219,21 @@ func (CharacterValue) ChildStorables() []atree.Storable {
 	return nil
 }
 
-func (v CharacterValue) GetMember(context MemberAccessibleContext, _ LocationRange, name string) Value {
+func (v CharacterValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	switch name {
+	case sema.CharacterTypeUtf8FieldName:
+		common.UseMemory(context, common.NewBytesMemoryUsage(len(v.Str)))
+		return ByteSliceToByteArrayValue(context, []byte(v.Str))
+	}
+
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v CharacterValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
 	switch name {
 	case sema.ToStringFunctionName:
 		return NewBoundHostFunctionValue(
@@ -240,11 +254,8 @@ func (v CharacterValue) GetMember(context MemberAccessibleContext, _ LocationRan
 				)
 			},
 		)
-
-	case sema.CharacterTypeUtf8FieldName:
-		common.UseMemory(context, common.NewBytesMemoryUsage(len(v.Str)))
-		return ByteSliceToByteArrayValue(context, []byte(v.Str))
 	}
+
 	return nil
 }
 

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -479,7 +479,7 @@ func (v *CompositeValue) GetMember(context MemberAccessibleContext, locationRang
 		return injectedField
 	}
 
-	if function := v.GetFunction(context, locationRange, name); function != nil {
+	if function := v.GetMethod(context, locationRange, name); function != nil {
 		return function
 	}
 
@@ -534,7 +534,7 @@ func (v *CompositeValue) GetInjectedField(context MemberAccessibleContext, name 
 	return value
 }
 
-func (v *CompositeValue) GetFunction(context FunctionCreationContext, locationRange LocationRange, name string) FunctionValue {
+func (v *CompositeValue) GetMethod(context MemberAccessibleContext, locationRange LocationRange, name string) FunctionValue {
 	if v.Functions == nil {
 		v.Functions = context.GetCompositeValueFunctions(v, locationRange)
 	}

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -479,7 +479,7 @@ func (v *CompositeValue) GetMember(context MemberAccessibleContext, locationRang
 		return injectedField
 	}
 
-	if function := v.GetMethod(context, locationRange, name); function != nil {
+	if function := context.GetMethod(v, name, locationRange); function != nil {
 		return function
 	}
 

--- a/interpreter/value_deployedcontract.go
+++ b/interpreter/value_deployedcontract.go
@@ -52,6 +52,7 @@ func NewDeployedContractValue(
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	publicTypesFuncValue := newPublicTypesFunctionValue(

--- a/interpreter/value_deployment_result.go
+++ b/interpreter/value_deployment_result.go
@@ -45,5 +45,6 @@ func NewDeploymentResultValue(
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 }

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -799,8 +799,19 @@ func (v *DictionaryValue) GetMember(context MemberAccessibleContext, locationRan
 						nil,
 						false, // value is an element of parent container because it is returned from iterator.
 					)
-			})
+			},
+		)
+	}
 
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v *DictionaryValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	switch name {
 	case "remove":
 		return NewBoundHostFunctionValue(
 			context,

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -138,6 +138,15 @@ func (v *EphemeralReferenceValue) GetMember(context MemberAccessibleContext, loc
 	return getMember(context, v.Value, locationRange, name)
 }
 
+func (v *EphemeralReferenceValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	// TODO:
+	return nil
+}
+
 func (v *EphemeralReferenceValue) RemoveMember(
 	context ValueTransferContext,
 	locationRange LocationRange,

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -135,16 +135,26 @@ func (v *EphemeralReferenceValue) ReferencedValue(
 }
 
 func (v *EphemeralReferenceValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getMember(context, v.Value, locationRange, name)
+	var result Value
+
+	if memberAccessibleValue, ok := v.Value.(MemberAccessibleValue); ok {
+		result = memberAccessibleValue.GetMember(context, locationRange, name)
+	}
+
+	if result == nil {
+		// NOTE: Must call the `GetMethod` of the `EphemeralReferenceValue`, not of the referenced-value.
+		result = context.GetMethod(v, name, locationRange)
+	}
+
+	return result
 }
 
 func (v *EphemeralReferenceValue) GetMethod(
 	context MemberAccessibleContext,
-	locationRange LocationRange,
+	_ LocationRange,
 	name string,
 ) FunctionValue {
-	// TODO:
-	return nil
+	return getBuiltinFunctionMember(context, v.Value, name)
 }
 
 func (v *EphemeralReferenceValue) RemoveMember(

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -528,7 +528,15 @@ func ConvertFix64(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 }
 
 func (v Fix64Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.Fix64Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v Fix64Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.Fix64Type, locationRange)
 }
 
 func (Fix64Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -268,6 +268,15 @@ func (f *HostFunctionValue) GetMember(context MemberAccessibleContext, _ Locatio
 	return nil
 }
 
+func (v *HostFunctionValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	// TODO:
+	return nil
+}
+
 func (*HostFunctionValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	// Host functions have no removable members (fields / functions)
 	panic(errors.NewUnreachableError())

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -269,11 +269,10 @@ func (f *HostFunctionValue) GetMember(context MemberAccessibleContext, _ Locatio
 }
 
 func (v *HostFunctionValue) GetMethod(
-	context MemberAccessibleContext,
-	locationRange LocationRange,
-	name string,
+	_ MemberAccessibleContext,
+	_ LocationRange,
+	_ string,
 ) FunctionValue {
-	// TODO:
 	return nil
 }
 

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -522,7 +522,15 @@ func (v IntValue) BitwiseRightShift(context ValueStaticTypeContext, other Intege
 }
 
 func (v IntValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.IntType, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v IntValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.IntType, locationRange)
 }
 
 func (IntValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -739,7 +739,15 @@ func (v Int128Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 }
 
 func (v Int128Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.Int128Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v Int128Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.Int128Type, locationRange)
 }
 
 func (Int128Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -614,7 +614,16 @@ func (v Int16Value) BitwiseRightShift(context ValueStaticTypeContext, other Inte
 }
 
 func (v Int16Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.Int16Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+
+}
+
+func (v Int16Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.Int16Type, locationRange)
 }
 
 func (Int16Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -706,7 +706,16 @@ func (v Int256Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 }
 
 func (v Int256Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.Int256Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+
+}
+
+func (v Int256Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.Int256Type, locationRange)
 }
 
 func (Int256Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -614,7 +614,15 @@ func (v Int32Value) BitwiseRightShift(context ValueStaticTypeContext, other Inte
 }
 
 func (v Int32Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.Int32Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v Int32Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.Int32Type, locationRange)
 }
 
 func (Int32Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -608,7 +608,15 @@ func (v Int64Value) BitwiseRightShift(context ValueStaticTypeContext, other Inte
 }
 
 func (v Int64Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.Int64Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v Int64Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.Int64Type, locationRange)
 }
 
 func (Int64Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -613,7 +613,15 @@ func (v Int8Value) BitwiseRightShift(context ValueStaticTypeContext, other Integ
 }
 
 func (v Int8Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.Int8Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v Int8Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.Int8Type, locationRange)
 }
 
 func (Int8Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -99,6 +99,14 @@ var nilValueMapFunction = NewUnmeteredStaticHostFunctionValue(
 )
 
 func (v NilValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v NilValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
 	switch name {
 	case sema.OptionalTypeMapFunctionName:
 		return nilValueMapFunction

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -49,7 +49,13 @@ type NumberValue interface {
 	ToBigEndianBytes() []byte
 }
 
-func getNumberValueMember(context MemberAccessibleContext, v NumberValue, name string, typ sema.Type, locationRange LocationRange) Value {
+func getNumberValueFunctionMember(
+	context MemberAccessibleContext,
+	v NumberValue,
+	name string,
+	typ sema.Type,
+	locationRange LocationRange,
+) FunctionValue {
 	switch name {
 
 	case sema.ToStringFunctionName:

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -111,6 +111,14 @@ func (v PathValue) MeteredString(context ValueStringContext, _ SeenReferences, _
 }
 
 func (v PathValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v PathValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
 	switch name {
 
 	case sema.ToStringFunctionName:

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -180,6 +180,14 @@ func (v *PathCapabilityValue) GetMember(context MemberAccessibleContext, locatio
 	return nil
 }
 
+func (v *PathCapabilityValue) GetMethod(
+	_ MemberAccessibleContext,
+	_ LocationRange,
+	_ string,
+) FunctionValue {
+	return nil
+}
+
 func (*PathCapabilityValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -154,6 +154,22 @@ func (v *PathCapabilityValue) newCheckFunction(
 
 func (v *PathCapabilityValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
 	switch name {
+	case sema.CapabilityTypeAddressFieldName:
+		return v.address
+
+	case sema.CapabilityTypeIDFieldName:
+		return InvalidCapabilityID
+	}
+
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v *PathCapabilityValue) GetMethod(
+	context MemberAccessibleContext,
+	_ LocationRange,
+	name string,
+) FunctionValue {
+	switch name {
 	case sema.CapabilityTypeBorrowFunctionName:
 		var borrowType *sema.ReferenceType
 		if v.BorrowType != nil {
@@ -169,22 +185,7 @@ func (v *PathCapabilityValue) GetMember(context MemberAccessibleContext, locatio
 			borrowType, _ = MustConvertStaticToSemaType(v.BorrowType, context).(*sema.ReferenceType)
 		}
 		return v.newCheckFunction(context, borrowType)
-
-	case sema.CapabilityTypeAddressFieldName:
-		return v.address
-
-	case sema.CapabilityTypeIDFieldName:
-		return InvalidCapabilityID
 	}
-
-	return nil
-}
-
-func (v *PathCapabilityValue) GetMethod(
-	_ MemberAccessibleContext,
-	_ LocationRange,
-	_ string,
-) FunctionValue {
 	return nil
 }
 

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -146,7 +146,15 @@ func (v *SomeValue) MeteredString(context ValueStringContext, seenReferences See
 	return v.value.MeteredString(context, seenReferences, locationRange)
 }
 
-func (v *SomeValue) GetMember(context MemberAccessibleContext, _ LocationRange, name string) Value {
+func (v *SomeValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v *SomeValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
 	switch name {
 	case sema.OptionalTypeMapFunctionName:
 		innerValueType := MustConvertStaticToSemaType(

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -219,6 +219,15 @@ func (v *StorageReferenceValue) GetMember(context MemberAccessibleContext, locat
 	return member
 }
 
+func (v *StorageReferenceValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	// TODO:
+	return nil
+}
+
 func (v *StorageReferenceValue) RemoveMember(
 	context ValueTransferContext,
 	locationRange LocationRange,

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -250,12 +250,6 @@ func (v *StorageCapabilityControllerValue) GetMember(context MemberAccessibleCon
 	case sema.StorageCapabilityControllerTypeTagFieldName:
 		return v.GetTag(context)
 
-	case sema.StorageCapabilityControllerTypeSetTagFunctionName:
-		if v.setTagFunction == nil {
-			v.setTagFunction = v.newSetTagFunction(context)
-		}
-		return v.setTagFunction
-
 	case sema.StorageCapabilityControllerTypeCapabilityIDFieldName:
 		return v.CapabilityID
 
@@ -264,6 +258,25 @@ func (v *StorageCapabilityControllerValue) GetMember(context MemberAccessibleCon
 
 	case sema.StorageCapabilityControllerTypeCapabilityFieldName:
 		return v.GetCapability(context)
+
+		// NOTE: when adding new functions, ensure checkDeleted is called,
+		// by e.g. using StorageCapabilityControllerValue.newHostFunction
+	}
+
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v *StorageCapabilityControllerValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	switch name {
+	case sema.StorageCapabilityControllerTypeSetTagFunctionName:
+		if v.setTagFunction == nil {
+			v.setTagFunction = v.newSetTagFunction(context)
+		}
+		return v.setTagFunction
 
 	case sema.StorageCapabilityControllerTypeDeleteFunctionName:
 		if v.deleteFunction == nil {

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -362,7 +362,17 @@ func (v *StringValue) GetMember(context MemberAccessibleContext, locationRange L
 
 	case sema.StringTypeUtf8FieldName:
 		return ByteSliceToByteArrayValue(context, []byte(v.Str))
+	}
 
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v *StringValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	switch name {
 	case sema.StringTypeConcatFunctionName:
 		return NewBoundHostFunctionValue(
 			context,

--- a/interpreter/value_test.go
+++ b/interpreter/value_test.go
@@ -4373,6 +4373,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 					nil,
 					nil,
 					nil,
+					nil,
 				)
 			},
 			true,
@@ -4388,6 +4389,7 @@ func TestValue_ConformsToStaticType(t *testing.T) {
 					map[string]Value{
 						"foo": newInvalidCompositeValue(inter),
 					},
+					nil,
 					nil,
 					nil,
 					nil,

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -441,7 +441,15 @@ func (v UFix64Value) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []
 }
 
 func (v UFix64Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.UFix64Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v UFix64Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.UFix64Type, locationRange)
 }
 
 func (UFix64Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -590,7 +590,15 @@ func (v UIntValue) BitwiseRightShift(context ValueStaticTypeContext, other Integ
 }
 
 func (v UIntValue) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.UIntType, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v UIntValue) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.UIntType, locationRange)
 }
 
 func (UIntValue) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -636,7 +636,15 @@ func (v UInt128Value) BitwiseRightShift(context ValueStaticTypeContext, other In
 }
 
 func (v UInt128Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.UInt128Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v UInt128Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.UInt128Type, locationRange)
 }
 
 func (UInt128Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -497,7 +497,15 @@ func (v UInt16Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 }
 
 func (v UInt16Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.UInt16Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v UInt16Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.UInt16Type, locationRange)
 }
 
 func (UInt16Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -636,7 +636,15 @@ func (v UInt256Value) BitwiseRightShift(context ValueStaticTypeContext, other In
 }
 
 func (v UInt256Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.UInt256Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v UInt256Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.UInt256Type, locationRange)
 }
 
 func (UInt256Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -498,7 +498,15 @@ func (v UInt32Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 }
 
 func (v UInt32Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.UInt32Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v UInt32Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.UInt32Type, locationRange)
 }
 
 func (UInt32Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -526,7 +526,15 @@ func (v UInt64Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 }
 
 func (v UInt64Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.UInt64Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v UInt64Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.UInt64Type, locationRange)
 }
 
 func (UInt64Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -548,7 +548,15 @@ func (v UInt8Value) BitwiseRightShift(context ValueStaticTypeContext, other Inte
 }
 
 func (v UInt8Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.UInt8Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v UInt8Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.UInt8Type, locationRange)
 }
 
 func (UInt8Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -541,7 +541,15 @@ func (v Word128Value) BitwiseRightShift(context ValueStaticTypeContext, other In
 }
 
 func (v Word128Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.Word128Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v Word128Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.Word128Type, locationRange)
 }
 
 func (Word128Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -393,7 +393,15 @@ func (v Word16Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 }
 
 func (v Word16Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.Word16Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v Word16Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.Word16Type, locationRange)
 }
 
 func (Word16Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -542,7 +542,15 @@ func (v Word256Value) BitwiseRightShift(context ValueStaticTypeContext, other In
 }
 
 func (v Word256Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.Word256Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v Word256Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.Word256Type, locationRange)
 }
 
 func (Word256Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -394,7 +394,15 @@ func (v Word32Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 }
 
 func (v Word32Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.Word32Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v Word32Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.Word32Type, locationRange)
 }
 
 func (Word32Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -422,7 +422,15 @@ func (v Word64Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 }
 
 func (v Word64Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.Word64Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v Word64Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.Word64Type, locationRange)
 }
 
 func (Word64Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -393,7 +393,15 @@ func (v Word8Value) BitwiseRightShift(context ValueStaticTypeContext, other Inte
 }
 
 func (v Word8Value) GetMember(context MemberAccessibleContext, locationRange LocationRange, name string) Value {
-	return getNumberValueMember(context, v, name, sema.Word8Type, locationRange)
+	return context.GetMethod(v, name, locationRange)
+}
+
+func (v Word8Value) GetMethod(
+	context MemberAccessibleContext,
+	locationRange LocationRange,
+	name string,
+) FunctionValue {
+	return getNumberValueFunctionMember(context, v, name, sema.Word8Type, locationRange)
 }
 
 func (Word8Value) RemoveMember(_ ValueTransferContext, _ LocationRange, _ string) Value {

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -340,6 +340,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 				nil,
 				nil,
 				nil,
+				nil,
 			),
 		}
 
@@ -417,6 +418,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 				nil,
 				nil,
 				nil,
+				nil,
 			),
 		}
 
@@ -482,6 +484,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 			Value: interpreter.NewSimpleCompositeValue(nil,
 				yType.ID(),
 				interpreter.ConvertSemaCompositeTypeToStaticCompositeType(nil, yType),
+				nil,
 				nil,
 				nil,
 				nil,
@@ -567,6 +570,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 			Value: interpreter.NewSimpleCompositeValue(nil,
 				yType.ID(),
 				interpreter.ConvertSemaCompositeTypeToStaticCompositeType(nil, yType),
+				nil,
 				nil,
 				nil,
 				nil,

--- a/stdlib/hashalgorithm.go
+++ b/stdlib/hashalgorithm.go
@@ -58,6 +58,7 @@ func NewHashAlgorithmCase(
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	value.Fields = map[string]interpreter.Value{
 		sema.EnumRawValueFieldName:                    rawValue,

--- a/stdlib/rlp.go
+++ b/stdlib/rlp.go
@@ -165,6 +165,7 @@ var rlpContractValue = interpreter.NewSimpleCompositeValue(
 	nil,
 	nil,
 	nil,
+	nil,
 )
 
 var RLPContract = StandardLibraryValue{

--- a/stdlib/signaturealgorithm.go
+++ b/stdlib/signaturealgorithm.go
@@ -44,6 +44,7 @@ func NewSignatureAlgorithmCase(rawValue interpreter.UInt8Value) interpreter.Memb
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 }
 

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -73,9 +73,9 @@ type Invokable interface {
 func ParseCheckAndPrepare(t testing.TB, code string, compile bool) Invokable {
 	t.Helper()
 
-	//if !compile {
-	//	return parseCheckAndInterpret(t, code)
-	//}
+	if !compile {
+		return parseCheckAndInterpret(t, code)
+	}
 
 	// TODO: Uncomment once the compiler branch is merged to master.
 	//vmConfig := &vm.Config{}

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -73,9 +73,9 @@ type Invokable interface {
 func ParseCheckAndPrepare(t testing.TB, code string, compile bool) Invokable {
 	t.Helper()
 
-	if !compile {
-		return parseCheckAndInterpret(t, code)
-	}
+	//if !compile {
+	//	return parseCheckAndInterpret(t, code)
+	//}
 
 	// TODO: Uncomment once the compiler branch is merged to master.
 	//vmConfig := &vm.Config{}


### PR DESCRIPTION
## Description

Port the changes to the `interpreter` package (splitting of function members from field members) made in:
- https://github.com/onflow/cadence/pull/3886
- https://github.com/onflow/cadence/pull/3890

### Note:

Only did the `git format-patch` for the diff between the base-commit and the head of the PR (extracted it from the CI run), for the two PRs. Doing the format-patch for the entire two branches require a lots of rebasing and conflict resolutions - and no longer a viable option.

```
git format-patch --stdout 6eb67216fbef77b906ba088d5e66d071cb1bd090...0459b3eddd1e856b382af27dc09e18563273260f  -- . ':!bbq' ':!runtime/bbq' | git am -3 

git format-patch --stdout 16109d9163a626707d55688a108a55a946bacb2c...723c91189a2800566c31a32de4170dd1593c3fbc  -- . ':!bbq' ':!runtime/bbq' | git am -3
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
