### PR TITLE
[Compiler] Make the location-range field settable in all interpreter errors

### DIFF
--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -240,7 +240,7 @@ func (c *Config) EmitEvent(
 ) {
 	onEventEmitted := c.interpreterConfig.OnEventEmitted
 	if onEventEmitted == nil {
-		panic(interpreter.EventEmissionUnavailableError{
+		panic(&interpreter.EventEmissionUnavailableError{
 			LocationRange: locationRange,
 		})
 	}

--- a/bbq/vm/test/runtime_test.go
+++ b/bbq/vm/test/runtime_test.go
@@ -222,7 +222,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 	//
 	//	_, err := compileAndInvoke(t, code, "test")
 	//	require.Error(t, err)
-	//	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	//	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+	//	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	//})
 	//
 	//t.Run("stack to account readonly", func(t *testing.T) {
@@ -253,7 +254,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 	//
 	//	_, err := inter.Invoke("test")
 	//	RequireError(t, err)
-	//	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	//	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+	//	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	//})
 	//
 	//t.Run("account to stack", func(t *testing.T) {
@@ -319,7 +321,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 	//
 	//	_, err := inter.Invoke("test", arrayRef)
 	//	RequireError(t, err)
-	//	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	//	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+	//	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	//})
 	//
 	//t.Run("stack to stack", func(t *testing.T) {
@@ -358,7 +361,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 	//
 	//	_, err := compileAndInvoke(t, code, "test")
 	//	require.Error(t, err)
-	//	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	//	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+	//	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	//})
 	//
 	//t.Run("one account to another account", func(t *testing.T) {
@@ -448,7 +452,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 	//
 	//	_, err := inter.Invoke("test", arrayRef1, arrayRef2)
 	//	RequireError(t, err)
-	//	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	//	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+	//	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	//})
 }
 

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -5052,7 +5052,7 @@ func TestCasting(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(
 			t,
-			interpreter.ForceCastTypeMismatchError{
+			&interpreter.ForceCastTypeMismatchError{
 				ExpectedType: sema.IntType,
 				ActualType:   sema.BoolType,
 				LocationRange: interpreter.LocationRange{
@@ -5819,7 +5819,9 @@ func TestCompileForce(t *testing.T) {
 			interpreter.Nil,
 		)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, interpreter.ForceNilError{})
+
+		var forceNilError *interpreter.ForceNilError
+		require.ErrorAs(t, err, &forceNilError)
 	})
 
 	t.Run("nil, AnyStruct", func(t *testing.T) {
@@ -5836,7 +5838,8 @@ func TestCompileForce(t *testing.T) {
 			interpreter.Nil,
 		)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, interpreter.ForceNilError{})
+		var forceNilError *interpreter.ForceNilError
+		require.ErrorAs(t, err, &forceNilError)
 	})
 
 	t.Run("non-optional", func(t *testing.T) {

--- a/bbq/vm/value_composite.go
+++ b/bbq/vm/value_composite.go
@@ -30,7 +30,7 @@ func newCompositeValueFields(context *Context, compositeKind common.CompositeKin
 
 		uuidHandler := context.interpreterConfig.UUIDHandler
 		if uuidHandler == nil {
-			panic(interpreter.UUIDUnavailableError{
+			panic(&interpreter.UUIDUnavailableError{
 				// TODO:
 				LocationRange: EmptyLocationRange,
 			})

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -985,7 +985,7 @@ func opGetField(vm *VM, ins opcode.InstructionGetField) {
 
 	fieldValue := memberAccessibleValue.GetMember(vm.context, EmptyLocationRange, fieldName)
 	if fieldValue == nil {
-		panic(interpreter.UseBeforeInitializationError{
+		panic(&interpreter.UseBeforeInitializationError{
 			Name: fieldName,
 		})
 	}
@@ -1092,7 +1092,7 @@ func opForceCast(vm *VM, ins opcode.InstructionForceCast) {
 		targetSemaType := interpreter.MustConvertStaticToSemaType(targetType, vm.context)
 		valueSemaType := interpreter.MustConvertStaticToSemaType(valueType, vm.context)
 
-		panic(interpreter.ForceCastTypeMismatchError{
+		panic(&interpreter.ForceCastTypeMismatchError{
 			ExpectedType:  targetSemaType,
 			ActualType:    valueSemaType,
 			LocationRange: vm.LocationRange(),
@@ -1169,7 +1169,7 @@ func opUnwrap(vm *VM) {
 	case *interpreter.SomeValue:
 		vm.replaceTop(value.InnerValue())
 	case interpreter.NilValue:
-		panic(interpreter.ForceNilError{})
+		panic(&interpreter.ForceNilError{})
 	default:
 		// Non-optional. Leave as is.
 	}

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -754,7 +754,8 @@ func TestInterpretAccountStorageSave(t *testing.T) {
 			_, err := inter.Invoke("test")
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.OverwriteError{})
+			var overwriteError *interpreter.OverwriteError
+			require.ErrorAs(t, err, &overwriteError)
 		})
 	})
 
@@ -795,7 +796,8 @@ func TestInterpretAccountStorageSave(t *testing.T) {
 			_, err := inter.Invoke("test")
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.OverwriteError{})
+			var overwriteError *interpreter.OverwriteError
+			require.ErrorAs(t, err, &overwriteError)
 		})
 	})
 }
@@ -952,7 +954,8 @@ func TestInterpretAccountStorageLoad(t *testing.T) {
 			_, err = inter.Invoke("loadR2")
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+			var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+			require.ErrorAs(t, err, &forceCastTypeMismatchError)
 
 			// NOTE: check loaded value was *not* removed from storage
 			require.Len(t, getAccountValues(), 1)
@@ -1029,7 +1032,8 @@ func TestInterpretAccountStorageLoad(t *testing.T) {
 			_, err = inter.Invoke("loadS2")
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+			var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+			require.ErrorAs(t, err, &forceCastTypeMismatchError)
 
 			// NOTE: check loaded value was *not* removed from storage
 			require.Len(t, getAccountValues(), 1)
@@ -1115,7 +1119,8 @@ func TestInterpretAccountStorageCopy(t *testing.T) {
 		_, err = inter.Invoke("copyS2")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+		var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+		require.ErrorAs(t, err, &forceCastTypeMismatchError)
 
 		// NOTE: check loaded value was *not* removed from storage
 		require.Len(t, getAccountValues(), 1)
@@ -1275,7 +1280,8 @@ func TestInterpretAccountStorageBorrow(t *testing.T) {
 			_, err = inter.Invoke("borrowR2")
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+			var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+			require.ErrorAs(t, err, &forceCastTypeMismatchError)
 
 			// NOTE: check loaded value was *not* removed from storage
 			require.Len(t, getAccountValues(), 1)
@@ -1286,7 +1292,8 @@ func TestInterpretAccountStorageBorrow(t *testing.T) {
 			_, err := inter.Invoke("changeAfterBorrow")
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.DereferenceError{})
+			var derefError *interpreter.DereferenceError
+			require.ErrorAs(t, err, &derefError)
 		})
 
 		t.Run("check R2 with wrong path", func(t *testing.T) {
@@ -1453,7 +1460,8 @@ func TestInterpretAccountStorageBorrow(t *testing.T) {
 			_, err = inter.Invoke("borrowS2")
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+			var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+			require.ErrorAs(t, err, &forceCastTypeMismatchError)
 
 			// NOTE: check loaded value was *not* removed from storage
 			require.Len(t, getAccountValues(), 1)
@@ -1464,14 +1472,16 @@ func TestInterpretAccountStorageBorrow(t *testing.T) {
 			_, err := inter.Invoke("changeAfterBorrow")
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.DereferenceError{})
+			var dereferenceError *interpreter.DereferenceError
+			require.ErrorAs(t, err, &dereferenceError)
 		})
 
 		t.Run("borrow as invalid type", func(t *testing.T) {
 			_, err = inter.Invoke("invalidBorrowS")
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+			var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+			require.ErrorAs(t, err, &forceCastTypeMismatchError)
 		})
 	})
 }

--- a/interpreter/array_test.go
+++ b/interpreter/array_test.go
@@ -152,5 +152,6 @@ func TestCheckArrayReferenceTypeInferenceWithDowncasting(t *testing.T) {
 
 	_, err := inter.Invoke("test")
 	require.Error(t, err)
-	require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+	var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+		require.ErrorAs(t, err, &forceCastTypeMismatchError)
 }

--- a/interpreter/array_test.go
+++ b/interpreter/array_test.go
@@ -153,5 +153,5 @@ func TestCheckArrayReferenceTypeInferenceWithDowncasting(t *testing.T) {
 	_, err := inter.Invoke("test")
 	require.Error(t, err)
 	var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
-		require.ErrorAs(t, err, &forceCastTypeMismatchError)
+	require.ErrorAs(t, err, &forceCastTypeMismatchError)
 }

--- a/interpreter/attachments_test.go
+++ b/interpreter/attachments_test.go
@@ -99,7 +99,8 @@ func TestInterpretAttachmentStruct(t *testing.T) {
     `)
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.DuplicateAttachmentError{})
+		var duplicateAttachmentError *interpreter.DuplicateAttachmentError
+		require.ErrorAs(t, err, &duplicateAttachmentError)
 	})
 
 	t.Run("reference", func(t *testing.T) {
@@ -299,7 +300,8 @@ func TestInterpretAttachmentResource(t *testing.T) {
     `)
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.DuplicateAttachmentError{})
+		var duplicateAttachmentError *interpreter.DuplicateAttachmentError
+		require.ErrorAs(t, err, &duplicateAttachmentError)
 	})
 
 	t.Run("attach and remove", func(t *testing.T) {
@@ -829,7 +831,8 @@ func TestInterpretAttachmentBaseUse(t *testing.T) {
 	    `)
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("return from function", func(t *testing.T) {
@@ -990,7 +993,8 @@ func TestInterpretAttachmentSelfUse(t *testing.T) {
 	    `)
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("return from function", func(t *testing.T) {
@@ -1620,7 +1624,8 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
 		)
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("destroyed", func(t *testing.T) {
@@ -1649,7 +1654,8 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
 		)
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("nested", func(t *testing.T) {
@@ -1699,7 +1705,8 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
 		)
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("base reference", func(t *testing.T) {
@@ -1744,7 +1751,8 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
 		)
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("nested destroyed", func(t *testing.T) {
@@ -1782,7 +1790,8 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
 		)
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("self reference", func(t *testing.T) {
@@ -1826,7 +1835,8 @@ func TestInterpretAttachmentResourceReferenceInvalidation(t *testing.T) {
 		)
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 }
 
@@ -1877,7 +1887,8 @@ func TestInterpretAttachmentDefensiveCheck(t *testing.T) {
 		})
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidAttachmentOperationTargetError{})
+		var attachmentError *interpreter.InvalidAttachmentOperationTargetError
+		require.ErrorAs(t, err, &attachmentError)
 	})
 
 	t.Run("reference remove", func(t *testing.T) {
@@ -1897,7 +1908,8 @@ func TestInterpretAttachmentDefensiveCheck(t *testing.T) {
 		})
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidAttachmentOperationTargetError{})
+		var attachmentError *interpreter.InvalidAttachmentOperationTargetError
+		require.ErrorAs(t, err, &attachmentError)
 	})
 
 	t.Run("array attach", func(t *testing.T) {
@@ -1916,7 +1928,8 @@ func TestInterpretAttachmentDefensiveCheck(t *testing.T) {
 		})
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidAttachmentOperationTargetError{})
+		var attachmentError *interpreter.InvalidAttachmentOperationTargetError
+		require.ErrorAs(t, err, &attachmentError)
 	})
 
 	t.Run("array remove", func(t *testing.T) {
@@ -1935,7 +1948,8 @@ func TestInterpretAttachmentDefensiveCheck(t *testing.T) {
 		})
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidAttachmentOperationTargetError{})
+		var attachmentError *interpreter.InvalidAttachmentOperationTargetError
+		require.ErrorAs(t, err, &attachmentError)
 	})
 
 	t.Run("enum attach", func(t *testing.T) {
@@ -1958,7 +1972,8 @@ func TestInterpretAttachmentDefensiveCheck(t *testing.T) {
 		})
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidAttachmentOperationTargetError{})
+		var attachmentError *interpreter.InvalidAttachmentOperationTargetError
+		require.ErrorAs(t, err, &attachmentError)
 	})
 
 	t.Run("enum remove", func(t *testing.T) {
@@ -1981,7 +1996,8 @@ func TestInterpretAttachmentDefensiveCheck(t *testing.T) {
 		})
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidAttachmentOperationTargetError{})
+		var attachmentError *interpreter.InvalidAttachmentOperationTargetError
+		require.ErrorAs(t, err, &attachmentError)
 	})
 }
 
@@ -2317,7 +2333,8 @@ func TestInterpretMutationDuringForEachAttachment(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.AttachmentIterationMutationError{})
+		var attachmentError *interpreter.AttachmentIterationMutationError
+		require.ErrorAs(t, err, &attachmentError)
 	})
 
 	t.Run("basic remove", func(t *testing.T) {
@@ -2339,7 +2356,8 @@ func TestInterpretMutationDuringForEachAttachment(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.AttachmentIterationMutationError{})
+		var attachmentError *interpreter.AttachmentIterationMutationError
+		require.ErrorAs(t, err, &attachmentError)
 	})
 
 	t.Run("attach to other", func(t *testing.T) {
@@ -2406,7 +2424,8 @@ func TestInterpretMutationDuringForEachAttachment(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.AttachmentIterationMutationError{})
+		var attachmentError *interpreter.AttachmentIterationMutationError
+		require.ErrorAs(t, err, &attachmentError)
 	})
 
 	t.Run("nested iteration of same", func(t *testing.T) {
@@ -2429,7 +2448,8 @@ func TestInterpretMutationDuringForEachAttachment(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.AttachmentIterationMutationError{})
+		var attachmentError *interpreter.AttachmentIterationMutationError
+		require.ErrorAs(t, err, &attachmentError)
 	})
 
 	t.Run("nested iteration ok", func(t *testing.T) {
@@ -2607,6 +2627,7 @@ func TestInterpretAttachmentSelfInvalidationInIteration(t *testing.T) {
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 }

--- a/interpreter/bitwise_test.go
+++ b/interpreter/bitwise_test.go
@@ -270,7 +270,7 @@ func TestInterpretBitwiseNegativeShift(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var shiftErr interpreter.NegativeShiftError
+		var shiftErr *interpreter.NegativeShiftError
 		require.ErrorAs(t, err, &shiftErr)
 	})
 
@@ -287,7 +287,7 @@ func TestInterpretBitwiseNegativeShift(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var shiftErr interpreter.NegativeShiftError
+		var shiftErr *interpreter.NegativeShiftError
 		require.ErrorAs(t, err, &shiftErr)
 	})
 
@@ -304,7 +304,7 @@ func TestInterpretBitwiseNegativeShift(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var shiftErr interpreter.NegativeShiftError
+		var shiftErr *interpreter.NegativeShiftError
 		require.ErrorAs(t, err, &shiftErr)
 	})
 
@@ -321,7 +321,7 @@ func TestInterpretBitwiseNegativeShift(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var shiftErr interpreter.NegativeShiftError
+		var shiftErr *interpreter.NegativeShiftError
 		require.ErrorAs(t, err, &shiftErr)
 	})
 
@@ -338,7 +338,7 @@ func TestInterpretBitwiseNegativeShift(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var shiftErr interpreter.NegativeShiftError
+		var shiftErr *interpreter.NegativeShiftError
 		require.ErrorAs(t, err, &shiftErr)
 	})
 
@@ -355,7 +355,7 @@ func TestInterpretBitwiseNegativeShift(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var shiftErr interpreter.NegativeShiftError
+		var shiftErr *interpreter.NegativeShiftError
 		require.ErrorAs(t, err, &shiftErr)
 	})
 }
@@ -638,7 +638,7 @@ func TestInterpretBitwiseLeftShift128(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var shiftErr interpreter.NegativeShiftError
+		var shiftErr *interpreter.NegativeShiftError
 		require.ErrorAs(t, err, &shiftErr)
 	})
 
@@ -830,7 +830,7 @@ func TestInterpretBitwiseLeftShift256(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var shiftErr interpreter.NegativeShiftError
+		var shiftErr *interpreter.NegativeShiftError
 		require.ErrorAs(t, err, &shiftErr)
 	})
 
@@ -960,7 +960,7 @@ func TestInterpretBitwiseRightShift128(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var shiftErr interpreter.NegativeShiftError
+		var shiftErr *interpreter.NegativeShiftError
 		require.ErrorAs(t, err, &shiftErr)
 	})
 
@@ -1090,7 +1090,7 @@ func TestInterpretBitwiseRightShift256(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var shiftErr interpreter.NegativeShiftError
+		var shiftErr *interpreter.NegativeShiftError
 		require.ErrorAs(t, err, &shiftErr)
 	})
 

--- a/interpreter/composite_value_test.go
+++ b/interpreter/composite_value_test.go
@@ -210,7 +210,7 @@ func TestInterpretContractTransfer(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var nonTransferableValueError interpreter.NonTransferableValueError
+		var nonTransferableValueError *interpreter.NonTransferableValueError
 		require.ErrorAs(t, err, &nonTransferableValueError)
 	}
 

--- a/interpreter/condition_test.go
+++ b/interpreter/condition_test.go
@@ -217,7 +217,7 @@ func assertConditionError(
 		return
 	}
 
-	var conditionErr interpreter.ConditionError
+	var conditionErr *interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
 
 	assert.Equal(t,
@@ -241,7 +241,7 @@ func assertConditionErrorWithMessage(
 		return
 	}
 
-	var conditionErr interpreter.ConditionError
+	var conditionErr *interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
 
 	assert.Equal(

--- a/interpreter/condition_test.go
+++ b/interpreter/condition_test.go
@@ -796,9 +796,9 @@ func TestInterpretInitializerWithInterfacePreCondition(t *testing.T) {
 		err    error
 		events int
 	}{
-		0: {interpreter.ConditionError{}, 0},
+		0: {&interpreter.ConditionError{}, 0},
 		1: {nil, 2},
-		2: {interpreter.ConditionError{}, 1},
+		2: {&interpreter.ConditionError{}, 1},
 	}
 
 	for _, compositeKind := range common.CompositeKindsWithFieldsAndFunctions {

--- a/interpreter/container_mutation_test.go
+++ b/interpreter/container_mutation_test.go
@@ -84,8 +84,8 @@ func TestInterpretArrayMutation(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		mutationError := &interpreter.ContainerMutationError{}
-		require.ErrorAs(t, err, mutationError)
+		var mutationError *interpreter.ContainerMutationError
+		require.ErrorAs(t, err, &mutationError)
 
 		assert.Equal(t, sema.StringType, mutationError.ExpectedType)
 		assert.Equal(t, sema.IntType, mutationError.ActualType)
@@ -104,8 +104,8 @@ func TestInterpretArrayMutation(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		mutationError := &interpreter.ContainerMutationError{}
-		require.ErrorAs(t, err, mutationError)
+		var mutationError *interpreter.ContainerMutationError
+		require.ErrorAs(t, err, &mutationError)
 
 		assert.Equal(t, sema.StringType, mutationError.ExpectedType)
 		assert.Equal(t, sema.IntType, mutationError.ActualType)
@@ -159,8 +159,8 @@ func TestInterpretArrayMutation(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		mutationError := &interpreter.ContainerMutationError{}
-		require.ErrorAs(t, err, mutationError)
+		var mutationError *interpreter.ContainerMutationError
+		require.ErrorAs(t, err, &mutationError)
 
 		assert.Equal(t, sema.StringType, mutationError.ExpectedType)
 		assert.Equal(t, sema.IntType, mutationError.ActualType)
@@ -179,8 +179,8 @@ func TestInterpretArrayMutation(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		mutationError := &interpreter.ContainerMutationError{}
-		require.ErrorAs(t, err, mutationError)
+		var mutationError *interpreter.ContainerMutationError
+		require.ErrorAs(t, err, &mutationError)
 
 		assert.Equal(t, sema.StringType, mutationError.ExpectedType)
 		assert.Equal(t, sema.IntType, mutationError.ActualType)
@@ -234,8 +234,8 @@ func TestInterpretArrayMutation(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		mutationError := &interpreter.ContainerMutationError{}
-		require.ErrorAs(t, err, mutationError)
+		var mutationError *interpreter.ContainerMutationError
+		require.ErrorAs(t, err, &mutationError)
 
 		assert.Equal(t, sema.StringType, mutationError.ExpectedType)
 		assert.Equal(t, sema.IntType, mutationError.ActualType)
@@ -256,7 +256,8 @@ func TestInterpretArrayMutation(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.ContainerMutationError{})
+		var mutationError *interpreter.ContainerMutationError
+		require.ErrorAs(t, err, &mutationError)
 
 		// Check original array
 
@@ -295,8 +296,8 @@ func TestInterpretArrayMutation(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		mutationError := &interpreter.ContainerMutationError{}
-		require.ErrorAs(t, err, mutationError)
+		var mutationError *interpreter.ContainerMutationError
+		require.ErrorAs(t, err, &mutationError)
 
 		assert.Equal(t, sema.StringType, mutationError.ExpectedType)
 		assert.Equal(t, sema.IntType, mutationError.ActualType)
@@ -495,8 +496,8 @@ func TestInterpretArrayMutation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		mutationError := &interpreter.ContainerMutationError{}
-		require.ErrorAs(t, err, mutationError)
+		var mutationError *interpreter.ContainerMutationError
+		require.ErrorAs(t, err, &mutationError)
 
 		// Expected type
 		require.IsType(t, &sema.OptionalType{}, mutationError.ExpectedType)
@@ -562,8 +563,8 @@ func TestInterpretDictionaryMutation(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		mutationError := &interpreter.ContainerMutationError{}
-		require.ErrorAs(t, err, mutationError)
+		var mutationError *interpreter.ContainerMutationError
+		require.ErrorAs(t, err, &mutationError)
 
 		assert.Equal(t,
 			&sema.OptionalType{
@@ -641,8 +642,8 @@ func TestInterpretDictionaryMutation(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		mutationError := &interpreter.ContainerMutationError{}
-		require.ErrorAs(t, err, mutationError)
+		var mutationError *interpreter.ContainerMutationError
+		require.ErrorAs(t, err, &mutationError)
 
 		assert.Equal(t, sema.StringType, mutationError.ExpectedType)
 		assert.Equal(t, sema.IntType, mutationError.ActualType)
@@ -661,8 +662,8 @@ func TestInterpretDictionaryMutation(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		mutationError := &interpreter.ContainerMutationError{}
-		require.ErrorAs(t, err, mutationError)
+		var mutationError *interpreter.ContainerMutationError
+		require.ErrorAs(t, err, &mutationError)
 
 		assert.Equal(t, sema.PublicPathType, mutationError.ExpectedType)
 		assert.Equal(t, sema.PrivatePathType, mutationError.ActualType)
@@ -682,8 +683,8 @@ func TestInterpretDictionaryMutation(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		mutationError := &interpreter.ContainerMutationError{}
-		require.ErrorAs(t, err, mutationError)
+		var mutationError *interpreter.ContainerMutationError
+		require.ErrorAs(t, err, &mutationError)
 
 		assert.Equal(t,
 			&sema.OptionalType{
@@ -893,8 +894,8 @@ func TestInterpretDictionaryMutation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		mutationError := &interpreter.ContainerMutationError{}
-		require.ErrorAs(t, err, mutationError)
+		var mutationError *interpreter.ContainerMutationError
+		require.ErrorAs(t, err, &mutationError)
 
 		// Expected type
 		require.IsType(t, &sema.OptionalType{}, mutationError.ExpectedType)
@@ -996,7 +997,9 @@ func TestInterpretContainerMutationWhileIterating(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		assert.ErrorAs(t, err, &interpreter.ContainerMutatedDuringIterationError{})
+
+		var containerMutationError *interpreter.ContainerMutatedDuringIterationError
+		require.ErrorAs(t, err, &containerMutationError)
 	})
 
 	t.Run("array, remove", func(t *testing.T) {
@@ -1017,7 +1020,8 @@ func TestInterpretContainerMutationWhileIterating(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		assert.ErrorAs(t, err, &interpreter.ContainerMutatedDuringIterationError{})
+		var containerMutationError *interpreter.ContainerMutatedDuringIterationError
+		require.ErrorAs(t, err, &containerMutationError)
 	})
 
 	t.Run("dictionary, add", func(t *testing.T) {
@@ -1043,7 +1047,8 @@ func TestInterpretContainerMutationWhileIterating(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		assert.ErrorAs(t, err, &interpreter.ContainerMutatedDuringIterationError{})
+		var containerMutationError *interpreter.ContainerMutatedDuringIterationError
+		require.ErrorAs(t, err, &containerMutationError)
 	})
 
 	t.Run("dictionary, remove", func(t *testing.T) {
@@ -1067,7 +1072,8 @@ func TestInterpretContainerMutationWhileIterating(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		assert.ErrorAs(t, err, &interpreter.ContainerMutatedDuringIterationError{})
+		var containerMutationError *interpreter.ContainerMutatedDuringIterationError
+		require.ErrorAs(t, err, &containerMutationError)
 	})
 
 	t.Run("resource dictionary, remove", func(t *testing.T) {
@@ -1095,7 +1101,8 @@ func TestInterpretContainerMutationWhileIterating(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		assert.ErrorAs(t, err, &interpreter.ContainerMutatedDuringIterationError{})
+		var containerMutationError *interpreter.ContainerMutatedDuringIterationError
+		require.ErrorAs(t, err, &containerMutationError)
 	})
 }
 

--- a/interpreter/contract_test.go
+++ b/interpreter/contract_test.go
@@ -163,6 +163,7 @@ func TestInterpretContractUseBeforeInitializationComplete(t *testing.T) {
 
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.UseBeforeInitializationError{})
+		var initializationError *interpreter.UseBeforeInitializationError
+		require.ErrorAs(t, err, &initializationError)
 	})
 }

--- a/interpreter/dynamic_casting_test.go
+++ b/interpreter/dynamic_casting_test.go
@@ -172,7 +172,8 @@ func TestInterpretDynamicCastingNumber(t *testing.T) {
 								} else {
 									RequireError(t, err)
 
-									require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+									var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+									require.ErrorAs(t, err, &forceCastTypeMismatchError)
 								}
 							})
 						}
@@ -270,7 +271,8 @@ func TestInterpretDynamicCastingVoid(t *testing.T) {
 						} else {
 							RequireError(t, err)
 
-							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+							var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+							require.ErrorAs(t, err, &forceCastTypeMismatchError)
 						}
 					})
 				}
@@ -363,7 +365,8 @@ func TestInterpretDynamicCastingString(t *testing.T) {
 						} else {
 							RequireError(t, err)
 
-							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+							var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+							require.ErrorAs(t, err, &forceCastTypeMismatchError)
 						}
 					})
 				}
@@ -456,7 +459,8 @@ func TestInterpretDynamicCastingBool(t *testing.T) {
 						} else {
 							RequireError(t, err)
 
-							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+							var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+							require.ErrorAs(t, err, &forceCastTypeMismatchError)
 						}
 					})
 				}
@@ -554,7 +558,8 @@ func TestInterpretDynamicCastingAddress(t *testing.T) {
 						} else {
 							RequireError(t, err)
 
-							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+							var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+							require.ErrorAs(t, err, &forceCastTypeMismatchError)
 						}
 					})
 				}
@@ -645,7 +650,8 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 					} else {
 						RequireError(t, err)
 
-						require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+						var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+						require.ErrorAs(t, err, &forceCastTypeMismatchError)
 					}
 				})
 
@@ -688,7 +694,8 @@ func TestInterpretDynamicCastingStruct(t *testing.T) {
 						} else {
 							RequireError(t, err)
 
-							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+							var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+							require.ErrorAs(t, err, &forceCastTypeMismatchError)
 						}
 					})
 				}
@@ -794,7 +801,8 @@ func testResourceCastInvalid(t *testing.T, types, fromType, targetType string, o
 	case ast.OperationForceCast:
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+		var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+		require.ErrorAs(t, err, &forceCastTypeMismatchError)
 
 	default:
 		panic(errors.NewUnreachableError())
@@ -939,7 +947,8 @@ func testStructCastInvalid(t *testing.T, types, fromType, targetType string, ope
 	case ast.OperationForceCast:
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+		var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+		require.ErrorAs(t, err, &forceCastTypeMismatchError)
 
 	default:
 		panic(errors.NewUnreachableError())
@@ -1151,7 +1160,8 @@ func TestInterpretDynamicCastingSome(t *testing.T) {
 						} else {
 							RequireError(t, err)
 
-							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+							var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+							require.ErrorAs(t, err, &forceCastTypeMismatchError)
 						}
 					})
 				}
@@ -1259,7 +1269,8 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 						} else {
 							RequireError(t, err)
 
-							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+							var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+							require.ErrorAs(t, err, &forceCastTypeMismatchError)
 						}
 					})
 				}
@@ -1293,7 +1304,8 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 				} else {
 					RequireError(t, err)
 
-					require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+					var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+					require.ErrorAs(t, err, &forceCastTypeMismatchError)
 				}
 			})
 		})
@@ -1311,7 +1323,8 @@ func TestInterpretDynamicCastingArray(t *testing.T) {
 
 		RequireError(t, err)
 
-		assert.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+		var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+		assert.ErrorAs(t, err, &forceCastTypeMismatchError)
 	})
 }
 
@@ -1417,7 +1430,8 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 						} else {
 							RequireError(t, err)
 
-							require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+							var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+							require.ErrorAs(t, err, &forceCastTypeMismatchError)
 						}
 					})
 				}
@@ -1450,7 +1464,8 @@ func TestInterpretDynamicCastingDictionary(t *testing.T) {
 				} else {
 					RequireError(t, err)
 
-					require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+					var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+					require.ErrorAs(t, err, &forceCastTypeMismatchError)
 				}
 			})
 		})
@@ -1512,7 +1527,8 @@ func TestInterpretDynamicCastingInclusiveRange(t *testing.T) {
 				} else {
 					RequireError(t, err)
 
-					require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+					var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+					require.ErrorAs(t, err, &forceCastTypeMismatchError)
 				}
 			})
 		})
@@ -2334,7 +2350,8 @@ func testReferenceCastInvalid(t *testing.T, types, fromType, targetType string, 
 	case ast.OperationForceCast:
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+		var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+		require.ErrorAs(t, err, &forceCastTypeMismatchError)
 
 	default:
 		panic(errors.NewUnreachableError())
@@ -3533,7 +3550,8 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 								} else {
 									RequireError(t, err)
 
-									require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+									var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+									require.ErrorAs(t, err, &forceCastTypeMismatchError)
 								}
 							})
 						}
@@ -3642,7 +3660,8 @@ func TestInterpretDynamicCastingFunctionType(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+		var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+		require.ErrorAs(t, err, &forceCastTypeMismatchError)
 	})
 
 	t.Run("return type covariance", func(t *testing.T) {
@@ -3681,7 +3700,8 @@ func TestInterpretDynamicCastingFunctionType(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+		var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+		require.ErrorAs(t, err, &forceCastTypeMismatchError)
 	})
 
 	t.Run("bound function casting", func(t *testing.T) {
@@ -3753,7 +3773,8 @@ func TestInterpretDynamicCastingReferenceCasting(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		assert.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+		var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+		assert.ErrorAs(t, err, &forceCastTypeMismatchError)
 	})
 
 	t.Run("nested in dictionary", func(t *testing.T) {
@@ -3776,7 +3797,8 @@ func TestInterpretDynamicCastingReferenceCasting(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		assert.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+		var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+		assert.ErrorAs(t, err, &forceCastTypeMismatchError)
 	})
 
 	t.Run("use of storage reference", func(t *testing.T) {
@@ -3842,7 +3864,7 @@ func TestInterpretDynamicCastingReferenceCasting(t *testing.T) {
 
 				// StorageReferenceValue.ReferencedValue turns the ForceCastTypeMismatchError
 				// of the failed dereference into a DereferenceError
-				var dereferenceError interpreter.DereferenceError
+				var dereferenceError *interpreter.DereferenceError
 				require.ErrorAs(t, err, &dereferenceError)
 
 				assert.Equal(t, 22, dereferenceError.LocationRange.StartPosition().Line)
@@ -3974,7 +3996,7 @@ func TestInterpretDynamicCastingOptionalUnwrapping(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var forceCastTypeMismatchError interpreter.ForceCastTypeMismatchError
+		var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
 		assert.ErrorAs(t, err, &forceCastTypeMismatchError)
 
 		startPos := forceCastTypeMismatchError.LocationRange.StartPosition()

--- a/interpreter/encode.go
+++ b/interpreter/encode.go
@@ -1399,7 +1399,7 @@ func (t *CapabilityStaticType) Encode(e *cbor.StreamEncoder) error {
 }
 
 func (t FunctionStaticType) Encode(_ *cbor.StreamEncoder) error {
-	return NonStorableStaticTypeError{
+	return &NonStorableStaticTypeError{
 		Type: t.Type,
 	}
 }

--- a/interpreter/entitlements_test.go
+++ b/interpreter/entitlements_test.go
@@ -1115,7 +1115,7 @@ func TestInterpretEntitledResult(t *testing.T) {
 			var panicError stdlib.PanicError
 			require.ErrorAs(t, err, &panicError)
 		} else {
-			var conditionError interpreter.ConditionError
+			var conditionError *interpreter.ConditionError
 			require.ErrorAs(t, err, &conditionError)
 		}
 	})

--- a/interpreter/errors.go
+++ b/interpreter/errors.go
@@ -729,11 +729,11 @@ type TypeLoadingError struct {
 	TypeID TypeID
 }
 
-var _ errors.UserError = &TypeLoadingError{}
+var _ errors.UserError = TypeLoadingError{}
 
-func (*TypeLoadingError) IsUserError() {}
+func (TypeLoadingError) IsUserError() {}
 
-func (e *TypeLoadingError) Error() string {
+func (e TypeLoadingError) Error() string {
 	return fmt.Sprintf("failed to load type: %s", e.TypeID)
 }
 
@@ -887,11 +887,11 @@ type NonStorableValueError struct {
 	Value Value
 }
 
-var _ errors.UserError = &NonStorableValueError{}
+var _ errors.UserError = NonStorableValueError{}
 
-func (*NonStorableValueError) IsUserError() {}
+func (NonStorableValueError) IsUserError() {}
 
-func (e *NonStorableValueError) Error() string {
+func (e NonStorableValueError) Error() string {
 	return "cannot store non-storable value"
 }
 
@@ -900,11 +900,11 @@ type NonStorableStaticTypeError struct {
 	Type sema.Type
 }
 
-var _ errors.UserError = &NonStorableStaticTypeError{}
+var _ errors.UserError = NonStorableStaticTypeError{}
 
-func (*NonStorableStaticTypeError) IsUserError() {}
+func (NonStorableStaticTypeError) IsUserError() {}
 
-func (e *NonStorableStaticTypeError) Error() string {
+func (e NonStorableStaticTypeError) Error() string {
 	return fmt.Sprintf(
 		"cannot store non-storable type: `%s`",
 		e.Type.QualifiedString(),
@@ -917,11 +917,11 @@ type InterfaceMissingLocationError struct {
 	QualifiedIdentifier string
 }
 
-var _ errors.UserError = &InterfaceMissingLocationError{}
+var _ errors.UserError = InterfaceMissingLocationError{}
 
-func (*InterfaceMissingLocationError) IsUserError() {}
+func (InterfaceMissingLocationError) IsUserError() {}
 
-func (e *InterfaceMissingLocationError) Error() string {
+func (e InterfaceMissingLocationError) Error() string {
 	return fmt.Sprintf(
 		"tried to look up interface %s without a location",
 		e.QualifiedIdentifier,
@@ -1398,11 +1398,11 @@ func (e *ResourceLossError) SetLocationRange(locationRange LocationRange) {
 
 type InvalidCapabilityIDError struct{}
 
-var _ errors.InternalError = &InvalidCapabilityIDError{}
+var _ errors.InternalError = InvalidCapabilityIDError{}
 
-func (*InvalidCapabilityIDError) IsInternalError() {}
+func (InvalidCapabilityIDError) IsInternalError() {}
 
-func (e *InvalidCapabilityIDError) Error() string {
+func (e InvalidCapabilityIDError) Error() string {
 	return fmt.Sprintf(
 		"%s capability created with invalid ID",
 		errors.InternalErrorMessagePrefix,

--- a/interpreter/errors.go
+++ b/interpreter/errors.go
@@ -243,7 +243,7 @@ type RedeclarationError struct {
 	Name string
 }
 
-var _ errors.UserError = &RedeclarationError{}
+var _ errors.UserError = RedeclarationError{}
 
 func (RedeclarationError) IsUserError() {}
 

--- a/interpreter/errors_test.go
+++ b/interpreter/errors_test.go
@@ -48,7 +48,7 @@ func TestErrorOutputIncludesLocationRage(t *testing.T) {
 	require.Equal(t,
 		Error{
 			Location: TestLocation,
-			Err: DereferenceError{
+			Err: &DereferenceError{
 				Cause: "the value being referenced has been destroyed or moved",
 				LocationRange: LocationRange{
 					Location: TestLocation,

--- a/interpreter/errors_test.go
+++ b/interpreter/errors_test.go
@@ -32,7 +32,7 @@ import (
 func TestOverwriteError_Error(t *testing.T) {
 
 	require.EqualError(t,
-		OverwriteError{
+		&OverwriteError{
 			Address: NewUnmeteredAddressValueFromBytes([]byte{0x1}),
 			Path: PathValue{
 				Domain:     common.PathDomainStorage,

--- a/interpreter/fixedpoint_test.go
+++ b/interpreter/fixedpoint_test.go
@@ -330,7 +330,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.UnderflowError{})
+		var underflowError *interpreter.UnderflowError
+		require.ErrorAs(t, err, &underflowError)
 	})
 
 	t.Run("invalid UFix64 > max Fix64 int to Fix64", func(t *testing.T) {
@@ -350,7 +351,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.OverflowError{})
+		var overflowError *interpreter.OverflowError
+		require.ErrorAs(t, err, &overflowError)
 	})
 
 	t.Run("invalid negative integer to UFix64", func(t *testing.T) {
@@ -379,7 +381,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 					err,
 				)
 
-				require.ErrorAs(t, err, &interpreter.UnderflowError{})
+				var underflowError *interpreter.UnderflowError
+				require.ErrorAs(t, err, &underflowError)
 			})
 		}
 	})
@@ -417,7 +420,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				_, err := inter.Invoke("test")
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.OverflowError{})
+				var overflowError *interpreter.OverflowError
+		require.ErrorAs(t, err, &overflowError)
 			})
 		}
 	})
@@ -454,7 +458,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				_, err := inter.Invoke("test")
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.OverflowError{})
+				var overflowError *interpreter.OverflowError
+		require.ErrorAs(t, err, &overflowError)
 			})
 		}
 	})
@@ -491,7 +496,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				_, err := inter.Invoke("test")
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.OverflowError{})
+				var overflowError *interpreter.OverflowError
+		require.ErrorAs(t, err, &overflowError)
 			})
 		}
 	})
@@ -528,7 +534,8 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				_, err := inter.Invoke("test")
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.UnderflowError{})
+				var underflowError *interpreter.UnderflowError
+				require.ErrorAs(t, err, &underflowError)
 			})
 		}
 	})

--- a/interpreter/fixedpoint_test.go
+++ b/interpreter/fixedpoint_test.go
@@ -416,7 +416,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				RequireError(t, err)
 
 				var overflowError *interpreter.OverflowError
-		require.ErrorAs(t, err, &overflowError)
+				require.ErrorAs(t, err, &overflowError)
 			})
 		}
 	})
@@ -454,7 +454,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				RequireError(t, err)
 
 				var overflowError *interpreter.OverflowError
-		require.ErrorAs(t, err, &overflowError)
+				require.ErrorAs(t, err, &overflowError)
 			})
 		}
 	})
@@ -492,7 +492,7 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				RequireError(t, err)
 
 				var overflowError *interpreter.OverflowError
-		require.ErrorAs(t, err, &overflowError)
+				require.ErrorAs(t, err, &overflowError)
 			})
 		}
 	})

--- a/interpreter/for_test.go
+++ b/interpreter/for_test.go
@@ -777,7 +777,7 @@ func TestInterpretStorageReferencesInForLoop(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 		var dereferenceError *interpreter.DereferenceError
-			require.ErrorAs(t, err, &dereferenceError)
+		require.ErrorAs(t, err, &dereferenceError)
 	})
 }
 

--- a/interpreter/for_test.go
+++ b/interpreter/for_test.go
@@ -460,7 +460,8 @@ func TestInterpretEphemeralReferencesInForLoop(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("Auth ref", func(t *testing.T) {
@@ -574,7 +575,8 @@ func TestInterpretEphemeralReferencesInForLoop(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.ContainerMutatedDuringIterationError{})
+		var containerMutationError *interpreter.ContainerMutatedDuringIterationError
+		require.ErrorAs(t, err, &containerMutationError)
 	})
 
 	t.Run("Mutating reference to struct array", func(t *testing.T) {
@@ -602,7 +604,8 @@ func TestInterpretEphemeralReferencesInForLoop(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		assert.ErrorAs(t, err, &interpreter.ContainerMutatedDuringIterationError{})
+		var containerMutationError *interpreter.ContainerMutatedDuringIterationError
+		require.ErrorAs(t, err, &containerMutationError)
 	})
 
 	t.Run("String ref", func(t *testing.T) {
@@ -773,7 +776,8 @@ func TestInterpretStorageReferencesInForLoop(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.DereferenceError{})
+		var dereferenceError *interpreter.DereferenceError
+			require.ErrorAs(t, err, &dereferenceError)
 	})
 }
 

--- a/interpreter/function_test.go
+++ b/interpreter/function_test.go
@@ -230,7 +230,8 @@ func TestInterpretResultVariable(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = inter.Invoke("getID")
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("reference invalidation, non optional", func(t *testing.T) {
@@ -289,7 +290,8 @@ func TestInterpretResultVariable(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = inter.Invoke("getID")
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 }
 
@@ -393,7 +395,7 @@ func TestInterpretGenericFunctionSubtyping(t *testing.T) {
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
 
-		var typeErr interpreter.ForceCastTypeMismatchError
+		var typeErr *interpreter.ForceCastTypeMismatchError
 		require.ErrorAs(t, err, &typeErr)
 	})
 }

--- a/interpreter/import_test.go
+++ b/interpreter/import_test.go
@@ -393,7 +393,7 @@ func TestInterpretResourceConstructionThroughIndirectImport(t *testing.T) {
 	_, err = inter.Invoke("test", rConstructor)
 	RequireError(t, err)
 
-	var resourceConstructionError interpreter.ResourceConstructionError
+	var resourceConstructionError *interpreter.ResourceConstructionError
 	require.ErrorAs(t, err, &resourceConstructionError)
 
 	assert.Equal(t,

--- a/interpreter/integers_test.go
+++ b/interpreter/integers_test.go
@@ -246,7 +246,8 @@ func TestInterpretAddressConversion(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.OverflowError{})
+		var overflowError *interpreter.OverflowError
+		require.ErrorAs(t, err, &overflowError)
 	})
 
 	t.Run("conversion function, underflow", func(t *testing.T) {
@@ -263,7 +264,8 @@ func TestInterpretAddressConversion(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.UnderflowError{})
+		var underflowError *interpreter.UnderflowError
+		require.ErrorAs(t, err, &underflowError)
 	})
 }
 
@@ -734,7 +736,14 @@ func TestInterpretIntegerConversion(t *testing.T) {
 						sema.Word256Type:
 					default:
 						t.Run("underflow", func(t *testing.T) {
-							test(t, sourceType, targetType, sourceValues.min, nil, interpreter.UnderflowError{})
+							test(
+								t,
+								sourceType,
+								targetType,
+								sourceValues.min,
+								nil,
+								&interpreter.UnderflowError{},
+							)
 						})
 					}
 				}
@@ -761,7 +770,14 @@ func TestInterpretIntegerConversion(t *testing.T) {
 						sema.Word256Type:
 					default:
 						t.Run("overflow", func(t *testing.T) {
-							test(t, sourceType, targetType, sourceValues.max, nil, interpreter.OverflowError{})
+							test(
+								t,
+								sourceType,
+								targetType,
+								sourceValues.max,
+								nil,
+								&interpreter.OverflowError{},
+							)
 						})
 					}
 				}
@@ -772,7 +788,14 @@ func TestInterpretIntegerConversion(t *testing.T) {
 
 				if sourceMaxInt != nil && (targetMaxInt == nil || sourceMaxInt.Cmp(targetMaxInt) < 0) {
 					t.Run("max", func(t *testing.T) {
-						test(t, sourceType, targetType, sourceValues.max, nil, nil)
+						test(
+							t,
+							sourceType,
+							targetType,
+							sourceValues.max,
+							nil,
+							nil,
+						)
 					})
 				}
 			})

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -946,7 +946,7 @@ func (interpreter *Interpreter) visitCondition(condition ast.Condition, kind ast
 			message = messageValue.(*StringValue).Str
 		}
 
-		panic(ConditionError{
+		panic(&ConditionError{
 			ConditionKind: kind,
 			Message:       message,
 			LocationRange: LocationRange{

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -4814,7 +4814,7 @@ func (interpreter *Interpreter) GetEntitlementType(typeID common.TypeID) (*sema.
 
 	ty := elaboration.EntitlementType(typeID)
 	if ty == nil {
-		return nil,TypeLoadingError{
+		return nil, TypeLoadingError{
 			TypeID: typeID,
 		}
 	}
@@ -4831,7 +4831,7 @@ func (interpreter *Interpreter) GetEntitlementMapType(typeID common.TypeID) (*se
 	if location == nil {
 		ty := sema.BuiltinEntitlementMappings[qualifiedIdentifier]
 		if ty == nil {
-			return nil,TypeLoadingError{
+			return nil, TypeLoadingError{
 				TypeID: typeID,
 			}
 		}
@@ -4841,14 +4841,14 @@ func (interpreter *Interpreter) GetEntitlementMapType(typeID common.TypeID) (*se
 
 	elaboration := interpreter.getElaboration(location)
 	if elaboration == nil {
-		return nil,TypeLoadingError{
+		return nil, TypeLoadingError{
 			TypeID: typeID,
 		}
 	}
 
 	ty := elaboration.EntitlementMapType(typeID)
 	if ty == nil {
-		return nil,TypeLoadingError{
+		return nil, TypeLoadingError{
 			TypeID: typeID,
 		}
 	}
@@ -5045,7 +5045,7 @@ func (interpreter *Interpreter) GetCompositeType(
 		}
 	}
 
-	return nil,TypeLoadingError{
+	return nil, TypeLoadingError{
 		TypeID: typeID,
 	}
 }
@@ -5085,14 +5085,14 @@ func (interpreter *Interpreter) GetInterfaceType(
 
 	elaboration := interpreter.getElaboration(location)
 	if elaboration == nil {
-		return nil,TypeLoadingError{
+		return nil, TypeLoadingError{
 			TypeID: typeID,
 		}
 	}
 
 	ty := elaboration.InterfaceType(typeID)
 	if ty == nil {
-		return nil,TypeLoadingError{
+		return nil, TypeLoadingError{
 			TypeID: typeID,
 		}
 	}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1419,7 +1419,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 				if compositeType.Kind == common.CompositeKindResource &&
 					invocationContext.GetLocation() != compositeType.Location {
 
-					panic(ResourceConstructionError{
+					panic(&ResourceConstructionError{
 						CompositeType: compositeType,
 						LocationRange: locationRange,
 					})
@@ -1444,7 +1444,7 @@ func (interpreter *Interpreter) declareNonEnumCompositeValue(
 
 					uuidHandler := config.UUIDHandler
 					if uuidHandler == nil {
-						panic(UUIDUnavailableError{
+						panic(&UUIDUnavailableError{
 							LocationRange: locationRange,
 						})
 					}
@@ -1914,7 +1914,7 @@ func TransferAndConvert(
 
 		resultSemaType := MustConvertStaticToSemaType(resultStaticType, context)
 
-		panic(ValueTransferTypeError{
+		panic(&ValueTransferTypeError{
 			ExpectedType:  targetType,
 			ActualType:    resultSemaType,
 			LocationRange: locationRange,
@@ -2346,7 +2346,7 @@ func shouldConvertReference(
 func checkMappedEntitlements(unwrappedTargetType *sema.ReferenceType, locationRange LocationRange) {
 	// check defensively that we never create a runtime mapped entitlement value
 	if _, isMappedAuth := unwrappedTargetType.Authorization.(*sema.EntitlementMapAccess); isMappedAuth {
-		panic(UnexpectedMappedEntitlementError{
+		panic(&UnexpectedMappedEntitlementError{
 			Type:          unwrappedTargetType,
 			LocationRange: locationRange,
 		})
@@ -4386,7 +4386,7 @@ func AccountStorageIterate(
 		// In order to be safe, we perform this check here to effectively enforce
 		// that users return `false` from their callback in all cases where storage is mutated.
 		if invocationContext.StorageMutatedDuringIteration() {
-			panic(StorageMutatedDuringIterationError{
+			panic(&StorageMutatedDuringIterationError{
 				LocationRange: locationRange,
 			})
 		}
@@ -4547,7 +4547,7 @@ func AccountStorageSave(
 
 	if StoredValueExists(context, address, domain, storageMapKey) {
 		panic(
-			OverwriteError{
+			&OverwriteError{
 				Address:       addressValue,
 				Path:          path,
 				LocationRange: locationRange,
@@ -4734,7 +4734,7 @@ func AccountStorageRead(
 	if !IsSubTypeOfSemaType(invocationContext, valueStaticType, typeParameter) {
 		valueSemaType := MustConvertStaticToSemaType(valueStaticType, invocationContext)
 
-		panic(ForceCastTypeMismatchError{
+		panic(&ForceCastTypeMismatchError{
 			ExpectedType:  typeParameter,
 			ActualType:    valueSemaType,
 			LocationRange: locationRange,
@@ -4927,7 +4927,7 @@ func (interpreter *Interpreter) GetEntitlementType(typeID common.TypeID) (*sema.
 
 	ty := elaboration.EntitlementType(typeID)
 	if ty == nil {
-		return nil, TypeLoadingError{
+		return nil,TypeLoadingError{
 			TypeID: typeID,
 		}
 	}
@@ -4944,7 +4944,7 @@ func (interpreter *Interpreter) GetEntitlementMapType(typeID common.TypeID) (*se
 	if location == nil {
 		ty := sema.BuiltinEntitlementMappings[qualifiedIdentifier]
 		if ty == nil {
-			return nil, TypeLoadingError{
+			return nil,TypeLoadingError{
 				TypeID: typeID,
 			}
 		}
@@ -4954,14 +4954,14 @@ func (interpreter *Interpreter) GetEntitlementMapType(typeID common.TypeID) (*se
 
 	elaboration := interpreter.getElaboration(location)
 	if elaboration == nil {
-		return nil, TypeLoadingError{
+		return nil,TypeLoadingError{
 			TypeID: typeID,
 		}
 	}
 
 	ty := elaboration.EntitlementMapType(typeID)
 	if ty == nil {
-		return nil, TypeLoadingError{
+		return nil,TypeLoadingError{
 			TypeID: typeID,
 		}
 	}
@@ -5158,7 +5158,7 @@ func (interpreter *Interpreter) GetCompositeType(
 		}
 	}
 
-	return nil, TypeLoadingError{
+	return nil,TypeLoadingError{
 		TypeID: typeID,
 	}
 }
@@ -5182,7 +5182,7 @@ func (interpreter *Interpreter) GetInterfaceType(
 		if interfaceType != nil {
 			return interfaceType, nil
 		}
-		return nil, InterfaceMissingLocationError{
+		return nil, &InterfaceMissingLocationError{
 			QualifiedIdentifier: qualifiedIdentifier,
 		}
 	}
@@ -5198,14 +5198,14 @@ func (interpreter *Interpreter) GetInterfaceType(
 
 	elaboration := interpreter.getElaboration(location)
 	if elaboration == nil {
-		return nil, TypeLoadingError{
+		return nil,TypeLoadingError{
 			TypeID: typeID,
 		}
 	}
 
 	ty := elaboration.InterfaceType(typeID)
 	if ty == nil {
-		return nil, TypeLoadingError{
+		return nil,TypeLoadingError{
 			TypeID: typeID,
 		}
 	}
@@ -5381,7 +5381,7 @@ func checkContainerMutation(
 	actualElementType := element.StaticType(context)
 
 	if !IsSubType(context, actualElementType, elementType) {
-		panic(ContainerMutationError{
+		panic(&ContainerMutationError{
 			ExpectedType:  MustConvertStaticToSemaType(elementType, context),
 			ActualType:    MustSemaTypeOfValue(element, context),
 			LocationRange: locationRange,
@@ -5675,7 +5675,7 @@ func (interpreter *Interpreter) startResourceTracking(
 	// resource variable that has not been invalidated properly.
 	// This should not be allowed, and must have been caught by the checker ideally.
 	if _, exists := interpreter.SharedState.resourceVariables[resourceKindedValue]; exists {
-		panic(InvalidatedResourceError{
+		panic(&InvalidatedResourceError{
 			LocationRange: LocationRange{
 				Location:    interpreter.Location,
 				HasPosition: hasPosition,
@@ -5710,7 +5710,7 @@ func (interpreter *Interpreter) checkInvalidatedResourceUse(
 	//
 	// Note: if the `resourceVariables` doesn't have a mapping, that implies an invalidated resource.
 	if existingVar, exists := interpreter.SharedState.resourceVariables[resourceKindedValue]; !exists || existingVar != variable {
-		panic(InvalidatedResourceError{
+		panic(&InvalidatedResourceError{
 			LocationRange: LocationRange{
 				Location:    interpreter.Location,
 				HasPosition: hasPosition,
@@ -5912,7 +5912,7 @@ func (interpreter *Interpreter) ValidateMutation(valueID atree.ValueID, location
 	if !present {
 		return
 	}
-	panic(ContainerMutatedDuringIterationError{
+	panic(&ContainerMutatedDuringIterationError{
 		LocationRange: locationRange,
 	})
 }
@@ -5941,7 +5941,7 @@ func (interpreter *Interpreter) EnforceNotResourceDestruction(
 ) {
 	_, exists := interpreter.SharedState.destroyedResources[valueID]
 	if exists {
-		panic(DestroyedResourceError{
+		panic(&DestroyedResourceError{
 			LocationRange: locationRange,
 		})
 	}
@@ -5981,7 +5981,7 @@ func checkResourceLoss(context ValueStaticTypeContext, value Value, locationRang
 	}
 
 	if !resourceKindedValue.isInvalidatedResource(context) {
-		panic(ResourceLossError{
+		panic(&ResourceLossError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/interpreter_expression.go
+++ b/interpreter/interpreter_expression.go
@@ -269,7 +269,7 @@ func (interpreter *Interpreter) memberExpressionGetterSetter(
 			}
 
 			if resultValue == nil && !allowMissing {
-				panic(UseBeforeInitializationError{
+				panic(&UseBeforeInitializationError{
 					Name:          identifier,
 					LocationRange: locationRange,
 				})
@@ -365,7 +365,7 @@ func (interpreter *Interpreter) checkMemberAccess(
 		if _, ok := targetStaticType.(*OptionalStaticType); !ok {
 			targetSemaType := MustConvertStaticToSemaType(targetStaticType, interpreter)
 
-			panic(MemberAccessTypeError{
+			panic(&MemberAccessTypeError{
 				ExpectedType:  expectedType,
 				ActualType:    targetSemaType,
 				LocationRange: locationRange,
@@ -376,7 +376,7 @@ func (interpreter *Interpreter) checkMemberAccess(
 	if !IsSubTypeOfSemaType(interpreter, targetStaticType, expectedType) {
 		targetSemaType := MustConvertStaticToSemaType(targetStaticType, interpreter)
 
-		panic(MemberAccessTypeError{
+		panic(&MemberAccessTypeError{
 			ExpectedType:  expectedType,
 			ActualType:    targetSemaType,
 			LocationRange: locationRange,
@@ -423,13 +423,13 @@ func CheckInvalidatedResourceOrResourceReference(
 	switch value := value.(type) {
 	case ResourceKindedValue:
 		if value.isInvalidatedResource(context) {
-			panic(InvalidatedResourceError{
+			panic(&InvalidatedResourceError{
 				LocationRange: locationRange,
 			})
 		}
 	case *EphemeralReferenceValue:
 		if value.Value == nil {
-			panic(InvalidatedResourceReferenceError{
+			panic(&InvalidatedResourceReferenceError{
 				LocationRange: locationRange,
 			})
 		} else {
@@ -461,7 +461,7 @@ func (interpreter *Interpreter) VisitBinaryExpression(expression *ast.BinaryExpr
 	}
 
 	error := func(right Value) {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     expression.Operation,
 			LeftType:      leftValue.StaticType(interpreter),
 			RightType:     right.StaticType(interpreter),
@@ -679,7 +679,7 @@ func (interpreter *Interpreter) testComparison(left, right Value, expression *as
 	rightComparable, rightOk := right.(ComparableValue)
 
 	if !leftOk || !rightOk {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     expression.Operation,
 			LeftType:      left.StaticType(interpreter),
 			RightType:     right.StaticType(interpreter),
@@ -1373,7 +1373,7 @@ func (interpreter *Interpreter) VisitCastingExpression(expression *ast.CastingEx
 					HasPosition: expression.Expression,
 				}
 
-				panic(ForceCastTypeMismatchError{
+				panic(&ForceCastTypeMismatchError{
 					ExpectedType:  expectedType,
 					ActualType:    valueSemaType,
 					LocationRange: locationRange,
@@ -1510,7 +1510,7 @@ func CreateReferenceValue(
 		case NilValue:
 			// Case (3.b) value is nil.
 			// Since the resulting type can NOT accommodate a nil (non-optional reference), error-out.
-			panic(NonOptionalReferenceToNilError{
+			panic(&NonOptionalReferenceToNilError{
 				ReferenceType: typ,
 				LocationRange: locationRange,
 			})
@@ -1525,7 +1525,7 @@ func CreateReferenceValue(
 				// result reference type is unauthorized
 				staticType := value.StaticType(context)
 				if typ.Authorization != sema.UnauthorizedAccess || !IsSubTypeOfSemaType(context, staticType, typ) {
-					panic(InvalidMemberReferenceError{
+					panic(&InvalidMemberReferenceError{
 						ExpectedType:  typ,
 						ActualType:    MustConvertStaticToSemaType(staticType, context),
 						LocationRange: locationRange,
@@ -1573,7 +1573,7 @@ func (interpreter *Interpreter) VisitForceExpression(expression *ast.ForceExpres
 
 	case NilValue:
 		panic(
-			ForceNilError{
+			&ForceNilError{
 				LocationRange: LocationRange{
 					Location:    interpreter.Location,
 					HasPosition: expression,
@@ -1611,14 +1611,14 @@ func (interpreter *Interpreter) VisitAttachExpression(attachExpression *ast.Atta
 
 	// we enforce this in the checker, but check defensively anyway
 	if !ok || !base.Kind.SupportsAttachments() {
-		panic(InvalidAttachmentOperationTargetError{
+		panic(&InvalidAttachmentOperationTargetError{
 			Value:         attachTarget,
 			LocationRange: locationRange,
 		})
 	}
 
 	if inIteration := interpreter.SharedState.inAttachmentIteration(base); inIteration {
-		panic(AttachmentIterationMutationError{
+		panic(&AttachmentIterationMutationError{
 			Value:         base,
 			LocationRange: locationRange,
 		})

--- a/interpreter/interpreter_statement.go
+++ b/interpreter/interpreter_statement.go
@@ -369,7 +369,7 @@ func (interpreter *Interpreter) EmitEvent(
 
 	onEventEmitted := config.OnEventEmitted
 	if onEventEmitted == nil {
-		panic(EventEmissionUnavailableError{
+		panic(&EventEmissionUnavailableError{
 			LocationRange: locationRange,
 		})
 	}
@@ -442,14 +442,14 @@ func (interpreter *Interpreter) VisitRemoveStatement(removeStatement *ast.Remove
 
 	// we enforce this in the checker, but check defensively anyways
 	if !ok || !base.Kind.SupportsAttachments() {
-		panic(InvalidAttachmentOperationTargetError{
+		panic(&InvalidAttachmentOperationTargetError{
 			Value:         removeTarget,
 			LocationRange: locationRange,
 		})
 	}
 
 	if inIteration := interpreter.SharedState.inAttachmentIteration(base); inIteration {
-		panic(AttachmentIterationMutationError{
+		panic(&AttachmentIterationMutationError{
 			Value:         base,
 			LocationRange: locationRange,
 		})
@@ -648,7 +648,7 @@ func (interpreter *Interpreter) checkSwapValue(value Value, expression ast.Expre
 	}
 
 	if expression, ok := expression.(*ast.MemberExpression); ok {
-		panic(UseBeforeInitializationError{
+		panic(&UseBeforeInitializationError{
 			Name: expression.Identifier.Identifier,
 			LocationRange: LocationRange{
 				Location:    interpreter.Location,

--- a/interpreter/invocation_test.go
+++ b/interpreter/invocation_test.go
@@ -44,7 +44,8 @@ func TestInterpretFunctionInvocationCheckArgumentTypes(t *testing.T) {
 	_, err := inter.Invoke("test", interpreter.TrueValue)
 	RequireError(t, err)
 
-	require.ErrorAs(t, err, &interpreter.ValueTransferTypeError{})
+	var transferTypeError *interpreter.ValueTransferTypeError
+	require.ErrorAs(t, err, &transferTypeError)
 }
 
 func TestInterpretSelfDeclaration(t *testing.T) {
@@ -169,5 +170,6 @@ func TestInterpretRejectUnboxedInvocation(t *testing.T) {
 	)
 	RequireError(t, err)
 
-	require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+	var memberAccessTypeError *interpreter.MemberAccessTypeError
+	require.ErrorAs(t, err, &memberAccessTypeError)
 }

--- a/interpreter/member_test.go
+++ b/interpreter/member_test.go
@@ -113,12 +113,12 @@ func TestInterpretMemberAccessType(t *testing.T) {
 				_, err = inter.Invoke("get", value)
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+				var memberAccessTypeError *interpreter.MemberAccessTypeError
+				require.ErrorAs(t, err, &memberAccessTypeError)
 
 				_, err = inter.Invoke("set", value)
 				RequireError(t, err)
-
-				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+				require.ErrorAs(t, err, &memberAccessTypeError)
 			})
 		})
 
@@ -193,7 +193,8 @@ func TestInterpretMemberAccessType(t *testing.T) {
 				)
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+				var memberAccessTypeError *interpreter.MemberAccessTypeError
+				require.ErrorAs(t, err, &memberAccessTypeError)
 			})
 		})
 	})
@@ -284,12 +285,12 @@ func TestInterpretMemberAccessType(t *testing.T) {
 				_, err = inter.Invoke("get", value)
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+				var memberAccessTypeError *interpreter.MemberAccessTypeError
+				require.ErrorAs(t, err, &memberAccessTypeError)
 
 				_, err = inter.Invoke("set", value)
 				RequireError(t, err)
-
-				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+				require.ErrorAs(t, err, &memberAccessTypeError)
 			})
 		})
 
@@ -372,7 +373,8 @@ func TestInterpretMemberAccessType(t *testing.T) {
 				)
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+				var memberAccessTypeError *interpreter.MemberAccessTypeError
+				require.ErrorAs(t, err, &memberAccessTypeError)
 			})
 		})
 	})
@@ -475,12 +477,12 @@ func TestInterpretMemberAccessType(t *testing.T) {
 				_, err = inter.Invoke("get", ref)
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+				var memberAccessTypeError *interpreter.MemberAccessTypeError
+				require.ErrorAs(t, err, &memberAccessTypeError)
 
 				_, err = inter.Invoke("set", ref)
 				RequireError(t, err)
-
-				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+				require.ErrorAs(t, err, &memberAccessTypeError)
 			})
 		})
 
@@ -579,7 +581,8 @@ func TestInterpretMemberAccessType(t *testing.T) {
 				)
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.MemberAccessTypeError{})
+				var memberAccessTypeError *interpreter.MemberAccessTypeError
+				require.ErrorAs(t, err, &memberAccessTypeError)
 			})
 		})
 	})
@@ -725,7 +728,9 @@ func TestInterpretMemberAccess(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.NonOptionalReferenceToNilError{})
+
+		var referenceToNilError *interpreter.NonOptionalReferenceToNilError
+		require.ErrorAs(t, err, &referenceToNilError)
 	})
 
 	t.Run("composite reference, primitive field", func(t *testing.T) {
@@ -1251,7 +1256,8 @@ func TestInterpretNestedReferenceMemberAccess(t *testing.T) {
         `)
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidMemberReferenceError{})
+		var invalidMemberReferenceError *interpreter.InvalidMemberReferenceError
+		require.ErrorAs(t, err, &invalidMemberReferenceError)
 	})
 
 	t.Run("field", func(t *testing.T) {
@@ -1277,7 +1283,8 @@ func TestInterpretNestedReferenceMemberAccess(t *testing.T) {
         `)
 
 		_, err := inter.Invoke("test")
-		require.ErrorAs(t, err, &interpreter.InvalidMemberReferenceError{})
+		var invalidMemberReferenceError *interpreter.InvalidMemberReferenceError
+		require.ErrorAs(t, err, &invalidMemberReferenceError)
 	})
 
 	t.Run("referenceArray", func(t *testing.T) {

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -754,7 +754,7 @@ func TestInterpretInvalidStringIndexing(t *testing.T) {
 			_, err := inter.Invoke("test", indexValue)
 			RequireError(t, err)
 
-			var indexErr interpreter.StringIndexOutOfBoundsError
+			var indexErr *interpreter.StringIndexOutOfBoundsError
 			require.ErrorAs(t, err, &indexErr)
 
 			assert.Equal(t, index, indexErr.Index)
@@ -841,7 +841,7 @@ func TestInterpretStringSlicing(t *testing.T) {
 		{"abcdef", 1, 6, "bcdef", nil},
 		// Invalid indices
 		{"abcdef", -1, 0, "", func(t *testing.T, err error) {
-			var sliceErr interpreter.StringSliceIndicesError
+			var sliceErr *interpreter.StringSliceIndicesError
 			require.ErrorAs(t, err, &sliceErr)
 
 			assert.Equal(t, -1, sliceErr.FromIndex)
@@ -857,7 +857,7 @@ func TestInterpretStringSlicing(t *testing.T) {
 			)
 		}},
 		{"abcdef", 0, -1, "", func(t *testing.T, err error) {
-			var sliceErr interpreter.StringSliceIndicesError
+			var sliceErr *interpreter.StringSliceIndicesError
 			require.ErrorAs(t, err, &sliceErr)
 
 			assert.Equal(t, 0, sliceErr.FromIndex)
@@ -873,7 +873,7 @@ func TestInterpretStringSlicing(t *testing.T) {
 			)
 		}},
 		{"abcdef", 0, 10, "", func(t *testing.T, err error) {
-			var sliceErr interpreter.StringSliceIndicesError
+			var sliceErr *interpreter.StringSliceIndicesError
 			require.ErrorAs(t, err, &sliceErr)
 
 			assert.Equal(t, 0, sliceErr.FromIndex)
@@ -889,7 +889,7 @@ func TestInterpretStringSlicing(t *testing.T) {
 			)
 		}},
 		{"abcdef", 2, 1, "", func(t *testing.T, err error) {
-			var indexErr interpreter.InvalidSliceIndexError
+			var indexErr *interpreter.InvalidSliceIndexError
 			require.ErrorAs(t, err, &indexErr)
 
 			assert.Equal(t, 2, indexErr.FromIndex)
@@ -5833,7 +5833,7 @@ func TestInterpretArraySlicing(t *testing.T) {
 		{"[1, 2, 3, 4, 5, 6]", 1, 6, "[2, 3, 4, 5, 6]", nil},
 		// Invalid indices
 		{"[1, 2, 3, 4, 5, 6]", -1, 0, "", func(t *testing.T, err error) {
-			var sliceErr interpreter.ArraySliceIndicesError
+			var sliceErr *interpreter.ArraySliceIndicesError
 			require.ErrorAs(t, err, &sliceErr)
 
 			assert.Equal(t, -1, sliceErr.FromIndex)
@@ -5849,7 +5849,7 @@ func TestInterpretArraySlicing(t *testing.T) {
 			)
 		}},
 		{"[1, 2, 3, 4, 5, 6]", 0, -1, "", func(t *testing.T, err error) {
-			var sliceErr interpreter.ArraySliceIndicesError
+			var sliceErr *interpreter.ArraySliceIndicesError
 			require.ErrorAs(t, err, &sliceErr)
 
 			assert.Equal(t, 0, sliceErr.FromIndex)
@@ -5865,7 +5865,7 @@ func TestInterpretArraySlicing(t *testing.T) {
 			)
 		}},
 		{"[1, 2, 3, 4, 5, 6]", 0, 10, "", func(t *testing.T, err error) {
-			var sliceErr interpreter.ArraySliceIndicesError
+			var sliceErr *interpreter.ArraySliceIndicesError
 			require.ErrorAs(t, err, &sliceErr)
 
 			assert.Equal(t, 0, sliceErr.FromIndex)
@@ -5881,7 +5881,7 @@ func TestInterpretArraySlicing(t *testing.T) {
 			)
 		}},
 		{"[1, 2, 3, 4, 5, 6]", 2, 1, "", func(t *testing.T, err error) {
-			var indexErr interpreter.InvalidSliceIndexError
+			var indexErr *interpreter.InvalidSliceIndexError
 			require.ErrorAs(t, err, &indexErr)
 
 			assert.Equal(t, 2, indexErr.FromIndex)
@@ -8863,7 +8863,8 @@ func TestInterpretNonStorageReferenceToOptional(t *testing.T) {
 		_, err := inter.Invoke("testNil")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.ForceNilError{})
+		var forceNilError *interpreter.ForceNilError
+		require.ErrorAs(t, err, &forceNilError)
 	})
 }
 
@@ -9241,7 +9242,8 @@ func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.ResourceLossError{})
+		var resourceLossError *interpreter.ResourceLossError
+		require.ErrorAs(t, err, &resourceLossError)
 	})
 
 	t.Run("existing to nil", func(t *testing.T) {
@@ -9277,7 +9279,8 @@ func TestInterpretResourceAssignmentForceTransfer(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.ResourceLossError{})
+		var resourceLossError *interpreter.ResourceLossError
+		require.ErrorAs(t, err, &resourceLossError)
 	})
 
 	t.Run("force-assignment initialization", func(t *testing.T) {
@@ -9369,7 +9372,8 @@ func TestInterpretForce(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.ForceNilError{})
+		var forceNilError *interpreter.ForceNilError
+		require.ErrorAs(t, err, &forceNilError)
 	})
 
 	t.Run("nil, AnyStruct", func(t *testing.T) {
@@ -9388,7 +9392,8 @@ func TestInterpretForce(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.ForceNilError{})
+		var forceNilError *interpreter.ForceNilError
+		require.ErrorAs(t, err, &forceNilError)
 	})
 
 	t.Run("non-optional", func(t *testing.T) {
@@ -9978,7 +9983,7 @@ func TestInterpretMissingMember(t *testing.T) {
 	_, err := inter.Invoke("test")
 	RequireError(t, err)
 
-	var missingMemberError interpreter.UseBeforeInitializationError
+	var missingMemberError *interpreter.UseBeforeInitializationError
 	require.ErrorAs(t, err, &missingMemberError)
 
 	require.Equal(t, "y", missingMemberError.Name)
@@ -11983,7 +11988,8 @@ func TestInterpretDictionaryDuplicateKey(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.DuplicateKeyInResourceDictionaryError{})
+		var duplicateKeyError *interpreter.DuplicateKeyInResourceDictionaryError
+		require.ErrorAs(t, err, &duplicateKeyError)
 	})
 
 	t.Run("resource", func(t *testing.T) {
@@ -12007,7 +12013,8 @@ func TestInterpretDictionaryDuplicateKey(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.ResourceLossError{})
+		var resourceLossError *interpreter.ResourceLossError
+		require.ErrorAs(t, err, &resourceLossError)
 	})
 }
 
@@ -12477,7 +12484,8 @@ func TestInterpretSwapDictionaryKeysWithSideEffects(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		assert.ErrorAs(t, err, &interpreter.UseBeforeInitializationError{})
+		var initializationError *interpreter.UseBeforeInitializationError
+		require.ErrorAs(t, err, &initializationError)
 
 		require.Empty(t, getEvents())
 	})

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -8732,7 +8732,7 @@ func TestInterpretConformToImportedInterface(t *testing.T) {
 	interpreterErr := err.(interpreter.Error)
 
 	require.IsType(t,
-		interpreter.ConditionError{},
+		&interpreter.ConditionError{},
 		interpreterErr.Err,
 	)
 }

--- a/interpreter/range_value_test.go
+++ b/interpreter/range_value_test.go
@@ -524,7 +524,7 @@ func TestInclusiveRangeConstructionInvalid(t *testing.T) {
 
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, expectedError)
+			require.ErrorAs(t, err, &expectedError)
 			require.True(t, strings.Contains(err.Error(), expectedMessage))
 		})
 	}

--- a/interpreter/reference_test.go
+++ b/interpreter/reference_test.go
@@ -127,7 +127,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var containerMutationErr interpreter.ContainerMutationError
+		var containerMutationErr *interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationErr)
 	})
 
@@ -161,7 +161,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var containerMutationErr interpreter.ContainerMutationError
+		var containerMutationErr *interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationErr)
 	})
 
@@ -200,7 +200,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var containerMutationError interpreter.ContainerMutationError
+		var containerMutationError *interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
 	})
 
@@ -238,7 +238,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var containerMutationError interpreter.ContainerMutationError
+		var containerMutationError *interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
 	})
 
@@ -282,7 +282,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var containerMutationError interpreter.ContainerMutationError
+		var containerMutationError *interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
 	})
 
@@ -324,7 +324,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var containerMutationError interpreter.ContainerMutationError
+		var containerMutationError *interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
 	})
 
@@ -352,7 +352,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var containerMutationError interpreter.ContainerMutationError
+		var containerMutationError *interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
 	})
 
@@ -382,7 +382,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var containerMutationError interpreter.ContainerMutationError
+		var containerMutationError *interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
 	})
 
@@ -406,7 +406,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var containerMutationError interpreter.ContainerMutationError
+		var containerMutationError *interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
 	})
 
@@ -430,7 +430,7 @@ func TestInterpretContainerVariance(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var containerMutationError interpreter.ContainerMutationError
+		var containerMutationError *interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &containerMutationError)
 	})
 }
@@ -565,7 +565,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("stack to account readonly", func(t *testing.T) {
@@ -596,7 +597,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("account to stack", func(t *testing.T) {
@@ -662,7 +664,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("test", arrayRef)
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("stack to stack", func(t *testing.T) {
@@ -705,7 +708,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("one account to another account", func(t *testing.T) {
@@ -795,7 +799,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("test", arrayRef1, arrayRef2)
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("account to stack to same account", func(t *testing.T) {
@@ -868,7 +873,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("test", arrayRef)
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("account to stack storage reference", func(t *testing.T) {
@@ -904,7 +910,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.DereferenceError{})
+		var dereferenceError *interpreter.DereferenceError
+			require.ErrorAs(t, err, &dereferenceError)
 	})
 
 	t.Run("multiple references with moves", func(t *testing.T) {
@@ -998,12 +1005,13 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 		// First reference must be invalid
 		_, err = inter.Invoke("getRef1Id")
 		RequireError(t, err)
-		assert.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		assert.ErrorAs(t, err, &invalidatedResourceReferenceError)
 
 		// Second reference must be invalid
 		_, err = inter.Invoke("getRef2Id")
 		RequireError(t, err)
-		assert.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		assert.ErrorAs(t, err, &invalidatedResourceReferenceError)
 
 		// Third reference must be valid
 		result, err := inter.Invoke("getRef3Id")
@@ -1058,7 +1066,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("ref target is field", func(t *testing.T) {
@@ -1102,7 +1111,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("resource is array element", func(t *testing.T) {
@@ -1141,7 +1151,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("resource is dictionary entry", func(t *testing.T) {
@@ -1180,7 +1191,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("nested resource in composite", func(t *testing.T) {
@@ -1234,7 +1246,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("nested resource in dictionary", func(t *testing.T) {
@@ -1267,7 +1280,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("nested resource in array", func(t *testing.T) {
@@ -1300,7 +1314,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("nested optional resource", func(t *testing.T) {
@@ -1345,7 +1360,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("reference created by field access", func(t *testing.T) {
@@ -1391,7 +1407,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("reference created by index access", func(t *testing.T) {
@@ -1430,7 +1447,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("reference created by field and index access", func(t *testing.T) {
@@ -1476,7 +1494,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("downcasted reference", func(t *testing.T) {
@@ -1511,7 +1530,8 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 }
 
@@ -1558,7 +1578,8 @@ func TestInterpretResourceReferenceInvalidationOnDestroy(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("ref source is field", func(t *testing.T) {
@@ -1601,7 +1622,8 @@ func TestInterpretResourceReferenceInvalidationOnDestroy(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 
 	})
 }
@@ -1647,7 +1669,8 @@ func TestInterpretReferenceTrackingOnInvocation(t *testing.T) {
 	_, err := inter.Invoke("main")
 	RequireError(t, err)
 
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 func TestInterpretInvalidReferenceToOptionalConfusion(t *testing.T) {
@@ -1671,7 +1694,8 @@ func TestInterpretInvalidReferenceToOptionalConfusion(t *testing.T) {
 	_, err := inter.Invoke("main")
 	RequireError(t, err)
 
-	require.ErrorAs(t, err, &interpreter.NonOptionalReferenceToNilError{})
+	var referenceToNilError *interpreter.NonOptionalReferenceToNilError
+		require.ErrorAs(t, err, &referenceToNilError)
 }
 
 func TestInterpretReferenceToOptional(t *testing.T) {
@@ -1690,7 +1714,8 @@ func TestInterpretReferenceToOptional(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.NonOptionalReferenceToNilError{})
+		var referenceToNilError *interpreter.NonOptionalReferenceToNilError
+		require.ErrorAs(t, err, &referenceToNilError)
 	})
 
 	t.Run("nil in optional", func(t *testing.T) {
@@ -1742,7 +1767,8 @@ func TestInterpretInvalidatedReferenceToOptional(t *testing.T) {
 	_, err := inter.Invoke("main")
 	RequireError(t, err)
 
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 func TestInterpretReferenceToReference(t *testing.T) {
@@ -1768,7 +1794,8 @@ func TestInterpretReferenceToReference(t *testing.T) {
 		_, err = inter.Invoke("main")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.NestedReferenceError{})
+		var nestedReferenceError *interpreter.NestedReferenceError
+		require.ErrorAs(t, err, &nestedReferenceError)
 	})
 
 	t.Run("upcast to anystruct", func(t *testing.T) {
@@ -1785,7 +1812,8 @@ func TestInterpretReferenceToReference(t *testing.T) {
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.NestedReferenceError{})
+		var nestedReferenceError *interpreter.NestedReferenceError
+		require.ErrorAs(t, err, &nestedReferenceError)
 	})
 
 	t.Run("optional", func(t *testing.T) {
@@ -1808,7 +1836,8 @@ func TestInterpretReferenceToReference(t *testing.T) {
 		_, err = inter.Invoke("main")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.NestedReferenceError{})
+		var nestedReferenceError *interpreter.NestedReferenceError
+		require.ErrorAs(t, err, &nestedReferenceError)
 	})
 
 	t.Run("upcast to optional anystruct", func(t *testing.T) {
@@ -1825,7 +1854,8 @@ func TestInterpretReferenceToReference(t *testing.T) {
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.NestedReferenceError{})
+		var nestedReferenceError *interpreter.NestedReferenceError
+		require.ErrorAs(t, err, &nestedReferenceError)
 	})
 
 	t.Run("reference to storage reference", func(t *testing.T) {
@@ -1850,7 +1880,8 @@ func TestInterpretReferenceToReference(t *testing.T) {
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.NestedReferenceError{})
+		var nestedReferenceError *interpreter.NestedReferenceError
+		require.ErrorAs(t, err, &nestedReferenceError)
 	})
 
 	t.Run("nested optional reference as AnyStruct", func(t *testing.T) {
@@ -1869,7 +1900,8 @@ func TestInterpretReferenceToReference(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.NestedReferenceError{})
+		var nestedReferenceError *interpreter.NestedReferenceError
+		require.ErrorAs(t, err, &nestedReferenceError)
 	})
 }
 
@@ -3063,7 +3095,8 @@ func TestInterpretDereference(t *testing.T) {
 			_, err = inter.Invoke("main")
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.ResourceReferenceDereferenceError{})
+			var dereferenceError *interpreter.ResourceReferenceDereferenceError
+			require.ErrorAs(t, err, &dereferenceError)
 		})
 
 		t.Run("array", func(t *testing.T) {
@@ -3094,7 +3127,8 @@ func TestInterpretDereference(t *testing.T) {
 			_, err = inter.Invoke("main")
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.ResourceReferenceDereferenceError{})
+			var dereferenceError *interpreter.ResourceReferenceDereferenceError
+			require.ErrorAs(t, err, &dereferenceError)
 		})
 	})
 
@@ -3142,7 +3176,7 @@ func TestInterpretOptionalReference(t *testing.T) {
 		_, err := inter.Invoke("absent")
 		RequireError(t, err)
 
-		var forceNilError interpreter.ForceNilError
+		var forceNilError *interpreter.ForceNilError
 		require.ErrorAs(t, err, &forceNilError)
 	})
 
@@ -3190,7 +3224,7 @@ func TestInterpretHostFunctionReferenceInvalidation(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		invalidatedRefError := interpreter.InvalidatedResourceReferenceError{}
+		var invalidatedRefError *interpreter.InvalidatedResourceReferenceError
 		assert.ErrorAs(t, err, &invalidatedRefError)
 	})
 
@@ -3266,7 +3300,7 @@ func TestInterpretHostFunctionReferenceInvalidation(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		invalidatedRefError := interpreter.InvalidatedResourceReferenceError{}
+		var invalidatedRefError *interpreter.InvalidatedResourceReferenceError
 		assert.ErrorAs(t, err, &invalidatedRefError)
 	})
 
@@ -3474,7 +3508,8 @@ func TestInterpretCreatingCircularDependentResource(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		assert.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		assert.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("resource field", func(t *testing.T) {
@@ -3508,6 +3543,7 @@ func TestInterpretCreatingCircularDependentResource(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		assert.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		assert.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 }

--- a/interpreter/reference_test.go
+++ b/interpreter/reference_test.go
@@ -911,7 +911,7 @@ func TestInterpretResourceReferenceInvalidationOnMove(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 		var dereferenceError *interpreter.DereferenceError
-			require.ErrorAs(t, err, &dereferenceError)
+		require.ErrorAs(t, err, &dereferenceError)
 	})
 
 	t.Run("multiple references with moves", func(t *testing.T) {
@@ -1670,7 +1670,7 @@ func TestInterpretReferenceTrackingOnInvocation(t *testing.T) {
 	RequireError(t, err)
 
 	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
-		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
+	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 func TestInterpretInvalidReferenceToOptionalConfusion(t *testing.T) {
@@ -1695,7 +1695,7 @@ func TestInterpretInvalidReferenceToOptionalConfusion(t *testing.T) {
 	RequireError(t, err)
 
 	var referenceToNilError *interpreter.NonOptionalReferenceToNilError
-		require.ErrorAs(t, err, &referenceToNilError)
+	require.ErrorAs(t, err, &referenceToNilError)
 }
 
 func TestInterpretReferenceToOptional(t *testing.T) {
@@ -1768,7 +1768,7 @@ func TestInterpretInvalidatedReferenceToOptional(t *testing.T) {
 	RequireError(t, err)
 
 	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
-		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
+	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 func TestInterpretReferenceToReference(t *testing.T) {

--- a/interpreter/resources_test.go
+++ b/interpreter/resources_test.go
@@ -333,7 +333,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
@@ -379,7 +379,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
@@ -425,7 +425,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
@@ -471,7 +471,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
@@ -514,7 +514,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
@@ -554,7 +554,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
@@ -594,7 +594,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
@@ -634,7 +634,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
@@ -676,7 +676,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
@@ -717,7 +717,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
@@ -755,7 +755,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
@@ -788,7 +788,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
@@ -821,7 +821,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 			})
 
@@ -852,7 +852,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
@@ -903,7 +903,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
@@ -948,7 +948,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
@@ -993,7 +993,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
@@ -1038,7 +1038,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 19, invalidatedResourceErr.StartPosition().Line)
@@ -1079,7 +1079,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
@@ -1117,7 +1117,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
@@ -1155,7 +1155,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
@@ -1193,7 +1193,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
@@ -1234,7 +1234,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
@@ -1274,7 +1274,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 13, invalidatedResourceErr.StartPosition().Line)
@@ -1312,7 +1312,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
@@ -1344,7 +1344,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
@@ -1376,7 +1376,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
@@ -1408,7 +1408,7 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 				_, err = inter.Invoke("test")
 				RequireError(t, err)
 
-				var invalidatedResourceErr interpreter.InvalidatedResourceError
+				var invalidatedResourceErr *interpreter.InvalidatedResourceError
 				require.ErrorAs(t, err, &invalidatedResourceErr)
 
 				assert.Equal(t, 7, invalidatedResourceErr.StartPosition().Line)
@@ -1442,7 +1442,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+		var invalidatedResourceError *interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceError)
 	})
 
 	t.Run("in reference expression", func(t *testing.T) {
@@ -1471,7 +1472,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+		var invalidatedResourceError *interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceError)
 	})
 
 	t.Run("in conditional expression", func(t *testing.T) {
@@ -1508,7 +1510,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+		var invalidatedResourceError *interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceError)
 	})
 
 	t.Run("in force expression", func(t *testing.T) {
@@ -1537,7 +1540,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+		var invalidatedResourceError *interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceError)
 	})
 
 	t.Run("in destroy expression", func(t *testing.T) {
@@ -1565,7 +1569,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+		var invalidatedResourceError *interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceError)
 	})
 
 	t.Run("in function invocation expression", func(t *testing.T) {
@@ -1597,7 +1602,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+		var invalidatedResourceError *interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceError)
 	})
 
 	t.Run("in array expression", func(t *testing.T) {
@@ -1626,7 +1632,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+		var invalidatedResourceError *interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceError)
 	})
 
 	t.Run("in dictionary expression", func(t *testing.T) {
@@ -1655,7 +1662,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+		var invalidatedResourceError *interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceError)
 	})
 
 	t.Run("with inner conditional expression", func(t *testing.T) {
@@ -1688,7 +1696,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+		var invalidatedResourceError *interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceError)
 	})
 
 	t.Run("force move", func(t *testing.T) {
@@ -1721,7 +1730,8 @@ func TestInterpretInvalidatedResourceValidation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+		var invalidatedResourceError *interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceError)
 	})
 }
 
@@ -1753,7 +1763,8 @@ func TestInterpretResourceInvalidationWithConditionalExprInDestroy(t *testing.T)
 	_, err = inter.Invoke("test")
 	RequireError(t, err)
 
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+	var invalidatedResourceError *interpreter.InvalidatedResourceError
+	require.ErrorAs(t, err, &invalidatedResourceError)
 }
 
 func TestInterpretResourceUseAfterInvalidation(t *testing.T) {
@@ -1795,7 +1806,7 @@ func TestInterpretResourceUseAfterInvalidation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		invalidatedResourceError := interpreter.InvalidatedResourceError{}
+		var invalidatedResourceError *interpreter.InvalidatedResourceError
 		require.ErrorAs(t, err, &invalidatedResourceError)
 
 		// error must be thrown at field access
@@ -1832,7 +1843,8 @@ func TestInterpretResourceUseAfterInvalidation(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+		var invalidatedResourceError *interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceError)
 	})
 }
 
@@ -1894,7 +1906,8 @@ func TestInterpreterResourcePostCondition(t *testing.T) {
 
 	_, err := inter.Invoke("test")
 	RequireError(t, err)
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+	var invalidatedResourceError *interpreter.InvalidatedResourceError
+	require.ErrorAs(t, err, &invalidatedResourceError)
 }
 
 func TestInterpreterResourcePreAndPostCondition(t *testing.T) {
@@ -1934,7 +1947,8 @@ func TestInterpreterResourcePreAndPostCondition(t *testing.T) {
 
 	_, err := inter.Invoke("test")
 	RequireError(t, err)
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+	var invalidatedResourceError *interpreter.InvalidatedResourceError
+	require.ErrorAs(t, err, &invalidatedResourceError)
 }
 
 func TestInterpreterResourceConditionAdditionalParam(t *testing.T) {
@@ -2056,7 +2070,8 @@ func TestInterpreterResourceDoubleWrappedPostCondition(t *testing.T) {
 
 	_, err := inter.Invoke("test")
 	RequireError(t, err)
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+	var invalidatedResourceError *interpreter.InvalidatedResourceError
+	require.ErrorAs(t, err, &invalidatedResourceError)
 }
 
 func TestInterpretOptionalResourceReference(t *testing.T) {
@@ -2088,7 +2103,8 @@ func TestInterpretOptionalResourceReference(t *testing.T) {
 
 	_, err := inter.Invoke("test")
 	RequireError(t, err)
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 func TestInterpretArrayOptionalResourceReference(t *testing.T) {
@@ -2120,7 +2136,8 @@ func TestInterpretArrayOptionalResourceReference(t *testing.T) {
 
 	_, err := inter.Invoke("test")
 	RequireError(t, err)
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 func TestInterpretResourceDestroyedInPreCondition(t *testing.T) {
@@ -2171,7 +2188,8 @@ func TestInterpretResourceDestroyedInPreCondition(t *testing.T) {
 	_, err = inter.Invoke("test")
 	RequireError(t, err)
 
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+	var invalidatedResourceError *interpreter.InvalidatedResourceError
+	require.ErrorAs(t, err, &invalidatedResourceError)
 }
 
 func TestInterpretResourceFunctionReferenceValidity(t *testing.T) {
@@ -2963,7 +2981,8 @@ func TestInterpretNestedSwap(t *testing.T) {
 	_, err = inter.Invoke("main")
 	RequireError(t, err)
 
-	assert.ErrorAs(t, err, &interpreter.UseBeforeInitializationError{})
+	var initializationError *interpreter.UseBeforeInitializationError
+	require.ErrorAs(t, err, &initializationError)
 
 	assert.Equal(t,
 		[]string{
@@ -3011,8 +3030,8 @@ func TestInterpretMovedResourceInOptionalBinding(t *testing.T) {
 
 	_, err = inter.Invoke("main")
 	RequireError(t, err)
-	invalidResourceError := &interpreter.InvalidatedResourceError{}
-	require.ErrorAs(t, err, invalidResourceError)
+	var invalidResourceError *interpreter.InvalidatedResourceError
+	require.ErrorAs(t, err, &invalidResourceError)
 
 	// Error must be thrown at `copy2: <- victim`
 	errorStartPos := invalidResourceError.LocationRange.StartPosition()
@@ -3054,8 +3073,8 @@ func TestInterpretMovedResourceInSecondValue(t *testing.T) {
 
 	_, err = inter.Invoke("main")
 	RequireError(t, err)
-	invalidResourceError := &interpreter.InvalidatedResourceError{}
-	require.ErrorAs(t, err, invalidResourceError)
+	var invalidResourceError *interpreter.InvalidatedResourceError
+	require.ErrorAs(t, err, &invalidResourceError)
 
 	// Error must be thrown at `copy2: <- victim`
 	errorStartPos := invalidResourceError.LocationRange.StartPosition()
@@ -3117,7 +3136,8 @@ func TestInterpretResourceLoss(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.ResourceLossError{})
+		var resourceLossError *interpreter.ResourceLossError
+		require.ErrorAs(t, err, &resourceLossError)
 	})
 
 	t.Run("force nil assignment", func(t *testing.T) {
@@ -3142,7 +3162,8 @@ func TestInterpretResourceLoss(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.ResourceLossError{})
+		var resourceLossError *interpreter.ResourceLossError
+		require.ErrorAs(t, err, &resourceLossError)
 	})
 }
 
@@ -3189,7 +3210,8 @@ func TestInterpretPreConditionResourceMove(t *testing.T) {
 
 	_, err = inter.Invoke("main")
 	RequireError(t, err)
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+	var invalidatedResourceError *interpreter.InvalidatedResourceError
+	require.ErrorAs(t, err, &invalidatedResourceError)
 }
 
 func TestInterpretResourceSelfSwap(t *testing.T) {
@@ -3211,7 +3233,7 @@ func TestInterpretResourceSelfSwap(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		var invalidatedResourceErr interpreter.InvalidatedResourceError
+		var invalidatedResourceErr *interpreter.InvalidatedResourceError
 		require.ErrorAs(t, err, &invalidatedResourceErr)
 	})
 
@@ -3230,7 +3252,7 @@ func TestInterpretResourceSelfSwap(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		var invalidatedResourceErr interpreter.InvalidatedResourceError
+		var invalidatedResourceErr *interpreter.InvalidatedResourceError
 		require.ErrorAs(t, err, &invalidatedResourceErr)
 	})
 
@@ -3247,7 +3269,7 @@ func TestInterpretResourceSelfSwap(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		var invalidatedResourceErr interpreter.InvalidatedResourceError
+		var invalidatedResourceErr *interpreter.InvalidatedResourceError
 		require.ErrorAs(t, err, &invalidatedResourceErr)
 	})
 
@@ -3264,7 +3286,7 @@ func TestInterpretResourceSelfSwap(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		var invalidatedResourceErr interpreter.InvalidatedResourceError
+		var invalidatedResourceErr *interpreter.InvalidatedResourceError
 		require.ErrorAs(t, err, &invalidatedResourceErr)
 	})
 }
@@ -3375,7 +3397,8 @@ func TestInterpretInvalidatingLoopedReference(t *testing.T) {
 
 	_, err := inter.Invoke("main")
 	RequireError(t, err)
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 func TestInterpretInvalidatingAttachmentLoopedReference(t *testing.T) {
@@ -3471,7 +3494,8 @@ func TestInterpretInvalidatingAttachmentLoopedReference(t *testing.T) {
 
 	_, err := inter.Invoke("main")
 	RequireError(t, err)
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 func TestInterpretResourceReferenceInvalidation(t *testing.T) {
@@ -3499,7 +3523,8 @@ func TestInterpretResourceReferenceInvalidation(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("incomplete optional indirection", func(t *testing.T) {
@@ -3530,7 +3555,8 @@ func TestInterpretResourceReferenceInvalidation(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("optional indirection", func(t *testing.T) {
@@ -3561,7 +3587,8 @@ func TestInterpretResourceReferenceInvalidation(t *testing.T) {
 
 		_, err := inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("invalid reference logged in array", func(t *testing.T) {
@@ -3589,7 +3616,8 @@ func TestInterpretResourceReferenceInvalidation(t *testing.T) {
 
 		_, err = inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("invalid optional reference logged in array", func(t *testing.T) {
@@ -3621,7 +3649,8 @@ func TestInterpretResourceReferenceInvalidation(t *testing.T) {
 
 		_, err = inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("invalid reference logged in dict", func(t *testing.T) {
@@ -3647,7 +3676,8 @@ func TestInterpretResourceReferenceInvalidation(t *testing.T) {
 
 		_, err = inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("invalid reference logged in composite", func(t *testing.T) {
@@ -3680,7 +3710,8 @@ func TestInterpretResourceReferenceInvalidation(t *testing.T) {
 
 		_, err = inter.Invoke("main")
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 }
 
@@ -3765,7 +3796,7 @@ func TestInterpretInvalidNilCoalescingResourceDuplication(t *testing.T) {
 		_, err = inter.Invoke("main")
 		RequireError(t, err)
 
-		var destroyedResourceErr interpreter.DestroyedResourceError
+		var destroyedResourceErr *interpreter.DestroyedResourceError
 		require.ErrorAs(t, err, &destroyedResourceErr)
 	})
 

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -292,7 +292,7 @@ func (v *SimpleCompositeValue) Transfer(
 	}
 
 	if v.isTransaction {
-		panic(NonTransferableValueError{
+		panic(&NonTransferableValueError{
 			Value: v,
 		})
 	}

--- a/interpreter/string_test.go
+++ b/interpreter/string_test.go
@@ -130,7 +130,7 @@ func TestInterpretStringDecodeHex(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var typedErr interpreter.InvalidHexByteError
+		var typedErr *interpreter.InvalidHexByteError
 		require.ErrorAs(t, err, &typedErr)
 		require.Equal(t, byte('x'), typedErr.Byte)
 	})
@@ -148,7 +148,7 @@ func TestInterpretStringDecodeHex(t *testing.T) {
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
 
-		var typedErr interpreter.InvalidHexLengthError
+		var typedErr *interpreter.InvalidHexLengthError
 		require.ErrorAs(t, err, &typedErr)
 	})
 }

--- a/interpreter/transactions_test.go
+++ b/interpreter/transactions_test.go
@@ -122,7 +122,7 @@ func TestInterpretTransactions(t *testing.T) {
 		err := inter.InvokeTransaction(nil)
 		RequireError(t, err)
 
-		var conditionErr interpreter.ConditionError
+		var conditionErr *interpreter.ConditionError
 		require.ErrorAs(t, err, &conditionErr)
 
 		assert.Equal(t,
@@ -184,7 +184,7 @@ func TestInterpretTransactions(t *testing.T) {
 		err := inter.InvokeTransaction(nil)
 		RequireError(t, err)
 
-		var conditionErr interpreter.ConditionError
+		var conditionErr *interpreter.ConditionError
 		require.ErrorAs(t, err, &conditionErr)
 
 		assert.Equal(t,
@@ -451,7 +451,8 @@ func TestInterpretInvalidTransferInExecute(t *testing.T) {
 	)
 
 	err := inter.InvokeTransaction(nil, signer1)
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceError{})
+	var invalidatedResourceError *interpreter.InvalidatedResourceError
+	require.ErrorAs(t, err, &invalidatedResourceError)
 }
 
 func TestInterpretInvalidRecursiveTransferInExecute(t *testing.T) {
@@ -477,7 +478,8 @@ func TestInterpretInvalidRecursiveTransferInExecute(t *testing.T) {
         `)
 
 		err := inter.InvokeTransaction(nil)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("Dictionary", func(t *testing.T) {
@@ -499,7 +501,8 @@ func TestInterpretInvalidRecursiveTransferInExecute(t *testing.T) {
         `)
 
 		err := inter.InvokeTransaction(nil)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 
 	t.Run("resource", func(t *testing.T) {
@@ -527,6 +530,7 @@ func TestInterpretInvalidRecursiveTransferInExecute(t *testing.T) {
         `)
 
 		err := inter.InvokeTransaction(nil)
-		require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
 }

--- a/interpreter/transfer_test.go
+++ b/interpreter/transfer_test.go
@@ -94,7 +94,8 @@ func TestInterpretTransferCheck(t *testing.T) {
 		_, err = inter.Invoke("test")
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.ValueTransferTypeError{})
+		var transferTypeError *interpreter.ValueTransferTypeError
+	require.ErrorAs(t, err, &transferTypeError)
 	})
 
 	t.Run("contract and intersection type", func(t *testing.T) {

--- a/interpreter/transfer_test.go
+++ b/interpreter/transfer_test.go
@@ -95,7 +95,7 @@ func TestInterpretTransferCheck(t *testing.T) {
 		RequireError(t, err)
 
 		var transferTypeError *interpreter.ValueTransferTypeError
-	require.ErrorAs(t, err, &transferTypeError)
+		require.ErrorAs(t, err, &transferTypeError)
 	})
 
 	t.Run("contract and intersection type", func(t *testing.T) {

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -272,7 +272,7 @@ type atreeContainerBackedValue interface {
 func safeAdd(a, b int, locationRange LocationRange) int {
 	// INT32-C
 	if (b > 0) && (a > (goMaxInt - b)) {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	} else if (b < 0) && (a < (goMinInt - b)) {
@@ -289,7 +289,7 @@ func safeMul(a, b int, locationRange LocationRange) int {
 		if b > 0 {
 			// positive * positive = positive. overflow?
 			if a > (goMaxInt / b) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -312,7 +312,7 @@ func safeMul(a, b int, locationRange LocationRange) int {
 		} else {
 			// negative * negative = positive. overflow?
 			if (a != 0) && (b < (goMaxInt / a)) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -276,7 +276,7 @@ func safeAdd(a, b int, locationRange LocationRange) int {
 			LocationRange: locationRange,
 		})
 	} else if (b < 0) && (a < (goMinInt - b)) {
-		panic(UnderflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -296,7 +296,7 @@ func safeMul(a, b int, locationRange LocationRange) int {
 		} else {
 			// positive * negative = negative. underflow?
 			if b < (goMinInt / a) {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -305,7 +305,7 @@ func safeMul(a, b int, locationRange LocationRange) int {
 		if b > 0 {
 			// negative * positive = negative. underflow?
 			if a < (goMinInt / b) {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -1345,7 +1345,7 @@ func (v *ArrayValue) Transfer(
 	if preventTransfer == nil {
 		preventTransfer = map[atree.ValueID]struct{}{}
 	} else if _, ok := preventTransfer[currentValueID]; ok {
-		panic(RecursiveTransferError{
+		panic(&RecursiveTransferError{
 			LocationRange: locationRange,
 		})
 	}
@@ -1580,7 +1580,7 @@ func (v *ArrayValue) Slice(
 	// atree's Array.RangeIterator function will check the upper bound and report an atree.SliceOutOfBoundsError
 
 	if fromIndex < 0 || toIndex < 0 {
-		panic(ArraySliceIndicesError{
+		panic(&ArraySliceIndicesError{
 			FromIndex:     fromIndex,
 			UpToIndex:     toIndex,
 			Size:          v.Count(),
@@ -1594,7 +1594,7 @@ func (v *ArrayValue) Slice(
 
 		var sliceOutOfBoundsError *atree.SliceOutOfBoundsError
 		if goerrors.As(err, &sliceOutOfBoundsError) {
-			panic(ArraySliceIndicesError{
+			panic(&ArraySliceIndicesError{
 				FromIndex:     fromIndex,
 				UpToIndex:     toIndex,
 				Size:          v.Count(),
@@ -1604,7 +1604,7 @@ func (v *ArrayValue) Slice(
 
 		var invalidSliceIndexError *atree.InvalidSliceIndexError
 		if goerrors.As(err, &invalidSliceIndexError) {
-			panic(InvalidSliceIndexError{
+			panic(&InvalidSliceIndexError{
 				FromIndex:     fromIndex,
 				UpToIndex:     toIndex,
 				LocationRange: locationRange,

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -1194,7 +1194,7 @@ func (v *CompositeValue) Transfer(
 	if preventTransfer == nil {
 		preventTransfer = map[atree.ValueID]struct{}{}
 	} else if _, ok := preventTransfer[currentValueID]; ok {
-		panic(RecursiveTransferError{
+		panic(&RecursiveTransferError{
 			LocationRange: locationRange,
 		})
 	}
@@ -1207,7 +1207,7 @@ func (v *CompositeValue) Transfer(
 	isResourceKinded := v.IsResourceKinded(context)
 
 	if needsStoreTo && v.Kind == common.CompositeKindContract {
-		panic(NonTransferableValueError{
+		panic(&NonTransferableValueError{
 			Value: v,
 		})
 	}
@@ -1874,7 +1874,7 @@ func (v *CompositeValue) SetTypeKey(
 ) {
 	memberName := AttachmentMemberName(string(attachmentType.ID()))
 	if v.SetMember(context, locationRange, memberName, attachment) {
-		panic(DuplicateAttachmentError{
+		panic(&DuplicateAttachmentError{
 			AttachmentType: attachmentType,
 			Value:          v,
 			LocationRange:  locationRange,

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -125,7 +125,7 @@ func NewDictionaryValueWithAddress(
 		// then we need to prevent a resource loss
 		if _, ok := existingValue.(*SomeValue); ok {
 			if v.IsResourceKinded(context) {
-				panic(DuplicateKeyInResourceDictionaryError{
+				panic(&DuplicateKeyInResourceDictionaryError{
 					LocationRange: locationRange,
 				})
 			}
@@ -1328,7 +1328,7 @@ func (v *DictionaryValue) Transfer(
 	if preventTransfer == nil {
 		preventTransfer = map[atree.ValueID]struct{}{}
 	} else if _, ok := preventTransfer[currentValueID]; ok {
-		panic(RecursiveTransferError{
+		panic(&RecursiveTransferError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -52,7 +52,7 @@ func NewUnmeteredEphemeralReferenceValue(
 	locationRange LocationRange,
 ) *EphemeralReferenceValue {
 	if reference, isReference := value.(ReferenceValue); isReference {
-		panic(NestedReferenceError{
+		panic(&NestedReferenceError{
 			Value:         reference,
 			LocationRange: locationRange,
 		})

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -52,7 +52,7 @@ func NewFix64ValueWithInteger(gauge common.MemoryGauge, constructor func() int64
 func NewUnmeteredFix64ValueWithInteger(integer int64, locationRange LocationRange) Fix64Value {
 
 	if integer < sema.Fix64TypeMinInt {
-		panic(UnderflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -142,7 +142,7 @@ func (v Fix64Value) Negate(context NumberValueArithmeticContext, locationRange L
 func (v Fix64Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -160,7 +160,7 @@ func (v Fix64Value) Plus(context NumberValueArithmeticContext, other NumberValue
 func (v Fix64Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -184,7 +184,7 @@ func (v Fix64Value) SaturatingPlus(context NumberValueArithmeticContext, other N
 func (v Fix64Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -199,7 +199,7 @@ func (v Fix64Value) Minus(context NumberValueArithmeticContext, other NumberValu
 				LocationRange: locationRange,
 			})
 		} else if (o < 0) && (v > (math.MaxInt64 + o)) {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -213,7 +213,7 @@ func (v Fix64Value) Minus(context NumberValueArithmeticContext, other NumberValu
 func (v Fix64Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -240,7 +240,7 @@ var maxInt64Big = big.NewInt(math.MaxInt64)
 func (v Fix64Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -256,7 +256,7 @@ func (v Fix64Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		result.Div(result, sema.Fix64FactorBig)
 
 		if result.Cmp(minInt64Big) < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		} else if result.Cmp(maxInt64Big) > 0 {
@@ -274,7 +274,7 @@ func (v Fix64Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 func (v Fix64Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -304,7 +304,7 @@ func (v Fix64Value) SaturatingMul(context NumberValueArithmeticContext, other Nu
 func (v Fix64Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -320,7 +320,7 @@ func (v Fix64Value) Div(context NumberValueArithmeticContext, other NumberValue,
 		result.Div(result, b)
 
 		if result.Cmp(minInt64Big) < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		} else if result.Cmp(maxInt64Big) > 0 {
@@ -338,7 +338,7 @@ func (v Fix64Value) Div(context NumberValueArithmeticContext, other NumberValue,
 func (v Fix64Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -368,7 +368,7 @@ func (v Fix64Value) SaturatingDiv(context NumberValueArithmeticContext, other Nu
 func (v Fix64Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -379,7 +379,7 @@ func (v Fix64Value) Mod(context NumberValueArithmeticContext, other NumberValue,
 	// v - int(v/o) * o
 	quotient, ok := v.Div(context, o, locationRange).(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -404,7 +404,7 @@ func (v Fix64Value) Mod(context NumberValueArithmeticContext, other NumberValue,
 func (v Fix64Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -418,7 +418,7 @@ func (v Fix64Value) Less(context ValueComparisonContext, other ComparableValue, 
 func (v Fix64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -432,7 +432,7 @@ func (v Fix64Value) LessEqual(context ValueComparisonContext, other ComparableVa
 func (v Fix64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -446,7 +446,7 @@ func (v Fix64Value) Greater(context ValueComparisonContext, other ComparableValu
 func (v Fix64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Fix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -58,7 +58,7 @@ func NewUnmeteredFix64ValueWithInteger(integer int64, locationRange LocationRang
 	}
 
 	if integer > sema.Fix64TypeMaxInt {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -127,7 +127,7 @@ func (v Fix64Value) ToInt(_ LocationRange) int {
 func (v Fix64Value) Negate(context NumberValueArithmeticContext, locationRange LocationRange) NumberValue {
 	// INT32-C
 	if v == math.MinInt64 {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -195,7 +195,7 @@ func (v Fix64Value) Minus(context NumberValueArithmeticContext, other NumberValu
 	valueGetter := func() int64 {
 		// INT32-C
 		if (o > 0) && (v < (math.MinInt64 + o)) {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		} else if (o < 0) && (v > (math.MaxInt64 + o)) {
@@ -260,7 +260,7 @@ func (v Fix64Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 				LocationRange: locationRange,
 			})
 		} else if result.Cmp(maxInt64Big) > 0 {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -324,7 +324,7 @@ func (v Fix64Value) Div(context NumberValueArithmeticContext, other NumberValue,
 				LocationRange: locationRange,
 			})
 		} else if result.Cmp(maxInt64Big) > 0 {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -481,7 +481,7 @@ func ConvertFix64(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 
 	case UFix64Value:
 		if value.UFix64Value > Fix64MaxValue {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -501,7 +501,7 @@ func ConvertFix64(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 			// allows us to call `v.Int64()` safely.
 
 			if !v.IsInt64() {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -482,7 +482,7 @@ func GetReceiver(
 		// `storageRef.ReferencedValue` above already checks for the type validity, if it's not nil.
 		// If nil, that means the value has been moved out of storage.
 		if receiver == nil {
-			panic(ReferencedValueChangedError{
+			panic(&ReferencedValueChangedError{
 				LocationRange: locationRange,
 			})
 		}

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -172,7 +172,7 @@ func (v IntValue) Negate(context NumberValueArithmeticContext, _ LocationRange) 
 func (v IntValue) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -189,8 +189,8 @@ func (v IntValue) Plus(context NumberValueArithmeticContext, other NumberValue, 
 func (v IntValue) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -205,7 +205,7 @@ func (v IntValue) SaturatingPlus(context NumberValueArithmeticContext, other Num
 func (v IntValue) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -225,8 +225,8 @@ func (v IntValue) Minus(context NumberValueArithmeticContext, other NumberValue,
 func (v IntValue) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -241,7 +241,7 @@ func (v IntValue) SaturatingMinus(context NumberValueArithmeticContext, other Nu
 func (v IntValue) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -262,7 +262,7 @@ func (v IntValue) Mod(context NumberValueArithmeticContext, other NumberValue, l
 func (v IntValue) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -282,8 +282,8 @@ func (v IntValue) Mul(context NumberValueArithmeticContext, other NumberValue, l
 func (v IntValue) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -298,7 +298,7 @@ func (v IntValue) SaturatingMul(context NumberValueArithmeticContext, other Numb
 func (v IntValue) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -319,8 +319,8 @@ func (v IntValue) Div(context NumberValueArithmeticContext, other NumberValue, l
 func (v IntValue) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -335,7 +335,7 @@ func (v IntValue) SaturatingDiv(context NumberValueArithmeticContext, other Numb
 func (v IntValue) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -349,7 +349,7 @@ func (v IntValue) Less(context ValueComparisonContext, other ComparableValue, lo
 func (v IntValue) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -363,7 +363,7 @@ func (v IntValue) LessEqual(context ValueComparisonContext, other ComparableValu
 func (v IntValue) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -377,7 +377,7 @@ func (v IntValue) Greater(context ValueComparisonContext, other ComparableValue,
 func (v IntValue) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -419,7 +419,7 @@ func (v IntValue) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []byt
 func (v IntValue) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -440,7 +440,7 @@ func (v IntValue) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, 
 func (v IntValue) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -461,7 +461,7 @@ func (v IntValue) BitwiseXor(context ValueStaticTypeContext, other IntegerValue,
 func (v IntValue) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -482,7 +482,7 @@ func (v IntValue) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue,
 func (v IntValue) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -503,7 +503,7 @@ func (v IntValue) BitwiseLeftShift(context ValueStaticTypeContext, other Integer
 func (v IntValue) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(IntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),

--- a/interpreter/value_int.go
+++ b/interpreter/value_int.go
@@ -115,7 +115,7 @@ func (IntValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool {
 func (v IntValue) ToInt(locationRange LocationRange) int {
 	result, err := v.IntValue.ToInt()
 	if _, ok := err.(values.OverflowError); ok {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -124,7 +124,7 @@ func (v IntValue) ToInt(locationRange LocationRange) int {
 
 func (v IntValue) ToUint32(locationRange LocationRange) uint32 {
 	if !v.BigInt.IsUint64() {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -132,7 +132,7 @@ func (v IntValue) ToUint32(locationRange LocationRange) uint32 {
 	result := v.BigInt.Uint64()
 
 	if result > math.MaxUint32 {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -125,7 +125,7 @@ func (Int128Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool 
 
 func (v Int128Value) ToInt(locationRange LocationRange) int {
 	if !v.BigInt.IsInt64() {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -165,7 +165,7 @@ func (v Int128Value) Negate(context NumberValueArithmeticContext, locationRange 
 	//       ...
 	//   }
 	if v.BigInt.Cmp(sema.Int128TypeMinIntBig) == 0 {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -208,7 +208,7 @@ func (v Int128Value) Plus(context NumberValueArithmeticContext, other NumberValu
 				LocationRange: locationRange,
 			})
 		} else if res.Cmp(sema.Int128TypeMaxIntBig) > 0 {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -288,7 +288,7 @@ func (v Int128Value) Minus(context NumberValueArithmeticContext, other NumberVal
 				LocationRange: locationRange,
 			})
 		} else if res.Cmp(sema.Int128TypeMaxIntBig) > 0 {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -383,7 +383,7 @@ func (v Int128Value) Mul(context NumberValueArithmeticContext, other NumberValue
 				LocationRange: locationRange,
 			})
 		} else if res.Cmp(sema.Int128TypeMaxIntBig) > 0 {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -446,7 +446,7 @@ func (v Int128Value) Div(context NumberValueArithmeticContext, other NumberValue
 		}
 		res.SetInt64(-1)
 		if (v.BigInt.Cmp(sema.Int128TypeMinIntBig) == 0) && (o.BigInt.Cmp(res) == 0) {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -598,7 +598,7 @@ func ConvertInt128(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 		}
 
 		if v.Cmp(sema.Int128TypeMaxIntBig) > 0 {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		} else if v.Cmp(sema.Int128TypeMinIntBig) < 0 {

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -180,7 +180,7 @@ func (v Int128Value) Negate(context NumberValueArithmeticContext, locationRange 
 func (v Int128Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -204,7 +204,7 @@ func (v Int128Value) Plus(context NumberValueArithmeticContext, other NumberValu
 		res := new(big.Int)
 		res.Add(v.BigInt, o.BigInt)
 		if res.Cmp(sema.Int128TypeMinIntBig) < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		} else if res.Cmp(sema.Int128TypeMaxIntBig) > 0 {
@@ -222,7 +222,7 @@ func (v Int128Value) Plus(context NumberValueArithmeticContext, other NumberValu
 func (v Int128Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -260,7 +260,7 @@ func (v Int128Value) SaturatingPlus(context NumberValueArithmeticContext, other 
 func (v Int128Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -284,7 +284,7 @@ func (v Int128Value) Minus(context NumberValueArithmeticContext, other NumberVal
 		res := new(big.Int)
 		res.Sub(v.BigInt, o.BigInt)
 		if res.Cmp(sema.Int128TypeMinIntBig) < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		} else if res.Cmp(sema.Int128TypeMaxIntBig) > 0 {
@@ -302,7 +302,7 @@ func (v Int128Value) Minus(context NumberValueArithmeticContext, other NumberVal
 func (v Int128Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -340,7 +340,7 @@ func (v Int128Value) SaturatingMinus(context NumberValueArithmeticContext, other
 func (v Int128Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -352,7 +352,7 @@ func (v Int128Value) Mod(context NumberValueArithmeticContext, other NumberValue
 		res := new(big.Int)
 		// INT33-C
 		if o.BigInt.Cmp(res) == 0 {
-			panic(DivisionByZeroError{
+			panic(&DivisionByZeroError{
 				LocationRange: locationRange,
 			})
 		}
@@ -367,7 +367,7 @@ func (v Int128Value) Mod(context NumberValueArithmeticContext, other NumberValue
 func (v Int128Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -379,7 +379,7 @@ func (v Int128Value) Mul(context NumberValueArithmeticContext, other NumberValue
 		res := new(big.Int)
 		res.Mul(v.BigInt, o.BigInt)
 		if res.Cmp(sema.Int128TypeMinIntBig) < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		} else if res.Cmp(sema.Int128TypeMaxIntBig) > 0 {
@@ -397,7 +397,7 @@ func (v Int128Value) Mul(context NumberValueArithmeticContext, other NumberValue
 func (v Int128Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -423,7 +423,7 @@ func (v Int128Value) SaturatingMul(context NumberValueArithmeticContext, other N
 func (v Int128Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -440,7 +440,7 @@ func (v Int128Value) Div(context NumberValueArithmeticContext, other NumberValue
 		//       ...
 		//   }
 		if o.BigInt.Cmp(res) == 0 {
-			panic(DivisionByZeroError{
+			panic(&DivisionByZeroError{
 				LocationRange: locationRange,
 			})
 		}
@@ -461,7 +461,7 @@ func (v Int128Value) Div(context NumberValueArithmeticContext, other NumberValue
 func (v Int128Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -478,7 +478,7 @@ func (v Int128Value) SaturatingDiv(context NumberValueArithmeticContext, other N
 		//       ...
 		//   }
 		if o.BigInt.Cmp(res) == 0 {
-			panic(DivisionByZeroError{
+			panic(&DivisionByZeroError{
 				LocationRange: locationRange,
 			})
 		}
@@ -497,7 +497,7 @@ func (v Int128Value) SaturatingDiv(context NumberValueArithmeticContext, other N
 func (v Int128Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -512,7 +512,7 @@ func (v Int128Value) Less(context ValueComparisonContext, other ComparableValue,
 func (v Int128Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -527,7 +527,7 @@ func (v Int128Value) LessEqual(context ValueComparisonContext, other ComparableV
 func (v Int128Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -542,7 +542,7 @@ func (v Int128Value) Greater(context ValueComparisonContext, other ComparableVal
 func (v Int128Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -602,7 +602,7 @@ func ConvertInt128(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 				LocationRange: locationRange,
 			})
 		} else if v.Cmp(sema.Int128TypeMinIntBig) < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -616,7 +616,7 @@ func ConvertInt128(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 func (v Int128Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -636,7 +636,7 @@ func (v Int128Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValu
 func (v Int128Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -656,7 +656,7 @@ func (v Int128Value) BitwiseXor(context ValueStaticTypeContext, other IntegerVal
 func (v Int128Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -676,7 +676,7 @@ func (v Int128Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerVal
 func (v Int128Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -685,7 +685,7 @@ func (v Int128Value) BitwiseLeftShift(context ValueStaticTypeContext, other Inte
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}
@@ -712,7 +712,7 @@ func (v Int128Value) BitwiseLeftShift(context ValueStaticTypeContext, other Inte
 func (v Int128Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -721,7 +721,7 @@ func (v Int128Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -103,7 +103,7 @@ func (v Int16Value) ToInt(_ LocationRange) int {
 func (v Int16Value) Negate(context NumberValueArithmeticContext, locationRange LocationRange) NumberValue {
 	// INT32-C
 	if v == math.MinInt16 {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -128,7 +128,7 @@ func (v Int16Value) Plus(context NumberValueArithmeticContext, other NumberValue
 
 	// INT32-C
 	if (o > 0) && (v > (math.MaxInt16 - o)) {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v < (math.MinInt16 - o)) {
@@ -181,7 +181,7 @@ func (v Int16Value) Minus(context NumberValueArithmeticContext, other NumberValu
 
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt16 + o)) {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v > (math.MaxInt16 + o)) {
@@ -262,7 +262,7 @@ func (v Int16Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		if o > 0 {
 			// positive * positive = positive. overflow?
 			if v > (math.MaxInt16 / o) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -285,7 +285,7 @@ func (v Int16Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		} else {
 			// negative * negative = positive. overflow?
 			if (v != 0) && (o < (math.MaxInt16 / v)) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -361,7 +361,7 @@ func (v Int16Value) Div(context NumberValueArithmeticContext, other NumberValue,
 			LocationRange: locationRange,
 		})
 	} else if (v == math.MinInt16) && (o == -1) {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -480,7 +480,7 @@ func ConvertInt16(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 		case BigNumberValue:
 			v := value.ToBigInt(memoryGauge)
 			if v.Cmp(sema.Int16TypeMaxInt) > 0 {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			} else if v.Cmp(sema.Int16TypeMinInt) < 0 {
@@ -493,7 +493,7 @@ func ConvertInt16(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 		case NumberValue:
 			v := value.ToInt(locationRange)
 			if v > math.MaxInt16 {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			} else if v < math.MinInt16 {

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -118,7 +118,7 @@ func (v Int16Value) Negate(context NumberValueArithmeticContext, locationRange L
 func (v Int16Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -132,7 +132,7 @@ func (v Int16Value) Plus(context NumberValueArithmeticContext, other NumberValue
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v < (math.MinInt16 - o)) {
-		panic(UnderflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -147,7 +147,7 @@ func (v Int16Value) Plus(context NumberValueArithmeticContext, other NumberValue
 func (v Int16Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -171,7 +171,7 @@ func (v Int16Value) SaturatingPlus(context NumberValueArithmeticContext, other N
 func (v Int16Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -185,7 +185,7 @@ func (v Int16Value) Minus(context NumberValueArithmeticContext, other NumberValu
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v > (math.MaxInt16 + o)) {
-		panic(UnderflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -200,7 +200,7 @@ func (v Int16Value) Minus(context NumberValueArithmeticContext, other NumberValu
 func (v Int16Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -224,7 +224,7 @@ func (v Int16Value) SaturatingMinus(context NumberValueArithmeticContext, other 
 func (v Int16Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -234,7 +234,7 @@ func (v Int16Value) Mod(context NumberValueArithmeticContext, other NumberValue,
 
 	// INT33-C
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	}
@@ -249,7 +249,7 @@ func (v Int16Value) Mod(context NumberValueArithmeticContext, other NumberValue,
 func (v Int16Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -269,7 +269,7 @@ func (v Int16Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		} else {
 			// positive * negative = negative. underflow?
 			if o < (math.MinInt16 / v) {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -278,7 +278,7 @@ func (v Int16Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		if o > 0 {
 			// negative * positive = negative. underflow?
 			if v < (math.MinInt16 / o) {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -302,7 +302,7 @@ func (v Int16Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 func (v Int16Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -346,7 +346,7 @@ func (v Int16Value) SaturatingMul(context NumberValueArithmeticContext, other Nu
 func (v Int16Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -357,7 +357,7 @@ func (v Int16Value) Div(context NumberValueArithmeticContext, other NumberValue,
 	// INT33-C
 	// https://golang.org/ref/spec#Integer_operators
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	} else if (v == math.MinInt16) && (o == -1) {
@@ -376,7 +376,7 @@ func (v Int16Value) Div(context NumberValueArithmeticContext, other NumberValue,
 func (v Int16Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -388,7 +388,7 @@ func (v Int16Value) SaturatingDiv(context NumberValueArithmeticContext, other Nu
 		// INT33-C
 		// https://golang.org/ref/spec#Integer_operators
 		if o == 0 {
-			panic(DivisionByZeroError{
+			panic(&DivisionByZeroError{
 				LocationRange: locationRange,
 			})
 		} else if (v == math.MinInt16) && (o == -1) {
@@ -403,7 +403,7 @@ func (v Int16Value) SaturatingDiv(context NumberValueArithmeticContext, other Nu
 func (v Int16Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -417,7 +417,7 @@ func (v Int16Value) Less(context ValueComparisonContext, other ComparableValue, 
 func (v Int16Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -431,7 +431,7 @@ func (v Int16Value) LessEqual(context ValueComparisonContext, other ComparableVa
 func (v Int16Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -445,7 +445,7 @@ func (v Int16Value) Greater(context ValueComparisonContext, other ComparableValu
 func (v Int16Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -484,7 +484,7 @@ func ConvertInt16(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 					LocationRange: locationRange,
 				})
 			} else if v.Cmp(sema.Int16TypeMinInt) < 0 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -497,7 +497,7 @@ func ConvertInt16(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 					LocationRange: locationRange,
 				})
 			} else if v < math.MinInt16 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -514,7 +514,7 @@ func ConvertInt16(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 func (v Int16Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -532,7 +532,7 @@ func (v Int16Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue
 func (v Int16Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -550,7 +550,7 @@ func (v Int16Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValu
 func (v Int16Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -568,7 +568,7 @@ func (v Int16Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValu
 func (v Int16Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -577,7 +577,7 @@ func (v Int16Value) BitwiseLeftShift(context ValueStaticTypeContext, other Integ
 	}
 
 	if o < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}
@@ -592,7 +592,7 @@ func (v Int16Value) BitwiseLeftShift(context ValueStaticTypeContext, other Integ
 func (v Int16Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -601,7 +601,7 @@ func (v Int16Value) BitwiseRightShift(context ValueStaticTypeContext, other Inte
 	}
 
 	if o < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -149,7 +149,7 @@ func (v Int256Value) Negate(context NumberValueArithmeticContext, locationRange 
 func (v Int256Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -173,7 +173,7 @@ func (v Int256Value) Plus(context NumberValueArithmeticContext, other NumberValu
 		res := new(big.Int)
 		res.Add(v.BigInt, o.BigInt)
 		if res.Cmp(sema.Int256TypeMinIntBig) < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		} else if res.Cmp(sema.Int256TypeMaxIntBig) > 0 {
@@ -191,7 +191,7 @@ func (v Int256Value) Plus(context NumberValueArithmeticContext, other NumberValu
 func (v Int256Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -229,7 +229,7 @@ func (v Int256Value) SaturatingPlus(context NumberValueArithmeticContext, other 
 func (v Int256Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -253,7 +253,7 @@ func (v Int256Value) Minus(context NumberValueArithmeticContext, other NumberVal
 		res := new(big.Int)
 		res.Sub(v.BigInt, o.BigInt)
 		if res.Cmp(sema.Int256TypeMinIntBig) < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		} else if res.Cmp(sema.Int256TypeMaxIntBig) > 0 {
@@ -271,7 +271,7 @@ func (v Int256Value) Minus(context NumberValueArithmeticContext, other NumberVal
 func (v Int256Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -309,7 +309,7 @@ func (v Int256Value) SaturatingMinus(context NumberValueArithmeticContext, other
 func (v Int256Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -321,7 +321,7 @@ func (v Int256Value) Mod(context NumberValueArithmeticContext, other NumberValue
 		res := new(big.Int)
 		// INT33-C
 		if o.BigInt.Cmp(res) == 0 {
-			panic(DivisionByZeroError{
+			panic(&DivisionByZeroError{
 				LocationRange: locationRange,
 			})
 		}
@@ -336,7 +336,7 @@ func (v Int256Value) Mod(context NumberValueArithmeticContext, other NumberValue
 func (v Int256Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -348,7 +348,7 @@ func (v Int256Value) Mul(context NumberValueArithmeticContext, other NumberValue
 		res := new(big.Int)
 		res.Mul(v.BigInt, o.BigInt)
 		if res.Cmp(sema.Int256TypeMinIntBig) < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		} else if res.Cmp(sema.Int256TypeMaxIntBig) > 0 {
@@ -366,7 +366,7 @@ func (v Int256Value) Mul(context NumberValueArithmeticContext, other NumberValue
 func (v Int256Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -392,7 +392,7 @@ func (v Int256Value) SaturatingMul(context NumberValueArithmeticContext, other N
 func (v Int256Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -409,7 +409,7 @@ func (v Int256Value) Div(context NumberValueArithmeticContext, other NumberValue
 		//       ...
 		//   }
 		if o.BigInt.Cmp(res) == 0 {
-			panic(DivisionByZeroError{
+			panic(&DivisionByZeroError{
 				LocationRange: locationRange,
 			})
 		}
@@ -429,7 +429,7 @@ func (v Int256Value) Div(context NumberValueArithmeticContext, other NumberValue
 func (v Int256Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -446,7 +446,7 @@ func (v Int256Value) SaturatingDiv(context NumberValueArithmeticContext, other N
 		//       ...
 		//   }
 		if o.BigInt.Cmp(res) == 0 {
-			panic(DivisionByZeroError{
+			panic(&DivisionByZeroError{
 				LocationRange: locationRange,
 			})
 		}
@@ -464,7 +464,7 @@ func (v Int256Value) SaturatingDiv(context NumberValueArithmeticContext, other N
 func (v Int256Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -479,7 +479,7 @@ func (v Int256Value) Less(context ValueComparisonContext, other ComparableValue,
 func (v Int256Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -494,7 +494,7 @@ func (v Int256Value) LessEqual(context ValueComparisonContext, other ComparableV
 func (v Int256Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -509,7 +509,7 @@ func (v Int256Value) Greater(context ValueComparisonContext, other ComparableVal
 func (v Int256Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -569,7 +569,7 @@ func ConvertInt256(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 				LocationRange: locationRange,
 			})
 		} else if v.Cmp(sema.Int256TypeMinIntBig) < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -583,7 +583,7 @@ func ConvertInt256(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 func (v Int256Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -603,7 +603,7 @@ func (v Int256Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValu
 func (v Int256Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -623,7 +623,7 @@ func (v Int256Value) BitwiseXor(context ValueStaticTypeContext, other IntegerVal
 func (v Int256Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -643,7 +643,7 @@ func (v Int256Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerVal
 func (v Int256Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -652,7 +652,7 @@ func (v Int256Value) BitwiseLeftShift(context ValueStaticTypeContext, other Inte
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}
@@ -679,7 +679,7 @@ func (v Int256Value) BitwiseLeftShift(context ValueStaticTypeContext, other Inte
 func (v Int256Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -688,7 +688,7 @@ func (v Int256Value) BitwiseRightShift(context ValueStaticTypeContext, other Int
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -94,7 +94,7 @@ func (Int256Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool 
 
 func (v Int256Value) ToInt(locationRange LocationRange) int {
 	if !v.BigInt.IsInt64() {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -134,7 +134,7 @@ func (v Int256Value) Negate(context NumberValueArithmeticContext, locationRange 
 	//       ...
 	//   }
 	if v.BigInt.Cmp(sema.Int256TypeMinIntBig) == 0 {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -177,7 +177,7 @@ func (v Int256Value) Plus(context NumberValueArithmeticContext, other NumberValu
 				LocationRange: locationRange,
 			})
 		} else if res.Cmp(sema.Int256TypeMaxIntBig) > 0 {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -257,7 +257,7 @@ func (v Int256Value) Minus(context NumberValueArithmeticContext, other NumberVal
 				LocationRange: locationRange,
 			})
 		} else if res.Cmp(sema.Int256TypeMaxIntBig) > 0 {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -352,7 +352,7 @@ func (v Int256Value) Mul(context NumberValueArithmeticContext, other NumberValue
 				LocationRange: locationRange,
 			})
 		} else if res.Cmp(sema.Int256TypeMaxIntBig) > 0 {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -415,7 +415,7 @@ func (v Int256Value) Div(context NumberValueArithmeticContext, other NumberValue
 		}
 		res.SetInt64(-1)
 		if (v.BigInt.Cmp(sema.Int256TypeMinIntBig) == 0) && (o.BigInt.Cmp(res) == 0) {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -565,7 +565,7 @@ func ConvertInt256(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 		}
 
 		if v.Cmp(sema.Int256TypeMaxIntBig) > 0 {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		} else if v.Cmp(sema.Int256TypeMinIntBig) < 0 {

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -118,7 +118,7 @@ func (v Int32Value) Negate(context NumberValueArithmeticContext, locationRange L
 func (v Int32Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -132,7 +132,7 @@ func (v Int32Value) Plus(context NumberValueArithmeticContext, other NumberValue
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v < (math.MinInt32 - o)) {
-		panic(UnderflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -147,7 +147,7 @@ func (v Int32Value) Plus(context NumberValueArithmeticContext, other NumberValue
 func (v Int32Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -171,7 +171,7 @@ func (v Int32Value) SaturatingPlus(context NumberValueArithmeticContext, other N
 func (v Int32Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -185,7 +185,7 @@ func (v Int32Value) Minus(context NumberValueArithmeticContext, other NumberValu
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v > (math.MaxInt32 + o)) {
-		panic(UnderflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -200,7 +200,7 @@ func (v Int32Value) Minus(context NumberValueArithmeticContext, other NumberValu
 func (v Int32Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -224,7 +224,7 @@ func (v Int32Value) SaturatingMinus(context NumberValueArithmeticContext, other 
 func (v Int32Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -234,7 +234,7 @@ func (v Int32Value) Mod(context NumberValueArithmeticContext, other NumberValue,
 
 	// INT33-C
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	}
@@ -249,7 +249,7 @@ func (v Int32Value) Mod(context NumberValueArithmeticContext, other NumberValue,
 func (v Int32Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -269,7 +269,7 @@ func (v Int32Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		} else {
 			// positive * negative = negative. underflow?
 			if o < (math.MinInt32 / v) {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -278,7 +278,7 @@ func (v Int32Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		if o > 0 {
 			// negative * positive = negative. underflow?
 			if v < (math.MinInt32 / o) {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -302,7 +302,7 @@ func (v Int32Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 func (v Int32Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -346,7 +346,7 @@ func (v Int32Value) SaturatingMul(context NumberValueArithmeticContext, other Nu
 func (v Int32Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -357,7 +357,7 @@ func (v Int32Value) Div(context NumberValueArithmeticContext, other NumberValue,
 	// INT33-C
 	// https://golang.org/ref/spec#Integer_operators
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	} else if (v == math.MinInt32) && (o == -1) {
@@ -376,7 +376,7 @@ func (v Int32Value) Div(context NumberValueArithmeticContext, other NumberValue,
 func (v Int32Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -388,7 +388,7 @@ func (v Int32Value) SaturatingDiv(context NumberValueArithmeticContext, other Nu
 		// INT33-C
 		// https://golang.org/ref/spec#Integer_operators
 		if o == 0 {
-			panic(DivisionByZeroError{
+			panic(&DivisionByZeroError{
 				LocationRange: locationRange,
 			})
 		} else if (v == math.MinInt32) && (o == -1) {
@@ -404,7 +404,7 @@ func (v Int32Value) SaturatingDiv(context NumberValueArithmeticContext, other Nu
 func (v Int32Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -418,7 +418,7 @@ func (v Int32Value) Less(context ValueComparisonContext, other ComparableValue, 
 func (v Int32Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -432,7 +432,7 @@ func (v Int32Value) LessEqual(context ValueComparisonContext, other ComparableVa
 func (v Int32Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -446,7 +446,7 @@ func (v Int32Value) Greater(context ValueComparisonContext, other ComparableValu
 func (v Int32Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -484,7 +484,7 @@ func ConvertInt32(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 					LocationRange: locationRange,
 				})
 			} else if v.Cmp(sema.Int32TypeMinInt) < 0 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -497,7 +497,7 @@ func ConvertInt32(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 					LocationRange: locationRange,
 				})
 			} else if v < math.MinInt32 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -514,7 +514,7 @@ func ConvertInt32(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 func (v Int32Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -532,7 +532,7 @@ func (v Int32Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue
 func (v Int32Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -550,7 +550,7 @@ func (v Int32Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValu
 func (v Int32Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -568,7 +568,7 @@ func (v Int32Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValu
 func (v Int32Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -577,7 +577,7 @@ func (v Int32Value) BitwiseLeftShift(context ValueStaticTypeContext, other Integ
 	}
 
 	if o < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}
@@ -592,7 +592,7 @@ func (v Int32Value) BitwiseLeftShift(context ValueStaticTypeContext, other Integ
 func (v Int32Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -601,7 +601,7 @@ func (v Int32Value) BitwiseRightShift(context ValueStaticTypeContext, other Inte
 	}
 
 	if o < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -103,7 +103,7 @@ func (v Int32Value) ToInt(_ LocationRange) int {
 func (v Int32Value) Negate(context NumberValueArithmeticContext, locationRange LocationRange) NumberValue {
 	// INT32-C
 	if v == math.MinInt32 {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -128,7 +128,7 @@ func (v Int32Value) Plus(context NumberValueArithmeticContext, other NumberValue
 
 	// INT32-C
 	if (o > 0) && (v > (math.MaxInt32 - o)) {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v < (math.MinInt32 - o)) {
@@ -181,7 +181,7 @@ func (v Int32Value) Minus(context NumberValueArithmeticContext, other NumberValu
 
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt32 + o)) {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v > (math.MaxInt32 + o)) {
@@ -262,7 +262,7 @@ func (v Int32Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		if o > 0 {
 			// positive * positive = positive. overflow?
 			if v > (math.MaxInt32 / o) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -285,7 +285,7 @@ func (v Int32Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		} else {
 			// negative * negative = positive. overflow?
 			if (v != 0) && (o < (math.MaxInt32 / v)) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -361,7 +361,7 @@ func (v Int32Value) Div(context NumberValueArithmeticContext, other NumberValue,
 			LocationRange: locationRange,
 		})
 	} else if (v == math.MinInt32) && (o == -1) {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -480,7 +480,7 @@ func ConvertInt32(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 		case BigNumberValue:
 			v := value.ToBigInt(memoryGauge)
 			if v.Cmp(sema.Int32TypeMaxInt) > 0 {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			} else if v.Cmp(sema.Int32TypeMinInt) < 0 {
@@ -493,7 +493,7 @@ func ConvertInt32(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 		case NumberValue:
 			v := value.ToInt(locationRange)
 			if v > math.MaxInt32 {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			} else if v < math.MinInt32 {

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -103,7 +103,7 @@ func (v Int64Value) ToInt(_ LocationRange) int {
 func (v Int64Value) Negate(context NumberValueArithmeticContext, locationRange LocationRange) NumberValue {
 	// INT32-C
 	if v == math.MinInt64 {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -118,7 +118,7 @@ func (v Int64Value) Negate(context NumberValueArithmeticContext, locationRange L
 func safeAddInt64(a, b int64, locationRange LocationRange) int64 {
 	// INT32-C
 	if (b > 0) && (a > (math.MaxInt64 - b)) {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	} else if (b < 0) && (a < (math.MinInt64 - b)) {
@@ -184,7 +184,7 @@ func (v Int64Value) Minus(context NumberValueArithmeticContext, other NumberValu
 
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt64 + o)) {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v > (math.MaxInt64 + o)) {
@@ -265,7 +265,7 @@ func (v Int64Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		if o > 0 {
 			// positive * positive = positive. overflow?
 			if v > (math.MaxInt64 / o) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -288,7 +288,7 @@ func (v Int64Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		} else {
 			// negative * negative = positive. overflow?
 			if (v != 0) && (o < (math.MaxInt64 / v)) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -364,7 +364,7 @@ func (v Int64Value) Div(context NumberValueArithmeticContext, other NumberValue,
 			LocationRange: locationRange,
 		})
 	} else if (v == math.MinInt64) && (o == -1) {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -483,7 +483,7 @@ func ConvertInt64(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 		case BigNumberValue:
 			v := value.ToBigInt(memoryGauge)
 			if v.Cmp(sema.Int64TypeMaxInt) > 0 {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			} else if v.Cmp(sema.Int64TypeMinInt) < 0 {

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -122,7 +122,7 @@ func safeAddInt64(a, b int64, locationRange LocationRange) int64 {
 			LocationRange: locationRange,
 		})
 	} else if (b < 0) && (a < (math.MinInt64 - b)) {
-		panic(UnderflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -132,7 +132,7 @@ func safeAddInt64(a, b int64, locationRange LocationRange) int64 {
 func (v Int64Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -150,7 +150,7 @@ func (v Int64Value) Plus(context NumberValueArithmeticContext, other NumberValue
 func (v Int64Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -174,7 +174,7 @@ func (v Int64Value) SaturatingPlus(context NumberValueArithmeticContext, other N
 func (v Int64Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -188,7 +188,7 @@ func (v Int64Value) Minus(context NumberValueArithmeticContext, other NumberValu
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v > (math.MaxInt64 + o)) {
-		panic(UnderflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -203,7 +203,7 @@ func (v Int64Value) Minus(context NumberValueArithmeticContext, other NumberValu
 func (v Int64Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -227,7 +227,7 @@ func (v Int64Value) SaturatingMinus(context NumberValueArithmeticContext, other 
 func (v Int64Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -237,7 +237,7 @@ func (v Int64Value) Mod(context NumberValueArithmeticContext, other NumberValue,
 
 	// INT33-C
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	}
@@ -252,7 +252,7 @@ func (v Int64Value) Mod(context NumberValueArithmeticContext, other NumberValue,
 func (v Int64Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -272,7 +272,7 @@ func (v Int64Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		} else {
 			// positive * negative = negative. underflow?
 			if o < (math.MinInt64 / v) {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -281,7 +281,7 @@ func (v Int64Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		if o > 0 {
 			// negative * positive = negative. underflow?
 			if v < (math.MinInt64 / o) {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -305,7 +305,7 @@ func (v Int64Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 func (v Int64Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -349,7 +349,7 @@ func (v Int64Value) SaturatingMul(context NumberValueArithmeticContext, other Nu
 func (v Int64Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -360,7 +360,7 @@ func (v Int64Value) Div(context NumberValueArithmeticContext, other NumberValue,
 	// INT33-C
 	// https://golang.org/ref/spec#Integer_operators
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	} else if (v == math.MinInt64) && (o == -1) {
@@ -379,7 +379,7 @@ func (v Int64Value) Div(context NumberValueArithmeticContext, other NumberValue,
 func (v Int64Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -391,7 +391,7 @@ func (v Int64Value) SaturatingDiv(context NumberValueArithmeticContext, other Nu
 		// INT33-C
 		// https://golang.org/ref/spec#Integer_operators
 		if o == 0 {
-			panic(DivisionByZeroError{
+			panic(&DivisionByZeroError{
 				LocationRange: locationRange,
 			})
 		} else if (v == math.MinInt64) && (o == -1) {
@@ -406,7 +406,7 @@ func (v Int64Value) SaturatingDiv(context NumberValueArithmeticContext, other Nu
 func (v Int64Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -420,7 +420,7 @@ func (v Int64Value) Less(context ValueComparisonContext, other ComparableValue, 
 func (v Int64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -434,7 +434,7 @@ func (v Int64Value) LessEqual(context ValueComparisonContext, other ComparableVa
 func (v Int64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -449,7 +449,7 @@ func (v Int64Value) Greater(context ValueComparisonContext, other ComparableValu
 func (v Int64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -487,7 +487,7 @@ func ConvertInt64(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 					LocationRange: locationRange,
 				})
 			} else if v.Cmp(sema.Int64TypeMinInt) < 0 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -508,7 +508,7 @@ func ConvertInt64(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 func (v Int64Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -526,7 +526,7 @@ func (v Int64Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue
 func (v Int64Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -544,7 +544,7 @@ func (v Int64Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValu
 func (v Int64Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -562,7 +562,7 @@ func (v Int64Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValu
 func (v Int64Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -571,7 +571,7 @@ func (v Int64Value) BitwiseLeftShift(context ValueStaticTypeContext, other Integ
 	}
 
 	if o < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}
@@ -586,7 +586,7 @@ func (v Int64Value) BitwiseLeftShift(context ValueStaticTypeContext, other Integ
 func (v Int64Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -595,7 +595,7 @@ func (v Int64Value) BitwiseRightShift(context ValueStaticTypeContext, other Inte
 	}
 
 	if o < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -101,7 +101,7 @@ func (v Int8Value) ToInt(_ LocationRange) int {
 func (v Int8Value) Negate(context NumberValueArithmeticContext, locationRange LocationRange) NumberValue {
 	// INT32-C
 	if v == math.MinInt8 {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -126,7 +126,7 @@ func (v Int8Value) Plus(context NumberValueArithmeticContext, other NumberValue,
 
 	// INT32-C
 	if (o > 0) && (v > (math.MaxInt8 - o)) {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v < (math.MinInt8 - o)) {
@@ -179,7 +179,7 @@ func (v Int8Value) Minus(context NumberValueArithmeticContext, other NumberValue
 
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt8 + o)) {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v > (math.MaxInt8 + o)) {
@@ -260,7 +260,7 @@ func (v Int8Value) Mul(context NumberValueArithmeticContext, other NumberValue, 
 		if o > 0 {
 			// positive * positive = positive. overflow?
 			if v > (math.MaxInt8 / o) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -283,7 +283,7 @@ func (v Int8Value) Mul(context NumberValueArithmeticContext, other NumberValue, 
 		} else {
 			// negative * negative = positive. overflow?
 			if (v != 0) && (o < (math.MaxInt8 / v)) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -360,7 +360,7 @@ func (v Int8Value) Div(context NumberValueArithmeticContext, other NumberValue, 
 			LocationRange: locationRange,
 		})
 	} else if (v == math.MinInt8) && (o == -1) {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -479,7 +479,7 @@ func ConvertInt8(memoryGauge common.MemoryGauge, value Value, locationRange Loca
 		case BigNumberValue:
 			v := value.ToBigInt(memoryGauge)
 			if v.Cmp(sema.Int8TypeMaxInt) > 0 {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			} else if v.Cmp(sema.Int8TypeMinInt) < 0 {
@@ -492,7 +492,7 @@ func ConvertInt8(memoryGauge common.MemoryGauge, value Value, locationRange Loca
 		case NumberValue:
 			v := value.ToInt(locationRange)
 			if v > math.MaxInt8 {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			} else if v < math.MinInt8 {

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -116,7 +116,7 @@ func (v Int8Value) Negate(context NumberValueArithmeticContext, locationRange Lo
 func (v Int8Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -130,7 +130,7 @@ func (v Int8Value) Plus(context NumberValueArithmeticContext, other NumberValue,
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v < (math.MinInt8 - o)) {
-		panic(UnderflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -145,7 +145,7 @@ func (v Int8Value) Plus(context NumberValueArithmeticContext, other NumberValue,
 func (v Int8Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -169,7 +169,7 @@ func (v Int8Value) SaturatingPlus(context NumberValueArithmeticContext, other Nu
 func (v Int8Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -183,7 +183,7 @@ func (v Int8Value) Minus(context NumberValueArithmeticContext, other NumberValue
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v > (math.MaxInt8 + o)) {
-		panic(UnderflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -198,7 +198,7 @@ func (v Int8Value) Minus(context NumberValueArithmeticContext, other NumberValue
 func (v Int8Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -222,7 +222,7 @@ func (v Int8Value) SaturatingMinus(context NumberValueArithmeticContext, other N
 func (v Int8Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -232,7 +232,7 @@ func (v Int8Value) Mod(context NumberValueArithmeticContext, other NumberValue, 
 
 	// INT33-C
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	}
@@ -247,7 +247,7 @@ func (v Int8Value) Mod(context NumberValueArithmeticContext, other NumberValue, 
 func (v Int8Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -267,7 +267,7 @@ func (v Int8Value) Mul(context NumberValueArithmeticContext, other NumberValue, 
 		} else {
 			// positive * negative = negative. underflow?
 			if o < (math.MinInt8 / v) {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -276,7 +276,7 @@ func (v Int8Value) Mul(context NumberValueArithmeticContext, other NumberValue, 
 		if o > 0 {
 			// negative * positive = negative. underflow?
 			if v < (math.MinInt8 / o) {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -300,7 +300,7 @@ func (v Int8Value) Mul(context NumberValueArithmeticContext, other NumberValue, 
 func (v Int8Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -345,7 +345,7 @@ func (v Int8Value) SaturatingMul(context NumberValueArithmeticContext, other Num
 func (v Int8Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -356,7 +356,7 @@ func (v Int8Value) Div(context NumberValueArithmeticContext, other NumberValue, 
 	// INT33-C
 	// https://golang.org/ref/spec#Integer_operators
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	} else if (v == math.MinInt8) && (o == -1) {
@@ -375,7 +375,7 @@ func (v Int8Value) Div(context NumberValueArithmeticContext, other NumberValue, 
 func (v Int8Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -387,7 +387,7 @@ func (v Int8Value) SaturatingDiv(context NumberValueArithmeticContext, other Num
 		// INT33-C
 		// https://golang.org/ref/spec#Integer_operators
 		if o == 0 {
-			panic(DivisionByZeroError{
+			panic(&DivisionByZeroError{
 				LocationRange: locationRange,
 			})
 		} else if (v == math.MinInt8) && (o == -1) {
@@ -402,7 +402,7 @@ func (v Int8Value) SaturatingDiv(context NumberValueArithmeticContext, other Num
 func (v Int8Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -416,7 +416,7 @@ func (v Int8Value) Less(context ValueComparisonContext, other ComparableValue, l
 func (v Int8Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -430,7 +430,7 @@ func (v Int8Value) LessEqual(context ValueComparisonContext, other ComparableVal
 func (v Int8Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -444,7 +444,7 @@ func (v Int8Value) Greater(context ValueComparisonContext, other ComparableValue
 func (v Int8Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -483,7 +483,7 @@ func ConvertInt8(memoryGauge common.MemoryGauge, value Value, locationRange Loca
 					LocationRange: locationRange,
 				})
 			} else if v.Cmp(sema.Int8TypeMinInt) < 0 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -496,7 +496,7 @@ func ConvertInt8(memoryGauge common.MemoryGauge, value Value, locationRange Loca
 					LocationRange: locationRange,
 				})
 			} else if v < math.MinInt8 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -513,7 +513,7 @@ func ConvertInt8(memoryGauge common.MemoryGauge, value Value, locationRange Loca
 func (v Int8Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -531,7 +531,7 @@ func (v Int8Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue,
 func (v Int8Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -549,7 +549,7 @@ func (v Int8Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue
 func (v Int8Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -567,7 +567,7 @@ func (v Int8Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue
 func (v Int8Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -576,7 +576,7 @@ func (v Int8Value) BitwiseLeftShift(context ValueStaticTypeContext, other Intege
 	}
 
 	if o < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}
@@ -591,7 +591,7 @@ func (v Int8Value) BitwiseLeftShift(context ValueStaticTypeContext, other Intege
 func (v Int8Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Int8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -600,7 +600,7 @@ func (v Int8Value) BitwiseRightShift(context ValueStaticTypeContext, other Integ
 	}
 
 	if o < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_publickey.go
+++ b/interpreter/value_publickey.go
@@ -64,7 +64,7 @@ func NewPublicKeyValue(
 
 	err := validatePublicKey(context, locationRange, publicKeyValue)
 	if err != nil {
-		panic(InvalidPublicKeyError{
+		panic(&InvalidPublicKeyError{
 			PublicKey:     publicKey,
 			Err:           err,
 			LocationRange: locationRange,

--- a/interpreter/value_range.go
+++ b/interpreter/value_range.go
@@ -47,7 +47,7 @@ func NewInclusiveRangeValue(
 	if startComparable.Greater(context, endComparable, locationRange) {
 		elemSemaTy := MustConvertStaticToSemaType(rangeStaticType.ElementType, context)
 		if elemSemaTy.Tag().BelongsTo(sema.UnsignedIntegerTypeTag) {
-			panic(InclusiveRangeConstructionError{
+			panic(&InclusiveRangeConstructionError{
 				LocationRange: locationRange,
 				Message: fmt.Sprintf(
 					"step value cannot be negative for unsigned integer type %s",
@@ -91,7 +91,7 @@ func NewInclusiveRangeValueWithStep(
 
 	// Validate that the step is non-zero.
 	if step.Equal(context, locationRange, zeroValue) {
-		panic(InclusiveRangeConstructionError{
+		panic(&InclusiveRangeConstructionError{
 			LocationRange: locationRange,
 			Message:       "step value cannot be zero",
 		})
@@ -103,7 +103,7 @@ func NewInclusiveRangeValueWithStep(
 	// If start == end, step doesn't matter.
 	if isSequenceMovingAwayFromEnd(context, locationRange, start, end, step, zeroValue) {
 
-		panic(InclusiveRangeConstructionError{
+		panic(&InclusiveRangeConstructionError{
 			LocationRange: locationRange,
 			Message: fmt.Sprintf(
 				"sequence is moving away from end: %s due to the value of step: %s and start: %s",

--- a/interpreter/value_reference.go
+++ b/interpreter/value_reference.go
@@ -58,7 +58,7 @@ func DereferenceValue(
 
 	// Defensive check: ensure that the referenced value is not a resource
 	if referencedValue.IsResourceKinded(context) {
-		panic(ResourceReferenceDereferenceError{
+		panic(&ResourceReferenceDereferenceError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -134,7 +134,7 @@ func (v *StorageReferenceValue) dereference(context ValueStaticTypeContext, loca
 	}
 
 	if reference, isReference := referenced.(ReferenceValue); isReference {
-		panic(NestedReferenceError{
+		panic(&NestedReferenceError{
 			Value:         reference,
 			LocationRange: locationRange,
 		})

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -146,7 +146,7 @@ func (v *StorageReferenceValue) dereference(context ValueStaticTypeContext, loca
 		if !IsSubTypeOfSemaType(context, staticType, v.BorrowedType) {
 			semaType := MustConvertStaticToSemaType(staticType, context)
 
-			return nil, ForceCastTypeMismatchError{
+			return nil, &ForceCastTypeMismatchError{
 				ExpectedType:  v.BorrowedType,
 				ActualType:    semaType,
 				LocationRange: locationRange,
@@ -166,10 +166,10 @@ func (v *StorageReferenceValue) ReferencedValue(
 	if err == nil {
 		return referencedValue
 	}
-	if forceCastErr, ok := err.(ForceCastTypeMismatchError); ok {
+	if forceCastErr, ok := err.(*ForceCastTypeMismatchError); ok {
 		if errorOnFailedDereference {
 			// relay the type mismatch error with a dereference error context
-			panic(DereferenceError{
+			panic(&DereferenceError{
 				ExpectedType:  forceCastErr.ExpectedType,
 				ActualType:    forceCastErr.ActualType,
 				LocationRange: locationRange,
@@ -186,7 +186,7 @@ func (v *StorageReferenceValue) mustReferencedValue(
 ) Value {
 	referencedValue := v.ReferencedValue(context, locationRange, true)
 	if referencedValue == nil {
-		panic(DereferenceError{
+		panic(&DereferenceError{
 			Cause:         "no value is stored at this path",
 			LocationRange: locationRange,
 		})

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -155,7 +155,7 @@ func (v *StringValue) Equal(_ ValueComparisonContext, _ LocationRange, other Val
 func (v *StringValue) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	otherString, ok := other.(*StringValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -169,7 +169,7 @@ func (v *StringValue) Less(context ValueComparisonContext, other ComparableValue
 func (v *StringValue) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	otherString, ok := other.(*StringValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -183,7 +183,7 @@ func (v *StringValue) LessEqual(context ValueComparisonContext, other Comparable
 func (v *StringValue) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	otherString, ok := other.(*StringValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -197,7 +197,7 @@ func (v *StringValue) Greater(context ValueComparisonContext, other ComparableVa
 func (v *StringValue) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	otherString, ok := other.(*StringValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -270,7 +270,7 @@ func (v *StringValue) slice(fromIndex int, toIndex int, locationRange LocationRa
 	length := v.Length()
 
 	if fromIndex < 0 || fromIndex > length || toIndex < 0 || toIndex > length {
-		panic(StringSliceIndicesError{
+		panic(&StringSliceIndicesError{
 			FromIndex:     fromIndex,
 			UpToIndex:     toIndex,
 			Length:        length,
@@ -279,7 +279,7 @@ func (v *StringValue) slice(fromIndex int, toIndex int, locationRange LocationRa
 	}
 
 	if fromIndex > toIndex {
-		panic(InvalidSliceIndexError{
+		panic(&InvalidSliceIndexError{
 			FromIndex:     fromIndex,
 			UpToIndex:     toIndex,
 			LocationRange: locationRange,
@@ -320,7 +320,7 @@ func (v *StringValue) checkBounds(index int, locationRange LocationRange) {
 	length := v.Length()
 
 	if index < 0 || index >= length {
-		panic(StringIndexOutOfBoundsError{
+		panic(&StringIndexOutOfBoundsError{
 			Index:         index,
 			Length:        length,
 			LocationRange: locationRange,
@@ -828,14 +828,14 @@ func (v *StringValue) DecodeHex(context ArrayCreationContext, locationRange Loca
 	bs, err := hex.DecodeString(v.Str)
 	if err != nil {
 		if err, ok := err.(hex.InvalidByteError); ok {
-			panic(InvalidHexByteError{
+			panic(&InvalidHexByteError{
 				LocationRange: locationRange,
 				Byte:          byte(err),
 			})
 		}
 
 		if err == hex.ErrLength {
-			panic(InvalidHexLengthError{
+			panic(&InvalidHexLengthError{
 				LocationRange: locationRange,
 			})
 		}

--- a/interpreter/value_test.go
+++ b/interpreter/value_test.go
@@ -3462,19 +3462,26 @@ func TestPublicKeyValue(t *testing.T) {
 			UInt8Value(sema.SignatureAlgorithmECDSA_secp256k1.RawValue()),
 		)
 
-		assert.PanicsWithValue(t,
-			InvalidPublicKeyError{PublicKey: publicKey, Err: fakeError},
-			func() {
-				_ = NewPublicKeyValue(
-					inter,
-					EmptyLocationRange,
-					publicKey,
-					sigAlgo,
-					func(context PublicKeyValidationContext, locationRange LocationRange, publicKey *CompositeValue) error {
-						return fakeError
-					},
+		func() {
+			defer func() {
+				r :=  recover()
+				assert.Equal(
+					t,
+					&InvalidPublicKeyError{PublicKey: publicKey, Err: fakeError},
+					r,
 				)
-			})
+			}()
+
+			_ = NewPublicKeyValue(
+				inter,
+				EmptyLocationRange,
+				publicKey,
+				sigAlgo,
+				func(context PublicKeyValidationContext, locationRange LocationRange, publicKey *CompositeValue) error {
+					return fakeError
+				},
+			)
+		}()
 	})
 }
 

--- a/interpreter/value_test.go
+++ b/interpreter/value_test.go
@@ -3464,7 +3464,7 @@ func TestPublicKeyValue(t *testing.T) {
 
 		func() {
 			defer func() {
-				r :=  recover()
+				r := recover()
 				assert.Equal(
 					t,
 					&InvalidPublicKeyError{PublicKey: publicKey, Err: fakeError},

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -97,7 +97,7 @@ func ConvertUFix64(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 
 	case Fix64Value:
 		if value < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -113,7 +113,7 @@ func ConvertUFix64(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 			v := value.ToBigInt(memoryGauge)
 
 			if v.Sign() < 0 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -138,7 +138,7 @@ func ConvertUFix64(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 		converter := func() uint64 {
 			v := value.ToInt(locationRange)
 			if v < 0 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -210,7 +210,7 @@ func (v UFix64Value) Negate(NumberValueArithmeticContext, LocationRange) NumberV
 func (v UFix64Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -227,7 +227,7 @@ func (v UFix64Value) Plus(context NumberValueArithmeticContext, other NumberValu
 func (v UFix64Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -245,7 +245,7 @@ func (v UFix64Value) SaturatingPlus(context NumberValueArithmeticContext, other 
 func (v UFix64Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -263,7 +263,7 @@ func (v UFix64Value) Minus(context NumberValueArithmeticContext, other NumberVal
 func (v UFix64Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -281,7 +281,7 @@ func (v UFix64Value) SaturatingMinus(context NumberValueArithmeticContext, other
 func (v UFix64Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -299,7 +299,7 @@ func (v UFix64Value) Mul(context NumberValueArithmeticContext, other NumberValue
 func (v UFix64Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -317,7 +317,7 @@ func (v UFix64Value) SaturatingMul(context NumberValueArithmeticContext, other N
 func (v UFix64Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -335,8 +335,8 @@ func (v UFix64Value) Div(context NumberValueArithmeticContext, other NumberValue
 func (v UFix64Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -351,7 +351,7 @@ func (v UFix64Value) SaturatingDiv(context NumberValueArithmeticContext, other N
 func (v UFix64Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -369,7 +369,7 @@ func (v UFix64Value) Mod(context NumberValueArithmeticContext, other NumberValue
 func (v UFix64Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -383,7 +383,7 @@ func (v UFix64Value) Less(context ValueComparisonContext, other ComparableValue,
 func (v UFix64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -397,7 +397,7 @@ func (v UFix64Value) LessEqual(context ValueComparisonContext, other ComparableV
 func (v UFix64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -411,7 +411,7 @@ func (v UFix64Value) Greater(context ValueComparisonContext, other ComparableVal
 func (v UFix64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UFix64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -46,7 +46,7 @@ func NewUFix64ValueWithInteger(gauge common.MemoryGauge, constructor func() uint
 	})
 	if err != nil {
 		if _, ok := err.(values.OverflowError); ok {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -61,7 +61,7 @@ func NewUnmeteredUFix64ValueWithInteger(integer uint64, locationRange LocationRa
 	ufix64Value, err := values.NewUnmeteredUFix64ValueWithInteger(integer)
 	if err != nil {
 		if _, ok := err.(values.OverflowError); ok {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -123,7 +123,7 @@ func ConvertUFix64(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 			// allows us to call `v.UInt64()` safely.
 
 			if !v.IsUint64() {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -135,7 +135,7 @@ func (v UIntValue) IsImportable(_ ValueImportableContext, _ LocationRange) bool 
 
 func (v UIntValue) ToInt(locationRange LocationRange) int {
 	if !v.BigInt.IsInt64() {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -541,7 +541,7 @@ func (v UIntValue) BitwiseLeftShift(context ValueStaticTypeContext, other Intege
 	}
 
 	if !o.BigInt.IsUint64() {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -574,7 +574,7 @@ func (v UIntValue) BitwiseRightShift(context ValueStaticTypeContext, other Integ
 		})
 	}
 	if !o.BigInt.IsUint64() {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -81,7 +81,7 @@ func ConvertUInt(memoryGauge common.MemoryGauge, value Value, locationRange Loca
 			func() *big.Int {
 				v := value.ToBigInt(memoryGauge)
 				if v.Sign() < 0 {
-					panic(UnderflowError{
+					panic(&UnderflowError{
 						LocationRange: locationRange,
 					})
 				}
@@ -92,7 +92,7 @@ func ConvertUInt(memoryGauge common.MemoryGauge, value Value, locationRange Loca
 	case NumberValue:
 		v := value.ToInt(locationRange)
 		if v < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -176,7 +176,7 @@ func (v UIntValue) Negate(NumberValueArithmeticContext, LocationRange) NumberVal
 func (v UIntValue) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -197,8 +197,8 @@ func (v UIntValue) Plus(context NumberValueArithmeticContext, other NumberValue,
 func (v UIntValue) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -213,7 +213,7 @@ func (v UIntValue) SaturatingPlus(context NumberValueArithmeticContext, other Nu
 func (v UIntValue) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -229,7 +229,7 @@ func (v UIntValue) Minus(context NumberValueArithmeticContext, other NumberValue
 			res.Sub(v.BigInt, o.BigInt)
 			// INT30-C
 			if res.Sign() < 0 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -241,7 +241,7 @@ func (v UIntValue) Minus(context NumberValueArithmeticContext, other NumberValue
 func (v UIntValue) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -267,7 +267,7 @@ func (v UIntValue) SaturatingMinus(context NumberValueArithmeticContext, other N
 func (v UIntValue) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -282,7 +282,7 @@ func (v UIntValue) Mod(context NumberValueArithmeticContext, other NumberValue, 
 			res := new(big.Int)
 			// INT33-C
 			if o.BigInt.Cmp(res) == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -295,7 +295,7 @@ func (v UIntValue) Mod(context NumberValueArithmeticContext, other NumberValue, 
 func (v UIntValue) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -316,8 +316,8 @@ func (v UIntValue) Mul(context NumberValueArithmeticContext, other NumberValue, 
 func (v UIntValue) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -332,7 +332,7 @@ func (v UIntValue) SaturatingMul(context NumberValueArithmeticContext, other Num
 func (v UIntValue) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -347,7 +347,7 @@ func (v UIntValue) Div(context NumberValueArithmeticContext, other NumberValue, 
 			res := new(big.Int)
 			// INT33-C
 			if o.BigInt.Cmp(res) == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -359,8 +359,8 @@ func (v UIntValue) Div(context NumberValueArithmeticContext, other NumberValue, 
 func (v UIntValue) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -375,7 +375,7 @@ func (v UIntValue) SaturatingDiv(context NumberValueArithmeticContext, other Num
 func (v UIntValue) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -390,7 +390,7 @@ func (v UIntValue) Less(context ValueComparisonContext, other ComparableValue, l
 func (v UIntValue) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -405,7 +405,7 @@ func (v UIntValue) LessEqual(context ValueComparisonContext, other ComparableVal
 func (v UIntValue) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -420,7 +420,7 @@ func (v UIntValue) Greater(context ValueComparisonContext, other ComparableValue
 func (v UIntValue) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -463,7 +463,7 @@ func (v UIntValue) HashInput(_ common.MemoryGauge, _ LocationRange, scratch []by
 func (v UIntValue) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -484,7 +484,7 @@ func (v UIntValue) BitwiseOr(context ValueStaticTypeContext, other IntegerValue,
 func (v UIntValue) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -505,7 +505,7 @@ func (v UIntValue) BitwiseXor(context ValueStaticTypeContext, other IntegerValue
 func (v UIntValue) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -526,7 +526,7 @@ func (v UIntValue) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue
 func (v UIntValue) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -535,7 +535,7 @@ func (v UIntValue) BitwiseLeftShift(context ValueStaticTypeContext, other Intege
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}
@@ -560,7 +560,7 @@ func (v UIntValue) BitwiseLeftShift(context ValueStaticTypeContext, other Intege
 func (v UIntValue) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UIntValue)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -569,7 +569,7 @@ func (v UIntValue) BitwiseRightShift(context ValueStaticTypeContext, other Integ
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -94,7 +94,7 @@ func (UInt128Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool
 
 func (v UInt128Value) ToInt(locationRange LocationRange) int {
 	if !v.BigInt.IsInt64() {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -159,7 +159,7 @@ func (v UInt128Value) Plus(context NumberValueArithmeticContext, other NumberVal
 			//  }
 			//
 			if sum.Cmp(sema.UInt128TypeMaxIntBig) > 0 {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -314,7 +314,7 @@ func (v UInt128Value) Mul(context NumberValueArithmeticContext, other NumberValu
 			res := new(big.Int)
 			res.Mul(v.BigInt, o.BigInt)
 			if res.Cmp(sema.UInt128TypeMaxIntBig) > 0 {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -496,7 +496,7 @@ func ConvertUInt128(memoryGauge common.MemoryGauge, value Value, locationRange L
 			}
 
 			if v.Cmp(sema.UInt128TypeMaxIntBig) > 0 {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			} else if v.Sign() < 0 {

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -135,7 +135,7 @@ func (v UInt128Value) Negate(NumberValueArithmeticContext, LocationRange) Number
 func (v UInt128Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -171,7 +171,7 @@ func (v UInt128Value) Plus(context NumberValueArithmeticContext, other NumberVal
 func (v UInt128Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -205,7 +205,7 @@ func (v UInt128Value) SaturatingPlus(context NumberValueArithmeticContext, other
 func (v UInt128Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -229,7 +229,7 @@ func (v UInt128Value) Minus(context NumberValueArithmeticContext, other NumberVa
 			//   }
 			//
 			if diff.Cmp(sema.UInt128TypeMinIntBig) < 0 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -241,7 +241,7 @@ func (v UInt128Value) Minus(context NumberValueArithmeticContext, other NumberVa
 func (v UInt128Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -275,7 +275,7 @@ func (v UInt128Value) SaturatingMinus(context NumberValueArithmeticContext, othe
 func (v UInt128Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -288,7 +288,7 @@ func (v UInt128Value) Mod(context NumberValueArithmeticContext, other NumberValu
 		func() *big.Int {
 			res := new(big.Int)
 			if o.BigInt.Cmp(res) == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -300,7 +300,7 @@ func (v UInt128Value) Mod(context NumberValueArithmeticContext, other NumberValu
 func (v UInt128Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -326,7 +326,7 @@ func (v UInt128Value) Mul(context NumberValueArithmeticContext, other NumberValu
 func (v UInt128Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -350,7 +350,7 @@ func (v UInt128Value) SaturatingMul(context NumberValueArithmeticContext, other 
 func (v UInt128Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -363,7 +363,7 @@ func (v UInt128Value) Div(context NumberValueArithmeticContext, other NumberValu
 		func() *big.Int {
 			res := new(big.Int)
 			if o.BigInt.Cmp(res) == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -376,8 +376,8 @@ func (v UInt128Value) Div(context NumberValueArithmeticContext, other NumberValu
 func (v UInt128Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -392,7 +392,7 @@ func (v UInt128Value) SaturatingDiv(context NumberValueArithmeticContext, other 
 func (v UInt128Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -407,7 +407,7 @@ func (v UInt128Value) Less(context ValueComparisonContext, other ComparableValue
 func (v UInt128Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -422,7 +422,7 @@ func (v UInt128Value) LessEqual(context ValueComparisonContext, other Comparable
 func (v UInt128Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -437,7 +437,7 @@ func (v UInt128Value) Greater(context ValueComparisonContext, other ComparableVa
 func (v UInt128Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -500,7 +500,7 @@ func ConvertUInt128(memoryGauge common.MemoryGauge, value Value, locationRange L
 					LocationRange: locationRange,
 				})
 			} else if v.Sign() < 0 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -513,7 +513,7 @@ func ConvertUInt128(memoryGauge common.MemoryGauge, value Value, locationRange L
 func (v UInt128Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -533,7 +533,7 @@ func (v UInt128Value) BitwiseOr(context ValueStaticTypeContext, other IntegerVal
 func (v UInt128Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -553,7 +553,7 @@ func (v UInt128Value) BitwiseXor(context ValueStaticTypeContext, other IntegerVa
 func (v UInt128Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -574,7 +574,7 @@ func (v UInt128Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerVa
 func (v UInt128Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -583,7 +583,7 @@ func (v UInt128Value) BitwiseLeftShift(context ValueStaticTypeContext, other Int
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}
@@ -609,7 +609,7 @@ func (v UInt128Value) BitwiseLeftShift(context ValueStaticTypeContext, other Int
 func (v UInt128Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -618,7 +618,7 @@ func (v UInt128Value) BitwiseRightShift(context ValueStaticTypeContext, other In
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -104,7 +104,7 @@ func (v UInt16Value) Negate(NumberValueArithmeticContext, LocationRange) NumberV
 func (v UInt16Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -130,7 +130,7 @@ func (v UInt16Value) Plus(context NumberValueArithmeticContext, other NumberValu
 func (v UInt16Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -154,7 +154,7 @@ func (v UInt16Value) SaturatingPlus(context NumberValueArithmeticContext, other 
 func (v UInt16Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -168,7 +168,7 @@ func (v UInt16Value) Minus(context NumberValueArithmeticContext, other NumberVal
 			diff := v - o
 			// INT30-C
 			if diff > v {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -180,7 +180,7 @@ func (v UInt16Value) Minus(context NumberValueArithmeticContext, other NumberVal
 func (v UInt16Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -204,7 +204,7 @@ func (v UInt16Value) SaturatingMinus(context NumberValueArithmeticContext, other
 func (v UInt16Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -216,7 +216,7 @@ func (v UInt16Value) Mod(context NumberValueArithmeticContext, other NumberValue
 		context,
 		func() uint16 {
 			if o == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -228,7 +228,7 @@ func (v UInt16Value) Mod(context NumberValueArithmeticContext, other NumberValue
 func (v UInt16Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -253,7 +253,7 @@ func (v UInt16Value) Mul(context NumberValueArithmeticContext, other NumberValue
 func (v UInt16Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -276,7 +276,7 @@ func (v UInt16Value) SaturatingMul(context NumberValueArithmeticContext, other N
 func (v UInt16Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -288,7 +288,7 @@ func (v UInt16Value) Div(context NumberValueArithmeticContext, other NumberValue
 		context,
 		func() uint16 {
 			if o == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -300,8 +300,8 @@ func (v UInt16Value) Div(context NumberValueArithmeticContext, other NumberValue
 func (v UInt16Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -316,7 +316,7 @@ func (v UInt16Value) SaturatingDiv(context NumberValueArithmeticContext, other N
 func (v UInt16Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -330,7 +330,7 @@ func (v UInt16Value) Less(context ValueComparisonContext, other ComparableValue,
 func (v UInt16Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -344,7 +344,7 @@ func (v UInt16Value) LessEqual(context ValueComparisonContext, other ComparableV
 func (v UInt16Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -358,7 +358,7 @@ func (v UInt16Value) Greater(context ValueComparisonContext, other ComparableVal
 func (v UInt16Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -404,7 +404,7 @@ func ConvertUInt16(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 func (v UInt16Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -423,7 +423,7 @@ func (v UInt16Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValu
 func (v UInt16Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -442,7 +442,7 @@ func (v UInt16Value) BitwiseXor(context ValueStaticTypeContext, other IntegerVal
 func (v UInt16Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -461,7 +461,7 @@ func (v UInt16Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerVal
 func (v UInt16Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -480,7 +480,7 @@ func (v UInt16Value) BitwiseLeftShift(context ValueStaticTypeContext, other Inte
 func (v UInt16Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -118,7 +118,7 @@ func (v UInt16Value) Plus(context NumberValueArithmeticContext, other NumberValu
 			sum := v + o
 			// INT30-C
 			if sum < v {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -241,7 +241,7 @@ func (v UInt16Value) Mul(context NumberValueArithmeticContext, other NumberValue
 		func() uint16 {
 			// INT30-C
 			if (v > 0) && (o > 0) && (v > (math.MaxUint16 / o)) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -94,7 +94,7 @@ func (UInt256Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool
 
 func (v UInt256Value) ToInt(locationRange LocationRange) int {
 	if !v.BigInt.IsInt64() {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -160,7 +160,7 @@ func (v UInt256Value) Plus(context NumberValueArithmeticContext, other NumberVal
 			//  }
 			//
 			if sum.Cmp(sema.UInt256TypeMaxIntBig) > 0 {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -317,7 +317,7 @@ func (v UInt256Value) Mul(context NumberValueArithmeticContext, other NumberValu
 			res := new(big.Int)
 			res.Mul(v.BigInt, o.BigInt)
 			if res.Cmp(sema.UInt256TypeMaxIntBig) > 0 {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -497,7 +497,7 @@ func ConvertUInt256(memoryGauge common.MemoryGauge, value Value, locationRange L
 			}
 
 			if v.Cmp(sema.UInt256TypeMaxIntBig) > 0 {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			} else if v.Sign() < 0 {

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -136,7 +136,7 @@ func (v UInt256Value) Negate(NumberValueArithmeticContext, LocationRange) Number
 func (v UInt256Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -173,7 +173,7 @@ func (v UInt256Value) Plus(context NumberValueArithmeticContext, other NumberVal
 func (v UInt256Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -207,7 +207,7 @@ func (v UInt256Value) SaturatingPlus(context NumberValueArithmeticContext, other
 func (v UInt256Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -231,7 +231,7 @@ func (v UInt256Value) Minus(context NumberValueArithmeticContext, other NumberVa
 			//   }
 			//
 			if diff.Cmp(sema.UInt256TypeMinIntBig) < 0 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -243,7 +243,7 @@ func (v UInt256Value) Minus(context NumberValueArithmeticContext, other NumberVa
 func (v UInt256Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -278,7 +278,7 @@ func (v UInt256Value) SaturatingMinus(context NumberValueArithmeticContext, othe
 func (v UInt256Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -291,7 +291,7 @@ func (v UInt256Value) Mod(context NumberValueArithmeticContext, other NumberValu
 		func() *big.Int {
 			res := new(big.Int)
 			if o.BigInt.Cmp(res) == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -303,7 +303,7 @@ func (v UInt256Value) Mod(context NumberValueArithmeticContext, other NumberValu
 func (v UInt256Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -329,7 +329,7 @@ func (v UInt256Value) Mul(context NumberValueArithmeticContext, other NumberValu
 func (v UInt256Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -353,7 +353,7 @@ func (v UInt256Value) SaturatingMul(context NumberValueArithmeticContext, other 
 func (v UInt256Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -366,7 +366,7 @@ func (v UInt256Value) Div(context NumberValueArithmeticContext, other NumberValu
 		func() *big.Int {
 			res := new(big.Int)
 			if o.BigInt.Cmp(res) == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -378,8 +378,8 @@ func (v UInt256Value) Div(context NumberValueArithmeticContext, other NumberValu
 func (v UInt256Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -394,7 +394,7 @@ func (v UInt256Value) SaturatingDiv(context NumberValueArithmeticContext, other 
 func (v UInt256Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -409,7 +409,7 @@ func (v UInt256Value) Less(context ValueComparisonContext, other ComparableValue
 func (v UInt256Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -424,7 +424,7 @@ func (v UInt256Value) LessEqual(context ValueComparisonContext, other Comparable
 func (v UInt256Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -439,7 +439,7 @@ func (v UInt256Value) Greater(context ValueComparisonContext, other ComparableVa
 func (v UInt256Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -501,7 +501,7 @@ func ConvertUInt256(memoryGauge common.MemoryGauge, value Value, locationRange L
 					LocationRange: locationRange,
 				})
 			} else if v.Sign() < 0 {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -514,7 +514,7 @@ func ConvertUInt256(memoryGauge common.MemoryGauge, value Value, locationRange L
 func (v UInt256Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -534,7 +534,7 @@ func (v UInt256Value) BitwiseOr(context ValueStaticTypeContext, other IntegerVal
 func (v UInt256Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -554,7 +554,7 @@ func (v UInt256Value) BitwiseXor(context ValueStaticTypeContext, other IntegerVa
 func (v UInt256Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -574,7 +574,7 @@ func (v UInt256Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerVa
 func (v UInt256Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -583,7 +583,7 @@ func (v UInt256Value) BitwiseLeftShift(context ValueStaticTypeContext, other Int
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}
@@ -609,7 +609,7 @@ func (v UInt256Value) BitwiseLeftShift(context ValueStaticTypeContext, other Int
 func (v UInt256Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -618,7 +618,7 @@ func (v UInt256Value) BitwiseRightShift(context ValueStaticTypeContext, other In
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -105,7 +105,7 @@ func (v UInt32Value) Negate(NumberValueArithmeticContext, LocationRange) NumberV
 func (v UInt32Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -131,7 +131,7 @@ func (v UInt32Value) Plus(context NumberValueArithmeticContext, other NumberValu
 func (v UInt32Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -155,7 +155,7 @@ func (v UInt32Value) SaturatingPlus(context NumberValueArithmeticContext, other 
 func (v UInt32Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -169,7 +169,7 @@ func (v UInt32Value) Minus(context NumberValueArithmeticContext, other NumberVal
 			diff := v - o
 			// INT30-C
 			if diff > v {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -181,7 +181,7 @@ func (v UInt32Value) Minus(context NumberValueArithmeticContext, other NumberVal
 func (v UInt32Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -205,7 +205,7 @@ func (v UInt32Value) SaturatingMinus(context NumberValueArithmeticContext, other
 func (v UInt32Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -217,7 +217,7 @@ func (v UInt32Value) Mod(context NumberValueArithmeticContext, other NumberValue
 		context,
 		func() uint32 {
 			if o == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -229,7 +229,7 @@ func (v UInt32Value) Mod(context NumberValueArithmeticContext, other NumberValue
 func (v UInt32Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -253,7 +253,7 @@ func (v UInt32Value) Mul(context NumberValueArithmeticContext, other NumberValue
 func (v UInt32Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -277,7 +277,7 @@ func (v UInt32Value) SaturatingMul(context NumberValueArithmeticContext, other N
 func (v UInt32Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -289,7 +289,7 @@ func (v UInt32Value) Div(context NumberValueArithmeticContext, other NumberValue
 		context,
 		func() uint32 {
 			if o == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -301,8 +301,8 @@ func (v UInt32Value) Div(context NumberValueArithmeticContext, other NumberValue
 func (v UInt32Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -317,7 +317,7 @@ func (v UInt32Value) SaturatingDiv(context NumberValueArithmeticContext, other N
 func (v UInt32Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -331,7 +331,7 @@ func (v UInt32Value) Less(context ValueComparisonContext, other ComparableValue,
 func (v UInt32Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -345,7 +345,7 @@ func (v UInt32Value) LessEqual(context ValueComparisonContext, other ComparableV
 func (v UInt32Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -359,7 +359,7 @@ func (v UInt32Value) Greater(context ValueComparisonContext, other ComparableVal
 func (v UInt32Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -405,7 +405,7 @@ func ConvertUInt32(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 func (v UInt32Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -424,7 +424,7 @@ func (v UInt32Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValu
 func (v UInt32Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -443,7 +443,7 @@ func (v UInt32Value) BitwiseXor(context ValueStaticTypeContext, other IntegerVal
 func (v UInt32Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -462,7 +462,7 @@ func (v UInt32Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerVal
 func (v UInt32Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -481,7 +481,7 @@ func (v UInt32Value) BitwiseLeftShift(context ValueStaticTypeContext, other Inte
 func (v UInt32Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -119,7 +119,7 @@ func (v UInt32Value) Plus(context NumberValueArithmeticContext, other NumberValu
 			sum := v + o
 			// INT30-C
 			if sum < v {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -241,7 +241,7 @@ func (v UInt32Value) Mul(context NumberValueArithmeticContext, other NumberValue
 		context,
 		func() uint32 {
 			if (v > 0) && (o > 0) && (v > (math.MaxUint32 / o)) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -103,7 +103,7 @@ func (v UInt64Value) MeteredString(context ValueStringContext, _ SeenReferences,
 
 func (v UInt64Value) ToInt(locationRange LocationRange) int {
 	if v > math.MaxInt64 {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}
@@ -146,7 +146,7 @@ func (v UInt64Value) Plus(context NumberValueArithmeticContext, other NumberValu
 			result, err := values.SafeAddUint64(uint64(v), uint64(o))
 			if err != nil {
 				if _, ok := err.(values.OverflowError); ok {
-					panic(OverflowError{
+					panic(&OverflowError{
 						LocationRange: locationRange,
 					})
 				}
@@ -270,7 +270,7 @@ func (v UInt64Value) Mul(context NumberValueArithmeticContext, other NumberValue
 		context,
 		func() uint64 {
 			if (v > 0) && (o > 0) && (v > (math.MaxUint64 / o)) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -132,7 +132,7 @@ func (v UInt64Value) Negate(NumberValueArithmeticContext, LocationRange) NumberV
 func (v UInt64Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -160,7 +160,7 @@ func (v UInt64Value) Plus(context NumberValueArithmeticContext, other NumberValu
 func (v UInt64Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -184,7 +184,7 @@ func (v UInt64Value) SaturatingPlus(context NumberValueArithmeticContext, other 
 func (v UInt64Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -198,7 +198,7 @@ func (v UInt64Value) Minus(context NumberValueArithmeticContext, other NumberVal
 			diff := v - o
 			// INT30-C
 			if diff > v {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -210,7 +210,7 @@ func (v UInt64Value) Minus(context NumberValueArithmeticContext, other NumberVal
 func (v UInt64Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -234,7 +234,7 @@ func (v UInt64Value) SaturatingMinus(context NumberValueArithmeticContext, other
 func (v UInt64Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -246,7 +246,7 @@ func (v UInt64Value) Mod(context NumberValueArithmeticContext, other NumberValue
 		context,
 		func() uint64 {
 			if o == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -258,7 +258,7 @@ func (v UInt64Value) Mod(context NumberValueArithmeticContext, other NumberValue
 func (v UInt64Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -282,7 +282,7 @@ func (v UInt64Value) Mul(context NumberValueArithmeticContext, other NumberValue
 func (v UInt64Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -305,7 +305,7 @@ func (v UInt64Value) SaturatingMul(context NumberValueArithmeticContext, other N
 func (v UInt64Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -317,7 +317,7 @@ func (v UInt64Value) Div(context NumberValueArithmeticContext, other NumberValue
 		context,
 		func() uint64 {
 			if o == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -329,8 +329,8 @@ func (v UInt64Value) Div(context NumberValueArithmeticContext, other NumberValue
 func (v UInt64Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -345,7 +345,7 @@ func (v UInt64Value) SaturatingDiv(context NumberValueArithmeticContext, other N
 func (v UInt64Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -359,7 +359,7 @@ func (v UInt64Value) Less(context ValueComparisonContext, other ComparableValue,
 func (v UInt64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -373,7 +373,7 @@ func (v UInt64Value) LessEqual(context ValueComparisonContext, other ComparableV
 func (v UInt64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -387,7 +387,7 @@ func (v UInt64Value) Greater(context ValueComparisonContext, other ComparableVal
 func (v UInt64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -433,7 +433,7 @@ func ConvertUInt64(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 func (v UInt64Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -452,7 +452,7 @@ func (v UInt64Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValu
 func (v UInt64Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -471,7 +471,7 @@ func (v UInt64Value) BitwiseXor(context ValueStaticTypeContext, other IntegerVal
 func (v UInt64Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -490,7 +490,7 @@ func (v UInt64Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerVal
 func (v UInt64Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -509,7 +509,7 @@ func (v UInt64Value) BitwiseLeftShift(context ValueStaticTypeContext, other Inte
 func (v UInt64Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -117,7 +117,7 @@ func (v UInt8Value) Plus(context NumberValueArithmeticContext, other NumberValue
 		sum := v + o
 		// INT30-C
 		if sum < v {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -236,7 +236,7 @@ func (v UInt8Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 		func() uint8 {
 			// INT30-C
 			if (v > 0) && (o > 0) && (v > (math.MaxUint8 / o)) {
-				panic(OverflowError{
+				panic(&OverflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -392,7 +392,7 @@ func ConvertUnsigned[T Unsigned](
 	case BigNumberValue:
 		v := value.ToBigInt(memoryGauge)
 		if v.Cmp(maxBigNumber) > 0 {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		} else if v.Sign() < 0 {
@@ -405,7 +405,7 @@ func ConvertUnsigned[T Unsigned](
 	case NumberValue:
 		v := value.ToInt(locationRange)
 		if maxNumber > 0 && v > maxNumber {
-			panic(OverflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		} else if v < 0 {

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -105,7 +105,7 @@ func (v UInt8Value) Negate(NumberValueArithmeticContext, LocationRange) NumberVa
 func (v UInt8Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -128,7 +128,7 @@ func (v UInt8Value) Plus(context NumberValueArithmeticContext, other NumberValue
 func (v UInt8Value) SaturatingPlus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingAddFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -149,7 +149,7 @@ func (v UInt8Value) SaturatingPlus(context NumberValueArithmeticContext, other N
 func (v UInt8Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -163,7 +163,7 @@ func (v UInt8Value) Minus(context NumberValueArithmeticContext, other NumberValu
 			diff := v - o
 			// INT30-C
 			if diff > v {
-				panic(UnderflowError{
+				panic(&UnderflowError{
 					LocationRange: locationRange,
 				})
 			}
@@ -175,7 +175,7 @@ func (v UInt8Value) Minus(context NumberValueArithmeticContext, other NumberValu
 func (v UInt8Value) SaturatingMinus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingSubtractFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -199,7 +199,7 @@ func (v UInt8Value) SaturatingMinus(context NumberValueArithmeticContext, other 
 func (v UInt8Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -211,7 +211,7 @@ func (v UInt8Value) Mod(context NumberValueArithmeticContext, other NumberValue,
 		context,
 		func() uint8 {
 			if o == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -223,7 +223,7 @@ func (v UInt8Value) Mod(context NumberValueArithmeticContext, other NumberValue,
 func (v UInt8Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -248,7 +248,7 @@ func (v UInt8Value) Mul(context NumberValueArithmeticContext, other NumberValue,
 func (v UInt8Value) SaturatingMul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			FunctionName:  sema.NumericTypeSaturatingMultiplyFunctionName,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -271,7 +271,7 @@ func (v UInt8Value) SaturatingMul(context NumberValueArithmeticContext, other Nu
 func (v UInt8Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -283,7 +283,7 @@ func (v UInt8Value) Div(context NumberValueArithmeticContext, other NumberValue,
 		context,
 		func() uint8 {
 			if o == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -295,8 +295,8 @@ func (v UInt8Value) Div(context NumberValueArithmeticContext, other NumberValue,
 func (v UInt8Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	defer func() {
 		r := recover()
-		if _, ok := r.(InvalidOperandsError); ok {
-			panic(InvalidOperandsError{
+		if _, ok := r.(*InvalidOperandsError); ok {
+			panic(&InvalidOperandsError{
 				FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
 				LeftType:      v.StaticType(context),
 				RightType:     other.StaticType(context),
@@ -311,7 +311,7 @@ func (v UInt8Value) SaturatingDiv(context NumberValueArithmeticContext, other Nu
 func (v UInt8Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -325,7 +325,7 @@ func (v UInt8Value) Less(context ValueComparisonContext, other ComparableValue, 
 func (v UInt8Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -339,7 +339,7 @@ func (v UInt8Value) LessEqual(context ValueComparisonContext, other ComparableVa
 func (v UInt8Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -353,7 +353,7 @@ func (v UInt8Value) Greater(context ValueComparisonContext, other ComparableValu
 func (v UInt8Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -396,7 +396,7 @@ func ConvertUnsigned[T Unsigned](
 				LocationRange: locationRange,
 			})
 		} else if v.Sign() < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -409,7 +409,7 @@ func ConvertUnsigned[T Unsigned](
 				LocationRange: locationRange,
 			})
 		} else if v < 0 {
-			panic(UnderflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		}
@@ -455,7 +455,7 @@ func ConvertUInt8(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 func (v UInt8Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -474,7 +474,7 @@ func (v UInt8Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue
 func (v UInt8Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -493,7 +493,7 @@ func (v UInt8Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValu
 func (v UInt8Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -512,7 +512,7 @@ func (v UInt8Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValu
 func (v UInt8Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -531,7 +531,7 @@ func (v UInt8Value) BitwiseLeftShift(context ValueStaticTypeContext, other Integ
 func (v UInt8Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(UInt8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -94,7 +94,7 @@ func (Word128Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool
 
 func (v Word128Value) ToInt(locationRange LocationRange) int {
 	if !v.BigInt.IsInt64() {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -135,7 +135,7 @@ func (v Word128Value) Negate(NumberValueArithmeticContext, LocationRange) Number
 func (v Word128Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -177,7 +177,7 @@ func (v Word128Value) SaturatingPlus(_ NumberValueArithmeticContext, _ NumberVal
 func (v Word128Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -219,7 +219,7 @@ func (v Word128Value) SaturatingMinus(_ NumberValueArithmeticContext, _ NumberVa
 func (v Word128Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -232,7 +232,7 @@ func (v Word128Value) Mod(context NumberValueArithmeticContext, other NumberValu
 		func() *big.Int {
 			res := new(big.Int)
 			if o.BigInt.Cmp(res) == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -244,7 +244,7 @@ func (v Word128Value) Mod(context NumberValueArithmeticContext, other NumberValu
 func (v Word128Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -272,7 +272,7 @@ func (v Word128Value) SaturatingMul(_ NumberValueArithmeticContext, _ NumberValu
 func (v Word128Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -285,7 +285,7 @@ func (v Word128Value) Div(context NumberValueArithmeticContext, other NumberValu
 		func() *big.Int {
 			res := new(big.Int)
 			if o.BigInt.Cmp(res) == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -302,7 +302,7 @@ func (v Word128Value) SaturatingDiv(_ NumberValueArithmeticContext, _ NumberValu
 func (v Word128Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -317,7 +317,7 @@ func (v Word128Value) Less(context ValueComparisonContext, other ComparableValue
 func (v Word128Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -332,7 +332,7 @@ func (v Word128Value) LessEqual(context ValueComparisonContext, other Comparable
 func (v Word128Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -347,7 +347,7 @@ func (v Word128Value) Greater(context ValueComparisonContext, other ComparableVa
 func (v Word128Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -419,7 +419,7 @@ func ConvertWord128(memoryGauge common.MemoryGauge, value Value, locationRange L
 func (v Word128Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -439,7 +439,7 @@ func (v Word128Value) BitwiseOr(context ValueStaticTypeContext, other IntegerVal
 func (v Word128Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -459,7 +459,7 @@ func (v Word128Value) BitwiseXor(context ValueStaticTypeContext, other IntegerVa
 func (v Word128Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -480,7 +480,7 @@ func (v Word128Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerVa
 func (v Word128Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -489,7 +489,7 @@ func (v Word128Value) BitwiseLeftShift(context ValueStaticTypeContext, other Int
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}
@@ -515,7 +515,7 @@ func (v Word128Value) BitwiseLeftShift(context ValueStaticTypeContext, other Int
 func (v Word128Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word128Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation: ast.OperationBitwiseRightShift,
 			LeftType:  v.StaticType(context),
 			RightType: other.StaticType(context),
@@ -523,7 +523,7 @@ func (v Word128Value) BitwiseRightShift(context ValueStaticTypeContext, other In
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -105,7 +105,7 @@ func (v Word16Value) Negate(NumberValueArithmeticContext, LocationRange) NumberV
 func (v Word16Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -127,7 +127,7 @@ func (v Word16Value) SaturatingPlus(NumberValueArithmeticContext, NumberValue, L
 func (v Word16Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -149,7 +149,7 @@ func (v Word16Value) SaturatingMinus(NumberValueArithmeticContext, NumberValue, 
 func (v Word16Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -158,7 +158,7 @@ func (v Word16Value) Mod(context NumberValueArithmeticContext, other NumberValue
 	}
 
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	}
@@ -173,7 +173,7 @@ func (v Word16Value) Mod(context NumberValueArithmeticContext, other NumberValue
 func (v Word16Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -195,7 +195,7 @@ func (v Word16Value) SaturatingMul(NumberValueArithmeticContext, NumberValue, Lo
 func (v Word16Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -204,7 +204,7 @@ func (v Word16Value) Div(context NumberValueArithmeticContext, other NumberValue
 	}
 
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	}
@@ -223,7 +223,7 @@ func (v Word16Value) SaturatingDiv(NumberValueArithmeticContext, NumberValue, Lo
 func (v Word16Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -237,7 +237,7 @@ func (v Word16Value) Less(context ValueComparisonContext, other ComparableValue,
 func (v Word16Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -251,7 +251,7 @@ func (v Word16Value) LessEqual(context ValueComparisonContext, other ComparableV
 func (v Word16Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -265,7 +265,7 @@ func (v Word16Value) Greater(context ValueComparisonContext, other ComparableVal
 func (v Word16Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -305,7 +305,7 @@ func ConvertWord16(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 func (v Word16Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -323,7 +323,7 @@ func (v Word16Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValu
 func (v Word16Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -341,7 +341,7 @@ func (v Word16Value) BitwiseXor(context ValueStaticTypeContext, other IntegerVal
 func (v Word16Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -359,7 +359,7 @@ func (v Word16Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerVal
 func (v Word16Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -377,7 +377,7 @@ func (v Word16Value) BitwiseLeftShift(context ValueStaticTypeContext, other Inte
 func (v Word16Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word16Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -94,7 +94,7 @@ func (Word256Value) IsImportable(_ ValueImportableContext, _ LocationRange) bool
 
 func (v Word256Value) ToInt(locationRange LocationRange) int {
 	if !v.BigInt.IsInt64() {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -135,7 +135,7 @@ func (v Word256Value) Negate(NumberValueArithmeticContext, LocationRange) Number
 func (v Word256Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -177,7 +177,7 @@ func (v Word256Value) SaturatingPlus(_ NumberValueArithmeticContext, _ NumberVal
 func (v Word256Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -219,7 +219,7 @@ func (v Word256Value) SaturatingMinus(_ NumberValueArithmeticContext, _ NumberVa
 func (v Word256Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -232,7 +232,7 @@ func (v Word256Value) Mod(context NumberValueArithmeticContext, other NumberValu
 		func() *big.Int {
 			res := new(big.Int)
 			if o.BigInt.Cmp(res) == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -244,7 +244,7 @@ func (v Word256Value) Mod(context NumberValueArithmeticContext, other NumberValu
 func (v Word256Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -272,7 +272,7 @@ func (v Word256Value) SaturatingMul(_ NumberValueArithmeticContext, _ NumberValu
 func (v Word256Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -285,7 +285,7 @@ func (v Word256Value) Div(context NumberValueArithmeticContext, other NumberValu
 		func() *big.Int {
 			res := new(big.Int)
 			if o.BigInt.Cmp(res) == 0 {
-				panic(DivisionByZeroError{
+				panic(&DivisionByZeroError{
 					LocationRange: locationRange,
 				})
 			}
@@ -302,7 +302,7 @@ func (v Word256Value) SaturatingDiv(_ NumberValueArithmeticContext, _ NumberValu
 func (v Word256Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -317,7 +317,7 @@ func (v Word256Value) Less(context ValueComparisonContext, other ComparableValue
 func (v Word256Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -332,7 +332,7 @@ func (v Word256Value) LessEqual(context ValueComparisonContext, other Comparable
 func (v Word256Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -347,7 +347,7 @@ func (v Word256Value) Greater(context ValueComparisonContext, other ComparableVa
 func (v Word256Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -419,7 +419,7 @@ func ConvertWord256(memoryGauge common.MemoryGauge, value Value, locationRange L
 func (v Word256Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -439,7 +439,7 @@ func (v Word256Value) BitwiseOr(context ValueStaticTypeContext, other IntegerVal
 func (v Word256Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -459,7 +459,7 @@ func (v Word256Value) BitwiseXor(context ValueStaticTypeContext, other IntegerVa
 func (v Word256Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -480,7 +480,7 @@ func (v Word256Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerVa
 func (v Word256Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -489,7 +489,7 @@ func (v Word256Value) BitwiseLeftShift(context ValueStaticTypeContext, other Int
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}
@@ -515,7 +515,7 @@ func (v Word256Value) BitwiseLeftShift(context ValueStaticTypeContext, other Int
 func (v Word256Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word256Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -524,7 +524,7 @@ func (v Word256Value) BitwiseRightShift(context ValueStaticTypeContext, other In
 	}
 
 	if o.BigInt.Sign() < 0 {
-		panic(NegativeShiftError{
+		panic(&NegativeShiftError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -106,7 +106,7 @@ func (v Word32Value) Negate(NumberValueArithmeticContext, LocationRange) NumberV
 func (v Word32Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -128,7 +128,7 @@ func (v Word32Value) SaturatingPlus(NumberValueArithmeticContext, NumberValue, L
 func (v Word32Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -150,7 +150,7 @@ func (v Word32Value) SaturatingMinus(NumberValueArithmeticContext, NumberValue, 
 func (v Word32Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -159,7 +159,7 @@ func (v Word32Value) Mod(context NumberValueArithmeticContext, other NumberValue
 	}
 
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	}
@@ -174,7 +174,7 @@ func (v Word32Value) Mod(context NumberValueArithmeticContext, other NumberValue
 func (v Word32Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -196,7 +196,7 @@ func (v Word32Value) SaturatingMul(NumberValueArithmeticContext, NumberValue, Lo
 func (v Word32Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -205,7 +205,7 @@ func (v Word32Value) Div(context NumberValueArithmeticContext, other NumberValue
 	}
 
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	}
@@ -224,7 +224,7 @@ func (v Word32Value) SaturatingDiv(NumberValueArithmeticContext, NumberValue, Lo
 func (v Word32Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -238,7 +238,7 @@ func (v Word32Value) Less(context ValueComparisonContext, other ComparableValue,
 func (v Word32Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -252,7 +252,7 @@ func (v Word32Value) LessEqual(context ValueComparisonContext, other ComparableV
 func (v Word32Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -266,7 +266,7 @@ func (v Word32Value) Greater(context ValueComparisonContext, other ComparableVal
 func (v Word32Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -306,7 +306,7 @@ func ConvertWord32(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 func (v Word32Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -324,7 +324,7 @@ func (v Word32Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValu
 func (v Word32Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -342,7 +342,7 @@ func (v Word32Value) BitwiseXor(context ValueStaticTypeContext, other IntegerVal
 func (v Word32Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -360,7 +360,7 @@ func (v Word32Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerVal
 func (v Word32Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -378,7 +378,7 @@ func (v Word32Value) BitwiseLeftShift(context ValueStaticTypeContext, other Inte
 func (v Word32Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word32Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -105,7 +105,7 @@ func (v Word64Value) MeteredString(context ValueStringContext, _ SeenReferences,
 
 func (v Word64Value) ToInt(locationRange LocationRange) int {
 	if v > math.MaxInt64 {
-		panic(OverflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -134,7 +134,7 @@ func (v Word64Value) Negate(NumberValueArithmeticContext, LocationRange) NumberV
 func (v Word64Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -156,7 +156,7 @@ func (v Word64Value) SaturatingPlus(NumberValueArithmeticContext, NumberValue, L
 func (v Word64Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -178,7 +178,7 @@ func (v Word64Value) SaturatingMinus(NumberValueArithmeticContext, NumberValue, 
 func (v Word64Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -187,7 +187,7 @@ func (v Word64Value) Mod(context NumberValueArithmeticContext, other NumberValue
 	}
 
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	}
@@ -202,7 +202,7 @@ func (v Word64Value) Mod(context NumberValueArithmeticContext, other NumberValue
 func (v Word64Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -224,7 +224,7 @@ func (v Word64Value) SaturatingMul(NumberValueArithmeticContext, NumberValue, Lo
 func (v Word64Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -233,7 +233,7 @@ func (v Word64Value) Div(context NumberValueArithmeticContext, other NumberValue
 	}
 
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	}
@@ -252,7 +252,7 @@ func (v Word64Value) SaturatingDiv(NumberValueArithmeticContext, NumberValue, Lo
 func (v Word64Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -266,7 +266,7 @@ func (v Word64Value) Less(context ValueComparisonContext, other ComparableValue,
 func (v Word64Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -280,7 +280,7 @@ func (v Word64Value) LessEqual(context ValueComparisonContext, other ComparableV
 func (v Word64Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -294,7 +294,7 @@ func (v Word64Value) Greater(context ValueComparisonContext, other ComparableVal
 func (v Word64Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -334,7 +334,7 @@ func ConvertWord64(memoryGauge common.MemoryGauge, value Value, locationRange Lo
 func (v Word64Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -352,7 +352,7 @@ func (v Word64Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValu
 func (v Word64Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -370,7 +370,7 @@ func (v Word64Value) BitwiseXor(context ValueStaticTypeContext, other IntegerVal
 func (v Word64Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -388,7 +388,7 @@ func (v Word64Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerVal
 func (v Word64Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -406,7 +406,7 @@ func (v Word64Value) BitwiseLeftShift(context ValueStaticTypeContext, other Inte
 func (v Word64Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word64Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -105,7 +105,7 @@ func (v Word8Value) Negate(NumberValueArithmeticContext, LocationRange) NumberVa
 func (v Word8Value) Plus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationPlus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -127,7 +127,7 @@ func (v Word8Value) SaturatingPlus(NumberValueArithmeticContext, NumberValue, Lo
 func (v Word8Value) Minus(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMinus,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -149,7 +149,7 @@ func (v Word8Value) SaturatingMinus(NumberValueArithmeticContext, NumberValue, L
 func (v Word8Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMod,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -158,7 +158,7 @@ func (v Word8Value) Mod(context NumberValueArithmeticContext, other NumberValue,
 	}
 
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	}
@@ -173,7 +173,7 @@ func (v Word8Value) Mod(context NumberValueArithmeticContext, other NumberValue,
 func (v Word8Value) Mul(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationMul,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -195,7 +195,7 @@ func (v Word8Value) SaturatingMul(NumberValueArithmeticContext, NumberValue, Loc
 func (v Word8Value) Div(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationDiv,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -204,7 +204,7 @@ func (v Word8Value) Div(context NumberValueArithmeticContext, other NumberValue,
 	}
 
 	if o == 0 {
-		panic(DivisionByZeroError{
+		panic(&DivisionByZeroError{
 			LocationRange: locationRange,
 		})
 	}
@@ -223,7 +223,7 @@ func (v Word8Value) SaturatingDiv(NumberValueArithmeticContext, NumberValue, Loc
 func (v Word8Value) Less(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLess,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -237,7 +237,7 @@ func (v Word8Value) Less(context ValueComparisonContext, other ComparableValue, 
 func (v Word8Value) LessEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationLessEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -251,7 +251,7 @@ func (v Word8Value) LessEqual(context ValueComparisonContext, other ComparableVa
 func (v Word8Value) Greater(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreater,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -265,7 +265,7 @@ func (v Word8Value) Greater(context ValueComparisonContext, other ComparableValu
 func (v Word8Value) GreaterEqual(context ValueComparisonContext, other ComparableValue, locationRange LocationRange) BoolValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationGreaterEqual,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -305,7 +305,7 @@ func ConvertWord8(memoryGauge common.MemoryGauge, value Value, locationRange Loc
 func (v Word8Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseOr,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -323,7 +323,7 @@ func (v Word8Value) BitwiseOr(context ValueStaticTypeContext, other IntegerValue
 func (v Word8Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseXor,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -341,7 +341,7 @@ func (v Word8Value) BitwiseXor(context ValueStaticTypeContext, other IntegerValu
 func (v Word8Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseAnd,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -359,7 +359,7 @@ func (v Word8Value) BitwiseAnd(context ValueStaticTypeContext, other IntegerValu
 func (v Word8Value) BitwiseLeftShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseLeftShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),
@@ -377,7 +377,7 @@ func (v Word8Value) BitwiseLeftShift(context ValueStaticTypeContext, other Integ
 func (v Word8Value) BitwiseRightShift(context ValueStaticTypeContext, other IntegerValue, locationRange LocationRange) IntegerValue {
 	o, ok := other.(Word8Value)
 	if !ok {
-		panic(InvalidOperandsError{
+		panic(&InvalidOperandsError{
 			Operation:     ast.OperationBitwiseRightShift,
 			LeftType:      v.StaticType(context),
 			RightType:     other.StaticType(context),

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -353,7 +353,8 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		)
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.OverflowError{})
+		var overflowError *interpreter.OverflowError
+		require.ErrorAs(t, err, &overflowError)
 	})
 
 	t.Run("get index overflow", func(t *testing.T) {
@@ -381,7 +382,8 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		)
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.OverflowError{})
+		var overflowError *interpreter.OverflowError
+		require.ErrorAs(t, err, &overflowError)
 	})
 
 	t.Run("revoke existing key", func(t *testing.T) {
@@ -553,7 +555,8 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		)
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.OverflowError{})
+		var overflowError *interpreter.OverflowError
+		require.ErrorAs(t, err, &overflowError)
 	})
 
 	t.Run("revoke index overflow", func(t *testing.T) {
@@ -581,7 +584,8 @@ func TestRuntimeAuthAccountKeys(t *testing.T) {
 		)
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.OverflowError{})
+		var overflowError *interpreter.OverflowError
+		require.ErrorAs(t, err, &overflowError)
 	})
 
 }
@@ -897,7 +901,8 @@ func TestRuntimePublicAccountKeys(t *testing.T) {
 		_, err := test.executeScript(testEnv.runtime, testEnv.runtimeInterface)
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.OverflowError{})
+		var overflowError *interpreter.OverflowError
+		require.ErrorAs(t, err, &overflowError)
 	})
 
 	t.Run("get index overflow", func(t *testing.T) {
@@ -919,7 +924,8 @@ func TestRuntimePublicAccountKeys(t *testing.T) {
 		_, err := test.executeScript(testEnv.runtime, testEnv.runtimeInterface)
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.OverflowError{})
+		var overflowError *interpreter.OverflowError
+		require.ErrorAs(t, err, &overflowError)
 	})
 
 	t.Run("get revoked key", func(t *testing.T) {
@@ -1563,7 +1569,9 @@ func TestRuntimePublicKey(t *testing.T) {
 				RequireError(t, err)
 
 				assert.ErrorAs(t, err, &errorToReturn)
-				assert.ErrorAs(t, err, &interpreter.InvalidPublicKeyError{})
+
+				var publicKeyError *interpreter.InvalidPublicKeyError
+				assert.ErrorAs(t, err, &publicKeyError)
 			}
 		}
 	})

--- a/runtime/attachments_test.go
+++ b/runtime/attachments_test.go
@@ -229,7 +229,8 @@ func TestRuntimeAccountAttachmentExportFailure(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 func TestRuntimeAccountAttachmentExport(t *testing.T) {

--- a/runtime/attachments_test.go
+++ b/runtime/attachments_test.go
@@ -230,7 +230,7 @@ func TestRuntimeAccountAttachmentExportFailure(t *testing.T) {
 	)
 	require.Error(t, err)
 	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
-		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
+	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 func TestRuntimeAccountAttachmentExport(t *testing.T) {

--- a/runtime/capabilities_test.go
+++ b/runtime/capabilities_test.go
@@ -374,7 +374,8 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 			_, err := invoke("testSwap")
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.DereferenceError{})
+			var dereferenceError *interpreter.DereferenceError
+			require.ErrorAs(t, err, &dereferenceError)
 		})
 
 		t.Run("testRI", func(t *testing.T) {
@@ -696,7 +697,8 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 			_, err := invoke("testSwap")
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.DereferenceError{})
+			var dereferenceError *interpreter.DereferenceError
+			require.ErrorAs(t, err, &dereferenceError)
 		})
 
 		t.Run("testSI", func(t *testing.T) {

--- a/runtime/capabilitycontrollers_test.go
+++ b/runtime/capabilitycontrollers_test.go
@@ -1193,7 +1193,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						)
 						RequireError(t, err)
 
-						var overwriteErr interpreter.OverwriteError
+						var overwriteErr *interpreter.OverwriteError
 						require.ErrorAs(t, err, &overwriteErr)
 
 						require.Equal(t,
@@ -1228,7 +1228,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						)
 						RequireError(t, err)
 
-						var overwriteErr interpreter.OverwriteError
+						var overwriteErr *interpreter.OverwriteError
 						require.ErrorAs(t, err, &overwriteErr)
 
 						require.Equal(t,
@@ -1272,7 +1272,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						)
 						RequireError(t, err)
 
-						var publishingError interpreter.CapabilityAddressPublishingError
+						var publishingError *interpreter.CapabilityAddressPublishingError
 						require.ErrorAs(t, err, &publishingError)
 						assert.Equal(t,
 							interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x2}),
@@ -1318,7 +1318,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 						)
 						RequireError(t, err)
 
-						var publishingError interpreter.CapabilityAddressPublishingError
+						var publishingError *interpreter.CapabilityAddressPublishingError
 						require.ErrorAs(t, err, &publishingError)
 						assert.Equal(t,
 							interpreter.NewUnmeteredAddressValueFromBytes([]byte{0x2}),
@@ -1493,7 +1493,8 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 			)
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.InvalidCapabilityIssueTypeError{})
+			var capabilityIssueTypeError *interpreter.InvalidCapabilityIssueTypeError
+			require.ErrorAs(t, err, &capabilityIssueTypeError)
 
 			require.Equal(t,
 				[]string{},
@@ -2177,7 +2178,8 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 			)
 			RequireError(t, err)
 
-			require.ErrorAs(t, err, &interpreter.InvalidCapabilityIssueTypeError{})
+			var capabilityIssueTypeError *interpreter.InvalidCapabilityIssueTypeError
+			require.ErrorAs(t, err, &capabilityIssueTypeError)
 
 			require.Equal(t,
 				[]string{},

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -5363,7 +5363,7 @@ func TestRuntimeDestroyedResourceReferenceExport(t *testing.T) {
 	)
 	require.Error(t, err)
 	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
-		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
+	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 func TestRuntimeDeploymentResultValueImportExport(t *testing.T) {

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -3489,7 +3489,7 @@ func TestRuntimeMalformedArgumentPassing(t *testing.T) {
 				RequireError(t, err)
 				assertUserError(t, err)
 
-				var containerMutationError interpreter.ContainerMutationError
+				var containerMutationError *interpreter.ContainerMutationError
 				require.ErrorAs(t, err, &containerMutationError)
 			} else {
 				require.NoError(t, err)
@@ -4031,7 +4031,7 @@ func TestRuntimeImportExportDictionaryValue(t *testing.T) {
 		RequireError(t, err)
 		assertUserError(t, err)
 
-		var argErr interpreter.ContainerMutationError
+		var argErr *interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &argErr)
 	})
 }
@@ -4408,7 +4408,10 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 
 						var invalidEntryPointArgumentError *InvalidEntryPointArgumentError
 						assert.ErrorAs(t, err, &invalidEntryPointArgumentError)
-						assert.ErrorAs(t, err, &interpreter.InvalidPublicKeyError{})
+
+						var publicKeyError *interpreter.InvalidPublicKeyError
+						assert.ErrorAs(t, err, &publicKeyError)
+
 						assert.ErrorAs(t, err, &publicKeyActualError)
 					}
 				},
@@ -5359,7 +5362,8 @@ func TestRuntimeDestroyedResourceReferenceExport(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 func TestRuntimeDeploymentResultValueImportExport(t *testing.T) {

--- a/runtime/entitlements_test.go
+++ b/runtime/entitlements_test.go
@@ -213,7 +213,8 @@ func TestRuntimeAccountEntitlementSaveAndLoadFail(t *testing.T) {
 		},
 	)
 
-	require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+	var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+		require.ErrorAs(t, err, &forceCastTypeMismatchError)
 }
 
 func TestRuntimeAccountEntitlementAttachment(t *testing.T) {
@@ -599,7 +600,8 @@ func TestRuntimeAccountEntitlementCapabilityCasting(t *testing.T) {
 		},
 	)
 
-	require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+	var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+		require.ErrorAs(t, err, &forceCastTypeMismatchError)
 }
 
 func TestRuntimeAccountEntitlementCapabilityDictionary(t *testing.T) {
@@ -714,7 +716,8 @@ func TestRuntimeAccountEntitlementCapabilityDictionary(t *testing.T) {
 		},
 	)
 
-	require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+	var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+		require.ErrorAs(t, err, &forceCastTypeMismatchError)
 }
 
 func TestRuntimeAccountEntitlementGenericCapabilityDictionary(t *testing.T) {

--- a/runtime/entitlements_test.go
+++ b/runtime/entitlements_test.go
@@ -214,7 +214,7 @@ func TestRuntimeAccountEntitlementSaveAndLoadFail(t *testing.T) {
 	)
 
 	var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
-		require.ErrorAs(t, err, &forceCastTypeMismatchError)
+	require.ErrorAs(t, err, &forceCastTypeMismatchError)
 }
 
 func TestRuntimeAccountEntitlementAttachment(t *testing.T) {
@@ -601,7 +601,7 @@ func TestRuntimeAccountEntitlementCapabilityCasting(t *testing.T) {
 	)
 
 	var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
-		require.ErrorAs(t, err, &forceCastTypeMismatchError)
+	require.ErrorAs(t, err, &forceCastTypeMismatchError)
 }
 
 func TestRuntimeAccountEntitlementCapabilityDictionary(t *testing.T) {
@@ -717,7 +717,7 @@ func TestRuntimeAccountEntitlementCapabilityDictionary(t *testing.T) {
 	)
 
 	var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
-		require.ErrorAs(t, err, &forceCastTypeMismatchError)
+	require.ErrorAs(t, err, &forceCastTypeMismatchError)
 }
 
 func TestRuntimeAccountEntitlementGenericCapabilityDictionary(t *testing.T) {

--- a/runtime/errors_test.go
+++ b/runtime/errors_test.go
@@ -76,7 +76,7 @@ func TestErrorInterfaceConformance(t *testing.T) {
 		parser.Error{},
 		interpreter.Error{},
 		runtime.Error{},
-		interpreter.StackTraceError{},
+		&interpreter.StackTraceError{},
 	}
 
 	errorsToSkip := make(map[string]any)

--- a/runtime/resource_duplicate_test.go
+++ b/runtime/resource_duplicate_test.go
@@ -197,7 +197,7 @@ func TestRuntimeResourceDuplicationWithContractTransferInTransaction(t *testing.
 	)
 	RequireError(t, err)
 
-	var forceNilError interpreter.ForceNilError
+	var forceNilError *interpreter.ForceNilError
 	require.ErrorAs(t, err, &forceNilError)
 }
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -4594,7 +4594,7 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 
 					assertRuntimeErrorIsUserError(t, err)
 
-					require.ErrorAs(t, err, &interpreter.ConditionError{})
+					require.ErrorAs(t, err, &&interpreter.ConditionError{})
 				}
 			})
 		}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -609,7 +609,7 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 
 				assertRuntimeErrorIsUserError(t, err)
 
-				var argErr interpreter.ContainerMutationError
+				var argErr *interpreter.ContainerMutationError
 				require.ErrorAs(t, err, &argErr)
 			},
 		},
@@ -1000,7 +1000,7 @@ func TestRuntimeScriptArguments(t *testing.T) {
 
 				assertRuntimeErrorIsUserError(t, err)
 
-				var argErr interpreter.ContainerMutationError
+				var argErr *interpreter.ContainerMutationError
 				require.ErrorAs(t, err, &argErr)
 			},
 		},
@@ -3113,7 +3113,8 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 		if *compile {
 			require.ErrorContains(t, err, "invalid transfer: expected 'String', found 'Int'")
 		} else {
-			require.ErrorAs(t, err, &interpreter.ValueTransferTypeError{})
+			var transferTypeError *interpreter.ValueTransferTypeError
+			require.ErrorAs(t, err, &transferTypeError)
 		}
 
 	})
@@ -4594,7 +4595,8 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 
 					assertRuntimeErrorIsUserError(t, err)
 
-					require.ErrorAs(t, err, &&interpreter.ConditionError{})
+					var conditionErr *interpreter.ConditionError
+					require.ErrorAs(t, err, &conditionErr)
 				}
 			})
 		}
@@ -7179,7 +7181,7 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
 
 		assertRuntimeErrorIsUserError(t, err)
 
-		var typeErr interpreter.ContainerMutationError
+		var typeErr *interpreter.ContainerMutationError
 		require.ErrorAs(t, err, &typeErr)
 	})
 
@@ -8416,7 +8418,7 @@ func TestRuntimeInvalidatedResourceUse(t *testing.T) {
 	)
 	RequireError(t, err)
 
-	var invalidatedResourceReferenceError interpreter.InvalidatedResourceReferenceError
+	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
 	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 
 }
@@ -8696,7 +8698,8 @@ func TestRuntimeReturnDestroyedOptional(t *testing.T) {
 	)
 
 	RequireError(t, err)
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 type computationHitsExceededError struct {
@@ -10126,7 +10129,7 @@ func TestRuntimeStorageReferenceStaticTypeSpoofing(t *testing.T) {
 		)
 
 		require.Error(t, err)
-		var dereferenceError interpreter.DereferenceError
+		var dereferenceError *interpreter.DereferenceError
 		require.ErrorAs(t, err, &dereferenceError)
 	})
 
@@ -10279,7 +10282,7 @@ func TestRuntimeStorageReferenceStaticTypeSpoofing(t *testing.T) {
 		)
 
 		require.Error(t, err)
-		var dereferenceError interpreter.DereferenceError
+		var dereferenceError *interpreter.DereferenceError
 		require.ErrorAs(t, err, &dereferenceError)
 	})
 }
@@ -10536,7 +10539,8 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 	)
 	RequireError(t, err)
 
-	require.ErrorAs(t, err, &interpreter.InvalidatedResourceReferenceError{})
+	var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
+	require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 }
 
 func TestRuntimeValueTransferResourceLoss(t *testing.T) {
@@ -10975,7 +10979,7 @@ func TestRuntimeAccountStorageBorrowEphemeralReferenceValue(t *testing.T) {
 	)
 	RequireError(t, err)
 
-	var nestedReferenceErr interpreter.NestedReferenceError
+	var nestedReferenceErr *interpreter.NestedReferenceError
 	require.ErrorAs(t, err, &nestedReferenceErr)
 }
 
@@ -11218,7 +11222,8 @@ func TestRuntimeForbidPublicEntitlementPublish(t *testing.T) {
 		)
 
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.EntitledCapabilityPublishingError{})
+		var capabilityPublishingError *interpreter.EntitledCapabilityPublishingError
+		require.ErrorAs(t, err, &capabilityPublishingError)
 	})
 
 	t.Run("non entitled capability", func(t *testing.T) {
@@ -11332,7 +11337,8 @@ func TestRuntimeForbidPublicEntitlementPublish(t *testing.T) {
 		)
 
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.EntitledCapabilityPublishingError{})
+		var capabilityPublishingError *interpreter.EntitledCapabilityPublishingError
+		require.ErrorAs(t, err, &capabilityPublishingError)
 	})
 }
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -1417,7 +1417,8 @@ func TestRuntimeStorageReferenceDowncast(t *testing.T) {
 		},
 	)
 
-	require.ErrorAs(t, err, &interpreter.ForceCastTypeMismatchError{})
+	var forceCastTypeMismatchError *interpreter.ForceCastTypeMismatchError
+	require.ErrorAs(t, err, &forceCastTypeMismatchError)
 }
 
 func TestRuntimeStorageNonStorable(t *testing.T) {
@@ -5027,7 +5028,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 		)
 		RequireError(t, err)
 
-		require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
+		var storageMutationError *interpreter.StorageMutatedDuringIterationError
+		require.ErrorAs(t, err, &storageMutationError)
 	})
 
 	t.Run("forEachStored with early termination", func(t *testing.T) {
@@ -5167,7 +5169,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			if continueAfterMutation {
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
+				var storageMutationError *interpreter.StorageMutatedDuringIterationError
+				require.ErrorAs(t, err, &storageMutationError)
 			} else {
 				require.NoError(t, err)
 			}
@@ -5219,7 +5222,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			if continueAfterMutation {
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
+				var storageMutationError *interpreter.StorageMutatedDuringIterationError
+				require.ErrorAs(t, err, &storageMutationError)
 			} else {
 				require.NoError(t, err)
 			}
@@ -5273,7 +5277,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			if continueAfterMutation {
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
+				var storageMutationError *interpreter.StorageMutatedDuringIterationError
+				require.ErrorAs(t, err, &storageMutationError)
 			} else {
 				require.NoError(t, err)
 			}
@@ -5330,7 +5335,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			if continueAfterMutation {
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
+				var storageMutationError *interpreter.StorageMutatedDuringIterationError
+				require.ErrorAs(t, err, &storageMutationError)
 			} else {
 				require.NoError(t, err)
 			}
@@ -5376,7 +5382,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			if continueAfterMutation {
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
+				var storageMutationError *interpreter.StorageMutatedDuringIterationError
+				require.ErrorAs(t, err, &storageMutationError)
 			} else {
 				require.NoError(t, err)
 			}
@@ -5424,7 +5431,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			if continueAfterMutation {
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
+				var storageMutationError *interpreter.StorageMutatedDuringIterationError
+				require.ErrorAs(t, err, &storageMutationError)
 			} else {
 				require.NoError(t, err)
 			}
@@ -5472,7 +5480,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			if continueAfterMutation {
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
+				var storageMutationError *interpreter.StorageMutatedDuringIterationError
+				require.ErrorAs(t, err, &storageMutationError)
 			} else {
 				require.NoError(t, err)
 			}
@@ -5547,7 +5556,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			if continueAfterMutation {
 				RequireError(t, err)
 
-				require.ErrorAs(t, err, &interpreter.StorageMutatedDuringIterationError{})
+				var storageMutationError *interpreter.StorageMutatedDuringIterationError
+				require.ErrorAs(t, err, &storageMutationError)
 			} else {
 				require.NoError(t, err)
 			}
@@ -5942,7 +5952,8 @@ func TestRuntimeStorageReferenceBoundFunction(t *testing.T) {
 		)
 
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.ReferencedValueChangedError{})
+		var referencedValueChangedError *interpreter.ReferencedValueChangedError
+		require.ErrorAs(t, err, &referencedValueChangedError)
 	})
 
 	t.Run("struct", func(t *testing.T) {
@@ -5994,7 +6005,8 @@ func TestRuntimeStorageReferenceBoundFunction(t *testing.T) {
 			})
 
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.ReferencedValueChangedError{})
+		var referencedValueChangedError *interpreter.ReferencedValueChangedError
+		require.ErrorAs(t, err, &referencedValueChangedError)
 	})
 
 	t.Run("replace resource", func(t *testing.T) {
@@ -6104,7 +6116,8 @@ func TestRuntimeStorageReferenceBoundFunction(t *testing.T) {
 		)
 
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.DereferenceError{})
+		var dereferenceError *interpreter.DereferenceError
+		require.ErrorAs(t, err, &dereferenceError)
 	})
 
 }
@@ -6203,7 +6216,8 @@ func TestRuntimeStorageReferenceAccess(t *testing.T) {
 			},
 		)
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.DereferenceError{})
+		var dereferenceError *interpreter.DereferenceError
+		require.ErrorAs(t, err, &dereferenceError)
 	})
 
 	t.Run("optional reference", func(t *testing.T) {
@@ -6232,7 +6246,8 @@ func TestRuntimeStorageReferenceAccess(t *testing.T) {
 			},
 		)
 		RequireError(t, err)
-		require.ErrorAs(t, err, &interpreter.DereferenceError{})
+		var dereferenceError *interpreter.DereferenceError
+		require.ErrorAs(t, err, &dereferenceError)
 	})
 }
 

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -1007,7 +1007,7 @@ func newAccountInboxUnpublishFunction(
 				ty := sema.NewCapabilityType(inter, typeParameterPair.Value)
 				publishedType := publishedValue.Value.StaticType(invocation.InvocationContext)
 				if !interpreter.IsSubTypeOfSemaType(inter, publishedType, ty) {
-					panic(interpreter.ForceCastTypeMismatchError{
+					panic(&interpreter.ForceCastTypeMismatchError{
 						ExpectedType:  ty,
 						ActualType:    interpreter.MustConvertStaticToSemaType(publishedType, inter),
 						LocationRange: locationRange,
@@ -1097,7 +1097,7 @@ func newAccountInboxClaimFunction(
 				ty := sema.NewCapabilityType(inter, typeParameterPair.Value)
 				publishedType := publishedValue.Value.StaticType(invocation.InvocationContext)
 				if !interpreter.IsSubTypeOfSemaType(inter, publishedType, ty) {
-					panic(interpreter.ForceCastTypeMismatchError{
+					panic(&interpreter.ForceCastTypeMismatchError{
 						ExpectedType:  ty,
 						ActualType:    interpreter.MustConvertStaticToSemaType(publishedType, inter),
 						LocationRange: locationRange,
@@ -2752,7 +2752,7 @@ func checkAndIssueStorageCapabilityControllerWithType(
 
 	borrowType, ok := ty.(*sema.ReferenceType)
 	if !ok {
-		panic(interpreter.InvalidCapabilityIssueTypeError{
+		panic(&interpreter.InvalidCapabilityIssueTypeError{
 			ExpectedTypeDescription: "reference type",
 			ActualType:              ty,
 			LocationRange:           locationRange,
@@ -2930,7 +2930,7 @@ func checkAndIssueAccountCapabilityControllerWithType(
 
 	typeBound := sema.AccountReferenceType
 	if !sema.IsSubType(ty, typeBound) {
-		panic(interpreter.InvalidCapabilityIssueTypeError{
+		panic(&interpreter.InvalidCapabilityIssueTypeError{
 			ExpectedTypeDescription: fmt.Sprintf("`%s`", typeBound.QualifiedString()),
 			ActualType:              ty,
 			LocationRange:           locationRange,
@@ -3584,7 +3584,7 @@ func AccountCapabilitiesPublish(
 
 	capabilityAddressValue := capabilityValue.Address()
 	if capabilityAddressValue != accountAddressValue {
-		panic(interpreter.CapabilityAddressPublishingError{
+		panic(&interpreter.CapabilityAddressPublishingError{
 			LocationRange:     locationRange,
 			CapabilityAddress: capabilityAddressValue,
 			AccountAddress:    accountAddressValue,
@@ -3622,7 +3622,7 @@ func AccountCapabilitiesPublish(
 				panic(err)
 			}
 			if !valid {
-				panic(interpreter.EntitledCapabilityPublishingError{
+				panic(&interpreter.EntitledCapabilityPublishingError{
 					LocationRange: locationRange,
 					BorrowType:    capabilityBorrowType,
 					Path:          pathValue,
@@ -3641,7 +3641,7 @@ func AccountCapabilitiesPublish(
 		domain,
 		storageMapKey,
 	) {
-		panic(interpreter.OverwriteError{
+		panic(&interpreter.OverwriteError{
 			Address:       accountAddressValue,
 			Path:          pathValue,
 			LocationRange: locationRange,

--- a/stdlib/range.go
+++ b/stdlib/range.go
@@ -132,7 +132,7 @@ var InclusiveRangeConstructorFunction = NewStandardLibraryStaticFunction(
 		startStaticType := start.StaticType(invocationContext)
 		endStaticType := end.StaticType(invocationContext)
 		if !startStaticType.Equal(endStaticType) {
-			panic(interpreter.InclusiveRangeConstructionError{
+			panic(&interpreter.InclusiveRangeConstructionError{
 				LocationRange: locationRange,
 				Message: fmt.Sprintf(
 					"start and end are of different types. start: %s and end: %s",
@@ -153,7 +153,7 @@ var InclusiveRangeConstructorFunction = NewStandardLibraryStaticFunction(
 
 			stepStaticType := step.StaticType(invocationContext)
 			if stepStaticType != startStaticType {
-				panic(interpreter.InclusiveRangeConstructionError{
+				panic(&interpreter.InclusiveRangeConstructionError{
 					LocationRange: locationRange,
 					Message: fmt.Sprintf(
 						"step must be of the same type as start and end. start/end: %s and step: %s",

--- a/stdlib/test.go
+++ b/stdlib/test.go
@@ -445,7 +445,7 @@ func newMatcherWithGenericTestFunction(
 				if !interpreter.IsSubTypeOfSemaType(invocationContext, argumentStaticType, parameterType) {
 					argumentSemaType := interpreter.MustConvertStaticToSemaType(argumentStaticType, invocationContext)
 
-					panic(interpreter.TypeMismatchError{
+					panic(&interpreter.TypeMismatchError{
 						ExpectedType:  parameterType,
 						ActualType:    argumentSemaType,
 						LocationRange: invocation.LocationRange,

--- a/stdlib/test_test.go
+++ b/stdlib/test_test.go
@@ -222,7 +222,9 @@ func TestTestNewMatcher(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
-		assert.ErrorAs(t, err, &interpreter.TypeMismatchError{})
+
+		var typeMismatchError *interpreter.TypeMismatchError
+		require.ErrorAs(t, err, &typeMismatchError)
 	})
 
 	t.Run("custom resource matcher", func(t *testing.T) {
@@ -368,7 +370,8 @@ func TestTestNewMatcher(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
-		assert.ErrorAs(t, err, &interpreter.TypeMismatchError{})
+		var typeMismatchError *interpreter.TypeMismatchError
+		require.ErrorAs(t, err, &typeMismatchError)
 	})
 }
 
@@ -1895,7 +1898,8 @@ func TestTestExpect(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
-		assert.ErrorAs(t, err, &interpreter.TypeMismatchError{})
+		var typeMismatchError *interpreter.TypeMismatchError
+		require.ErrorAs(t, err, &typeMismatchError)
 	})
 
 	t.Run("with explicit types", func(t *testing.T) {


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3922

## Description

Apply the concept/changes of https://github.com/onflow/cadence/pull/3946 to all interpreter errors.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
