### PR TITLE
Ensure unbounded loops in parser eventually make progress

### DIFF
--- a/cmd/lex/main.go
+++ b/cmd/lex/main.go
@@ -1,0 +1,78 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"runtime/debug"
+
+	"github.com/onflow/cadence/parser/lexer"
+)
+
+func main() {
+
+	var path string
+	if len(os.Args) > 1 {
+		path = os.Args[1]
+	}
+
+	var (
+		data []byte
+		err  error
+	)
+	if len(path) == 0 {
+		data, err = io.ReadAll(bufio.NewReader(os.Stdin))
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error reading file %s: %v\n", path, err)
+		os.Exit(1)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%s", debug.Stack())
+		}
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	}()
+
+	_, _ = fmt.Fprintf(os.Stderr, "lexing %s\n", path)
+
+	tokens, err := lexer.Lex(data, nil)
+	if err != nil {
+		return
+	}
+	defer tokens.Reclaim()
+
+	for {
+		token := tokens.Next()
+		if token.Type == lexer.TokenEOF {
+			break
+		}
+
+		fmt.Printf("%s-%s: %s\n", token.StartPos, token.EndPos, token.Type)
+	}
+}

--- a/parser/comment.go
+++ b/parser/comment.go
@@ -26,7 +26,7 @@ import (
 func (p *parser) parseBlockComment() (endToken lexer.Token, ok bool) {
 	var depth int
 
-	var progress parserProgress
+	progress := p.newProgress()
 
 	for p.checkProgress(&progress) {
 

--- a/parser/comment.go
+++ b/parser/comment.go
@@ -19,13 +19,17 @@
 package parser
 
 import (
+	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/parser/lexer"
 )
 
 func (p *parser) parseBlockComment() (endToken lexer.Token, ok bool) {
 	var depth int
 
-	for {
+	var progress parserProgress
+
+	for p.checkProgress(&progress) {
+
 		switch p.current.Type {
 		case lexer.TokenBlockCommentStart:
 			p.next()
@@ -61,4 +65,6 @@ func (p *parser) parseBlockComment() (endToken lexer.Token, ok bool) {
 			return
 		}
 	}
+
+	panic(errors.NewUnreachableError())
 }

--- a/parser/comment_test.go
+++ b/parser/comment_test.go
@@ -1,0 +1,33 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBlockCommentEmpty(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := testParseProgram(`/**/`)
+	require.NoError(t, err)
+}

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -31,7 +31,9 @@ import (
 )
 
 func parseDeclarations(p *parser, endTokenType lexer.TokenType) (declarations []ast.Declaration, err error) {
-	for {
+	var progress parserProgress
+	for p.checkProgress(&progress) {
+
 		_, docString := p.parseTrivia(triviaOptions{
 			skipNewlines:    true,
 			parseDocStrings: true,
@@ -60,6 +62,8 @@ func parseDeclarations(p *parser, endTokenType lexer.TokenType) (declarations []
 			declarations = append(declarations, declaration)
 		}
 	}
+
+	panic(errors.NewUnreachableError())
 }
 
 func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
@@ -76,7 +80,8 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 	staticModifierEnabled := p.config.StaticModifierEnabled
 	nativeModifierEnabled := p.config.NativeModifierEnabled
 
-	for {
+	var progress parserProgress
+	for p.checkProgress(&progress) {
 		p.skipSpaceAndComments()
 
 		switch p.current.Type {
@@ -278,6 +283,8 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 
 		return nil, nil
 	}
+
+	panic(errors.NewUnreachableError())
 }
 
 func handlePriv(p *parser) {
@@ -707,8 +714,11 @@ func parseImportDeclaration(p *parser) (*ast.ImportDeclaration, error) {
 	parseMoreIdentifiers := func() error {
 		expectCommaOrFrom := false
 
-		atEnd := false
-		for !atEnd {
+		var (
+			atEnd    bool
+			progress parserProgress
+		)
+		for !atEnd && p.checkProgress(&progress) {
 			p.nextSemanticToken()
 
 			switch p.current.Type {
@@ -1131,7 +1141,8 @@ func parseEntitlementMapping(p *parser, docString string) (*ast.EntitlementMapRe
 func parseEntitlementMappingsAndInclusions(p *parser, endTokenType lexer.TokenType) ([]ast.EntitlementMapElement, error) {
 	var elements []ast.EntitlementMapElement
 
-	for {
+	var progress parserProgress
+	for p.checkProgress(&progress) {
 		_, docString := p.parseTrivia(triviaOptions{
 			skipNewlines:    true,
 			parseDocStrings: true,
@@ -1171,6 +1182,8 @@ func parseEntitlementMappingsAndInclusions(p *parser, endTokenType lexer.TokenTy
 			}
 		}
 	}
+
+	panic(errors.NewUnreachableError())
 }
 
 // parseEntitlementOrMappingDeclaration parses an entitlement declaration,
@@ -1321,7 +1334,8 @@ func parseCompositeOrInterfaceDeclaration(
 	var isInterface bool
 	var identifier ast.Identifier
 
-	for {
+	var progress parserProgress
+	for p.checkProgress(&progress) {
 		p.skipSpaceAndComments()
 		if !p.current.Is(lexer.TokenIdentifier) {
 			return nil, p.syntaxError(
@@ -1516,7 +1530,8 @@ func parseMembersAndNestedDeclarations(p *parser, endTokenType lexer.TokenType) 
 
 	var declarations []ast.Declaration
 
-	for {
+	var progress parserProgress
+	for p.checkProgress(&progress) {
 		_, docString := p.parseTrivia(triviaOptions{
 			skipNewlines:    true,
 			parseDocStrings: true,
@@ -1544,6 +1559,8 @@ func parseMembersAndNestedDeclarations(p *parser, endTokenType lexer.TokenType) 
 			declarations = append(declarations, memberOrNestedDeclaration)
 		}
 	}
+
+	panic(errors.NewUnreachableError())
 }
 
 // parseMemberOrNestedDeclaration parses a composite or interface member,
@@ -1575,7 +1592,8 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 	staticModifierEnabled := p.config.StaticModifierEnabled
 	nativeModifierEnabled := p.config.NativeModifierEnabled
 
-	for {
+	var progress parserProgress
+	for p.checkProgress(&progress) {
 		p.skipSpaceAndComments()
 
 		switch p.current.Type {
@@ -1826,6 +1844,8 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 
 		return nil, nil
 	}
+
+	panic(errors.NewUnreachableError())
 }
 
 func rejectAllModifiers(

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -31,7 +31,8 @@ import (
 )
 
 func parseDeclarations(p *parser, endTokenType lexer.TokenType) (declarations []ast.Declaration, err error) {
-	var progress parserProgress
+	progress := p.newProgress()
+
 	for p.checkProgress(&progress) {
 
 		_, docString := p.parseTrivia(triviaOptions{
@@ -80,8 +81,10 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 	staticModifierEnabled := p.config.StaticModifierEnabled
 	nativeModifierEnabled := p.config.NativeModifierEnabled
 
-	var progress parserProgress
+	progress := p.newProgress()
+
 	for p.checkProgress(&progress) {
+
 		p.skipSpaceAndComments()
 
 		switch p.current.Type {
@@ -714,11 +717,11 @@ func parseImportDeclaration(p *parser) (*ast.ImportDeclaration, error) {
 	parseMoreIdentifiers := func() error {
 		expectCommaOrFrom := false
 
-		var (
-			atEnd    bool
-			progress parserProgress
-		)
+		var atEnd bool
+		progress := p.newProgress()
+
 		for !atEnd && p.checkProgress(&progress) {
+
 			p.nextSemanticToken()
 
 			switch p.current.Type {
@@ -1141,8 +1144,10 @@ func parseEntitlementMapping(p *parser, docString string) (*ast.EntitlementMapRe
 func parseEntitlementMappingsAndInclusions(p *parser, endTokenType lexer.TokenType) ([]ast.EntitlementMapElement, error) {
 	var elements []ast.EntitlementMapElement
 
-	var progress parserProgress
+	progress := p.newProgress()
+
 	for p.checkProgress(&progress) {
+
 		_, docString := p.parseTrivia(triviaOptions{
 			skipNewlines:    true,
 			parseDocStrings: true,
@@ -1334,9 +1339,12 @@ func parseCompositeOrInterfaceDeclaration(
 	var isInterface bool
 	var identifier ast.Identifier
 
-	var progress parserProgress
+	progress := p.newProgress()
+
 	for p.checkProgress(&progress) {
+
 		p.skipSpaceAndComments()
+
 		if !p.current.Is(lexer.TokenIdentifier) {
 			return nil, p.syntaxError(
 				"expected %s, got %s",
@@ -1530,8 +1538,10 @@ func parseMembersAndNestedDeclarations(p *parser, endTokenType lexer.TokenType) 
 
 	var declarations []ast.Declaration
 
-	var progress parserProgress
+	progress := p.newProgress()
+
 	for p.checkProgress(&progress) {
+
 		_, docString := p.parseTrivia(triviaOptions{
 			skipNewlines:    true,
 			parseDocStrings: true,
@@ -1592,8 +1602,10 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 	staticModifierEnabled := p.config.StaticModifierEnabled
 	nativeModifierEnabled := p.config.NativeModifierEnabled
 
-	var progress parserProgress
+	progress := p.newProgress()
+
 	for p.checkProgress(&progress) {
+
 		p.skipSpaceAndComments()
 
 		switch p.current.Type {

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -1004,10 +1004,10 @@ func defineInvocationExpression() {
 func parseArgumentListRemainder(p *parser) (arguments []*ast.Argument, endPos ast.Position, err error) {
 	expectArgument := true
 
-	var (
-		atEnd    bool
-		progress parserProgress
-	)
+	var atEnd bool
+
+	progress := p.newProgress()
+
 	for !atEnd && p.checkProgress(&progress) {
 
 		p.skipSpaceAndComments()
@@ -1168,7 +1168,7 @@ func defineStringExpression() {
 			// flag for ending " check
 			missingEnd := true
 
-			var progress parserProgress
+			progress := p.newProgress()
 
 			for curToken.Is(lexer.TokenString) &&
 				p.checkProgress(&progress) {
@@ -1246,7 +1246,7 @@ func defineArrayExpression() {
 
 			var values []ast.Expression
 
-			var progress parserProgress
+			progress := p.newProgress()
 
 			for !p.current.Is(lexer.TokenBracketClose) &&
 				p.checkProgress(&progress) {
@@ -1293,7 +1293,8 @@ func defineDictionaryExpression() {
 
 			var entries []ast.DictionaryEntry
 
-			var progress parserProgress
+			progress := p.newProgress()
+
 			for !p.current.Is(lexer.TokenBraceClose) &&
 				p.checkProgress(&progress) {
 
@@ -1552,7 +1553,8 @@ func parseExpression(p *parser, rightBindingPower int) (ast.Expression, error) {
 		return nil, err
 	}
 
-	var progress parserProgress
+	progress := p.newProgress()
+
 	for p.checkProgress(&progress) {
 
 		// Automatically skip any trivia between the left and right expression.

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -1002,9 +1002,14 @@ func defineInvocationExpression() {
 }
 
 func parseArgumentListRemainder(p *parser) (arguments []*ast.Argument, endPos ast.Position, err error) {
-	atEnd := false
 	expectArgument := true
-	for !atEnd {
+
+	var (
+		atEnd    bool
+		progress parserProgress
+	)
+	for !atEnd && p.checkProgress(&progress) {
+
 		p.skipSpaceAndComments()
 
 		switch p.current.Type {
@@ -1163,7 +1168,11 @@ func defineStringExpression() {
 			// flag for ending " check
 			missingEnd := true
 
-			for curToken.Is(lexer.TokenString) {
+			var progress parserProgress
+
+			for curToken.Is(lexer.TokenString) &&
+				p.checkProgress(&progress) {
+
 				literal = p.tokenSource(curToken)
 
 				// remove quotation marks if they exist
@@ -1236,8 +1245,14 @@ func defineArrayExpression() {
 			p.skipSpaceAndComments()
 
 			var values []ast.Expression
-			for !p.current.Is(lexer.TokenBracketClose) {
+
+			var progress parserProgress
+
+			for !p.current.Is(lexer.TokenBracketClose) &&
+				p.checkProgress(&progress) {
+
 				p.skipSpaceAndComments()
+
 				if len(values) > 0 {
 					if !p.current.Is(lexer.TokenComma) {
 						break
@@ -1277,8 +1292,13 @@ func defineDictionaryExpression() {
 			p.skipSpaceAndComments()
 
 			var entries []ast.DictionaryEntry
-			for !p.current.Is(lexer.TokenBraceClose) {
+
+			var progress parserProgress
+			for !p.current.Is(lexer.TokenBraceClose) &&
+				p.checkProgress(&progress) {
+
 				p.skipSpaceAndComments()
+
 				if len(entries) > 0 {
 					if !p.current.Is(lexer.TokenComma) {
 						break
@@ -1532,7 +1552,9 @@ func parseExpression(p *parser, rightBindingPower int) (ast.Expression, error) {
 		return nil, err
 	}
 
-	for {
+	var progress parserProgress
+	for p.checkProgress(&progress) {
+
 		// Automatically skip any trivia between the left and right expression.
 		// However, do not automatically skip newlines:
 		// Some left denotations do not support newlines before them,

--- a/parser/function.go
+++ b/parser/function.go
@@ -53,9 +53,14 @@ func parseParameterList(p *parser, expectDefaultArguments bool) (*ast.ParameterL
 
 	expectParameter := true
 
-	atEnd := false
-	for !atEnd {
+	var (
+		atEnd    bool
+		progress parserProgress
+	)
+	for !atEnd && p.checkProgress(&progress) {
+
 		p.skipSpaceAndComments()
+
 		switch p.current.Type {
 		case lexer.TokenIdentifier:
 			if !expectParameter {
@@ -218,9 +223,14 @@ func parseTypeParameterList(p *parser) (*ast.TypeParameterList, error) {
 
 	expectTypeParameter := true
 
-	atEnd := false
-	for !atEnd {
+	var (
+		atEnd    bool
+		progress parserProgress
+	)
+	for !atEnd && p.checkProgress(&progress) {
+
 		p.skipSpaceAndComments()
+
 		switch p.current.Type {
 		case lexer.TokenIdentifier:
 			if !expectTypeParameter {

--- a/parser/function.go
+++ b/parser/function.go
@@ -53,10 +53,9 @@ func parseParameterList(p *parser, expectDefaultArguments bool) (*ast.ParameterL
 
 	expectParameter := true
 
-	var (
-		atEnd    bool
-		progress parserProgress
-	)
+	var atEnd bool
+	progress := p.newProgress()
+
 	for !atEnd && p.checkProgress(&progress) {
 
 		p.skipSpaceAndComments()
@@ -223,10 +222,9 @@ func parseTypeParameterList(p *parser) (*ast.TypeParameterList, error) {
 
 	expectTypeParameter := true
 
-	var (
-		atEnd    bool
-		progress parserProgress
-	)
+	var atEnd bool
+	progress := p.newProgress()
+
 	for !atEnd && p.checkProgress(&progress) {
 
 		p.skipSpaceAndComments()

--- a/parser/lexer/lexer_test.go
+++ b/parser/lexer/lexer_test.go
@@ -1804,6 +1804,44 @@ func TestLexBlockComment(t *testing.T) {
 			},
 		)
 	})
+
+	t.Run("empty", func(t *testing.T) {
+		testLex(t,
+			`/**/`,
+			[]token{
+				{
+					Token: Token{
+						Type: TokenBlockCommentStart,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+							EndPos:   ast.Position{Line: 1, Column: 1, Offset: 1},
+						},
+					},
+					Source: "/*",
+				},
+				{
+					Token: Token{
+						Type: TokenBlockCommentEnd,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 2, Offset: 2},
+							EndPos:   ast.Position{Line: 1, Column: 3, Offset: 3},
+						},
+					},
+					Source: "*/",
+				},
+				{
+					Token: Token{
+						Type: TokenEOF,
+						Range: ast.Range{
+							StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+							EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+						},
+					},
+				},
+			},
+		)
+	})
+
 }
 
 func TestLexIntegerLiterals(t *testing.T) {

--- a/parser/lexer/state.go
+++ b/parser/lexer/state.go
@@ -346,10 +346,12 @@ func blockCommentState(nesting int) stateFn {
 		case '/':
 			beforeSlashOffset := l.prevEndOffset
 			if l.acceptOne('*') {
-				starOffset := l.endOffset
-				l.endOffset = beforeSlashOffset
-				l.emitType(TokenBlockCommentContent)
-				l.endOffset = starOffset
+				if beforeSlashOffset-l.startOffset > 0 {
+					starOffset := l.endOffset
+					l.endOffset = beforeSlashOffset
+					l.emitType(TokenBlockCommentContent)
+					l.endOffset = starOffset
+				}
 				l.emitType(TokenBlockCommentStart)
 				return blockCommentState(nesting + 1)
 			}
@@ -357,10 +359,12 @@ func blockCommentState(nesting int) stateFn {
 		case '*':
 			beforeStarOffset := l.prevEndOffset
 			if l.acceptOne('/') {
-				slashOffset := l.endOffset
-				l.endOffset = beforeStarOffset
-				l.emitType(TokenBlockCommentContent)
-				l.endOffset = slashOffset
+				if beforeStarOffset-l.startOffset > 0 {
+					slashOffset := l.endOffset
+					l.endOffset = beforeStarOffset
+					l.emitType(TokenBlockCommentContent)
+					l.endOffset = slashOffset
+				}
 				l.emitType(TokenBlockCommentEnd)
 				return blockCommentState(nesting - 1)
 			}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -583,14 +583,16 @@ func (p *parser) endAmbiguity() {
 }
 
 type parserProgress struct {
-	offset int
+	initialized bool
+	offset      int
 }
 
 // checkProgress checks that the parser has made progress since it was called last with this parserProgress.
 func (p *parser) checkProgress(progress *parserProgress) bool {
 	parserOffset := p.current.StartPos.Offset
 
-	if progress.offset == 0 {
+	if !progress.initialized {
+		progress.initialized = true
 		progress.offset = parserOffset
 		return true
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -455,10 +455,9 @@ func (p *parser) parseTrivia(options triviaOptions) (containsNewline bool, docSt
 
 	var insideLineDocString bool
 
-	var (
-		atEnd    bool
-		progress parserProgress
-	)
+	var atEnd bool
+	progress := p.newProgress()
+
 	for !atEnd && p.checkProgress(&progress) {
 
 		switch p.current.Type {
@@ -583,24 +582,22 @@ func (p *parser) endAmbiguity() {
 }
 
 type parserProgress struct {
-	initialized bool
-	offset      int
+	offset int
+}
+
+func (p *parser) newProgress() parserProgress {
+	return parserProgress{
+		// -1, because the first call of checkProgress should succeed
+		offset: p.current.StartPos.Offset - 1,
+	}
 }
 
 // checkProgress checks that the parser has made progress since it was called last with this parserProgress.
 func (p *parser) checkProgress(progress *parserProgress) bool {
 	parserOffset := p.current.StartPos.Offset
-
-	if !progress.initialized {
-		progress.initialized = true
-		progress.offset = parserOffset
-		return true
-	}
-
 	if parserOffset == progress.offset {
 		panic(errors.NewUnexpectedError("parser did not make progress"))
 	}
-
 	progress.offset = parserOffset
 	return true
 }

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -26,9 +26,13 @@ import (
 
 func parseStatements(p *parser, isEndToken func(token lexer.Token) bool) (statements []ast.Statement, err error) {
 	sawSemicolon := false
-	var progress parserProgress
+
+	progress := p.newProgress()
+
 	for p.checkProgress(&progress) {
+
 		p.skipSpaceAndComments()
+
 		switch p.current.Type {
 		case lexer.TokenSemicolon:
 			sawSemicolon = true
@@ -303,7 +307,8 @@ func parseIfStatement(p *parser) (*ast.IfStatement, error) {
 
 	var ifStatements []*ast.IfStatement
 
-	var progress parserProgress
+	progress := p.newProgress()
+
 	for p.checkProgress(&progress) {
 
 		startPos := p.current.StartPos
@@ -587,12 +592,13 @@ func parseConditions(p *parser, startPos ast.Position) (*ast.Conditions, error) 
 
 	var conditions []ast.Condition
 
-	var (
-		done     bool
-		progress parserProgress
-	)
+	var done bool
+	progress := p.newProgress()
+
 	for !done && p.checkProgress(&progress) {
+
 		p.skipSpaceAndComments()
+
 		switch p.current.Type {
 		case lexer.TokenSemicolon:
 			p.next()
@@ -733,7 +739,8 @@ func parseSwitchCases(p *parser) (cases []*ast.SwitchCase, err error) {
 		p.next()
 	}
 
-	var progress parserProgress
+	progress := p.newProgress()
+
 	for p.checkProgress(&progress) {
 
 		p.skipSpaceAndComments()

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -26,7 +26,8 @@ import (
 
 func parseStatements(p *parser, isEndToken func(token lexer.Token) bool) (statements []ast.Statement, err error) {
 	sawSemicolon := false
-	for {
+	var progress parserProgress
+	for p.checkProgress(&progress) {
 		p.skipSpaceAndComments()
 		switch p.current.Type {
 		case lexer.TokenSemicolon:
@@ -68,6 +69,8 @@ func parseStatements(p *parser, isEndToken func(token lexer.Token) bool) (statem
 			sawSemicolon = false
 		}
 	}
+
+	panic(errors.NewUnreachableError())
 }
 
 func parseStatement(p *parser) (ast.Statement, error) {
@@ -300,8 +303,11 @@ func parseIfStatement(p *parser) (*ast.IfStatement, error) {
 
 	var ifStatements []*ast.IfStatement
 
-	for {
+	var progress parserProgress
+	for p.checkProgress(&progress) {
+
 		startPos := p.current.StartPos
+
 		p.nextSemanticToken()
 
 		var variableDeclaration *ast.VariableDeclaration
@@ -581,8 +587,11 @@ func parseConditions(p *parser, startPos ast.Position) (*ast.Conditions, error) 
 
 	var conditions []ast.Condition
 
-	var done bool
-	for !done {
+	var (
+		done     bool
+		progress parserProgress
+	)
+	for !done && p.checkProgress(&progress) {
 		p.skipSpaceAndComments()
 		switch p.current.Type {
 		case lexer.TokenSemicolon:
@@ -724,7 +733,9 @@ func parseSwitchCases(p *parser) (cases []*ast.SwitchCase, err error) {
 		p.next()
 	}
 
-	for {
+	var progress parserProgress
+	for p.checkProgress(&progress) {
+
 		p.skipSpaceAndComments()
 
 		switch p.current.Type {
@@ -756,6 +767,8 @@ func parseSwitchCases(p *parser) (cases []*ast.SwitchCase, err error) {
 			reportUnexpected()
 		}
 	}
+
+	panic(errors.NewUnreachableError())
 }
 
 // parseSwitchCase parses a switch case (hasExpression == true)

--- a/parser/transaction.go
+++ b/parser/transaction.go
@@ -144,10 +144,9 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 
 	sawPost := false
 
-	var (
-		atEnd    bool
-		progress parserProgress
-	)
+	var atEnd bool
+	progress := p.newProgress()
+
 	for !atEnd && p.checkProgress(&progress) {
 
 		p.skipSpaceAndComments()
@@ -218,7 +217,8 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 }
 
 func parseTransactionFields(p *parser) (fields []*ast.FieldDeclaration, err error) {
-	var progress parserProgress
+	progress := p.newProgress()
+
 	for p.checkProgress(&progress) {
 
 		_, docString := p.parseTrivia(triviaOptions{

--- a/parser/transaction.go
+++ b/parser/transaction.go
@@ -21,6 +21,7 @@ package parser
 import (
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/parser/lexer"
 )
 
@@ -142,8 +143,13 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 	var endPos ast.Position
 
 	sawPost := false
-	atEnd := false
-	for !atEnd {
+
+	var (
+		atEnd    bool
+		progress parserProgress
+	)
+	for !atEnd && p.checkProgress(&progress) {
+
 		p.skipSpaceAndComments()
 
 		switch p.current.Type {
@@ -212,7 +218,9 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 }
 
 func parseTransactionFields(p *parser) (fields []*ast.FieldDeclaration, err error) {
-	for {
+	var progress parserProgress
+	for p.checkProgress(&progress) {
+
 		_, docString := p.parseTrivia(triviaOptions{
 			skipNewlines:    true,
 			parseDocStrings: true,
@@ -253,6 +261,8 @@ func parseTransactionFields(p *parser) (fields []*ast.FieldDeclaration, err erro
 			return
 		}
 	}
+
+	panic(errors.NewUnreachableError())
 }
 
 func parseTransactionExecute(p *parser) (*ast.SpecialFunctionDeclaration, error) {

--- a/parser/type.go
+++ b/parser/type.go
@@ -169,7 +169,8 @@ func defineParenthesizedTypes() {
 func parseNominalTypeRemainder(p *parser, token lexer.Token) (*ast.NominalType, error) {
 	var nestedIdentifiers []ast.Identifier
 
-	var progress parserProgress
+	progress := p.newProgress()
+
 	for p.current.Is(lexer.TokenDot) &&
 		p.checkProgress(&progress) {
 
@@ -341,10 +342,9 @@ func defineIntersectionOrDictionaryType() {
 
 			expectType := true
 
-			var (
-				atEnd    bool
-				progress parserProgress
-			)
+			var atEnd bool
+			progress := p.newProgress()
+
 			for !atEnd && p.checkProgress(&progress) {
 
 				p.skipSpaceAndComments()
@@ -542,10 +542,9 @@ func parseNominalTypes(
 ) {
 	expectType := true
 
-	var (
-		atEnd    bool
-		progress parserProgress
-	)
+	var atEnd bool
+	progress := p.newProgress()
+
 	for !atEnd && p.checkProgress(&progress) {
 
 		p.skipSpaceAndComments()
@@ -607,10 +606,9 @@ func parseParameterTypeAnnotations(p *parser) (typeAnnotations []*ast.TypeAnnota
 
 	expectTypeAnnotation := true
 
-	var (
-		atEnd    bool
-		progress parserProgress
-	)
+	var atEnd bool
+	progress := p.newProgress()
+
 	for !atEnd && p.checkProgress(&progress) {
 
 		p.skipSpaceAndComments()
@@ -681,7 +679,8 @@ func parseType(p *parser, rightBindingPower int) (ast.Type, error) {
 		return nil, err
 	}
 
-	var progress parserProgress
+	progress := p.newProgress()
+
 	for p.checkProgress(&progress) {
 
 		var done bool
@@ -847,10 +846,9 @@ func parseCommaSeparatedTypeAnnotations(
 ) {
 	expectTypeAnnotation := true
 
-	var (
-		atEnd    bool
-		progress parserProgress
-	)
+	var atEnd bool
+	progress := p.newProgress()
+
 	for !atEnd && p.checkProgress(&progress) {
 
 		p.skipSpaceAndComments()

--- a/parser/type.go
+++ b/parser/type.go
@@ -169,7 +169,10 @@ func defineParenthesizedTypes() {
 func parseNominalTypeRemainder(p *parser, token lexer.Token) (*ast.NominalType, error) {
 	var nestedIdentifiers []ast.Identifier
 
-	for p.current.Is(lexer.TokenDot) {
+	var progress parserProgress
+	for p.current.Is(lexer.TokenDot) &&
+		p.checkProgress(&progress) {
+
 		// Skip the dot
 		p.next()
 
@@ -336,11 +339,14 @@ func defineIntersectionOrDictionaryType() {
 
 			var firstType ast.Type
 
-			atEnd := false
-
 			expectType := true
 
-			for !atEnd {
+			var (
+				atEnd    bool
+				progress parserProgress
+			)
+			for !atEnd && p.checkProgress(&progress) {
+
 				p.skipSpaceAndComments()
 
 				switch p.current.Type {
@@ -535,8 +541,13 @@ func parseNominalTypes(
 	err error,
 ) {
 	expectType := true
-	atEnd := false
-	for !atEnd {
+
+	var (
+		atEnd    bool
+		progress parserProgress
+	)
+	for !atEnd && p.checkProgress(&progress) {
+
 		p.skipSpaceAndComments()
 
 		switch p.current.Type {
@@ -596,9 +607,14 @@ func parseParameterTypeAnnotations(p *parser) (typeAnnotations []*ast.TypeAnnota
 
 	expectTypeAnnotation := true
 
-	atEnd := false
-	for !atEnd {
+	var (
+		atEnd    bool
+		progress parserProgress
+	)
+	for !atEnd && p.checkProgress(&progress) {
+
 		p.skipSpaceAndComments()
+
 		switch p.current.Type {
 		case lexer.TokenComma:
 			if expectTypeAnnotation {
@@ -665,7 +681,9 @@ func parseType(p *parser, rightBindingPower int) (ast.Type, error) {
 		return nil, err
 	}
 
-	for {
+	var progress parserProgress
+	for p.checkProgress(&progress) {
+
 		var done bool
 		left, err, done = applyTypeMetaLeftDenotation(p, rightBindingPower, left)
 		if err != nil {
@@ -828,8 +846,13 @@ func parseCommaSeparatedTypeAnnotations(
 	err error,
 ) {
 	expectTypeAnnotation := true
-	atEnd := false
-	for !atEnd {
+
+	var (
+		atEnd    bool
+		progress parserProgress
+	)
+	for !atEnd && p.checkProgress(&progress) {
+
 		p.skipSpaceAndComments()
 
 		switch p.current.Type {


### PR DESCRIPTION
## Description

Follow up to https://github.com/onflow/cadence-internal/pull/335: Defensively check that all unbounded loops eventually make progress, i.e. the token offset changed during iteration.

Inspired by the same technique used in the Swift parser: https://github.com/swiftlang/swift-syntax/blob/29fd4ccb861e39520fea2eeb2157dd42a31d8880/Sources/SwiftParser/LoopProgressCondition.swift

The backward compatibility check [showed](https://github.com/onflow/cadence/actions/runs/15261918089/job/42921201721?pr=3974) that the current implementation of block comments is not compatible with this check: The lexer potentially emitted empty block content tokens, which are correctly skipped by the block comment parser, but this looks like a stall to the progress check. Therefore, this PR also improves the lexer to not emit empty block content tokens. A reproducer was added in https://github.com/onflow/cadence/pull/3974/files#diff-7e00f62438b5e2e571684438e3d48cead624ae24dde2fa6e37f6b0de40aa79f3R31

Also add a command to lex source, which helps with debugging the lexer.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
