### PR TITLE
[Compiler] Unify emission of event value and event fields, enable event emission in VM environment

### DIFF
--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -191,10 +191,10 @@ func compiledFTTransfer(tb testing.TB) {
 			)
 		},
 		OnEventEmitted: func(
-			_ *interpreter.Interpreter,
+			_ interpreter.ValueExportContext,
 			_ interpreter.LocationRange,
-			_ *interpreter.CompositeValue,
 			_ *sema.CompositeType,
+			_ []interpreter.Value,
 		) error {
 			// NO-OP
 			return nil

--- a/bbq/vm/test/interpreter_test.go
+++ b/bbq/vm/test/interpreter_test.go
@@ -333,10 +333,10 @@ func interpreterFTTransfer(tb testing.TB) {
 			)
 		},
 		OnEventEmitted: func(
-			_ *interpreter.Interpreter,
+			_ interpreter.ValueExportContext,
 			_ interpreter.LocationRange,
-			_ *interpreter.CompositeValue,
 			_ *sema.CompositeType,
+			_ []interpreter.Value,
 		) error {
 			// NO-OP
 			return nil

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -3030,12 +3030,14 @@ func TestDefaultFunctions(t *testing.T) {
 		}
 
 		var uuid uint64 = 42
-		vmConfig.WithInterpreterConfig(&interpreter.Config{
-			UUIDHandler: func() (uint64, error) {
-				uuid++
-				return uuid, nil
+		vmConfig.WithInterpreterConfig(
+			&interpreter.Config{
+				UUIDHandler: func() (uint64, error) {
+					uuid++
+					return uuid, nil
+				},
 			},
-		})
+		)
 
 		contractsAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -3161,12 +3163,14 @@ func TestDefaultFunctions(t *testing.T) {
 		}
 
 		var uuid uint64 = 42
-		vmConfig.WithInterpreterConfig(&interpreter.Config{
-			UUIDHandler: func() (uint64, error) {
-				uuid++
-				return uuid, nil
+		vmConfig.WithInterpreterConfig(
+			&interpreter.Config{
+				UUIDHandler: func() (uint64, error) {
+					uuid++
+					return uuid, nil
+				},
 			},
-		})
+		)
 
 		contractsAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -3294,12 +3298,14 @@ func TestDefaultFunctions(t *testing.T) {
 		}
 
 		var uuid uint64 = 42
-		vmConfig.WithInterpreterConfig(&interpreter.Config{
-			UUIDHandler: func() (uint64, error) {
-				uuid++
-				return uuid, nil
+		vmConfig.WithInterpreterConfig(
+			&interpreter.Config{
+				UUIDHandler: func() (uint64, error) {
+					uuid++
+					return uuid, nil
+				},
 			},
-		})
+		)
 
 		contractsAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -4767,24 +4773,33 @@ func TestEmit(t *testing.T) {
 	var eventEmitted bool
 
 	vmConfig := vm.NewConfig(interpreter.NewInMemoryStorage(nil))
-	vmConfig.OnEventEmitted = func(eventValues []interpreter.Value, eventType *interpreter.CompositeStaticType) error {
-		require.False(t, eventEmitted)
-		eventEmitted = true
+	vmConfig.WithInterpreterConfig(
+		&interpreter.Config{
+			OnEventEmitted: func(
+				context interpreter.ValueExportContext,
+				locationRange interpreter.LocationRange,
+				eventType *sema.CompositeType,
+				eventFields []interpreter.Value,
+			) error {
+				require.False(t, eventEmitted)
+				eventEmitted = true
 
-		assert.Equal(t,
-			[]interpreter.Value{
-				interpreter.NewUnmeteredIntValueFromInt64(1),
+				assert.Equal(t,
+					[]interpreter.Value{
+						interpreter.NewUnmeteredIntValueFromInt64(1),
+					},
+					eventFields,
+				)
+
+				assert.Equal(t,
+					TestLocation.TypeID(nil, "Inc"),
+					eventType.ID(),
+				)
+
+				return nil
 			},
-			eventValues,
-		)
-
-		assert.Equal(t,
-			TestLocation.TypeID(nil, "Inc"),
-			eventType.ID(),
-		)
-
-		return nil
-	}
+		},
+	)
 
 	_, err := CompileAndInvokeWithOptions(t,
 		`
@@ -6937,35 +6952,43 @@ func TestEmitInContract(t *testing.T) {
 			contractsAddress.HexWithPrefix(),
 		)
 
-		txLocation := NewTransactionLocationGenerator()
-
 		eventEmitted := false
-		vmConfig.OnEventEmitted = func(eventValues []interpreter.Value, eventType *interpreter.CompositeStaticType) error {
-			require.False(t, eventEmitted)
-			eventEmitted = true
+		vmConfig.WithInterpreterConfig(&interpreter.Config{
+			OnEventEmitted: func(
+				context interpreter.ValueExportContext,
+				locationRange interpreter.LocationRange,
+				eventType *sema.CompositeType,
+				eventFields []interpreter.Value,
+			) error {
+				require.False(t, eventEmitted)
+				eventEmitted = true
 
-			assert.Equal(t,
-				[]interpreter.Value{},
-				eventValues,
-			)
+				assert.Equal(t,
+					cLocation.TypeID(nil, "C.TestEvent"),
+					eventType.ID(),
+				)
 
-			assert.Equal(t,
-				cLocation.TypeID(nil, "C.TestEvent"),
-				eventType.ID(),
-			)
+				assert.Equal(t,
+					[]interpreter.Value{},
+					eventFields,
+				)
 
-			return nil
-		}
-
-		txProgram := ParseCheckAndCompile(t, tx, txLocation(), programs)
-		txVM := vm.NewVM(txLocation(), txProgram, vmConfig)
+				return nil
+			},
+		})
 
 		require.False(t, eventEmitted)
 
-		result, err := txVM.Invoke("main")
-
+		result, err := compileAndInvokeWithOptionsAndPrograms(
+			t,
+			tx,
+			"main",
+			CompilerAndVMOptions{
+				VMConfig: vmConfig,
+			},
+			programs,
+		)
 		require.NoError(t, err)
-		require.Equal(t, 0, txVM.StackSize())
 
 		require.True(t, eventEmitted)
 		require.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(10), result)
@@ -7095,35 +7118,45 @@ func TestInheritedConditions(t *testing.T) {
 			contractsAddress.HexWithPrefix(),
 		)
 
-		txLocation := NewTransactionLocationGenerator()
-
 		eventEmitted := false
-		vmConfig.OnEventEmitted = func(eventValues []interpreter.Value, eventType *interpreter.CompositeStaticType) error {
-			require.False(t, eventEmitted)
-			eventEmitted = true
+		vmConfig.WithInterpreterConfig(
+			&interpreter.Config{
+				OnEventEmitted: func(
+					context interpreter.ValueExportContext,
+					locationRange interpreter.LocationRange,
+					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
+				) error {
+					require.False(t, eventEmitted)
+					eventEmitted = true
 
-			assert.Equal(t,
-				[]interpreter.Value{},
-				eventValues,
-			)
+					assert.Equal(t,
+						cLocation.TypeID(nil, "B.TestEvent"),
+						eventType.ID(),
+					)
 
-			assert.Equal(t,
-				cLocation.TypeID(nil, "B.TestEvent"),
-				eventType.ID(),
-			)
+					assert.Equal(t,
+						[]interpreter.Value{},
+						eventFields,
+					)
 
-			return nil
-		}
-
-		txProgram := ParseCheckAndCompile(t, tx, txLocation(), programs)
-		txVM := vm.NewVM(txLocation(), txProgram, vmConfig)
+					return nil
+				},
+			},
+		)
 
 		require.False(t, eventEmitted)
 
-		result, err := txVM.Invoke("main")
-
+		result, err := compileAndInvokeWithOptionsAndPrograms(
+			t,
+			tx,
+			"main",
+			CompilerAndVMOptions{
+				VMConfig: vmConfig,
+			},
+			programs,
+		)
 		require.NoError(t, err)
-		require.Equal(t, 0, txVM.StackSize())
 
 		require.True(t, eventEmitted)
 		require.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(10), result)
@@ -7164,12 +7197,14 @@ func TestInheritedConditions(t *testing.T) {
 		}
 
 		var uuid uint64 = 42
-		vmConfig.WithInterpreterConfig(&interpreter.Config{
-			UUIDHandler: func() (uint64, error) {
-				uuid++
-				return uuid, nil
+		vmConfig.WithInterpreterConfig(
+			&interpreter.Config{
+				UUIDHandler: func() (uint64, error) {
+					uuid++
+					return uuid, nil
+				},
 			},
-		})
+		)
 
 		contractsAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -7265,35 +7300,44 @@ func TestInheritedConditions(t *testing.T) {
 			contractsAddress.HexWithPrefix(),
 		)
 
-		txLocation := NewTransactionLocationGenerator()
-
 		eventEmitted := false
-		vmConfig.OnEventEmitted = func(eventValues []interpreter.Value, eventType *interpreter.CompositeStaticType) error {
-			require.False(t, eventEmitted)
-			eventEmitted = true
+		vmConfig.WithInterpreterConfig(
+			&interpreter.Config{
+				OnEventEmitted: func(
+					context interpreter.ValueExportContext,
+					locationRange interpreter.LocationRange,
+					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
+				) error {
+					require.False(t, eventEmitted)
+					eventEmitted = true
 
-			assert.Equal(t,
-				[]interpreter.Value{},
-				eventValues,
-			)
+					assert.Equal(t,
+						cLocation.TypeID(nil, "A.TestEvent"),
+						eventType.ID(),
+					)
 
-			assert.Equal(t,
-				cLocation.TypeID(nil, "A.TestEvent"),
-				eventType.ID(),
-			)
+					assert.Equal(t,
+						[]interpreter.Value{},
+						eventFields,
+					)
 
-			return nil
-		}
-
-		txProgram := ParseCheckAndCompile(t, tx, txLocation(), programs)
-		txVM := vm.NewVM(txLocation(), txProgram, vmConfig)
-
+					return nil
+				},
+			},
+		)
 		require.False(t, eventEmitted)
 
-		result, err := txVM.Invoke("main")
-
+		result, err := compileAndInvokeWithOptionsAndPrograms(
+			t,
+			tx,
+			"main",
+			CompilerAndVMOptions{
+				VMConfig: vmConfig,
+			},
+			programs,
+		)
 		require.NoError(t, err)
-		require.Equal(t, 0, txVM.StackSize())
 
 		require.True(t, eventEmitted)
 		require.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(10), result)

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -32,6 +32,7 @@ import (
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
+	"github.com/onflow/cadence/sema"
 )
 
 type Variable = interpreter.SimpleVariable
@@ -1317,21 +1318,20 @@ func (vm *VM) run() {
 }
 
 func onEmitEvent(vm *VM, ins opcode.InstructionEmitEvent) {
-	// Load arguments
-	eventValues := vm.popN(int(ins.ArgCount))
-
-	onEventEmitted := vm.context.OnEventEmitted
-	if onEventEmitted == nil {
-		return
-	}
+	context := vm.context
 
 	typeIndex := ins.Type
-	eventType := vm.loadType(typeIndex).(*interpreter.CompositeStaticType)
+	eventStaticType := vm.loadType(typeIndex).(*interpreter.CompositeStaticType)
+	eventSemaType := interpreter.MustConvertStaticToSemaType(eventStaticType, context).(*sema.CompositeType)
 
-	err := onEventEmitted(eventValues, eventType)
-	if err != nil {
-		panic(err)
-	}
+	eventFields := vm.popN(int(ins.ArgCount))
+
+	context.EmitEvent(
+		context,
+		EmptyLocationRange,
+		eventSemaType,
+		eventFields,
+	)
 }
 
 func opNewClosure(vm *VM, ins opcode.InstructionNewClosure) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -405,16 +405,24 @@ func (*StandardLibraryHandler) BLSAggregateSignatures(_ [][]byte) ([]byte, error
 
 func (h *StandardLibraryHandler) NewOnEventEmittedHandler() interpreter.OnEventEmittedFunc {
 	return func(
-		inter *interpreter.Interpreter,
+		_ interpreter.ValueExportContext,
 		locationRange interpreter.LocationRange,
-		event *interpreter.CompositeValue,
-		_ *sema.CompositeType,
+		eventType *sema.CompositeType,
+		eventFields []interpreter.Value,
 	) error {
 		fmt.Printf(
-			"EVENT @ %s: %s\n",
+			"EVENT @ %s: %s(",
 			formatLocationRange(locationRange),
-			event.String(),
+			eventType.ID(),
 		)
+		for i, field := range eventFields {
+			if i > 0 {
+				fmt.Print(", ")
+			}
+			fmt.Print(field)
+		}
+		fmt.Println(")")
+
 		return nil
 	}
 }

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -408,7 +408,12 @@ type ValueWalkContext interface {
 var _ ValueWalkContext = &Interpreter{}
 
 type EventContext interface {
-	EmitEventValue(event *CompositeValue, eventType *sema.CompositeType, locationRange LocationRange)
+	EmitEvent(
+		context ValueExportContext,
+		locationRange LocationRange,
+		eventType *sema.CompositeType,
+		eventFields []Value,
+	)
 }
 
 var _ EventContext = &Interpreter{}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -58,10 +58,10 @@ type getterSetter struct {
 
 // OnEventEmittedFunc is a function that is triggered when an event is emitted by the program.
 type OnEventEmittedFunc func(
-	inter *Interpreter,
+	context ValueExportContext,
 	locationRange LocationRange,
-	event *CompositeValue,
 	eventType *sema.CompositeType,
+	eventFields []Value,
 ) error
 
 // OnStatementFunc is a function that is triggered when a statement is about to be executed.

--- a/interpreter/interpreter_statement.go
+++ b/interpreter/interpreter_statement.go
@@ -362,8 +362,12 @@ func (interpreter *Interpreter) visitForStatementBody(
 	return nil, false
 }
 
-func (interpreter *Interpreter) EmitEventValue(event *CompositeValue, eventType *sema.CompositeType, locationRange LocationRange) {
-
+func (interpreter *Interpreter) EmitEvent(
+	context ValueExportContext,
+	locationRange LocationRange,
+	eventType *sema.CompositeType,
+	eventFields []Value,
+) {
 	config := interpreter.SharedState.Config
 
 	onEventEmitted := config.OnEventEmitted
@@ -373,7 +377,12 @@ func (interpreter *Interpreter) EmitEventValue(event *CompositeValue, eventType 
 		})
 	}
 
-	err := onEventEmitted(interpreter, locationRange, event, eventType)
+	err := onEventEmitted(
+		context,
+		locationRange,
+		eventType,
+		eventFields,
+	)
 	if err != nil {
 		panic(err)
 	}
@@ -393,9 +402,35 @@ func (interpreter *Interpreter) VisitEmitStatement(statement *ast.EmitStatement)
 		HasPosition: statement,
 	}
 
-	interpreter.EmitEventValue(event, eventType, locationRange)
+	eventFields := extractEventFields(interpreter, event, eventType)
+
+	interpreter.EmitEvent(
+		interpreter,
+		locationRange,
+		eventType,
+		eventFields,
+	)
 
 	return nil
+}
+
+func extractEventFields(
+	gauge common.MemoryGauge,
+	event *CompositeValue, eventType *sema.CompositeType) []Value {
+
+	count := len(eventType.ConstructorParameters)
+	if count == 0 {
+		return nil
+	}
+
+	eventFields := make([]Value, count)
+
+	for i, parameter := range eventType.ConstructorParameters {
+		value := event.GetField(gauge, parameter.Identifier)
+		eventFields[i] = value
+	}
+
+	return eventFields
 }
 
 func (interpreter *Interpreter) VisitRemoveStatement(removeStatement *ast.RemoveStatement) StatementResult {

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -6454,34 +6454,47 @@ func TestInterpretResourceMoveInArrayAndDestroy(t *testing.T) {
 
 	t.Parallel()
 
-	var events []*interpreter.CompositeValue
+	var eventTypes []*sema.CompositeType
+	var eventsFields [][]interpreter.Value
 
-	inter, err := parseCheckAndInterpretWithOptions(t, `
-      resource Foo {
-		  event ResourceDestroyed(bar: Int = self.bar)
-          var bar: Int
+	inter, err := parseCheckAndInterpretWithOptions(t,
+		`
+          resource Foo {
+              event ResourceDestroyed(
+                  bar: Int = self.bar
+              )
 
-          init(bar: Int) {
-              self.bar = bar
+              var bar: Int
+
+              init(bar: Int) {
+                  self.bar = bar
+              }
           }
-      }
 
-      fun test(): Int {
-          let foo1 <- create Foo(bar: 1)
-          let foo2 <- create Foo(bar: 2)
-          let foos <- [<-foo1, <-foo2]
-          let bar = foos[1].bar
-          destroy foos
-          return bar
-      }
-    `, ParseCheckAndInterpretOptions{
-		Config: &interpreter.Config{
-			OnEventEmitted: func(_ *interpreter.Interpreter, _ interpreter.LocationRange, event *interpreter.CompositeValue, eventType *sema.CompositeType) error {
-				events = append(events, event)
-				return nil
+          fun test(): Int {
+              let foo1 <- create Foo(bar: 1)
+              let foo2 <- create Foo(bar: 2)
+              let foos <- [<-foo1, <-foo2]
+              let bar = foos[1].bar
+              destroy foos
+              return bar
+          }
+        `,
+		ParseCheckAndInterpretOptions{
+			Config: &interpreter.Config{
+				OnEventEmitted: func(
+					_ interpreter.ValueExportContext,
+					_ interpreter.LocationRange,
+					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
+				) error {
+					eventTypes = append(eventTypes, eventType)
+					eventsFields = append(eventsFields, eventFields)
+					return nil
+				},
 			},
 		},
-	})
+	)
 	require.NoError(t, err)
 
 	value, err := inter.Invoke("test")
@@ -6494,53 +6507,86 @@ func TestInterpretResourceMoveInArrayAndDestroy(t *testing.T) {
 		value,
 	)
 
-	require.Len(t, events, 2)
-	require.Equal(t, "Foo.ResourceDestroyed", events[0].QualifiedIdentifier)
-	require.Equal(t, interpreter.NewIntValueFromInt64(nil, 1), events[0].GetField(inter, "bar"))
-	require.Equal(t, "Foo.ResourceDestroyed", events[1].QualifiedIdentifier)
-	require.Equal(t, interpreter.NewIntValueFromInt64(nil, 2), events[1].GetField(inter, "bar"))
+	require.Len(t, eventTypes, 2)
+	require.Equal(t, "Foo.ResourceDestroyed", eventTypes[0].QualifiedIdentifier())
+	require.Equal(t, "Foo.ResourceDestroyed", eventTypes[1].QualifiedIdentifier())
+
+	require.Equal(t,
+		[][]interpreter.Value{
+			{
+				interpreter.NewIntValueFromInt64(nil, 1),
+			},
+			{
+				interpreter.NewIntValueFromInt64(nil, 2),
+			},
+		},
+		eventsFields,
+	)
 }
 
 func TestInterpretResourceMoveInDictionaryAndDestroy(t *testing.T) {
 
 	t.Parallel()
 
-	var events []*interpreter.CompositeValue
+	var eventTypes []*sema.CompositeType
+	var eventsFields [][]interpreter.Value
 
-	inter, err := parseCheckAndInterpretWithOptions(t, `
-      resource Foo {
-		  event ResourceDestroyed(bar: Int = self.bar)
-          var bar: Int
+	inter, err := parseCheckAndInterpretWithOptions(t,
+		`
+          resource Foo {
+              event ResourceDestroyed(
+                  bar: Int = self.bar
+              )
 
-          init(bar: Int) {
-              self.bar = bar
+              var bar: Int
+
+              init(bar: Int) {
+                  self.bar = bar
+              }
           }
-      }
 
-      fun test() {
-          let foo1 <- create Foo(bar: 1)
-          let foo2 <- create Foo(bar: 2)
-          let foos <- {"foo1": <-foo1, "foo2": <-foo2}
-          destroy foos
-      }
-    `, ParseCheckAndInterpretOptions{
-		Config: &interpreter.Config{
-			OnEventEmitted: func(_ *interpreter.Interpreter, _ interpreter.LocationRange, event *interpreter.CompositeValue, eventType *sema.CompositeType) error {
-				events = append(events, event)
-				return nil
+          fun test() {
+              let foo1 <- create Foo(bar: 1)
+              let foo2 <- create Foo(bar: 2)
+              let foos <- {"foo1": <-foo1, "foo2": <-foo2}
+              destroy foos
+          }
+        `,
+		ParseCheckAndInterpretOptions{
+			Config: &interpreter.Config{
+				OnEventEmitted: func(
+					_ interpreter.ValueExportContext,
+					_ interpreter.LocationRange,
+					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
+				) error {
+					eventTypes = append(eventTypes, eventType)
+					eventsFields = append(eventsFields, eventFields)
+					return nil
+				},
 			},
 		},
-	})
+	)
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test")
 	require.NoError(t, err)
 
-	require.Len(t, events, 2)
-	require.Equal(t, "Foo.ResourceDestroyed", events[0].QualifiedIdentifier)
-	require.Equal(t, interpreter.NewIntValueFromInt64(nil, 1), events[0].GetField(inter, "bar"))
-	require.Equal(t, "Foo.ResourceDestroyed", events[1].QualifiedIdentifier)
-	require.Equal(t, interpreter.NewIntValueFromInt64(nil, 2), events[1].GetField(inter, "bar"))
+	require.Len(t, eventTypes, 2)
+	require.Equal(t, "Foo.ResourceDestroyed", eventTypes[0].QualifiedIdentifier())
+	require.Equal(t, "Foo.ResourceDestroyed", eventTypes[1].QualifiedIdentifier())
+
+	require.Equal(t,
+		[][]interpreter.Value{
+			{
+				interpreter.NewIntValueFromInt64(nil, 1),
+			},
+			{
+				interpreter.NewIntValueFromInt64(nil, 2),
+			},
+		},
+		eventsFields,
+	)
 }
 
 func TestInterpretClosure(t *testing.T) {
@@ -6980,213 +7026,287 @@ func TestInterpretResourceDestroyExpressionDestructor(t *testing.T) {
 
 	t.Parallel()
 
-	var events []*interpreter.CompositeValue
+	var eventTypes []*sema.CompositeType
+	var eventsFields [][]interpreter.Value
 
-	inter, err := parseCheckAndInterpretWithOptions(t, `
-        resource R {
-			event ResourceDestroyed()
-	    }
+	inter, err := parseCheckAndInterpretWithOptions(t,
+		`
+           resource R {
+               event ResourceDestroyed()
+           }
 
-       fun test() {
-           let r <- create R()
-           destroy r
-       }
-    `, ParseCheckAndInterpretOptions{
-		Config: &interpreter.Config{
-			OnEventEmitted: func(_ *interpreter.Interpreter, _ interpreter.LocationRange, event *interpreter.CompositeValue, eventType *sema.CompositeType) error {
-				events = append(events, event)
-				return nil
+           fun test() {
+               let r <- create R()
+               destroy r
+           }
+        `,
+		ParseCheckAndInterpretOptions{
+			Config: &interpreter.Config{
+				OnEventEmitted: func(
+					_ interpreter.ValueExportContext,
+					_ interpreter.LocationRange,
+					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
+				) error {
+					eventTypes = append(eventTypes, eventType)
+					eventsFields = append(eventsFields, eventFields)
+					return nil
+				},
 			},
 		},
-	})
+	)
 
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test")
 	require.NoError(t, err)
 
-	require.Len(t, events, 1)
-	require.Equal(t, "R.ResourceDestroyed", events[0].QualifiedIdentifier)
+	require.Len(t, eventTypes, 1)
+	require.Equal(t, "R.ResourceDestroyed", eventTypes[0].QualifiedIdentifier())
 }
 
 func TestInterpretResourceDestroyExpressionNestedResources(t *testing.T) {
 
 	t.Parallel()
 
-	var events []*interpreter.CompositeValue
+	var eventTypes []*sema.CompositeType
+	var eventsFields [][]interpreter.Value
 
-	inter, err := parseCheckAndInterpretWithOptions(t, `
-      resource B {
-		var foo: Int
-		event ResourceDestroyed(foo: Int = self.foo)
+	inter, err := parseCheckAndInterpretWithOptions(t,
+		`
+          resource B {
+            var foo: Int
 
-		init() {
-			self.foo = 5
-		}
-	  }
+            event ResourceDestroyed(
+                foo: Int = self.foo
+            )
 
-      resource A {
-		  event ResourceDestroyed(foo: Int = self.b.foo)
-
-          let b: @B
-
-          init(b: @B) {
-              self.b <- b
+            init() {
+                self.foo = 5
+            }
           }
-      }
 
-      fun test() {
-          let b <- create B()
-          let a <- create A(b: <-b)
-          destroy a
-      }
-    `, ParseCheckAndInterpretOptions{
-		Config: &interpreter.Config{
-			OnEventEmitted: func(_ *interpreter.Interpreter, _ interpreter.LocationRange, event *interpreter.CompositeValue, eventType *sema.CompositeType) error {
-				events = append(events, event)
-				return nil
+          resource A {
+              event ResourceDestroyed(
+                  foo: Int = self.b.foo
+              )
+
+              let b: @B
+
+              init(b: @B) {
+                  self.b <- b
+              }
+          }
+
+          fun test() {
+              let b <- create B()
+              let a <- create A(b: <-b)
+              destroy a
+          }
+        `,
+		ParseCheckAndInterpretOptions{
+			Config: &interpreter.Config{
+				OnEventEmitted: func(
+					_ interpreter.ValueExportContext,
+					_ interpreter.LocationRange,
+					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
+				) error {
+					eventTypes = append(eventTypes, eventType)
+					eventsFields = append(eventsFields, eventFields)
+					return nil
+				},
 			},
 		},
-	})
+	)
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test")
 	require.NoError(t, err)
 
-	require.Len(t, events, 2)
-	require.Equal(t, "B.ResourceDestroyed", events[0].QualifiedIdentifier)
-	require.Equal(t, interpreter.NewIntValueFromInt64(nil, 5), events[0].GetField(inter, "foo"))
-	require.Equal(t, "A.ResourceDestroyed", events[1].QualifiedIdentifier)
-	require.Equal(t, interpreter.NewIntValueFromInt64(nil, 5), events[1].GetField(inter, "foo"))
+	require.Len(t, eventTypes, 2)
+	require.Equal(t, "B.ResourceDestroyed", eventTypes[0].QualifiedIdentifier())
+	require.Equal(t, "A.ResourceDestroyed", eventTypes[1].QualifiedIdentifier())
+
+	require.Equal(t,
+		[][]interpreter.Value{
+			{
+				interpreter.NewIntValueFromInt64(nil, 5),
+			}, {
+				interpreter.NewIntValueFromInt64(nil, 5),
+			},
+		},
+		eventsFields,
+	)
 }
 
 func TestInterpretResourceDestroyArray(t *testing.T) {
 
 	t.Parallel()
 
-	var events []*interpreter.CompositeValue
+	var eventTypes []*sema.CompositeType
+	var eventsFields [][]interpreter.Value
 
-	inter, err := parseCheckAndInterpretWithOptions(t, `
-      resource R {
-		event ResourceDestroyed()
-	  }
+	inter, err := parseCheckAndInterpretWithOptions(t,
+		`
+          resource R {
+              event ResourceDestroyed()
+          }
 
-      fun test() {
-          let rs <- [<-create R(), <-create R()]
-          destroy rs
-      }
-    `, ParseCheckAndInterpretOptions{
-		Config: &interpreter.Config{
-			OnEventEmitted: func(_ *interpreter.Interpreter, _ interpreter.LocationRange, event *interpreter.CompositeValue, eventType *sema.CompositeType) error {
-				events = append(events, event)
-				return nil
+          fun test() {
+              let rs <- [<-create R(), <-create R()]
+              destroy rs
+          }
+        `,
+		ParseCheckAndInterpretOptions{
+			Config: &interpreter.Config{
+				OnEventEmitted: func(
+					_ interpreter.ValueExportContext,
+					_ interpreter.LocationRange,
+					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
+				) error {
+					eventTypes = append(eventTypes, eventType)
+					eventsFields = append(eventsFields, eventFields)
+					return nil
+				},
 			},
 		},
-	})
+	)
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test")
 	require.NoError(t, err)
 
-	require.Len(t, events, 2)
-	require.Equal(t, "R.ResourceDestroyed", events[0].QualifiedIdentifier)
-	require.Equal(t, "R.ResourceDestroyed", events[1].QualifiedIdentifier)
+	require.Len(t, eventTypes, 2)
+	require.Equal(t, "R.ResourceDestroyed", eventTypes[0].QualifiedIdentifier())
+	require.Equal(t, "R.ResourceDestroyed", eventTypes[1].QualifiedIdentifier())
 }
 
 func TestInterpretResourceDestroyDictionary(t *testing.T) {
 
 	t.Parallel()
 
-	var events []*interpreter.CompositeValue
+	var eventTypes []*sema.CompositeType
+	var eventsFields [][]interpreter.Value
 
-	inter, err := parseCheckAndInterpretWithOptions(t, `
-	  resource R {
-		event ResourceDestroyed()
-	  }
+	inter, err := parseCheckAndInterpretWithOptions(t,
+		`
+          resource R {
+              event ResourceDestroyed()
+          }
 
-      fun test() {
-          let rs <- {"r1": <-create R(), "r2": <-create R()}
-          destroy rs
-      }
-    `, ParseCheckAndInterpretOptions{
-		Config: &interpreter.Config{
-			OnEventEmitted: func(_ *interpreter.Interpreter, _ interpreter.LocationRange, event *interpreter.CompositeValue, eventType *sema.CompositeType) error {
-				events = append(events, event)
-				return nil
+          fun test() {
+              let rs <- {"r1": <-create R(), "r2": <-create R()}
+              destroy rs
+          }
+        `,
+		ParseCheckAndInterpretOptions{
+			Config: &interpreter.Config{
+				OnEventEmitted: func(
+					_ interpreter.ValueExportContext,
+					_ interpreter.LocationRange,
+					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
+				) error {
+					eventTypes = append(eventTypes, eventType)
+					eventsFields = append(eventsFields, eventFields)
+					return nil
+				},
 			},
 		},
-	})
+	)
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test")
 	require.NoError(t, err)
 
-	require.Len(t, events, 2)
-	require.Equal(t, "R.ResourceDestroyed", events[0].QualifiedIdentifier)
-	require.Equal(t, "R.ResourceDestroyed", events[1].QualifiedIdentifier)
+	require.Len(t, eventTypes, 2)
+	require.Equal(t, "R.ResourceDestroyed", eventTypes[0].QualifiedIdentifier())
+	require.Equal(t, "R.ResourceDestroyed", eventTypes[1].QualifiedIdentifier())
 }
 
 func TestInterpretResourceDestroyOptionalSome(t *testing.T) {
 
 	t.Parallel()
 
-	var events []*interpreter.CompositeValue
+	var eventTypes []*sema.CompositeType
+	var eventsFields [][]interpreter.Value
 
-	inter, err := parseCheckAndInterpretWithOptions(t, `
-      resource R { 
-		event ResourceDestroyed()
-	  }
+	inter, err := parseCheckAndInterpretWithOptions(t,
+		`
+          resource R {
+              event ResourceDestroyed()
+          }
 
-      fun test() {
-          let maybeR: @R? <- create R()
-          destroy maybeR
-      }
-    `, ParseCheckAndInterpretOptions{
-		Config: &interpreter.Config{
-			OnEventEmitted: func(_ *interpreter.Interpreter, _ interpreter.LocationRange, event *interpreter.CompositeValue, eventType *sema.CompositeType) error {
-				events = append(events, event)
-				return nil
+          fun test() {
+              let maybeR: @R? <- create R()
+              destroy maybeR
+          }
+        `,
+		ParseCheckAndInterpretOptions{
+			Config: &interpreter.Config{
+				OnEventEmitted: func(
+					_ interpreter.ValueExportContext,
+					_ interpreter.LocationRange,
+					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
+				) error {
+					eventTypes = append(eventTypes, eventType)
+					eventsFields = append(eventsFields, eventFields)
+					return nil
+				},
 			},
 		},
-	})
+	)
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test")
 	require.NoError(t, err)
 
-	require.Len(t, events, 1)
-	require.Equal(t, "R.ResourceDestroyed", events[0].QualifiedIdentifier)
+	require.Len(t, eventTypes, 1)
+	require.Equal(t, "R.ResourceDestroyed", eventTypes[0].QualifiedIdentifier())
 }
 
 func TestInterpretResourceDestroyOptionalNil(t *testing.T) {
 
 	t.Parallel()
 
-	var events []*interpreter.CompositeValue
+	var eventTypes []*sema.CompositeType
+	var eventsFields [][]interpreter.Value
 
-	inter, err := parseCheckAndInterpretWithOptions(t, `
-      resource R {
-		event ResourceDestroyed()
-	  }
+	inter, err := parseCheckAndInterpretWithOptions(t,
+		`
+          resource R {
+              event ResourceDestroyed()
+          }
 
-      fun test() {
-          let maybeR: @R? <- nil
-          destroy maybeR
-      }
-    `, ParseCheckAndInterpretOptions{
-		Config: &interpreter.Config{
-			OnEventEmitted: func(_ *interpreter.Interpreter, _ interpreter.LocationRange, event *interpreter.CompositeValue, eventType *sema.CompositeType) error {
-				events = append(events, event)
-				return nil
+          fun test() {
+              let maybeR: @R? <- nil
+              destroy maybeR
+          }
+        `,
+		ParseCheckAndInterpretOptions{
+			Config: &interpreter.Config{
+				OnEventEmitted: func(
+					_ interpreter.ValueExportContext,
+					_ interpreter.LocationRange,
+					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
+				) error {
+					eventTypes = append(eventTypes, eventType)
+					eventsFields = append(eventsFields, eventFields)
+					return nil
+				},
 			},
 		},
-	})
+	)
 	require.NoError(t, err)
 
 	_, err = inter.Invoke("test")
 	require.NoError(t, err)
 
-	require.Len(t, events, 0)
+	require.Len(t, eventTypes, 0)
 }
 
 // TestInterpretInterfaceInitializer tests that the interface's initializer
@@ -7228,7 +7348,8 @@ func TestInterpretEmitEvent(t *testing.T) {
 
 	t.Parallel()
 
-	var actualEvents []interpreter.Value
+	var eventTypes []*sema.CompositeType
+	var eventsFields [][]interpreter.Value
 
 	inter, err := parseCheckAndInterpretWithOptions(t,
 		`
@@ -7244,12 +7365,13 @@ func TestInterpretEmitEvent(t *testing.T) {
 		ParseCheckAndInterpretOptions{
 			Config: &interpreter.Config{
 				OnEventEmitted: func(
-					_ *interpreter.Interpreter,
+					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
-					event *interpreter.CompositeValue,
 					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
 				) error {
-					actualEvents = append(actualEvents, event)
+					eventTypes = append(eventTypes, eventType)
+					eventsFields = append(eventsFields, eventFields)
 					return nil
 				},
 			},
@@ -7263,78 +7385,28 @@ func TestInterpretEmitEvent(t *testing.T) {
 	transferEventType := RequireGlobalType(t, inter.Program.Elaboration, "Transfer")
 	transferAmountEventType := RequireGlobalType(t, inter.Program.Elaboration, "TransferAmount")
 
-	fields1 := []interpreter.CompositeField{
-		{
-			Name:  "to",
-			Value: interpreter.NewUnmeteredIntValueFromInt64(1),
-		},
-		{
-			Name:  "from",
-			Value: interpreter.NewUnmeteredIntValueFromInt64(2),
-		},
-	}
+	require.Len(t, eventTypes, 3)
+	require.Equal(t, TestLocation.QualifiedIdentifier(transferEventType.ID()), eventTypes[0].QualifiedIdentifier())
+	require.Equal(t, TestLocation.QualifiedIdentifier(transferEventType.ID()), eventTypes[1].QualifiedIdentifier())
+	require.Equal(t, TestLocation.QualifiedIdentifier(transferAmountEventType.ID()), eventTypes[2].QualifiedIdentifier())
 
-	fields2 := []interpreter.CompositeField{
-		{
-			Name:  "to",
-			Value: interpreter.NewUnmeteredIntValueFromInt64(3),
+	require.Equal(t,
+		[][]interpreter.Value{
+			{
+				interpreter.NewUnmeteredIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
+			},
+			{
+				interpreter.NewUnmeteredIntValueFromInt64(3),
+				interpreter.NewUnmeteredIntValueFromInt64(4),
+			},
+			{
+				interpreter.NewUnmeteredIntValueFromInt64(1),
+				interpreter.NewUnmeteredIntValueFromInt64(2),
+				interpreter.NewUnmeteredIntValueFromInt64(100),
+			},
 		},
-		{
-			Name:  "from",
-			Value: interpreter.NewUnmeteredIntValueFromInt64(4),
-		},
-	}
-
-	fields3 := []interpreter.CompositeField{
-		{
-			Name:  "to",
-			Value: interpreter.NewUnmeteredIntValueFromInt64(1),
-		},
-		{
-			Name:  "from",
-			Value: interpreter.NewUnmeteredIntValueFromInt64(2),
-		},
-		{
-			Name:  "amount",
-			Value: interpreter.NewUnmeteredIntValueFromInt64(100),
-		},
-	}
-
-	expectedEvents := []interpreter.Value{
-		interpreter.NewCompositeValue(
-			inter,
-			interpreter.EmptyLocationRange,
-			TestLocation,
-			TestLocation.QualifiedIdentifier(transferEventType.ID()),
-			common.CompositeKindEvent,
-			fields1,
-			common.ZeroAddress,
-		),
-		interpreter.NewCompositeValue(
-			inter,
-			interpreter.EmptyLocationRange,
-			TestLocation,
-			TestLocation.QualifiedIdentifier(transferEventType.ID()),
-			common.CompositeKindEvent,
-			fields2,
-			common.ZeroAddress,
-		),
-		interpreter.NewCompositeValue(
-			inter,
-			interpreter.EmptyLocationRange,
-			TestLocation,
-			TestLocation.QualifiedIdentifier(transferAmountEventType.ID()),
-			common.CompositeKindEvent,
-			fields3,
-			common.ZeroAddress,
-		),
-	}
-
-	AssertValueSlicesEqual(
-		t,
-		inter,
-		expectedEvents,
-		actualEvents,
+		eventsFields,
 	)
 }
 
@@ -7342,7 +7414,8 @@ func TestInterpretReferenceEventParameter(t *testing.T) {
 
 	t.Parallel()
 
-	var actualEvents []interpreter.Value
+	var eventTypes []*sema.CompositeType
+	var eventsFields [][]interpreter.Value
 
 	inter, err := parseCheckAndInterpretWithOptions(t,
 		`
@@ -7355,12 +7428,13 @@ func TestInterpretReferenceEventParameter(t *testing.T) {
 		ParseCheckAndInterpretOptions{
 			Config: &interpreter.Config{
 				OnEventEmitted: func(
-					_ *interpreter.Interpreter,
+					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
-					event *interpreter.CompositeValue,
 					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
 				) error {
-					actualEvents = append(actualEvents, event)
+					eventTypes = append(eventTypes, eventType)
+					eventsFields = append(eventsFields, eventFields)
 					return nil
 				},
 			},
@@ -7405,29 +7479,10 @@ func TestInterpretReferenceEventParameter(t *testing.T) {
 
 	eventType := RequireGlobalType(t, inter.Program.Elaboration, "TestEvent")
 
-	expectedEvents := []interpreter.Value{
-		interpreter.NewCompositeValue(
-			inter,
-			interpreter.EmptyLocationRange,
-			TestLocation,
-			TestLocation.QualifiedIdentifier(eventType.ID()),
-			common.CompositeKindEvent,
-			[]interpreter.CompositeField{
-				{
-					Name:  "ref",
-					Value: ref,
-				},
-			},
-			common.ZeroAddress,
-		),
-	}
+	require.Len(t, eventTypes, 1)
+	require.Equal(t, TestLocation.QualifiedIdentifier(eventType.ID()), eventTypes[0].QualifiedIdentifier())
 
-	AssertValueSlicesEqual(
-		t,
-		inter,
-		expectedEvents,
-		actualEvents,
-	)
+	// TODO: ref
 }
 
 type testValue struct {
@@ -7710,7 +7765,8 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 				Kind: common.DeclarationKindStructure,
 			})
 
-			var actualEvents []interpreter.Value
+			var eventTypes []*sema.CompositeType
+			var eventsFields [][]interpreter.Value
 
 			inter, err := parseCheckAndInterpretWithOptions(
 				t, code, ParseCheckAndInterpretOptions{
@@ -7725,12 +7781,13 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 					Config: &interpreter.Config{
 						Storage: storage,
 						OnEventEmitted: func(
-							_ *interpreter.Interpreter,
+							_ interpreter.ValueExportContext,
 							_ interpreter.LocationRange,
-							event *interpreter.CompositeValue,
 							eventType *sema.CompositeType,
+							eventFields []interpreter.Value,
 						) error {
-							actualEvents = append(actualEvents, event)
+							eventTypes = append(eventTypes, eventType)
+							eventsFields = append(eventsFields, eventFields)
 							return nil
 						},
 					},
@@ -7743,30 +7800,20 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 
 			testType := RequireGlobalType(t, inter.Program.Elaboration, "Test")
 
-			fields := []interpreter.CompositeField{
-				{
-					Name:  "value",
-					Value: testCase.value,
-				},
-			}
+			require.Len(t, eventTypes, 1)
+			require.Equal(t,
+				TestLocation.QualifiedIdentifier(testType.ID()),
+				eventTypes[0].QualifiedIdentifier(),
+			)
 
-			expectedEvents := []interpreter.Value{
-				interpreter.NewCompositeValue(
-					inter,
-					interpreter.EmptyLocationRange,
-					TestLocation,
-					TestLocation.QualifiedIdentifier(testType.ID()),
-					common.CompositeKindEvent,
-					fields,
-					common.ZeroAddress,
-				),
-			}
-
+			require.Len(t, eventsFields, 1)
 			AssertValueSlicesEqual(
 				t,
 				inter,
-				expectedEvents,
-				actualEvents,
+				[]interpreter.Value{
+					testCase.value,
+				},
+				eventsFields[0],
 			)
 		})
 	}
@@ -9599,65 +9646,95 @@ func TestInterpretNestedDestroy(t *testing.T) {
 
 	t.Parallel()
 
-	var events []*interpreter.CompositeValue
+	var eventTypes []*sema.CompositeType
+	var eventsFields [][]interpreter.Value
 
-	inter, err := parseCheckAndInterpretWithOptions(t, `
-      resource B {
-            let id: Int
-			init(_ id: Int){
-				self.id = id
-			}
+	inter, err := parseCheckAndInterpretWithOptions(t,
+		`
+            resource B {
+                let id: Int
 
-			event ResourceDestroyed(id: Int = self.id)
-		}
+                init(_ id: Int) {
+                    self.id = id
+                }
 
-		resource A {
-			let id: Int
-			let bs: @[B]
+                event ResourceDestroyed(
+                    id: Int = self.id
+                )
+            }
 
-			event ResourceDestroyed(id: Int = self.id, bCount: Int = self.bs.length)
+            resource A {
+                let id: Int
+                let bs: @[B]
 
-			init(_ id: Int){
-				self.id = id
-				self.bs <- []
-			}
+                event ResourceDestroyed(
+                    id: Int = self.id,
+                    bCount: Int = self.bs.length
+                )
 
-			fun add(_ b: @B){
-				self.bs.append(<-b)
-			}
-		}
+                init(_ id: Int) {
+                    self.id = id
+                    self.bs <- []
+                }
 
-      fun test() {
-          let a <- create A(1)
-          a.add(<- create B(2))
-          a.add(<- create B(3))
-          a.add(<- create B(4))
+                fun add(_ b: @B) {
+                    self.bs.append(<-b)
+                }
+            }
 
-              destroy a
-          }
-        `, ParseCheckAndInterpretOptions{
-		Config: &interpreter.Config{
-			OnEventEmitted: func(_ *interpreter.Interpreter, _ interpreter.LocationRange, event *interpreter.CompositeValue, eventType *sema.CompositeType) error {
-				events = append(events, event)
-				return nil
+            fun test() {
+                let a <- create A(1)
+                a.add(<- create B(2))
+                a.add(<- create B(3))
+                a.add(<- create B(4))
+
+                destroy a
+            }
+        `,
+		ParseCheckAndInterpretOptions{
+			Config: &interpreter.Config{
+				OnEventEmitted: func(
+					_ interpreter.ValueExportContext,
+					_ interpreter.LocationRange,
+					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
+				) error {
+					eventTypes = append(eventTypes, eventType)
+					eventsFields = append(eventsFields, eventFields)
+					return nil
+				},
 			},
 		},
-	})
+	)
 	require.NoError(t, err)
 
 	value, err := inter.Invoke("test")
 	require.NoError(t, err)
 
-	require.Len(t, events, 4)
-	require.Equal(t, "B.ResourceDestroyed", events[0].QualifiedIdentifier)
-	require.Equal(t, interpreter.NewIntValueFromInt64(nil, 2), events[0].GetField(inter, "id"))
-	require.Equal(t, "B.ResourceDestroyed", events[1].QualifiedIdentifier)
-	require.Equal(t, interpreter.NewIntValueFromInt64(nil, 3), events[1].GetField(inter, "id"))
-	require.Equal(t, "B.ResourceDestroyed", events[2].QualifiedIdentifier)
-	require.Equal(t, interpreter.NewIntValueFromInt64(nil, 4), events[2].GetField(inter, "id"))
-	require.Equal(t, "A.ResourceDestroyed", events[3].QualifiedIdentifier)
-	require.Equal(t, interpreter.NewIntValueFromInt64(nil, 1), events[3].GetField(inter, "id"))
-	require.Equal(t, interpreter.NewIntValueFromInt64(nil, 3), events[3].GetField(inter, "bCount"))
+	require.Len(t, eventTypes, 4)
+	require.Equal(t, "B.ResourceDestroyed", eventTypes[0].QualifiedIdentifier())
+	require.Equal(t, "B.ResourceDestroyed", eventTypes[1].QualifiedIdentifier())
+	require.Equal(t, "B.ResourceDestroyed", eventTypes[2].QualifiedIdentifier())
+	require.Equal(t, "A.ResourceDestroyed", eventTypes[3].QualifiedIdentifier())
+
+	require.Equal(t,
+		[][]interpreter.Value{
+			{
+				interpreter.NewIntValueFromInt64(nil, 2),
+			},
+			{
+				interpreter.NewIntValueFromInt64(nil, 3),
+			},
+			{
+				interpreter.NewIntValueFromInt64(nil, 4),
+			},
+			{
+				interpreter.NewIntValueFromInt64(nil, 1),
+				interpreter.NewIntValueFromInt64(nil, 3),
+			},
+		},
+		eventsFields,
+	)
 
 	AssertValuesEqual(
 		t,
@@ -12337,7 +12414,10 @@ func TestInterpretSwapDictionaryKeysWithSideEffects(t *testing.T) {
 
 		inter, getEvents, err := parseCheckAndInterpretWithEvents(t, `
           resource Resource {
-			  event ResourceDestroyed(value: Int = self.value)
+			  event ResourceDestroyed(
+                  value: Int = self.value
+              )
+
               var value: Int
 
               init(_ value: Int) {

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -379,8 +379,10 @@ func (v *CompositeValue) Destroy(context ResourceDestructionContext, locationRan
 		event := constructor.Invoke(eventConstructorInvocation).(*CompositeValue)
 		eventType := MustSemaTypeOfValue(event, context).(*sema.CompositeType)
 
+		eventFields := extractEventFields(context, event, eventType)
+
 		// emit the event once destruction is complete
-		defer context.EmitEventValue(event, eventType, locationRange)
+		defer context.EmitEvent(context, locationRange, eventType, eventFields)
 	}
 
 	valueID := v.ValueID()

--- a/runtime/events.go
+++ b/runtime/events.go
@@ -25,29 +25,6 @@ import (
 	"github.com/onflow/cadence/sema"
 )
 
-func emitEventValue(
-	context interpreter.ValueExportContext,
-	locationRange interpreter.LocationRange,
-	eventType *sema.CompositeType,
-	event *interpreter.CompositeValue,
-	emitEvent func(cadence.Event) error,
-) {
-	fields := make([]interpreter.Value, len(eventType.ConstructorParameters))
-
-	for i, parameter := range eventType.ConstructorParameters {
-		value := event.GetField(context, parameter.Identifier)
-		fields[i] = value
-	}
-
-	EmitEventFields(
-		context,
-		locationRange,
-		eventType,
-		fields,
-		emitEvent,
-	)
-}
-
 func EmitEventFields(
 	context interpreter.ValueExportContext,
 	locationRange interpreter.LocationRange,

--- a/runtime/handlers.go
+++ b/runtime/handlers.go
@@ -257,16 +257,16 @@ func newOnMeterComputation(i *Interface) interpreter.OnMeterComputationFunc {
 
 func newOnEventEmittedHandler(i *Interface) interpreter.OnEventEmittedFunc {
 	return func(
-		inter *interpreter.Interpreter,
+		context interpreter.ValueExportContext,
 		locationRange interpreter.LocationRange,
-		eventValue *interpreter.CompositeValue,
 		eventType *sema.CompositeType,
+		eventFields []interpreter.Value,
 	) error {
-		emitEventValue(
-			inter,
+		EmitEventFields(
+			context,
 			locationRange,
 			eventType,
-			eventValue,
+			eventFields,
 			(*i).EmitEvent,
 		)
 

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -116,6 +116,7 @@ func (e *vmEnvironment) newVMConfig() *vm.Config {
 		InjectedCompositeFieldsHandler: newInjectedCompositeFieldsHandler(e),
 		UUIDHandler:                    newUUIDHandler(&e.Interface),
 		AccountHandler:                 e.newAccountValue,
+		OnEventEmitted:                 newOnEventEmittedHandler(&e.Interface),
 	})
 	config.WithAccountHandler(e)
 	return config

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -342,8 +342,8 @@ func parseCheckAndInterpretWithOptionsAndMemoryMeteringAndAtreeValidations(
 }
 
 type TestEvent struct {
-	Event     *interpreter.CompositeValue
-	EventType *sema.CompositeType
+	EventType   *sema.CompositeType
+	EventFields []interpreter.Value
 }
 
 func ParseCheckAndInterpretWithEvents(t *testing.T, code string) (
@@ -358,15 +358,18 @@ func ParseCheckAndInterpretWithEvents(t *testing.T, code string) (
 		ParseCheckAndInterpretOptions{
 			Config: &interpreter.Config{
 				OnEventEmitted: func(
-					_ *interpreter.Interpreter,
+					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
-					event *interpreter.CompositeValue,
 					eventType *sema.CompositeType,
+					eventFields []interpreter.Value,
 				) error {
-					events = append(events, TestEvent{
-						Event:     event,
-						EventType: eventType,
-					})
+					events = append(
+						events,
+						TestEvent{
+							EventType:   eventType,
+							EventFields: eventFields,
+						},
+					)
 					return nil
 				},
 			},


### PR DESCRIPTION
Work towards #3856 

## Description

Event emission was not available in the VM environment and not properly set up in the VM config/context yet either.

Clean up the event emission in the interpreter and VM to always emit event type + event fields, instead of having two handlers, one for event type + event value, and one for event type + event fields.

Finally, hook up the event handler in the VM environment, which allows contract invocations to observe emitted events.

While updating the event-related tests my OCD kicked in and I cleaned up whitespace and unnecessary access modifiers along the way. Apppologies for the large diff. 

Best viewed with whitespace disabled: https://github.com/onflow/cadence/pull/3916/files?w=1

I will backport the changes outside the `bbq` package pack to `master` once this PR got merged.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
