### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/docs/cadence.ebnf
+++ b/docs/cadence.ebnf
@@ -291,7 +291,7 @@ statement
 (*
   only parse the return value expression if it is
   on the same line. this prevents the return statement
-  from greedily taking an expression from a potentialy
+  from greedily taking an expression from a potentially
   following expression statement
 *)
 returnStatement

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,7 +20,7 @@ release a new version of Cadence.
 
 ### Checking backward compatibility
 
-Cadence releases should be backwards compatible and are not supposed to have any breaking changes. There may be exceptions from this rule - in those cases any Cadence release that contains breaking changes must be discussed with the wider Flow community and there must be a consensus that the breaking changes are requried to improveve Cadence.
+Cadence releases should be backwards compatible and are not supposed to have any breaking changes. There may be exceptions from this rule - in those cases any Cadence release that contains breaking changes must be discussed with the wider Flow community and there must be a consensus that the breaking changes are required to improveve Cadence.
 This step ensures the version that is going to be released does not contain such changes.
 
 _If it is expected to have breaking changes in the new version, you may skip this step and proceed to the [releasing](#releasing)

--- a/sema/account.gen.go
+++ b/sema/account.gen.go
@@ -680,7 +680,7 @@ if the given code does not declare exactly one contract or contract interface,
 or if the given name does not match the name of the contract/contract interface declaration in the code.
 
 Returns the deployment result.
-Result would contain the deployed contract for the updated contract, if the update was successfull.
+Result would contain the deployed contract for the updated contract, if the update was successful.
 Otherwise, the deployed contract would be nil.
 `
 

--- a/stdlib/rlp/rlp.go
+++ b/stdlib/rlp/rlp.go
@@ -72,7 +72,7 @@ func ReadSize(inp []byte, startIndex int) (isString bool, dataStartIndex, dataSi
 	firstByte := inp[startIndex]
 	startIndex++
 
-	// single character space - first byte holds the data itslef
+	// single character space - first byte holds the data itself
 	if firstByte <= ByteRangeEnd {
 		return true, startIndex - 1, 1, nil
 	}


### PR DESCRIPTION
This PR fixes several typos across different files:

- docs/cadence.ebnf: Fix "potentialy" -> "potentially"
- docs/releasing.md: Fix "improveve" -> "improve" 
- sema/account.gen.go: Fix "successfull" -> "successful"
- stdlib/rlp/rlp.go: Fix "itslef" -> "itself"

These are simple spelling corrections with no functional changes.