### PR TITLE
[Compiler] Improve invocation of external functions and transactions

### DIFF
--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -282,7 +282,7 @@ func compiledFTTransfer(tb testing.TB) {
 		setupTxVM := vm.NewVM(txLocation, program, vmConfig)
 
 		authorizer := vm.NewAuthAccountReferenceValue(setupTxVM.Context(), accountHandler, address)
-		err := setupTxVM.ExecuteTransaction(nil, authorizer)
+		err := setupTxVM.InvokeTransaction(nil, authorizer)
 		require.NoError(tb, err)
 		require.Equal(tb, 0, setupTxVM.StackSize())
 	}
@@ -315,7 +315,7 @@ func compiledFTTransfer(tb testing.TB) {
 	}
 
 	mintTxAuthorizer := vm.NewAuthAccountReferenceValue(mintTxVM.Context(), accountHandler, contractsAddress)
-	err := mintTxVM.ExecuteTransaction(mintTxArgs, mintTxAuthorizer)
+	err := mintTxVM.InvokeTransaction(mintTxArgs, mintTxAuthorizer)
 	require.NoError(tb, err)
 	require.Equal(tb, 0, mintTxVM.StackSize())
 
@@ -368,7 +368,7 @@ func compiledFTTransfer(tb testing.TB) {
 
 	for loop() {
 
-		err := tokenTransferTxVM.ExecuteTransaction(tokenTransferTxArgs, tokenTransferTxAuthorizer)
+		err := tokenTransferTxVM.InvokeTransaction(tokenTransferTxArgs, tokenTransferTxAuthorizer)
 		require.NoError(tb, err)
 		require.Equal(tb, 0, tokenTransferTxVM.StackSize())
 

--- a/bbq/vm/test/interpreter_test.go
+++ b/bbq/vm/test/interpreter_test.go
@@ -434,7 +434,7 @@ func interpreterFTTransfer(tb testing.TB) {
 		interpreter.EmptyLocationRange,
 	)
 
-	err = inter.InvokeTransaction(0, signer)
+	err = inter.InvokeTransaction(nil, signer)
 	require.NoError(tb, err)
 
 	// Run setup account transaction
@@ -466,7 +466,7 @@ func interpreterFTTransfer(tb testing.TB) {
 			interpreter.EmptyLocationRange,
 		)
 
-		err = inter.InvokeTransaction(0, signer)
+		err = inter.InvokeTransaction(nil, signer)
 		require.NoError(tb, err)
 	}
 
@@ -489,9 +489,10 @@ func interpreterFTTransfer(tb testing.TB) {
 	)
 
 	err = inter.InvokeTransaction(
-		0,
-		interpreter.AddressValue(senderAddress),
-		interpreter.NewUnmeteredUFix64ValueWithInteger(total, interpreter.EmptyLocationRange),
+		[]interpreter.Value{
+			interpreter.AddressValue(senderAddress),
+			interpreter.NewUnmeteredUFix64ValueWithInteger(total, interpreter.EmptyLocationRange),
+		},
 		signer,
 	)
 	require.NoError(tb, err)
@@ -535,9 +536,10 @@ func interpreterFTTransfer(tb testing.TB) {
 	for loop() {
 
 		err = inter.InvokeTransaction(
-			0,
-			transferAmount,
-			interpreter.AddressValue(receiverAddress),
+			[]interpreter.Value{
+				transferAmount,
+				interpreter.AddressValue(receiverAddress),
+			},
 			signer,
 		)
 		require.NoError(tb, err)

--- a/bbq/vm/test/runtime_test.go
+++ b/bbq/vm/test/runtime_test.go
@@ -179,7 +179,7 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 	txVM := vm.NewVM(txLocation(), program, vmConfig)
 
 	authorizer := vm.NewAuthAccountReferenceValue(txVM.Context(), accountHandler, authorizerAddress)
-	err := txVM.ExecuteTransaction(nil, authorizer)
+	err := txVM.InvokeTransaction(nil, authorizer)
 	require.NoError(t, err)
 	require.Equal(t, 0, txVM.StackSize())
 }

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -1709,24 +1709,21 @@ func TestTransaction(t *testing.T) {
 
 		vmContext := vmInstance.Context()
 
-		err := vmInstance.ExecuteTransaction(nil)
+		err := vmInstance.InvokeTransaction(nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
 		// Rerun the same again using internal functions, to get the access to the transaction value.
 
-		transaction, err := vmInstance.InvokeExternally(commons.TransactionWrapperCompositeName)
+		transaction, err := vmInstance.InvokeTransactionWrapper()
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
-		require.IsType(t, &interpreter.CompositeValue{}, transaction)
-		compositeValue := transaction.(*interpreter.CompositeValue)
-
 		// At the beginning, 'a' is uninitialized
-		assert.Nil(t, compositeValue.GetMember(vmContext, vm.EmptyLocationRange, "a"))
+		assert.Nil(t, transaction.GetMember(vmContext, vm.EmptyLocationRange, "a"))
 
 		// Invoke 'prepare'
-		_, err = vmInstance.InvokeExternally(commons.TransactionPrepareFunctionName, transaction)
+		err = vmInstance.InvokeTransactionPrepare(transaction, nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1734,11 +1731,11 @@ func TestTransaction(t *testing.T) {
 		assert.Equal(
 			t,
 			interpreter.NewUnmeteredStringValue("Hello!"),
-			compositeValue.GetMember(vmContext, vm.EmptyLocationRange, "a"),
+			transaction.GetMember(vmContext, vm.EmptyLocationRange, "a"),
 		)
 
 		// Invoke 'execute'
-		_, err = vmInstance.InvokeExternally(commons.TransactionExecuteFunctionName, transaction)
+		err = vmInstance.InvokeTransactionExecute(transaction)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1746,7 +1743,7 @@ func TestTransaction(t *testing.T) {
 		assert.Equal(
 			t,
 			interpreter.NewUnmeteredStringValue("Hello again!"),
-			compositeValue.GetMember(vmContext, vm.EmptyLocationRange, "a"),
+			transaction.GetMember(vmContext, vm.EmptyLocationRange, "a"),
 		)
 	})
 
@@ -1783,24 +1780,21 @@ func TestTransaction(t *testing.T) {
 			interpreter.NewUnmeteredStringValue("Hello again!"),
 		}
 
-		err := vmInstance.ExecuteTransaction(args)
+		err := vmInstance.InvokeTransaction(args)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
 		// Rerun the same again using internal functions, to get the access to the transaction value.
 
-		transaction, err := vmInstance.InvokeExternally(commons.TransactionWrapperCompositeName)
+		transaction, err := vmInstance.InvokeTransactionWrapper()
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
-		require.IsType(t, &interpreter.CompositeValue{}, transaction)
-		compositeValue := transaction.(*interpreter.CompositeValue)
-
 		// At the beginning, 'a' is uninitialized
-		assert.Nil(t, compositeValue.GetMember(vmContext, vm.EmptyLocationRange, "a"))
+		assert.Nil(t, transaction.GetMember(vmContext, vm.EmptyLocationRange, "a"))
 
 		// Invoke 'prepare'
-		_, err = vmInstance.InvokeExternally(commons.TransactionPrepareFunctionName, transaction)
+		err = vmInstance.InvokeTransactionPrepare(transaction, nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1808,11 +1802,11 @@ func TestTransaction(t *testing.T) {
 		assert.Equal(
 			t,
 			interpreter.NewUnmeteredStringValue("Hello!"),
-			compositeValue.GetMember(vmContext, vm.EmptyLocationRange, "a"),
+			transaction.GetMember(vmContext, vm.EmptyLocationRange, "a"),
 		)
 
 		// Invoke 'execute'
-		_, err = vmInstance.InvokeExternally(commons.TransactionExecuteFunctionName, transaction)
+		err = vmInstance.InvokeTransactionExecute(transaction)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1820,7 +1814,7 @@ func TestTransaction(t *testing.T) {
 		assert.Equal(
 			t,
 			interpreter.NewUnmeteredStringValue("Hello again!"),
-			compositeValue.GetMember(vmContext, vm.EmptyLocationRange, "a"),
+			transaction.GetMember(vmContext, vm.EmptyLocationRange, "a"),
 		)
 	})
 
@@ -1900,7 +1894,7 @@ func TestTransaction(t *testing.T) {
 			},
 		)
 
-		err := vmInstance.ExecuteTransaction(nil)
+		err := vmInstance.InvokeTransaction(nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -1979,7 +1973,7 @@ func TestTransaction(t *testing.T) {
 			},
 		)
 
-		err := vmInstance.ExecuteTransaction(nil)
+		err := vmInstance.InvokeTransaction(nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, vmInstance.StackSize())
 
@@ -2063,7 +2057,7 @@ func TestTransaction(t *testing.T) {
 			},
 		)
 
-		err := vmInstance.ExecuteTransaction(nil)
+		err := vmInstance.InvokeTransaction(nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "pre/post condition failed")
 
@@ -2148,7 +2142,7 @@ func TestTransaction(t *testing.T) {
 			},
 		)
 
-		err := vmInstance.ExecuteTransaction(nil)
+		err := vmInstance.InvokeTransaction(nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "pre/post condition failed")
 

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -493,11 +493,13 @@ func (v *BoundFunctionPointerValue) initializeFunctionType(context interpreter.V
 }
 
 func (v *BoundFunctionPointerValue) Invoke(invocation interpreter.Invocation) interpreter.Value {
-	arguments := make([]Value, 0, len(invocation.Arguments)+1)
-	arguments = append(arguments, v.Receiver(invocation.InvocationContext))
+	context := invocation.InvocationContext
+
+	arguments := make([]Value, 0, 1+len(invocation.Arguments))
+	arguments = append(arguments, v.Receiver(context))
 	arguments = append(arguments, invocation.Arguments...)
 
-	return invocation.InvocationContext.InvokeFunction(
+	return context.InvokeFunction(
 		v,
 		arguments,
 	)

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -518,24 +518,28 @@ func InvokeFunction(errorHandler ErrorHandler, function FunctionValue, invocatio
 	return
 }
 
-func (interpreter *Interpreter) InvokeTransaction(index int, arguments ...Value) (err error) {
+func (interpreter *Interpreter) InvokeTransaction(arguments []Value, signers ...Value) (err error) {
 
 	// recover internal panics and return them as an error
 	defer interpreter.RecoverErrors(func(internalErr error) {
 		err = internalErr
 	})
 
-	if index >= len(interpreter.Transactions) {
-		return TransactionNotDeclaredError{Index: index}
-	}
+	const transactionIndex = 0
 
-	functionValue := interpreter.Transactions[index]
+	functionValue := interpreter.Transactions[transactionIndex]
 
-	transactionType := interpreter.Program.Elaboration.TransactionTypes[index]
+	transactionType := interpreter.Program.Elaboration.TransactionTypes[transactionIndex]
 	functionType := transactionType.EntryPointFunctionType()
 
-	_, err = InvokeExternally(interpreter, functionValue, functionType, arguments)
-	return err
+	_, err = InvokeExternally(
+		interpreter,
+		functionValue,
+		functionType,
+		common.Concat(arguments, signers),
+	)
+
+	return
 }
 
 func (interpreter *Interpreter) RecoverErrors(onError func(error)) {

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -279,9 +279,9 @@ func (executor *contractFunctionExecutor) executeWithVM(
 	)
 
 	// receiver + arguments
-	invocationArguments := make([]interpreter.Value, 0, 1+len(executor.arguments))
-	invocationArguments = append(invocationArguments, contractValue)
-	invocationArguments, err = executor.appendArguments(context, invocationArguments)
+	arguments := make([]interpreter.Value, 0, len(executor.arguments))
+
+	arguments, err = executor.appendArguments(context, arguments)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +290,11 @@ func (executor *contractFunctionExecutor) executeWithVM(
 	semaType := interpreter.MustConvertStaticToSemaType(staticType, context)
 	qualifiedFuncName := commons.TypeQualifiedName(semaType, executor.functionName)
 
-	value, err := executor.vm.InvokeExternally(qualifiedFuncName, invocationArguments...)
+	value, err := executor.vm.InvokeMethodExternally(
+		qualifiedFuncName,
+		contractValue,
+		arguments...,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -268,7 +268,7 @@ func (executor *transactionExecutor) transactionExecutionFunction(
 			err = internalErr
 		})
 
-		values, err := importValidatedArguments(
+		arguments, err := importValidatedArguments(
 			inter,
 			executor.environment,
 			interpreter.EmptyLocationRange,
@@ -279,8 +279,10 @@ func (executor *transactionExecutor) transactionExecutionFunction(
 			return nil, err
 		}
 
-		values = append(values, authorizerValues(inter)...)
-		err = inter.InvokeTransaction(0, values...)
+		signers := authorizerValues(inter)
+
+		err = inter.InvokeTransaction(arguments, signers...)
+
 		return nil, err
 	}
 }

--- a/test_utils/common_utils/utils.go
+++ b/test_utils/common_utils/utils.go
@@ -42,6 +42,7 @@ type Invokable interface {
 	interpreter.ValueComparisonContext
 	interpreter.InvocationContext
 	Invoke(functionName string, arguments ...interpreter.Value) (value interpreter.Value, err error)
+	InvokeTransaction(arguments []interpreter.Value, signers ...interpreter.Value) error
 	GetGlobal(name string) interpreter.Value
 
 	GlobalTypeGetter

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -75,6 +75,16 @@ func (v *VMInvokable) Invoke(functionName string, arguments ...interpreter.Value
 	return
 }
 
+func (v *VMInvokable) InvokeTransaction(arguments []interpreter.Value, signers ...interpreter.Value) (err error) {
+	err = v.vmInstance.InvokeTransaction(arguments, signers...)
+
+	// Reset the VM after a function invocation,
+	// so the same vm can be re-used for subsequent invocation.
+	v.vmInstance.Reset()
+
+	return
+}
+
 func (v *VMInvokable) GetGlobal(name string) interpreter.Value {
 	return v.vmInstance.Global(name)
 }


### PR DESCRIPTION
Work towards #3922 

## Description

- Improve external invocation of methods (bound function pointers) and transactions:
  - Validate and prepare arguments of external invocations by reusing functionality from interpreter
  - Add `VM.InvokeMethodExternally` for invoking methods directly, which properly prepares a bound function pointer and only validates/prepares the arguments excluding the receiver
- Limit execution of transactions in interpreter to just the first one, as the compiler/VM also only supports one, and we do not have a use case for multiple transactions in a single program (yet)
- Enable tests in `interpreter/transactions_test.go` to be run with the compiler/VM, except:
  - Tests relying on transaction pre/post conditions (not implemented yet)
  - Resource-invalidation related tests (not implemented yet?)
- Also abstract tests from implementation details of transaction execution in the VM by adding separate functions of the phases (`VM.InvokeTransactionWrapper`, `VM.InvokeTransactionInit`, `VM.InvokeTransactionPrepare`, etc.)

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
