### PR TITLE
[Compiler] Enable more interpreter tests to be run with the compiler / VM

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1505,7 +1505,11 @@ func (c *Compiler[_, _]) VisitIntegerExpression(expression *ast.IntegerExpressio
 		data = value.Bytes()
 
 	default:
-		panic(errors.NewUnexpectedError("unsupported constant kind: %s", constantKind))
+		panic(errors.NewUnexpectedError(
+			"unsupported integer type %s / constant kind %s",
+			integerType,
+			constantKind,
+		))
 	}
 
 	c.emitGetConstant(c.addConstant(constantKind, data))

--- a/bbq/constant/kind.go
+++ b/bbq/constant/kind.go
@@ -97,7 +97,7 @@ func FromSemaType(ty sema.Type) Kind {
 		return Address
 
 	// Int*
-	case sema.IntType, sema.IntegerType:
+	case sema.IntType, sema.IntegerType, sema.SignedIntegerType:
 		return Int
 	case sema.Int8Type:
 		return Int8
@@ -125,7 +125,7 @@ func FromSemaType(ty sema.Type) Kind {
 		return UInt64
 	case sema.UInt128Type:
 		return UInt128
-	case sema.UInt256Type:
+	case sema.UInt256Type, sema.FixedSizeUnsignedIntegerType:
 		return UInt256
 
 	// Word*

--- a/interpreter/builtinfunctions_test.go
+++ b/interpreter/builtinfunctions_test.go
@@ -41,7 +41,7 @@ func TestInterpretToString(t *testing.T) {
 
 		t.Run(ty.String(), func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       let x: %s = 42
@@ -55,7 +55,7 @@ func TestInterpretToString(t *testing.T) {
 				t,
 				inter,
 				interpreter.NewUnmeteredStringValue("42"),
-				inter.Globals.Get("y").GetValue(inter),
+				inter.GetGlobal("y"),
 			)
 		})
 	}
@@ -64,7 +64,7 @@ func TestInterpretToString(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           let x: Address = 0x42
           let y = x.toString()
         `)
@@ -73,7 +73,7 @@ func TestInterpretToString(t *testing.T) {
 			t,
 			inter,
 			interpreter.NewUnmeteredStringValue("0x0000000000000042"),
-			inter.Globals.Get("y").GetValue(inter),
+			inter.GetGlobal("y"),
 		)
 	})
 
@@ -94,7 +94,7 @@ func TestInterpretToString(t *testing.T) {
 				expected = interpreter.NewUnmeteredStringValue("12.34000000")
 			}
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       let x: %s = %s
@@ -109,7 +109,7 @@ func TestInterpretToString(t *testing.T) {
 				t,
 				inter,
 				expected,
-				inter.Globals.Get("y").GetValue(inter),
+				inter.GetGlobal("y"),
 			)
 		})
 	}
@@ -147,7 +147,7 @@ func TestInterpretToBytes(t *testing.T) {
 				interpreter.NewUnmeteredUInt8Value(0x34),
 				interpreter.NewUnmeteredUInt8Value(0x56),
 			),
-			inter.Globals.Get("y").GetValue(inter),
+			inter.GetGlobal("y"),
 		)
 	})
 }

--- a/interpreter/equality_test.go
+++ b/interpreter/equality_test.go
@@ -60,7 +60,7 @@ func TestInterpretEquality(t *testing.T) {
 		baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
 		interpreter.Declare(baseActivation, capabilityValueDeclaration)
 
-		inter, err := parseCheckAndInterpretWithOptions(t,
+		inter, err := parseCheckAndPrepareWithOptions(t,
 			`
               let maybeCapNonNil: Capability? = cap
               let maybeCapNil: Capability? = nil
@@ -86,14 +86,14 @@ func TestInterpretEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("res1").GetValue(inter),
+			inter.GetGlobal("res1"),
 		)
 
 		AssertValuesEqual(
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("res2").GetValue(inter),
+			inter.GetGlobal("res2"),
 		)
 	})
 
@@ -101,7 +101,7 @@ func TestInterpretEquality(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
 		  fun func() {}
 
           let maybeFuncNonNil: (fun(): Void)? = func
@@ -114,14 +114,14 @@ func TestInterpretEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("res1").GetValue(inter),
+			inter.GetGlobal("res1"),
 		)
 
 		AssertValuesEqual(
 			t,
 			inter,
 			interpreter.TrueValue,
-			inter.Globals.Get("res2").GetValue(inter),
+			inter.GetGlobal("res2"),
 		)
 	})
 
@@ -129,7 +129,7 @@ func TestInterpretEquality(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           let n: Int? = 1
           let res = nil == n
 		`)
@@ -138,7 +138,7 @@ func TestInterpretEquality(t *testing.T) {
 			t,
 			inter,
 			interpreter.FalseValue,
-			inter.Globals.Get("res").GetValue(inter),
+			inter.GetGlobal("res"),
 		)
 	})
 }
@@ -198,7 +198,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 						op.Symbol(),
 					)
 
-					inter := parseCheckAndInterpret(t, code)
+					inter := parseCheckAndPrepare(t, code)
 
 					result, err := inter.Invoke("test")
 
@@ -262,7 +262,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 						op.Symbol(),
 					)
 
-					inter := parseCheckAndInterpret(t, code)
+					inter := parseCheckAndPrepare(t, code)
 
 					result, err := inter.Invoke("test")
 
@@ -312,7 +312,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 						op.Symbol(),
 					)
 
-					inter := parseCheckAndInterpret(t, code)
+					inter := parseCheckAndPrepare(t, code)
 
 					result, err := inter.Invoke("test")
 
@@ -362,7 +362,7 @@ func TestInterpretEqualityOnNumericSuperTypes(t *testing.T) {
 						op.Symbol(),
 					)
 
-					inter := parseCheckAndInterpret(t, code)
+					inter := parseCheckAndPrepare(t, code)
 
 					result, err := inter.Invoke("test")
 

--- a/interpreter/fixedpoint_test.go
+++ b/interpreter/fixedpoint_test.go
@@ -37,7 +37,7 @@ func TestInterpretNegativeZeroFixedPoint(t *testing.T) {
 
 	t.Parallel()
 
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
       let x = -0.42
     `)
 
@@ -45,7 +45,7 @@ func TestInterpretNegativeZeroFixedPoint(t *testing.T) {
 		t,
 		inter,
 		interpreter.NewUnmeteredFix64Value(-42000000),
-		inter.Globals.Get("x").GetValue(inter),
+		inter.GetGlobal("x"),
 	)
 }
 
@@ -76,7 +76,7 @@ func TestInterpretFixedPointConversionAndAddition(t *testing.T) {
 
 		t.Run(fixedPointType, func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       let x: %[1]s = 1.23
@@ -91,21 +91,21 @@ func TestInterpretFixedPointConversionAndAddition(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				value,
-				inter.Globals.Get("y").GetValue(inter),
+				inter.GetGlobal("y"),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				interpreter.TrueValue,
-				inter.Globals.Get("z").GetValue(inter),
+				inter.GetGlobal("z"),
 			)
 
 		})
@@ -145,7 +145,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 			t.Run(testName, func(t *testing.T) {
 
-				inter := parseCheckAndInterpret(t,
+				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
                           let x: %[1]s = 50.0
@@ -160,14 +160,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					fixedPointValue,
-					inter.Globals.Get("x").GetValue(inter),
+					inter.GetGlobal("x"),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					integerValue,
-					inter.Globals.Get("y").GetValue(inter),
+					inter.GetGlobal("y"),
 				)
 			})
 		}
@@ -191,7 +191,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					value,
 				)
 
-				inter := parseCheckAndInterpret(t, code)
+				inter := parseCheckAndPrepare(t, code)
 
 				expected := interpreter.NewUnmeteredUFix64Value(value * sema.Fix64Factor)
 
@@ -199,14 +199,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("x").GetValue(inter),
+					inter.GetGlobal("x"),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("y").GetValue(inter),
+					inter.GetGlobal("y"),
 				)
 			})
 		}
@@ -231,7 +231,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					value,
 				)
 
-				inter := parseCheckAndInterpret(t, code)
+				inter := parseCheckAndPrepare(t, code)
 
 				expected := interpreter.NewUnmeteredFix64Value(value * sema.Fix64Factor)
 
@@ -239,14 +239,14 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("x").GetValue(inter),
+					inter.GetGlobal("x"),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("y").GetValue(inter),
+					inter.GetGlobal("y"),
 				)
 			})
 		}
@@ -266,20 +266,20 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					value,
 				)
 
-				inter := parseCheckAndInterpret(t, code)
+				inter := parseCheckAndPrepare(t, code)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					interpreter.NewUnmeteredFix64Value(value*sema.Fix64Factor),
-					inter.Globals.Get("x").GetValue(inter),
+					inter.GetGlobal("x"),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					interpreter.NewUnmeteredUFix64Value(uint64(value*sema.Fix64Factor)),
-					inter.Globals.Get("y").GetValue(inter),
+					inter.GetGlobal("y"),
 				)
 			})
 		}
@@ -299,20 +299,20 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					value,
 				)
 
-				inter := parseCheckAndInterpret(t, code)
+				inter := parseCheckAndPrepare(t, code)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					interpreter.NewUnmeteredUFix64Value(uint64(value*sema.Fix64Factor)),
-					inter.Globals.Get("x").GetValue(inter),
+					inter.GetGlobal("x"),
 				)
 
 				AssertValuesEqual(
 					t,
 					inter,
 					interpreter.NewUnmeteredFix64Value(value*sema.Fix64Factor),
-					inter.Globals.Get("y").GetValue(inter),
+					inter.GetGlobal("y"),
 				)
 			})
 		}
@@ -320,7 +320,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 	t.Run("invalid negative Fix64 to UFix64", func(t *testing.T) {
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
 		  fun test(): UFix64 {
 		      let x: Fix64 = -1.0
 		      return UFix64(x)
@@ -335,7 +335,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 	t.Run("invalid UFix64 > max Fix64 int to Fix64", func(t *testing.T) {
 
-		inter := parseCheckAndInterpret(t,
+		inter := parseCheckAndPrepare(t,
 			fmt.Sprintf(
 				`
 		          fun test(): Fix64 {
@@ -359,7 +359,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 			t.Run(integerType.String(), func(t *testing.T) {
 
-				inter := parseCheckAndInterpret(t,
+				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
 	                     fun test(): UFix64 {
@@ -373,11 +373,6 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 				_, err := inter.Invoke("test")
 				RequireError(t, err)
-
-				require.IsType(t,
-					interpreter.Error{},
-					err,
-				)
 
 				require.ErrorAs(t, err, &interpreter.UnderflowError{})
 			})
@@ -401,7 +396,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 			t.Run(integerType.String(), func(t *testing.T) {
 
-				inter := parseCheckAndInterpret(t,
+				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
 	                     fun test(): UFix64 {
@@ -438,7 +433,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 			t.Run(integerType.String(), func(t *testing.T) {
 
-				inter := parseCheckAndInterpret(t,
+				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
 	                     fun test(): UFix64 {
@@ -475,7 +470,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 			t.Run(integerType.String(), func(t *testing.T) {
 
-				inter := parseCheckAndInterpret(t,
+				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
 	                     fun test(): Fix64 {
@@ -512,7 +507,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 
 			t.Run(integerType.String(), func(t *testing.T) {
 
-				inter := parseCheckAndInterpret(t,
+				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
 	                     fun test(): Fix64 {

--- a/interpreter/integers_test.go
+++ b/interpreter/integers_test.go
@@ -82,7 +82,7 @@ func TestInterpretIntegerConversions(t *testing.T) {
 
 		t.Run(integerType, func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       let x: %[1]s = 50
@@ -97,21 +97,21 @@ func TestInterpretIntegerConversions(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				value,
-				inter.Globals.Get("y").GetValue(inter),
+				inter.GetGlobal("y"),
 			)
 
 			AssertValuesEqual(
 				t,
 				inter,
 				interpreter.TrueValue,
-				inter.Globals.Get("z").GetValue(inter),
+				inter.GetGlobal("z"),
 			)
 
 		})
@@ -135,7 +135,7 @@ func TestInterpretWordOverflowConversions(t *testing.T) {
 
 		t.Run(typeName, func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       let x = %s
@@ -149,7 +149,7 @@ func TestInterpretWordOverflowConversions(t *testing.T) {
 			require.Equal(
 				t,
 				"0",
-				inter.Globals.Get("y").GetValue(inter).String(),
+				inter.GetGlobal("y").String(),
 			)
 		})
 	}
@@ -172,7 +172,7 @@ func TestInterpretWordUnderflowConversions(t *testing.T) {
 
 		t.Run(typeName, func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       let x = 0
@@ -185,7 +185,7 @@ func TestInterpretWordUnderflowConversions(t *testing.T) {
 			require.Equal(
 				t,
 				value.String(),
-				inter.Globals.Get("y").GetValue(inter).String(),
+				inter.GetGlobal("y").String(),
 			)
 		})
 	}
@@ -199,7 +199,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           let x: Address = 0x1
         `)
 
@@ -209,7 +209,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 			interpreter.AddressValue{
 				0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
 			},
-			inter.Globals.Get("x").GetValue(inter),
+			inter.GetGlobal("x"),
 		)
 
 	})
@@ -218,7 +218,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           let x = Address(0x2)
         `)
 
@@ -228,7 +228,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 			interpreter.AddressValue{
 				0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2,
 			},
-			inter.Globals.Get("x").GetValue(inter),
+			inter.GetGlobal("x"),
 		)
 	})
 
@@ -236,7 +236,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           fun test() {
               let y = 0x1111111111111111111
               let x = Address(y)
@@ -253,7 +253,7 @@ func TestInterpretAddressConversion(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           fun test() {
               let y = -0x1
               let x = Address(y)
@@ -275,7 +275,7 @@ func TestInterpretIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T
 
 		t.Run(integerType, func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       let x: %s = 50
@@ -288,7 +288,7 @@ func TestInterpretIntegerLiteralTypeConversionInVariableDeclaration(t *testing.T
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 
 		})
@@ -303,7 +303,7 @@ func TestInterpretIntegerLiteralTypeConversionInVariableDeclarationOptional(t *t
 
 		t.Run(integerType, func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                         let x: %s? = 50
@@ -316,7 +316,7 @@ func TestInterpretIntegerLiteralTypeConversionInVariableDeclarationOptional(t *t
 				t,
 				inter,
 				interpreter.NewUnmeteredSomeValueNonCopying(value),
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 		})
 	}
@@ -330,7 +330,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
 
 		t.Run(integerType, func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       var x: %s = 50
@@ -346,7 +346,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 
 			_, err := inter.Invoke("test")
@@ -357,7 +357,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignment(t *testing.T) {
 				t,
 				inter,
 				numberValue.Plus(inter, numberValue, interpreter.EmptyLocationRange),
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 		})
 	}
@@ -371,7 +371,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T)
 
 		t.Run(integerType, func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       var x: %s? = 50
@@ -387,7 +387,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T)
 				t,
 				inter,
 				interpreter.NewUnmeteredSomeValueNonCopying(value),
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 
 			_, err := inter.Invoke("test")
@@ -401,7 +401,7 @@ func TestInterpretIntegerLiteralTypeConversionInAssignmentOptional(t *testing.T)
 				interpreter.NewUnmeteredSomeValueNonCopying(
 					numberValue.Plus(inter, numberValue, interpreter.EmptyLocationRange),
 				),
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 		})
 	}
@@ -415,7 +415,7 @@ func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgument(t *testing.
 
 		t.Run(integerType, func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       fun test(_ x: %[1]s): %[1]s {
@@ -431,7 +431,7 @@ func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgument(t *testing.
 				t,
 				inter,
 				value,
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 		})
 	}
@@ -445,7 +445,7 @@ func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgumentOptional(t *
 
 		t.Run(integerType, func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                         fun test(_ x: %[1]s?): %[1]s? {
@@ -461,7 +461,7 @@ func TestInterpretIntegerLiteralTypeConversionInFunctionCallArgumentOptional(t *
 				t,
 				inter,
 				interpreter.NewUnmeteredSomeValueNonCopying(value),
-				inter.Globals.Get("x").GetValue(inter),
+				inter.GetGlobal("x"),
 			)
 		})
 	}
@@ -475,7 +475,7 @@ func TestInterpretIntegerLiteralTypeConversionInReturn(t *testing.T) {
 
 		t.Run(integerType, func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       fun test(): %s {
@@ -507,7 +507,7 @@ func TestInterpretIntegerLiteralTypeConversionInReturnOptional(t *testing.T) {
 
 		t.Run(integerType, func(t *testing.T) {
 
-			inter := parseCheckAndInterpret(t,
+			inter := parseCheckAndPrepare(t,
 				fmt.Sprintf(
 					`
                       fun test(): %s? {
@@ -544,13 +544,13 @@ func TestInterpretIntegerConversion(t *testing.T) {
 		expectedError error,
 	) {
 
-		inter := parseCheckAndInterpret(t,
+		inter := parseCheckAndPrepare(t,
 			fmt.Sprintf(
 				`
                   fun test(value: %[1]s): %[2]s {
                       return %[2]s(value)
                   }
-				`,
+                `,
 				sourceType,
 				targetType,
 			),
@@ -794,8 +794,8 @@ func TestInterpretIntegerMinMax(t *testing.T) {
 		inter := parseCheckAndInterpret(t,
 			fmt.Sprintf(
 				`
-				  let x = %s.%s
-				`,
+                  let x = %s.%s
+                `,
 				ty,
 				field,
 			),
@@ -929,11 +929,14 @@ func TestInterpretStringIntegerConversion(t *testing.T) {
 			high = big.NewInt(math.MaxInt64)
 		}
 
-		code := fmt.Sprintf(`
-			fun testFromString(_ input: String): Int? {
-				return %s.fromString(input).map(Int)
-			}
-		`, typ.String())
+		code := fmt.Sprintf(
+			`
+              fun testFromString(_ input: String): Int? {
+                  return %s.fromString(input).map(Int)
+              }
+            `,
+			typ,
+		)
 		inter := parseCheckAndInterpret(t, code)
 
 		placeInRange := func(x *big.Int) *big.Int {


### PR DESCRIPTION
Work towards #3922 
Depends on #3948

## Description

Enable tests for:
- Builtin functions. Only some, added TODOs for missing functions to #3804 
- Equality
- Integer values
- Fixed-point values

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
