### PR TITLE
[Compiler] Fix compilation of inherited conditions with different parameters

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -66,6 +66,12 @@ type Compiler[E, T any] struct {
 	// Then the compiler uses these indices to patch the jumps for return statements.
 	postConditionsIndices map[*ast.FunctionBlock]int
 
+	// inheritedConditionParamBindings keeps a mapping between the parameter names
+	// of an interface-function and the parameter names of its-implementation,
+	// for each inherited condition.
+	inheritedConditionParamBindings       map[ast.Statement]map[string]string
+	currentInheritedConditionParamBinding map[string]string
+
 	// postConditionsIndex is the statement-index of the post-conditions for the current function.
 	postConditionsIndex int
 
@@ -464,7 +470,12 @@ func (c *Compiler[E, T]) Compile() *bbq.Program[E, T] {
 		c.DesugaredElaboration,
 		c.location,
 	)
-	c.Program, c.postConditionsIndices = desugar.Run()
+
+	desugaredProgram := desugar.Run()
+
+	c.Program = desugaredProgram.program
+	c.postConditionsIndices = desugaredProgram.postConditionIndices
+	c.inheritedConditionParamBindings = desugaredProgram.inheritedConditionParamBinding
 
 	for _, declaration := range c.Program.ImportDeclarations() {
 		c.compileDeclaration(declaration)
@@ -980,7 +991,7 @@ func (c *Compiler[_, _]) VisitContinueStatement(_ *ast.ContinueStatement) (_ str
 func (c *Compiler[_, _]) VisitIfStatement(statement *ast.IfStatement) (_ struct{}) {
 	// If-statements can be coming from inherited conditions.
 	// If so, use the corresponding elaboration.
-	c.withConditionElaboration(statement, func() {
+	c.compilePotentiallyInheritedCode(statement, func() {
 		var (
 			elseJump            int
 			additionalThenScope bool
@@ -1161,7 +1172,7 @@ func (c *Compiler[_, _]) VisitForStatement(statement *ast.ForStatement) (_ struc
 func (c *Compiler[_, _]) VisitEmitStatement(statement *ast.EmitStatement) (_ struct{}) {
 	// Emit statements can be coming from inherited conditions.
 	// If so, use the corresponding elaboration.
-	c.withConditionElaboration(
+	c.compilePotentiallyInheritedCode(
 		statement,
 		func() {
 			invocationExpression := statement.InvocationExpression
@@ -1242,7 +1253,7 @@ func (c *Compiler[_, _]) VisitVariableDeclaration(declaration *ast.VariableDecla
 
 	// Some variable declarations can be coming from inherited before-statements.
 	// If so, use the corresponding elaboration.
-	c.withConditionElaboration(declaration, func() {
+	c.compilePotentiallyInheritedCode(declaration, func() {
 
 		// TODO: second value
 
@@ -1553,6 +1564,16 @@ func (c *Compiler[_, _]) VisitIdentifierExpression(expression *ast.IdentifierExp
 }
 
 func (c *Compiler[_, _]) emitVariableLoad(name string) {
+
+	if c.currentInheritedConditionParamBinding != nil {
+		// If the current compiling code is an inherited code, then bind
+		// the inherited parameter names to the implementation's parameter names.
+		mappedName, ok := c.currentInheritedConditionParamBinding[name]
+		if ok {
+			name = mappedName
+		}
+	}
+
 	local := c.currentFunction.findLocal(name)
 	if local != nil {
 		c.emitGetLocal(local.index)
@@ -2586,13 +2607,18 @@ func (c *Compiler[_, _]) generateEmptyInit() {
 	c.VisitSpecialFunctionDeclaration(emptyInitializer)
 }
 
-func (c *Compiler[_, _]) withConditionElaboration(statement ast.Statement, f func()) {
+func (c *Compiler[_, _]) compilePotentiallyInheritedCode(statement ast.Statement, f func()) {
 	stmtElaboration, ok := c.DesugaredElaboration.conditionsElaborations[statement]
 	if ok {
 		prevElaboration := c.DesugaredElaboration
 		c.DesugaredElaboration = stmtElaboration
+
+		preIsInheritedCode := c.currentInheritedConditionParamBinding
+		c.currentInheritedConditionParamBinding = c.inheritedConditionParamBindings[statement]
+
 		defer func() {
 			c.DesugaredElaboration = prevElaboration
+			c.currentInheritedConditionParamBinding = preIsInheritedCode
 		}()
 	}
 	f()

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -4323,7 +4323,6 @@ func TestFunctionPostConditions(t *testing.T) {
 		assert.ErrorContains(t, err, "pre/post condition failed")
 	})
 
-
 	t.Run("inherited with different param names", func(t *testing.T) {
 
 		t.Parallel()

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -7317,7 +7317,7 @@ func TestInterpretInterfaceInitializer(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
       struct interface I {
           init(a a1: Bool) {
               pre { a1 }
@@ -7334,15 +7334,11 @@ func TestInterpretInterfaceInitializer(t *testing.T) {
     `)
 
 	_, err := inter.Invoke("test")
-	require.IsType(t,
-		interpreter.Error{},
-		err,
-	)
-	interpreterErr := err.(interpreter.Error)
 
-	require.IsType(t,
-		interpreter.ConditionError{},
-		interpreterErr.Err,
+	assertConditionError(
+		t,
+		err,
+		ast.ConditionKindPre,
 	)
 }
 


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/3931

## Description

Solution:
- Keep a parameter names mapping for inherited conditions. The mapping is produced at the time of desugaring.
- When compiling an inherited condition, apply the mapping during variable lookup.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
