### PR TITLE
[Compiler] Register type constructor functions in VM, run runtime-type tests with compiler/VM

### DIFF
--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -97,20 +97,15 @@ func (c *Config) GetInterfaceType(
 		}
 	}
 
-	compositeKindedType := c.TypeLoader(location, typeID)
-	if compositeKindedType != nil {
-
-		inter, ok := compositeKindedType.(*sema.InterfaceType)
-		if !ok {
-			panic(errors.NewUnreachableError())
+	ty := c.TypeLoader(location, typeID)
+	interfaceType, ok := ty.(*sema.InterfaceType)
+	if !ok {
+		return nil, interpreter.TypeLoadingError{
+			TypeID: typeID,
 		}
-
-		return inter, nil
 	}
 
-	return nil, interpreter.TypeLoadingError{
-		TypeID: typeID,
-	}
+	return interfaceType, nil
 }
 
 func (c *Config) GetCompositeType(
@@ -126,20 +121,15 @@ func (c *Config) GetCompositeType(
 		}
 	}
 
-	compositeKindedType := c.TypeLoader(location, typeID)
-	if compositeKindedType != nil {
-
-		compositeType, ok := compositeKindedType.(*sema.CompositeType)
-		if !ok {
-			panic(errors.NewUnreachableError())
+	ty := c.TypeLoader(location, typeID)
+	compositeType, ok := ty.(*sema.CompositeType)
+	if !ok {
+		return nil, interpreter.TypeLoadingError{
+			TypeID: typeID,
 		}
-
-		return compositeType, nil
 	}
 
-	return nil, interpreter.TypeLoadingError{
-		TypeID: typeID,
-	}
+	return compositeType, nil
 }
 
 func (c *Config) GetEntitlementType(typeID interpreter.TypeID) (*sema.EntitlementType, error) {
@@ -159,20 +149,15 @@ func (c *Config) GetEntitlementType(typeID interpreter.TypeID) (*sema.Entitlemen
 		return ty, nil
 	}
 
-	typ := c.TypeLoader(location, typeID)
-	if typ != nil {
-
-		entitlementType, ok := typ.(*sema.EntitlementType)
-		if !ok {
-			panic(errors.NewUnreachableError())
+	ty := c.TypeLoader(location, typeID)
+	entitlementType, ok := ty.(*sema.EntitlementType)
+	if !ok {
+		return nil, interpreter.TypeLoadingError{
+			TypeID: typeID,
 		}
-
-		return entitlementType, nil
 	}
 
-	return nil, interpreter.TypeLoadingError{
-		TypeID: typeID,
-	}
+	return entitlementType, nil
 }
 
 func (c *Config) GetEntitlementMapType(typeID interpreter.TypeID) (*sema.EntitlementMapType, error) {
@@ -192,20 +177,15 @@ func (c *Config) GetEntitlementMapType(typeID interpreter.TypeID) (*sema.Entitle
 		return ty, nil
 	}
 
-	typ := c.TypeLoader(location, typeID)
-	if typ != nil {
-
-		entitlementMapType, ok := typ.(*sema.EntitlementMapType)
-		if !ok {
-			panic(errors.NewUnreachableError())
+	ty := c.TypeLoader(location, typeID)
+	entitlementMapType, ok := ty.(*sema.EntitlementMapType)
+	if !ok {
+		return nil, interpreter.TypeLoadingError{
+			TypeID: typeID,
 		}
-
-		return entitlementMapType, nil
 	}
 
-	return nil, interpreter.TypeLoadingError{
-		TypeID: typeID,
-	}
+	return entitlementMapType, nil
 }
 
 func (c *Config) MeterComputation(usage common.ComputationUsage) error {

--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -154,7 +154,6 @@ func init() {
 	)
 
 	// Type constructors
-	// TODO: add the remaining type constructor functions
 
 	RegisterFunction(
 		NewNativeFunctionValue(
@@ -171,17 +170,160 @@ func init() {
 
 	RegisterFunction(
 		NewNativeFunctionValue(
+			sema.OptionalTypeFunctionName,
+			sema.OptionalTypeFunctionType,
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+
+				typeValue := arguments[0].(interpreter.TypeValue)
+
+				return interpreter.ConstructOptionalTypeValue(context, typeValue)
+			},
+		),
+	)
+
+	RegisterFunction(
+		NewNativeFunctionValue(
+			sema.VariableSizedArrayTypeFunctionName,
+			sema.VariableSizedArrayTypeFunctionType,
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+
+				typeValue := arguments[0].(interpreter.TypeValue)
+
+				return interpreter.ConstructVariableSizedArrayTypeValue(
+					context,
+					typeValue,
+				)
+			},
+		),
+	)
+
+	RegisterFunction(
+		NewNativeFunctionValue(
+			sema.ConstantSizedArrayTypeFunctionName,
+			sema.ConstantSizedArrayTypeFunctionType,
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+
+				typeValue := arguments[0].(interpreter.TypeValue)
+				sizeValue := arguments[1].(interpreter.IntValue)
+
+				return interpreter.ConstructConstantSizedArrayTypeValue(
+					context,
+					EmptyLocationRange,
+					typeValue,
+					sizeValue,
+				)
+			},
+		),
+	)
+
+	RegisterFunction(
+		NewNativeFunctionValue(
+			sema.DictionaryTypeFunctionName,
+			sema.DictionaryTypeFunctionType,
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+
+				keyTypeValue := arguments[0].(interpreter.TypeValue)
+				valueTypeValue := arguments[1].(interpreter.TypeValue)
+
+				return interpreter.ConstructDictionaryTypeValue(
+					context,
+					keyTypeValue,
+					valueTypeValue,
+				)
+			},
+		),
+	)
+
+	RegisterFunction(
+		NewNativeFunctionValue(
+			sema.CompositeTypeFunctionName,
+			sema.CompositeTypeFunctionType,
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+
+				typeIDValue := arguments[0].(*interpreter.StringValue)
+
+				return interpreter.ConstructCompositeTypeValue(context, typeIDValue)
+			},
+		),
+	)
+
+	RegisterFunction(
+		NewNativeFunctionValue(
+			sema.FunctionTypeFunctionName,
+			sema.FunctionTypeFunctionType,
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+
+				parameterTypeValues := arguments[0].(*interpreter.ArrayValue)
+				returnTypeValue := arguments[1].(interpreter.TypeValue)
+
+				return interpreter.ConstructFunctionTypeValue(
+					context,
+					EmptyLocationRange,
+					parameterTypeValues,
+					returnTypeValue,
+				)
+			},
+		),
+	)
+
+	RegisterFunction(
+		NewNativeFunctionValue(
 			sema.ReferenceTypeFunctionName,
 			sema.ReferenceTypeFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+
 				entitlementValues := arguments[0].(*interpreter.ArrayValue)
 				typeValue := arguments[1].(interpreter.TypeValue)
+
 				return interpreter.ConstructReferenceTypeValue(
 					context,
 					EmptyLocationRange,
 					entitlementValues,
 					typeValue,
 				)
+			},
+		),
+	)
+
+	RegisterFunction(
+		NewNativeFunctionValue(
+			sema.IntersectionTypeFunctionName,
+			sema.IntersectionTypeFunctionType,
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+
+				intersectionIDs := arguments[0].(*interpreter.ArrayValue)
+
+				return interpreter.ConstructIntersectionTypeValue(
+					context,
+					EmptyLocationRange,
+					intersectionIDs,
+				)
+			},
+		),
+	)
+
+	RegisterFunction(
+		NewNativeFunctionValue(
+			sema.CapabilityTypeFunctionName,
+			sema.CapabilityTypeFunctionType,
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+
+				typeValue := arguments[0].(interpreter.TypeValue)
+
+				return interpreter.ConstructCapabilityTypeValue(context, typeValue)
+			},
+		),
+	)
+
+	RegisterFunction(
+		NewNativeFunctionValue(
+			sema.InclusiveRangeTypeFunctionName,
+			sema.InclusiveRangeTypeFunctionType,
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+
+				typeValue := arguments[0].(interpreter.TypeValue)
+
+				return interpreter.ConstructInclusiveRangeTypeValue(context, typeValue)
 			},
 		),
 	)

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -555,13 +555,14 @@ func contractValueHandler(contractName string, arguments ...vm.Value) vm.Contrac
 	}
 }
 
-func typeLoader(
-	tb testing.TB,
+func CompiledProgramsTypeLoader(
 	programs CompiledPrograms,
 ) func(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
 	return func(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
 		program, ok := programs[location]
-		require.True(tb, ok, "cannot find elaboration for %s", location)
+		if !ok {
+			return nil
+		}
 
 		elaboration := program.DesugaredElaboration
 
@@ -659,7 +660,7 @@ func PrepareVMConfig(
 	}
 
 	if config.TypeLoader == nil {
-		config.TypeLoader = typeLoader(tb, programs)
+		config.TypeLoader = CompiledProgramsTypeLoader(programs)
 	}
 
 	if config.ImportHandler == nil {

--- a/interpreter/runtimetype_test.go
+++ b/interpreter/runtimetype_test.go
@@ -33,7 +33,7 @@ func TestInterpretOptionalType(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
       let a = OptionalType(Type<String>())
       let b = OptionalType(Type<Int>()) 
 
@@ -50,7 +50,7 @@ func TestInterpretOptionalType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeString,
 			},
 		},
-		inter.Globals.Get("a").GetValue(inter),
+		inter.GetGlobal("a"),
 	)
 
 	assert.Equal(t,
@@ -59,7 +59,7 @@ func TestInterpretOptionalType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("b").GetValue(inter),
+		inter.GetGlobal("b"),
 	)
 
 	assert.Equal(t,
@@ -68,7 +68,7 @@ func TestInterpretOptionalType(t *testing.T) {
 				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, TestLocation, "R"),
 			},
 		},
-		inter.Globals.Get("c").GetValue(inter),
+		inter.GetGlobal("c"),
 	)
 
 	assert.Equal(t,
@@ -79,12 +79,12 @@ func TestInterpretOptionalType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("d").GetValue(inter),
+		inter.GetGlobal("d"),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(inter),
-		inter.Globals.Get("e").GetValue(inter),
+		inter.GetGlobal("a"),
+		inter.GetGlobal("e"),
 	)
 }
 
@@ -92,7 +92,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
       let a = VariableSizedArrayType(Type<String>())
       let b = VariableSizedArrayType(Type<Int>()) 
 
@@ -109,7 +109,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeString,
 			},
 		},
-		inter.Globals.Get("a").GetValue(inter),
+		inter.GetGlobal("a"),
 	)
 
 	assert.Equal(t,
@@ -118,7 +118,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				Type: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("b").GetValue(inter),
+		inter.GetGlobal("b"),
 	)
 
 	assert.Equal(t,
@@ -127,7 +127,7 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, TestLocation, "R"),
 			},
 		},
-		inter.Globals.Get("c").GetValue(inter),
+		inter.GetGlobal("c"),
 	)
 
 	assert.Equal(t,
@@ -138,11 +138,11 @@ func TestInterpretVariableSizedArrayType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("d").GetValue(inter),
+		inter.GetGlobal("d"),
 	)
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(inter),
-		inter.Globals.Get("e").GetValue(inter),
+		inter.GetGlobal("a"),
+		inter.GetGlobal("e"),
 	)
 }
 
@@ -150,7 +150,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
       let a = ConstantSizedArrayType(type: Type<String>(), size: 10)
       let b = ConstantSizedArrayType(type: Type<Int>(), size: 5) 
 
@@ -168,7 +168,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(10),
 			},
 		},
-		inter.Globals.Get("a").GetValue(inter),
+		inter.GetGlobal("a"),
 	)
 
 	assert.Equal(t,
@@ -178,7 +178,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(5),
 			},
 		},
-		inter.Globals.Get("b").GetValue(inter),
+		inter.GetGlobal("b"),
 	)
 
 	assert.Equal(t,
@@ -188,7 +188,7 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(400),
 			},
 		},
-		inter.Globals.Get("c").GetValue(inter),
+		inter.GetGlobal("c"),
 	)
 
 	assert.Equal(t,
@@ -201,12 +201,12 @@ func TestInterpretConstantSizedArrayType(t *testing.T) {
 				Size: int64(6),
 			},
 		},
-		inter.Globals.Get("d").GetValue(inter),
+		inter.GetGlobal("d"),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(inter),
-		inter.Globals.Get("e").GetValue(inter),
+		inter.GetGlobal("a"),
+		inter.GetGlobal("e"),
 	)
 }
 
@@ -214,7 +214,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
       let a = DictionaryType(key: Type<String>(), value: Type<Int>())!
       let b = DictionaryType(key: Type<Int>(), value: Type<String>())!
 
@@ -234,7 +234,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 				ValueType: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("a").GetValue(inter),
+		inter.GetGlobal("a"),
 	)
 
 	assert.Equal(t,
@@ -244,7 +244,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 				ValueType: interpreter.PrimitiveStaticTypeString,
 			},
 		},
-		inter.Globals.Get("b").GetValue(inter),
+		inter.GetGlobal("b"),
 	)
 
 	assert.Equal(t,
@@ -254,7 +254,7 @@ func TestInterpretDictionaryType(t *testing.T) {
 				KeyType:   interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("c").GetValue(inter),
+		inter.GetGlobal("c"),
 	)
 
 	assert.Equal(t,
@@ -267,17 +267,17 @@ func TestInterpretDictionaryType(t *testing.T) {
 				KeyType: interpreter.PrimitiveStaticTypeBool,
 			},
 		},
-		inter.Globals.Get("d").GetValue(inter),
+		inter.GetGlobal("d"),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(inter),
-		inter.Globals.Get("e").GetValue(inter),
+		inter.GetGlobal("a"),
+		inter.GetGlobal("e"),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("f").GetValue(inter),
+		inter.GetGlobal("f"),
 	)
 }
 
@@ -285,7 +285,7 @@ func TestInterpretCompositeType(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
       resource R {}
       struct S {}
       struct interface B {}
@@ -301,56 +301,63 @@ func TestInterpretCompositeType(t *testing.T) {
       let f = CompositeType("S.test.F")!
 	  let g = CompositeType("PublicKey")!
 	  let h = CompositeType("HashAlgorithm")!
+
+      let i = CompositeType("X")
     `)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, TestLocation, "R"),
 		},
-		inter.Globals.Get("a").GetValue(inter),
+		inter.GetGlobal("a"),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, TestLocation, "S"),
 		},
-		inter.Globals.Get("b").GetValue(inter),
+		inter.GetGlobal("b"),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("c").GetValue(inter),
+		inter.GetGlobal("c"),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("d").GetValue(inter),
+		inter.GetGlobal("d"),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(inter),
-		inter.Globals.Get("e").GetValue(inter),
+		inter.GetGlobal("a"),
+		inter.GetGlobal("e"),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, TestLocation, "F"),
 		},
-		inter.Globals.Get("f").GetValue(inter),
+		inter.GetGlobal("f"),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, nil, "PublicKey"),
 		},
-		inter.Globals.Get("g").GetValue(inter),
+		inter.GetGlobal("g"),
 	)
 
 	assert.Equal(t,
 		interpreter.TypeValue{
 			Type: interpreter.NewCompositeStaticTypeComputeTypeID(nil, nil, "HashAlgorithm"),
 		},
-		inter.Globals.Get("h").GetValue(inter),
+		inter.GetGlobal("h"),
+	)
+
+	assert.Equal(t,
+		interpreter.Nil,
+		inter.GetGlobal("i"),
 	)
 }
 
@@ -358,7 +365,7 @@ func TestInterpretFunctionType(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
       let a = FunctionType(parameters: [Type<String>()], return: Type<Int>())
       let b = FunctionType(parameters: [Type<String>(), Type<Int>()], return: Type<Bool>())
       let c = FunctionType(parameters: [], return: Type<String>())
@@ -379,7 +386,7 @@ func TestInterpretFunctionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("a").GetValue(inter),
+		inter.GetGlobal("a"),
 	)
 
 	assert.Equal(t,
@@ -394,7 +401,7 @@ func TestInterpretFunctionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("b").GetValue(inter),
+		inter.GetGlobal("b"),
 	)
 
 	assert.Equal(t,
@@ -405,12 +412,12 @@ func TestInterpretFunctionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("c").GetValue(inter),
+		inter.GetGlobal("c"),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(inter),
-		inter.Globals.Get("d").GetValue(inter),
+		inter.GetGlobal("a"),
+		inter.GetGlobal("d"),
 	)
 }
 
@@ -418,7 +425,7 @@ func TestInterpretReferenceType(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
       resource R {}
       struct S {}
 	  entitlement X
@@ -428,6 +435,7 @@ func TestInterpretReferenceType(t *testing.T) {
       let c = ReferenceType(entitlements: ["S.test.X"], type: Type<S>())!
       let d = Type<auth(X) &R>()
 	  let e = ReferenceType(entitlements: ["S.test.Y"], type: Type<S>())
+      let f = ReferenceType(entitlements: ["X"], type: Type<@R>())
     `)
 
 	assert.Equal(t,
@@ -442,7 +450,7 @@ func TestInterpretReferenceType(t *testing.T) {
 				),
 			},
 		},
-		inter.Globals.Get("a").GetValue(inter),
+		inter.GetGlobal("a"),
 	)
 
 	assert.Equal(t,
@@ -452,7 +460,7 @@ func TestInterpretReferenceType(t *testing.T) {
 				Authorization:  interpreter.UnauthorizedAccess,
 			},
 		},
-		inter.Globals.Get("b").GetValue(inter),
+		inter.GetGlobal("b"),
 	)
 
 	assert.Equal(t,
@@ -467,17 +475,22 @@ func TestInterpretReferenceType(t *testing.T) {
 				),
 			},
 		},
-		inter.Globals.Get("c").GetValue(inter),
+		inter.GetGlobal("c"),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(inter),
-		inter.Globals.Get("d").GetValue(inter),
+		inter.GetGlobal("a"),
+		inter.GetGlobal("d"),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("e").GetValue(inter),
+		inter.GetGlobal("e"),
+	)
+
+	assert.Equal(t,
+		interpreter.Nil,
+		inter.GetGlobal("f"),
 	)
 }
 
@@ -485,7 +498,7 @@ func TestInterpretIntersectionType(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
       resource interface R {}
       struct interface S {}
       resource A : R {}
@@ -517,12 +530,12 @@ func TestInterpretIntersectionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("a").GetValue(inter),
+		inter.GetGlobal("a"),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("c").GetValue(inter),
+		inter.GetGlobal("c"),
 	)
 
 	assert.Equal(t,
@@ -533,12 +546,12 @@ func TestInterpretIntersectionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("b").GetValue(inter),
+		inter.GetGlobal("b"),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("j").GetValue(inter),
+		inter.GetGlobal("j"),
 	)
 
 	assert.Equal(t,
@@ -550,22 +563,22 @@ func TestInterpretIntersectionType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("k").GetValue(inter),
+		inter.GetGlobal("k"),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("f").GetValue(inter),
+		inter.GetGlobal("f"),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(inter),
-		inter.Globals.Get("h").GetValue(inter),
+		inter.GetGlobal("a"),
+		inter.GetGlobal("h"),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("b").GetValue(inter),
-		inter.Globals.Get("i").GetValue(inter),
+		inter.GetGlobal("b"),
+		inter.GetGlobal("i"),
 	)
 }
 
@@ -573,7 +586,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
       let a = CapabilityType(Type<&String>())!
       let b = CapabilityType(Type<&Int>())!
 
@@ -593,7 +606,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("a").GetValue(inter),
+		inter.GetGlobal("a"),
 	)
 
 	assert.Equal(t,
@@ -605,7 +618,7 @@ func TestInterpretCapabilityType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("b").GetValue(inter),
+		inter.GetGlobal("b"),
 	)
 
 	assert.Equal(t,
@@ -617,17 +630,17 @@ func TestInterpretCapabilityType(t *testing.T) {
 				},
 			},
 		},
-		inter.Globals.Get("c").GetValue(inter),
+		inter.GetGlobal("c"),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("d").GetValue(inter),
+		inter.GetGlobal("d"),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(inter),
-		inter.Globals.Get("e").GetValue(inter),
+		inter.GetGlobal("a"),
+		inter.GetGlobal("e"),
 	)
 }
 
@@ -635,7 +648,7 @@ func TestInterpretInclusiveRangeType(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
 		let a = InclusiveRangeType(Type<Int>())!
 		let b = InclusiveRangeType(Type<&Int>())
 
@@ -652,26 +665,26 @@ func TestInterpretInclusiveRangeType(t *testing.T) {
 				ElementType: interpreter.PrimitiveStaticTypeInt,
 			},
 		},
-		inter.Globals.Get("a").GetValue(inter),
+		inter.GetGlobal("a"),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("b").GetValue(inter),
+		inter.GetGlobal("b"),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("c").GetValue(inter),
+		inter.GetGlobal("c"),
 	)
 
 	assert.Equal(t,
 		interpreter.Nil,
-		inter.Globals.Get("d").GetValue(inter),
+		inter.GetGlobal("d"),
 	)
 
 	assert.Equal(t,
-		inter.Globals.Get("a").GetValue(inter),
-		inter.Globals.Get("e").GetValue(inter),
+		inter.GetGlobal("a"),
+		inter.GetGlobal("e"),
 	)
 }

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -244,7 +244,9 @@ func ParseCheckAndPrepareWithOptions(
 		Config: options.CheckerConfig,
 	}
 
-	programs := map[common.Location]*CompiledProgram{}
+	programs := CompiledPrograms{}
+
+	vmConfig.TypeLoader = compilerUtils.CompiledProgramsTypeLoader(programs)
 
 	vmInstance := compilerUtils.CompileAndPrepareToInvoke(
 		tb,


### PR DESCRIPTION
Work towards #3922 


## Description

- Improve type lookup in the the VM config
- Register the type constructor functions in the VM. They had already previously been registered in the compiler
- Enable all tests in `interpreter/runtimetype_tests.go` to be run with the compiler/VM

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
