### PR TITLE
[Compiler] Cache compiled programs

### DIFF
--- a/runtime/checking_environment.go
+++ b/runtime/checking_environment.go
@@ -390,15 +390,8 @@ func (e *checkingEnvironment) getProgram(
 			Elaboration: elaboration,
 		}
 
-		var compiledProgram compiledProgram
-		compile := e.compile
-		if compile != nil {
-			compiledProgram = compile(interpreterProgram, location)
-		}
-
 		return &Program{
 			interpreterProgram: interpreterProgram,
-			compiledProgram:    compiledProgram,
 		}, nil
 	}
 

--- a/runtime/checking_environment.go
+++ b/runtime/checking_environment.go
@@ -64,14 +64,20 @@ type checkingEnvironment struct {
 	// Base value activations are lazily / implicitly created
 	// by DeclareValue / semaBaseActivationFor
 	baseValueActivationsByLocation map[common.Location]*sema.VariableActivation
+
+	// compile is the optional function used to compile the program
+	compile compileFunc
 }
 
-func newCheckingEnvironment() *checkingEnvironment {
+type compileFunc func(program *interpreter.Program, location common.Location) compiledProgram
+
+func newCheckingEnvironment(compile compileFunc) *checkingEnvironment {
 	defaultBaseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
 	defaultBaseTypeActivation := sema.NewVariableActivation(sema.BaseTypeActivation)
 	env := &checkingEnvironment{
 		defaultBaseValueActivation: defaultBaseValueActivation,
 		defaultBaseTypeActivation:  defaultBaseTypeActivation,
+		compile:                    compile,
 	}
 	env.config = env.newConfig()
 	return env
@@ -218,7 +224,7 @@ func (e *checkingEnvironment) resolveImport(
 	}
 
 	return sema.ElaborationImport{
-		Elaboration: program.Elaboration,
+		Elaboration: program.interpreterProgram.Elaboration,
 	}, nil
 }
 
@@ -264,7 +270,7 @@ func (e *checkingEnvironment) ParseAndCheckProgram(
 	*interpreter.Program,
 	error,
 ) {
-	return e.getProgram(
+	program, err := e.getProgram(
 		location,
 		func() ([]byte, error) {
 			return code, nil
@@ -276,6 +282,10 @@ func (e *checkingEnvironment) ParseAndCheckProgram(
 			location: true,
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
+	return program.interpreterProgram, nil
 }
 
 // parseAndCheckProgram parses and checks the given program.
@@ -331,7 +341,7 @@ func (e *checkingEnvironment) GetProgram(
 	storeProgram bool,
 	checkedImports importResolutionResults,
 ) (
-	*interpreter.Program,
+	*Program,
 	error,
 ) {
 	return e.getProgram(
@@ -352,10 +362,10 @@ func (e *checkingEnvironment) getProgram(
 	getAndSetProgram bool,
 	checkedImports importResolutionResults,
 ) (
-	program *interpreter.Program,
+	program *Program,
 	err error,
 ) {
-	load := func() (*interpreter.Program, error) {
+	load := func() (*Program, error) {
 		code, err := getCode()
 		if err != nil {
 			return nil, err
@@ -375,9 +385,20 @@ func (e *checkingEnvironment) getProgram(
 			return nil, err
 		}
 
-		return &interpreter.Program{
+		interpreterProgram := &interpreter.Program{
 			Program:     parsedProgram,
 			Elaboration: elaboration,
+		}
+
+		var compiledProgram compiledProgram
+		compile := e.compile
+		if compile != nil {
+			compiledProgram = compile(interpreterProgram, location)
+		}
+
+		return &Program{
+			interpreterProgram: interpreterProgram,
+			compiledProgram:    compiledProgram,
 		}, nil
 	}
 
@@ -386,7 +407,7 @@ func (e *checkingEnvironment) getProgram(
 	}
 
 	errors.WrapPanic(func() {
-		program, err = e.runtimeInterface.GetOrLoadProgram(location, func() (program *interpreter.Program, err error) {
+		program, err = e.runtimeInterface.GetOrLoadProgram(location, func() (program *Program, err error) {
 			// Loading is done by Cadence.
 			// If it panics with a user error, e.g. when parsing fails due to a memory metering error,
 			// then do not treat it as an external error (the load callback is called by the embedder)

--- a/runtime/checking_environment.go
+++ b/runtime/checking_environment.go
@@ -64,20 +64,14 @@ type checkingEnvironment struct {
 	// Base value activations are lazily / implicitly created
 	// by DeclareValue / semaBaseActivationFor
 	baseValueActivationsByLocation map[common.Location]*sema.VariableActivation
-
-	// compile is the optional function used to compile the program
-	compile compileFunc
 }
 
-type compileFunc func(program *interpreter.Program, location common.Location) compiledProgram
-
-func newCheckingEnvironment(compile compileFunc) *checkingEnvironment {
+func newCheckingEnvironment() *checkingEnvironment {
 	defaultBaseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
 	defaultBaseTypeActivation := sema.NewVariableActivation(sema.BaseTypeActivation)
 	env := &checkingEnvironment{
 		defaultBaseValueActivation: defaultBaseValueActivation,
 		defaultBaseTypeActivation:  defaultBaseTypeActivation,
-		compile:                    compile,
 	}
 	env.config = env.newConfig()
 	return env

--- a/runtime/contract_update_test.go
+++ b/runtime/contract_update_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/encoding/json"
-	"github.com/onflow/cadence/interpreter"
 	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/stdlib"
 	. "github.com/onflow/cadence/test_utils/common_utils"
@@ -45,7 +44,7 @@ func TestRuntimeContractUpdateWithDependencies(t *testing.T) {
 	}
 	var checkGetAndSetProgram, getProgramCalled bool
 
-	programs := map[Location]*interpreter.Program{}
+	programs := map[Location]*Program{}
 	clearPrograms := func() {
 		for l := range programs {
 			delete(programs, l)
@@ -74,11 +73,11 @@ func TestRuntimeContractUpdateWithDependencies(t *testing.T) {
 		OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 			return json.Decode(nil, b)
 		},
-		OnGetAndSetProgram: func(
+		OnGetOrLoadProgram: func(
 			location Location,
-			load func() (*interpreter.Program, error),
+			load func() (*Program, error),
 		) (
-			program *interpreter.Program,
+			program *Program,
 			err error,
 		) {
 			_, isTransactionLocation := location.(common.TransactionLocation)
@@ -695,7 +694,7 @@ func TestRuntimeContractUpdateWithOldProgramError(t *testing.T) {
 	}
 	var checkGetAndSetProgram, getProgramCalled bool
 
-	programs := map[Location]*interpreter.Program{}
+	programs := map[Location]*Program{}
 	clearPrograms := func() {
 		for l := range programs {
 			delete(programs, l)
@@ -727,11 +726,11 @@ func TestRuntimeContractUpdateWithOldProgramError(t *testing.T) {
 		OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 			return json.Decode(nil, b)
 		},
-		OnGetAndSetProgram: func(
+		OnGetOrLoadProgram: func(
 			location Location,
-			load func() (*interpreter.Program, error),
+			load func() (*Program, error),
 		) (
-			program *interpreter.Program,
+			program *Program,
 			err error,
 		) {
 			_, isTransactionLocation := location.(common.TransactionLocation)

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -2951,15 +2951,15 @@ func TestRuntimeContractUpdateProgramCaching(t *testing.T) {
 		programSets = locationAccessCounts{}
 
 		runtimeInterface = &TestRuntimeInterface{
-			OnGetAndSetProgram: func(
+			OnGetOrLoadProgram: func(
 				location Location,
-				load func() (*interpreter.Program, error),
+				load func() (*Program, error),
 			) (
-				program *interpreter.Program,
+				program *Program,
 				err error,
 			) {
 				if runtimeInterface.Programs == nil {
-					runtimeInterface.Programs = map[Location]*interpreter.Program{}
+					runtimeInterface.Programs = map[Location]*Program{}
 				}
 
 				var ok bool

--- a/runtime/empty.go
+++ b/runtime/empty.go
@@ -46,7 +46,7 @@ func (EmptyRuntimeInterface) ResolveLocation(_ []Identifier, _ Location) ([]Reso
 	panic("unexpected call to ResolveLocation")
 }
 
-func (EmptyRuntimeInterface) GetOrLoadProgram(_ Location, _ func() (*interpreter.Program, error)) (*interpreter.Program, error) {
+func (EmptyRuntimeInterface) GetOrLoadProgram(_ Location, _ func() (*Program, error)) (*Program, error) {
 	panic("unexpected call to GetOrLoadProgram")
 }
 

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -121,7 +121,7 @@ func NewInterpreterEnvironment(config Config) *interpreterEnvironment {
 
 	env := &interpreterEnvironment{
 		config:                        config,
-		checkingEnvironment:           newCheckingEnvironment(),
+		checkingEnvironment:           newCheckingEnvironment(nil),
 		defaultBaseActivation:         defaultBaseActivation,
 		stackDepthLimiter:             newStackDepthLimiter(config.StackDepthLimit),
 		SimpleContractAdditionTracker: stdlib.NewSimpleContractAdditionTracker(),
@@ -414,7 +414,15 @@ func (e *interpreterEnvironment) newImportLocationHandler() interpreter.ImportLo
 			panic(err)
 		}
 
-		subInterpreter, err := inter.NewSubInterpreter(program, location)
+		var interpreterProgram *interpreter.Program
+		if program != nil {
+			interpreterProgram = program.interpreterProgram
+		}
+
+		subInterpreter, err := inter.NewSubInterpreter(
+			interpreterProgram,
+			location,
+		)
 		if err != nil {
 			panic(err)
 		}

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -121,7 +121,7 @@ func NewInterpreterEnvironment(config Config) *interpreterEnvironment {
 
 	env := &interpreterEnvironment{
 		config:                        config,
-		checkingEnvironment:           newCheckingEnvironment(nil),
+		checkingEnvironment:           newCheckingEnvironment(),
 		defaultBaseActivation:         defaultBaseActivation,
 		stackDepthLimiter:             newStackDepthLimiter(config.StackDepthLimit),
 		SimpleContractAdditionTracker: stdlib.NewSimpleContractAdditionTracker(),

--- a/runtime/external.go
+++ b/runtime/external.go
@@ -119,9 +119,9 @@ func (e ExternalInterface) GetCode(location Location) (code []byte, err error) {
 
 func (e ExternalInterface) GetOrLoadProgram(
 	location Location,
-	load func() (*interpreter.Program, error),
+	load func() (*Program, error),
 ) (
-	program *interpreter.Program,
+	program *Program,
 	err error,
 ) {
 	errors.WrapPanic(func() {

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -56,8 +56,8 @@ type Interface interface {
 	// - Do NOT implement this as a cache!
 	GetOrLoadProgram(
 		location Location,
-		load func() (*interpreter.Program, error),
-	) (*interpreter.Program, error)
+		load func() (*Program, error),
+	) (*Program, error)
 	// SetInterpreterSharedState sets the shared state of all interpreters.
 	SetInterpreterSharedState(state *interpreter.SharedState)
 	// GetInterpreterSharedState gets the shared state of all interpreters.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -31,6 +31,11 @@ import (
 	"github.com/onflow/cadence/stdlib"
 )
 
+type Program struct {
+	interpreterProgram *interpreter.Program
+	compiledProgram
+}
+
 type Script struct {
 	Source    []byte
 	Arguments [][]byte

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -33,7 +33,7 @@ import (
 
 type Program struct {
 	interpreterProgram *interpreter.Program
-	compiledProgram
+	compiledProgram    *compiledProgram
 }
 
 type Script struct {

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -3646,10 +3646,10 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		runtimeInterface = newRuntimeInterface()
 
-		runtimeInterface.OnGetAndSetProgram = func(
+		runtimeInterface.OnGetOrLoadProgram = func(
 			location Location,
-			load func() (*interpreter.Program, error),
-		) (*interpreter.Program, error) {
+			load func() (*Program, error),
+		) (*Program, error) {
 			program, err := load()
 			if err != nil {
 				// Return a wrapped error

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -283,6 +283,14 @@ func (e *vmEnvironment) loadProgram(location common.Location) (*Program, error) 
 		return nil, err
 	}
 
+	// TODO: Maybe make the `program.compiledProgram` a pointer?
+	if program.compiledProgram.program == nil {
+		compile := e.checkingEnvironment.compile
+		if compile != nil {
+			program.compiledProgram = compile(program.interpreterProgram, location)
+		}
+	}
+
 	return program, nil
 }
 

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -42,7 +42,6 @@ type compiledProgram struct {
 type vmEnvironmentReconfigured struct {
 	Interface
 	storage *Storage
-	compiledPrograms
 }
 
 type vmEnvironment struct {
@@ -78,13 +77,10 @@ var _ common.MemoryGauge = &vmEnvironment{}
 
 func newVMEnvironment(config Config) *vmEnvironment {
 	env := &vmEnvironment{
-		vmEnvironmentReconfigured: vmEnvironmentReconfigured{
-			compiledPrograms: make(compiledPrograms),
-		},
 		config:                        config,
-		checkingEnvironment:           newCheckingEnvironment(),
 		SimpleContractAdditionTracker: stdlib.NewSimpleContractAdditionTracker(),
 	}
+	env.checkingEnvironment = newCheckingEnvironment(env.compileProgram)
 	env.vmConfig = env.newVMConfig()
 	env.compilerConfig = env.newCompilerConfig()
 	return env
@@ -152,7 +148,6 @@ func (e *vmEnvironment) Configure(
 	// TODO:
 	coverageReport *CoverageReport,
 ) {
-	clear(e.compiledPrograms)
 	e.Interface = runtimeInterface
 	e.storage = storage
 	e.vmConfig.SetStorage(storage)
@@ -277,7 +272,7 @@ func (e *vmEnvironment) ProgramLog(message string, _ interpreter.LocationRange) 
 	return e.Interface.ProgramLog(message)
 }
 
-func (e *vmEnvironment) loadProgram(location common.Location) (*interpreter.Program, error) {
+func (e *vmEnvironment) loadProgram(location common.Location) (*Program, error) {
 	const getAndSetProgram = true
 	program, err := e.checkingEnvironment.GetProgram(
 		location,
@@ -297,7 +292,7 @@ func (e *vmEnvironment) loadElaboration(location common.Location) (*sema.Elabora
 		return nil, err
 	}
 
-	return program.Elaboration, nil
+	return program.interpreterProgram.Elaboration, nil
 }
 
 func (e *vmEnvironment) loadType(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
@@ -344,37 +339,27 @@ func (e *vmEnvironment) compileProgram(
 		e.compilerConfig,
 	)
 
-	compiledProgram := compiledProgram{
+	return compiledProgram{
 		program:              comp.Compile(),
 		desugaredElaboration: comp.DesugaredElaboration,
 	}
-	e.compiledPrograms[location] = compiledProgram
-	return compiledProgram
-}
-
-func (e *vmEnvironment) loadAndCompileProgram(location common.Location) compiledProgram {
-	program, err := e.loadProgram(location)
-	if err != nil {
-		panic(fmt.Errorf("failed to load program for location %s: %w", location, err))
-	}
-
-	return e.compileProgram(program, location)
 }
 
 func (e *vmEnvironment) resolveDesugaredElaboration(location common.Location) (*compiler.DesugaredElaboration, error) {
-	compiledProgram, ok := e.compiledPrograms[location]
-	if !ok {
-		compiledProgram = e.loadAndCompileProgram(location)
+	program, err := e.loadProgram(location)
+	if err != nil {
+		return nil, err
 	}
-	return compiledProgram.desugaredElaboration, nil
+
+	return program.desugaredElaboration, nil
 }
 
 func (e *vmEnvironment) importProgram(location common.Location) *bbq.InstructionProgram {
-	compiledProgram, ok := e.compiledPrograms[location]
-	if !ok {
-		compiledProgram = e.loadAndCompileProgram(location)
+	program, err := e.loadProgram(location)
+	if err != nil {
+		panic(fmt.Errorf("failed to load program for imported location %s: %w", location, err))
 	}
-	return compiledProgram.program
+	return program.program
 }
 
 func (e *vmEnvironment) newVM(

--- a/test_utils/runtime_utils/testinterface.go
+++ b/test_utils/runtime_utils/testinterface.go
@@ -42,10 +42,10 @@ type TestRuntimeInterface struct {
 
 	OnResolveLocation  sema.LocationHandlerFunc
 	OnGetCode          func(_ runtime.Location) ([]byte, error)
-	OnGetAndSetProgram func(
+	OnGetOrLoadProgram func(
 		location runtime.Location,
-		load func() (*interpreter.Program, error),
-	) (*interpreter.Program, error)
+		load func() (*runtime.Program, error),
+	) (*runtime.Program, error)
 	OnSetInterpreterSharedState func(state *interpreter.SharedState)
 	OnGetInterpreterSharedState func() *interpreter.SharedState
 	OnCreateAccount             func(payer runtime.Address) (address runtime.Address, err error)
@@ -97,7 +97,7 @@ type TestRuntimeInterface struct {
 	OnGetAccountAvailableBalance func(_ runtime.Address) (uint64, error)
 	OnGetStorageUsed             func(_ runtime.Address) (uint64, error)
 	OnGetStorageCapacity         func(_ runtime.Address) (uint64, error)
-	Programs                     map[runtime.Location]*interpreter.Program
+	Programs                     map[runtime.Location]*runtime.Program
 	OnImplementationDebugLog     func(message string) error
 	OnValidatePublicKey          func(publicKey *stdlib.PublicKey) error
 	OnBLSVerifyPOP               func(pk *stdlib.PublicKey, s []byte) (bool, error)
@@ -165,14 +165,14 @@ func (i *TestRuntimeInterface) GetCode(location runtime.Location) ([]byte, error
 
 func (i *TestRuntimeInterface) GetOrLoadProgram(
 	location runtime.Location,
-	load func() (*interpreter.Program, error),
+	load func() (*runtime.Program, error),
 ) (
-	program *interpreter.Program,
+	program *runtime.Program,
 	err error,
 ) {
-	if i.OnGetAndSetProgram == nil {
+	if i.OnGetOrLoadProgram == nil {
 		if i.Programs == nil {
-			i.Programs = map[runtime.Location]*interpreter.Program{}
+			i.Programs = map[runtime.Location]*runtime.Program{}
 		}
 
 		var ok bool
@@ -191,7 +191,7 @@ func (i *TestRuntimeInterface) GetOrLoadProgram(
 		return
 	}
 
-	return i.OnGetAndSetProgram(location, load)
+	return i.OnGetOrLoadProgram(location, load)
 }
 
 func (i *TestRuntimeInterface) SetInterpreterSharedState(state *interpreter.SharedState) {


### PR DESCRIPTION
Work towards #3954

## Description

Use the existing program caching infrastructure, `runtime.Interface.GetOrLoadProgram`, to have the embedder also cache the compilation result, in addition to the existing parsing result (AST) and type checking result (elaboration)

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
