### PR TITLE
Improve error wrapping of runtime interface calls

### DIFF
--- a/runtime/code.go
+++ b/runtime/code.go
@@ -20,8 +20,6 @@ package runtime
 
 import (
 	"github.com/onflow/cadence/common"
-	"github.com/onflow/cadence/errors"
-	"github.com/onflow/cadence/interpreter"
 )
 
 func getLocationCodeFromInterface(
@@ -32,16 +30,9 @@ func getLocationCodeFromInterface(
 	err error,
 ) {
 	if addressLocation, ok := location.(common.AddressLocation); ok {
-		errors.WrapPanic(func() {
-			code, err = i.GetAccountContractCode(addressLocation)
-		})
+		code, err = i.GetAccountContractCode(addressLocation)
 	} else {
-		errors.WrapPanic(func() {
-			code, err = i.GetCode(location)
-		})
-	}
-	if err != nil {
-		err = interpreter.WrappedExternalError(err)
+		code, err = i.GetCode(location)
 	}
 	return
 }

--- a/runtime/events.go
+++ b/runtime/events.go
@@ -59,10 +59,8 @@ func EmitEventFields(
 		panic(err)
 	}
 
-	errors.WrapPanic(func() {
-		err = emitEvent(exportedEvent)
-	})
+	err = emitEvent(exportedEvent)
 	if err != nil {
-		panic(interpreter.WrappedExternalError(err))
+		panic(err)
 	}
 }

--- a/runtime/external.go
+++ b/runtime/external.go
@@ -1,0 +1,643 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"time"
+
+	"github.com/onflow/atree"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/interpreter"
+	"github.com/onflow/cadence/sema"
+)
+
+// ExternalInterface is an implementation of runtime.Interface which forwards all calls to the embedded Interface.
+// All calls' panics and errors are wrapped.
+type ExternalInterface struct {
+	Interface Interface
+}
+
+var _ Interface = ExternalInterface{}
+var _ Metrics = ExternalInterface{}
+
+func (e ExternalInterface) MeterMemory(usage common.MemoryUsage) (err error) {
+	errors.WrapPanic(func() {
+		err = e.Interface.MeterMemory(usage)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) MeterComputation(operationType common.ComputationKind, intensity uint) (err error) {
+	errors.WrapPanic(func() {
+		err = e.Interface.MeterComputation(operationType, intensity)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) ComputationUsed() (usage uint64, err error) {
+	errors.WrapPanic(func() {
+		usage, err = e.Interface.ComputationUsed()
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) MemoryUsed() (usage uint64, err error) {
+	errors.WrapPanic(func() {
+		usage, err = e.Interface.MemoryUsed()
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) InteractionUsed() (usage uint64, err error) {
+	errors.WrapPanic(func() {
+		usage, err = e.Interface.InteractionUsed()
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) ResolveLocation(
+	identifiers []Identifier,
+	location Location,
+) (
+	locations []ResolvedLocation,
+	err error,
+) {
+	errors.WrapPanic(func() {
+		locations, err = e.Interface.ResolveLocation(identifiers, location)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) GetCode(location Location) (code []byte, err error) {
+	errors.WrapPanic(func() {
+		code, err = e.Interface.GetCode(location)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) GetOrLoadProgram(
+	location Location,
+	load func() (*interpreter.Program, error),
+) (
+	program *interpreter.Program,
+	err error,
+) {
+	errors.WrapPanic(func() {
+		program, err = e.Interface.GetOrLoadProgram(location, load)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) SetInterpreterSharedState(state *interpreter.SharedState) {
+	errors.WrapPanic(func() {
+		e.Interface.SetInterpreterSharedState(state)
+	})
+	// No error to wrap
+}
+
+func (e ExternalInterface) GetInterpreterSharedState() (state *interpreter.SharedState) {
+	errors.WrapPanic(func() {
+		state = e.Interface.GetInterpreterSharedState()
+	})
+	// No error to wrap
+	return
+}
+
+func (e ExternalInterface) GetValue(owner, key []byte) (value []byte, err error) {
+	errors.WrapPanic(func() {
+		value, err = e.Interface.GetValue(owner, key)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) SetValue(owner, key, value []byte) (err error) {
+	errors.WrapPanic(func() {
+		err = e.Interface.SetValue(owner, key, value)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) ValueExists(owner, key []byte) (exists bool, err error) {
+	errors.WrapPanic(func() {
+		exists, err = e.Interface.ValueExists(owner, key)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) AllocateSlabIndex(owner []byte) (index atree.SlabIndex, err error) {
+	errors.WrapPanic(func() {
+		index, err = e.Interface.AllocateSlabIndex(owner)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) CreateAccount(payer Address) (address Address, err error) {
+	errors.WrapPanic(func() {
+		address, err = e.Interface.CreateAccount(payer)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) AddAccountKey(
+	address Address,
+	publicKey *PublicKey,
+	hashAlgo HashAlgorithm,
+	weight int,
+) (
+	key *AccountKey,
+	err error,
+) {
+	errors.WrapPanic(func() {
+		key, err = e.Interface.AddAccountKey(
+			address,
+			publicKey,
+			hashAlgo,
+			weight,
+		)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) GetAccountKey(address Address, index uint32) (key *AccountKey, err error) {
+	errors.WrapPanic(func() {
+		key, err = e.Interface.GetAccountKey(address, index)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) AccountKeysCount(address Address) (count uint32, err error) {
+	errors.WrapPanic(func() {
+		count, err = e.Interface.AccountKeysCount(address)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) RevokeAccountKey(address Address, index uint32) (key *AccountKey, err error) {
+	errors.WrapPanic(func() {
+		key, err = e.Interface.RevokeAccountKey(address, index)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) UpdateAccountContractCode(location common.AddressLocation, code []byte) (err error) {
+	errors.WrapPanic(func() {
+		err = e.Interface.UpdateAccountContractCode(location, code)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) GetAccountContractCode(location common.AddressLocation) (code []byte, err error) {
+	errors.WrapPanic(func() {
+		code, err = e.Interface.GetAccountContractCode(location)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) RemoveAccountContractCode(location common.AddressLocation) (err error) {
+	errors.WrapPanic(func() {
+		err = e.Interface.RemoveAccountContractCode(location)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) GetSigningAccounts() (addresses []Address, err error) {
+	errors.WrapPanic(func() {
+		addresses, err = e.Interface.GetSigningAccounts()
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) ProgramLog(message string) (err error) {
+	errors.WrapPanic(func() {
+		err = e.Interface.ProgramLog(message)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) EmitEvent(event cadence.Event) (err error) {
+	errors.WrapPanic(func() {
+		err = e.Interface.EmitEvent(event)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) GenerateUUID() (uuid uint64, err error) {
+	errors.WrapPanic(func() {
+		uuid, err = e.Interface.GenerateUUID()
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) DecodeArgument(argument []byte, argumentType cadence.Type) (value cadence.Value, err error) {
+	errors.WrapPanic(func() {
+		value, err = e.Interface.DecodeArgument(argument, argumentType)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) GetCurrentBlockHeight() (height uint64, err error) {
+	errors.WrapPanic(func() {
+		height, err = e.Interface.GetCurrentBlockHeight()
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) GetBlockAtHeight(height uint64) (block Block, exists bool, err error) {
+	errors.WrapPanic(func() {
+		block, exists, err = e.Interface.GetBlockAtHeight(height)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) ReadRandom(bytes []byte) (err error) {
+	errors.WrapPanic(func() {
+		err = e.Interface.ReadRandom(bytes)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) VerifySignature(
+	signature []byte,
+	tag string,
+	signedData []byte,
+	publicKey []byte,
+	signatureAlgorithm SignatureAlgorithm,
+	hashAlgorithm HashAlgorithm,
+) (
+	valid bool,
+	err error,
+) {
+	errors.WrapPanic(func() {
+		valid, err = e.Interface.VerifySignature(
+			signature,
+			tag,
+			signedData,
+			publicKey,
+			signatureAlgorithm,
+			hashAlgorithm,
+		)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) Hash(data []byte, tag string, hashAlgorithm HashAlgorithm) (hash []byte, err error) {
+	errors.WrapPanic(func() {
+		hash, err = e.Interface.Hash(data, tag, hashAlgorithm)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) GetAccountBalance(address common.Address) (value uint64, err error) {
+	errors.WrapPanic(func() {
+		value, err = e.Interface.GetAccountBalance(address)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) GetAccountAvailableBalance(address common.Address) (value uint64, err error) {
+	errors.WrapPanic(func() {
+		value, err = e.Interface.GetAccountAvailableBalance(address)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) GetStorageUsed(address Address) (usage uint64, err error) {
+	errors.WrapPanic(func() {
+		usage, err = e.Interface.GetStorageUsed(address)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) GetStorageCapacity(address Address) (capacity uint64, err error) {
+	errors.WrapPanic(func() {
+		capacity, err = e.Interface.GetStorageCapacity(address)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) ImplementationDebugLog(message string) (err error) {
+	errors.WrapPanic(func() {
+		err = e.Interface.ImplementationDebugLog(message)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) ValidatePublicKey(key *PublicKey) (err error) {
+	errors.WrapPanic(func() {
+		err = e.Interface.ValidatePublicKey(key)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) GetAccountContractNames(address Address) (names []string, err error) {
+	errors.WrapPanic(func() {
+		names, err = e.Interface.GetAccountContractNames(address)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) RecordTrace(
+	operation string,
+	location Location,
+	duration time.Duration,
+	attrs []attribute.KeyValue,
+) {
+	errors.WrapPanic(func() {
+		e.Interface.RecordTrace(
+			operation,
+			location,
+			duration,
+			attrs,
+		)
+	})
+	// No error to wrap
+}
+
+func (e ExternalInterface) BLSVerifyPOP(publicKey *PublicKey, signature []byte) (valid bool, err error) {
+	errors.WrapPanic(func() {
+		valid, err = e.Interface.BLSVerifyPOP(publicKey, signature)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) BLSAggregateSignatures(signatures [][]byte) (signature []byte, err error) {
+	errors.WrapPanic(func() {
+		signature, err = e.Interface.BLSAggregateSignatures(signatures)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) BLSAggregatePublicKeys(publicKeys []*PublicKey) (publicKey *PublicKey, err error) {
+	errors.WrapPanic(func() {
+		publicKey, err = e.Interface.BLSAggregatePublicKeys(publicKeys)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) ResourceOwnerChanged(
+	interpreter *interpreter.Interpreter,
+	resource *interpreter.CompositeValue,
+	oldOwner common.Address,
+	newOwner common.Address,
+) {
+	errors.WrapPanic(func() {
+		e.Interface.ResourceOwnerChanged(interpreter, resource, oldOwner, newOwner)
+	})
+	// No error to wrap
+}
+
+func (e ExternalInterface) GenerateAccountID(address common.Address) (id uint64, err error) {
+	errors.WrapPanic(func() {
+		id, err = e.Interface.GenerateAccountID(address)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) RecoverProgram(program *ast.Program, location common.Location) (code []byte, err error) {
+	errors.WrapPanic(func() {
+		code, err = e.Interface.RecoverProgram(program, location)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) ValidateAccountCapabilitiesGet(
+	context interpreter.AccountCapabilityGetValidationContext,
+	locationRange interpreter.LocationRange,
+	address interpreter.AddressValue,
+	path interpreter.PathValue,
+	wantedBorrowType *sema.ReferenceType,
+	capabilityBorrowType *sema.ReferenceType,
+) (
+	valid bool,
+	err error,
+) {
+	errors.WrapPanic(func() {
+		valid, err = e.Interface.ValidateAccountCapabilitiesGet(
+			context,
+			locationRange,
+			address,
+			path,
+			wantedBorrowType,
+			capabilityBorrowType,
+		)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) ValidateAccountCapabilitiesPublish(
+	context interpreter.AccountCapabilityPublishValidationContext,
+	locationRange interpreter.LocationRange,
+	address interpreter.AddressValue,
+	path interpreter.PathValue,
+	capabilityBorrowType *interpreter.ReferenceStaticType,
+) (
+	ok bool,
+	err error,
+) {
+	errors.WrapPanic(func() {
+		ok, err = e.Interface.ValidateAccountCapabilitiesPublish(
+			context,
+			locationRange,
+			address,
+			path,
+			capabilityBorrowType,
+		)
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) MinimumRequiredVersion() (version string, err error) {
+	errors.WrapPanic(func() {
+		version, err = e.Interface.MinimumRequiredVersion()
+	})
+	if err != nil {
+		err = interpreter.WrappedExternalError(err)
+	}
+	return
+}
+
+func (e ExternalInterface) ProgramParsed(location Location, duration time.Duration) {
+	metrics, ok := e.Interface.(Metrics)
+	if !ok {
+		return
+	}
+	errors.WrapPanic(func() {
+		metrics.ProgramParsed(location, duration)
+	})
+	// No error to wrap
+}
+
+func (e ExternalInterface) ProgramChecked(location Location, duration time.Duration) {
+	metrics, ok := e.Interface.(Metrics)
+	if !ok {
+		return
+	}
+	errors.WrapPanic(func() {
+		metrics.ProgramChecked(location, duration)
+	})
+	// No error to wrap
+}
+
+func (e ExternalInterface) ProgramInterpreted(location Location, duration time.Duration) {
+	metrics, ok := e.Interface.(Metrics)
+	if !ok {
+		return
+	}
+	errors.WrapPanic(func() {
+		metrics.ProgramInterpreted(location, duration)
+	})
+	// No error to wrap
+}

--- a/runtime/handlers.go
+++ b/runtime/handlers.go
@@ -24,7 +24,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/onflow/cadence/common"
-	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/stdlib"
@@ -96,24 +95,15 @@ func newValidateAccountCapabilitiesGetHandler(i *Interface) interpreter.Validate
 		wantedBorrowType *sema.ReferenceType,
 		capabilityBorrowType *sema.ReferenceType,
 	) (bool, error) {
-		var (
-			ok  bool
-			err error
+
+		return (*i).ValidateAccountCapabilitiesGet(
+			context,
+			locationRange,
+			address,
+			path,
+			wantedBorrowType,
+			capabilityBorrowType,
 		)
-		errors.WrapPanic(func() {
-			ok, err = (*i).ValidateAccountCapabilitiesGet(
-				context,
-				locationRange,
-				address,
-				path,
-				wantedBorrowType,
-				capabilityBorrowType,
-			)
-		})
-		if err != nil {
-			err = interpreter.WrappedExternalError(err)
-		}
-		return ok, err
 	}
 }
 
@@ -125,34 +115,19 @@ func newValidateAccountCapabilitiesPublishHandler(i *Interface) interpreter.Vali
 		path interpreter.PathValue,
 		capabilityBorrowType *interpreter.ReferenceStaticType,
 	) (bool, error) {
-		var (
-			ok  bool
-			err error
+
+		return (*i).ValidateAccountCapabilitiesPublish(
+			context,
+			locationRange,
+			address,
+			path,
+			capabilityBorrowType,
 		)
-		errors.WrapPanic(func() {
-			ok, err = (*i).ValidateAccountCapabilitiesPublish(
-				context,
-				locationRange,
-				address,
-				path,
-				capabilityBorrowType,
-			)
-		})
-		if err != nil {
-			err = interpreter.WrappedExternalError(err)
-		}
-		return ok, err
 	}
 }
 
 func configureVersionedFeatures(i Interface) {
-	var (
-		minimumRequiredVersion string
-		err                    error
-	)
-	errors.WrapPanic(func() {
-		minimumRequiredVersion, err = i.MinimumRequiredVersion()
-	})
+	minimumRequiredVersion, err := i.MinimumRequiredVersion()
 	if err != nil {
 		panic(err)
 	}
@@ -168,21 +143,18 @@ func newOnRecordTraceHandler(i *Interface) interpreter.OnRecordTraceFunc {
 		duration time.Duration,
 		attrs []attribute.KeyValue,
 	) {
-		errors.WrapPanic(func() {
-			(*i).RecordTrace(functionName, interpreter.Location, duration, attrs)
-		})
+		(*i).RecordTrace(
+			functionName,
+			interpreter.Location,
+			duration,
+			attrs,
+		)
 	}
 }
 
 func newUUIDHandler(i *Interface) interpreter.UUIDHandlerFunc {
 	return func() (uuid uint64, err error) {
-		errors.WrapPanic(func() {
-			uuid, err = (*i).GenerateUUID()
-		})
-		if err != nil {
-			err = interpreter.WrappedExternalError(err)
-		}
-		return
+		return (*i).GenerateUUID()
 	}
 }
 
@@ -232,25 +204,20 @@ func newResourceOwnerChangedHandler(i *Interface) interpreter.OnResourceOwnerCha
 		oldOwner common.Address,
 		newOwner common.Address,
 	) {
-		errors.WrapPanic(func() {
-			(*i).ResourceOwnerChanged(
-				interpreter,
-				resource,
-				oldOwner,
-				newOwner,
-			)
-		})
+		(*i).ResourceOwnerChanged(
+			interpreter,
+			resource,
+			oldOwner,
+			newOwner,
+		)
 	}
 }
 
 func newOnMeterComputation(i *Interface) interpreter.OnMeterComputationFunc {
 	return func(compKind common.ComputationKind, intensity uint) {
-		var err error
-		errors.WrapPanic(func() {
-			err = (*i).MeterComputation(compKind, intensity)
-		})
+		err := (*i).MeterComputation(compKind, intensity)
 		if err != nil {
-			panic(interpreter.WrappedExternalError(err))
+			panic(err)
 		}
 	}
 }

--- a/runtime/location.go
+++ b/runtime/location.go
@@ -18,11 +18,6 @@
 
 package runtime
 
-import (
-	"github.com/onflow/cadence/errors"
-	"github.com/onflow/cadence/interpreter"
-)
-
 func ResolveLocationWithInterface(
 	i Interface,
 	identifiers []Identifier,
@@ -31,11 +26,5 @@ func ResolveLocationWithInterface(
 	res []ResolvedLocation,
 	err error,
 ) {
-	errors.WrapPanic(func() {
-		res, err = i.ResolveLocation(identifiers, location)
-	})
-	if err != nil {
-		err = interpreter.WrappedExternalError(err)
-	}
-	return
+	return i.ResolveLocation(identifiers, location)
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -172,6 +172,11 @@ func (r *runtime) NewScriptExecutor(
 	script Script,
 	context Context,
 ) Executor {
+
+	context.Interface = ExternalInterface{
+		Interface: context.Interface,
+	}
+
 	return newScriptExecutor(r, script, context)
 }
 
@@ -190,6 +195,11 @@ func (r *runtime) NewContractFunctionExecutor(
 	argumentTypes []sema.Type,
 	context Context,
 ) Executor {
+
+	context.Interface = ExternalInterface{
+		Interface: context.Interface,
+	}
+
 	return newContractFunctionExecutor(
 		r,
 		contractLocation,
@@ -217,6 +227,11 @@ func (r *runtime) InvokeContractFunction(
 }
 
 func (r *runtime) NewTransactionExecutor(script Script, context Context) Executor {
+
+	context.Interface = ExternalInterface{
+		Interface: context.Interface,
+	}
+
 	return newTransactionExecutor(r, script, context)
 }
 
@@ -299,6 +314,11 @@ func (r *runtime) ParseAndCheckProgram(
 	if environment == nil {
 		environment = NewBaseInterpreterEnvironment(r.defaultConfig)
 	}
+
+	context.Interface = ExternalInterface{
+		Interface: context.Interface,
+	}
+
 	environment.Configure(
 		context.Interface,
 		codesAndPrograms,
@@ -323,6 +343,10 @@ func (r *runtime) Storage(context Context) (*Storage, *interpreter.Interpreter, 
 	location := context.Location
 
 	codesAndPrograms := NewCodesAndPrograms()
+
+	context.Interface = ExternalInterface{
+		Interface: context.Interface,
+	}
 
 	runtimeInterface := context.Interface
 
@@ -380,6 +404,10 @@ func (r *runtime) ReadStored(
 		location,
 		codesAndPrograms,
 	)
+
+	context.Interface = ExternalInterface{
+		Interface: context.Interface,
+	}
 
 	_, inter, err := r.Storage(context)
 	if err != nil {

--- a/runtime/slabindex.go
+++ b/runtime/slabindex.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
-	"github.com/onflow/cadence/interpreter"
 )
 
 // readSlabIndexFromRegister returns register value as atree.SlabIndex.
@@ -36,13 +35,9 @@ func readSlabIndexFromRegister(
 	address common.Address,
 	key []byte,
 ) (atree.SlabIndex, bool, error) {
-	var data []byte
-	var err error
-	errors.WrapPanic(func() {
-		data, err = ledger.GetValue(address[:], key)
-	})
+	data, err := ledger.GetValue(address[:], key)
 	if err != nil {
-		return atree.SlabIndex{}, false, interpreter.WrappedExternalError(err)
+		return atree.SlabIndex{}, false, err
 	}
 
 	dataLength := len(data)
@@ -71,16 +66,14 @@ func writeSlabIndexToRegister(
 	key []byte,
 	slabIndex atree.SlabIndex,
 ) error {
-	var err error
-	errors.WrapPanic(func() {
-		err = ledger.SetValue(
-			address[:],
-			key,
-			slabIndex[:],
-		)
-	})
+
+	err := ledger.SetValue(
+		address[:],
+		key,
+		slabIndex[:],
+	)
 	if err != nil {
-		return interpreter.WrappedExternalError(err)
+		return err
 	}
 	return nil
 }

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -156,10 +156,7 @@ func (executor *transactionExecutor) preprocess() (err error) {
 	transactionType := transactions[0]
 	executor.transactionType = transactionType
 
-	var authorizerAddresses []Address
-	errors.WrapPanic(func() {
-		authorizerAddresses, err = runtimeInterface.GetSigningAccounts()
-	})
+	authorizerAddresses, err := runtimeInterface.GetSigningAccounts()
 	if err != nil {
 		return newError(err, location, codesAndPrograms)
 	}

--- a/runtime/validation.go
+++ b/runtime/validation.go
@@ -62,16 +62,11 @@ func importValidatedArguments(
 		argument := arguments[parameterIndex]
 
 		exportedParameterType := ExportMeteredType(context, parameterType, map[sema.TypeID]cadence.Type{})
-		var value cadence.Value
-		var err error
 
-		errors.WrapPanic(func() {
-			value, err = decoder.DecodeArgument(
-				argument,
-				exportedParameterType,
-			)
-		})
-
+		value, err := decoder.DecodeArgument(
+			argument,
+			exportedParameterType,
+		)
 		if err != nil {
 			return nil, &InvalidEntryPointArgumentError{
 				Index: parameterIndex,

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -155,11 +155,9 @@ func NewAccountConstructor(creator AccountCreator) StandardLibraryValue {
 				inter,
 				func() (address common.Address) {
 					var err error
-					errors.WrapPanic(func() {
-						address, err = creator.CreateAccount(payerAddress)
-					})
+					address, err = creator.CreateAccount(payerAddress)
 					if err != nil {
-						panic(interpreter.WrappedExternalError(err))
+						panic(err)
 					}
 
 					return
@@ -462,16 +460,13 @@ func newAccountBalanceGetFunction(
 	address := addressValue.ToAddress()
 
 	return func() interpreter.UFix64Value {
-		return interpreter.NewUFix64Value(gauge, func() (balance uint64) {
-			var err error
-			errors.WrapPanic(func() {
-				balance, err = provider.GetAccountBalance(address)
-			})
+		return interpreter.NewUFix64Value(gauge, func() uint64 {
+			balance, err := provider.GetAccountBalance(address)
 			if err != nil {
-				panic(interpreter.WrappedExternalError(err))
+				panic(err)
 			}
 
-			return
+			return balance
 		})
 	}
 }
@@ -491,16 +486,13 @@ func newAccountAvailableBalanceGetFunction(
 	address := addressValue.ToAddress()
 
 	return func() interpreter.UFix64Value {
-		return interpreter.NewUFix64Value(gauge, func() (balance uint64) {
-			var err error
-			errors.WrapPanic(func() {
-				balance, err = provider.GetAccountAvailableBalance(address)
-			})
+		return interpreter.NewUFix64Value(gauge, func() uint64 {
+			balance, err := provider.GetAccountAvailableBalance(address)
 			if err != nil {
-				panic(interpreter.WrappedExternalError(err))
+				panic(err)
 			}
 
-			return
+			return balance
 		})
 	}
 }
@@ -531,12 +523,9 @@ func newStorageUsedGetFunction(
 		return interpreter.NewUInt64Value(
 			context,
 			func() uint64 {
-				var capacity uint64
-				errors.WrapPanic(func() {
-					capacity, err = provider.GetStorageUsed(address)
-				})
+				capacity, err := provider.GetStorageUsed(address)
 				if err != nil {
-					panic(interpreter.WrappedExternalError(err))
+					panic(err)
 				}
 				return capacity
 			},
@@ -570,12 +559,9 @@ func newStorageCapacityGetFunction(
 		return interpreter.NewUInt64Value(
 			context,
 			func() uint64 {
-				var capacity uint64
-				errors.WrapPanic(func() {
-					capacity, err = provider.GetStorageCapacity(address)
-				})
+				capacity, err := provider.GetStorageCapacity(address)
 				if err != nil {
-					panic(interpreter.WrappedExternalError(err))
+					panic(err)
 				}
 				return capacity
 			},
@@ -632,12 +618,9 @@ func newAccountKeysAddFunction(
 
 				weight := weightValue.ToInt(locationRange)
 
-				var accountKey *AccountKey
-				errors.WrapPanic(func() {
-					accountKey, err = handler.AddAccountKey(address, publicKey, hashAlgo, weight)
-				})
+				accountKey, err := handler.AddAccountKey(address, publicKey, hashAlgo, weight)
 				if err != nil {
-					panic(interpreter.WrappedExternalError(err))
+					panic(err)
 				}
 
 				handler.EmitEvent(
@@ -705,14 +688,9 @@ func newAccountKeysGetFunction(
 				locationRange := invocation.LocationRange
 				index := indexValue.ToUint32(locationRange)
 
-				var err error
-				var accountKey *AccountKey
-				errors.WrapPanic(func() {
-					accountKey, err = provider.GetAccountKey(address, index)
-				})
-
+				accountKey, err := provider.GetAccountKey(address, index)
 				if err != nil {
-					panic(interpreter.WrappedExternalError(err))
+					panic(err)
 				}
 
 				// Here it is expected the host function to return a nil key, if a key is not found at the given index.
@@ -778,25 +756,16 @@ func newAccountKeysForEachFunction(
 					)
 				}
 
-				var count uint32
-				var err error
-
-				errors.WrapPanic(func() {
-					count, err = provider.AccountKeysCount(address)
-				})
-
+				count, err := provider.AccountKeysCount(address)
 				if err != nil {
-					panic(interpreter.WrappedExternalError(err))
+					panic(err)
 				}
 
-				var accountKey *AccountKey
-
 				for index := uint32(0); index < count; index++ {
-					errors.WrapPanic(func() {
-						accountKey, err = provider.GetAccountKey(address, index)
-					})
+
+					accountKey, err := provider.GetAccountKey(address, index)
 					if err != nil {
-						panic(interpreter.WrappedExternalError(err))
+						panic(err)
 					}
 
 					// Here it is expected the host function to return a nil key, if a key is not found at the given index.
@@ -850,13 +819,11 @@ func newAccountKeysCountGetter(
 			var count uint32
 			var err error
 
-			errors.WrapPanic(func() {
-				count, err = provider.AccountKeysCount(address)
-			})
+			count, err = provider.AccountKeysCount(address)
 			if err != nil {
 				// The provider might not be able to fetch the number of account keys
 				// e.g. when the account does not exist
-				panic(interpreter.WrappedExternalError(err))
+				panic(err)
 			}
 
 			return uint64(count)
@@ -896,13 +863,9 @@ func newAccountKeysRevokeFunction(
 				locationRange := invocation.LocationRange
 				index := indexValue.ToUint32(locationRange)
 
-				var err error
-				var accountKey *AccountKey
-				errors.WrapPanic(func() {
-					accountKey, err = handler.RevokeAccountKey(address, index)
-				})
+				accountKey, err := handler.RevokeAccountKey(address, index)
 				if err != nil {
-					panic(interpreter.WrappedExternalError(err))
+					panic(err)
 				}
 
 				// Here it is expected the host function to return a nil key, if a key is not found at the given index.
@@ -1209,13 +1172,9 @@ func newAccountContractsGetNamesFunction(
 		context interpreter.MemberAccessibleContext,
 		locationRange interpreter.LocationRange,
 	) *interpreter.ArrayValue {
-		var names []string
-		var err error
-		errors.WrapPanic(func() {
-			names, err = provider.GetAccountContractNames(address)
-		})
+		names, err := provider.GetAccountContractNames(address)
 		if err != nil {
-			panic(interpreter.WrappedExternalError(err))
+			panic(err)
 		}
 
 		values := make([]interpreter.Value, len(names))
@@ -1276,13 +1235,9 @@ func newAccountContractsGetFunction(
 				name := nameValue.Str
 				location := common.NewAddressLocation(invocation.InvocationContext, address, name)
 
-				var code []byte
-				var err error
-				errors.WrapPanic(func() {
-					code, err = provider.GetAccountContractCode(location)
-				})
+				code, err := provider.GetAccountContractCode(location)
 				if err != nil {
-					panic(interpreter.WrappedExternalError(err))
+					panic(err)
 				}
 
 				if len(code) > 0 {
@@ -1350,13 +1305,9 @@ func newAccountContractsBorrowFunction(
 
 				// Check if the contract exists
 
-				var code []byte
-				var err error
-				errors.WrapPanic(func() {
-					code, err = handler.GetAccountContractCode(location)
-				})
+				code, err := handler.GetAccountContractCode(location)
 				if err != nil {
-					panic(interpreter.WrappedExternalError(err))
+					panic(err)
 				}
 				if len(code) == 0 {
 					return interpreter.Nil
@@ -1955,11 +1906,9 @@ func updateAccountContractCode(
 	}
 
 	// NOTE: only update account code if contract instantiation succeeded
-	errors.WrapPanic(func() {
-		err = handler.UpdateAccountContractCode(location, code)
-	})
+	err = handler.UpdateAccountContractCode(location, code)
 	if err != nil {
-		return interpreter.WrappedExternalError(err)
+		return err
 	}
 
 	if createContract {
@@ -2112,13 +2061,9 @@ func newAccountContractsRemoveFunction(
 
 				// Get the current code
 
-				var code []byte
-				var err error
-				errors.WrapPanic(func() {
-					code, err = handler.GetAccountContractCode(location)
-				})
+				code, err := handler.GetAccountContractCode(location)
 				if err != nil {
-					panic(interpreter.WrappedExternalError(err))
+					panic(err)
 				}
 
 				// Only remove the contract code, remove the contract value, and emit an event,
@@ -2142,11 +2087,9 @@ func newAccountContractsRemoveFunction(
 						})
 					}
 
-					errors.WrapPanic(func() {
-						err = handler.RemoveAccountContractCode(location)
-					})
+					err = handler.RemoveAccountContractCode(location)
 					if err != nil {
-						panic(interpreter.WrappedExternalError(err))
+						panic(err)
 					}
 
 					// NOTE: the contract recording function delays the write
@@ -2860,13 +2803,9 @@ func IssueStorageCapabilityController(
 
 	// Create and write StorageCapabilityController
 
-	var capabilityID uint64
-	var err error
-	errors.WrapPanic(func() {
-		capabilityID, err = handler.GenerateAccountID(address)
-	})
+	capabilityID, err := handler.GenerateAccountID(address)
 	if err != nil {
-		panic(interpreter.WrappedExternalError(err))
+		panic(err)
 	}
 	if capabilityID == 0 {
 		panic(errors.NewUnexpectedError("invalid zero account ID"))
@@ -3039,13 +2978,9 @@ func IssueAccountCapabilityController(
 ) interpreter.UInt64Value {
 	// Create and write AccountCapabilityController
 
-	var capabilityID uint64
-	var err error
-	errors.WrapPanic(func() {
-		capabilityID, err = handler.GenerateAccountID(address)
-	})
+	capabilityID, err := handler.GenerateAccountID(address)
 	if err != nil {
-		panic(interpreter.WrappedExternalError(err))
+		panic(err)
 	}
 	if capabilityID == 0 {
 		panic(errors.NewUnexpectedError("invalid zero account ID"))

--- a/stdlib/block.go
+++ b/stdlib/block.go
@@ -175,14 +175,11 @@ func getBlockAtHeight(
 	exists bool,
 ) {
 	var err error
-	errors.WrapPanic(func() {
-		block, exists, err = provider.GetBlockAtHeight(height)
-	})
+	block, exists, err = provider.GetBlockAtHeight(height)
 	if err != nil {
-		panic(interpreter.WrappedExternalError(err))
+		panic(err)
 	}
-
-	return block, exists
+	return
 }
 
 type CurrentBlockProvider interface {
@@ -198,13 +195,9 @@ func NewGetCurrentBlockFunction(provider CurrentBlockProvider) StandardLibraryVa
 		getCurrentBlockFunctionDocString,
 		func(invocation interpreter.Invocation) interpreter.Value {
 
-			var height uint64
-			var err error
-			errors.WrapPanic(func() {
-				height, err = provider.GetCurrentBlockHeight()
-			})
+			height, err := provider.GetCurrentBlockHeight()
 			if err != nil {
-				panic(interpreter.WrappedExternalError(err))
+				panic(err)
 			}
 
 			block, exists := getBlockAtHeight(

--- a/stdlib/bls.go
+++ b/stdlib/bls.go
@@ -82,11 +82,7 @@ func newBLSAggregatePublicKeysFunction(
 				locationRange,
 			)
 
-			var err error
-			var aggregatedPublicKey *PublicKey
-			errors.WrapPanic(func() {
-				aggregatedPublicKey, err = aggregator.BLSAggregatePublicKeys(publicKeys)
-			})
+			aggregatedPublicKey, err := aggregator.BLSAggregatePublicKeys(publicKeys)
 
 			// If the crypto layer produces an error, we have invalid input, return nil
 			if err != nil {
@@ -160,11 +156,7 @@ func newBLSAggregateSignaturesFunction(
 				locationRange,
 			)
 
-			var err error
-			var aggregatedSignature []byte
-			errors.WrapPanic(func() {
-				aggregatedSignature, err = aggregator.BLSAggregateSignatures(bytesArray)
-			})
+			aggregatedSignature, err := aggregator.BLSAggregateSignatures(bytesArray)
 
 			// If the crypto layer produces an error, we have invalid input, return nil
 			if err != nil {

--- a/stdlib/hashalgorithm.go
+++ b/stdlib/hashalgorithm.go
@@ -154,12 +154,9 @@ func hash(
 
 	hashAlgorithm := NewHashAlgorithmFromValue(context, locationRange, hashAlgorithmValue)
 
-	var result []byte
-	errors.WrapPanic(func() {
-		result, err = hasher.Hash(data, tag, hashAlgorithm)
-	})
+	result, err := hasher.Hash(data, tag, hashAlgorithm)
 	if err != nil {
-		panic(interpreter.WrappedExternalError(err))
+		panic(err)
 	}
 	return interpreter.ByteSliceToByteArrayValue(context, result)
 }

--- a/stdlib/log.go
+++ b/stdlib/log.go
@@ -19,7 +19,6 @@
 package stdlib
 
 import (
-	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 )
@@ -73,12 +72,9 @@ func Log(
 ) interpreter.Value {
 	message := value.MeteredString(context, interpreter.SeenReferences{}, locationRange)
 
-	var err error
-	errors.WrapPanic(func() {
-		err = logger.ProgramLog(message, locationRange)
-	})
+	err := logger.ProgramLog(message, locationRange)
 	if err != nil {
-		panic(interpreter.WrappedExternalError(err))
+		panic(err)
 	}
 
 	return interpreter.Void

--- a/stdlib/publickey.go
+++ b/stdlib/publickey.go
@@ -65,13 +65,7 @@ func newPublicKeyValidationHandler(validator PublicKeyValidator) interpreter.Pub
 			return err
 		}
 
-		errors.WrapPanic(func() {
-			err = validator.ValidatePublicKey(publicKey)
-		})
-		if err != nil {
-			err = interpreter.WrappedExternalError(err)
-		}
-		return err
+		return validator.ValidatePublicKey(publicKey)
 	}
 }
 
@@ -270,20 +264,16 @@ func newPublicKeyVerifySignatureFunction(
 				return interpreter.FalseValue
 			}
 
-			var valid bool
-			errors.WrapPanic(func() {
-				valid, err = verifier.VerifySignature(
-					signature,
-					domainSeparationTag,
-					signedData,
-					publicKey.PublicKey,
-					publicKey.SignAlgo,
-					hashAlgorithm,
-				)
-			})
-
+			valid, err := verifier.VerifySignature(
+				signature,
+				domainSeparationTag,
+				signedData,
+				publicKey.PublicKey,
+				publicKey.SignAlgo,
+				hashAlgorithm,
+			)
 			if err != nil {
-				panic(interpreter.WrappedExternalError(err))
+				panic(err)
 			}
 
 			return interpreter.BoolValue(valid)
@@ -332,12 +322,9 @@ func newPublicKeyVerifyPoPFunction(
 				panic(err)
 			}
 
-			var valid bool
-			errors.WrapPanic(func() {
-				valid, err = verifier.BLSVerifyPOP(publicKey, signature)
-			})
+			valid, err := verifier.BLSVerifyPOP(publicKey, signature)
 			if err != nil {
-				panic(interpreter.WrappedExternalError(err))
+				panic(err)
 			}
 			return interpreter.BoolValue(valid)
 		},

--- a/stdlib/random.go
+++ b/stdlib/random.go
@@ -98,12 +98,9 @@ type RandomGenerator interface {
 }
 
 func getRandomBytes(buffer []byte, generator RandomGenerator) {
-	var err error
-	errors.WrapPanic(func() {
-		err = generator.ReadRandom(buffer)
-	})
+	err := generator.ReadRandom(buffer)
 	if err != nil {
-		panic(interpreter.WrappedExternalError(err))
+		panic(err)
 	}
 }
 


### PR DESCRIPTION
## Description

Calls of the `runtime.Interface` functions may panic or return an error. All such function calls must be properly wrapped.

Clean up the various places in the code base (e.g. storage, stdlib, etc.) where interface calls occur directly or indirectly, and centralize the wrapping of runtime interface errors at the boundary between Cadence and the external embedder (e.g. FVM). Introduce `runtime.ExternalInterface`, a wrapper around the interface given to Cadence by the embedder.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
