### PR TITLE
[Compiler] Implement saturating arithmetic functions in VM

### DIFF
--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -307,7 +307,7 @@ func registerSaturatingArithmeticFunctions(t sema.SaturatingArithmeticType) {
 		op func(context *Context, v, other interpreter.NumberValue) interpreter.NumberValue,
 	) {
 		RegisterTypeBoundFunction(
-			string(t.ID()),
+			commons.TypeQualifier(t),
 			NewNativeFunctionValue(
 				functionName,
 				sema.SaturatingArithmeticTypeFunctionTypes[t],

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -7894,3 +7894,24 @@ func TestInvocationExpressionEvaluationOrder(t *testing.T) {
 		)
 	})
 }
+
+func TestSaturatingArithmetic(t *testing.T) {
+
+	t.Parallel()
+
+	result, err := CompileAndInvoke(t,
+		`
+          fun test(): UFix64 {
+              return (1.0).saturatingSubtract(2.0)
+          }
+        `,
+		"test",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		interpreter.NewUnmeteredUFix64Value(0),
+		result,
+	)
+}


### PR DESCRIPTION
Work towards #3856 

## Description

The [`FlowFees` contract](https://github.com/onflow/flow-core-contracts/blob/81b89f94c10988d4194fddbff137ac6798adc57b/contracts/FlowStorageFees.cdc) uses saturating arithmetic functions.

Implement them in the VM.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
