### PR TITLE
[Compiler] Pass `vm.Context` instead of `vm.Config` to contract function handler

### DIFF
--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -290,4 +290,7 @@ func (c *Config) SetStorage(storage interpreter.Storage) {
 	c.storage = storage
 }
 
-type ContractValueHandler func(conf *Config, location common.Location) *interpreter.CompositeValue
+type ContractValueHandler func(
+	context *Context,
+	location common.Location,
+) *interpreter.CompositeValue

--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -236,7 +236,7 @@ func (c *Context) GetMethod(
 
 	qualifiedFuncName := commons.TypeQualifiedName(semaType, name)
 
-	method := c.lookupFunction(location, qualifiedFuncName)
+	method := c.GetFunction(location, qualifiedFuncName)
 	if method == nil {
 		return nil
 	}
@@ -250,6 +250,6 @@ func (c *Context) GetMethod(
 func (c *Context) GetFunction(
 	location common.Location,
 	name string,
-) interpreter.FunctionValue {
+) FunctionValue {
 	return c.lookupFunction(location, name)
 }

--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -246,3 +246,10 @@ func (c *Context) GetMethod(
 		method,
 	)
 }
+
+func (c *Context) GetFunction(
+	location common.Location,
+	name string,
+) interpreter.FunctionValue {
+	return c.lookupFunction(location, name)
+}

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -181,7 +181,7 @@ func loadContractValue(contract *bbq.Contract, context *Context) Value {
 		contract.Name,
 	)
 
-	var contractValue interpreter.Value = context.ContractValueHandler(context.Config, location)
+	var contractValue interpreter.Value = context.ContractValueHandler(context, location)
 
 	staticType := contractValue.StaticType(context)
 	semaType, err := interpreter.ConvertStaticToSemaType(context, staticType)

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -232,7 +232,10 @@ func compiledFTTransfer(tb testing.TB) {
 	vmConfig.ImportHandler = importHandler
 
 	contractValues := make(map[common.Location]*interpreter.CompositeValue)
-	vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+	vmConfig.ContractValueHandler = func(
+		_ *vm.Context,
+		location common.Location,
+	) *interpreter.CompositeValue {
 		return contractValues[location]
 	}
 

--- a/bbq/vm/test/runtime_test.go
+++ b/bbq/vm/test/runtime_test.go
@@ -164,7 +164,7 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 
 	vmConfig := vm.NewConfig(storage)
 	vmConfig.ImportHandler = importHandler
-	vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+	vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 		switch location {
 		case barLocation:
 			return barContractValue

--- a/bbq/vm/test/vm_bench_test.go
+++ b/bbq/vm/test/vm_bench_test.go
@@ -273,7 +273,7 @@ func BenchmarkContractImport(b *testing.B) {
 		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		},
-		ContractValueHandler: func(_ *vm.Config, _ common.Location) *interpreter.CompositeValue {
+		ContractValueHandler: func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
 			return importedContractValue
 		},
 	}
@@ -414,7 +414,7 @@ func BenchmarkMethodCall(b *testing.B) {
 			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
-			ContractValueHandler: func(_ *vm.Config, _ common.Location) *interpreter.CompositeValue {
+			ContractValueHandler: func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
 				return importedContractValue
 			},
 			TypeLoader: func(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
@@ -525,7 +525,7 @@ func BenchmarkMethodCall(b *testing.B) {
 			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
-			ContractValueHandler: func(_ *vm.Config, _ common.Location) *interpreter.CompositeValue {
+			ContractValueHandler: func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
 				return importedContractValue
 			},
 		}

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -590,7 +590,7 @@ func TestContractImport(t *testing.T) {
 			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
-			ContractValueHandler: func(*vm.Config, common.Location) *interpreter.CompositeValue {
+			ContractValueHandler: func(*vm.Context, common.Location) *interpreter.CompositeValue {
 				return importedContractValue
 			},
 			TypeLoader: func(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
@@ -687,7 +687,7 @@ func TestContractImport(t *testing.T) {
 			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
-			ContractValueHandler: func(*vm.Config, common.Location) *interpreter.CompositeValue {
+			ContractValueHandler: func(*vm.Context, common.Location) *interpreter.CompositeValue {
 				return importedContractValue
 			},
 			TypeLoader: func(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
@@ -804,7 +804,7 @@ func TestContractImport(t *testing.T) {
 				require.Equal(t, fooLocation, location)
 				return fooProgram
 			},
-			ContractValueHandler: func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+			ContractValueHandler: func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 				require.Equal(t, fooLocation, location)
 				return fooContractValue
 			},
@@ -894,7 +894,7 @@ func TestContractImport(t *testing.T) {
 					return nil
 				}
 			},
-			ContractValueHandler: func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+			ContractValueHandler: func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 				switch location {
 				case fooLocation:
 					return fooContractValue
@@ -1107,7 +1107,7 @@ func TestContractImport(t *testing.T) {
 					return nil
 				}
 			},
-			ContractValueHandler: func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+			ContractValueHandler: func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 				switch location {
 				case barLocation:
 					return barContractValue
@@ -1465,7 +1465,7 @@ func TestContractField(t *testing.T) {
 			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
-			ContractValueHandler: func(_ *vm.Config, _ common.Location) *interpreter.CompositeValue {
+			ContractValueHandler: func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
 				return importedContractValue
 			},
 			TypeLoader: func(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
@@ -1556,7 +1556,7 @@ func TestContractField(t *testing.T) {
 			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
-			ContractValueHandler: func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+			ContractValueHandler: func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 				return importedContractValue
 			},
 			TypeLoader: func(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
@@ -2262,7 +2262,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 				return importedProgram
 			},
-			ContractValueHandler: func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+			ContractValueHandler: func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 				return importedContractValue
 			},
 			TypeLoader: func(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
@@ -2438,7 +2438,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 
 		implProgramVMConfig := &vm.Config{
 			ImportHandler: bazImportHandler,
-			ContractValueHandler: func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+			ContractValueHandler: func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 				switch location {
 				case fooLocation:
 					return fooContractValue
@@ -2531,7 +2531,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 
 		vmConfig := &vm.Config{
 			ImportHandler: scriptImportHandler,
-			ContractValueHandler: func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+			ContractValueHandler: func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 				switch location {
 				case barLocation:
 					return barContractValue
@@ -2638,7 +2638,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 
 		vmConfig = &vm.Config{
 			ImportHandler: scriptImportHandler,
-			ContractValueHandler: func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+			ContractValueHandler: func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 				switch location {
 				case fooLocation:
 					return fooContractValue
@@ -3076,7 +3076,7 @@ func TestDefaultFunctions(t *testing.T) {
 			}
 			return program.Program
 		}
-		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 			contractValue, ok := contractValues[location]
 			if !ok {
 				assert.FailNow(t, "invalid location")
@@ -3211,7 +3211,7 @@ func TestDefaultFunctions(t *testing.T) {
 			}
 			return program.Program
 		}
-		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 			contractValue, ok := contractValues[location]
 			if !ok {
 				assert.FailNow(t, "invalid location")
@@ -3348,7 +3348,7 @@ func TestDefaultFunctions(t *testing.T) {
 			}
 			return program.Program
 		}
-		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 			contractValue, ok := contractValues[location]
 			if !ok {
 				assert.FailNow(t, "invalid location")
@@ -3688,7 +3688,7 @@ func TestFunctionPreConditions(t *testing.T) {
 			}
 			return program.Program
 		}
-		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 			contractValue, ok := contractValues[location]
 			if !ok {
 				assert.FailNow(t, "invalid location")
@@ -6075,7 +6075,7 @@ func TestContractAccount(t *testing.T) {
 		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		},
-		ContractValueHandler: func(*vm.Config, common.Location) *interpreter.CompositeValue {
+		ContractValueHandler: func(*vm.Context, common.Location) *interpreter.CompositeValue {
 			return importedContractValue
 		},
 		TypeLoader: func(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
@@ -6199,7 +6199,7 @@ func TestResourceOwner(t *testing.T) {
 		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		},
-		ContractValueHandler: func(*vm.Config, common.Location) *interpreter.CompositeValue {
+		ContractValueHandler: func(*vm.Context, common.Location) *interpreter.CompositeValue {
 			return importedContractValue
 		},
 		TypeLoader: func(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
@@ -6328,7 +6328,7 @@ func TestResourceUUID(t *testing.T) {
 		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		},
-		ContractValueHandler: func(*vm.Config, common.Location) *interpreter.CompositeValue {
+		ContractValueHandler: func(*vm.Context, common.Location) *interpreter.CompositeValue {
 			return importedContractValue
 		},
 		TypeLoader: func(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
@@ -6722,7 +6722,7 @@ func TestContractClosure(t *testing.T) {
 		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
 			return importedProgram
 		},
-		ContractValueHandler: func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+		ContractValueHandler: func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 			return importedContractValue
 		},
 		TypeLoader: func(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
@@ -6957,7 +6957,7 @@ func TestEmitInContract(t *testing.T) {
 			}
 			return program.Program
 		}
-		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 			contractValue, ok := contractValues[location]
 			if !ok {
 				assert.FailNow(t, "invalid location")
@@ -7104,7 +7104,7 @@ func TestInheritedConditions(t *testing.T) {
 			}
 			return program.Program
 		}
-		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 			contractValue, ok := contractValues[location]
 			if !ok {
 				assert.FailNow(t, "invalid location")
@@ -7269,7 +7269,7 @@ func TestInheritedConditions(t *testing.T) {
 			}
 			return program.Program
 		}
-		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 			contractValue, ok := contractValues[location]
 			if !ok {
 				assert.FailNow(t, "invalid location")
@@ -7446,7 +7446,7 @@ func TestInheritedConditions(t *testing.T) {
 
 		vmConfig := vm.NewConfig(storage)
 
-		vmConfig.ContractValueHandler = func(_ *vm.Config, location common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 			contractValue, ok := contractValues[location]
 			if !ok {
 				assert.FailNow(t, "invalid location")

--- a/bbq/vm/tracer.go
+++ b/bbq/vm/tracer.go
@@ -28,19 +28,19 @@ import (
 // TODO: Refactor and re-use the tracing from the interpreter.
 type Tracer struct{}
 
-func (ctx Tracer) TracingEnabled() bool {
+func (t Tracer) TracingEnabled() bool {
 	return false
 }
 
-func (ctx Tracer) ReportArrayValueDeepRemoveTrace(_ string, _ int, _ time.Duration) {
+func (t Tracer) ReportArrayValueDeepRemoveTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx Tracer) ReportArrayValueTransferTrace(_ string, _ int, _ time.Duration) {
+func (t Tracer) ReportArrayValueTransferTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx Tracer) ReportArrayValueConstructTrace(_ string, _ int, _ time.Duration) {
+func (t Tracer) ReportArrayValueConstructTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
@@ -52,19 +52,19 @@ func (c *Context) ReportArrayValueConformsToStaticTypeTrace(_ string, _ int, _ t
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx Tracer) ReportDictionaryValueTransferTrace(_ string, _ int, _ time.Duration) {
+func (t Tracer) ReportDictionaryValueTransferTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx Tracer) ReportDictionaryValueDeepRemoveTrace(_ string, _ int, _ time.Duration) {
+func (t Tracer) ReportDictionaryValueDeepRemoveTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx Tracer) ReportCompositeValueDeepRemoveTrace(_ string, _ string, _ string, _ time.Duration) {
+func (t Tracer) ReportCompositeValueDeepRemoveTrace(_ string, _ string, _ string, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx Tracer) ReportDictionaryValueGetMemberTrace(_ string, _ int, _ string, _ time.Duration) {
+func (t Tracer) ReportDictionaryValueGetMemberTrace(_ string, _ int, _ string, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
@@ -80,34 +80,34 @@ func (c *Context) ReportDictionaryValueConformsToStaticTypeTrace(_ string, _ int
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx Tracer) ReportCompositeValueTransferTrace(_ string, _ string, _ string, _ time.Duration) {
+func (t Tracer) ReportCompositeValueTransferTrace(_ string, _ string, _ string, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx Tracer) ReportCompositeValueSetMemberTrace(_ string, _ string, _ string, _ string, _ time.Duration) {
+func (t Tracer) ReportCompositeValueSetMemberTrace(_ string, _ string, _ string, _ string, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx Tracer) ReportCompositeValueGetMemberTrace(_ string, _ string, _ string, _ string, _ time.Duration) {
+func (t Tracer) ReportCompositeValueGetMemberTrace(_ string, _ string, _ string, _ string, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx Tracer) ReportCompositeValueConstructTrace(_ string, _ string, _ string, _ time.Duration) {
+func (t Tracer) ReportCompositeValueConstructTrace(_ string, _ string, _ string, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Context) ReportCompositeValueDestroyTrace(_ string, _ string, _ string, _ time.Duration) {
+func (t Tracer) ReportCompositeValueDestroyTrace(_ string, _ string, _ string, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Context) ReportCompositeValueConformsToStaticTypeTrace(_ string, _ string, _ string, _ time.Duration) {
+func (t Tracer) ReportCompositeValueConformsToStaticTypeTrace(_ string, _ string, _ string, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Context) ReportCompositeValueRemoveMemberTrace(_ string, _ string, _ string, _ string, _ time.Duration) {
+func (t Tracer) ReportCompositeValueRemoveMemberTrace(_ string, _ string, _ string, _ string, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx Tracer) ReportDomainStorageMapDeepRemoveTrace(_ string, _ int, _ time.Duration) {
+func (t Tracer) ReportDomainStorageMapDeepRemoveTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -122,14 +122,17 @@ func (e *vmEnvironment) newVMConfig() *vm.Config {
 	return config
 }
 
-func (e *vmEnvironment) loadContractValue(conf *vm.Config, location common.Location) *interpreter.CompositeValue {
+func (e *vmEnvironment) loadContractValue(
+	context *vm.Context,
+	location common.Location,
+) *interpreter.CompositeValue {
 	addressLocation, ok := location.(common.AddressLocation)
 	if !ok {
 		panic(fmt.Errorf("cannot get contract value for non-address location %T", location))
 	}
 
 	return loadContractValue(
-		vm.NewContext(conf),
+		context,
 		addressLocation,
 		e.storage,
 	)


### PR DESCRIPTION
## Description

Just a cleanup: `ContractValueHandler` used to accept a `vm.Config` which only has limited configurations. Instead pass  a `vm.Context` that provides more functionality.

This also eliminates the need for creating a new context in `(*vmEnvironment).loadContractValue` method.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
