### PR TITLE
[v1.4] Revert "Remove register reads related to account storage format V1"

### DIFF
--- a/runtime/account_storage.go
+++ b/runtime/account_storage.go
@@ -288,6 +288,36 @@ func getAccountStorageMapFromRegister(
 	return interpreter.NewAccountStorageMapWithRootID(slabStorage, slabID), nil
 }
 
+func hasAccountStorageMap(
+	ledger atree.Ledger,
+	address common.Address,
+) (bool, error) {
+
+	_, registerExists, err := readAccountStorageSlabIndexFromRegister(
+		ledger,
+		address,
+	)
+	if err != nil {
+		return false, err
+	}
+	return registerExists, nil
+}
+
+// hasDomainRegister returns true if given account has given domain register.
+// NOTE: account storage format v1 has domain registers.
+func hasDomainRegister(ledger atree.Ledger, address common.Address, domain common.StorageDomain) (bool, error) {
+	_, domainExists, err := readSlabIndexFromRegister(
+		ledger,
+		address,
+		[]byte(domain.Identifier()),
+	)
+	if err != nil {
+		return false, err
+	}
+
+	return domainExists, nil
+}
+
 func (s *AccountStorage) cachedRootSlabIDs() []atree.SlabID {
 
 	var slabIDs []atree.SlabID

--- a/runtime/sharedstate_test.go
+++ b/runtime/sharedstate_test.go
@@ -213,6 +213,60 @@ func TestRuntimeSharedState(t *testing.T) {
 
 	require.Equal(t,
 		[]ownerKeyPair{
+			// Read account register to check if it is a migrated account
+			// Read returns no value.
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			// Read contract domain register.
+			// Read returns no value.
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainContract.Identifier()),
+			},
+			// Read all available domain registers to check if it is a new account
+			// Read returns no value.
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.PathDomainStorage.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.PathDomainPrivate.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.PathDomainPublic.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainContract.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainInbox.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainCapabilityController.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainCapabilityControllerTag.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainPathCapability.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainAccountCapability.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
 			{
 				owner: signerAddress[:],
 				key:   []byte(AccountStorageKey),

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -38,12 +38,24 @@ const (
 
 type StorageConfig struct{}
 
+type StorageFormat uint8
+
+const (
+	StorageFormatUnknown StorageFormat = iota
+	StorageFormatV1
+	StorageFormatV2
+)
+
 type Storage struct {
 	*atree.PersistentSlabStorage
 
 	// cachedDomainStorageMaps is a cache of domain storage maps.
 	// Key is StorageKey{address, domain} and value is domain storage map.
 	cachedDomainStorageMaps map[interpreter.StorageDomainKey]*interpreter.DomainStorageMap
+
+	// cachedV1Accounts contains the cached result of determining
+	// if the account is in storage format v1 or not.
+	cachedV1Accounts map[common.Address]bool
 
 	// contractUpdates is a cache of contract updates.
 	// Key is StorageKey{contract_address, contract_name} and value is contract composite value.
@@ -150,12 +162,160 @@ func (s *Storage) GetDomainStorageMap(
 		}
 	}()
 
-	return s.AccountStorage.GetDomainStorageMap(
+	// Check if cached account format is available.
+
+	cachedFormat, known := s.getCachedAccountFormat(address)
+	if known {
+		return s.getDomainStorageMap(
+			cachedFormat,
+			storageMutationTracker,
+			address,
+			domain,
+			createIfNotExists,
+		)
+	}
+
+	// Check if account is v2 (by reading "stored" register).
+
+	if s.isV2Account(address) {
+		return s.getDomainStorageMapForV2Account(
+			storageMutationTracker,
+			address,
+			domain,
+			createIfNotExists,
+		)
+	}
+
+	// Check if account is v1 (by reading requested domain register).
+
+	ok, err := hasDomainRegister(s.Ledger, address, domain)
+	if err != nil {
+		panic(err)
+	}
+	if ok {
+		panic(AccountStorageFormatV1Error{
+			Address: address,
+		})
+	}
+
+	// Domain register doesn't exist.
+
+	// Return early if !createIfNotExists to avoid more register reading.
+
+	if !createIfNotExists {
+		return nil
+	}
+
+	// At this point, account is either new account or v1 account without requested domain register.
+
+	// Check if account is v1 (by reading more domain registers)
+
+	if s.isV1Account(address) {
+		panic(AccountStorageFormatV1Error{
+			Address: address,
+		})
+	}
+
+	// New account is treated as v2 account when feature flag is enabled.
+
+	return s.getDomainStorageMapForV2Account(
 		storageMutationTracker,
 		address,
 		domain,
 		createIfNotExists,
 	)
+}
+
+func (s *Storage) getDomainStorageMapForV2Account(
+	storageMutationTracker interpreter.StorageMutationTracker,
+	address common.Address,
+	domain common.StorageDomain,
+	createIfNotExists bool,
+) *interpreter.DomainStorageMap {
+	domainStorageMap := s.AccountStorage.GetDomainStorageMap(
+		storageMutationTracker,
+		address,
+		domain,
+		createIfNotExists,
+	)
+
+	s.cacheIsV1Account(address, false)
+
+	return domainStorageMap
+}
+
+func (s *Storage) getDomainStorageMap(
+	format StorageFormat,
+	storageMutationTracker interpreter.StorageMutationTracker,
+	address common.Address,
+	domain common.StorageDomain,
+	createIfNotExists bool,
+) *interpreter.DomainStorageMap {
+	switch format {
+
+	case StorageFormatV1:
+		panic(AccountStorageFormatV1Error{Address: address})
+
+	case StorageFormatV2:
+		return s.getDomainStorageMapForV2Account(
+			storageMutationTracker,
+			address,
+			domain,
+			createIfNotExists,
+		)
+
+	default:
+		panic(errors.NewUnreachableError())
+	}
+}
+
+func (s *Storage) getCachedAccountFormat(address common.Address) (format StorageFormat, known bool) {
+	isV1, cached := s.cachedV1Accounts[address]
+	if !cached {
+		return StorageFormatUnknown, false
+	}
+	if isV1 {
+		return StorageFormatV1, true
+	} else {
+		return StorageFormatV2, true
+	}
+}
+
+// isV2Account returns true if given account is in account storage format v2.
+func (s *Storage) isV2Account(address common.Address) bool {
+	accountStorageMapExists, err := hasAccountStorageMap(s.Ledger, address)
+	if err != nil {
+		panic(err)
+	}
+
+	return accountStorageMapExists
+}
+
+// isV1Account returns true if given account is in account storage format v1
+// by checking if any of the domain registers exist.
+func (s *Storage) isV1Account(address common.Address) (isV1 bool) {
+
+	// Check if a storage map register exists for any of the domains.
+	// Check the most frequently used domains first, such as storage, public, private.
+	for _, domain := range common.AllStorageDomains {
+		domainExists, err := hasDomainRegister(s.Ledger, address, domain)
+		if err != nil {
+			panic(err)
+		}
+
+		if domainExists {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (s *Storage) cacheIsV1Account(address common.Address, isV1 bool) {
+	if s.cachedV1Accounts == nil {
+		s.cachedV1Accounts = map[common.Address]bool{}
+	}
+	s.cachedV1Accounts[address] = isV1
 }
 
 func (s *Storage) cacheDomainStorageMap(
@@ -367,6 +527,35 @@ func (s *Storage) CheckHealth() error {
 	return nil
 }
 
+// AccountStorageFormat returns either StorageFormatV1 or StorageFormatV2 for existing accounts,
+// and StorageFormatUnknown for non-existing accounts.
+func (s *Storage) AccountStorageFormat(address common.Address) (format StorageFormat) {
+	cachedFormat, known := s.getCachedAccountFormat(address)
+	if known {
+		return cachedFormat
+	}
+
+	defer func() {
+		// Cache account fomat
+		switch format {
+		case StorageFormatV1:
+			s.cacheIsV1Account(address, true)
+		case StorageFormatV2:
+			s.cacheIsV1Account(address, false)
+		}
+	}()
+
+	if s.isV2Account(address) {
+		return StorageFormatV2
+	}
+
+	if s.isV1Account(address) {
+		return StorageFormatV1
+	}
+
+	return StorageFormatUnknown
+}
+
 type UnreferencedRootSlabsError struct {
 	UnreferencedRootSlabIDs []atree.SlabID
 }
@@ -380,6 +569,22 @@ func (e UnreferencedRootSlabsError) Error() string {
 		"%s slabs not referenced: %s",
 		errors.InternalErrorMessagePrefix,
 		e.UnreferencedRootSlabIDs,
+	)
+}
+
+type AccountStorageFormatV1Error struct {
+	Address common.Address
+}
+
+var _ errors.InternalError = UnreferencedRootSlabsError{}
+
+func (AccountStorageFormatV1Error) IsUserError() {}
+
+func (e AccountStorageFormatV1Error) Error() string {
+	return fmt.Sprintf(
+		"%s account %s is still in account storage format V1",
+		errors.InternalErrorMessagePrefix,
+		e.Address.HexWithPrefix(),
 	)
 }
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -6514,7 +6514,7 @@ func TestRuntimeStorageForNewAccount(t *testing.T) {
 	})
 }
 
-func TestRuntimeStorage2(t *testing.T) {
+func TestRuntimeStorageForMigratedAccount(t *testing.T) {
 	t.Parallel()
 
 	address := common.MustBytesToAddress([]byte{0x1})
@@ -7019,6 +7019,365 @@ func TestRuntimeStorage2(t *testing.T) {
 	})
 }
 
+func TestRuntimeStorageForUnmigratedAccount(t *testing.T) {
+
+	t.Parallel()
+
+	address := common.MustBytesToAddress([]byte{0x1})
+
+	newTestLedgerWithUnmigratedAccount := func(
+		onRead LedgerOnRead,
+		onWrite LedgerOnWrite,
+		address common.Address,
+		domains []common.StorageDomain,
+		domainStorageMapCount int,
+	) (TestLedger, accountStorageMapValues) {
+		ledger := NewTestLedger(nil, nil)
+		storage := NewStorage(
+			ledger,
+			nil,
+			StorageConfig{},
+		)
+
+		inter := NewTestInterpreter(t)
+
+		accountValues := make(accountStorageMapValues)
+
+		random := rand.New(rand.NewSource(42))
+
+		for _, domain := range domains {
+			accountValues[domain] = make(domainStorageMapValues)
+
+			// Create domain storage map
+			domainStorageMap := interpreter.NewDomainStorageMap(nil, storage, atree.Address(address))
+
+			// Write domain register
+			domainStorageMapValueID := domainStorageMap.ValueID()
+			err := ledger.SetValue(address[:], []byte(domain.Identifier()), domainStorageMapValueID[8:])
+			require.NoError(t, err)
+
+			// Write elements to to domain storage map
+			for len(accountValues[domain]) < domainStorageMapCount {
+				n := random.Int()
+				key := interpreter.StringStorageMapKey(strconv.Itoa(n))
+				value := interpreter.NewUnmeteredIntValueFromInt64(int64(n))
+
+				_ = domainStorageMap.WriteValue(inter, key, value)
+
+				accountValues[domain][key] = value
+			}
+		}
+
+		// Commit changes
+		const commitContractUpdates = false
+		err := storage.Commit(inter, commitContractUpdates)
+		require.NoError(t, err)
+
+		// Create a new storage
+		newLedger := NewTestLedgerWithData(onRead, onWrite, ledger.StoredValues, ledger.StorageIndices)
+
+		return newLedger, accountValues
+	}
+
+	// This test reads non-existent domain storage map and commit changes.
+	// pre-condition: storage contains domain register and domain storage map
+	// post-condition: no change
+	// migration: none because only read ops.
+	t.Run("read non-existent domain storage map", func(t *testing.T) {
+		existingDomains := []common.StorageDomain{
+			common.PathDomainStorage.StorageDomain(),
+		}
+
+		var writeCount int
+
+		// Create storage with unmigrated accounts
+		const domainStorageMapCount = 5
+		ledger, _ := newTestLedgerWithUnmigratedAccount(
+			nil,
+			LedgerOnWriteCounter(&writeCount),
+			address,
+			existingDomains,
+			domainStorageMapCount)
+		storage := NewStorage(
+			ledger,
+			nil,
+			StorageConfig{},
+		)
+
+		inter := NewTestInterpreterWithStorage(t, storage)
+
+		// Get non-existent domain storage map
+		nonExistingDomain := common.PathDomainPublic.StorageDomain()
+		const createIfNotExists = false
+		domainStorageMap := storage.GetDomainStorageMap(inter, address, nonExistingDomain, createIfNotExists)
+		require.Nil(t, domainStorageMap)
+
+		// Commit changes
+		const commitContractUpdates = false
+		err := storage.Commit(inter, commitContractUpdates)
+		require.NoError(t, err)
+
+		// Check there are no writes to underlying storage
+		require.Equal(t, 0, writeCount)
+	})
+
+	// This test reads existing domain storage map and commit changes.
+	// pre-condition: storage contains domain register and domain storage map
+	// post-condition: no change
+	// migration: none because only read ops
+	readExistingDomainTestCases := []struct {
+		name              string
+		createIfNotExists bool
+	}{
+		{name: "(createIfNotExists is true)", createIfNotExists: true},
+		{name: "(createIfNotExists is false)", createIfNotExists: false},
+	}
+
+	for _, tc := range readExistingDomainTestCases {
+		t.Run("read existing domain storage map "+tc.name, func(t *testing.T) {
+
+			var writeCount int
+
+			existingDomains := []common.StorageDomain{common.PathDomainStorage.StorageDomain()}
+			const existingDomainStorageMapCount = 5
+
+			// Create storage with existing domain storage map
+			ledger, accountValues := newTestLedgerWithUnmigratedAccount(
+				nil,
+				LedgerOnWriteCounter(&writeCount),
+				address,
+				existingDomains,
+				existingDomainStorageMapCount,
+			)
+			storage := NewStorage(
+				ledger,
+				nil,
+				StorageConfig{},
+			)
+
+			inter := NewTestInterpreterWithStorage(t, storage)
+
+			// Read existing domain storage map
+			for domain := range accountValues {
+				require.PanicsWithValue(t,
+					AccountStorageFormatV1Error{Address: address},
+					func() {
+						storage.GetDomainStorageMap(inter, address, domain, tc.createIfNotExists)
+					},
+				)
+			}
+
+			// Commit changes
+			const commitContractUpdates = false
+			err := storage.Commit(inter, commitContractUpdates)
+			require.NoError(t, err)
+
+			// Check storage health after commit
+			err = storage.CheckHealth()
+			require.NoError(t, err)
+
+			// Check writes to underlying storage
+			require.Equal(t, 0, writeCount)
+		})
+	}
+
+	// This test creates and writes to new domain storage map and commit changes.
+	// pre-condition: storage contains
+	// - domain register
+	// - domain storage map
+	// post-condition: storage contains
+	// - account register
+	// - account storage map with existing and new domain storage map.
+	// migration: yes
+	createDomainTestCases := []struct {
+		name                          string
+		existingDomains               []common.StorageDomain
+		newDomains                    []common.StorageDomain
+		existingDomainStorageMapCount int
+		newDomainStorageMapCount      int
+		isNewDomainStorageMapInlined  bool
+	}{
+		{
+			name:                          "empty domain storage map",
+			existingDomains:               []common.StorageDomain{common.PathDomainStorage.StorageDomain()},
+			existingDomainStorageMapCount: 5,
+			newDomains:                    []common.StorageDomain{common.PathDomainPublic.StorageDomain()},
+			newDomainStorageMapCount:      0,
+			isNewDomainStorageMapInlined:  true,
+		},
+		{
+			name:                          "small domain storage map",
+			existingDomains:               []common.StorageDomain{common.PathDomainStorage.StorageDomain()},
+			existingDomainStorageMapCount: 5,
+			newDomains:                    []common.StorageDomain{common.PathDomainPublic.StorageDomain()},
+			newDomainStorageMapCount:      10,
+			isNewDomainStorageMapInlined:  true,
+		},
+		{
+			name:                          "large domain storage map",
+			existingDomains:               []common.StorageDomain{common.PathDomainStorage.StorageDomain()},
+			existingDomainStorageMapCount: 5,
+			newDomains:                    []common.StorageDomain{common.PathDomainPublic.StorageDomain()},
+			newDomainStorageMapCount:      20,
+			isNewDomainStorageMapInlined:  false,
+		},
+	}
+
+	for _, tc := range createDomainTestCases {
+		t.Run("create and write "+tc.name, func(t *testing.T) {
+
+			var writeCount int
+
+			// Create storage with existing account storage map
+			ledger, _ := newTestLedgerWithUnmigratedAccount(
+				nil,
+				LedgerOnWriteCounter(&writeCount),
+				address,
+				tc.existingDomains,
+				tc.existingDomainStorageMapCount,
+			)
+			storage := NewStorage(
+				ledger,
+				nil,
+				StorageConfig{},
+			)
+
+			inter := NewTestInterpreterWithStorage(t, storage)
+
+			// Create and write to new domain storage map
+			for _, domain := range tc.newDomains {
+				require.PanicsWithValue(t,
+					AccountStorageFormatV1Error{Address: address},
+					func() {
+						const createIfNotExists = true
+						storage.GetDomainStorageMap(inter, address, domain, createIfNotExists)
+					},
+				)
+			}
+
+			// Commit changes
+			const commitContractUpdates = false
+			err := storage.Commit(inter, commitContractUpdates)
+			require.NoError(t, err)
+
+			// Check storage health after commit
+			err = storage.CheckHealth()
+			require.NoError(t, err)
+
+			// Check there are no writes to underlying storage
+			require.Equal(t, 0, writeCount)
+		})
+	}
+
+	// This test reads and writes to existing domain storage map and commit changes.
+	// pre-condition: storage contains
+	// - domain register
+	// - domain storage map
+	// post-condition: storage contains
+	// - account register
+	// - account storage map with updated domain storage map.
+	// migration: yes
+	t.Run("read and write to existing domain storage map", func(t *testing.T) {
+
+		var writeCount int
+
+		domains := []common.StorageDomain{common.PathDomainStorage.StorageDomain()}
+		const existingDomainStorageMapCount = 5
+
+		// Create storage with existing domain storage maps
+		ledger, _ := newTestLedgerWithUnmigratedAccount(
+			nil,
+			LedgerOnWriteCounter(&writeCount),
+			address,
+			domains,
+			existingDomainStorageMapCount,
+		)
+		storage := NewStorage(
+			ledger,
+			nil,
+			StorageConfig{},
+		)
+
+		inter := NewTestInterpreterWithStorage(t, storage)
+
+		// write to existing domain storage map (createIfNotExists is false)
+		for _, domain := range domains {
+
+			require.PanicsWithValue(t,
+				AccountStorageFormatV1Error{Address: address},
+				func() {
+					const createIfNotExists = false
+					storage.GetDomainStorageMap(inter, address, domain, createIfNotExists)
+				},
+			)
+		}
+
+		// Commit changes
+		const commitContractUpdates = false
+		err := storage.Commit(inter, commitContractUpdates)
+		require.NoError(t, err)
+
+		// Check storage health after commit
+		err = storage.CheckHealth()
+		require.NoError(t, err)
+
+		// Check there are no writes to underlying storage
+		require.Equal(t, 0, writeCount)
+	})
+
+	// This test storage map operations (including account migration) with intermittent Commit()
+	// - read domain storage map and commit
+	// - write to domain storage map and commit (including account migration)
+	// - remove all elements from domain storage map and commit
+	// - read domain storage map and commit
+	t.Run("read, commit, update, commit, remove, commit", func(t *testing.T) {
+
+		var writeCount int
+
+		domains := []common.StorageDomain{common.PathDomainStorage.StorageDomain()}
+		const domainStorageMapCount = 5
+
+		// Create storage with existing account storage map
+		ledger, _ := newTestLedgerWithUnmigratedAccount(
+			nil,
+			LedgerOnWriteCounter(&writeCount),
+			address,
+			domains,
+			domainStorageMapCount,
+		)
+		storage := NewStorage(
+			ledger,
+			nil,
+			StorageConfig{},
+		)
+
+		inter := NewTestInterpreterWithStorage(t, storage)
+
+		for _, domain := range domains {
+
+			require.PanicsWithValue(t,
+				AccountStorageFormatV1Error{Address: address},
+				func() {
+					const createIfNotExists = false
+					storage.GetDomainStorageMap(inter, address, domain, createIfNotExists)
+				},
+			)
+		}
+
+		// Commit changes
+		const commitContractUpdates = false
+		err := storage.Commit(inter, commitContractUpdates)
+		require.NoError(t, err)
+
+		// Check storage health after commit
+		err = storage.CheckHealth()
+		require.NoError(t, err)
+
+		// Check there are no writes to underlying storage
+		require.Equal(t, 0, writeCount)
+	})
+}
+
 // TestRuntimeStorageDomainStorageMapInlinedState tests inlined state
 // of domain storage map when large number of elements are inserted,
 // updated, and removed from domain storage map.
@@ -7294,22 +7653,35 @@ func TestGetDomainStorageMapRegisterReadsForNewAccount(t *testing.T) {
 			createIfNotExists:             false,
 			expectedDomainStorageMapIsNil: true,
 			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
 				{
 					owner: address[:],
 					key:   []byte(AccountStorageKey),
+				},
+				// Check domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
 				},
 			},
 			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
 				// Second GetDomainStorageMap() has the same register reading as the first GetDomainStorageMap()
 				// because account status can't be cached in previous call.
 
+				// Check if account is v2
 				{
 					owner: address[:],
 					key:   []byte(AccountStorageKey),
 				},
+				// Check domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
 			},
 			expectedReadsSet: map[string]struct{}{
-				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)): {},
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):          {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage): {},
 			},
 		},
 		{
@@ -7318,6 +7690,53 @@ func TestGetDomainStorageMapRegisterReadsForNewAccount(t *testing.T) {
 			createIfNotExists:             true,
 			expectedDomainStorageMapIsNil: false,
 			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Check domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+				// Check all domain registers
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainStorage.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainPrivate.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainPublic.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainContract.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainInbox.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainCapabilityController.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainCapabilityControllerTag.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathCapability.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainAccountCapability.Identifier()),
+				},
 				// Read account register to load account storage map
 				{
 					owner: address[:],
@@ -7329,7 +7748,16 @@ func TestGetDomainStorageMapRegisterReadsForNewAccount(t *testing.T) {
 				// domain storage map is created and cached in the first GetDomainStorageMap().
 			},
 			expectedReadsSet: map[string]struct{}{
-				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)): {},
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):                      {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage):             {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathPrivate):             {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathPublic):              {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainContract):                {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainInbox):                   {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainCapabilityController):    {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainCapabilityControllerTag): {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathCapability):          {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainAccountCapability):       {},
 			},
 		},
 	}
@@ -7383,14 +7811,302 @@ func TestGetDomainStorageMapRegisterReadsForNewAccount(t *testing.T) {
 	}
 }
 
-func TestGetDomainStorageMapRegisterReads(t *testing.T) {
+func TestGetDomainStorageMapRegisterReadsForV1Account(t *testing.T) {
+
 	t.Parallel()
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
 	type getStorageDataFunc func() (storedValues map[string][]byte, StorageIndices map[string]uint64)
 
-	createAccountWithDomain := func(
+	createV1AccountWithDomain := func(
+		address common.Address,
+		domain common.StorageDomain,
+	) getStorageDataFunc {
+		return func() (storedValues map[string][]byte, StorageIndices map[string]uint64) {
+			ledger := NewTestLedger(nil, nil)
+
+			persistentSlabStorage := NewPersistentSlabStorage(ledger, nil)
+
+			orderedMap, err := atree.NewMap(
+				persistentSlabStorage,
+				atree.Address(address),
+				atree.NewDefaultDigesterBuilder(),
+				interpreter.EmptyTypeInfo{},
+			)
+			require.NoError(t, err)
+
+			slabIndex := orderedMap.SlabID().Index()
+
+			for i := range 3 {
+
+				key := interpreter.StringStorageMapKey(strconv.Itoa(i))
+
+				value := interpreter.NewUnmeteredIntValueFromInt64(int64(i))
+
+				existingStorable, err := orderedMap.Set(
+					key.AtreeValueCompare,
+					key.AtreeValueHashInput,
+					key.AtreeValue(),
+					value,
+				)
+				require.NoError(t, err)
+				require.Nil(t, existingStorable)
+			}
+
+			// Commit domain storage map
+			err = persistentSlabStorage.FastCommit(runtime.NumCPU())
+			require.NoError(t, err)
+
+			// Create domain register
+			err = ledger.SetValue(address[:], []byte(domain.Identifier()), slabIndex[:])
+			require.NoError(t, err)
+
+			return ledger.StoredValues, ledger.StorageIndices
+		}
+	}
+
+	testCases := []struct {
+		name                                       string
+		getStorageData                             getStorageDataFunc
+		domain                                     common.StorageDomain
+		createIfNotExists                          bool
+		expectedDomainStorageMapIsNil              bool
+		expectedReadsFor1stGetDomainStorageMapCall []ownerKeyPair
+		expectedReadsFor2ndGetDomainStorageMapCall []ownerKeyPair
+		expectedReadsSet                           map[string]struct{}
+	}{
+		{
+			name:                          "domain storage map does not exist, createIfNotExists = false",
+			getStorageData:                createV1AccountWithDomain(address, common.StorageDomainPathPublic),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             false,
+			expectedDomainStorageMapIsNil: true,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Check domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Check domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+			},
+			expectedReadsSet: map[string]struct{}{
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):          {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage): {},
+			},
+		},
+		{
+			name:                          "domain storage map does not exist, createIfNotExists = true",
+			getStorageData:                createV1AccountWithDomain(address, common.StorageDomainPathPublic),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             true,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Check domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+				// Check all domain registers until any existing domain is checked
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainStorage.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainPrivate.Identifier()),
+				},
+				{
+					owner: address[:],
+					key:   []byte(common.PathDomainPublic.Identifier()),
+				},
+				// Check domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reading from second GetDomainStorageMap() because
+				// domain storage map is created and cached in the first
+				// GetDomainStorageMap().
+			},
+			expectedReadsSet: map[string]struct{}{
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):          {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage): {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathPrivate): {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathPublic):  {},
+			},
+		},
+		{
+			name:                          "domain storage map exists, createIfNotExists = false",
+			getStorageData:                createV1AccountWithDomain(address, common.StorageDomainPathStorage),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             false,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Check domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+				// Read domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+				// Read domain storage map register
+				{
+					owner: address[:],
+					key:   []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1},
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reading from second GetDomainStorageMap() because
+				// domain storage map is created and cached in the first
+				// GetDomainStorageMap().
+			},
+			expectedReadsSet: map[string]struct{}{
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):           {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage):  {},
+				concatRegisterAddressAndKey(address, []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
+			},
+		},
+		{
+			name:                          "domain storage map exists, createIfNotExists = true",
+			getStorageData:                createV1AccountWithDomain(address, common.StorageDomainPathStorage),
+			domain:                        common.StorageDomainPathStorage,
+			createIfNotExists:             true,
+			expectedDomainStorageMapIsNil: false,
+			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
+				// Check given domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+				// Read given domain register
+				{
+					owner: address[:],
+					key:   []byte(common.StorageDomainPathStorage.Identifier()),
+				},
+				// Read domain storage map register
+				{
+					owner: address[:],
+					key:   []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1},
+				},
+			},
+			expectedReadsFor2ndGetDomainStorageMapCall: []ownerKeyPair{
+				// No register reading from second GetDomainStorageMap() because
+				// domain storage map is created and cached in the first
+				// GetDomainStorageMap().
+			},
+			expectedReadsSet: map[string]struct{}{
+				concatRegisterAddressAndKey(address, []byte(AccountStorageKey)):           {},
+				concatRegisterAddressAndDomain(address, common.StorageDomainPathStorage):  {},
+				concatRegisterAddressAndKey(address, []byte{'$', 0, 0, 0, 0, 0, 0, 0, 1}): {},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			storedValues, storedIndices := tc.getStorageData()
+
+			var ledgerReads []ownerKeyPair
+			ledgerReadsSet := make(map[string]struct{})
+
+			ledger := NewTestLedgerWithData(
+				func(owner, key, _ []byte) {
+					ledgerReads = append(
+						ledgerReads,
+						ownerKeyPair{
+							owner: owner,
+							key:   key,
+						},
+					)
+					ledgerReadsSet[string(owner)+"|"+string(key)] = struct{}{}
+				},
+				nil,
+				storedValues,
+				storedIndices,
+			)
+
+			storage := NewStorage(
+				ledger,
+				nil,
+				StorageConfig{},
+			)
+
+			inter := NewTestInterpreterWithStorage(t, storage)
+
+			perform := func() {
+
+				domainStorageMap := storage.GetDomainStorageMap(inter, address, tc.domain, tc.createIfNotExists)
+				require.Equal(t, tc.expectedDomainStorageMapIsNil, domainStorageMap == nil)
+				require.Equal(t, tc.expectedReadsFor1stGetDomainStorageMapCall, ledgerReads)
+
+				ledgerReads = ledgerReads[:0]
+
+				domainStorageMap = storage.GetDomainStorageMap(inter, address, tc.domain, tc.createIfNotExists)
+				require.Equal(t, tc.expectedDomainStorageMapIsNil, domainStorageMap == nil)
+				require.Equal(t, tc.expectedReadsFor2ndGetDomainStorageMapCall, ledgerReads)
+
+				// Check underlying ledger reads
+				require.Equal(t, len(ledgerReadsSet), len(tc.expectedReadsSet))
+				for k := range ledgerReadsSet {
+					require.Contains(t, tc.expectedReadsSet, k)
+				}
+			}
+
+			if !tc.createIfNotExists && tc.expectedDomainStorageMapIsNil {
+				perform()
+			} else {
+				require.PanicsWithValue(t, AccountStorageFormatV1Error{Address: address}, perform)
+			}
+		})
+	}
+}
+
+func TestGetDomainStorageMapRegisterReadsForV2Account(t *testing.T) {
+	t.Parallel()
+
+	address := common.MustBytesToAddress([]byte{0x1})
+
+	type getStorageDataFunc func() (storedValues map[string][]byte, StorageIndices map[string]uint64)
+
+	createV2AccountWithDomain := func(
 		address common.Address,
 		domain common.StorageDomain,
 	) getStorageDataFunc {
@@ -7468,11 +8184,16 @@ func TestGetDomainStorageMapRegisterReads(t *testing.T) {
 	}{
 		{
 			name:                          "domain storage map does not exist, createIfNotExists = false",
-			getStorageData:                createAccountWithDomain(address, common.StorageDomainPathPublic),
+			getStorageData:                createV2AccountWithDomain(address, common.StorageDomainPathPublic),
 			domain:                        common.StorageDomainPathStorage,
 			createIfNotExists:             false,
 			expectedDomainStorageMapIsNil: true,
 			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
 				// Read account register
 				{
 					owner: address[:],
@@ -7496,11 +8217,16 @@ func TestGetDomainStorageMapRegisterReads(t *testing.T) {
 		},
 		{
 			name:                          "domain storage map does not exist, createIfNotExists = true",
-			getStorageData:                createAccountWithDomain(address, common.StorageDomainPathPublic),
+			getStorageData:                createV2AccountWithDomain(address, common.StorageDomainPathPublic),
 			domain:                        common.StorageDomainPathStorage,
 			createIfNotExists:             true,
 			expectedDomainStorageMapIsNil: false,
 			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
 				// Read account register
 				{
 					owner: address[:],
@@ -7524,11 +8250,16 @@ func TestGetDomainStorageMapRegisterReads(t *testing.T) {
 		},
 		{
 			name:                          "domain storage map exists, createIfNotExists = false",
-			getStorageData:                createAccountWithDomain(address, common.StorageDomainPathStorage),
+			getStorageData:                createV2AccountWithDomain(address, common.StorageDomainPathStorage),
 			domain:                        common.StorageDomainPathStorage,
 			createIfNotExists:             false,
 			expectedDomainStorageMapIsNil: false,
 			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
 				// Read account register
 				{
 					owner: address[:],
@@ -7552,11 +8283,16 @@ func TestGetDomainStorageMapRegisterReads(t *testing.T) {
 		},
 		{
 			name:                          "domain storage map exists, createIfNotExists = true",
-			getStorageData:                createAccountWithDomain(address, common.StorageDomainPathStorage),
+			getStorageData:                createV2AccountWithDomain(address, common.StorageDomainPathStorage),
 			domain:                        common.StorageDomainPathStorage,
 			createIfNotExists:             true,
 			expectedDomainStorageMapIsNil: false,
 			expectedReadsFor1stGetDomainStorageMapCall: []ownerKeyPair{
+				// Check if account is v2
+				{
+					owner: address[:],
+					key:   []byte(AccountStorageKey),
+				},
 				// Read account register
 				{
 					owner: address[:],
@@ -7761,4 +8497,11 @@ func concatRegisterAddressAndKey(
 	key []byte,
 ) string {
 	return string(address[:]) + "|" + string(key)
+}
+
+func concatRegisterAddressAndDomain(
+	address common.Address,
+	domain common.StorageDomain,
+) string {
+	return string(address[:]) + "|" + domain.Identifier()
 }


### PR DESCRIPTION
Depends on #3966

## Description

Bring back #3962. It got merged, but the target branch `v1.4` was re-created from `v1.4.0`, and should get #3966 first.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
