### PR TITLE
Fix version of parser NPM package

### DIFF
--- a/npm-packages/cadence-parser/package.json
+++ b/npm-packages/cadence-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-parser",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "The Cadence parser",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {


### PR DESCRIPTION
## Description

`make release` currently fails because the version of the parser NPM package is wrong. 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
