### PR TITLE
[Compiler] Compile position info as a line-number table

### DIFF
--- a/bbq/compiler/function.go
+++ b/bbq/compiler/function.go
@@ -22,6 +22,7 @@ import (
 	"math"
 
 	"github.com/onflow/cadence/activations"
+	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/bbq/opcode"
 	"github.com/onflow/cadence/errors"
 )
@@ -37,6 +38,7 @@ type function[E any] struct {
 	upvalues       []opcode.Upvalue
 	upvalueIndices map[opcode.Upvalue]uint16
 	typeIndex      uint16
+	lineNumbers    bbq.LineNumberTable
 }
 
 func newFunction[E any](

--- a/bbq/function.go
+++ b/bbq/function.go
@@ -26,6 +26,7 @@ type Function[E any] struct {
 	TypeParameterCount uint16
 	LocalCount         uint16
 	TypeIndex          uint16
+	LineNumbers        LineNumberTable
 }
 
 func (f Function[E]) IsAnonymous() bool {

--- a/bbq/line_number_table.go
+++ b/bbq/line_number_table.go
@@ -1,0 +1,58 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bbq
+
+import "github.com/onflow/cadence/ast"
+
+// LineNumberTable holds the instruction-index to source-position mapping.
+// It only maintains an entry for an instruction only if the position info
+// got changed during that instruction.
+// i.e: If multiple consecutive instructions were emitted for the same source-code position,
+// then only the first instruction of that instruction-set would be available in the table.
+type LineNumberTable struct {
+	positions []PositionInfo
+}
+
+func (t *LineNumberTable) AddPositionInfo(bytecodeIndex uint16, position ast.Position) {
+	t.positions = append(
+		t.positions,
+		PositionInfo{
+			instructionIndex: bytecodeIndex,
+			position:         position,
+		},
+	)
+}
+
+func (t *LineNumberTable) GetSourcePosition(instructionIndex uint16) ast.Position {
+	var lastChangedPosition ast.Position
+
+	for _, positionInfo := range t.positions {
+		if instructionIndex < positionInfo.instructionIndex {
+			break
+		}
+		lastChangedPosition = positionInfo.position
+	}
+
+	return lastChangedPosition
+}
+
+type PositionInfo struct {
+	instructionIndex uint16
+	position         ast.Position
+}

--- a/bbq/line_number_table.go
+++ b/bbq/line_number_table.go
@@ -26,15 +26,15 @@ import "github.com/onflow/cadence/ast"
 // i.e: If multiple consecutive instructions were emitted for the same source-code position,
 // then only the first instruction of that instruction-set would be available in the table.
 type LineNumberTable struct {
-	positions []PositionInfo
+	Positions []PositionInfo
 }
 
 func (t *LineNumberTable) AddPositionInfo(bytecodeIndex uint16, position ast.Position) {
-	t.positions = append(
-		t.positions,
+	t.Positions = append(
+		t.Positions,
 		PositionInfo{
-			instructionIndex: bytecodeIndex,
-			position:         position,
+			InstructionIndex: bytecodeIndex,
+			Position:         position,
 		},
 	)
 }
@@ -42,17 +42,17 @@ func (t *LineNumberTable) AddPositionInfo(bytecodeIndex uint16, position ast.Pos
 func (t *LineNumberTable) GetSourcePosition(instructionIndex uint16) ast.Position {
 	var lastChangedPosition ast.Position
 
-	for _, positionInfo := range t.positions {
-		if instructionIndex < positionInfo.instructionIndex {
+	for _, positionInfo := range t.Positions {
+		if instructionIndex < positionInfo.InstructionIndex {
 			break
 		}
-		lastChangedPosition = positionInfo.position
+		lastChangedPosition = positionInfo.Position
 	}
 
 	return lastChangedPosition
 }
 
 type PositionInfo struct {
-	instructionIndex uint16
-	position         ast.Position
+	InstructionIndex uint16
+	Position         ast.Position
 }

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -5062,6 +5062,16 @@ func TestCasting(t *testing.T) {
 			interpreter.ForceCastTypeMismatchError{
 				ExpectedType: sema.IntType,
 				ActualType:   sema.BoolType,
+				LocationRange: interpreter.LocationRange{
+					Location: TestLocation,
+					HasPosition: vm.Positioned{
+						StartPos: ast.Position{
+							Offset: 70,
+							Line:   3,
+							Column: 25,
+						},
+					},
+				},
 			},
 		)
 	})

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -1665,7 +1665,11 @@ func (vm *VM) Global(name string) Value {
 func (vm *VM) LocationRange() interpreter.LocationRange {
 	currentFunction := vm.callFrame.function
 	lineNumbers := currentFunction.Function.LineNumbers
-	position := lineNumbers.GetSourcePosition(vm.ip)
+
+	// `vm.ip` always points to the next instruction.
+	lastInstructionIndex := vm.ip - 1
+
+	position := lineNumbers.GetSourcePosition(lastInstructionIndex)
 
 	return interpreter.LocationRange{
 		Location: currentFunction.Executable.Location,

--- a/interpreter/dynamic_casting_test.go
+++ b/interpreter/dynamic_casting_test.go
@@ -3974,7 +3974,19 @@ func TestInterpretDynamicCastingOptionalUnwrapping(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		assert.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+		var forceCastTypeMismatchError interpreter.ForceCastTypeMismatchError
+		assert.ErrorAs(t, err, &forceCastTypeMismatchError)
+
+		startPos := forceCastTypeMismatchError.LocationRange.StartPosition()
+		assert.Equal(
+			t,
+			ast.Position{
+				Offset: 56,
+				Line:   4,
+				Column: 17,
+			},
+			startPos,
+		)
 	})
 
 	t.Run("string as!", func(t *testing.T) {


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3804

## Description

Embed the position info in the bytecode as a separate line-number table. This follows a similar approach to Java's [LineNumberTable attribute](https://docs.oracle.com/javase/specs/jvms/se10/html/jvms-4.html#jvms-4.7.12).

Currently there is one table per-function (as opposed to one table per-file in Java) because the instructions are indexed per-function.


### Next up:
At the moment, to all the interpreter code that were re-used by the VM (where almost all the errors are thrown), a `LocationRange` instance must be passed in as an argument. However, creating an `LocationRange` for each operation is extremely/unacceptably expensive in VM.

Therefore, we would need to refactor all places where an `LocationRange` is passed, to accept a "location range getter" instead, so that the `LocationRange` is created only if an error occurred (i.e: only on-demand).
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
