### PR TITLE
[Compiler] Remove dependency to `interpreter.Config` from VM

### DIFF
--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -146,7 +146,7 @@ func init() {
 				address := arguments[0].(interpreter.AddressValue)
 				return NewAccountReferenceValue(
 					context,
-					context.GetAccountHandler(),
+					context.AccountHandler,
 					common.Address(address),
 				)
 			},

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -645,19 +645,13 @@ func PrepareVMConfig(
 		config = vm.NewConfig(storage)
 	}
 
-	if config.GetAccountHandler() == nil {
-		config = config.WithAccountHandler(&testAccountHandler{})
+	if config.AccountHandler == nil {
+		config.AccountHandler = &testAccountHandler{}
 	}
 
-	interpreterConfig := config.InterpreterConfig()
-	if interpreterConfig == nil {
-		interpreterConfig = &interpreter.Config{}
-		config = config.WithInterpreterConfig(interpreterConfig)
-	}
-
-	if interpreterConfig.UUIDHandler == nil {
+	if config.UUIDHandler == nil {
 		var uuid uint64
-		interpreterConfig.UUIDHandler = func() (uint64, error) {
+		config.UUIDHandler = func() (uint64, error) {
 			uuid++
 			return uuid, nil
 		}

--- a/bbq/vm/tracer.go
+++ b/bbq/vm/tracer.go
@@ -44,11 +44,11 @@ func (t Tracer) ReportArrayValueConstructTrace(_ string, _ int, _ time.Duration)
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Context) ReportArrayValueDestroyTrace(_ string, _ int, _ time.Duration) {
+func (t Tracer) ReportArrayValueDestroyTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Context) ReportArrayValueConformsToStaticTypeTrace(_ string, _ int, _ time.Duration) {
+func (t Tracer) ReportArrayValueConformsToStaticTypeTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
@@ -68,15 +68,15 @@ func (t Tracer) ReportDictionaryValueGetMemberTrace(_ string, _ int, _ string, _
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Context) ReportDictionaryValueConstructTrace(_ string, _ int, _ time.Duration) {
+func (t Tracer) ReportDictionaryValueConstructTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Context) ReportDictionaryValueDestroyTrace(_ string, _ int, _ time.Duration) {
+func (t Tracer) ReportDictionaryValueDestroyTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 
-func (c *Context) ReportDictionaryValueConformsToStaticTypeTrace(_ string, _ int, _ time.Duration) {
+func (t Tracer) ReportDictionaryValueConformsToStaticTypeTrace(_ string, _ int, _ time.Duration) {
 	panic(errors.NewUnreachableError())
 }
 

--- a/bbq/vm/value_account_capabilities.go
+++ b/bbq/vm/value_account_capabilities.go
@@ -52,7 +52,7 @@ func init() {
 
 				return stdlib.AccountCapabilitiesGet(
 					context,
-					context.GetAccountHandler(),
+					context.AccountHandler,
 					pathValue,
 					semaBorrowType,
 					false,
@@ -84,7 +84,7 @@ func init() {
 
 				return stdlib.AccountCapabilitiesGet(
 					context,
-					context.GetAccountHandler(),
+					context.AccountHandler,
 					pathValue,
 					semaBorrowType,
 					true,

--- a/bbq/vm/value_account_storagecapabilities.go
+++ b/bbq/vm/value_account_storagecapabilities.go
@@ -53,7 +53,7 @@ func init() {
 					arguments,
 					context,
 					EmptyLocationRange,
-					context.GetAccountHandler(),
+					context.AccountHandler,
 					accountAddress,
 					semaType,
 				)
@@ -88,7 +88,7 @@ func init() {
 
 				return stdlib.AccountStorageCapabilitiesIssueWithType(
 					context,
-					context.GetAccountHandler(),
+					context.AccountHandler,
 					typeValue,
 					accountAddress,
 					targetPathValue,
@@ -116,7 +116,7 @@ func init() {
 
 				return stdlib.AccountStorageCapabilitiesGetController(
 					context,
-					context.GetAccountHandler(),
+					context.AccountHandler,
 					capabilityIDValue,
 					accountAddress,
 					EmptyLocationRange,
@@ -143,7 +143,7 @@ func init() {
 
 				return stdlib.AccountStorageCapabilitiesGetControllers(
 					context,
-					context.GetAccountHandler(),
+					context.AccountHandler,
 					targetPathValue,
 					accountAddress,
 					EmptyLocationRange,
@@ -179,7 +179,7 @@ func init() {
 
 				return stdlib.AccountStorageCapabilitiesForeachController(
 					context,
-					context.GetAccountHandler(),
+					context.AccountHandler,
 					functionValue,
 					accountAddress,
 					targetPathValue,

--- a/bbq/vm/value_composite.go
+++ b/bbq/vm/value_composite.go
@@ -28,10 +28,9 @@ func newCompositeValueFields(context *Context, compositeKind common.CompositeKin
 
 	if compositeKind == common.CompositeKindResource {
 
-		uuidHandler := context.interpreterConfig.UUIDHandler
+		uuidHandler := context.UUIDHandler
 		if uuidHandler == nil {
 			panic(&interpreter.UUIDUnavailableError{
-				// TODO:
 				LocationRange: EmptyLocationRange,
 			})
 		}

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -658,9 +658,7 @@ func testAccountWithErrorHandlerWithCompiler(
 			return uuid, nil
 		}
 
-		vmConfig.WithInterpreterConfig(&interpreter.Config{
-			UUIDHandler: uuidHandler,
-		})
+		vmConfig.UUIDHandler = uuidHandler
 
 		elaboration := programs[parseAndCheckOptions.Location].DesugaredElaboration
 

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -200,7 +200,7 @@ type IterableValueForeachContext interface {
 var _ IterableValueForeachContext = &Interpreter{}
 
 type AccountHandlerContext interface {
-	AccountHandler() AccountHandlerFunc
+	GetAccountHandlerFunc() AccountHandlerFunc
 }
 
 var _ AccountHandlerContext = &Interpreter{}
@@ -214,7 +214,7 @@ type MemberAccessibleContext interface {
 	AccountContractBorrowContext
 	AttachmentContext
 
-	InjectedCompositeFieldsHandler() InjectedCompositeFieldsHandlerFunc
+	GetInjectedCompositeFieldsHandler() InjectedCompositeFieldsHandlerFunc
 	GetMemberAccessContextForLocation(location common.Location) MemberAccessibleContext
 
 	GetMethod(value MemberAccessibleValue, name string, locationRange LocationRange) FunctionValue
@@ -352,9 +352,9 @@ type BorrowCapabilityControllerContext interface {
 var _ BorrowCapabilityControllerContext = &Interpreter{}
 
 type CapabilityHandlers interface {
-	ValidateAccountCapabilitiesGetHandler() ValidateAccountCapabilitiesGetHandlerFunc
-	ValidateAccountCapabilitiesPublishHandler() ValidateAccountCapabilitiesPublishHandlerFunc
-	CapabilityBorrowHandler() CapabilityBorrowHandlerFunc
+	GetValidateAccountCapabilitiesGetHandler() ValidateAccountCapabilitiesGetHandlerFunc
+	GetValidateAccountCapabilitiesPublishHandler() ValidateAccountCapabilitiesPublishHandlerFunc
+	GetCapabilityBorrowHandler() CapabilityBorrowHandlerFunc
 }
 
 var _ CapabilityHandlers = &Interpreter{}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -4980,7 +4980,7 @@ func GetCompositeValueComputedFields(v *CompositeValue) map[string]ComputedField
 }
 
 func GetCompositeValueInjectedFields(context MemberAccessibleContext, v *CompositeValue) map[string]Value {
-	injectedCompositeFieldsHandler := context.InjectedCompositeFieldsHandler()
+	injectedCompositeFieldsHandler := context.GetInjectedCompositeFieldsHandler()
 	if injectedCompositeFieldsHandler == nil {
 		return nil
 	}
@@ -5729,7 +5729,7 @@ func CapabilityBorrow(
 		}
 	}
 
-	borrowHandler := invocationContext.CapabilityBorrowHandler()
+	borrowHandler := invocationContext.GetCapabilityBorrowHandler()
 
 	referenceValue := borrowHandler(
 		invocationContext,
@@ -5896,11 +5896,11 @@ func (interpreter *Interpreter) IsTypeInfoRecovered(location common.Location) bo
 	return elaboration.IsRecovered
 }
 
-func (interpreter *Interpreter) AccountHandler() AccountHandlerFunc {
+func (interpreter *Interpreter) GetAccountHandlerFunc() AccountHandlerFunc {
 	return interpreter.SharedState.Config.AccountHandler
 }
 
-func (interpreter *Interpreter) InjectedCompositeFieldsHandler() InjectedCompositeFieldsHandlerFunc {
+func (interpreter *Interpreter) GetInjectedCompositeFieldsHandler() InjectedCompositeFieldsHandlerFunc {
 	return interpreter.SharedState.Config.InjectedCompositeFieldsHandler
 }
 
@@ -5953,15 +5953,15 @@ func (interpreter *Interpreter) MutationDuringCapabilityControllerIteration() bo
 	return interpreter.SharedState.MutationDuringCapabilityControllerIteration
 }
 
-func (interpreter *Interpreter) ValidateAccountCapabilitiesGetHandler() ValidateAccountCapabilitiesGetHandlerFunc {
+func (interpreter *Interpreter) GetValidateAccountCapabilitiesGetHandler() ValidateAccountCapabilitiesGetHandlerFunc {
 	return interpreter.SharedState.Config.ValidateAccountCapabilitiesGetHandler
 }
 
-func (interpreter *Interpreter) ValidateAccountCapabilitiesPublishHandler() ValidateAccountCapabilitiesPublishHandlerFunc {
+func (interpreter *Interpreter) GetValidateAccountCapabilitiesPublishHandler() ValidateAccountCapabilitiesPublishHandlerFunc {
 	return interpreter.SharedState.Config.ValidateAccountCapabilitiesPublishHandler
 }
 
-func (interpreter *Interpreter) CapabilityBorrowHandler() CapabilityBorrowHandlerFunc {
+func (interpreter *Interpreter) GetCapabilityBorrowHandler() CapabilityBorrowHandlerFunc {
 	return interpreter.SharedState.Config.CapabilityBorrowHandler
 }
 

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -306,7 +306,7 @@ func (v *AccountCapabilityControllerValue) ReferenceValue(
 	locationRange LocationRange,
 ) ReferenceValue {
 
-	accountHandler := context.AccountHandler()
+	accountHandler := context.GetAccountHandlerFunc()
 	account := accountHandler(context, AddressValue(capabilityAddress))
 
 	// Account must be of `Account` type.

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -600,7 +600,7 @@ func (v *CompositeValue) OwnerValue(context MemberAccessibleContext, locationRan
 		return NilOptionalValue
 	}
 
-	accountHandler := context.AccountHandler()
+	accountHandler := context.GetAccountHandlerFunc()
 
 	ownerAccount := accountHandler(context, AddressValue(address))
 

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -107,13 +107,11 @@ func (e *vmEnvironment) newVMConfig() *vm.Config {
 	config.Logger = e
 	config.ContractValueHandler = e.loadContractValue
 	config.ImportHandler = e.importProgram
-	config.WithInterpreterConfig(&interpreter.Config{
-		InjectedCompositeFieldsHandler: newInjectedCompositeFieldsHandler(e),
-		UUIDHandler:                    newUUIDHandler(&e.Interface),
-		AccountHandler:                 e.newAccountValue,
-		OnEventEmitted:                 newOnEventEmittedHandler(&e.Interface),
-	})
-	config.WithAccountHandler(e)
+	config.InjectedCompositeFieldsHandler = newInjectedCompositeFieldsHandler(e)
+	config.UUIDHandler = newUUIDHandler(&e.Interface)
+	config.AccountHandlerFunc = e.newAccountValue
+	config.OnEventEmitted = newOnEventEmittedHandler(&e.Interface)
+	config.AccountHandler = e
 	return config
 }
 

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -3609,7 +3609,7 @@ func AccountCapabilitiesPublish(
 			panic(errors.NewUnreachableError())
 		}
 
-		publishHandler := invocationContext.ValidateAccountCapabilitiesPublishHandler()
+		publishHandler := invocationContext.GetValidateAccountCapabilitiesPublishHandler()
 		if publishHandler != nil {
 			valid, err := publishHandler(
 				invocationContext,
@@ -4109,7 +4109,7 @@ func AccountCapabilitiesGet(
 		panic(errors.NewUnreachableError())
 	}
 
-	getHandler := invocationContext.ValidateAccountCapabilitiesGetHandler()
+	getHandler := invocationContext.GetValidateAccountCapabilitiesGetHandler()
 	if getHandler != nil {
 		valid, err := getHandler(
 			invocationContext,

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -177,86 +177,97 @@ func ParseCheckAndPrepareWithOptions(
 		storage = interpreterConfig.Storage
 	}
 
-	vmConfig := vm.NewConfig(storage).
-		WithInterpreterConfig(interpreterConfig).
-		WithDebugEnabled()
-
+	programs := CompiledPrograms{}
 	var compilerConfig *compiler.Config
 
-	// If there are builtin functions provided externally (e.g: for tests),
-	// then convert them to corresponding functions in compiler and in vm.
-	if interpreterConfig != nil && interpreterConfig.BaseActivationHandler != nil {
-		baseActivation := interpreterConfig.BaseActivationHandler(nil)
-		baseActivationVariables := baseActivation.ValuesInFunction()
+	vmConfig := vm.NewConfig(storage).
+		WithDebugEnabled()
 
-		vmConfig.BuiltinGlobalsProvider = func() map[string]*vm.Variable {
-			builtinGlobals := vm.NativeFunctions()
+	vmConfig.TypeLoader = compilerUtils.CompiledProgramsTypeLoader(programs)
 
-			// Add the given built-in values.
-			// Convert the externally provided `interpreter.HostFunctionValue`s into `vm.NativeFunctionValue`s.
-			for name, variable := range baseActivationVariables { //nolint:maprange
+	if interpreterConfig != nil {
+		vmConfig.MemoryGauge = interpreterConfig.MemoryGauge
+		vmConfig.ComputationGauge = interpreterConfig.ComputationGauge
+		vmConfig.CapabilityCheckHandler = interpreterConfig.CapabilityCheckHandler
+		vmConfig.CapabilityBorrowHandler = interpreterConfig.CapabilityBorrowHandler
+		vmConfig.ValidateAccountCapabilitiesGetHandler = interpreterConfig.ValidateAccountCapabilitiesGetHandler
+		vmConfig.ValidateAccountCapabilitiesPublishHandler = interpreterConfig.ValidateAccountCapabilitiesPublishHandler
+		vmConfig.OnEventEmitted = interpreterConfig.OnEventEmitted
+		vmConfig.AccountHandlerFunc = interpreterConfig.AccountHandler
+		vmConfig.InjectedCompositeFieldsHandler = interpreterConfig.InjectedCompositeFieldsHandler
+		vmConfig.UUIDHandler = interpreterConfig.UUIDHandler
 
-				if builtinGlobals[name] != nil {
-					continue
-				}
+		// If there are builtin functions provided externally (e.g: for tests),
+		// then convert them to corresponding functions in compiler and in vm.
+		if interpreterConfig.BaseActivationHandler != nil {
+			baseActivation := interpreterConfig.BaseActivationHandler(nil)
+			baseActivationVariables := baseActivation.ValuesInFunction()
 
-				value := variable.GetValue(nil)
+			vmConfig.BuiltinGlobalsProvider = func() map[string]*vm.Variable {
+				builtinGlobals := vm.NativeFunctions()
 
-				if functionValue, ok := value.(*interpreter.HostFunctionValue); ok {
-					value = vm.NewNativeFunctionValue(
-						name,
-						functionValue.Type,
-						func(context *vm.Context, _ []interpreter.StaticType, arguments ...vm.Value) vm.Value {
-							invocation := interpreter.NewInvocation(
-								context,
-								nil,
-								nil,
-								arguments,
-								nil,
-								// TODO: provide these if they are needed for tests.
-								nil,
-								interpreter.EmptyLocationRange,
-							)
-							return functionValue.Function(invocation)
-						},
-					)
+				// Add the given built-in values.
+				// Convert the externally provided `interpreter.HostFunctionValue`s into `vm.NativeFunctionValue`s.
+				for name, variable := range baseActivationVariables { //nolint:maprange
 
-				}
-
-				vmVariable := &vm.Variable{}
-				vmVariable.InitializeWithValue(value)
-
-				builtinGlobals[name] = vmVariable
-			}
-
-			return builtinGlobals
-		}
-
-		// Register externally provided globals in compiler.
-		compilerConfig = &compiler.Config{
-			BuiltinGlobalsProvider: func() map[string]*compiler.Global {
-				globals := compiler.NativeFunctions()
-				for name := range baseActivationVariables { //nolint:maprange
-					if globals[name] != nil {
+					if builtinGlobals[name] != nil {
 						continue
 					}
-					globals[name] = &compiler.Global{
-						Name: name,
+
+					value := variable.GetValue(nil)
+
+					if functionValue, ok := value.(*interpreter.HostFunctionValue); ok {
+						value = vm.NewNativeFunctionValue(
+							name,
+							functionValue.Type,
+							func(context *vm.Context, _ []interpreter.StaticType, arguments ...vm.Value) vm.Value {
+								invocation := interpreter.NewInvocation(
+									context,
+									nil,
+									nil,
+									arguments,
+									nil,
+									// TODO: provide these if they are needed for tests.
+									nil,
+									interpreter.EmptyLocationRange,
+								)
+								return functionValue.Function(invocation)
+							},
+						)
+
 					}
+
+					vmVariable := &vm.Variable{}
+					vmVariable.InitializeWithValue(value)
+
+					builtinGlobals[name] = vmVariable
 				}
 
-				return globals
-			},
+				return builtinGlobals
+			}
+
+			// Register externally provided globals in compiler.
+			compilerConfig = &compiler.Config{
+				BuiltinGlobalsProvider: func() map[string]*compiler.Global {
+					globals := compiler.NativeFunctions()
+					for name := range baseActivationVariables { //nolint:maprange
+						if globals[name] != nil {
+							continue
+						}
+						globals[name] = &compiler.Global{
+							Name: name,
+						}
+					}
+
+					return globals
+				},
+			}
 		}
 	}
 
 	parseAndCheckOptions := &sema_utils.ParseAndCheckOptions{
 		Config: options.CheckerConfig,
 	}
-
-	programs := CompiledPrograms{}
-
-	vmConfig.TypeLoader = compilerUtils.CompiledProgramsTypeLoader(programs)
 
 	vmInstance := compilerUtils.CompileAndPrepareToInvoke(
 		tb,


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3922

## Description

Selectively added only the functions/handlers needed from the `interpreter.Config` to the `vm.Config`.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
