### PR TITLE
Error prompts

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -32,6 +32,8 @@ func NewUnreachableError() InternalError {
 
 const InternalErrorMessagePrefix = "internal error:"
 
+const ErrorPrompt = "\nWas this error unhelpful?\nConsider suggesting an improvement here: https://github.com/onflow/cadence/issues.\n"
+
 // InternalError is an implementation error, e.g: an unreachable code path (UnreachableError).
 // A program should never throw an InternalError in an ideal world.
 //

--- a/interpreter/errors.go
+++ b/interpreter/errors.go
@@ -74,6 +74,7 @@ func (e Error) Error() string {
 	if printErr != nil {
 		panic(printErr)
 	}
+	sb.WriteString(errors.ErrorPrompt)
 	return sb.String()
 }
 

--- a/interpreter/errors_test.go
+++ b/interpreter/errors_test.go
@@ -59,6 +59,6 @@ func TestErrorOutputIncludesLocationRage(t *testing.T) {
 				},
 			},
 		}.Error(),
-		"Execution failed:\nerror: dereference failed\n --> test:0:0\n",
+		"Execution failed:\nerror: dereference failed\n --> test:0:0\n\nWas this error unhelpful?\nConsider suggesting an improvement here: https://github.com/onflow/cadence/issues.\n",
 	)
 }

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -43,6 +43,7 @@ func (e Error) Error() string {
 	if printErr != nil {
 		panic(printErr)
 	}
+	sb.WriteString(errors.ErrorPrompt)
 	return sb.String()
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -856,7 +856,7 @@ func TestParseInvalidSingleQuoteImport(t *testing.T) {
 
 	_, err := testParseProgram(`import 'X'`)
 
-	require.EqualError(t, err, "Parsing failed:\nerror: unrecognized character: U+0027 '''\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n\nerror: unexpected end in import declaration: expected string, address, or identifier\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n\nWas this error unhelpful?\nConsider suggesting an improvement here: https://github.com/onflow/cadence/issues.\n")
+	require.ErrorContains(t, err, "Parsing failed:\nerror: unrecognized character: U+0027 '''\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n\nerror: unexpected end in import declaration: expected string, address, or identifier\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n")
 }
 
 func TestParseExpressionDepthLimit(t *testing.T) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -856,7 +856,7 @@ func TestParseInvalidSingleQuoteImport(t *testing.T) {
 
 	_, err := testParseProgram(`import 'X'`)
 
-	require.EqualError(t, err, "Parsing failed:\nerror: unrecognized character: U+0027 '''\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n\nerror: unexpected end in import declaration: expected string, address, or identifier\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n")
+	require.EqualError(t, err, "Parsing failed:\nerror: unrecognized character: U+0027 '''\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n\nerror: unexpected end in import declaration: expected string, address, or identifier\n --> :1:7\n  |\n1 | import 'X'\n  |        ^\n\nWas this error unhelpful?\nConsider suggesting an improvement here: https://github.com/onflow/cadence/issues.\n")
 }
 
 func TestParseExpressionDepthLimit(t *testing.T) {

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -95,7 +95,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 			var runtimeErr Error
 			require.ErrorAs(t, err, &runtimeErr)
 
-			assert.EqualError(t, runtimeErr, expectedErrorMessage)
+			assert.ErrorContains(t, runtimeErr, expectedErrorMessage)
 
 			assert.Len(t, runtimeErr.Codes, 2)
 			assert.Len(t, runtimeErr.Programs, programsCount)

--- a/runtime/error_test.go
+++ b/runtime/error_test.go
@@ -60,7 +60,7 @@ func TestRuntimeError(t *testing.T) {
 			},
 		)
 
-		require.EqualError(
+		require.ErrorContains(
 			t,
 			err,
 			"Execution failed:\n"+
@@ -93,7 +93,7 @@ func TestRuntimeError(t *testing.T) {
 				Location:  location,
 			},
 		)
-		require.EqualError(
+		require.ErrorContains(
 			t,
 			err,
 			"Execution failed:\n"+
@@ -133,7 +133,7 @@ func TestRuntimeError(t *testing.T) {
 				Location:  location,
 			},
 		)
-		require.EqualError(
+		require.ErrorContains(
 			t,
 			err,
 			"Execution failed:\n"+
@@ -171,7 +171,7 @@ func TestRuntimeError(t *testing.T) {
 				Location:  location,
 			},
 		)
-		require.EqualError(
+		require.ErrorContains(
 			t,
 			err,
 			"Execution failed:\n"+
@@ -221,7 +221,7 @@ func TestRuntimeError(t *testing.T) {
 			},
 		)
 
-		require.EqualError(t, err,
+		require.ErrorContains(t, err,
 			"Execution failed:\n"+
 				"  --> 0100000000000000000000000000000000000000000000000000000000000000:15:12\n"+
 				"   |\n"+
@@ -275,7 +275,7 @@ func TestRuntimeError(t *testing.T) {
 				Location:  location,
 			},
 		)
-		require.EqualError(
+		require.ErrorContains(
 			t,
 			err,
 			"Execution failed:\nerror: unexpected token: identifier\n"+
@@ -318,7 +318,7 @@ func TestRuntimeError(t *testing.T) {
 				Location:  location,
 			},
 		)
-		require.EqualError(
+		require.ErrorContains(
 			t,
 			err,
 			"Execution failed:\n"+
@@ -375,7 +375,7 @@ func TestRuntimeError(t *testing.T) {
 				Location:  location,
 			},
 		)
-		require.EqualError(
+		require.ErrorContains(
 			t,
 			err,
 			"Execution failed:\n"+
@@ -456,7 +456,7 @@ func TestRuntimeError(t *testing.T) {
 				Location:  location,
 			},
 		)
-		require.EqualError(t, err,
+		require.ErrorContains(t, err,
 			"Execution failed:\n"+
 				"error: function declarations are not valid at the top-level\n"+
 				" --> 0000000000000002.B:3:30\n"+

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -58,6 +58,7 @@ func (e Error) Error() string {
 	if printErr != nil {
 		panic(printErr)
 	}
+	sb.WriteString(errors.ErrorPrompt)
 	return sb.String()
 }
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -8077,6 +8077,9 @@ error: unexpectedly found nil while forcing an Optional value
  9 |         return a
 10 |             .firstIndex(of: 5)!
    |                ^^^^^^^^^^^^^^^^
+
+Was this error unhelpful?
+Consider suggesting an improvement here: https://github.com/onflow/cadence/issues.
 `
 
 	require.Equal(t, errorString, err.Error())
@@ -8130,6 +8133,9 @@ error: unexpectedly found nil while forcing an Optional value
 10 |             .firstIndex(of: 5)
 11 |                 ?.toString()!
    |                ^^^^^^^^^^^^^^
+
+Was this error unhelpful?
+Consider suggesting an improvement here: https://github.com/onflow/cadence/issues.
 `
 
 	require.Equal(t, errorString, err.Error())

--- a/sema/errors.go
+++ b/sema/errors.go
@@ -115,6 +115,7 @@ func (e CheckerError) Error() string {
 	if printErr != nil {
 		panic(printErr)
 	}
+	sb.WriteString(errors.ErrorPrompt)
 	return sb.String()
 }
 


### PR DESCRIPTION
Closes #3711

## Description

When reporting error messages, prompt the developer to report unhelpful error messages and to contribute improvements.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
