### PR TITLE
Refactor type constructors

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -3506,86 +3506,67 @@ func init() {
 			panic(fmt.Sprintf("missing fromBigEndianBytes implementation for number type: %s", numberType))
 		}
 	}
+}
 
-	// We assign this here because it depends on the interpreter, so this breaks the initialization cycle
-
-	// All of the following methods are static functions.
-	defineBaseValue(
-		BaseActivation,
-		sema.DictionaryTypeFunctionName,
-		NewUnmeteredStaticHostFunctionValue(
-			sema.DictionaryTypeFunctionType,
-			dictionaryTypeFunction,
-		))
-
-	defineBaseValue(
-		BaseActivation,
-		sema.CompositeTypeFunctionName,
-		NewUnmeteredStaticHostFunctionValue(
-			sema.CompositeTypeFunctionType,
-			compositeTypeFunction,
-		),
-	)
-
-	defineBaseValue(
-		BaseActivation,
-		sema.ReferenceTypeFunctionName,
-		NewUnmeteredStaticHostFunctionValue(
-			sema.ReferenceTypeFunctionType,
-			referenceTypeFunction,
-		),
-	)
-
-	defineBaseValue(
-		BaseActivation,
-		sema.FunctionTypeFunctionName,
-		NewUnmeteredStaticHostFunctionValue(
-			sema.FunctionTypeFunctionType,
-			functionTypeFunction,
-		),
-	)
-
-	defineBaseValue(
-		BaseActivation,
-		sema.IntersectionTypeFunctionName,
-		NewUnmeteredStaticHostFunctionValue(
-			sema.IntersectionTypeFunctionType,
-			intersectionTypeFunction,
+func ConstructOptionalTypeValue(context InvocationContext, typeValue TypeValue) Value {
+	return NewTypeValue(
+		context,
+		NewOptionalStaticType(
+			context,
+			typeValue.Type,
 		),
 	)
 }
 
-func dictionaryTypeFunction(invocation Invocation) Value {
-	inter := invocation.InvocationContext
+func ConstructVariableSizedArrayTypeValue(context InvocationContext, typeValue TypeValue) TypeValue {
+	return NewTypeValue(
+		context,
+		NewVariableSizedStaticType(
+			context,
+			typeValue.Type,
+		),
+	)
+}
 
-	keyTypeValue, ok := invocation.Arguments[0].(TypeValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
+func ConstructConstantSizedArrayTypeValue(
+	context InvocationContext,
+	locationRange LocationRange,
+	typeValue TypeValue,
+	sizeValue IntValue,
+) TypeValue {
+	return NewTypeValue(
+		context,
+		NewConstantSizedStaticType(
+			context,
+			typeValue.Type,
+			int64(sizeValue.ToInt(locationRange)),
+		),
+	)
+}
 
-	valueTypeValue, ok := invocation.Arguments[1].(TypeValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-
+func ConstructDictionaryTypeValue(
+	context InvocationContext,
+	keyTypeValue TypeValue,
+	valueTypeValue TypeValue,
+) Value {
 	keyType := keyTypeValue.Type
 	valueType := valueTypeValue.Type
 
 	// if the given key is not a valid dictionary key, it wouldn't make sense to create this type
 	if keyType == nil ||
 		!sema.IsSubType(
-			MustConvertStaticToSemaType(keyType, inter),
+			MustConvertStaticToSemaType(keyType, context),
 			sema.HashableStructType,
 		) {
 		return Nil
 	}
 
 	return NewSomeValueNonCopying(
-		inter,
+		context,
 		NewTypeValue(
-			inter,
+			context,
 			NewDictionaryStaticType(
-				inter,
+				context,
 				keyType,
 				valueType,
 			),
@@ -3593,32 +3574,71 @@ func dictionaryTypeFunction(invocation Invocation) Value {
 	)
 }
 
-func referenceTypeFunction(invocation Invocation) Value {
-	entitlementValues, ok := invocation.Arguments[0].(*ArrayValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
+func ConstructCompositeTypeValue(
+	context InvocationContext,
+	typeIDValue *StringValue,
+) Value {
+	typeID := typeIDValue.Str
+
+	composite, err := lookupComposite(context, typeID)
+	if err != nil {
+		return Nil
 	}
 
-	typeValue, ok := invocation.Arguments[1].(TypeValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-
-	invocationContext := invocation.InvocationContext
-	locationRange := invocation.LocationRange
-
-	return ConstructReferenceStaticType(
-		invocationContext,
-		entitlementValues,
-		locationRange,
-		typeValue,
+	return NewSomeValueNonCopying(
+		context,
+		NewTypeValue(
+			context,
+			ConvertSemaToStaticType(context, composite),
+		),
 	)
 }
 
-func ConstructReferenceStaticType(
+func ConstructFunctionTypeValue(
 	invocationContext InvocationContext,
-	entitlementValues *ArrayValue,
 	locationRange LocationRange,
+	parameterTypeValues *ArrayValue,
+	returnTypeValue TypeValue,
+) Value {
+	returnType := MustConvertStaticToSemaType(returnTypeValue.Type, invocationContext)
+
+	var parameterTypes []sema.Parameter
+	parameterCount := parameterTypeValues.Count()
+	if parameterCount > 0 {
+		parameterTypes = make([]sema.Parameter, 0, parameterCount)
+		parameterTypeValues.Iterate(
+			invocationContext,
+			func(param Value) bool {
+				semaType := MustConvertStaticToSemaType(param.(TypeValue).Type, invocationContext)
+				parameterTypes = append(
+					parameterTypes,
+					sema.Parameter{
+						TypeAnnotation: sema.NewTypeAnnotation(semaType),
+					},
+				)
+
+				// Continue iteration
+				return true
+			},
+			false,
+			locationRange,
+		)
+	}
+	functionStaticType := NewFunctionStaticType(
+		invocationContext,
+		sema.NewSimpleFunctionType(
+			sema.FunctionPurityImpure,
+			parameterTypes,
+			sema.NewTypeAnnotation(returnType),
+		),
+	)
+	return NewUnmeteredTypeValue(functionStaticType)
+}
+
+func ConstructReferenceTypeValue(
+	invocationContext InvocationContext,
+	locationRange LocationRange,
+	entitlementValues *ArrayValue,
 	typeValue TypeValue,
 ) Value {
 	authorization := UnauthorizedAccess
@@ -3675,81 +3695,11 @@ func ConstructReferenceStaticType(
 	)
 }
 
-func compositeTypeFunction(invocation Invocation) Value {
-	typeIDValue, ok := invocation.Arguments[0].(*StringValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-	typeID := typeIDValue.Str
-
-	composite, err := lookupComposite(invocation.InvocationContext, typeID)
-	if err != nil {
-		return Nil
-	}
-
-	return NewSomeValueNonCopying(
-		invocation.InvocationContext,
-		NewTypeValue(
-			invocation.InvocationContext,
-			ConvertSemaToStaticType(invocation.InvocationContext, composite),
-		),
-	)
-}
-
-func functionTypeFunction(invocation Invocation) Value {
-	interpreter := invocation.InvocationContext
-
-	parameters, ok := invocation.Arguments[0].(*ArrayValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-
-	typeValue, ok := invocation.Arguments[1].(TypeValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-
-	returnType := MustConvertStaticToSemaType(typeValue.Type, interpreter)
-
-	var parameterTypes []sema.Parameter
-	parameterCount := parameters.Count()
-	if parameterCount > 0 {
-		parameterTypes = make([]sema.Parameter, 0, parameterCount)
-		parameters.Iterate(
-			interpreter,
-			func(param Value) bool {
-				semaType := MustConvertStaticToSemaType(param.(TypeValue).Type, interpreter)
-				parameterTypes = append(
-					parameterTypes,
-					sema.Parameter{
-						TypeAnnotation: sema.NewTypeAnnotation(semaType),
-					},
-				)
-
-				// Continue iteration
-				return true
-			},
-			false,
-			invocation.LocationRange,
-		)
-	}
-	functionStaticType := NewFunctionStaticType(
-		interpreter,
-		sema.NewSimpleFunctionType(
-			sema.FunctionPurityImpure,
-			parameterTypes,
-			sema.NewTypeAnnotation(returnType),
-		),
-	)
-	return NewUnmeteredTypeValue(functionStaticType)
-}
-
-func intersectionTypeFunction(invocation Invocation) Value {
-	intersectionIDs, ok := invocation.Arguments[0].(*ArrayValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-
+func ConstructIntersectionTypeValue(
+	context InvocationContext,
+	locationRange LocationRange,
+	intersectionIDs *ArrayValue,
+) Value {
 	var staticIntersections []*InterfaceStaticType
 	var semaIntersections []*sema.InterfaceType
 
@@ -3760,14 +3710,14 @@ func intersectionTypeFunction(invocation Invocation) Value {
 
 		var invalidIntersectionID bool
 		intersectionIDs.Iterate(
-			invocation.InvocationContext,
+			context,
 			func(typeID Value) bool {
 				typeIDValue, ok := typeID.(*StringValue)
 				if !ok {
 					panic(errors.NewUnreachableError())
 				}
 
-				intersectedInterface, err := lookupInterface(invocation.InvocationContext, typeIDValue.Str)
+				intersectedInterface, err := lookupInterface(context, typeIDValue.Str)
 				if err != nil {
 					invalidIntersectionID = true
 					return true
@@ -3775,7 +3725,7 @@ func intersectionTypeFunction(invocation Invocation) Value {
 
 				staticIntersections = append(
 					staticIntersections,
-					ConvertSemaToStaticType(invocation.InvocationContext, intersectedInterface).(*InterfaceStaticType),
+					ConvertSemaToStaticType(context, intersectedInterface).(*InterfaceStaticType),
 				)
 				semaIntersections = append(semaIntersections, intersectedInterface)
 
@@ -3783,7 +3733,7 @@ func intersectionTypeFunction(invocation Invocation) Value {
 				return true
 			},
 			false,
-			invocation.LocationRange,
+			locationRange,
 		)
 
 		// If there are any invalid interfaces,
@@ -3795,7 +3745,7 @@ func intersectionTypeFunction(invocation Invocation) Value {
 
 	var invalidIntersectionType bool
 	sema.CheckIntersectionType(
-		invocation.InvocationContext,
+		context,
 		semaIntersections,
 		func(_ func(*ast.IntersectionType) error) {
 			invalidIntersectionType = true
@@ -3809,12 +3759,62 @@ func intersectionTypeFunction(invocation Invocation) Value {
 	}
 
 	return NewSomeValueNonCopying(
-		invocation.InvocationContext,
+		context,
 		NewTypeValue(
-			invocation.InvocationContext,
+			context,
 			NewIntersectionStaticType(
-				invocation.InvocationContext,
+				context,
 				staticIntersections,
+			),
+		),
+	)
+}
+
+func ConstructCapabilityTypeValue(
+	context InvocationContext,
+	typeValue TypeValue,
+) Value {
+
+	ty := typeValue.Type
+
+	// Capabilities must hold references
+	_, ok := ty.(*ReferenceStaticType)
+	if !ok {
+		return Nil
+	}
+
+	return NewSomeValueNonCopying(
+		context,
+		NewTypeValue(
+			context,
+			NewCapabilityStaticType(
+				context,
+				ty,
+			),
+		),
+	)
+}
+
+func ConstructInclusiveRangeTypeValue(
+	context InvocationContext,
+	typeValue TypeValue,
+) Value {
+
+	ty := typeValue.Type
+
+	// InclusiveRanges must hold integers
+	elemSemaTy := MustConvertStaticToSemaType(ty, context)
+	if !sema.IsSameTypeKind(elemSemaTy, sema.IntegerType) {
+		return Nil
+	}
+
+	return NewSomeValueNonCopying(
+		context,
+		NewTypeValue(
+			context,
+			NewInclusiveRangeStaticType(
+				context,
+				ty,
 			),
 		),
 	)
@@ -3822,7 +3822,6 @@ func intersectionTypeFunction(invocation Invocation) Value {
 
 func defineBaseFunctions(activation *VariableActivation) {
 	defineConverterFunctions(activation)
-	defineTypeFunction(activation)
 	defineRuntimeTypeConstructorFunctions(activation)
 	defineStringFunction(activation)
 }
@@ -3894,59 +3893,72 @@ func defineConverterFunctions(activation *VariableActivation) {
 }
 
 type runtimeTypeConstructor struct {
-	converter *HostFunctionValue
-	name      string
+	name        string
+	constructor *HostFunctionValue
 }
 
 // Constructor functions are stateless functions. Hence they can be re-used across interpreters.
 // They are also static functions.
 var runtimeTypeConstructors = []runtimeTypeConstructor{
 	{
+		name: sema.MetaTypeName,
+		constructor: NewUnmeteredStaticHostFunctionValue(
+			sema.MetaTypeFunctionType,
+			func(invocation Invocation) Value {
+				context := invocation.InvocationContext
+
+				typeParameterPair := invocation.TypeParameterTypes.Oldest()
+				if typeParameterPair == nil {
+					panic(errors.NewUnreachableError())
+				}
+
+				ty := typeParameterPair.Value
+
+				staticType := ConvertSemaToStaticType(context, ty)
+				return NewTypeValue(context, staticType)
+			},
+		),
+	},
+	{
 		name: sema.OptionalTypeFunctionName,
-		converter: NewUnmeteredStaticHostFunctionValue(
+		constructor: NewUnmeteredStaticHostFunctionValue(
 			sema.OptionalTypeFunctionType,
 			func(invocation Invocation) Value {
+				context := invocation.InvocationContext
+
 				typeValue, ok := invocation.Arguments[0].(TypeValue)
 				if !ok {
 					panic(errors.NewUnreachableError())
 				}
 
-				return NewTypeValue(
-					invocation.InvocationContext,
-					NewOptionalStaticType(
-						invocation.InvocationContext,
-						typeValue.Type,
-					),
-				)
+				return ConstructOptionalTypeValue(context, typeValue)
 			},
 		),
 	},
 	{
 		name: sema.VariableSizedArrayTypeFunctionName,
-		converter: NewUnmeteredStaticHostFunctionValue(
+		constructor: NewUnmeteredStaticHostFunctionValue(
 			sema.VariableSizedArrayTypeFunctionType,
 			func(invocation Invocation) Value {
+				context := invocation.InvocationContext
+
 				typeValue, ok := invocation.Arguments[0].(TypeValue)
 				if !ok {
 					panic(errors.NewUnreachableError())
 				}
 
-				return NewTypeValue(
-					invocation.InvocationContext,
-					//nolint:gosimple
-					NewVariableSizedStaticType(
-						invocation.InvocationContext,
-						typeValue.Type,
-					),
-				)
+				return ConstructVariableSizedArrayTypeValue(context, typeValue)
 			},
 		),
 	},
 	{
 		name: sema.ConstantSizedArrayTypeFunctionName,
-		converter: NewUnmeteredStaticHostFunctionValue(
+		constructor: NewUnmeteredStaticHostFunctionValue(
 			sema.ConstantSizedArrayTypeFunctionType,
 			func(invocation Invocation) Value {
+				context := invocation.InvocationContext
+				locationRange := invocation.LocationRange
+
 				typeValue, ok := invocation.Arguments[0].(TypeValue)
 				if !ok {
 					panic(errors.NewUnreachableError())
@@ -3957,76 +3969,161 @@ var runtimeTypeConstructors = []runtimeTypeConstructor{
 					panic(errors.NewUnreachableError())
 				}
 
-				return NewTypeValue(
-					invocation.InvocationContext,
-					NewConstantSizedStaticType(
-						invocation.InvocationContext,
-						typeValue.Type,
-						int64(sizeValue.ToInt(invocation.LocationRange)),
-					),
+				return ConstructConstantSizedArrayTypeValue(
+					context,
+					locationRange,
+					typeValue,
+					sizeValue,
+				)
+			},
+		),
+	},
+	{
+		name: sema.DictionaryTypeFunctionName,
+		constructor: NewUnmeteredStaticHostFunctionValue(
+			sema.DictionaryTypeFunctionType,
+			func(invocation Invocation) Value {
+				context := invocation.InvocationContext
+
+				keyTypeValue, ok := invocation.Arguments[0].(TypeValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				valueTypeValue, ok := invocation.Arguments[1].(TypeValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				return ConstructDictionaryTypeValue(
+					context,
+					keyTypeValue,
+					valueTypeValue,
+				)
+			},
+		),
+	},
+	{
+		name: sema.CompositeTypeFunctionName,
+		constructor: NewUnmeteredStaticHostFunctionValue(
+			sema.CompositeTypeFunctionType,
+			func(invocation Invocation) Value {
+				context := invocation.InvocationContext
+
+				typeIDValue, ok := invocation.Arguments[0].(*StringValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				return ConstructCompositeTypeValue(context, typeIDValue)
+			},
+		),
+	},
+	{
+		name: sema.FunctionTypeFunctionName,
+		constructor: NewUnmeteredStaticHostFunctionValue(
+			sema.FunctionTypeFunctionType,
+			func(invocation Invocation) Value {
+				interpreter := invocation.InvocationContext
+				locationRange := invocation.LocationRange
+
+				parameterTypeValues, ok := invocation.Arguments[0].(*ArrayValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				returnTypeValue, ok := invocation.Arguments[1].(TypeValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				return ConstructFunctionTypeValue(
+					interpreter,
+					locationRange,
+					parameterTypeValues,
+					returnTypeValue,
+				)
+			},
+		),
+	},
+
+	{
+		name: sema.ReferenceTypeFunctionName,
+		constructor: NewUnmeteredStaticHostFunctionValue(
+			sema.ReferenceTypeFunctionType,
+			func(invocation Invocation) Value {
+				invocationContext := invocation.InvocationContext
+				locationRange := invocation.LocationRange
+
+				entitlementValues, ok := invocation.Arguments[0].(*ArrayValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				typeValue, ok := invocation.Arguments[1].(TypeValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				return ConstructReferenceTypeValue(
+					invocationContext,
+					locationRange,
+					entitlementValues,
+					typeValue,
+				)
+			},
+		),
+	},
+	{
+		name: sema.IntersectionTypeFunctionName,
+		constructor: NewUnmeteredStaticHostFunctionValue(
+			sema.IntersectionTypeFunctionType,
+			func(invocation Invocation) Value {
+				context := invocation.InvocationContext
+				locationRange := invocation.LocationRange
+
+				intersectionIDs, ok := invocation.Arguments[0].(*ArrayValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				return ConstructIntersectionTypeValue(
+					context,
+					locationRange,
+					intersectionIDs,
 				)
 			},
 		),
 	},
 	{
 		name: sema.CapabilityTypeFunctionName,
-		converter: NewUnmeteredStaticHostFunctionValue(
+		constructor: NewUnmeteredStaticHostFunctionValue(
 			sema.CapabilityTypeFunctionType,
 			func(invocation Invocation) Value {
+				context := invocation.InvocationContext
+
 				typeValue, ok := invocation.Arguments[0].(TypeValue)
 				if !ok {
 					panic(errors.NewUnreachableError())
 				}
 
-				ty := typeValue.Type
-				// Capabilities must hold references
-				_, ok = ty.(*ReferenceStaticType)
-				if !ok {
-					return Nil
-				}
-
-				return NewSomeValueNonCopying(
-					invocation.InvocationContext,
-					NewTypeValue(
-						invocation.InvocationContext,
-						NewCapabilityStaticType(
-							invocation.InvocationContext,
-							ty,
-						),
-					),
-				)
+				return ConstructCapabilityTypeValue(context, typeValue)
 			},
 		),
 	},
 	{
 		name: sema.InclusiveRangeTypeFunctionName,
-		converter: NewUnmeteredStaticHostFunctionValue(
+		constructor: NewUnmeteredStaticHostFunctionValue(
 			sema.InclusiveRangeTypeFunctionType,
 			func(invocation Invocation) Value {
+				context := invocation.InvocationContext
+
 				typeValue, ok := invocation.Arguments[0].(TypeValue)
 				if !ok {
 					panic(errors.NewUnreachableError())
 				}
 
-				inter := invocation.InvocationContext
-
-				ty := typeValue.Type
-				// InclusiveRanges must hold integers
-				elemSemaTy := MustConvertStaticToSemaType(ty, inter)
-				if !sema.IsSameTypeKind(elemSemaTy, sema.IntegerType) {
-					return Nil
-				}
-
-				return NewSomeValueNonCopying(
-					inter,
-					NewTypeValue(
-						inter,
-						NewInclusiveRangeStaticType(
-							inter,
-							ty,
-						),
-					),
-				)
+				return ConstructInclusiveRangeTypeValue(context, typeValue)
 			},
 		),
 	},
@@ -4034,29 +4131,8 @@ var runtimeTypeConstructors = []runtimeTypeConstructor{
 
 func defineRuntimeTypeConstructorFunctions(activation *VariableActivation) {
 	for _, constructorFunc := range runtimeTypeConstructors {
-		defineBaseValue(activation, constructorFunc.name, constructorFunc.converter)
+		defineBaseValue(activation, constructorFunc.name, constructorFunc.constructor)
 	}
-}
-
-// typeFunction is the `Type` function. It is stateless, hence it can be re-used across interpreters.
-// It's also a static function.
-var typeFunction = NewUnmeteredStaticHostFunctionValue(
-	sema.MetaTypeFunctionType,
-	func(invocation Invocation) Value {
-		typeParameterPair := invocation.TypeParameterTypes.Oldest()
-		if typeParameterPair == nil {
-			panic(errors.NewUnreachableError())
-		}
-
-		ty := typeParameterPair.Value
-
-		staticType := ConvertSemaToStaticType(invocation.InvocationContext, ty)
-		return NewTypeValue(invocation.InvocationContext, staticType)
-	},
-)
-
-func defineTypeFunction(activation *VariableActivation) {
-	defineBaseValue(activation, sema.MetaTypeName, typeFunction)
 }
 
 func defineBaseValue(activation *VariableActivation, name string, value Value) {


### PR DESCRIPTION
Work towards #3922 

## Description

Unify code for registering the built-in type constructors, so that all constructor functions are defined in the same place (`runtimeTypeConstructors`), and for each constructor function there is a `Construct...TypeValue` Go function which can be called from the VM.

Best viewed side-by-side, as code moved around and the unified diff is messed up:
https://github.com/onflow/cadence/pull/3942/files?diff=split

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
