### PR TITLE
[Compiler] Refactor function invocation on vm

### DIFF
--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -204,8 +204,6 @@ func (c *Context) CallStack() []interpreter.Invocation {
 func (c *Context) InvokeFunction(
 	fn interpreter.FunctionValue,
 	arguments []interpreter.Value,
-	_ []sema.Type,
-	_ interpreter.LocationRange,
 ) interpreter.Value {
 	result, err := c.invokeFunction(fn, arguments)
 	if err != nil {

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -104,8 +104,6 @@ func LinkGlobals(
 				return context.InvokeFunction(
 					valueGetter,
 					nil,
-					nil,
-					EmptyLocationRange,
 				)
 			})
 		}

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -404,7 +404,7 @@ func compiledFTTransfer(tb testing.TB) {
 		validationScriptVM := vm.NewVM(scriptLocation, program, vmConfig)
 
 		addressValue := interpreter.AddressValue(address)
-		result, err := validationScriptVM.Invoke("main", addressValue)
+		result, err := validationScriptVM.InvokeExternally("main", addressValue)
 		require.NoError(tb, err)
 		require.Equal(tb, 0, validationScriptVM.StackSize())
 

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -486,7 +486,7 @@ func CompileAndInvokeWithOptions(
 
 	programVM := CompileAndPrepareToInvoke(t, code, options)
 
-	result, err := programVM.Invoke(funcName, arguments...)
+	result, err := programVM.InvokeExternally(funcName, arguments...)
 	if err == nil {
 		require.Equal(t, 0, programVM.StackSize())
 	}
@@ -549,8 +549,6 @@ func contractValueHandler(contractName string, arguments ...vm.Value) vm.Contrac
 		result := context.InvokeFunction(
 			contractInitializer,
 			arguments,
-			nil,
-			interpreter.EmptyLocationRange,
 		)
 
 		return result.(*interpreter.CompositeValue)
@@ -623,7 +621,7 @@ func compileAndInvokeWithOptionsAndPrograms(
 		vmConfig,
 	)
 
-	result, err := programVM.Invoke(funcName, arguments...)
+	result, err := programVM.InvokeExternally(funcName, arguments...)
 	if err == nil {
 		require.Equal(t, 0, programVM.StackSize())
 	}

--- a/bbq/vm/test/vm_bench_test.go
+++ b/bbq/vm/test/vm_bench_test.go
@@ -60,7 +60,7 @@ func BenchmarkRecursionFib(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 
-		result, err := vmInstance.Invoke(
+		result, err := vmInstance.InvokeExternally(
 			"fib",
 			interpreter.NewUnmeteredIntValueFromInt64(14),
 		)
@@ -91,7 +91,7 @@ func BenchmarkImperativeFib(b *testing.B) {
 	var value vm.Value = interpreter.NewUnmeteredIntValueFromInt64(14)
 
 	for i := 0; i < b.N; i++ {
-		_, err := vmInstance.Invoke("fib", value)
+		_, err := vmInstance.InvokeExternally("fib", value)
 		require.NoError(b, err)
 	}
 }
@@ -134,7 +134,7 @@ func BenchmarkNewStruct(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := vmInstance.Invoke("test", value)
+		_, err := vmInstance.InvokeExternally("test", value)
 		require.NoError(b, err)
 	}
 }
@@ -178,7 +178,7 @@ func BenchmarkNewResource(b *testing.B) {
 
 		vmConfig := &vm.Config{}
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
-		_, err := vmInstance.Invoke("test", value)
+		_, err := vmInstance.InvokeExternally("test", value)
 		require.NoError(b, err)
 	}
 }
@@ -323,7 +323,7 @@ func BenchmarkContractImport(b *testing.B) {
 		scriptLocation := runtime_utils.NewScriptLocationGenerator()
 
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
-		_, err = vmInstance.Invoke("test", value)
+		_, err = vmInstance.InvokeExternally("test", value)
 		require.NoError(b, err)
 	}
 }
@@ -437,7 +437,7 @@ func BenchmarkMethodCall(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
-			_, err := vmInstance.Invoke("test", value)
+			_, err := vmInstance.InvokeExternally("test", value)
 			require.NoError(b, err)
 		}
 	})
@@ -540,7 +540,7 @@ func BenchmarkMethodCall(b *testing.B) {
 		b.ReportAllocs()
 
 		for i := 0; i < b.N; i++ {
-			_, err := vmInstance.Invoke("test", value)
+			_, err := vmInstance.InvokeExternally("test", value)
 			require.NoError(b, err)
 		}
 	})

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -72,7 +72,7 @@ func TestRecursionFib(t *testing.T) {
 	vmConfig := &vm.Config{}
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-	result, err := vmInstance.Invoke(
+	result, err := vmInstance.InvokeExternally(
 		"fib",
 		interpreter.NewUnmeteredIntValueFromInt64(23),
 	)
@@ -113,7 +113,7 @@ func TestImperativeFib(t *testing.T) {
 	vmConfig := &vm.Config{}
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-	result, err := vmInstance.Invoke(
+	result, err := vmInstance.InvokeExternally(
 		"fib",
 		interpreter.NewUnmeteredIntValueFromInt64(7),
 	)
@@ -333,7 +333,7 @@ func TestNewStruct(t *testing.T) {
 		},
 	)
 
-	result, err := vmInstance.Invoke("test", interpreter.NewUnmeteredIntValueFromInt64(10))
+	result, err := vmInstance.InvokeExternally("test", interpreter.NewUnmeteredIntValueFromInt64(10))
 	require.NoError(t, err)
 	require.Equal(t, 0, vmInstance.StackSize())
 
@@ -495,7 +495,7 @@ func TestImport(t *testing.T) {
 
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-	result, err := vmInstance.Invoke("test")
+	result, err := vmInstance.InvokeExternally("test")
 	require.NoError(t, err)
 	require.Equal(t, 0, vmInstance.StackSize())
 
@@ -606,7 +606,7 @@ func TestContractImport(t *testing.T) {
 
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -703,7 +703,7 @@ func TestContractImport(t *testing.T) {
 
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -929,7 +929,7 @@ func TestContractImport(t *testing.T) {
 
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1138,7 +1138,7 @@ func TestContractImport(t *testing.T) {
 
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1321,7 +1321,7 @@ func TestFunctionOrder(t *testing.T) {
 		vmConfig := &vm.Config{}
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1480,7 +1480,7 @@ func TestContractField(t *testing.T) {
 		}
 
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1572,7 +1572,7 @@ func TestContractField(t *testing.T) {
 
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1643,7 +1643,7 @@ func TestNativeFunctions(t *testing.T) {
 		}
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-		_, err = vmInstance.Invoke("test")
+		_, err = vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1669,7 +1669,7 @@ func TestNativeFunctions(t *testing.T) {
 		vmConfig := &vm.Config{}
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1715,7 +1715,7 @@ func TestTransaction(t *testing.T) {
 
 		// Rerun the same again using internal functions, to get the access to the transaction value.
 
-		transaction, err := vmInstance.Invoke(commons.TransactionWrapperCompositeName)
+		transaction, err := vmInstance.InvokeExternally(commons.TransactionWrapperCompositeName)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1726,7 +1726,7 @@ func TestTransaction(t *testing.T) {
 		assert.Nil(t, compositeValue.GetMember(vmContext, vm.EmptyLocationRange, "a"))
 
 		// Invoke 'prepare'
-		_, err = vmInstance.Invoke(commons.TransactionPrepareFunctionName, transaction)
+		_, err = vmInstance.InvokeExternally(commons.TransactionPrepareFunctionName, transaction)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1738,7 +1738,7 @@ func TestTransaction(t *testing.T) {
 		)
 
 		// Invoke 'execute'
-		_, err = vmInstance.Invoke(commons.TransactionExecuteFunctionName, transaction)
+		_, err = vmInstance.InvokeExternally(commons.TransactionExecuteFunctionName, transaction)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1789,7 +1789,7 @@ func TestTransaction(t *testing.T) {
 
 		// Rerun the same again using internal functions, to get the access to the transaction value.
 
-		transaction, err := vmInstance.Invoke(commons.TransactionWrapperCompositeName)
+		transaction, err := vmInstance.InvokeExternally(commons.TransactionWrapperCompositeName)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1800,7 +1800,7 @@ func TestTransaction(t *testing.T) {
 		assert.Nil(t, compositeValue.GetMember(vmContext, vm.EmptyLocationRange, "a"))
 
 		// Invoke 'prepare'
-		_, err = vmInstance.Invoke(commons.TransactionPrepareFunctionName, transaction)
+		_, err = vmInstance.InvokeExternally(commons.TransactionPrepareFunctionName, transaction)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1812,7 +1812,7 @@ func TestTransaction(t *testing.T) {
 		)
 
 		// Invoke 'execute'
-		_, err = vmInstance.Invoke(commons.TransactionExecuteFunctionName, transaction)
+		_, err = vmInstance.InvokeExternally(commons.TransactionExecuteFunctionName, transaction)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -2277,7 +2277,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		}
 
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -2564,7 +2564,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		}
 
 		scriptVM := vm.NewVM(scriptLocation(), program, vmConfig)
-		implValue, err := scriptVM.Invoke("test")
+		implValue, err := scriptVM.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, scriptVM.StackSize())
 
@@ -2677,7 +2677,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 
 		scriptVM = vm.NewVM(scriptLocation(), program, vmConfig)
 
-		result, err := scriptVM.Invoke("test", implValue)
+		result, err := scriptVM.InvokeExternally("test", implValue)
 		require.NoError(t, err)
 		require.Equal(t, 0, scriptVM.StackSize())
 
@@ -2710,7 +2710,7 @@ func TestArrayLiteral(t *testing.T) {
 
 		vmContext := vmInstance.Context()
 
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -2749,7 +2749,7 @@ func TestArrayLiteral(t *testing.T) {
 		vmConfig := &vm.Config{}
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 		assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(5), result)
@@ -2777,7 +2777,7 @@ func TestArrayLiteral(t *testing.T) {
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 		vmContext := vmInstance.Context()
 
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -2814,7 +2814,7 @@ func TestDictionaryLiteral(t *testing.T) {
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 		vmContext := vmInstance.Context()
 
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -2914,7 +2914,7 @@ func TestResource(t *testing.T) {
 
 		vmContext := vmInstance.Context()
 
-		result, err := vmInstance.Invoke("test")
+		result, err := vmInstance.InvokeExternally("test")
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -3188,7 +3188,7 @@ func TestDefaultFunctions(t *testing.T) {
 		txProgram := ParseCheckAndCompile(t, tx, txLocation(), programs)
 		txVM := vm.NewVM(txLocation(), txProgram, vmConfig)
 
-		result, err := txVM.Invoke("main")
+		result, err := txVM.InvokeExternally("main")
 		require.NoError(t, err)
 		require.Equal(t, 0, txVM.StackSize())
 		require.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(7), result)
@@ -3314,7 +3314,7 @@ func TestDefaultFunctions(t *testing.T) {
 		txProgram := ParseCheckAndCompile(t, tx, txLocation(), programs)
 		txVM := vm.NewVM(txLocation(), txProgram, vmConfig)
 
-		result, err := txVM.Invoke("main")
+		result, err := txVM.InvokeExternally("main")
 		require.NoError(t, err)
 		require.Equal(t, 0, txVM.StackSize())
 		require.Equal(t, interpreter.NewUnmeteredStringValue("Hello from HelloInterface"), result)
@@ -3457,7 +3457,7 @@ func TestDefaultFunctions(t *testing.T) {
 		txProgram := ParseCheckAndCompile(t, tx, txLocation(), programs)
 		txVM := vm.NewVM(txLocation(), txProgram, vmConfig)
 
-		result, err := txVM.Invoke("main")
+		result, err := txVM.InvokeExternally("main")
 		require.NoError(t, err)
 		require.Equal(t, 0, txVM.StackSize())
 		require.Equal(t, interpreter.NewUnmeteredStringValue("Hello from Hello"), result)
@@ -6111,7 +6111,7 @@ func TestContractAccount(t *testing.T) {
 
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-	result, err := vmInstance.Invoke("test")
+	result, err := vmInstance.InvokeExternally("test")
 	require.NoError(t, err)
 	require.Equal(t, 0, vmInstance.StackSize())
 
@@ -6243,7 +6243,7 @@ func TestResourceOwner(t *testing.T) {
 
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-	result, err := vmInstance.Invoke("test")
+	result, err := vmInstance.InvokeExternally("test")
 	require.NoError(t, err)
 	require.Equal(t, 0, vmInstance.StackSize())
 
@@ -6352,7 +6352,7 @@ func TestResourceUUID(t *testing.T) {
 
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-	result, err := vmInstance.Invoke("test")
+	result, err := vmInstance.InvokeExternally("test")
 	require.NoError(t, err)
 	require.Equal(t, 0, vmInstance.StackSize())
 
@@ -6738,7 +6738,7 @@ func TestContractClosure(t *testing.T) {
 
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
-	result, err := vmInstance.Invoke("test")
+	result, err := vmInstance.InvokeExternally("test")
 	require.NoError(t, err)
 	require.Equal(t, 0, vmInstance.StackSize())
 	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(9), result)
@@ -7629,7 +7629,7 @@ func TestInheritedConditions(t *testing.T) {
 		txProgram := ParseCheckAndCompile(t, tx, txLocation(), programs)
 
 		txVM := vm.NewVM(txLocation(), txProgram, vmConfig)
-		result, err := txVM.Invoke("main")
+		result, err := txVM.InvokeExternally("main")
 		require.NoError(t, err)
 
 		require.Equal(t, 0, txVM.StackSize())

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -161,8 +161,6 @@ func (v CompiledFunctionValue) Invoke(invocation interpreter.Invocation) interpr
 	return invocation.InvocationContext.InvokeFunction(
 		v,
 		invocation.Arguments,
-		invocation.ArgumentTypes,
-		invocation.LocationRange,
 	)
 }
 
@@ -337,8 +335,6 @@ func (v NativeFunctionValue) Invoke(invocation interpreter.Invocation) interpret
 	return invocation.InvocationContext.InvokeFunction(
 		v,
 		invocation.Arguments,
-		invocation.ArgumentTypes,
-		invocation.LocationRange,
 	)
 }
 
@@ -483,10 +479,12 @@ func (v *BoundFunctionPointerValue) initializeFunctionType(context interpreter.V
 }
 
 func (v *BoundFunctionPointerValue) Invoke(invocation interpreter.Invocation) interpreter.Value {
+	arguments := make([]Value, 0, len(invocation.Arguments)+1)
+	arguments = append(arguments, v.Receiver)
+	arguments = append(arguments, invocation.Arguments...)
+
 	return invocation.InvocationContext.InvokeFunction(
 		v,
-		invocation.Arguments,
-		invocation.ArgumentTypes,
-		invocation.LocationRange,
+		arguments,
 	)
 }

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -744,7 +744,7 @@ func invokeFunction(
 	typeArguments []bbq.StaticType,
 ) {
 
-	// Handle all function types in a single methods, so this can be re-used everywhere.
+	// Handle all function types in a single place, so this can be re-used everywhere.
 
 	if boundFunction, ok := functionValue.(*BoundFunctionPointerValue); ok {
 		functionValue = boundFunction.Method

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -90,8 +90,7 @@ func NewVM(
 	}
 
 	// Delegate the function invocations to the vm.
-	// TODO: Fix: this should also be able to call native functions.
-	context.invokeFunction = vm.invoke
+	context.invokeFunction = vm.invokeExternally
 
 	context.lookupFunction = vm.maybeLookupFunction
 
@@ -266,7 +265,7 @@ func (vm *VM) popCallFrame() {
 	}
 }
 
-func (vm *VM) Invoke(name string, arguments ...Value) (v Value, err error) {
+func (vm *VM) InvokeExternally(name string, arguments ...Value) (v Value, err error) {
 	functionVariable, ok := vm.globals[name]
 	if !ok {
 		return nil, UnknownFunctionError{
@@ -286,10 +285,10 @@ func (vm *VM) Invoke(name string, arguments ...Value) (v Value, err error) {
 		err, _ = recovered.(error)
 	}()
 
-	return vm.invoke(function, arguments)
+	return vm.validateAndInvokeExternally(function, arguments)
 }
 
-func (vm *VM) invoke(function Value, arguments []Value) (Value, error) {
+func (vm *VM) validateAndInvokeExternally(function Value, arguments []Value) (Value, error) {
 	functionValue, ok := function.(CompiledFunctionValue)
 	if !ok {
 		return nil, interpreter.NotInvokableError{
@@ -297,15 +296,26 @@ func (vm *VM) invoke(function Value, arguments []Value) (Value, error) {
 		}
 	}
 
-	if len(arguments) != int(functionValue.Function.ParameterCount) {
+	paramCount := functionValue.Function.ParameterCount
+
+	if len(arguments) != int(paramCount) {
 		return nil, errors.NewDefaultUserError(
 			"wrong number of arguments: expected %d, found %d",
-			functionValue.Function.ParameterCount,
+			paramCount,
 			len(arguments),
 		)
 	}
 
-	vm.pushCallFrame(functionValue, arguments)
+	return vm.invokeExternally(functionValue, arguments)
+}
+
+func (vm *VM) invokeExternally(functionValue Value, arguments []Value) (Value, error) {
+	invokeFunction(
+		vm,
+		functionValue,
+		arguments,
+		nil,
+	)
 
 	vm.run()
 
@@ -318,7 +328,7 @@ func (vm *VM) invoke(function Value, arguments []Value) (Value, error) {
 
 func (vm *VM) InitializeContract(contractName string, arguments ...Value) (*interpreter.CompositeValue, error) {
 	contractInitializer := commons.QualifiedName(contractName, commons.InitFunctionName)
-	value, err := vm.Invoke(contractInitializer, arguments...)
+	value, err := vm.InvokeExternally(contractInitializer, arguments...)
 	if err != nil {
 		return nil, err
 	}
@@ -343,14 +353,14 @@ func (vm *VM) ExecuteTransaction(transactionArgs []Value, signers ...Value) (err
 	}()
 
 	// Create transaction value
-	transaction, err := vm.Invoke(commons.TransactionWrapperCompositeName)
+	transaction, err := vm.InvokeExternally(commons.TransactionWrapperCompositeName)
 	if err != nil {
 		return err
 	}
 
 	if initializerVariable, ok := vm.globals[commons.ProgramInitFunctionName]; ok {
 		initializer := initializerVariable.GetValue(vm.context)
-		_, err = vm.invoke(initializer, transactionArgs)
+		_, err = vm.validateAndInvokeExternally(initializer, transactionArgs)
 		if err != nil {
 			return err
 		}
@@ -363,7 +373,7 @@ func (vm *VM) ExecuteTransaction(transactionArgs []Value, signers ...Value) (err
 	// Invoke 'prepare', if exists.
 	if prepareVariable, ok := vm.globals[commons.TransactionPrepareFunctionName]; ok {
 		prepare := prepareVariable.GetValue(vm.context)
-		_, err = vm.invoke(prepare, prepareArgs)
+		_, err = vm.validateAndInvokeExternally(prepare, prepareArgs)
 		if err != nil {
 			return err
 		}
@@ -375,7 +385,7 @@ func (vm *VM) ExecuteTransaction(transactionArgs []Value, signers ...Value) (err
 	executeArgs := []Value{transaction}
 	if executeVariable, ok := vm.globals[commons.TransactionExecuteFunctionName]; ok {
 		execute := executeVariable.GetValue(vm.context)
-		_, err = vm.invoke(execute, executeArgs)
+		_, err = vm.validateAndInvokeExternally(execute, executeArgs)
 		return err
 	}
 
@@ -717,11 +727,11 @@ func opInvokeMethodDynamic(vm *VM, ins opcode.InstructionInvokeMethodDynamic) {
 		vm.context,
 		EmptyLocationRange,
 		funcName,
-	).(*BoundFunctionPointerValue)
+	)
 
 	invokeFunction(
 		vm,
-		functionValue.Method,
+		functionValue,
 		arguments,
 		typeArguments,
 	)
@@ -733,6 +743,12 @@ func invokeFunction(
 	arguments []Value,
 	typeArguments []bbq.StaticType,
 ) {
+
+	// Handle all function types in a single methods, so this can be re-used everywhere.
+
+	if boundFunction, ok := functionValue.(*BoundFunctionPointerValue); ok {
+		functionValue = boundFunction.Method
+	}
 
 	switch functionValue := functionValue.(type) {
 	case CompiledFunctionValue:

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -456,8 +456,6 @@ type InvocationContext interface {
 	InvokeFunction(
 		fn FunctionValue,
 		arguments []Value,
-		invocationArgumentTypes []sema.Type,
-		locationRange LocationRange,
 	) Value
 }
 

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -4280,7 +4280,8 @@ func AccountStorageIterate(
 		arguments := []Value{pathValue, runtimeType}
 		invocationArgumentTypes := []sema.Type{pathType, sema.MetaType}
 
-		result := invocationContext.InvokeFunction(
+		result := invokeIteratorFunction(
+			invocationContext,
 			fn,
 			arguments,
 			invocationArgumentTypes,
@@ -4316,17 +4317,28 @@ func AccountStorageIterate(
 }
 
 func (interpreter *Interpreter) InvokeFunction(
+	_ FunctionValue,
+	_ []Value,
+) Value {
+	// Interpreter's function values shouldn't/doesn't use `InvocationContext.InvokeFunction`.
+	// They directly use the methods of `Interpreter`.
+	// This indirection is only needed in VM.
+	panic(errors.NewUnreachableError())
+}
+
+func invokeIteratorFunction(
+	context InvocationContext,
 	fn FunctionValue,
 	arguments []Value,
 	invocationArgumentTypes []sema.Type,
 	locationRange LocationRange,
 ) Value {
-	fnType := fn.FunctionType(interpreter)
+	fnType := fn.FunctionType(context)
 	parameterTypes := fnType.ParameterTypes()
 	returnType := fnType.ReturnTypeAnnotation.Type
 
 	result := invokeFunctionValue(
-		interpreter,
+		context,
 		fn,
 		arguments,
 		nil,

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -32,7 +32,7 @@ import (
 	. "github.com/onflow/cadence/test_utils/common_utils"
 )
 
-var compile = flag.Bool("compile", false, "Run tests using the compiler")
+var compile = flag.Bool("compile", true, "Run tests using the compiler")
 
 func parseCheckAndPrepare(tb testing.TB, code string) Invokable {
 	tb.Helper()

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -32,7 +32,7 @@ import (
 	. "github.com/onflow/cadence/test_utils/common_utils"
 )
 
-var compile = flag.Bool("compile", true, "Run tests using the compiler")
+var compile = flag.Bool("compile", false, "Run tests using the compiler")
 
 func parseCheckAndPrepare(tb testing.TB, code string) Invokable {
 	tb.Helper()

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -3630,7 +3630,7 @@ func TestInterpretOptionalMap(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           let one: Int? = 42
           let result = one.map(fun (v: Int): String {
               return v.toString()
@@ -3651,7 +3651,7 @@ func TestInterpretOptionalMap(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           let none: Int? = nil
           let result = none.map(fun (v: Int): String {
               return v.toString()
@@ -3670,7 +3670,7 @@ func TestInterpretOptionalMap(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           struct S {
               fun map(f: fun(AnyStruct): String): String {
                   return "S.map"
@@ -5220,7 +5220,7 @@ func TestInterpretStructureFunctionBindingInside(t *testing.T) {
 	//        return bar()
 	//   }
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
         struct X {
             fun foo(): AnyStruct {
                 return self.bar

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -6247,7 +6247,7 @@ func TestInterpretDictionaryForEachKey(t *testing.T) {
 	t.Run("box and convert argument", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           fun test(): String? {
               let dict = {"answer": 42}
               var res: String? = nil
@@ -9809,7 +9809,7 @@ func TestInterpretInternalAssignment(t *testing.T) {
 	)
 }
 
-func TestInterpretVoidReturn_(t *testing.T) {
+func TestInterpretVoidReturn(t *testing.T) {
 	t.Parallel()
 
 	labelNamed := func(s string) string {

--- a/interpreter/path_test.go
+++ b/interpreter/path_test.go
@@ -38,7 +38,7 @@ func TestInterpretPath(t *testing.T) {
 
 		t.Run(fmt.Sprintf("valid: %s", domain.Identifier()), func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       let x = /%s/random
@@ -54,7 +54,7 @@ func TestInterpretPath(t *testing.T) {
 					Domain:     domain,
 					Identifier: "random",
 				},
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 		})
 	}
@@ -77,7 +77,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 
 			domainType := domainTypes[domain]
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       let x = %[1]s(identifier: "foo")!
@@ -91,7 +91,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 					Domain:     domain,
 					Identifier: "foo",
 				},
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 		})
 
@@ -101,7 +101,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 
 			domainType := domainTypes[domain]
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       let x = %[1]s(identifier: "2")!
@@ -115,7 +115,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 					Domain:     domain,
 					Identifier: "2",
 				},
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 		})
 
@@ -125,7 +125,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 
 			domainType := domainTypes[domain]
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       let x = %[1]s(identifier: "fo-o")!
@@ -139,7 +139,7 @@ func TestInterpretConvertStringToPath(t *testing.T) {
 					Domain:     domain,
 					Identifier: "fo-o",
 				},
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 		})
 	}

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -290,7 +290,7 @@ func (executor *contractFunctionExecutor) executeWithVM(
 	semaType := interpreter.MustConvertStaticToSemaType(staticType, context)
 	qualifiedFuncName := commons.TypeQualifiedName(semaType, executor.functionName)
 
-	value, err := executor.vm.Invoke(qualifiedFuncName, invocationArguments...)
+	value, err := executor.vm.InvokeExternally(qualifiedFuncName, invocationArguments...)
 	if err != nil {
 		return nil, err
 	}

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -65,7 +65,7 @@ func NewVMInvokable(
 }
 
 func (v *VMInvokable) Invoke(functionName string, arguments ...interpreter.Value) (value interpreter.Value, err error) {
-	value, err = v.vmInstance.Invoke(functionName, arguments...)
+	value, err = v.vmInstance.InvokeExternally(functionName, arguments...)
 
 	// Reset the VM after a function invocation,
 	// so the same vm can be re-used for subsequent invocation.


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3922

## Description

- Support invoking all function types externally (e.g: by native functions; in tests; etc.)
- At the interpreter, do not delegate the function value invocations to the "context" - Instead, use the interpreter methods to ensure the validations are properly executed (e.g: argument validations, transfers etc.). Only the final dispatching (`functionValue.Invoke()`) must be delegated to the  "context".

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
