### PR TITLE
Improve generation / tool usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ check-headers:
 
 .PHONY: generate
 generate:
+	go install golang.org/x/tools/cmd/stringer@v0.32.0
 	go generate -v ./...
 
 .PHONY: check-tidy

--- a/ast/access.go
+++ b/ast/access.go
@@ -26,7 +26,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=PrimitiveAccess
+//go:generate stringer -type=PrimitiveAccess
 
 type Access interface {
 	isAccess()

--- a/ast/conditionkind.go
+++ b/ast/conditionkind.go
@@ -24,7 +24,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=ConditionKind
+//go:generate stringer -type=ConditionKind
 
 type ConditionKind uint
 

--- a/ast/elementtype.go
+++ b/ast/elementtype.go
@@ -18,7 +18,7 @@
 
 package ast
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=ElementType
+//go:generate stringer -type=ElementType
 
 type ElementType uint64
 

--- a/ast/operation.go
+++ b/ast/operation.go
@@ -24,7 +24,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=Operation
+//go:generate stringer -type=Operation
 
 type Operation uint
 

--- a/ast/precedence.go
+++ b/ast/precedence.go
@@ -18,7 +18,7 @@
 
 package ast
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=precedence
+//go:generate stringer -type=precedence
 
 // precedence is the order of importance of expressions / operators.
 // NOTE: this enumeration does *NOT* influence parsing,

--- a/ast/transferoperation.go
+++ b/ast/transferoperation.go
@@ -24,7 +24,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=TransferOperation
+//go:generate stringer -type=TransferOperation
 
 type TransferOperation uint
 

--- a/ast/variablekind.go
+++ b/ast/variablekind.go
@@ -24,7 +24,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=VariableKind
+//go:generate stringer -type=VariableKind
 
 type VariableKind uint
 

--- a/common/compositekind.go
+++ b/common/compositekind.go
@@ -24,7 +24,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=CompositeKind
+//go:generate stringer -type=CompositeKind
 
 type CompositeKind uint
 

--- a/common/computationkind.go
+++ b/common/computationkind.go
@@ -18,7 +18,7 @@
 
 package common
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=ComputationKind -trimprefix=ComputationKind
+//go:generate stringer -type=ComputationKind -trimprefix=ComputationKind
 
 // ComputationKind captures kind of computation that would be used for metring computation
 type ComputationKind uint

--- a/common/controlstatement.go
+++ b/common/controlstatement.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=ControlStatement
+//go:generate stringer -type=ControlStatement
 
 type ControlStatement uint
 

--- a/common/declarationkind.go
+++ b/common/declarationkind.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=DeclarationKind
+//go:generate stringer -type=DeclarationKind
 
 type DeclarationKind uint
 

--- a/common/integerliteralkind.go
+++ b/common/integerliteralkind.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=IntegerLiteralKind
+//go:generate stringer -type=IntegerLiteralKind
 
 type IntegerLiteralKind uint
 

--- a/common/memorykind.go
+++ b/common/memorykind.go
@@ -18,7 +18,7 @@
 
 package common
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=MemoryKind -trimprefix=MemoryKind
+//go:generate stringer -type=MemoryKind -trimprefix=MemoryKind
 
 // MemoryKind
 type MemoryKind uint

--- a/common/operandside.go
+++ b/common/operandside.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=OperandSide
+//go:generate stringer -type=OperandSide
 
 type OperandSide uint
 

--- a/common/operationkind.go
+++ b/common/operationkind.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=OperationKind
+//go:generate stringer -type=OperationKind
 
 type OperationKind uint
 

--- a/common/pathdomain.go
+++ b/common/pathdomain.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=PathDomain
+//go:generate stringer -type=PathDomain
 
 type PathDomain uint8
 

--- a/encoding/ccf/simpletype.go
+++ b/encoding/ccf/simpletype.go
@@ -18,7 +18,7 @@
 
 package ccf
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=SimpleType
+//go:generate stringer -type=SimpleType
 
 import (
 	"github.com/onflow/cadence"

--- a/interpreter/primitivestatictype.go
+++ b/interpreter/primitivestatictype.go
@@ -28,7 +28,7 @@ import (
 	"github.com/onflow/cadence/values"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=PrimitiveStaticType -trimprefix=PrimitiveStaticType
+//go:generate stringer -type=PrimitiveStaticType -trimprefix=PrimitiveStaticType
 
 // PrimitiveStaticType
 

--- a/old_parser/invalidnumberliteralkind.go
+++ b/old_parser/invalidnumberliteralkind.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=InvalidNumberLiteralKind
+//go:generate stringer -type=InvalidNumberLiteralKind
 
 type InvalidNumberLiteralKind uint
 

--- a/parser/invalidnumberliteralkind.go
+++ b/parser/invalidnumberliteralkind.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=InvalidNumberLiteralKind
+//go:generate stringer -type=InvalidNumberLiteralKind
 
 type InvalidNumberLiteralKind uint
 

--- a/sema/accesscheckmode.go
+++ b/sema/accesscheckmode.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=AccessCheckMode
+//go:generate stringer -type=AccessCheckMode
 
 type AccessCheckMode uint
 

--- a/sema/binaryoperationkind.go
+++ b/sema/binaryoperationkind.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=BinaryOperationKind
+//go:generate stringer -type=BinaryOperationKind
 
 type BinaryOperationKind uint
 

--- a/sema/containerkind.go
+++ b/sema/containerkind.go
@@ -18,7 +18,7 @@
 
 package sema
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=ContainerKind
+//go:generate stringer -type=ContainerKind
 
 type ContainerKind uint
 

--- a/sema/crypto_algorithm_types.go
+++ b/sema/crypto_algorithm_types.go
@@ -23,8 +23,8 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=SignatureAlgorithm
-//go:generate go run golang.org/x/tools/cmd/stringer -type=HashAlgorithm
+//go:generate stringer -type=SignatureAlgorithm
+//go:generate stringer -type=HashAlgorithm
 
 var SignatureAlgorithmType = newNativeEnumType(
 	SignatureAlgorithmTypeName,

--- a/sema/resourceinvalidationkind.go
+++ b/sema/resourceinvalidationkind.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onflow/cadence/errors"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=ResourceInvalidationKind
+//go:generate stringer -type=ResourceInvalidationKind
 
 type ResourceInvalidationKind uint
 

--- a/sema/typeannotationstate.go
+++ b/sema/typeannotationstate.go
@@ -18,7 +18,7 @@
 
 package sema
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=TypeAnnotationState
+//go:generate stringer -type=TypeAnnotationState
 
 type TypeAnnotationState uint
 


### PR DESCRIPTION

## Description

Switch to `go install`, don't use `go run`.

Once we require Go v1.24 we can use the new `go get -tool` to add `stringer` as a tool dependency to the `go.mod` file.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
