### PR TITLE
[Compiler] Refactor qualified name generation

### DIFF
--- a/bbq/commons/constants.go
+++ b/bbq/commons/constants.go
@@ -36,6 +36,8 @@ const (
 
 	// Type qualifiers for built-in member functions
 
-	TypeQualifierArray      = "$Array"
-	TypeQualifierDictionary = "$Dictionary"
+	TypeQualifierArrayConstantSized = "$ArrayConstantSized"
+	TypeQualifierArrayVariableSized = "$ArrayVariableSized"
+	TypeQualifierDictionary         = "$Dictionary"
+	TypeQualifierFunction           = "$Function"
 )

--- a/bbq/commons/types.go
+++ b/bbq/commons/types.go
@@ -19,14 +19,33 @@
 package commons
 
 import (
-	"bytes"
-
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 )
 
-func TypeQualifiedName(typeName, functionName string) string {
+var BuiltinTypes = common.Concat[sema.Type](
+	sema.AllBuiltinTypes,
+	[]sema.Type{
+		&sema.ConstantSizedType{},
+		&sema.VariableSizedType{},
+		&sema.DictionaryType{},
+		&sema.FunctionType{},
+
+		// TODO: add other types. e.g; Optional, etc
+	},
+)
+
+func TypeQualifiedName(typ sema.Type, functionName string) string {
+	if typ == nil {
+		return functionName
+	}
+
+	typeQualifier := TypeQualifier(typ)
+	return typeQualifier + "." + functionName
+}
+
+func QualifiedName(typeName, functionName string) string {
 	if typeName == "" {
 		return functionName
 	}
@@ -43,10 +62,14 @@ func TypeQualifiedName(typeName, functionName string) string {
 // TODO: Maybe make this a method on the type
 func TypeQualifier(typ sema.Type) string {
 	switch typ := typ.(type) {
-	case sema.ArrayType:
-		return TypeQualifierArray
+	case *sema.ConstantSizedType:
+		return TypeQualifierArrayConstantSized
+	case *sema.VariableSizedType:
+		return TypeQualifierArrayVariableSized
 	case *sema.DictionaryType:
 		return TypeQualifierDictionary
+	case *sema.FunctionType:
+		return TypeQualifierFunction
 	case *sema.OptionalType:
 		return TypeQualifier(typ.Type)
 	case *sema.ReferenceType:
@@ -59,21 +82,4 @@ func TypeQualifier(typ sema.Type) string {
 	default:
 		return typ.QualifiedString()
 	}
-}
-
-func LocationToBytes(location common.Location) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := interpreter.CBOREncMode.NewStreamEncoder(&buf)
-
-	err := interpreter.EncodeLocation(enc, location)
-	if err != nil {
-		return nil, err
-	}
-
-	err = enc.Flush()
-	if err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
 }

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -21,7 +21,6 @@ package compiler
 import (
 	"math"
 	"math/big"
-	"strings"
 
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/bbq"
@@ -162,7 +161,7 @@ func (c *Compiler[_, _]) findGlobal(name string) *Global {
 	// e.g: SomeContract.Foo() == Foo(), within `SomeContract`.
 	if !c.compositeTypeStack.isEmpty() {
 		enclosingContract := c.compositeTypeStack.bottom()
-		typeQualifiedName := commons.TypeQualifiedName(enclosingContract.GetIdentifier(), name)
+		typeQualifiedName := commons.TypeQualifiedName(enclosingContract, name)
 		global, ok = c.Globals[typeQualifiedName]
 		if ok {
 			return global
@@ -415,7 +414,7 @@ func (c *Compiler[E, T]) Compile() *bbq.Program[E, T] {
 
 	// Reserve globals for functions/types before visiting their implementations.
 	c.reserveGlobalVars(
-		"",
+		nil,
 		variableDeclarations,
 		nil,
 		functionDeclarations,
@@ -451,7 +450,7 @@ func (c *Compiler[E, T]) Compile() *bbq.Program[E, T] {
 }
 
 func (c *Compiler[_, _]) reserveGlobalVars(
-	compositeTypeName string,
+	enclosingType sema.CompositeKindedType,
 	variableDecls []*ast.VariableDeclaration,
 	specialFunctionDecls []*ast.SpecialFunctionDeclaration,
 	functionDecls []*ast.FunctionDeclaration,
@@ -468,30 +467,31 @@ func (c *Compiler[_, _]) reserveGlobalVars(
 			common.DeclarationKindPrepare:
 			// Important: All special functions visited within `VisitSpecialFunctionDeclaration`
 			// must be also visited here. And must be visited only them. e.g: Don't visit inits.
-			funcName := commons.TypeQualifiedName(compositeTypeName, declaration.FunctionDeclaration.Identifier.Identifier)
+			funcName := commons.TypeQualifiedName(enclosingType, declaration.FunctionDeclaration.Identifier.Identifier)
 			c.addGlobal(funcName)
 		}
 	}
 
 	// Add natively provided methods as globals.
 	// Only do it for user-defined types (i.e: `compositeTypeName` is not empty).
-	if compositeTypeName != "" {
+	if enclosingType != nil {
 		for _, boundFunction := range commonBuiltinTypeBoundFunctions {
-			funcName := commons.TypeQualifiedName(compositeTypeName, boundFunction.name)
+			funcName := commons.TypeQualifiedName(enclosingType, boundFunction.name)
 			c.addGlobal(funcName)
 		}
 	}
 
 	for _, declaration := range functionDecls {
-		funcName := commons.TypeQualifiedName(compositeTypeName, declaration.Identifier.Identifier)
+		funcName := commons.TypeQualifiedName(enclosingType, declaration.Identifier.Identifier)
 		c.addGlobal(funcName)
 	}
 
 	for _, declaration := range compositeDecls {
-		qualifiedTypeName := commons.TypeQualifiedName(compositeTypeName, declaration.Identifier.Identifier)
+		compositeType := c.DesugaredElaboration.CompositeDeclarationType(declaration)
 
 		// Reserve a global-var for the value-constructor.
-		c.addGlobal(qualifiedTypeName)
+		constructorName := commons.TypeQualifier(compositeType)
+		c.addGlobal(constructorName)
 
 		// For composite types other than contracts, global variables
 		// reserved by the type-name will be used for the init method.
@@ -508,7 +508,7 @@ func (c *Compiler[_, _]) reserveGlobalVars(
 		members := declaration.Members
 
 		c.reserveGlobalVars(
-			qualifiedTypeName,
+			compositeType,
 			nil,
 			members.SpecialFunctions(),
 			members.Functions(),
@@ -519,12 +519,12 @@ func (c *Compiler[_, _]) reserveGlobalVars(
 
 	for _, declaration := range interfaceDecls {
 		// Don't need a global-var for the value-constructor for interfaces
-		qualifiedTypeName := commons.TypeQualifiedName(compositeTypeName, declaration.Identifier.Identifier)
 
 		members := declaration.Members
+		interfaceType := c.DesugaredElaboration.InterfaceDeclarationType(declaration)
 
 		c.reserveGlobalVars(
-			qualifiedTypeName,
+			interfaceType,
 			nil,
 			members.SpecialFunctions(),
 			members.Functions(),
@@ -1407,12 +1407,14 @@ func (c *Compiler[_, _]) VisitInvocationExpression(expression *ast.InvocationExp
 			panic(errors.NewUnreachableError())
 		}
 
-		typeName := commons.TypeQualifier(memberInfo.AccessedType)
 		var funcName string
 
 		invocationType := memberInfo.Member.TypeAnnotation.Type.(*sema.FunctionType)
 		if invocationType.IsConstructor {
-			funcName = commons.TypeQualifiedName(typeName, invokedExpr.Identifier.Identifier)
+			funcName = commons.TypeQualifiedName(
+				memberInfo.AccessedType,
+				invokedExpr.Identifier.Identifier,
+			)
 
 			// Calling a type constructor must be invoked statically. e.g: `SomeContract.Foo()`.
 			// Compile arguments
@@ -1460,7 +1462,10 @@ func (c *Compiler[_, _]) VisitInvocationExpression(expression *ast.InvocationExp
 
 		} else {
 			// Load function value
-			funcName = commons.TypeQualifiedName(typeName, invokedExpr.Identifier.Identifier)
+			funcName = commons.TypeQualifiedName(
+				memberInfo.AccessedType,
+				invokedExpr.Identifier.Identifier,
+			)
 			c.emitVariableLoad(funcName)
 
 			c.codeGen.Emit(opcode.InstructionInvokeMethodStatic{
@@ -1879,9 +1884,10 @@ func (c *Compiler[_, _]) VisitSpecialFunctionDeclaration(declaration *ast.Specia
 }
 
 func (c *Compiler[_, _]) compileInitializer(declaration *ast.SpecialFunctionDeclaration) {
-	enclosingCompositeTypeName := c.enclosingCompositeTypeFullyQualifiedName()
 	enclosingType := c.compositeTypeStack.top()
 	kind := enclosingType.GetCompositeKind()
+
+	constructorName := commons.TypeQualifier(enclosingType)
 
 	var functionName string
 	if kind == common.CompositeKindContract {
@@ -1892,7 +1898,7 @@ func (c *Compiler[_, _]) compileInitializer(declaration *ast.SpecialFunctionDecl
 	} else {
 		// Use the type name as the function name for initializer.
 		// So `x = Foo()` would directly call the init method.
-		functionName = enclosingCompositeTypeName
+		functionName = constructorName
 	}
 
 	parameterCount := 0
@@ -1950,7 +1956,7 @@ func (c *Compiler[_, _]) compileInitializer(declaration *ast.SpecialFunctionDecl
 
 		// Duplicate the top of stack and store it in both global variable and in `self`
 		c.codeGen.Emit(opcode.InstructionDup{})
-		global := c.findGlobal(enclosingCompositeTypeName)
+		global := c.findGlobal(constructorName)
 
 		c.codeGen.Emit(opcode.InstructionSetGlobal{
 			Global: global.Index,
@@ -1974,9 +1980,9 @@ func (c *Compiler[E, _]) VisitFunctionDeclaration(declaration *ast.FunctionDecla
 	previousFunction := c.currentFunction
 
 	var (
-		parameterCount  int
-		declareReceiver bool
-		functionName    string
+		parameterCount int
+		isObjectMethod bool
+		functionName   string
 	)
 
 	paramList := declaration.ParameterList
@@ -1990,17 +1996,17 @@ func (c *Compiler[E, _]) VisitFunctionDeclaration(declaration *ast.FunctionDecla
 
 	if previousFunction == nil {
 		// Global function or method
+		isObjectMethod = !c.compositeTypeStack.isEmpty()
 
-		declareReceiver = !c.compositeTypeStack.isEmpty()
+		var enclosingType sema.Type
+		if isObjectMethod {
+			enclosingType = c.compositeTypeStack.top()
 
-		functionName = commons.TypeQualifiedName(
-			c.enclosingCompositeTypeFullyQualifiedName(),
-			identifier,
-		)
-
-		if declareReceiver {
+			// Declare a receiver if this is an object method.
 			parameterCount++
 		}
+
+		functionName = commons.TypeQualifiedName(enclosingType, identifier)
 
 	} else {
 		innerFunctionLocal = c.currentFunction.declareLocal(identifier)
@@ -2029,7 +2035,7 @@ func (c *Compiler[E, _]) VisitFunctionDeclaration(declaration *ast.FunctionDecla
 		c.targetFunction(function)
 		defer c.targetFunction(previousFunction)
 
-		c.declareParameters(declaration.ParameterList, declareReceiver)
+		c.declareParameters(declaration.ParameterList, isObjectMethod)
 
 		c.compileFunctionBlock(
 			declaration.FunctionBlock,
@@ -2070,7 +2076,7 @@ func (c *Compiler[_, _]) VisitCompositeDeclaration(declaration *ast.CompositeDec
 	}
 
 	// Add the methods that are provided natively.
-	c.addBuiltinMethods()
+	c.addBuiltinMethods(compositeType)
 
 	for _, function := range declaration.Members.Functions() {
 		c.compileDeclaration(function)
@@ -2095,7 +2101,7 @@ func (c *Compiler[_, _]) VisitInterfaceDeclaration(declaration *ast.InterfaceDec
 	}()
 
 	// Add the methods that are provided natively.
-	c.addBuiltinMethods()
+	c.addBuiltinMethods(interfaceType)
 
 	for _, function := range declaration.Members.Functions() {
 		c.compileDeclaration(function)
@@ -2109,13 +2115,10 @@ func (c *Compiler[_, _]) VisitInterfaceDeclaration(declaration *ast.InterfaceDec
 	return
 }
 
-func (c *Compiler[_, _]) addBuiltinMethods() {
+func (c *Compiler[_, _]) addBuiltinMethods(typ sema.Type) {
 	for _, boundFunction := range commonBuiltinTypeBoundFunctions {
 		name := boundFunction.name
-		qualifiedName := commons.TypeQualifiedName(
-			c.enclosingCompositeTypeFullyQualifiedName(),
-			name,
-		)
+		qualifiedName := commons.TypeQualifiedName(typ, name)
 		c.addFunction(
 			name,
 			qualifiedName,
@@ -2284,22 +2287,6 @@ func (c *Compiler[_, T]) addCompiledType(ty sema.Type, data T) uint16 {
 	c.compiledTypes = append(c.compiledTypes, data)
 	c.types = append(c.types, ty)
 	return uint16(count)
-}
-
-func (c *Compiler[_, _]) enclosingCompositeTypeFullyQualifiedName() string {
-	if c.compositeTypeStack.isEmpty() {
-		return ""
-	}
-
-	var sb strings.Builder
-	for i, typ := range c.compositeTypeStack.elements {
-		if i > 0 {
-			sb.WriteRune('.')
-		}
-		sb.WriteString(typ.GetIdentifier())
-	}
-
-	return sb.String()
 }
 
 func (c *Compiler[E, T]) declareParameters(paramList *ast.ParameterList, declareReceiver bool) {

--- a/bbq/compiler/native_functions.go
+++ b/bbq/compiler/native_functions.go
@@ -19,7 +19,6 @@
 package compiler
 
 import (
-	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 
@@ -42,15 +41,6 @@ func NativeFunctions() map[string]*Global {
 	}
 	return funcs
 }
-
-var builtinTypes = common.Concat[sema.Type](
-	sema.AllBuiltinTypes,
-	[]sema.Type{
-		&sema.ConstantSizedType{},
-		&sema.VariableSizedType{},
-		&sema.DictionaryType{},
-	},
-)
 
 var stdlibFunctions = []string{
 	commons.LogFunctionName,
@@ -80,7 +70,7 @@ func init() {
 	// Because the native functions used by a program are also
 	// added to the imports section of the compiled program.
 	// Then the VM will link the imports (native functions) by the name.
-	for _, typ := range builtinTypes {
+	for _, typ := range commons.BuiltinTypes {
 		registerBoundFunctions(typ)
 	}
 
@@ -101,8 +91,7 @@ func init() {
 
 func registerBoundFunctions(typ sema.Type) {
 	for name := range typ.GetMembers() { //nolint:maprange
-		typeQualifier := commons.TypeQualifier(typ)
-		funcName := commons.TypeQualifiedName(typeQualifier, name)
+		funcName := commons.TypeQualifiedName(typ, name)
 		addNativeFunction(funcName)
 	}
 

--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -230,8 +230,7 @@ func (c *Context) GetMethod(
 		location = locatedType.GetLocation()
 	}
 
-	typeQualifier := commons.TypeQualifier(semaType)
-	qualifiedFuncName := commons.TypeQualifiedName(typeQualifier, name)
+	qualifiedFuncName := commons.TypeQualifiedName(semaType, name)
 
 	method := c.lookupFunction(location, qualifiedFuncName)
 	if method == nil {

--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -65,7 +65,7 @@ func registerFunction(functionName string, functionValue NativeFunctionValue) {
 
 func RegisterTypeBoundFunction(typeName string, functionValue NativeFunctionValue) {
 	// Update the name of the function to be type-qualified
-	qualifiedName := commons.TypeQualifiedName(typeName, functionValue.Name)
+	qualifiedName := commons.QualifiedName(typeName, functionValue.Name)
 	functionValue.Name = qualifiedName
 
 	RegisterFunction(functionValue)
@@ -75,7 +75,7 @@ func RegisterBuiltinTypeBoundFunction(typeName string, functionValue NativeFunct
 	// Here the function value is common for many types.
 	// Hence, do not update the function name to be type-qualified.
 	// Only the key in the map is type-qualified.
-	qualifiedName := commons.TypeQualifiedName(typeName, functionValue.Name)
+	qualifiedName := commons.QualifiedName(typeName, functionValue.Name)
 	registerFunction(qualifiedName, functionValue)
 }
 
@@ -209,8 +209,8 @@ func init() {
 }
 
 func registerCommonBuiltinTypeBoundFunctions() {
-	for _, builtinType := range sema.AllBuiltinTypes {
-		typeQualifier := string(builtinType.ID())
+	for _, builtinType := range commons.BuiltinTypes {
+		typeQualifier := commons.TypeQualifier(builtinType)
 		includeToStringFunction := sema.HasToStringFunction(builtinType)
 		registerBuiltinTypeBoundFunctions(typeQualifier)
 
@@ -229,16 +229,6 @@ func registerCommonBuiltinTypeBoundFunctions() {
 				),
 			)
 		}
-	}
-
-	derivedTypeQualifiers := []string{
-		commons.TypeQualifierArray,
-		commons.TypeQualifierDictionary,
-		// TODO: add other types. e.g; Optional, etc
-	}
-
-	for _, builtinType := range derivedTypeQualifiers {
-		registerBuiltinTypeBoundFunctions(builtinType)
 	}
 
 	for _, function := range commonBuiltinTypeBoundFunctions {

--- a/bbq/vm/value_array.go
+++ b/bbq/vm/value_array.go
@@ -29,7 +29,7 @@ import (
 
 func init() {
 	RegisterTypeBoundFunction(
-		commons.TypeQualifierArray,
+		commons.TypeQualifierArrayVariableSized,
 		NewBoundNativeFunctionValue(
 			sema.ArrayTypeAppendFunctionName,
 			// TODO:


### PR DESCRIPTION
## Description

Replaced the manual construction of the qualified-name in compiler with `commons.TypeQualifiedName` which relies on types (and type hierarchy) resolved by the checker, which is also what is used by the VM. This ensures the qualified-names are in sync between the compiler and the vm

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
