### PR TITLE
[Compiler] Compile global variables

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -73,8 +73,6 @@ type Compiler[E, T any] struct {
 	typesInPool     map[sema.TypeID]uint16
 	constantsInPool map[constantsCacheKey]*Constant
 
-	globalVariablesSet map[string]struct{}
-
 	// TODO: initialize
 	memoryGauge common.MemoryGauge
 
@@ -154,7 +152,6 @@ func newCompiler[E, T any](
 		importedGlobals:      globals,
 		typesInPool:          make(map[sema.TypeID]uint16),
 		constantsInPool:      make(map[constantsCacheKey]*Constant),
-		globalVariablesSet:   make(map[string]struct{}),
 		compositeTypeStack: &Stack[sema.CompositeKindedType]{
 			elements: make([]sema.CompositeKindedType, 0),
 		},
@@ -531,7 +528,6 @@ func (c *Compiler[_, _]) reserveGlobalVars(
 	for _, declaration := range variableDecls {
 		variableName := declaration.Identifier.Identifier
 		c.addGlobal(variableName)
-		c.globalVariablesSet[variableName] = struct{}{}
 	}
 
 	for _, declaration := range specialFunctionDecls {
@@ -1177,7 +1173,7 @@ func (c *Compiler[_, _]) VisitVariableDeclaration(declaration *ast.VariableDecla
 
 	variableName := declaration.Identifier.Identifier
 
-	_, isGlobalVar := c.globalVariablesSet[variableName]
+	isGlobalVar := c.currentFunction == nil
 
 	if isGlobalVar {
 		if declaration.Value == nil {

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -1444,24 +1444,49 @@ func TestCompileAssignGlobal(t *testing.T) {
 	)
 	program := comp.Compile()
 
-	require.Len(t, program.Functions, 1)
+	functions := program.Functions
 
-	functions := comp.ExportFunctions()
-	require.Equal(t, len(program.Functions), len(functions))
+	const (
+		xIndex = iota
+	)
+
+	// `test` function
+
+	require.Len(t, functions, 1)
+	require.Equal(t, len(functions), len(functions))
 
 	assert.Equal(t,
 		[]opcode.Instruction{
 			// x = 1
-			opcode.InstructionGetConstant{Constant: 0},
-			opcode.InstructionSetGlobal{Global: 0},
+			opcode.InstructionGetConstant{Constant: 1},
+			opcode.InstructionSetGlobal{Global: xIndex},
 
 			opcode.InstructionReturn{},
 		},
 		functions[0].Code,
 	)
 
+	// global var `x` initializer
+	variables := program.Variables
+	require.Len(t, variables, 1)
+	require.Equal(t, len(variables), len(variables))
+
+	assert.Equal(t,
+		[]opcode.Instruction{
+			// return 0
+			opcode.InstructionGetConstant{Constant: 0},
+			opcode.InstructionReturnValue{},
+		},
+		variables[xIndex].Getter.Code,
+	)
+
+	// Constants
 	assert.Equal(t,
 		[]constant.Constant{
+			{
+				Data: []byte{0x0},
+				Kind: constant.Int,
+			},
 			{
 				Data: []byte{0x1},
 				Kind: constant.Int,

--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -1214,7 +1214,7 @@ func (d *Desugar) VisitTransactionDeclaration(transaction *ast.TransactionDeclar
 		for index, parameter := range transaction.ParameterList.Parameters {
 			// Create global variables
 			// i.e: `var a: Type`
-			field := ast.NewVariableDeclaration(
+			variableDecl := ast.NewVariableDeclaration(
 				d.memoryGauge,
 				ast.AccessSelf,
 				false,
@@ -1228,7 +1228,7 @@ func (d *Desugar) VisitTransactionDeclaration(transaction *ast.TransactionDeclar
 				"",
 			)
 
-			varDeclarations = append(varDeclarations, field)
+			varDeclarations = append(varDeclarations, variableDecl)
 
 			// Create assignment from param to global var.
 			// i.e: `a = $param_a`

--- a/bbq/compiler/global_variable.go
+++ b/bbq/compiler/global_variable.go
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-package bbq
+package compiler
 
-type Variable[E any] struct {
+type globalVariable[E any] struct {
 	Name   string
-	Getter *Function[E]
+	Getter *function[E]
 }

--- a/bbq/program.go
+++ b/bbq/program.go
@@ -28,7 +28,7 @@ type Program[E, T any] struct {
 	Imports   []Import
 	Functions []Function[E]
 	Constants []constant.Constant
-	Variables []Variable
+	Variables []Variable[E]
 	Types     []T
 }
 

--- a/bbq/program_printer.go
+++ b/bbq/program_printer.go
@@ -75,6 +75,16 @@ func (p *ProgramPrinter[E, T]) PrintProgram(program *Program[E, T]) string {
 	p.printConstantPool(program.Constants)
 	p.printTypePool(program.Types)
 
+	for _, variable := range program.Variables {
+		p.printFunction(
+			variable.Getter,
+			program.Constants,
+			program.Types,
+			nil,
+		)
+		p.stringBuilder.WriteRune('\n')
+	}
+
 	var functionNames []string
 	if len(program.Functions) > 0 {
 		functionNames = make([]string, 0, len(program.Functions))

--- a/bbq/program_printer.go
+++ b/bbq/program_printer.go
@@ -76,8 +76,12 @@ func (p *ProgramPrinter[E, T]) PrintProgram(program *Program[E, T]) string {
 	p.printTypePool(program.Types)
 
 	for _, variable := range program.Variables {
+		if variable.Getter == nil {
+			continue
+		}
+
 		p.printFunction(
-			variable.Getter,
+			*variable.Getter,
 			program.Constants,
 			program.Types,
 			nil,

--- a/bbq/test_utils/utils.go
+++ b/bbq/test_utils/utils.go
@@ -134,7 +134,7 @@ func ParseCheckAndCompileCodeWithOptions(
 	const colorize = false
 	printer := bbq.NewInstructionsProgramPrinter(resolve, colorize)
 
-	_ = printer.PrintProgram(program)
+	fmt.Println(printer.PrintProgram(program))
 
 	// Replace the original elaboration with the extended one.
 	// Desugared elaboration is not needed during the compilation of the same program,

--- a/bbq/test_utils/utils.go
+++ b/bbq/test_utils/utils.go
@@ -134,7 +134,7 @@ func ParseCheckAndCompileCodeWithOptions(
 	const colorize = false
 	printer := bbq.NewInstructionsProgramPrinter(resolve, colorize)
 
-	fmt.Println(printer.PrintProgram(program))
+	_ = printer.PrintProgram(program)
 
 	// Replace the original elaboration with the extended one.
 	// Desugared elaboration is not needed during the compilation of the same program,

--- a/bbq/variable.go
+++ b/bbq/variable.go
@@ -18,6 +18,7 @@
 
 package bbq
 
-type Variable struct {
-	Name string
+type Variable[E any] struct {
+	Name   string
+	Getter Function[E]
 }

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -7952,4 +7952,31 @@ func TestGlobalVariables(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("overridden local var", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := CompileAndInvoke(t,
+			`
+              var a = 5
+
+              fun test(): Int {
+                  var a = 8
+                  return getGlobalA()
+              }
+
+              fun getGlobalA(): Int {
+                  return a
+              }
+            `,
+			"test",
+		)
+		require.NoError(t, err)
+
+		assert.Equal(
+			t,
+			interpreter.NewUnmeteredIntValueFromInt64(5),
+			result,
+		)
+	})
 }

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -7904,7 +7904,7 @@ func TestGlobalVariables(t *testing.T) {
               var b = a
 
               fun test(): Int {
-                  // Update 'a' before getting 'b' for the first time.
+                  // Update 'a' before getting 'b'.
                   a = 8
 
                   // Get 'b' for the fist time.
@@ -7917,7 +7917,7 @@ func TestGlobalVariables(t *testing.T) {
 
 		assert.Equal(
 			t,
-			interpreter.NewUnmeteredIntValueFromInt64(8),
+			interpreter.NewUnmeteredIntValueFromInt64(5),
 			result,
 		)
 	})

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -107,6 +107,8 @@ func NewVM(
 
 	vm.globals = linkedGlobals.indexedGlobals
 
+	vm.initializeGlobalVariables(program)
+
 	return vm
 }
 
@@ -1668,6 +1670,13 @@ func (vm *VM) Reset() {
 	vm.locals = vm.locals[:0]
 	vm.callstack = vm.callstack[:0]
 	vm.ipStack = vm.ipStack[:0]
+}
+
+func (vm *VM) initializeGlobalVariables(program *bbq.InstructionProgram) {
+	for _, variable := range program.Variables {
+		// Get the values to ensure they are initialized.
+		_ = vm.globals[variable.Name].GetValue(vm.context)
+	}
 }
 
 func printInstructionError(


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3804

## Description

Global variables are compiled as functions (with the same name). Then when linking, the getter of the `Variable` is set to this compiled synthetic function.

```cadence
var a = "hello, world!"
```

is compiled as 

```cadence
fun a(): T {
    return "hello, world!"
}
```

and the linker set this function `a` as the getter for the global variable `a`.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
