### PR TITLE
[Compiler] Run most metatype tests and all interface tests with compiler/VM

### DIFF
--- a/activations/activations.go
+++ b/activations/activations.go
@@ -70,8 +70,8 @@ func (a *Activation[T]) Find(name string) (_ T) {
 	return
 }
 
-// FunctionValues returns all values in the current function activation.
-func (a *Activation[T]) FunctionValues() map[string]T {
+// ValuesInFunction returns all values in the current function activation.
+func (a *Activation[T]) ValuesInFunction() map[string]T {
 
 	values := make(map[string]T)
 

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	common.MemoryGauge
 	commons.ImportHandler
 	ContractValueHandler
-	NativeFunctionsProvider
+	BuiltinGlobalsProvider
 	Tracer
 	stdlib.Logger
 

--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -39,7 +39,7 @@ var nativeFunctions = map[string]Value{}
 // It's always nil.
 var BuiltInLocation common.Location = nil
 
-type NativeFunctionsProvider func() map[string]*Variable
+type BuiltinGlobalsProvider func() map[string]*Variable
 
 func NativeFunctions() map[string]*Variable {
 	funcs := make(map[string]*Variable, len(nativeFunctions))

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -381,7 +381,7 @@ func CompileAndInvoke(
 	)
 }
 
-func NativeFunctionsWithLogAndPanic(logs *[]string) vm.NativeFunctionsProvider {
+func NativeFunctionsWithLogAndPanic(logs *[]string) vm.BuiltinGlobalsProvider {
 	return func() map[string]*vm.Variable {
 		funcs := vm.NativeFunctions()
 
@@ -451,7 +451,7 @@ func CompileAndInvokeWithLogs(
 	storage := interpreter.NewInMemoryStorage(nil)
 	vmConfig := vm.NewConfig(storage)
 
-	vmConfig.NativeFunctionsProvider = NativeFunctionsWithLogAndPanic(&logs)
+	vmConfig.BuiltinGlobalsProvider = NativeFunctionsWithLogAndPanic(&logs)
 
 	result, err = CompileAndInvokeWithOptions(
 		t,

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -1863,7 +1863,7 @@ func TestTransaction(t *testing.T) {
 
 		var logs []string
 
-		vmConfig.NativeFunctionsProvider = NativeFunctionsWithLogAndPanic(&logs)
+		vmConfig.BuiltinGlobalsProvider = NativeFunctionsWithLogAndPanic(&logs)
 
 		vmInstance := CompileAndPrepareToInvoke(t,
 			`
@@ -1946,7 +1946,7 @@ func TestTransaction(t *testing.T) {
 
 		var logs []string
 
-		vmConfig.NativeFunctionsProvider = NativeFunctionsWithLogAndPanic(&logs)
+		vmConfig.BuiltinGlobalsProvider = NativeFunctionsWithLogAndPanic(&logs)
 
 		vmInstance := CompileAndPrepareToInvoke(t,
 			`
@@ -2025,7 +2025,7 @@ func TestTransaction(t *testing.T) {
 
 		var logs []string
 
-		vmConfig.NativeFunctionsProvider = NativeFunctionsWithLogAndPanic(&logs)
+		vmConfig.BuiltinGlobalsProvider = NativeFunctionsWithLogAndPanic(&logs)
 
 		vmInstance := CompileAndPrepareToInvoke(t,
 			`
@@ -2109,7 +2109,7 @@ func TestTransaction(t *testing.T) {
 
 		var logs []string
 
-		vmConfig.NativeFunctionsProvider = NativeFunctionsWithLogAndPanic(&logs)
+		vmConfig.BuiltinGlobalsProvider = NativeFunctionsWithLogAndPanic(&logs)
 
 		vmInstance := CompileAndPrepareToInvoke(t,
 			`
@@ -3722,7 +3722,7 @@ func TestFunctionPreConditions(t *testing.T) {
 		var logs []string
 
 		config := vm.NewConfig(interpreter.NewInMemoryStorage(nil))
-		config.NativeFunctionsProvider = NativeFunctionsWithLogAndPanic(&logs)
+		config.BuiltinGlobalsProvider = NativeFunctionsWithLogAndPanic(&logs)
 
 		_, err := CompileAndInvokeWithOptions(
 			t,
@@ -3785,7 +3785,7 @@ func TestFunctionPreConditions(t *testing.T) {
 			return elaboration.InterfaceType(typeID)
 		}
 
-		vmConfig.NativeFunctionsProvider = NativeFunctionsWithLogAndPanic(&logs)
+		vmConfig.BuiltinGlobalsProvider = NativeFunctionsWithLogAndPanic(&logs)
 
 		activation := sema.NewVariableActivation(sema.BaseValueActivation)
 		activation.DeclareValue(stdlib.PanicFunction)
@@ -4161,7 +4161,7 @@ func TestFunctionPostConditions(t *testing.T) {
 		var logs []string
 
 		config := vm.NewConfig(interpreter.NewInMemoryStorage(nil))
-		config.NativeFunctionsProvider = NativeFunctionsWithLogAndPanic(&logs)
+		config.BuiltinGlobalsProvider = NativeFunctionsWithLogAndPanic(&logs)
 
 		_, err := CompileAndInvokeWithOptions(
 			t,
@@ -4671,7 +4671,7 @@ func TestBeforeFunctionInPostConditions(t *testing.T) {
 		var logs []string
 		vmConfig := vm.NewConfig(storage)
 
-		vmConfig.NativeFunctionsProvider = NativeFunctionsWithLogAndPanic(&logs)
+		vmConfig.BuiltinGlobalsProvider = NativeFunctionsWithLogAndPanic(&logs)
 
 		_, err := CompileAndInvokeWithOptions(t,
 			`
@@ -4754,7 +4754,7 @@ func TestBeforeFunctionInPostConditions(t *testing.T) {
 		var logs []string
 		vmConfig := vm.NewConfig(storage)
 
-		vmConfig.NativeFunctionsProvider = NativeFunctionsWithLogAndPanic(&logs)
+		vmConfig.BuiltinGlobalsProvider = NativeFunctionsWithLogAndPanic(&logs)
 
 		_, err := CompileAndInvokeWithOptions(t,
 			`
@@ -4841,7 +4841,7 @@ func TestBeforeFunctionInPostConditions(t *testing.T) {
 		var logs []string
 		vmConfig := vm.NewConfig(storage)
 
-		vmConfig.NativeFunctionsProvider = NativeFunctionsWithLogAndPanic(&logs)
+		vmConfig.BuiltinGlobalsProvider = NativeFunctionsWithLogAndPanic(&logs)
 
 		_, err := CompileAndInvokeWithOptions(t,
 			`
@@ -7570,7 +7570,7 @@ func TestInheritedConditions(t *testing.T) {
 		}
 
 		var logs []string
-		vmConfig.NativeFunctionsProvider = NativeFunctionsWithLogAndPanic(&logs)
+		vmConfig.BuiltinGlobalsProvider = NativeFunctionsWithLogAndPanic(&logs)
 
 		PrepareVMConfig(t, vmConfig, programs)
 
@@ -8267,7 +8267,7 @@ func TestGlobalVariables(t *testing.T) {
 		storage := interpreter.NewInMemoryStorage(nil)
 		vmConfig := vm.NewConfig(storage)
 
-		vmConfig.NativeFunctionsProvider = NativeFunctionsWithLogAndPanic(&logs)
+		vmConfig.BuiltinGlobalsProvider = NativeFunctionsWithLogAndPanic(&logs)
 
 		// Only prepare, do not invoke anything.
 

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -66,8 +66,8 @@ func NewVM(
 		context.storage = interpreter.NewInMemoryStorage(nil)
 	}
 
-	if context.NativeFunctionsProvider == nil {
-		context.NativeFunctionsProvider = NativeFunctions
+	if context.BuiltinGlobalsProvider == nil {
+		context.BuiltinGlobalsProvider = NativeFunctions
 	}
 
 	if context.referencedResourceKindedValues == nil {
@@ -80,7 +80,7 @@ func NewVM(
 			// It is NOT safe to re-use native functions map here because,
 			// once put into the cache, it will be updated by adding the
 			// globals of the current program.
-			indexedGlobals: context.NativeFunctionsProvider(),
+			indexedGlobals: context.BuiltinGlobalsProvider(),
 		},
 	}
 

--- a/cmd/execute/debugger.go
+++ b/cmd/execute/debugger.go
@@ -77,7 +77,7 @@ func (d *InteractiveDebugger) Show(names []string) {
 	current := d.debugger.CurrentActivation(inter)
 	switch len(names) {
 	case 0:
-		for name := range current.FunctionValues() { //nolint:maprange
+		for name := range current.ValuesInFunction() { //nolint:maprange
 			fmt.Println(name)
 		}
 

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -604,7 +604,7 @@ func testAccountWithErrorHandlerWithCompiler(
 
 	if compilerEnabled && *compile {
 		vmConfig := &vm.Config{
-			NativeFunctionsProvider: func() map[string]*vm.Variable {
+			BuiltinGlobalsProvider: func() map[string]*vm.Variable {
 				funcs := vm.NativeFunctions()
 				variable := &interpreter.SimpleVariable{}
 				variable.InitializeWithValue(accountValueDeclaration.Value)

--- a/interpreter/interface_test.go
+++ b/interpreter/interface_test.go
@@ -84,6 +84,7 @@ func parseCheckAndPrepareWithConditionLogs(
 				BaseActivationHandler: func(common.Location) *interpreter.VariableActivation {
 					return baseActivation
 				},
+				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 		},
 	)

--- a/interpreter/interface_test.go
+++ b/interpreter/interface_test.go
@@ -738,7 +738,7 @@ func TestInterpretInterfaceFunctionConditionsInheritance(t *testing.T) {
 
 		t.Parallel()
 
-		logFunctionType := sema.NewSimpleFunctionType(
+		myLogFunctionType := sema.NewSimpleFunctionType(
 			sema.FunctionPurityView,
 			[]sema.Parameter{
 				{
@@ -752,8 +752,8 @@ func TestInterpretInterfaceFunctionConditionsInheritance(t *testing.T) {
 
 		var logs []string
 		valueDeclaration := stdlib.NewStandardLibraryStaticFunction(
-			"log",
-			logFunctionType,
+			"myLog",
+			myLogFunctionType,
 			"",
 			func(invocation interpreter.Invocation) interpreter.Value {
 				msg := invocation.Arguments[0].(*interpreter.StringValue).Str
@@ -815,7 +815,7 @@ func TestInterpretInterfaceFunctionConditionsInheritance(t *testing.T) {
             }
 
             access(all) view fun print(_ msg: String): Bool {
-                log(msg)
+                myLog(msg)
                 return true
             }
 

--- a/interpreter/metatype_test.go
+++ b/interpreter/metatype_test.go
@@ -42,7 +42,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
            let result = Type<Int>() == Type<Int>()
         `)
 
@@ -50,7 +50,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("result").GetValue(inter),
+			inter.GetGlobal("result"),
 		)
 	})
 
@@ -58,7 +58,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
            let result = Type<Int>() == Type<String>()
         `)
 
@@ -66,7 +66,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(inter),
+			inter.GetGlobal("result"),
 		)
 	})
 
@@ -74,7 +74,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
            let result = Type<Int>() == Type<Int?>()
         `)
 
@@ -82,7 +82,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(inter),
+			inter.GetGlobal("result"),
 		)
 	})
 
@@ -90,7 +90,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
            let result = Type<&Int>() == Type<&Int>()
         `)
 
@@ -98,7 +98,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("result").GetValue(inter),
+			inter.GetGlobal("result"),
 		)
 	})
 
@@ -106,7 +106,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
            let result = Type<&Int>() == Type<&String>()
         `)
 
@@ -114,7 +114,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(inter),
+			inter.GetGlobal("result"),
 		)
 	})
 
@@ -137,7 +137,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 		baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
 		interpreter.Declare(baseActivation, valueDeclaration)
 
-		inter, err := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndPrepareWithOptions(t,
 			`
               let result = Type<Int>() == unknownType
             `,
@@ -160,7 +160,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(inter),
+			inter.GetGlobal("result"),
 		)
 	})
 
@@ -197,7 +197,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			interpreter.Declare(baseActivation, valueDeclaration)
 		}
 
-		inter, err := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndPrepareWithOptions(t,
 			`
               let result = unknownType1 == unknownType2
             `,
@@ -220,7 +220,7 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("result").GetValue(inter),
+			inter.GetGlobal("result"),
 		)
 	})
 }
@@ -233,7 +233,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           let type = Type<[Int]>()
           let identifier = type.identifier
         `)
@@ -242,7 +242,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("[Int]"),
-			inter.Globals.Get("identifier").GetValue(inter),
+			inter.GetGlobal("identifier"),
 		)
 	})
 
@@ -250,7 +250,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           struct S {}
 
           let type = Type<S>()
@@ -261,7 +261,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("S.test.S"),
-			inter.Globals.Get("identifier").GetValue(inter),
+			inter.GetGlobal("identifier"),
 		)
 	})
 
@@ -290,7 +290,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			interpreter.Declare(baseActivation, valueDeclaration)
 		}
 
-		inter, err := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndPrepareWithOptions(t,
 			`
               let identifier = unknownType.identifier
             `,
@@ -313,7 +313,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue(""),
-			inter.Globals.Get("identifier").GetValue(inter),
+			inter.GetGlobal("identifier"),
 		)
 	})
 
@@ -323,7 +323,7 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
 
 		// TypeValue.GetMember for `identifier` should not load the program
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
            fun test(_ type: Type): String {
                return type.identifier
            }
@@ -451,25 +451,28 @@ func TestInterpretIsInstance(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
-			inter, err := parseCheckAndInterpretWithOptions(t, testCase.code, ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+			inter, err := parseCheckAndPrepareWithOptions(t,
+				testCase.code,
+				ParseCheckAndInterpretOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
+					},
+					Config: &interpreter.Config{
+						BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+							return baseActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
-					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
-						return baseActivation
-					},
-				},
-			})
+			)
 			require.NoError(t, err)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				interpreter.BoolValue(testCase.result),
-				inter.Globals.Get("result").GetValue(inter),
+				inter.GetGlobal("result"),
 			)
 		})
 	}
@@ -595,23 +598,26 @@ func TestInterpretMetaTypeIsSubtype(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
-			inter, err := parseCheckAndInterpretWithOptions(t, testCase.code, ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+			inter, err := parseCheckAndPrepareWithOptions(t,
+				testCase.code,
+				ParseCheckAndInterpretOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
+					},
+					Config: &interpreter.Config{
+						BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+							return baseActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
-					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
-						return baseActivation
-					},
-				},
-			})
+			)
 			require.NoError(t, err)
 
 			assert.Equal(t,
 				interpreter.BoolValue(testCase.result),
-				inter.Globals.Get("result").GetValue(inter),
+				inter.GetGlobal("result"),
 			)
 		})
 	}
@@ -867,7 +873,7 @@ func TestInterpretMetaTypeHashInput(t *testing.T) {
 
 	// TypeValue.HashInput should not load the program
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
        fun test(_ type: Type) {
            {type: 1}
        }
@@ -946,7 +952,7 @@ func TestInterpretMetaTypeIsRecovered(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           let type = Type<Int>()
           let isRecovered = type.isRecovered
         `)
@@ -955,7 +961,7 @@ func TestInterpretMetaTypeIsRecovered(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("isRecovered").GetValue(inter),
+			inter.GetGlobal("isRecovered"),
 		)
 	})
 
@@ -963,7 +969,7 @@ func TestInterpretMetaTypeIsRecovered(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           struct S {}
 
           let type = Type<S>()
@@ -974,7 +980,7 @@ func TestInterpretMetaTypeIsRecovered(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("isRecovered").GetValue(inter),
+			inter.GetGlobal("isRecovered"),
 		)
 	})
 
@@ -1003,7 +1009,7 @@ func TestInterpretMetaTypeIsRecovered(t *testing.T) {
 			interpreter.Declare(baseActivation, valueDeclaration)
 		}
 
-		inter, err := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndPrepareWithOptions(t,
 			`
 	         let isRecovered = unknownType.isRecovered
 	       `,
@@ -1026,7 +1032,7 @@ func TestInterpretMetaTypeIsRecovered(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("isRecovered").GetValue(inter),
+			inter.GetGlobal("isRecovered"),
 		)
 	})
 
@@ -1098,7 +1104,7 @@ func TestInterpretMetaTypeAddress(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           let type = Type<Int>()
           let address = type.address
         `)
@@ -1107,7 +1113,7 @@ func TestInterpretMetaTypeAddress(t *testing.T) {
 			t,
 			inter,
 			interpreter.Nil,
-			inter.Globals.Get("address").GetValue(inter),
+			inter.GetGlobal("address"),
 		)
 	})
 
@@ -1219,7 +1225,7 @@ func TestInterpretMetaTypeAddress(t *testing.T) {
 			interpreter.Declare(baseActivation, valueDeclaration)
 		}
 
-		inter, err := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndPrepareWithOptions(t,
 			`
 	         let address = unknownType.address
 	       `,
@@ -1242,7 +1248,7 @@ func TestInterpretMetaTypeAddress(t *testing.T) {
 			t,
 			inter,
 			interpreter.Nil,
-			inter.Globals.Get("address").GetValue(inter),
+			inter.GetGlobal("address"),
 		)
 	})
 }
@@ -1255,7 +1261,7 @@ func TestInterpretMetaTypeContractName(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           let type = Type<Int>()
           let contractName = type.contractName
         `)
@@ -1264,7 +1270,7 @@ func TestInterpretMetaTypeContractName(t *testing.T) {
 			t,
 			inter,
 			interpreter.Nil,
-			inter.Globals.Get("contractName").GetValue(inter),
+			inter.GetGlobal("contractName"),
 		)
 	})
 
@@ -1406,7 +1412,7 @@ func TestInterpretMetaTypeContractName(t *testing.T) {
 			interpreter.Declare(baseActivation, valueDeclaration)
 		}
 
-		inter, err := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndPrepareWithOptions(t,
 			`
 	         let contractName = unknownType.contractName
 	       `,
@@ -1429,7 +1435,7 @@ func TestInterpretMetaTypeContractName(t *testing.T) {
 			t,
 			inter,
 			interpreter.Nil,
-			inter.Globals.Get("contractName").GetValue(inter),
+			inter.GetGlobal("contractName"),
 		)
 	})
 }

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -175,8 +175,8 @@ func ParseCheckAndPrepareWithOptions(
 	// If there are builtin functions provided externally (e.g: for tests),
 	// then convert them to corresponding functions in compiler and in vm.
 	if interpreterConfig != nil && interpreterConfig.BaseActivationHandler != nil {
-		activation := interpreterConfig.BaseActivationHandler(nil)
-		providedBuiltinFunctions := activation.FunctionValues()
+		baseActivation := interpreterConfig.BaseActivationHandler(nil)
+		baseActivationVariables := baseActivation.ValuesInFunction()
 
 		vmConfig.NativeFunctionsProvider = func() map[string]*vm.Variable {
 			funcs := vm.NativeFunctions()

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -178,7 +178,7 @@ func ParseCheckAndPrepareWithOptions(
 		baseActivation := interpreterConfig.BaseActivationHandler(nil)
 		baseActivationVariables := baseActivation.ValuesInFunction()
 
-		vmConfig.NativeFunctionsProvider = func() map[string]*vm.Variable {
+		vmConfig.BuiltinGlobalsProvider = func() map[string]*vm.Variable {
 			funcs := vm.NativeFunctions()
 
 			// Convert the externally provided `interpreter.HostFunctionValue`s into `vm.NativeFunctionValue`s.

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -179,22 +179,20 @@ func ParseCheckAndPrepareWithOptions(
 		baseActivationVariables := baseActivation.ValuesInFunction()
 
 		vmConfig.BuiltinGlobalsProvider = func() map[string]*vm.Variable {
-			funcs := vm.NativeFunctions()
+			builtinGlobals := vm.NativeFunctions()
 
+			// Add the given built-in values.
 			// Convert the externally provided `interpreter.HostFunctionValue`s into `vm.NativeFunctionValue`s.
-			for name, functionVariable := range providedBuiltinFunctions { //nolint:maprange
+			for name, variable := range baseActivationVariables { //nolint:maprange
 
-				value := functionVariable.GetValue(nil)
-				functionValue, ok := value.(*interpreter.HostFunctionValue)
-				if !ok {
+				if builtinGlobals[name] != nil {
 					continue
 				}
 
-				variable := &interpreter.SimpleVariable{}
-				funcs[name] = variable
+				value := variable.GetValue(nil)
 
-				variable.InitializeWithValue(
-					vm.NewNativeFunctionValue(
+				if functionValue, ok := value.(*interpreter.HostFunctionValue); ok {
+					value = vm.NewNativeFunctionValue(
 						name,
 						functionValue.Type,
 						func(context *vm.Context, _ []interpreter.StaticType, arguments ...vm.Value) vm.Value {
@@ -210,18 +208,24 @@ func ParseCheckAndPrepareWithOptions(
 							)
 							return functionValue.Function(invocation)
 						},
-					),
-				)
+					)
+
+				}
+
+				vmVariable := &vm.Variable{}
+				vmVariable.InitializeWithValue(value)
+
+				builtinGlobals[name] = vmVariable
 			}
 
-			return funcs
+			return builtinGlobals
 		}
 
-		// Register externally provided functions as globals in compiler.
+		// Register externally provided globals in compiler.
 		compilerConfig = &compiler.Config{
 			BuiltinGlobalsProvider: func() map[string]*compiler.Global {
 				globals := compiler.NativeFunctions()
-				for name := range providedBuiltinFunctions { //nolint:maprange
+				for name := range baseActivationVariables { //nolint:maprange
 					if globals[name] != nil {
 						continue
 					}


### PR DESCRIPTION
Work towards #3922

## Description

- Improve method naming of `Activations.FunctionValues`: Method all variables/values of the current function, not all function value variables of the activation stack
- Improve naming of "native function provider": Provider is used for all globals, i.e. global functions and non-function global values
- Fix global handling in test utils: Allow providing global non-functions, and only wrap function values. Also don't override existing globals, i.e. avoid re-wrapping functions which are already VM functions (e.g. the `Type` construction function)
- Enable most metatype tests to run with the compiler/VM. The remaining tests need support for imports, which will be addressed in a follow-up PR
- The test utils don't allow overriding built-ins. Refactor the interface tests to use a differently named function. While at it, clean up the repeated code and unnecessary access modifiers, and enable the remaining tests to be run with the compiler/VM

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
