### PR TITLE
Decouple NewEnumCaseValue from interpreter

### DIFF
--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -1145,8 +1145,7 @@ func (v *CompositeValue) Transfer(
 	address atree.Address,
 	remove bool,
 	storable atree.Storable,
-	preventTransfer map[atree.ValueID]struct {
-	},
+	preventTransfer map[atree.ValueID]struct{},
 	hasNoParentContainer bool,
 ) Value {
 
@@ -1584,7 +1583,7 @@ func (v *CompositeValue) SetNestedVariables(variables map[string]Variable) {
 }
 
 func NewEnumCaseValue(
-	interpreter *Interpreter,
+	context MemberAccessibleContext,
 	locationRange LocationRange,
 	enumType *sema.CompositeType,
 	rawValue NumberValue,
@@ -1599,7 +1598,7 @@ func NewEnumCaseValue(
 	}
 
 	v := NewCompositeValue(
-		interpreter,
+		context,
 		locationRange,
 		enumType.Location,
 		enumType.QualifiedIdentifier(),

--- a/interpreter/value_published.go
+++ b/interpreter/value_published.go
@@ -131,8 +131,7 @@ func (v *PublishedValue) Transfer(
 	address atree.Address,
 	remove bool,
 	storable atree.Storable,
-	preventTransfer map[atree.ValueID]struct {
-	},
+	preventTransfer map[atree.ValueID]struct{},
 	hasNoParentContainer bool,
 ) Value {
 	// NB: if the inner value of a PublishedValue can be a resource,

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -347,8 +347,7 @@ func (v *SomeValue) Transfer(
 	address atree.Address,
 	remove bool,
 	storable atree.Storable,
-	preventTransfer map[atree.ValueID]struct {
-	},
+	preventTransfer map[atree.ValueID]struct{},
 	hasNoParentContainer bool,
 ) Value {
 	innerValue := v.value


### PR DESCRIPTION
Work towards #3693 
Work towards #3849 

## Description

flow-go uses `NewEnumCaseValue` in the FVM, for the EVM implementation: https://github.com/onflow/flow-go/blob/6a11d9e230b76a57bfd7fb987793262cc233bf53/fvm/evm/impl/impl.go#L1013

To update FVM to latest Cadence `master` (and the compiler/VM feature branch), this function needs to be decoupled from the interpreter, as host functions are no longer passed invocations which provide access to an interpreter, but just an invocation context. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
