### PR TITLE
[Compiler] Fix argument compilation: transfer to parameter type, not argument type

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1570,7 +1570,7 @@ func isDynamicMethodInvocation(accessedType sema.Type) bool {
 func (c *Compiler[_, _]) compileArguments(arguments ast.Arguments, invocationTypes sema.InvocationExpressionTypes) {
 	for index, argument := range arguments {
 		c.compileExpression(argument.Expression)
-		c.emitTransfer(invocationTypes.ArgumentTypes[index])
+		c.emitTransfer(invocationTypes.ParameterTypes[index])
 	}
 
 	// TODO: Is this needed?

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -5491,13 +5491,25 @@ func TestCompileArgument(t *testing.T) {
 		functions[0].Code,
 	)
 
+	const (
+		// fTypeIndex is the index of the type of function `f`, which is the first type
+		fTypeIndex = iota //nolint:unused
+		// testTypeIndex is the index of the type of function `test`, which is the second type
+		testTypeIndex
+		// xParameterTypeIndex is the index of the type of parameter `x`, which is the third type
+		xParameterTypeIndex
+	)
+
+	// xIndex is the index of the local variable `x`, which is the first local variable
+	const xIndex = 0
+
 	assert.Equal(t,
 		[]opcode.Instruction{
 			opcode.InstructionGetConstant{},
-			opcode.InstructionSetLocal{Local: 0},
+			opcode.InstructionSetLocal{Local: xIndex},
 			opcode.InstructionGetGlobal{Global: 0},
-			opcode.InstructionGetLocal{Local: 0},
-			opcode.InstructionTransfer{Type: 2},
+			opcode.InstructionGetLocal{Local: xIndex},
+			opcode.InstructionTransfer{Type: xParameterTypeIndex},
 			opcode.InstructionInvoke{ArgCount: 1},
 			opcode.InstructionDrop{},
 			opcode.InstructionReturn{},

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -5458,3 +5458,79 @@ func TestCompileTransferNil(t *testing.T) {
 		functions[0].Code,
 	)
 }
+
+func TestCompileArgument(t *testing.T) {
+
+	t.Parallel()
+
+	checker, err := ParseAndCheck(t, `
+      fun f(_ x: Int?) {}
+
+      fun test() {
+          let x = 1
+          f(x)
+      }
+    `)
+	require.NoError(t, err)
+
+	comp := compiler.NewInstructionCompiler(
+		interpreter.ProgramFromChecker(checker),
+		checker.Location,
+	)
+	program := comp.Compile()
+
+	require.Len(t, program.Functions, 2)
+
+	functions := comp.ExportFunctions()
+	require.Equal(t, len(program.Functions), len(functions))
+
+	assert.Equal(t,
+		[]opcode.Instruction{
+			opcode.InstructionReturn{},
+		},
+		functions[0].Code,
+	)
+
+	assert.Equal(t,
+		[]opcode.Instruction{
+			opcode.InstructionGetConstant{},
+			opcode.InstructionSetLocal{Local: 0},
+			opcode.InstructionGetGlobal{Global: 0},
+			opcode.InstructionGetLocal{Local: 0},
+			opcode.InstructionTransfer{Type: 2},
+			opcode.InstructionInvoke{ArgCount: 1},
+			opcode.InstructionDrop{},
+			opcode.InstructionReturn{},
+		},
+		functions[1].Code,
+	)
+
+	assert.Equal(t,
+		[]bbq.StaticType{
+			interpreter.FunctionStaticType{
+				Type: sema.NewSimpleFunctionType(
+					sema.FunctionPurityImpure,
+					[]sema.Parameter{
+						{
+							Label:      sema.ArgumentLabelNotRequired,
+							Identifier: "x",
+							TypeAnnotation: sema.NewTypeAnnotation(
+								sema.NewOptionalType(nil, sema.IntType),
+							),
+						},
+					},
+					sema.VoidTypeAnnotation,
+				),
+			},
+			interpreter.FunctionStaticType{
+				Type: sema.NewSimpleFunctionType(
+					sema.FunctionPurityImpure,
+					[]sema.Parameter{},
+					sema.VoidTypeAnnotation,
+				),
+			},
+			interpreter.NewOptionalStaticType(nil, interpreter.PrimitiveStaticTypeInt),
+		},
+		program.Types,
+	)
+}

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -5495,7 +5495,7 @@ func TestCompileArgument(t *testing.T) {
 		// fTypeIndex is the index of the type of function `f`, which is the first type
 		fTypeIndex = iota //nolint:unused
 		// testTypeIndex is the index of the type of function `test`, which is the second type
-		testTypeIndex
+		testTypeIndex //nolint:unused
 		// xParameterTypeIndex is the index of the type of parameter `x`, which is the third type
 		xParameterTypeIndex
 	)

--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -465,6 +465,9 @@ var panicFuncInvocationTypes = sema.InvocationExpressionTypes{
 	ArgumentTypes: []sema.Type{
 		sema.StringType,
 	},
+	ParameterTypes: []sema.Type{
+		sema.StringType,
+	},
 }
 
 func (d *Desugar) desugarCondition(condition ast.Condition, inheritedFrom *sema.InterfaceType) ast.Statement {
@@ -1044,8 +1047,10 @@ func (d *Desugar) interfaceDelegationMethodCall(
 	}
 
 	invocationTypes := sema.InvocationExpressionTypes{
-		ReturnType:    funcType.ReturnTypeAnnotation.Type,
-		ArgumentTypes: funcType.ParameterTypes(),
+		ReturnType: funcType.ReturnTypeAnnotation.Type,
+		// TODO:
+		ArgumentTypes:  funcType.ParameterTypes(),
+		ParameterTypes: funcType.ParameterTypes(),
 	}
 
 	memberAccessInfo := sema.MemberAccessInfo{

--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -1046,11 +1046,23 @@ func (d *Desugar) interfaceDelegationMethodCall(
 		panic(errors.NewUnreachableError())
 	}
 
+	parameterTypes := funcType.ParameterTypes()
+
 	invocationTypes := sema.InvocationExpressionTypes{
-		ReturnType: funcType.ReturnTypeAnnotation.Type,
-		// TODO:
-		ArgumentTypes:  funcType.ParameterTypes(),
-		ParameterTypes: funcType.ParameterTypes(),
+		ReturnType:     funcType.ReturnTypeAnnotation.Type,
+		ParameterTypes: parameterTypes,
+		// The argument types are the same as the parameter types.
+		// We are simply performing a delegation invocation, inside the synthetic-wrapper function we created.
+		// For example:
+		//
+		//    fun defaultFunc(a1: T1, a2: T2): R {
+		//        return Interface.defaultFunc(a1, a2)
+		//    }
+		//
+		// Where `defaultFunc` wrapper is created using the same parameter types as `Interface.defaultFunc`.
+		// So the argument types to the invocation of `Interface.defaultFunc` are the same
+		// as the parameter types of `defaultFunc`/`Interface.defaultFunc`.
+		ArgumentTypes: parameterTypes,
 	}
 
 	memberAccessInfo := sema.MemberAccessInfo{

--- a/interpreter/interpreter_expression.go
+++ b/interpreter/interpreter_expression.go
@@ -1199,7 +1199,7 @@ func (interpreter *Interpreter) visitInvocationExpressionWithImplicitArgument(in
 
 	typeParameterTypes := invocationExpressionTypes.TypeArguments
 	argumentTypes := invocationExpressionTypes.ArgumentTypes
-	parameterTypes := invocationExpressionTypes.TypeParameterTypes
+	parameterTypes := invocationExpressionTypes.ParameterTypes
 	returnType := invocationExpressionTypes.ReturnType
 
 	// add the implicit argument to the end of the argument list, if it exists

--- a/sema/check_invocation_expression.go
+++ b/sema/check_invocation_expression.go
@@ -538,10 +538,10 @@ func (checker *Checker) checkInvocation(
 	checker.Elaboration.SetInvocationExpressionTypes(
 		invocationExpression,
 		InvocationExpressionTypes{
-			TypeArguments:      typeArguments,
-			TypeParameterTypes: parameterTypes,
-			ReturnType:         returnType,
-			ArgumentTypes:      argumentTypes,
+			TypeArguments:  typeArguments,
+			ParameterTypes: parameterTypes,
+			ReturnType:     returnType,
+			ArgumentTypes:  argumentTypes,
 		},
 	)
 

--- a/sema/elaboration.go
+++ b/sema/elaboration.go
@@ -68,10 +68,10 @@ type AssignmentStatementTypes struct {
 }
 
 type InvocationExpressionTypes struct {
-	ReturnType         Type
-	TypeArguments      *TypeParameterTypeOrderedMap
-	ArgumentTypes      []Type
-	TypeParameterTypes []Type
+	ReturnType     Type
+	TypeArguments  *TypeParameterTypeOrderedMap
+	ArgumentTypes  []Type
+	ParameterTypes []Type
 }
 
 type ArrayExpressionTypes struct {


### PR DESCRIPTION
Work towards #3856 

## Description

When transferring arguments, transfer to the *parameter type*, not the argument type.

Also rename the misleading field name in the elaboration.

IDK if the desugaring here is correct: https://github.com/onflow/cadence/pull/3918/files#diff-136d20e34597268ae788b3f11e31e23c55aeba34f27dd523babc79360bd08c17R1051-R1052.
Do we have to use the argument types here? How do we get them?

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
