### PR TITLE
[Compiler] Various improvements/fixes

### DIFF
--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -474,7 +474,7 @@ func (d *Desugar) desugarCondition(condition ast.Condition, inheritedFrom *sema.
 	// Therefore, add those transitive dependencies to the current compiling program.
 	// They will only be added to the final compiled program, if those are used in the code.
 	if inheritedFrom != nil {
-		elaboration, err := d.config.ElaborationResolver(inheritedFrom.Location)
+		elaboration, err := d.resolveElaboration(inheritedFrom.Location)
 		if err != nil {
 			panic(err)
 		}
@@ -664,6 +664,14 @@ func (d *Desugar) desugarCondition(condition ast.Condition, inheritedFrom *sema.
 	}
 }
 
+func (d *Desugar) resolveElaboration(location common.Location) (*DesugaredElaboration, error) {
+	if location == d.location {
+		return d.elaboration, nil
+	}
+
+	return d.config.ElaborationResolver(location)
+}
+
 func declaredContractType(containedType sema.ContainedType) sema.Type {
 	containerType := containedType.GetContainerType()
 	if containerType == nil {
@@ -759,7 +767,7 @@ func (d *Desugar) inheritedFunctionsWithConditions(compositeType sema.Conforming
 
 	compositeType.EffectiveInterfaceConformanceSet().ForEach(func(interfaceType *sema.InterfaceType) {
 
-		elaboration, err := d.config.ElaborationResolver(interfaceType.Location)
+		elaboration, err := d.resolveElaboration(interfaceType.Location)
 		if err != nil {
 			panic(err)
 		}
@@ -806,7 +814,7 @@ func (d *Desugar) inheritedDefaultFunctions(
 	for _, conformance := range compositeType.EffectiveInterfaceConformances() {
 		interfaceType := conformance.InterfaceType
 
-		elaboration, err := d.config.ElaborationResolver(interfaceType.Location)
+		elaboration, err := d.resolveElaboration(interfaceType.Location)
 		if err != nil {
 			panic(err)
 		}

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -69,16 +69,7 @@ func compiledFTTransfer(tb testing.TB) {
 	nextTransactionLocation := NewTransactionLocationGenerator()
 	nextScriptLocation := NewScriptLocationGenerator()
 
-	locationHandler := func(identifiers []ast.Identifier, location common.Location) ([]commons.ResolvedLocation, error) {
-		switch location.(type) {
-		case common.StringLocation:
-			return newStringLocationHandler(tb, contractsAddress)(identifiers, location)
-		case common.AddressLocation:
-			return NewSingleIdentifierLocationResolver(tb)(identifiers, location)
-		default:
-			panic(fmt.Errorf("unknown location type: %T", location))
-		}
-	}
+	locationHandler := newSingleAddressOrStringLocationHandler(tb, contractsAddress)
 
 	semaConfig := &sema.Config{
 		LocationHandler:            locationHandler,

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -12458,9 +12458,14 @@ func TestRuntimeInvokeContractFunctionImported(t *testing.T) {
         import Test2 from 0x01
 
         access(all) contract Test3 {
+
 			access(all) fun hello(): String {
 				return Test2.hello()
 			}
+
+			access(all) fun getSelfAccountAddress(): Address {
+                return self.account.address
+            }
         }
     `)
 
@@ -12515,6 +12520,8 @@ func TestRuntimeInvokeContractFunctionImported(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	// Call hello
+
 	result, err := runtime.InvokeContractFunction(
 		common.AddressLocation{
 			Address: addressValue,
@@ -12533,6 +12540,29 @@ func TestRuntimeInvokeContractFunctionImported(t *testing.T) {
 
 	require.Equal(t,
 		cadence.String("Hello World!"),
+		result,
+	)
+
+	// Call getSelfAccountAddress
+
+	result, err = runtime.InvokeContractFunction(
+		common.AddressLocation{
+			Address: addressValue,
+			Name:    "Test3",
+		},
+		"getSelfAccountAddress",
+		nil,
+		nil,
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
+		},
+	)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		cadence.Address(addressValue),
 		result,
 	)
 }

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -112,6 +112,9 @@ func (e *vmEnvironment) newVMConfig() *vm.Config {
 	config.Logger = e
 	config.ContractValueHandler = e.loadContractValue
 	config.ImportHandler = e.importProgram
+	config.WithInterpreterConfig(&interpreter.Config{
+		InjectedCompositeFieldsHandler: newInjectedCompositeFieldsHandler(e),
+	})
 	return config
 }
 


### PR DESCRIPTION
Work towards #3849 

## Description

Discovered while working on switching the fee deduction in FVM to use the VM.

- Desugaring may resolve its own location/elaboration. I couldn't quite determine when / why this was the case, but the current VM-based environment triggers a load/compile when the elaboration is not available yet, which resulted in an infinite recursion (import -> compile -> desugar -> ...). In particular, the desugaring of the `MetadataViews` contract triggered this bug.
- Add support for the injected contract `account` field in the VM environment

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
