### PR TITLE
Improve computation metering interface

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -110,12 +110,6 @@ type HasPrefix interface {
 	Prefix() string
 }
 
-// MemoryError indicates a memory limit has reached and should end
-// the Cadence parsing, checking, or interpretation.
-type MemoryError struct {
-	Err error
-}
-
 // SuggestedFix
 
 type HasSuggestedFixes[T any] interface {
@@ -127,16 +121,40 @@ type SuggestedFix[T any] struct {
 	TextEdits []T
 }
 
-var _ UserError = MemoryError{}
+// MemoryMeteringError indicates a memory limit has reached and should end
+// the Cadence parsing, checking, or interpretation.
+type MemoryMeteringError struct {
+	Err error
+}
 
-func (MemoryError) IsUserError() {}
+var _ UserError = MemoryMeteringError{}
 
-func (e MemoryError) Unwrap() error {
+func (MemoryMeteringError) IsUserError() {}
+
+func (e MemoryMeteringError) Unwrap() error {
 	return e.Err
 }
 
-func (e MemoryError) Error() string {
+func (e MemoryMeteringError) Error() string {
 	return fmt.Sprintf("memory error: %s", e.Err.Error())
+}
+
+// ComputationMeteringError indicates a memory limit has reached and should end
+// the Cadence parsing, checking, or interpretation.
+type ComputationMeteringError struct {
+	Err error
+}
+
+var _ UserError = ComputationMeteringError{}
+
+func (ComputationMeteringError) IsUserError() {}
+
+func (e ComputationMeteringError) Unwrap() error {
+	return e.Err
+}
+
+func (e ComputationMeteringError) Error() string {
+	return fmt.Sprintf("computation error: %s", e.Err.Error())
 }
 
 // UnexpectedError is the default implementation of InternalError interface.

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -436,6 +436,11 @@ func (n NoOpReferenceCreationContext) MeterMemory(usage common.MemoryUsage) erro
 	return nil
 }
 
+func (n NoOpReferenceCreationContext) MeterComputation(usage common.ComputationUsage) error {
+	// NO-OP
+	return nil
+}
+
 func (n NoOpReferenceCreationContext) ReadStored(storageAddress common.Address, domain common.StorageDomain, identifier interpreter.StorageMapKey) interpreter.Value {
 	// NO-OP
 	return nil

--- a/interpreter/config.go
+++ b/interpreter/config.go
@@ -23,8 +23,9 @@ import (
 )
 
 type Config struct {
-	MemoryGauge common.MemoryGauge
-	Storage     Storage
+	MemoryGauge      common.MemoryGauge
+	ComputationGauge common.ComputationGauge
+	Storage          Storage
 	// ImportLocationHandler is used to handle imports of locations
 	ImportLocationHandler ImportLocationHandlerFunc
 	// OnInvokedFunctionReturn is triggered when an invoked function returned
@@ -33,8 +34,6 @@ type Config struct {
 	OnRecordTrace OnRecordTraceFunc
 	// OnResourceOwnerChange is triggered when the owner of a resource changes
 	OnResourceOwnerChange OnResourceOwnerChangeFunc
-	// OnMeterComputation is triggered when a computation is about to happen
-	OnMeterComputation OnMeterComputationFunc
 	// InjectedCompositeFieldsHandler is used to initialize new composite values' fields
 	InjectedCompositeFieldsHandler InjectedCompositeFieldsHandlerFunc
 	// ContractValueHandler is used to handle imports of values

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -112,7 +112,7 @@ var _ ReferenceTracker = &Interpreter{}
 type ValueTransferContext interface {
 	StorageContext
 	ReferenceTracker
-	ComputationReporter
+	common.ComputationGauge
 	Tracer
 
 	OnResourceOwnerChange(
@@ -148,12 +148,6 @@ var _ ValueCreationContext = &Interpreter{}
 type ValueRemoveContext = ValueTransferContext
 
 var _ ValueRemoveContext = &Interpreter{}
-
-type ComputationReporter interface {
-	ReportComputation(compKind common.ComputationKind, intensity uint)
-}
-
-var _ ComputationReporter = &Interpreter{}
 
 type ContainerMutationContext interface {
 	ValueTransferContext
@@ -367,8 +361,7 @@ type CapabilityHandlers interface {
 var _ CapabilityHandlers = &Interpreter{}
 
 type StringValueFunctionContext interface {
-	common.MemoryGauge
-	ComputationReporter
+	common.Gauge
 }
 
 var _ StringValueFunctionContext = &Interpreter{}
@@ -543,6 +536,10 @@ func (ctx NoOpStringContext) MeterMemory(_ common.MemoryUsage) error {
 	return nil
 }
 
+func (ctx NoOpStringContext) MeterComputation(_ common.ComputationUsage) error {
+	panic(errors.NewUnreachableError())
+}
+
 func (ctx NoOpStringContext) WithMutationPrevention(_ atree.ValueID, f func()) {
 	f()
 }
@@ -604,10 +601,6 @@ func (ctx NoOpStringContext) ClearReferencedResourceKindedValues(_ atree.ValueID
 }
 
 func (ctx NoOpStringContext) ReferencedResourceKindedValues(_ atree.ValueID) map[*EphemeralReferenceValue]struct{} {
-	panic(errors.NewUnreachableError())
-}
-
-func (ctx NoOpStringContext) ReportComputation(_ common.ComputationKind, _ uint) {
 	panic(errors.NewUnreachableError())
 }
 

--- a/interpreter/interpreter_statement.go
+++ b/interpreter/interpreter_statement.go
@@ -36,12 +36,9 @@ func (interpreter *Interpreter) evalStatement(statement ast.Statement) Statement
 
 	interpreter.statement = statement
 
-	config := interpreter.SharedState.Config
+	common.UseComputation(interpreter, common.StatementComputationUsage)
 
-	onMeterComputation := config.OnMeterComputation
-	if onMeterComputation != nil {
-		onMeterComputation(common.ComputationKindStatement, 1)
-	}
+	config := interpreter.SharedState.Config
 
 	debugger := config.Debugger
 	if debugger != nil {

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -88,7 +88,13 @@ func NewArrayValueWithIterator(
 	countOverestimate uint64,
 	values func() Value,
 ) *ArrayValue {
-	context.ReportComputation(common.ComputationKindCreateArrayValue, 1)
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindCreateArrayValue,
+			Intensity: 1,
+		},
+	)
 
 	var v *ArrayValue
 
@@ -341,7 +347,13 @@ func (v *ArrayValue) IsStaleResource(context ValueStaticTypeContext) bool {
 
 func (v *ArrayValue) Destroy(context ResourceDestructionContext, locationRange LocationRange) {
 
-	context.ReportComputation(common.ComputationKindDestroyArrayValue, 1)
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindDestroyArrayValue,
+			Intensity: 1,
+		},
+	)
 
 	if context.TracingEnabled() {
 		startTime := time.Now()
@@ -411,7 +423,10 @@ func (v *ArrayValue) Concat(context ValueTransferContext, locationRange Location
 		func() Value {
 
 			// Meter computation for iterating the two arrays.
-			context.ReportComputation(common.ComputationKindLoop, 1)
+			common.UseComputation(
+				context,
+				common.LoopComputationUsage,
+			)
 
 			var value Value
 
@@ -1302,9 +1317,12 @@ func (v *ArrayValue) Transfer(
 	hasNoParentContainer bool,
 ) Value {
 
-	context.ReportComputation(
-		common.ComputationKindTransferArrayValue,
-		uint(v.Count()),
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindTransferArrayValue,
+			Intensity: uint64(v.Count()),
+		},
 	)
 
 	if context.TracingEnabled() {
@@ -1604,7 +1622,7 @@ func (v *ArrayValue) Slice(
 		func() Value {
 
 			// Meter computation for iterating the array.
-			context.ReportComputation(common.ComputationKindLoop, 1)
+			common.UseComputation(context, common.LoopComputationUsage)
 
 			atreeValue, err := iterator.Next()
 			if err != nil {
@@ -1651,7 +1669,10 @@ func (v *ArrayValue) Reverse(
 			}
 
 			// Meter computation for iterating the array.
-			context.ReportComputation(common.ComputationKindLoop, 1)
+			common.UseComputation(
+				context,
+				common.LoopComputationUsage,
+			)
 
 			value := v.Get(context, locationRange, index)
 			index--
@@ -1700,7 +1721,10 @@ func (v *ArrayValue) Filter(
 
 			for {
 				// Meter computation for iterating the array.
-				context.ReportComputation(common.ComputationKindLoop, 1)
+				common.UseComputation(
+					context,
+					common.LoopComputationUsage,
+				)
 
 				atreeValue, err := iterator.Next()
 				if err != nil {
@@ -1800,7 +1824,10 @@ func (v *ArrayValue) Map(
 		func() Value {
 
 			// Meter computation for iterating the array.
-			context.ReportComputation(common.ComputationKindLoop, 1)
+			common.UseComputation(
+				context,
+				common.LoopComputationUsage,
+			)
 
 			atreeValue, err := iterator.Next()
 			if err != nil {
@@ -1881,7 +1908,10 @@ func (v *ArrayValue) ToVariableSized(
 		func() Value {
 
 			// Meter computation for iterating the array.
-			context.ReportComputation(common.ComputationKindLoop, 1)
+			common.UseComputation(
+				context,
+				common.LoopComputationUsage,
+			)
 
 			atreeValue, err := iterator.Next()
 			if err != nil {
@@ -1950,7 +1980,10 @@ func (v *ArrayValue) ToConstantSized(
 		func() Value {
 
 			// Meter computation for iterating the array.
-			context.ReportComputation(common.ComputationKindLoop, 1)
+			common.UseComputation(
+				context,
+				common.LoopComputationUsage,
+			)
 
 			atreeValue, err := iterator.Next()
 			if err != nil {

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -117,7 +117,7 @@ func NewCompositeValueWithStaticType(
 }
 
 func NewCompositeValue(
-	ctx MemberAccessibleContext,
+	context MemberAccessibleContext,
 	locationRange LocationRange,
 	location common.Location,
 	qualifiedIdentifier string,
@@ -126,11 +126,17 @@ func NewCompositeValue(
 	address common.Address,
 ) *CompositeValue {
 
-	ctx.ReportComputation(common.ComputationKindCreateCompositeValue, 1)
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindCreateCompositeValue,
+			Intensity: 1,
+		},
+	)
 
 	var v *CompositeValue
 
-	if ctx.TracingEnabled() {
+	if context.TracingEnabled() {
 		startTime := time.Now()
 
 		defer func() {
@@ -144,7 +150,7 @@ func NewCompositeValue(
 			typeID := string(v.TypeID())
 			kind := v.Kind.String()
 
-			ctx.ReportCompositeValueConstructTrace(
+			context.ReportCompositeValueConstructTrace(
 				owner,
 				typeID,
 				kind,
@@ -155,11 +161,11 @@ func NewCompositeValue(
 
 	constructor := func() *atree.OrderedMap {
 		dictionary, err := atree.NewMap(
-			ctx.Storage(),
+			context.Storage(),
 			atree.Address(address),
 			atree.NewDefaultDigesterBuilder(),
 			NewCompositeTypeInfo(
-				ctx,
+				context,
 				location,
 				qualifiedIdentifier,
 				kind,
@@ -172,17 +178,17 @@ func NewCompositeValue(
 	}
 
 	typeInfo := NewCompositeTypeInfo(
-		ctx,
+		context,
 		location,
 		qualifiedIdentifier,
 		kind,
 	)
 
-	v = newCompositeValueFromConstructor(ctx, uint64(len(fields)), typeInfo, constructor)
+	v = newCompositeValueFromConstructor(context, uint64(len(fields)), typeInfo, constructor)
 
 	for _, field := range fields {
 		v.SetMember(
-			ctx,
+			context,
 			locationRange,
 			field.Name,
 			field.Value,
@@ -331,7 +337,13 @@ func (v *CompositeValue) defaultDestroyEventConstructors() (constructors []Funct
 
 func (v *CompositeValue) Destroy(context ResourceDestructionContext, locationRange LocationRange) {
 
-	context.ReportComputation(common.ComputationKindDestroyCompositeValue, 1)
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindDestroyCompositeValue,
+			Intensity: 1,
+		},
+	)
 
 	if context.TracingEnabled() {
 		startTime := time.Now()
@@ -1151,7 +1163,13 @@ func (v *CompositeValue) Transfer(
 	hasNoParentContainer bool,
 ) Value {
 
-	context.ReportComputation(common.ComputationKindTransferCompositeValue, 1)
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindTransferCompositeValue,
+			Intensity: 1,
+		},
+	)
 
 	if context.TracingEnabled() {
 		startTime := time.Now()

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -64,7 +64,13 @@ func NewDictionaryValueWithAddress(
 	keysAndValues ...Value,
 ) *DictionaryValue {
 
-	context.ReportComputation(common.ComputationKindCreateDictionaryValue, 1)
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindCreateDictionaryValue,
+			Intensity: 1,
+		},
+	)
 
 	var v *DictionaryValue
 
@@ -147,7 +153,14 @@ func newDictionaryValueWithIterator(
 	address common.Address,
 	values func() (Value, Value),
 ) *DictionaryValue {
-	context.ReportComputation(common.ComputationKindCreateDictionaryValue, 1)
+
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindCreateDictionaryValue,
+			Intensity: 1,
+		},
+	)
 
 	var v *DictionaryValue
 
@@ -480,7 +493,13 @@ func (v *DictionaryValue) IsStaleResource(context ValueStaticTypeContext) bool {
 
 func (v *DictionaryValue) Destroy(context ResourceDestructionContext, locationRange LocationRange) {
 
-	context.ReportComputation(common.ComputationKindDestroyDictionaryValue, 1)
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindDestroyDictionaryValue,
+			Intensity: 1,
+		},
+	)
 
 	if context.TracingEnabled() {
 		startTime := time.Now()
@@ -1281,9 +1300,12 @@ func (v *DictionaryValue) Transfer(
 	hasNoParentContainer bool,
 ) Value {
 
-	context.ReportComputation(
-		common.ComputationKindTransferDictionaryValue,
-		uint(v.Count()),
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindTransferDictionaryValue,
+			Intensity: uint64(v.Count()),
+		},
 	)
 
 	if context.TracingEnabled() {

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -235,7 +235,13 @@ func (v *StringValue) Concat(context StringValueFunctionContext, other *StringVa
 	memoryUsage := common.NewStringMemoryUsage(newLength)
 
 	// Meter computation as if the two strings were iterated.
-	context.ReportComputation(common.ComputationKindLoop, uint(newLength))
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindLoop,
+			Intensity: uint64(newLength),
+		},
+	)
 
 	return NewStringValue(
 		context,
@@ -574,10 +580,16 @@ func (v *StringValue) Length() int {
 	return v.length
 }
 
-func (v *StringValue) ToLower(interpreter StringValueFunctionContext) *StringValue {
+func (v *StringValue) ToLower(context StringValueFunctionContext) *StringValue {
 
 	// Meter computation as if the string was iterated.
-	interpreter.ReportComputation(common.ComputationKindLoop, uint(len(v.Str)))
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindLoop,
+			Intensity: uint64(len(v.Str)),
+		},
+	)
 
 	// Over-estimate resulting string length,
 	// as an uppercase character may be converted to several lower-case characters, e.g İ => [i, ̇]
@@ -595,7 +607,7 @@ func (v *StringValue) ToLower(interpreter StringValueFunctionContext) *StringVal
 	memoryUsage := common.NewStringMemoryUsage(lengthEstimate)
 
 	return NewStringValue(
-		interpreter,
+		context,
 		memoryUsage,
 		func() string {
 			return strings.ToLower(v.Str)
@@ -622,7 +634,10 @@ func (v *StringValue) Split(context ArrayCreationContext, locationRange Location
 		uint64(count),
 		func() Value {
 
-			context.ReportComputation(common.ComputationKindLoop, 1)
+			common.UseComputation(
+				context,
+				common.LoopComputationUsage,
+			)
 
 			if partIndex >= count {
 				return nil
@@ -709,8 +724,13 @@ func (v *StringValue) ReplaceAll(
 	memoryUsage := common.NewStringMemoryUsage(newByteLength)
 
 	// Meter computation as if the string was iterated.
-	context.ReportComputation(common.ComputationKindLoop, uint(len(v.Str)))
-
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindLoop,
+			Intensity: uint64(len(v.Str)),
+		},
+	)
 	remaining := v
 
 	return NewStringValue(
@@ -981,7 +1001,7 @@ func (v *StringValue) IndexOf(context StringValueFunctionContext, other *StringV
 	return NewIntValueFromInt64(context, int64(index))
 }
 
-func (v *StringValue) indexOf(reporter ComputationReporter, other *StringValue) (characterIndex int, byteOffset int) {
+func (v *StringValue) indexOf(gauge common.ComputationGauge, other *StringValue) (characterIndex int, byteOffset int) {
 
 	if len(other.Str) == 0 {
 		return 0, 0
@@ -998,7 +1018,13 @@ func (v *StringValue) indexOf(reporter ComputationReporter, other *StringValue) 
 
 	// Meter computation as if the string was iterated.
 	// This is a conservative over-estimation.
-	reporter.ReportComputation(common.ComputationKindLoop, uint(len(v.Str)*len(other.Str)))
+	common.UseComputation(
+		gauge,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindLoop,
+			Intensity: uint64(len(v.Str) * len(other.Str)),
+		},
+	)
 
 	v.prepareGraphemes()
 
@@ -1062,19 +1088,25 @@ func (v *StringValue) Count(context StringValueFunctionContext, locationRange Lo
 	return NewIntValueFromInt64(context, int64(index))
 }
 
-func (v *StringValue) count(reporter ComputationReporter, locationRange LocationRange, other *StringValue) int {
+func (v *StringValue) count(gauge common.ComputationGauge, locationRange LocationRange, other *StringValue) int {
 	if other.Length() == 0 {
 		return 1 + v.Length()
 	}
 
 	// Meter computation as if the string was iterated.
-	reporter.ReportComputation(common.ComputationKindLoop, uint(len(v.Str)))
+	common.UseComputation(
+		gauge,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindLoop,
+			Intensity: uint64(len(v.Str)),
+		},
+	)
 
 	remaining := v
 	count := 0
 
 	for {
-		index, _ := remaining.indexOf(reporter, other)
+		index, _ := remaining.indexOf(gauge, other)
 		if index == -1 {
 			return count
 		}
@@ -1220,7 +1252,10 @@ func stringFunctionJoin(invocation Invocation) Value {
 		func(element Value) (resume bool) {
 
 			// Meter computation for iterating the array.
-			inter.ReportComputation(common.ComputationKindLoop, 1)
+			common.UseComputation(
+				inter,
+				common.LoopComputationUsage,
+			)
 
 			// Add separator
 			if !first {

--- a/interpreter/value_test.go
+++ b/interpreter/value_test.go
@@ -63,19 +63,20 @@ var testCompositeValueType = &sema.CompositeType{
 func getMeterCompFuncWithExpectedKinds(
 	t *testing.T,
 	kinds []common.ComputationKind,
-	intensities []uint,
-) OnMeterComputationFunc {
+	intensities []uint64,
+) computationGaugeFunc {
 	if len(kinds) != len(intensities) {
 		t.Fatal("size of kinds doesn't match size of intensities")
 	}
 	expectedCompKindsIndex := 0
-	return func(compKind common.ComputationKind, intensity uint) {
+	return func(usage common.ComputationUsage) error {
 		if expectedCompKindsIndex >= len(kinds) {
 			t.Fatal("received an extra meterComputation call")
 		}
-		assert.Equal(t, kinds[expectedCompKindsIndex], compKind)
-		assert.Equal(t, intensities[expectedCompKindsIndex], intensity)
+		assert.Equal(t, kinds[expectedCompKindsIndex], usage.Kind)
+		assert.Equal(t, intensities[expectedCompKindsIndex], usage.Intensity)
 		expectedCompKindsIndex++
+		return nil
 	}
 }
 
@@ -141,7 +142,7 @@ func TestOwnerArrayDeepCopy(t *testing.T) {
 		TestLocation,
 		&Config{
 			Storage: storage,
-			OnMeterComputation: getMeterCompFuncWithExpectedKinds(t,
+			ComputationGauge: getMeterCompFuncWithExpectedKinds(t,
 				[]common.ComputationKind{
 					common.ComputationKindCreateCompositeValue,
 					common.ComputationKindCreateArrayValue,
@@ -149,7 +150,7 @@ func TestOwnerArrayDeepCopy(t *testing.T) {
 					common.ComputationKindTransferArrayValue,
 					common.ComputationKindTransferCompositeValue,
 				},
-				[]uint{1, 1, 1, 1, 1},
+				[]uint64{1, 1, 1, 1, 1},
 			),
 		},
 	)
@@ -534,7 +535,7 @@ func TestOwnerDictionaryCopy(t *testing.T) {
 		TestLocation,
 		&Config{
 			Storage: storage,
-			OnMeterComputation: getMeterCompFuncWithExpectedKinds(t,
+			ComputationGauge: getMeterCompFuncWithExpectedKinds(t,
 				[]common.ComputationKind{
 					common.ComputationKindCreateCompositeValue,
 					common.ComputationKindCreateDictionaryValue,
@@ -542,7 +543,7 @@ func TestOwnerDictionaryCopy(t *testing.T) {
 					common.ComputationKindTransferDictionaryValue,
 					common.ComputationKindTransferCompositeValue,
 				},
-				[]uint{1, 1, 1, 1, 1},
+				[]uint64{1, 1, 1, 1, 1},
 			),
 		},
 	)

--- a/old_parser/expression.go
+++ b/old_parser/expression.go
@@ -574,7 +574,7 @@ func defineLessThanOrTypeArgumentsExpression() {
 				defer func() {
 					err := recover()
 					// MemoryError should abort parsing
-					_, ok := err.(errors.MemoryError)
+					_, ok := err.(errors.MemoryMeteringError)
 					if ok {
 						panic(err)
 					}

--- a/old_parser/expression_test.go
+++ b/old_parser/expression_test.go
@@ -332,9 +332,9 @@ func TestParseAdvancedExpression(t *testing.T) {
 			ParseExpression(gauge, []byte("1 < 2"), Config{})
 		})()
 
-		require.IsType(t, errors.MemoryError{}, panicMsg)
+		require.IsType(t, errors.MemoryMeteringError{}, panicMsg)
 
-		fatalError, _ := panicMsg.(errors.MemoryError)
+		fatalError, _ := panicMsg.(errors.MemoryMeteringError)
 		var expectedError limitingMemoryGaugeError
 		assert.ErrorAs(t, fatalError, &expectedError)
 	})
@@ -355,9 +355,9 @@ func TestParseAdvancedExpression(t *testing.T) {
 			ParseExpression(gauge, []byte("1 < 2 > 3"), Config{})
 		})()
 
-		require.IsType(t, errors.MemoryError{}, panicMsg)
+		require.IsType(t, errors.MemoryMeteringError{}, panicMsg)
 
-		fatalError, _ := panicMsg.(errors.MemoryError)
+		fatalError, _ := panicMsg.(errors.MemoryMeteringError)
 		var expectedError limitingMemoryGaugeError
 		assert.ErrorAs(t, fatalError, &expectedError)
 	})

--- a/old_parser/lexer/lexer.go
+++ b/old_parser/lexer/lexer.go
@@ -170,7 +170,7 @@ func (l *lexer) run(state stateFn) {
 		if r := recover(); r != nil {
 			var err error
 			switch r := r.(type) {
-			case errors.MemoryError, errors.InternalError:
+			case errors.MemoryMeteringError, errors.InternalError:
 				// fatal errors and internal errors percolates up.
 				// Note: not all fatal errors are internal errors.
 				// e.g: memory limit exceeding is a fatal error, but also a user error.

--- a/old_parser/parser_test.go
+++ b/old_parser/parser_test.go
@@ -734,9 +734,9 @@ func TestParseArgumentList(t *testing.T) {
 
 		_, err := ParseArgumentList(gauge, []byte(`(1, b: true)`), Config{})
 		require.Len(t, err, 1)
-		require.IsType(t, errors.MemoryError{}, err[0])
+		require.IsType(t, errors.MemoryMeteringError{}, err[0])
 
-		fatalError, _ := err[0].(errors.MemoryError)
+		fatalError, _ := err[0].(errors.MemoryMeteringError)
 		var expectedError limitingMemoryGaugeError
 		assert.ErrorAs(t, fatalError, &expectedError)
 	})

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -569,7 +569,7 @@ func defineLessThanOrTypeArgumentsExpression() {
 				defer func() {
 					err := recover()
 					// MemoryError should abort parsing
-					_, ok := err.(errors.MemoryError)
+					_, ok := err.(errors.MemoryMeteringError)
 					if ok {
 						panic(err)
 					}

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -326,9 +326,9 @@ func TestParseAdvancedExpression(t *testing.T) {
 
 		_, errs := ParseExpression(gauge, []byte("1 < 2"), Config{})
 		require.Len(t, errs, 1)
-		require.IsType(t, errors.MemoryError{}, errs[0])
+		require.IsType(t, errors.MemoryMeteringError{}, errs[0])
 
-		fatalError, _ := errs[0].(errors.MemoryError)
+		fatalError, _ := errs[0].(errors.MemoryMeteringError)
 		var expectedError limitingMemoryGaugeError
 		assert.ErrorAs(t, fatalError, &expectedError)
 	})
@@ -342,9 +342,9 @@ func TestParseAdvancedExpression(t *testing.T) {
 
 		_, errs := ParseExpression(gauge, []byte("1 < 2 > 3"), Config{})
 		require.Len(t, errs, 1)
-		require.IsType(t, errors.MemoryError{}, errs[0])
+		require.IsType(t, errors.MemoryMeteringError{}, errs[0])
 
-		fatalError, _ := errs[0].(errors.MemoryError)
+		fatalError, _ := errs[0].(errors.MemoryMeteringError)
 		var expectedError limitingMemoryGaugeError
 		assert.ErrorAs(t, fatalError, &expectedError)
 	})

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -737,9 +737,9 @@ func TestParseArgumentList(t *testing.T) {
 		_, errs := ParseArgumentList(gauge, []byte(`(1, b: true)`), Config{})
 		require.Len(t, errs, 1)
 
-		require.IsType(t, errors.MemoryError{}, errs[0])
+		require.IsType(t, errors.MemoryMeteringError{}, errs[0])
 
-		fatalError, _ := errs[0].(errors.MemoryError)
+		fatalError, _ := errs[0].(errors.MemoryMeteringError)
 		var expectedError limitingMemoryGaugeError
 		assert.ErrorAs(t, fatalError, &expectedError)
 	})

--- a/runtime/empty.go
+++ b/runtime/empty.go
@@ -54,7 +54,7 @@ func (EmptyRuntimeInterface) GetAccountContractCode(_ common.AddressLocation) (c
 	panic("unexpected call to GetAccountContractCode")
 }
 
-func (EmptyRuntimeInterface) MeterComputation(_ common.ComputationKind, _ uint) error {
+func (EmptyRuntimeInterface) MeterComputation(_ common.ComputationUsage) error {
 	// NO-OP
 	return nil
 }

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -114,6 +114,7 @@ var _ stdlib.BLSSignatureAggregator = &interpreterEnvironment{}
 var _ stdlib.Hasher = &interpreterEnvironment{}
 var _ ArgumentDecoder = &interpreterEnvironment{}
 var _ common.MemoryGauge = &interpreterEnvironment{}
+var _ common.ComputationGauge = &interpreterEnvironment{}
 
 func NewInterpreterEnvironment(config Config) *interpreterEnvironment {
 	defaultBaseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
@@ -134,6 +135,7 @@ func NewInterpreterEnvironment(config Config) *interpreterEnvironment {
 func (e *interpreterEnvironment) NewInterpreterConfig() *interpreter.Config {
 	return &interpreter.Config{
 		MemoryGauge:                    e,
+		ComputationGauge:               e,
 		BaseActivationHandler:          e.getBaseActivation,
 		OnEventEmitted:                 newOnEventEmittedHandler(&e.Interface),
 		InjectedCompositeFieldsHandler: newInjectedCompositeFieldsHandler(e),
@@ -154,7 +156,6 @@ func (e *interpreterEnvironment) NewInterpreterConfig() *interpreter.Config {
 		AtreeStorageValidationEnabled:             false,
 		Debugger:                                  e.config.Debugger,
 		OnStatement:                               e.newOnStatementHandler(),
-		OnMeterComputation:                        newOnMeterComputation(&e.Interface),
 		OnFunctionInvocation:                      e.newOnFunctionInvocationHandler(),
 		OnInvokedFunctionReturn:                   e.newOnInvokedFunctionReturnHandler(),
 		CapabilityBorrowHandler:                   newCapabilityBorrowHandler(e),

--- a/runtime/external.go
+++ b/runtime/external.go
@@ -51,9 +51,9 @@ func (e ExternalInterface) MeterMemory(usage common.MemoryUsage) (err error) {
 	return
 }
 
-func (e ExternalInterface) MeterComputation(operationType common.ComputationKind, intensity uint) (err error) {
+func (e ExternalInterface) MeterComputation(usage common.ComputationUsage) (err error) {
 	errors.WrapPanic(func() {
-		err = e.Interface.MeterComputation(operationType, intensity)
+		err = e.Interface.MeterComputation(usage)
 	})
 	if err != nil {
 		err = interpreter.WrappedExternalError(err)

--- a/runtime/handlers.go
+++ b/runtime/handlers.go
@@ -213,15 +213,6 @@ func newResourceOwnerChangedHandler(i *Interface) interpreter.OnResourceOwnerCha
 	}
 }
 
-func newOnMeterComputation(i *Interface) interpreter.OnMeterComputationFunc {
-	return func(compKind common.ComputationKind, intensity uint) {
-		err := (*i).MeterComputation(compKind, intensity)
-		if err != nil {
-			panic(err)
-		}
-	}
-}
-
 func newOnEventEmittedHandler(i *Interface) interpreter.OnEventEmittedFunc {
 	return func(
 		context interpreter.ValueExportContext,

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -170,7 +170,7 @@ type MeterInterface interface {
 	MeterMemory(usage common.MemoryUsage) error
 	// MeterComputation is a callback method for metering computation, it returns error
 	// when computation passes the limit (set by the environment)
-	MeterComputation(operationType common.ComputationKind, intensity uint) error
+	MeterComputation(usage common.ComputationUsage) error
 	// ComputationUsed returns the total computation used in the current runtime.
 	ComputationUsed() (uint64, error)
 	// MemoryUsed returns the total memory (estimate) used in the current runtime.

--- a/runtime/runtime_memory_metering_test.go
+++ b/runtime/runtime_memory_metering_test.go
@@ -1019,8 +1019,8 @@ func TestRuntimeMemoryMeteringErrors(t *testing.T) {
 		require.IsType(t, Error{}, err)
 		runtimeError := err.(Error)
 
-		require.IsType(t, errors.MemoryError{}, runtimeError.Err)
-		fatalError := runtimeError.Err.(errors.MemoryError)
+		require.IsType(t, errors.MemoryMeteringError{}, runtimeError.Err)
+		fatalError := runtimeError.Err.(errors.MemoryMeteringError)
 
 		assert.Contains(t, fatalError.Error(), "memory limit exceeded")
 	})

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -264,9 +264,18 @@ func (s *Storage) commit(context interpreter.ValueTransferContext, commitContrac
 
 	size := slabStorage.DeltasSizeWithoutTempAddresses()
 	if size > 0 {
-		context.ReportComputation(common.ComputationKindEncodeValue, uint(size))
-		usage := common.NewBytesMemoryUsage(int(size))
-		common.UseMemory(context, usage)
+		common.UseComputation(
+			context,
+			common.ComputationUsage{
+				Kind:      common.ComputationKindEncodeValue,
+				Intensity: size,
+			},
+		)
+
+		common.UseMemory(
+			context,
+			common.NewBytesMemoryUsage(int(size)),
+		)
 	}
 
 	deltas := slabStorage.DeltasWithoutTempAddresses()

--- a/test_utils/runtime_utils/testinterface.go
+++ b/test_utils/runtime_utils/testinterface.go
@@ -73,7 +73,7 @@ type TestRuntimeInterface struct {
 		newAddress common.Address,
 	)
 	OnGenerateUUID       func() (uint64, error)
-	OnMeterComputation   func(compKind common.ComputationKind, intensity uint) error
+	OnMeterComputation   func(usage common.ComputationUsage) error
 	OnDecodeArgument     func(b []byte, t cadence.Type) (cadence.Value, error)
 	OnProgramParsed      func(location runtime.Location, duration time.Duration)
 	OnProgramChecked     func(location runtime.Location, duration time.Duration)
@@ -367,11 +367,11 @@ func (i *TestRuntimeInterface) GenerateUUID() (uint64, error) {
 	return i.OnGenerateUUID()
 }
 
-func (i *TestRuntimeInterface) MeterComputation(compKind common.ComputationKind, intensity uint) error {
+func (i *TestRuntimeInterface) MeterComputation(usage common.ComputationUsage) error {
 	if i.OnMeterComputation == nil {
 		return nil
 	}
-	return i.OnMeterComputation(compKind, intensity)
+	return i.OnMeterComputation(usage)
 }
 
 func (i *TestRuntimeInterface) DecodeArgument(b []byte, t cadence.Type) (cadence.Value, error) {


### PR DESCRIPTION

## Description

Refactor computation metering and make it similar to memory metering. Introduce similar types and functions.

This PR should not change what is and how it is being metered.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
