### PR TITLE
[v1.4] Port v1.4.1-rc.2

### DIFF
--- a/ast/string_test.go
+++ b/ast/string_test.go
@@ -20,12 +20,10 @@ package ast_test
 
 import (
 	"testing"
-	"testing/quick"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/cadence/ast"
-	"github.com/onflow/cadence/parser"
 )
 
 func TestQuoteString(t *testing.T) {
@@ -72,28 +70,4 @@ func TestQuoteString(t *testing.T) {
 		`"\""`,
 		ast.QuoteString(`"`),
 	)
-}
-
-func TestStringQuick(t *testing.T) {
-
-	t.Parallel()
-
-	f := func(text string) bool {
-		res, errs := parser.ParseExpression(
-			nil,
-			[]byte(ast.QuoteString(text)),
-			parser.Config{},
-		)
-		if len(errs) > 0 {
-			return false
-		}
-		literal, ok := res.(*ast.StringExpression)
-		if !ok {
-			return false
-		}
-		return literal.Value == text
-	}
-	if err := quick.Check(f, nil); err != nil {
-		t.Error(err)
-	}
 }

--- a/interpreter/reference_test.go
+++ b/interpreter/reference_test.go
@@ -3440,6 +3440,34 @@ func TestInterpretStorageReferenceBoundFunction(t *testing.T) {
 			value,
 		)
 	})
+
+	t.Run("on a type-changed value", func(t *testing.T) {
+
+		t.Parallel()
+
+		address := interpreter.NewUnmeteredAddressValueFromBytes([]byte{42})
+
+		inter, _ := testAccount(t, address, true, nil, `
+          fun test(): AnyStruct {
+              account.storage.save(["abc"] as [String], to: /storage/x)
+
+              let arrayRef = account.storage.borrow<auth(Mutate) &[AnyStruct]>(from: /storage/x)!
+
+              // Up-cast the function to return a super-type
+              var removeFunc = arrayRef.remove as! (fun(Int): AnyStruct)
+
+              // Replace with a new value with a different type
+              account.storage.load<[String]>(from:/storage/x)!
+              account.storage.save([123], to:/storage/x)
+
+              // Invoke the function pointer.
+              return removeFunc(0)
+          }
+        `, sema.Config{})
+
+		_, err := inter.Invoke("test")
+		require.NoError(t, err)
+	})
 }
 
 func TestInterpretCreatingCircularDependentResource(t *testing.T) {

--- a/interpreter/reference_test.go
+++ b/interpreter/reference_test.go
@@ -3466,7 +3466,9 @@ func TestInterpretStorageReferenceBoundFunction(t *testing.T) {
         `, sema.Config{})
 
 		_, err := inter.Invoke("test")
-		require.NoError(t, err)
+		RequireError(t, err)
+
+		require.ErrorAs(t, err, &interpreter.DereferenceError{})
 	})
 }
 

--- a/interpreter/string_test.go
+++ b/interpreter/string_test.go
@@ -937,3 +937,24 @@ func TestInterpretStringCount(t *testing.T) {
 		runTest(test)
 	}
 }
+
+func TestUnterminatedStringTemplate(t *testing.T) {
+
+	t.Parallel()
+
+	inter := parseCheckAndPrepare(t, `
+transaction {
+    prepare() {
+        let code = "\(a)
+    }
+}
+    `)
+
+	result, err := inter.Invoke("test")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		interpreter.TypeValue{Type: interpreter.PrimitiveStaticTypeCharacter},
+		result,
+	)
+}

--- a/interpreter/string_test.go
+++ b/interpreter/string_test.go
@@ -937,24 +937,3 @@ func TestInterpretStringCount(t *testing.T) {
 		runTest(test)
 	}
 }
-
-func TestUnterminatedStringTemplate(t *testing.T) {
-
-	t.Parallel()
-
-	inter := parseCheckAndPrepare(t, `
-transaction {
-    prepare() {
-        let code = "\(a)
-    }
-}
-    `)
-
-	result, err := inter.Invoke("test")
-	require.NoError(t, err)
-
-	require.Equal(t,
-		interpreter.TypeValue{Type: interpreter.PrimitiveStaticTypeCharacter},
-		result,
-	)
-}

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -232,14 +232,14 @@ func (v *StorageReferenceValue) GetMember(context MemberAccessibleContext, locat
 	// whether the member was accessed directly, or via a reference.
 
 	if boundFunction, isBoundFunction := member.(BoundFunctionValue); isBoundFunction {
-		referencedValueStaticType := referencedValue.StaticType(interpreter)
+		referencedValueStaticType := referencedValue.StaticType(context)
 
 		boundFunction.SelfReference = NewStorageReferenceValue(
-			interpreter,
+			context,
 			v.Authorization,
 			v.TargetStorageAddress,
 			v.TargetPath,
-			interpreter.MustConvertStaticToSemaType(referencedValueStaticType),
+			MustConvertStaticToSemaType(referencedValueStaticType, context),
 		)
 		return boundFunction
 	}

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -210,13 +210,37 @@ func (v *StorageReferenceValue) GetMember(context MemberAccessibleContext, locat
 	}
 
 	// If the member is a function, it is always a bound-function.
-	// By default, bound functions create and hold an ephemeral reference (`SelfReference`).
-	// For storage references, replace this default one with the actual storage reference.
+	// By default, bound functions create and hold an ephemeral reference
+	// (in `BoundFunctionValue.SelfReference`).
+	// For storage references, replace this default one with a storage reference.
+	//
+	// However, we cannot use the storage reference as-is:
+	// Because we look up the member on the referenced value,
+	// we also must use its type as the borrowed type for the `SelfReference` type,
+	// because during invocation the bound function can only be invoked
+	// if the type of the dereferenced value at that time still matches
+	// the type of the dereferenced value at the time of binding (here).
+	//
+	// For example, imagine storing a value of type T (e.g. `String`),
+	// creating a reference with a supertype (e.g. `AnyStruct`),
+	// and then creating a bound function on it.
+	// Then, if we change the storage location to store a value of unrelated type U instead (e.g. `Int`),
+	// and invoke the bound function, the bound function is potentially invalid.
+	//
 	// It is not possible (or a lot of work), to create the bound function with the storage reference
 	// when it was created originally, because `getMember(referencedValue, ...)` doesn't know
 	// whether the member was accessed directly, or via a reference.
+
 	if boundFunction, isBoundFunction := member.(BoundFunctionValue); isBoundFunction {
-		boundFunction.SelfReference = v
+		referencedValueStaticType := referencedValue.StaticType(interpreter)
+
+		boundFunction.SelfReference = NewStorageReferenceValue(
+			interpreter,
+			v.Authorization,
+			v.TargetStorageAddress,
+			v.TargetPath,
+			interpreter.MustConvertStaticToSemaType(referencedValueStaticType),
+		)
 		return boundFunction
 	}
 

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -307,9 +307,8 @@ func TestParseVariableDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte("static var x = 1"),
+		_, errs := testParseDeclarationsWithConfig(
+			"static var x = 1",
 			Config{
 				StaticModifierEnabled: true,
 			},
@@ -345,9 +344,8 @@ func TestParseVariableDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte("native var x = 1"),
+		_, errs := testParseDeclarationsWithConfig(
+			"native var x = 1",
 			Config{
 				NativeModifierEnabled: true,
 			},
@@ -1096,9 +1094,8 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := ParseDeclarations(
-			nil,
-			[]byte("native fun foo() {}"),
+		result, errs := testParseDeclarationsWithConfig(
+			"native fun foo() {}",
 			Config{
 				NativeModifierEnabled: true,
 			},
@@ -1169,9 +1166,8 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := ParseDeclarations(
-			nil,
-			[]byte("static fun foo() {}"),
+		result, errs := testParseDeclarationsWithConfig(
+			"static fun foo() {}",
 			Config{
 				StaticModifierEnabled: true,
 			},
@@ -1230,9 +1226,8 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := ParseDeclarations(
-			nil,
-			[]byte("static native fun foo() {}"),
+		result, errs := testParseDeclarationsWithConfig(
+			"static native fun foo() {}",
 			Config{
 				StaticModifierEnabled: true,
 				NativeModifierEnabled: true,
@@ -1292,9 +1287,8 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte("native static fun foo() {}"),
+		_, errs := testParseDeclarationsWithConfig(
+			"native static fun foo() {}",
 			Config{
 				StaticModifierEnabled: true,
 				NativeModifierEnabled: true,
@@ -1332,9 +1326,8 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := ParseDeclarations(
-			nil,
-			[]byte("access(all) static native fun foo() {}"),
+		result, errs := testParseDeclarationsWithConfig(
+			"access(all) static native fun foo() {}",
 			Config{
 				StaticModifierEnabled: true,
 				NativeModifierEnabled: true,
@@ -1427,9 +1420,8 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := ParseDeclarations(
-			nil,
-			[]byte("fun foo  < > () {}"),
+		result, errs := testParseDeclarationsWithConfig(
+			"fun foo  < > () {}",
 			Config{
 				TypeParametersEnabled: true,
 			},
@@ -1477,9 +1469,8 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := ParseDeclarations(
-			nil,
-			[]byte("fun foo  < A  > () {}"),
+		result, errs := testParseDeclarationsWithConfig(
+			"fun foo  < A  > () {}",
 			Config{
 				TypeParametersEnabled: true,
 			},
@@ -1534,9 +1525,8 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := ParseDeclarations(
-			nil,
-			[]byte("fun foo  < A  , B : C > () {}"),
+		result, errs := testParseDeclarationsWithConfig(
+			"fun foo  < A  , B : C > () {}",
 			Config{
 				TypeParametersEnabled: true,
 			},
@@ -1623,9 +1613,8 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte("fun foo  < "),
+		_, errs := testParseDeclarationsWithConfig(
+			"fun foo  < ",
 			Config{
 				TypeParametersEnabled: true,
 			},
@@ -1646,9 +1635,8 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte("fun foo  < A B > () { } "),
+		_, errs := testParseDeclarationsWithConfig(
+			"fun foo  < A B > () { } ",
 			Config{
 				TypeParametersEnabled: true,
 			},
@@ -4779,9 +4767,8 @@ func TestParseEnumDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte(" enum E { static case e }"),
+		_, errs := testParseDeclarationsWithConfig(
+			" enum E { static case e }",
 			Config{
 				StaticModifierEnabled: true,
 			},
@@ -4818,9 +4805,8 @@ func TestParseEnumDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte(" enum E { native case e }"),
+		_, errs := testParseDeclarationsWithConfig(
+			" enum E { native case e }",
 			Config{
 				NativeModifierEnabled: true,
 			},
@@ -6191,9 +6177,12 @@ func TestParseInvalidMember(t *testing.T) {
 	t.Run("ignore", func(t *testing.T) {
 		t.Parallel()
 
-		_, errs := ParseDeclarations(nil, []byte(code), Config{
-			IgnoreLeadingIdentifierEnabled: true,
-		})
+		_, errs := testParseDeclarationsWithConfig(
+			code,
+			Config{
+				IgnoreLeadingIdentifierEnabled: true,
+			},
+		)
 		require.Empty(t, errs)
 
 	})
@@ -6201,9 +6190,12 @@ func TestParseInvalidMember(t *testing.T) {
 	t.Run("report", func(t *testing.T) {
 		t.Parallel()
 
-		_, errs := ParseDeclarations(nil, []byte(code), Config{
-			IgnoreLeadingIdentifierEnabled: false,
-		})
+		_, errs := testParseDeclarationsWithConfig(
+			code,
+			Config{
+				IgnoreLeadingIdentifierEnabled: false,
+			},
+		)
 
 		AssertEqualWithDiff(t,
 			[]error{
@@ -6890,9 +6882,8 @@ func TestParsePragmaNoArguments(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte("static #foo"),
+		_, errs := testParseDeclarationsWithConfig(
+			"static #foo",
 			Config{
 				StaticModifierEnabled: true,
 			},
@@ -6928,9 +6919,8 @@ func TestParsePragmaNoArguments(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte("native #foo"),
+		_, errs := testParseDeclarationsWithConfig(
+			"native #foo",
 			Config{
 				NativeModifierEnabled: true,
 			},
@@ -7945,9 +7935,8 @@ func TestParseInvalidCompositeFunctionNames(t *testing.T) {
 
 			t.Run(testName, func(t *testing.T) {
 
-				_, err := ParseProgram(
-					nil,
-					[]byte(fmt.Sprintf(
+				_, err := testParseProgram(
+					fmt.Sprintf(
 						`
                           %[1]s %[2]s Test %[4]s {
                               fun init() %[3]s
@@ -7957,8 +7946,7 @@ func TestParseInvalidCompositeFunctionNames(t *testing.T) {
 						interfaceKeyword,
 						body,
 						baseType,
-					)),
-					Config{},
+					),
 				)
 
 				errs, ok := err.(Error)
@@ -8209,11 +8197,10 @@ func TestParseInvalidImportWithModifier(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte(`
+		_, errs := testParseDeclarationsWithConfig(
+			`
                 static import x from 0x1
-	        `),
+	        `,
 			Config{
 				StaticModifierEnabled: true,
 			},
@@ -8253,11 +8240,10 @@ func TestParseInvalidImportWithModifier(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte(`
+		_, errs := testParseDeclarationsWithConfig(
+			`
                 native import x from 0x1
-	        `),
+	        `,
 			Config{
 				NativeModifierEnabled: true,
 			},
@@ -8302,11 +8288,10 @@ func TestParseInvalidEventWithModifier(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte(`
+		_, errs := testParseDeclarationsWithConfig(
+			`
                 static event Foo()
-	        `),
+	        `,
 			Config{
 				StaticModifierEnabled: true,
 			},
@@ -8346,11 +8331,10 @@ func TestParseInvalidEventWithModifier(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte(`
+		_, errs := testParseDeclarationsWithConfig(
+			`
                 native event Foo()
-	        `),
+	        `,
 			Config{
 				NativeModifierEnabled: true,
 			},
@@ -8396,11 +8380,10 @@ func TestParseCompositeWithModifier(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte(`
+		_, errs := testParseDeclarationsWithConfig(
+			`
                 static struct Foo()
-	        `),
+	        `,
 			Config{
 				StaticModifierEnabled: true,
 			},
@@ -8440,11 +8423,10 @@ func TestParseCompositeWithModifier(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte(`
+		_, errs := testParseDeclarationsWithConfig(
+			`
                 native struct Foo()
-	        `),
+	        `,
 			Config{
 				NativeModifierEnabled: true,
 			},
@@ -8489,11 +8471,10 @@ func TestParseTransactionWithModifier(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte(`
+		_, errs := testParseDeclarationsWithConfig(
+			`
                 static transaction {}
-	        `),
+	        `,
 			Config{
 				StaticModifierEnabled: true,
 			},
@@ -8533,11 +8514,10 @@ func TestParseTransactionWithModifier(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := ParseDeclarations(
-			nil,
-			[]byte(`
+		_, errs := testParseDeclarationsWithConfig(
+			`
                 native transaction {}
-	        `),
+	        `,
 			Config{
 				NativeModifierEnabled: true,
 			},

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -1183,24 +1183,38 @@ func defineStringExpression() {
 
 				// parser already points to next token
 				curToken = p.current
+
 				if curToken.Is(lexer.TokenStringTemplate) {
+					// If the next token is a string template,
+					// then we need to parse the expression inside the template
+
 					// advance to the expression
 					p.next()
 					value, err := parseExpression(p, lowestBindingPower)
+
 					// consider invalid expression first
 					if err != nil {
 						return nil, err
 					}
+
 					_, err = p.mustOne(lexer.TokenParenClose)
 					if err != nil {
 						return nil, err
 					}
+
 					values = append(values, value)
+
 					// parser already points to next token
 					curToken = p.current
+
 					// safely call next because this should always be a string
 					p.next()
+
 					missingEnd = true
+				} else {
+					// If the next token is not a string template,
+					// then we are done with parsing the string literal
+					break
 				}
 			}
 

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -1232,7 +1232,8 @@ func defineStringExpression() {
 			} else {
 				return ast.NewStringTemplateExpression(
 					p.memoryGauge,
-					literals, values,
+					literals,
+					values,
 					ast.NewRange(p.memoryGauge,
 						startToken.StartPos,
 						endToken.EndPos),

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -6471,6 +6471,38 @@ func TestParseStringTemplate(t *testing.T) {
 			errs,
 		)
 	})
+
+	t.Run("unterminated second string literal, with templates", func(t *testing.T) {
+
+		t.Parallel()
+
+		code := `
+          let code = "sadas\(a)""\(a)
+        `
+
+		_, errs := testParseStatements(code)
+		AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid end of string literal: missing '\"'",
+					Pos: ast.Position{
+						Offset: 38,
+						Line:   2,
+						Column: 38,
+					},
+				},
+				&SyntaxError{
+					Message: "statements on the same line must be separated with a semicolon",
+					Pos: ast.Position{
+						Offset: 33,
+						Line:   2,
+						Column: 32,
+					},
+				},
+			},
+			errs,
+		)
+	})
 }
 
 func TestParseNilCoalescing(t *testing.T) {

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -7257,3 +7257,35 @@ func (g *limitingMemoryGauge) MeterMemory(usage common.MemoryUsage) error {
 
 	return nil
 }
+
+func TestParseUnterminatedStringLiteral(t *testing.T) {
+
+	t.Parallel()
+
+	code := `
+        let code = """
+    `
+
+	_, errs := testParseStatements(code)
+	AssertEqualWithDiff(t,
+		[]error{
+			&SyntaxError{
+				Message: "invalid end of string literal: missing '\"'",
+				Pos: ast.Position{
+					Offset: 23,
+					Line:   2,
+					Column: 22,
+				},
+			},
+			&SyntaxError{
+				Message: "statements on the same line must be separated with a semicolon",
+				Pos: ast.Position{
+					Offset: 22,
+					Line:   2,
+					Column: 21,
+				},
+			},
+		},
+		errs,
+	)
+}

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"testing/quick"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -7344,4 +7345,26 @@ func (g *limitingMemoryGauge) MeterMemory(usage common.MemoryUsage) error {
 	g.limits[usage.Kind] -= usage.Amount
 
 	return nil
+}
+
+func TestStringQuick(t *testing.T) {
+
+	t.Parallel()
+
+	f := func(text string) bool {
+		res, errs := testParseExpression(
+			ast.QuoteString(text),
+		)
+		if len(errs) > 0 {
+			return false
+		}
+		literal, ok := res.(*ast.StringExpression)
+		if !ok {
+			return false
+		}
+		return literal.Value == text
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
 }

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -6503,6 +6503,30 @@ func TestParseStringTemplate(t *testing.T) {
 			errs,
 		)
 	})
+
+	t.Run("unterminated string with template", func(t *testing.T) {
+
+		t.Parallel()
+
+		code := `
+          let code = "\(a)
+        `
+
+		_, errs := testParseStatements(code)
+		AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid end of string literal: missing '\"'",
+					Pos: ast.Position{
+						Offset: 27,
+						Line:   2,
+						Column: 27,
+					},
+				},
+			},
+			errs,
+		)
+	})
 }
 
 func TestParseNilCoalescing(t *testing.T) {

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -6439,6 +6439,38 @@ func TestParseStringTemplate(t *testing.T) {
 
 		AssertEqualWithDiff(t, expected, actual)
 	})
+
+	t.Run("unterminated second string literal", func(t *testing.T) {
+
+		t.Parallel()
+
+		code := `
+          let code = """
+        `
+
+		_, errs := testParseStatements(code)
+		AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "invalid end of string literal: missing '\"'",
+					Pos: ast.Position{
+						Offset: 25,
+						Line:   2,
+						Column: 24,
+					},
+				},
+				&SyntaxError{
+					Message: "statements on the same line must be separated with a semicolon",
+					Pos: ast.Position{
+						Offset: 24,
+						Line:   2,
+						Column: 23,
+					},
+				},
+			},
+			errs,
+		)
+	})
 }
 
 func TestParseNilCoalescing(t *testing.T) {
@@ -7256,36 +7288,4 @@ func (g *limitingMemoryGauge) MeterMemory(usage common.MemoryUsage) error {
 	g.limits[usage.Kind] -= usage.Amount
 
 	return nil
-}
-
-func TestParseUnterminatedStringLiteral(t *testing.T) {
-
-	t.Parallel()
-
-	code := `
-        let code = """
-    `
-
-	_, errs := testParseStatements(code)
-	AssertEqualWithDiff(t,
-		[]error{
-			&SyntaxError{
-				Message: "invalid end of string literal: missing '\"'",
-				Pos: ast.Position{
-					Offset: 23,
-					Line:   2,
-					Column: 22,
-				},
-			},
-			&SyntaxError{
-				Message: "statements on the same line must be separated with a semicolon",
-				Pos: ast.Position{
-					Offset: 22,
-					Line:   2,
-					Column: 21,
-				},
-			},
-		},
-		errs,
-	)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/parser/lexer"
+	"github.com/onflow/cadence/pretty"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 )
 
@@ -81,7 +82,26 @@ func (*testTokenStream) Reclaim() {
 }
 
 func testParseStatements(s string) ([]ast.Statement, []error) {
-	return ParseStatements(nil, []byte(s), Config{})
+	stmts, errs := ParseStatements(nil, []byte(s), Config{})
+
+	if errs != nil {
+		for _, err := range errs {
+			var sb strings.Builder
+			printer := pretty.NewErrorPrettyPrinter(&sb, true)
+			printErr := printer.PrettyPrintError(
+				err,
+				TestLocation,
+				map[common.Location][]byte{
+					TestLocation: []byte(s),
+				},
+			)
+
+			if printErr != nil {
+				panic(printErr)
+			}
+		}
+	}
+	return stmts, errs
 }
 
 func testParseDeclarations(s string) ([]ast.Declaration, []error) {

--- a/pretty/print.go
+++ b/pretty/print.go
@@ -321,7 +321,10 @@ func (p ErrorPrettyPrinter) writeCodeExcerpts(
 			p.writeString(emptyLineNumbers)
 
 			indicatorLength := excerpt.startPos.Column
-			if indicatorLength >= len(line) {
+			if indicatorLength > maxLineLength {
+				indicatorLength = maxLineLength
+			}
+			if indicatorLength > len(line) {
 				indicatorLength = len(line)
 			}
 

--- a/pretty/print.go
+++ b/pretty/print.go
@@ -321,8 +321,8 @@ func (p ErrorPrettyPrinter) writeCodeExcerpts(
 			p.writeString(emptyLineNumbers)
 
 			indicatorLength := excerpt.startPos.Column
-			if indicatorLength >= maxLineLength {
-				indicatorLength = maxLineLength
+			if indicatorLength >= len(line) {
+				indicatorLength = len(line)
 			}
 
 			p.writeString(" ")

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -12335,8 +12335,7 @@ func TestRuntimeFunctionTypeConfusion(t *testing.T) {
 	require.ErrorAs(t, err, &typeErr)
 }
 
-func TestRuntimeFunctionTypeConfusion(t *testing.T) {
-
+func TestRuntimeStorageReferenceBoundFunctionConfusion(t *testing.T) {
 	t.Parallel()
 
 	runtime := NewTestInterpreterRuntime()

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -12347,7 +12347,7 @@ func TestRuntimeFunctionTypeConfusion(t *testing.T) {
               account.storage.save([account] as AnyStruct, to:/storage/x)
               var r = account.storage.borrow<auth(Mutate) &[&Account]>(from:/storage/x)!
               var f = r.remove 
-              var ff = f as! (fun(Int):auth(Storage) &Account)
+              var ff = f as! (fun(Int): auth(Storage) &Account)
               account.storage.load<AnyStruct>(from:/storage/x)
               let publicAccount = getAccount(account.address)
               account.storage.save([publicAccount] as AnyStruct, to:/storage/x)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -12374,5 +12374,7 @@ func TestRuntimeFunctionTypeConfusion(t *testing.T) {
 			Location:  nextTransactionLocation(),
 		},
 	)
-	require.NoError(t, err)
+	RequireError(t, err)
+
+	require.ErrorAs(t, err, &interpreter.DereferenceError{})
 }

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v1.4.0"
+const Version = "v1.4.1-rc.1"


### PR DESCRIPTION


## Description

Port https://github.com/onflow/cadence-internal/pull/337. Includes:

- https://github.com/onflow/cadence-internal/pull/335
- https://github.com/onflow/cadence-internal/pull/336
- https://github.com/onflow/cadence-internal/pull/332

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
