### PR TITLE
[Compiler] Configure account handler in VM environment

### DIFF
--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -12466,6 +12466,10 @@ func TestRuntimeInvokeContractFunctionImported(t *testing.T) {
 			access(all) fun getSelfAccountAddress(): Address {
                 return self.account.address
             }
+
+            access(all) fun getAccountBalance(): UFix64 {
+                return getAccount(0x1).balance
+            }
         }
     `)
 
@@ -12486,6 +12490,9 @@ func TestRuntimeInvokeContractFunctionImported(t *testing.T) {
 		},
 		OnEmitEvent: func(event cadence.Event) error {
 			return nil
+		},
+		OnGetAccountBalance: func(_ Address) (uint64, error) {
+			return 0, nil
 		},
 	}
 
@@ -12563,6 +12570,29 @@ func TestRuntimeInvokeContractFunctionImported(t *testing.T) {
 
 	require.Equal(t,
 		cadence.Address(addressValue),
+		result,
+	)
+
+	// Call getAccountBalance
+
+	result, err = runtime.InvokeContractFunction(
+		common.AddressLocation{
+			Address: addressValue,
+			Name:    "Test3",
+		},
+		"getAccountBalance",
+		nil,
+		nil,
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
+		},
+	)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		cadence.UFix64(0),
 		result,
 	)
 }

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -115,6 +115,7 @@ func (e *vmEnvironment) newVMConfig() *vm.Config {
 	config.WithInterpreterConfig(&interpreter.Config{
 		InjectedCompositeFieldsHandler: newInjectedCompositeFieldsHandler(e),
 	})
+	config.WithAccountHandler(e)
 	return config
 }
 


### PR DESCRIPTION
Work towards #3849 

## Description

Set up the account handler of the VM environment's VM configuration.

This is needed for switching the fee deduction contract invocation in FVM to use the Cadence VM.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
