### PR TITLE
[v1.4] Fix version

### DIFF
--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 
 package cadence
 
-const Version = "v1.4.1-rc.1"
+const Version = "v1.4.0"


### PR DESCRIPTION

## Description

Releasing v1.4.1 failed https://github.com/onflow/cadence/actions/runs/15219735156/job/42812989707, because `version.go` is incorrect. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
