### PR TITLE
[Compiler] Improve and fix event emission

### DIFF
--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -1108,13 +1108,14 @@ func TestCompileEmit(t *testing.T) {
 
 	assert.Equal(t,
 		[]opcode.Instruction{
-			// Inc(val: x)
-			opcode.InstructionGetGlobal{Global: 1},
+			// x
 			opcode.InstructionGetLocal{Local: xIndex},
 			opcode.InstructionTransfer{Type: 1},
-			opcode.InstructionInvoke{ArgCount: 1},
 			// emit
-			opcode.InstructionEmitEvent{Type: 2},
+			opcode.InstructionEmitEvent{
+				Type:     2,
+				ArgCount: 1,
+			},
 
 			opcode.InstructionReturn{},
 		},

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -2227,9 +2227,10 @@ func (i InstructionIteratorNext) Encode(code *[]byte) {
 
 // InstructionEmitEvent
 //
-// Pops an event off the stack and then emits it.
+// Pops arguments of the stack and then emits an event with the given type with them.
 type InstructionEmitEvent struct {
-	Type uint16
+	Type     uint16
+	ArgCount uint16
 }
 
 var _ Instruction = InstructionEmitEvent{}
@@ -2248,6 +2249,8 @@ func (i InstructionEmitEvent) String() string {
 func (i InstructionEmitEvent) OperandsString(sb *strings.Builder, colorize bool) {
 	sb.WriteByte(' ')
 	printfArgument(sb, "type", i.Type, colorize)
+	sb.WriteByte(' ')
+	printfArgument(sb, "argCount", i.ArgCount, colorize)
 }
 
 func (i InstructionEmitEvent) ResolvedOperandsString(sb *strings.Builder,
@@ -2257,15 +2260,19 @@ func (i InstructionEmitEvent) ResolvedOperandsString(sb *strings.Builder,
 	colorize bool) {
 	sb.WriteByte(' ')
 	printfTypeArgument(sb, "type", types[i.Type], colorize)
+	sb.WriteByte(' ')
+	printfArgument(sb, "argCount", i.ArgCount, colorize)
 }
 
 func (i InstructionEmitEvent) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
 	emitUint16(code, i.Type)
+	emitUint16(code, i.ArgCount)
 }
 
 func DecodeEmitEvent(ip *uint16, code []byte) (i InstructionEmitEvent) {
 	i.Type = decodeUint16(ip, code)
+	i.ArgCount = decodeUint16(ip, code)
 	return i
 }
 

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -818,11 +818,13 @@
 
 - name: "emitEvent"
   description:
-    Pops an event off the stack and then emits it.
+    Pops arguments of the stack and then emits an event with the given type with them.
   operands:
     - name: "type"
       type: "typeIndex"
+    - name: "argCount"
+      type: "size"
   valueEffects:
     pop:
-      - name: "event"
-        type: "value"
+      - name: "arguments"
+        # TODO: count

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -99,8 +99,8 @@ func TestPrintResolved(t *testing.T) {
 		InstructionGetConstant{Constant: 0},
 		InstructionGetConstant{Constant: 1},
 
-		InstructionEmitEvent{Type: 0},
-		InstructionEmitEvent{Type: 1},
+		InstructionEmitEvent{Type: 0, ArgCount: 1},
+		InstructionEmitEvent{Type: 1, ArgCount: 2},
 
 		InstructionNewClosure{
 			Function: 0,
@@ -114,8 +114,8 @@ func TestPrintResolved(t *testing.T) {
 
 	const expected = ` 0 | GetConstant | constant:"foo"
  1 | GetConstant | constant:1(Int)
- 2 |   EmitEvent | type:"Int"
- 3 |   EmitEvent | type:"[String]"
+ 2 |   EmitEvent | type:"Int" argCount:1
+ 3 |   EmitEvent | type:"[String]" argCount:2
  4 |  NewClosure | function:bar upvalues:[]
  5 |  NewClosure | function:baz upvalues:[]
 
@@ -245,7 +245,7 @@ func TestPrintInstruction(t *testing.T) {
 		"IteratorHasNext": {byte(IteratorHasNext)},
 		"IteratorNext":    {byte(IteratorNext)},
 
-		"EmitEvent type:258": {byte(EmitEvent), 1, 2},
+		"EmitEvent type:258 argCount:772": {byte(EmitEvent), 1, 2, 3, 4},
 	}
 
 	// Check if there is any opcode that is not tested

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -29,7 +29,7 @@ import (
 
 // OnEventEmittedFunc is a function that is triggered when an event is emitted by the program.
 type OnEventEmittedFunc func(
-	event *interpreter.CompositeValue,
+	eventValues []interpreter.Value,
 	eventType *interpreter.CompositeStaticType,
 ) error
 

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -4767,9 +4767,16 @@ func TestEmit(t *testing.T) {
 	var eventEmitted bool
 
 	vmConfig := vm.NewConfig(interpreter.NewInMemoryStorage(nil))
-	vmConfig.OnEventEmitted = func(event *interpreter.CompositeValue, eventType *interpreter.CompositeStaticType) error {
+	vmConfig.OnEventEmitted = func(eventValues []interpreter.Value, eventType *interpreter.CompositeStaticType) error {
 		require.False(t, eventEmitted)
 		eventEmitted = true
+
+		assert.Equal(t,
+			[]interpreter.Value{
+				interpreter.NewUnmeteredIntValueFromInt64(1),
+			},
+			eventValues,
+		)
 
 		assert.Equal(t,
 			TestLocation.TypeID(nil, "Inc"),
@@ -6933,9 +6940,14 @@ func TestEmitInContract(t *testing.T) {
 		txLocation := NewTransactionLocationGenerator()
 
 		eventEmitted := false
-		vmConfig.OnEventEmitted = func(event *interpreter.CompositeValue, eventType *interpreter.CompositeStaticType) error {
+		vmConfig.OnEventEmitted = func(eventValues []interpreter.Value, eventType *interpreter.CompositeStaticType) error {
 			require.False(t, eventEmitted)
 			eventEmitted = true
+
+			assert.Equal(t,
+				[]interpreter.Value{},
+				eventValues,
+			)
 
 			assert.Equal(t,
 				cLocation.TypeID(nil, "C.TestEvent"),
@@ -7086,9 +7098,14 @@ func TestInheritedConditions(t *testing.T) {
 		txLocation := NewTransactionLocationGenerator()
 
 		eventEmitted := false
-		vmConfig.OnEventEmitted = func(event *interpreter.CompositeValue, eventType *interpreter.CompositeStaticType) error {
+		vmConfig.OnEventEmitted = func(eventValues []interpreter.Value, eventType *interpreter.CompositeStaticType) error {
 			require.False(t, eventEmitted)
 			eventEmitted = true
+
+			assert.Equal(t,
+				[]interpreter.Value{},
+				eventValues,
+			)
 
 			assert.Equal(t,
 				cLocation.TypeID(nil, "B.TestEvent"),
@@ -7251,9 +7268,14 @@ func TestInheritedConditions(t *testing.T) {
 		txLocation := NewTransactionLocationGenerator()
 
 		eventEmitted := false
-		vmConfig.OnEventEmitted = func(event *interpreter.CompositeValue, eventType *interpreter.CompositeStaticType) error {
+		vmConfig.OnEventEmitted = func(eventValues []interpreter.Value, eventType *interpreter.CompositeStaticType) error {
 			require.False(t, eventEmitted)
 			eventEmitted = true
+
+			assert.Equal(t,
+				[]interpreter.Value{},
+				eventValues,
+			)
 
 			assert.Equal(t,
 				cLocation.TypeID(nil, "A.TestEvent"),

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -1317,7 +1317,8 @@ func (vm *VM) run() {
 }
 
 func onEmitEvent(vm *VM, ins opcode.InstructionEmitEvent) {
-	eventValue := vm.pop().(*interpreter.CompositeValue)
+	// Load arguments
+	eventValues := vm.popN(int(ins.ArgCount))
 
 	onEventEmitted := vm.context.OnEventEmitted
 	if onEventEmitted == nil {
@@ -1327,7 +1328,7 @@ func onEmitEvent(vm *VM, ins opcode.InstructionEmitEvent) {
 	typeIndex := ins.Type
 	eventType := vm.loadType(typeIndex).(*interpreter.CompositeStaticType)
 
-	err := onEventEmitted(eventValue, eventType)
+	err := onEventEmitted(eventValues, eventType)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Work towards #3856 

## Description

Avoid the unnecessary allocation of a full composite value for an event. Also, fix event values/arguments, they were previously not stored in the event composite value.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
