### PR TITLE
[Compiler] Add support for resource fields in VM environment

### DIFF
--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -114,6 +114,8 @@ func (e *vmEnvironment) newVMConfig() *vm.Config {
 	config.ImportHandler = e.importProgram
 	config.WithInterpreterConfig(&interpreter.Config{
 		InjectedCompositeFieldsHandler: newInjectedCompositeFieldsHandler(e),
+		UUIDHandler:                    newUUIDHandler(&e.Interface),
+		AccountHandler:                 e.newAccountValue,
 	})
 	config.WithAccountHandler(e)
 	return config


### PR DESCRIPTION
Work towards #3856 

## Description

Enable resource UUID generation and use of resource `owner` field

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
