### PR TITLE
[Compiler] Implement `Number` types' methods and static functions 

### DIFF
--- a/bbq/commons/types.go
+++ b/bbq/commons/types.go
@@ -72,11 +72,11 @@ func TypeQualifier(typ sema.Type) string {
 	case *sema.FunctionType:
 		// This is only applicable for types that also has a constructor with the same name.
 		// e.g: `String` type has the `String()` constructor as well as the type on which
-		// functions can be called (`String.Join()`).
+		// functions can be called (`String.join()`).
 		// Thus, if a constructor function is used as a type-qualifier,
 		// then used the actual type associated with it (i.e: the return type).
-		if typ.IsConstructor {
-			return TypeQualifier(typ.ReturnTypeAnnotation.Type)
+		if typ.TypeFunctionType != nil {
+			return TypeQualifier(typ.TypeFunctionType)
 		}
 		return TypeQualifierFunction
 	case *sema.OptionalType:

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1819,8 +1819,11 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 	c.emitVariableLoad(funcName)
 
 	// An invocation can be either a method of a value (e.g: `"someString".Concat("otherString")`),
-	// or a function on a type (e.g: `String.Join(["someString", "otherString"], "separator")`).
-	if isFunctionOnType(accessedType) {
+	// or a function on a "type function" (e.g: `String.join(["someString", "otherString"], separator: ", ")`),
+	// where `String` is a function.
+	if accessedFunctionType, ok := accessedType.(*sema.FunctionType); ok &&
+		accessedFunctionType.TypeFunctionType != nil {
+
 		// Compile as static-function call.
 		// No receiver is loaded.
 		c.compileArguments(expression.Arguments, invocationTypes)
@@ -1843,11 +1846,6 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 			ArgCount: argsCountWithReceiver,
 		})
 	}
-}
-
-func isFunctionOnType(accessedType sema.Type) bool {
-	funcType, ok := accessedType.(*sema.FunctionType)
-	return ok && funcType.IsConstructor
 }
 
 func (c *Compiler[_, _]) compileMethodInvocationArguments(

--- a/bbq/compiler/native_functions.go
+++ b/bbq/compiler/native_functions.go
@@ -101,6 +101,8 @@ func init() {
 	// Value conversion functions
 	for _, declaration := range interpreter.ConverterDeclarations {
 		addNativeFunction(declaration.Name)
+		declarationVariable := sema.BaseValueActivation.Find(declaration.Name)
+		registerBoundFunctions(declarationVariable.Type)
 	}
 }
 

--- a/bbq/compiler/native_functions.go
+++ b/bbq/compiler/native_functions.go
@@ -85,7 +85,7 @@ func init() {
 		// Register the constructor. e.g: `String()`
 		addNativeFunction(constructor.name)
 
-		// Register the members of the constructor/type. e.g: `String.Join()`
+		// Register the members of the constructor/type. e.g: `String.join()`
 		registerBoundFunctions(constructor.typ)
 	}
 

--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -348,6 +348,20 @@ func init() {
 				},
 			),
 		)
+
+		if stringValueParser, ok := interpreter.StringValueParsers[declaration.Name]; ok {
+			RegisterTypeBoundFunction(
+				commons.TypeQualifier(stringValueParser.ReceiverType),
+				newFromStringFunction(stringValueParser),
+			)
+		}
+
+		if bigEndianBytesConverter, ok := interpreter.BigEndianBytesConverters[declaration.Name]; ok {
+			RegisterTypeBoundFunction(
+				commons.TypeQualifier(bigEndianBytesConverter.ReceiverType),
+				newFromBigEndianBytesFunction(bigEndianBytesConverter),
+			)
+		}
 	}
 
 	// Value constructors
@@ -514,4 +528,51 @@ func registerSaturatingArithmeticFunctions(t sema.SaturatingArithmeticType) {
 			},
 		)
 	}
+}
+
+func newFromStringFunction(typedParser interpreter.TypedStringValueParser) NativeFunctionValue {
+	functionType := sema.FromStringFunctionType(typedParser.ReceiverType)
+	parser := typedParser.Parser
+
+	return NewNativeFunctionValue(
+		sema.FromStringFunctionName,
+		functionType,
+		func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+			argument, ok := arguments[0].(*interpreter.StringValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+			return parser(context, argument.Str)
+		},
+	)
+}
+
+func newFromBigEndianBytesFunction(typedConverter interpreter.TypedBigEndianBytesConverter) NativeFunctionValue {
+	functionType := sema.FromBigEndianBytesFunctionType(typedConverter.ReceiverType)
+	byteLength := typedConverter.ByteLength
+	converter := typedConverter.Converter
+
+	return NewNativeFunctionValue(
+		sema.FromBigEndianBytesFunctionName,
+		functionType,
+		func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+
+			argument, ok := arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			bytes, err := interpreter.ByteArrayValueToByteSlice(context, argument, EmptyLocationRange)
+			if err != nil {
+				return interpreter.Nil
+			}
+
+			// overflow
+			if byteLength != 0 && uint(len(bytes)) > byteLength {
+				return interpreter.Nil
+			}
+
+			return interpreter.NewSomeValueNonCopying(context, converter(context, bytes))
+		},
+	)
 }

--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -333,10 +333,12 @@ func init() {
 		// NOTE: declare in loop, as captured in closure below
 		convert := declaration.Convert
 
+		functionType := sema.BaseValueActivation.Find(declaration.Name).Type.(*sema.FunctionType)
+
 		RegisterFunction(
 			NewNativeFunctionValue(
 				declaration.Name,
-				declaration.FunctionType,
+				functionType,
 				func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
 					return convert(
 						context.MemoryGauge,

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -8285,3 +8285,25 @@ func TestGlobalVariables(t *testing.T) {
 		)
 	})
 }
+
+func TestUserInvokesNativeFunction(t *testing.T) {
+
+	t.Parallel()
+
+	result, err := CompileAndInvoke(t,
+		`
+          fun test(): Int? {
+              let opt: UInt8? = 1
+              return opt.map(Int)
+          }
+        `,
+		"test",
+	)
+	require.NoError(t, err)
+	require.Equal(t,
+		interpreter.NewUnmeteredSomeValueNonCopying(
+			interpreter.NewUnmeteredIntValueFromInt64(1),
+		),
+		result,
+	)
+}

--- a/bbq/vm/value_number.go
+++ b/bbq/vm/value_number.go
@@ -45,5 +45,20 @@ func init() {
 				},
 			),
 		)
+
+		RegisterTypeBoundFunction(
+			typeName,
+			NewNativeFunctionValue(
+				sema.ToBigEndianBytesFunctionName,
+				sema.ToBigEndianBytesFunctionType,
+				func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+					number := arguments[receiverIndex].(interpreter.NumberValue)
+					return interpreter.ByteSliceToByteArrayValue(
+						context,
+						number.ToBigEndianBytes(),
+					)
+				},
+			),
+		)
 	}
 }

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -89,7 +89,15 @@ func NewVM(
 	}
 
 	// Delegate the function invocations to the vm.
-	context.invokeFunction = vm.invokeExternally
+	context.invokeFunction = func(function Value, arguments []Value) (Value, error) {
+		// invokeExternally runs the VM, which is incorrect for native functions.
+		if function, ok := function.(NativeFunctionValue); ok {
+			result := function.Function(vm.context, nil, arguments...)
+			return result, nil
+		}
+
+		return vm.invokeExternally(function, arguments)
+	}
 
 	context.lookupFunction = vm.maybeLookupFunction
 

--- a/interpreter/builtinfunctions_test.go
+++ b/interpreter/builtinfunctions_test.go
@@ -580,7 +580,7 @@ func TestInterpretToBigEndianBytes(t *testing.T) {
 
 			t.Run(fmt.Sprintf("%s: %s", ty, value), func(t *testing.T) {
 
-				inter := parseCheckAndInterpret(t,
+				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
 	                      let value: %s = %s
@@ -591,7 +591,7 @@ func TestInterpretToBigEndianBytes(t *testing.T) {
 					),
 				)
 
-				result := inter.Globals.Get("result").GetValue(inter)
+				result := inter.GetGlobal("result")
 
 				AssertValuesEqual(
 					t,
@@ -914,7 +914,7 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 	for ty, tests := range validTestsWithRoundtrip {
 		for value, expected := range tests {
 			t.Run(fmt.Sprintf("%s: %s", ty, value), func(t *testing.T) {
-				inter := parseCheckAndInterpret(t,
+				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
 	                      let resultOpt: %s? = %s.fromBigEndianBytes(%s)
@@ -933,13 +933,13 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 					t,
 					inter,
 					expected,
-					inter.Globals.Get("result").GetValue(inter),
+					inter.GetGlobal("result"),
 				)
 				AssertValuesEqual(
 					t,
 					inter,
 					interpreter.TrueValue,
-					inter.Globals.Get("roundTripEqual").GetValue(inter),
+					inter.GetGlobal("roundTripEqual"),
 				)
 			})
 		}
@@ -948,7 +948,7 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 	for ty, tests := range invalidTests {
 		for _, value := range tests {
 			t.Run(fmt.Sprintf("%s: %s", ty, value), func(t *testing.T) {
-				inter := parseCheckAndInterpret(t,
+				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
 	                      let result: %s? = %s.fromBigEndianBytes(%s)
@@ -963,7 +963,7 @@ func TestInterpretFromBigEndianBytes(t *testing.T) {
 					t,
 					inter,
 					interpreter.NilValue{},
-					inter.Globals.Get("result").GetValue(inter),
+					inter.GetGlobal("result"),
 				)
 			})
 		}

--- a/interpreter/fixedpoint_test.go
+++ b/interpreter/fixedpoint_test.go
@@ -687,7 +687,7 @@ func TestInterpretStringFixedPointConversion(t *testing.T) {
 				}
 			`, suite.name, suite.name)
 
-			inter := parseCheckAndInterpret(t, code)
+			inter := parseCheckAndPrepare(t, code)
 
 			testcases := genCases(suite.intBounds, suite.fracBounds)
 

--- a/interpreter/integers_test.go
+++ b/interpreter/integers_test.go
@@ -960,7 +960,7 @@ func TestInterpretStringIntegerConversion(t *testing.T) {
             `,
 			typ,
 		)
-		inter := parseCheckAndInterpret(t, code)
+		inter := parseCheckAndPrepare(t, code)
 
 		placeInRange := func(x *big.Int) *big.Int {
 			z := big.NewInt(0).Sub(high, low)

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -2753,18 +2753,20 @@ func (interpreter *Interpreter) WriteStored(
 	return accountStorage.WriteValue(interpreter, key, value)
 }
 
-type fromStringFunctionValue struct {
-	receiverType sema.Type
-	hostFunction *HostFunctionValue
+type TypedStringValueParser struct {
+	ReceiverType sema.Type
+	Parser       StringValueParser
 }
 
-// a function that attempts to create a Cadence value from a string, e.g. parsing a number from a string
-type stringValueParser func(common.MemoryGauge, string) OptionalValue
+// StringValueParser is a function that attempts to create a Cadence value from a string,
+// e.g. parsing a number from a string
+type StringValueParser func(common.MemoryGauge, string) OptionalValue
 
-func newFromStringFunction(ty sema.Type, parser stringValueParser) fromStringFunctionValue {
-	functionType := sema.FromStringFunctionType(ty)
+func newFromStringFunction(typedParser TypedStringValueParser) FunctionValue {
+	functionType := sema.FromStringFunctionType(typedParser.ReceiverType)
+	parser := typedParser.Parser
 
-	hostFunctionImpl := NewUnmeteredStaticHostFunctionValue(
+	return NewUnmeteredStaticHostFunctionValue(
 		functionType,
 		func(invocation Invocation) Value {
 			argument, ok := invocation.Arguments[0].(*StringValue)
@@ -2776,10 +2778,6 @@ func newFromStringFunction(ty sema.Type, parser stringValueParser) fromStringFun
 			return parser(inter, argument.Str)
 		},
 	)
-	return fromStringFunctionValue{
-		receiverType: ty,
-		hostFunction: hostFunctionImpl,
-	}
 }
 
 // default implementation for parsing a given unsigned numeric type from a string.
@@ -2789,7 +2787,7 @@ func unsignedIntValueParser[ValueType Value, IntType any](
 	bitSize int,
 	toValue func(common.MemoryGauge, func() IntType) ValueType,
 	fromUInt64 func(uint64) IntType,
-) stringValueParser {
+) StringValueParser {
 	return func(memoryGauge common.MemoryGauge, input string) OptionalValue {
 		val, err := strconv.ParseUint(input, 10, bitSize)
 		if err != nil {
@@ -2810,7 +2808,7 @@ func signedIntValueParser[ValueType Value, IntType any](
 	bitSize int,
 	toValue func(common.MemoryGauge, func() IntType) ValueType,
 	fromInt64 func(int64) IntType,
-) stringValueParser {
+) StringValueParser {
 
 	return func(memoryGauge common.MemoryGauge, input string) OptionalValue {
 		val, err := strconv.ParseInt(input, 10, bitSize)
@@ -2827,7 +2825,7 @@ func signedIntValueParser[ValueType Value, IntType any](
 
 // No need to use metered constructors for values represented by big.Ints,
 // since estimation is more granular than fixed-size types.
-func bigIntValueParser(convert func(*big.Int) (Value, bool)) stringValueParser {
+func bigIntValueParser(convert func(*big.Int) (Value, bool)) StringValueParser {
 	return func(memoryGauge common.MemoryGauge, input string) OptionalValue {
 		literalKind := common.IntegerLiteralKindDecimal
 		estimatedSize := common.OverEstimateBigIntFromString(input, literalKind)
@@ -2852,83 +2850,72 @@ func inRange(val *big.Int, low *big.Int, high *big.Int) bool {
 	return -1 < val.Cmp(low) && val.Cmp(high) < 1
 }
 
-func identity[T any](t T) T { return t }
+var StringValueParsers = func() map[string]TypedStringValueParser {
+	parsers := map[string]TypedStringValueParser{}
 
-var fromStringFunctionValues = func() map[string]fromStringFunctionValue {
-	u64_8 := func(n uint64) uint8 { return uint8(n) }
-	u64_16 := func(n uint64) uint16 { return uint16(n) }
-	u64_32 := func(n uint64) uint32 { return uint32(n) }
-	u64_64 := identity[uint64]
-
-	declarations := []fromStringFunctionValue{
-		// signed int values from 8 bit -> infinity
-		newFromStringFunction(sema.Int8Type, signedIntValueParser(8, NewInt8Value, func(n int64) int8 {
-			return int8(n)
-		})),
-		newFromStringFunction(sema.Int16Type, signedIntValueParser(16, NewInt16Value, func(n int64) int16 {
-			return int16(n)
-		})),
-		newFromStringFunction(sema.Int32Type, signedIntValueParser(32, NewInt32Value, func(n int64) int32 {
-			return int32(n)
-		})),
-		newFromStringFunction(sema.Int64Type, signedIntValueParser(64, NewInt64Value, identity[int64])),
-		newFromStringFunction(sema.Int128Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
+	for _, parser := range []TypedStringValueParser{
+		// Int*
+		{sema.Int8Type, signedIntValueParser(8, NewInt8Value, func(n int64) int8 { return int8(n) })},
+		{sema.Int16Type, signedIntValueParser(16, NewInt16Value, func(n int64) int16 { return int16(n) })},
+		{sema.Int32Type, signedIntValueParser(32, NewInt32Value, func(n int64) int32 { return int32(n) })},
+		{sema.Int64Type, signedIntValueParser(64, NewInt64Value, func(n int64) int64 { return n })},
+		{sema.Int128Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
 			if ok = inRange(b, sema.Int128TypeMinIntBig, sema.Int128TypeMaxIntBig); ok {
 				v = NewUnmeteredInt128ValueFromBigInt(b)
 			}
 			return
-		})),
-		newFromStringFunction(sema.Int256Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
+		})},
+		{sema.Int256Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
 			if ok = inRange(b, sema.Int256TypeMinIntBig, sema.Int256TypeMaxIntBig); ok {
 				v = NewUnmeteredInt256ValueFromBigInt(b)
 			}
 			return
-		})),
-		newFromStringFunction(sema.IntType, bigIntValueParser(func(b *big.Int) (Value, bool) {
+		})},
+		{sema.IntType, bigIntValueParser(func(b *big.Int) (Value, bool) {
 			return NewUnmeteredIntValueFromBigInt(b), true
-		})),
+		})},
 
-		// unsigned int values from 8 bit -> infinity
-		newFromStringFunction(sema.UInt8Type, unsignedIntValueParser(8, NewUInt8Value, u64_8)),
-		newFromStringFunction(sema.UInt16Type, unsignedIntValueParser(16, NewUInt16Value, u64_16)),
-		newFromStringFunction(sema.UInt32Type, unsignedIntValueParser(32, NewUInt32Value, u64_32)),
-		newFromStringFunction(sema.UInt64Type, unsignedIntValueParser(64, NewUInt64Value, u64_64)),
-		newFromStringFunction(sema.UInt128Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
+		// UInt*
+		{sema.UInt8Type, unsignedIntValueParser(8, NewUInt8Value, func(n uint64) uint8 { return uint8(n) })},
+		{sema.UInt16Type, unsignedIntValueParser(16, NewUInt16Value, func(n uint64) uint16 { return uint16(n) })},
+		{sema.UInt32Type, unsignedIntValueParser(32, NewUInt32Value, func(n uint64) uint32 { return uint32(n) })},
+		{sema.UInt64Type, unsignedIntValueParser(64, NewUInt64Value, func(n uint64) uint64 { return n })},
+		{sema.UInt128Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
 			if ok = inRange(b, sema.UInt128TypeMinIntBig, sema.UInt128TypeMaxIntBig); ok {
 				v = NewUnmeteredUInt128ValueFromBigInt(b)
 			}
 			return
-		})),
-		newFromStringFunction(sema.UInt256Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
+		})},
+		{sema.UInt256Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
 			if ok = inRange(b, sema.UInt256TypeMinIntBig, sema.UInt256TypeMaxIntBig); ok {
 				v = NewUnmeteredUInt256ValueFromBigInt(b)
 			}
 			return
-		})),
-		newFromStringFunction(sema.UIntType, bigIntValueParser(func(b *big.Int) (Value, bool) {
+		})},
+		{sema.UIntType, bigIntValueParser(func(b *big.Int) (Value, bool) {
 			return NewUnmeteredUIntValueFromBigInt(b), true
-		})),
+		})},
 
-		// machine-sized word types
-		newFromStringFunction(sema.Word8Type, unsignedIntValueParser(8, NewWord8Value, u64_8)),
-		newFromStringFunction(sema.Word16Type, unsignedIntValueParser(16, NewWord16Value, u64_16)),
-		newFromStringFunction(sema.Word32Type, unsignedIntValueParser(32, NewWord32Value, u64_32)),
-		newFromStringFunction(sema.Word64Type, unsignedIntValueParser(64, NewWord64Value, u64_64)),
-		newFromStringFunction(sema.Word128Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
+		// Word*
+		{sema.Word8Type, unsignedIntValueParser(8, NewWord8Value, func(n uint64) uint8 { return uint8(n) })},
+		{sema.Word16Type, unsignedIntValueParser(16, NewWord16Value, func(n uint64) uint16 { return uint16(n) })},
+		{sema.Word32Type, unsignedIntValueParser(32, NewWord32Value, func(n uint64) uint32 { return uint32(n) })},
+		{sema.Word64Type, unsignedIntValueParser(64, NewWord64Value, func(n uint64) uint64 { return n })},
+		{sema.Word128Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
 			if ok = inRange(b, sema.Word128TypeMinIntBig, sema.Word128TypeMaxIntBig); ok {
 				v = NewUnmeteredWord128ValueFromBigInt(b)
 			}
 			return
-		})),
-		newFromStringFunction(sema.Word256Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
+		})},
+		{sema.Word256Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
 			if ok = inRange(b, sema.Word256TypeMinIntBig, sema.Word256TypeMaxIntBig); ok {
 				v = NewUnmeteredWord256ValueFromBigInt(b)
 			}
 			return
-		})),
+		})},
 
-		// fixed-points
-		newFromStringFunction(sema.Fix64Type, func(memoryGauge common.MemoryGauge, input string) OptionalValue {
+		// Fix*
+		{sema.Fix64Type, func(memoryGauge common.MemoryGauge, input string) OptionalValue {
 			n, err := fixedpoint.ParseFix64(input)
 			if err != nil {
 				return NilOptionalValue
@@ -2937,24 +2924,27 @@ var fromStringFunctionValues = func() map[string]fromStringFunctionValue {
 			val := NewFix64Value(memoryGauge, n.Int64)
 			return NewSomeValueNonCopying(memoryGauge, val)
 
-		}),
-		newFromStringFunction(sema.UFix64Type, func(memoryGauge common.MemoryGauge, input string) OptionalValue {
+		}},
+
+		// UFix*
+		{sema.UFix64Type, func(memoryGauge common.MemoryGauge, input string) OptionalValue {
 			n, err := fixedpoint.ParseUFix64(input)
 			if err != nil {
 				return NilOptionalValue
 			}
 			val := NewUFix64Value(memoryGauge, n.Uint64)
 			return NewSomeValueNonCopying(memoryGauge, val)
-		}),
+		}},
+	} {
+		// index by type name
+		typeName := parser.ReceiverType.String()
+		if _, ok := parsers[typeName]; ok {
+			panic(errors.NewUnexpectedError("duplicate string value parser for type %s", typeName))
+		}
+		parsers[typeName] = parser
 	}
 
-	values := make(map[string]fromStringFunctionValue, len(declarations))
-	for _, decl := range declarations {
-		// index declaration by type name
-		values[decl.receiverType.String()] = decl
-	}
-
-	return values
+	return parsers
 }()
 
 type fromBigEndianBytesFunctionValue struct {
@@ -3397,7 +3387,7 @@ func init() {
 			panic(fmt.Sprintf("missing converter for number type: %s", numberType))
 		}
 
-		if _, ok := fromStringFunctionValues[typeName]; !ok {
+		if _, ok := StringValueParsers[typeName]; !ok {
 			panic(fmt.Sprintf("missing fromString implementation for number type: %s", numberType))
 		}
 
@@ -3762,9 +3752,9 @@ var converterFunctionValues = func() []converterFunction {
 			addMember(sema.NumberTypeMaxFieldName, declaration.max)
 		}
 
-		fromStringVal := fromStringFunctionValues[declaration.Name]
-
-		addMember(sema.FromStringFunctionName, fromStringVal.hostFunction)
+		if stringValueParser, ok := StringValueParsers[declaration.Name]; ok {
+			addMember(sema.FromStringFunctionName, newFromStringFunction(stringValueParser))
+		}
 
 		fromBigEndianBytesVal := fromBigEndianBytesFunctionValues[declaration.Name]
 

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -2771,7 +2771,6 @@ func newFromStringFunction(typedParser TypedStringValueParser) FunctionValue {
 		func(invocation Invocation) Value {
 			argument, ok := invocation.Arguments[0].(*StringValue)
 			if !ok {
-				// expect typechecker to catch a mismatch here
 				panic(errors.NewUnreachableError())
 			}
 			inter := invocation.InvocationContext
@@ -3218,7 +3217,6 @@ type ValueConverterDeclaration struct {
 	min             Value
 	max             Value
 	Convert         func(common.MemoryGauge, Value, LocationRange) Value
-	FunctionType    *sema.FunctionType
 	nestedVariables []struct {
 		Name  string
 		Value Value
@@ -3229,23 +3227,20 @@ type ValueConverterDeclaration struct {
 // It would be nice if return types in Go's function types would be covariant
 var ConverterDeclarations = []ValueConverterDeclaration{
 	{
-		Name:         sema.IntTypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.IntType),
+		Name: sema.IntTypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertInt(gauge, value, locationRange)
 		},
 	},
 	{
-		Name:         sema.UIntTypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.UIntType),
+		Name: sema.UIntTypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUInt(gauge, value, locationRange)
 		},
 		min: NewUnmeteredUIntValueFromBigInt(sema.UIntTypeMin),
 	},
 	{
-		Name:         sema.Int8TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.Int8Type),
+		Name: sema.Int8TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertInt8(gauge, value, locationRange)
 		},
@@ -3253,8 +3248,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredInt8Value(math.MaxInt8),
 	},
 	{
-		Name:         sema.Int16TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.Int16Type),
+		Name: sema.Int16TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertInt16(gauge, value, locationRange)
 		},
@@ -3262,8 +3256,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredInt16Value(math.MaxInt16),
 	},
 	{
-		Name:         sema.Int32TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.Int32Type),
+		Name: sema.Int32TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertInt32(gauge, value, locationRange)
 		},
@@ -3271,8 +3264,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredInt32Value(math.MaxInt32),
 	},
 	{
-		Name:         sema.Int64TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.Int64Type),
+		Name: sema.Int64TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertInt64(gauge, value, locationRange)
 		},
@@ -3280,8 +3272,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredInt64Value(math.MaxInt64),
 	},
 	{
-		Name:         sema.Int128TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.Int128Type),
+		Name: sema.Int128TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertInt128(gauge, value, locationRange)
 		},
@@ -3289,8 +3280,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
 	},
 	{
-		Name:         sema.Int256TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.Int256Type),
+		Name: sema.Int256TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertInt256(gauge, value, locationRange)
 		},
@@ -3298,8 +3288,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
 	},
 	{
-		Name:         sema.UInt8TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.UInt8Type),
+		Name: sema.UInt8TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUInt8(gauge, value, locationRange)
 		},
@@ -3307,8 +3296,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredUInt8Value(math.MaxUint8),
 	},
 	{
-		Name:         sema.UInt16TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.UInt16Type),
+		Name: sema.UInt16TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUInt16(gauge, value, locationRange)
 		},
@@ -3316,8 +3304,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredUInt16Value(math.MaxUint16),
 	},
 	{
-		Name:         sema.UInt32TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.UInt32Type),
+		Name: sema.UInt32TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUInt32(gauge, value, locationRange)
 		},
@@ -3325,8 +3312,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredUInt32Value(math.MaxUint32),
 	},
 	{
-		Name:         sema.UInt64TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.UInt64Type),
+		Name: sema.UInt64TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUInt64(gauge, value, locationRange)
 		},
@@ -3334,15 +3320,13 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredUInt64Value(math.MaxUint64),
 	},
 	{
-		Name:         sema.UInt128TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.UInt128Type),
-		Convert:      ConvertUInt128,
-		min:          NewUnmeteredUInt128ValueFromUint64(0),
-		max:          NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
+		Name:    sema.UInt128TypeName,
+		Convert: ConvertUInt128,
+		min:     NewUnmeteredUInt128ValueFromUint64(0),
+		max:     NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
 	},
 	{
-		Name:         sema.UInt256TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.UInt256Type),
+		Name: sema.UInt256TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUInt256(gauge, value, locationRange)
 		},
@@ -3350,8 +3334,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
 	},
 	{
-		Name:         sema.Word8TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.Word8Type),
+		Name: sema.Word8TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertWord8(gauge, value, locationRange)
 		},
@@ -3359,8 +3342,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredWord8Value(math.MaxUint8),
 	},
 	{
-		Name:         sema.Word16TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.Word16Type),
+		Name: sema.Word16TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertWord16(gauge, value, locationRange)
 		},
@@ -3368,8 +3350,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredWord16Value(math.MaxUint16),
 	},
 	{
-		Name:         sema.Word32TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.Word32Type),
+		Name: sema.Word32TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertWord32(gauge, value, locationRange)
 		},
@@ -3377,8 +3358,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredWord32Value(math.MaxUint32),
 	},
 	{
-		Name:         sema.Word64TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.Word64Type),
+		Name: sema.Word64TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertWord64(gauge, value, locationRange)
 		},
@@ -3386,22 +3366,19 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredWord64Value(math.MaxUint64),
 	},
 	{
-		Name:         sema.Word128TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.Word128Type),
-		Convert:      ConvertWord128,
-		min:          NewUnmeteredWord128ValueFromUint64(0),
-		max:          NewUnmeteredWord128ValueFromBigInt(sema.Word128TypeMaxIntBig),
+		Name:    sema.Word128TypeName,
+		Convert: ConvertWord128,
+		min:     NewUnmeteredWord128ValueFromUint64(0),
+		max:     NewUnmeteredWord128ValueFromBigInt(sema.Word128TypeMaxIntBig),
 	},
 	{
-		Name:         sema.Word256TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.Word256Type),
-		Convert:      ConvertWord256,
-		min:          NewUnmeteredWord256ValueFromUint64(0),
-		max:          NewUnmeteredWord256ValueFromBigInt(sema.Word256TypeMaxIntBig),
+		Name:    sema.Word256TypeName,
+		Convert: ConvertWord256,
+		min:     NewUnmeteredWord256ValueFromUint64(0),
+		max:     NewUnmeteredWord256ValueFromBigInt(sema.Word256TypeMaxIntBig),
 	},
 	{
-		Name:         sema.Fix64TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.Fix64Type),
+		Name: sema.Fix64TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertFix64(gauge, value, locationRange)
 		},
@@ -3409,8 +3386,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredFix64Value(math.MaxInt64),
 	},
 	{
-		Name:         sema.UFix64TypeName,
-		FunctionType: sema.NumberConversionFunctionType(sema.UFix64Type),
+		Name: sema.UFix64TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUFix64(gauge, value, locationRange)
 		},
@@ -3418,8 +3394,7 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		max: NewUnmeteredUFix64Value(math.MaxUint64),
 	},
 	{
-		Name:         sema.AddressTypeName,
-		FunctionType: sema.AddressConversionFunctionType,
+		Name: sema.AddressTypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertAddress(gauge, value, locationRange)
 		},
@@ -3445,22 +3420,19 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		},
 	},
 	{
-		Name:         sema.PublicPathType.Name,
-		FunctionType: sema.PublicPathConversionFunctionType,
+		Name: sema.PublicPathType.Name,
 		Convert: func(gauge common.MemoryGauge, value Value, _ LocationRange) Value {
 			return newPathFromStringValue(gauge, common.PathDomainPublic, value)
 		},
 	},
 	{
-		Name:         sema.PrivatePathType.Name,
-		FunctionType: sema.PrivatePathConversionFunctionType,
+		Name: sema.PrivatePathType.Name,
 		Convert: func(gauge common.MemoryGauge, value Value, _ LocationRange) Value {
 			return newPathFromStringValue(gauge, common.PathDomainPrivate, value)
 		},
 	},
 	{
-		Name:         sema.StoragePathType.Name,
-		FunctionType: sema.StoragePathConversionFunctionType,
+		Name: sema.StoragePathType.Name,
 		Convert: func(gauge common.MemoryGauge, value Value, _ LocationRange) Value {
 			return newPathFromStringValue(gauge, common.PathDomainStorage, value)
 		},
@@ -3880,10 +3852,17 @@ var converterFunctionValues = func() []converterFunction {
 	for index, declaration := range ConverterDeclarations {
 		// NOTE: declare in loop, as captured in closure below
 		convert := declaration.Convert
+
+		converterFunctionType := sema.BaseValueActivation.Find(declaration.Name).Type.(*sema.FunctionType)
+
 		converterFunctionValue := NewUnmeteredStaticHostFunctionValue(
-			declaration.FunctionType,
+			converterFunctionType,
 			func(invocation Invocation) Value {
-				return convert(invocation.InvocationContext, invocation.Arguments[0], invocation.LocationRange)
+				return convert(
+					invocation.InvocationContext,
+					invocation.Arguments[0],
+					invocation.LocationRange,
+				)
 			},
 		)
 

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -2855,86 +2855,152 @@ var StringValueParsers = func() map[string]TypedStringValueParser {
 
 	for _, parser := range []TypedStringValueParser{
 		// Int*
-		{sema.Int8Type, signedIntValueParser(8, NewInt8Value, func(n int64) int8 { return int8(n) })},
-		{sema.Int16Type, signedIntValueParser(16, NewInt16Value, func(n int64) int16 { return int16(n) })},
-		{sema.Int32Type, signedIntValueParser(32, NewInt32Value, func(n int64) int32 { return int32(n) })},
-		{sema.Int64Type, signedIntValueParser(64, NewInt64Value, func(n int64) int64 { return n })},
-		{sema.Int128Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
-			if ok = inRange(b, sema.Int128TypeMinIntBig, sema.Int128TypeMaxIntBig); ok {
-				v = NewUnmeteredInt128ValueFromBigInt(b)
-			}
-			return
-		})},
-		{sema.Int256Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
-			if ok = inRange(b, sema.Int256TypeMinIntBig, sema.Int256TypeMaxIntBig); ok {
-				v = NewUnmeteredInt256ValueFromBigInt(b)
-			}
-			return
-		})},
-		{sema.IntType, bigIntValueParser(func(b *big.Int) (Value, bool) {
-			return NewUnmeteredIntValueFromBigInt(b), true
-		})},
+		{
+			ReceiverType: sema.Int8Type,
+			Parser:       signedIntValueParser(8, NewInt8Value, func(n int64) int8 { return int8(n) }),
+		},
+		{
+			ReceiverType: sema.Int16Type,
+			Parser:       signedIntValueParser(16, NewInt16Value, func(n int64) int16 { return int16(n) }),
+		},
+		{
+			ReceiverType: sema.Int32Type,
+			Parser:       signedIntValueParser(32, NewInt32Value, func(n int64) int32 { return int32(n) }),
+		},
+		{
+			ReceiverType: sema.Int64Type,
+			Parser:       signedIntValueParser(64, NewInt64Value, func(n int64) int64 { return n }),
+		},
+		{
+			ReceiverType: sema.Int128Type,
+			Parser: bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
+				if ok = inRange(b, sema.Int128TypeMinIntBig, sema.Int128TypeMaxIntBig); ok {
+					v = NewUnmeteredInt128ValueFromBigInt(b)
+				}
+				return
+			}),
+		},
+		{
+			ReceiverType: sema.Int256Type,
+			Parser: bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
+				if ok = inRange(b, sema.Int256TypeMinIntBig, sema.Int256TypeMaxIntBig); ok {
+					v = NewUnmeteredInt256ValueFromBigInt(b)
+				}
+				return
+			}),
+		},
+		{
+			ReceiverType: sema.IntType,
+			Parser: bigIntValueParser(func(b *big.Int) (Value, bool) {
+				return NewUnmeteredIntValueFromBigInt(b), true
+			}),
+		},
 
 		// UInt*
-		{sema.UInt8Type, unsignedIntValueParser(8, NewUInt8Value, func(n uint64) uint8 { return uint8(n) })},
-		{sema.UInt16Type, unsignedIntValueParser(16, NewUInt16Value, func(n uint64) uint16 { return uint16(n) })},
-		{sema.UInt32Type, unsignedIntValueParser(32, NewUInt32Value, func(n uint64) uint32 { return uint32(n) })},
-		{sema.UInt64Type, unsignedIntValueParser(64, NewUInt64Value, func(n uint64) uint64 { return n })},
-		{sema.UInt128Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
-			if ok = inRange(b, sema.UInt128TypeMinIntBig, sema.UInt128TypeMaxIntBig); ok {
-				v = NewUnmeteredUInt128ValueFromBigInt(b)
-			}
-			return
-		})},
-		{sema.UInt256Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
-			if ok = inRange(b, sema.UInt256TypeMinIntBig, sema.UInt256TypeMaxIntBig); ok {
-				v = NewUnmeteredUInt256ValueFromBigInt(b)
-			}
-			return
-		})},
-		{sema.UIntType, bigIntValueParser(func(b *big.Int) (Value, bool) {
-			return NewUnmeteredUIntValueFromBigInt(b), true
-		})},
+		{
+			ReceiverType: sema.UInt8Type,
+			Parser:       unsignedIntValueParser(8, NewUInt8Value, func(n uint64) uint8 { return uint8(n) }),
+		},
+		{
+			ReceiverType: sema.UInt16Type,
+			Parser:       unsignedIntValueParser(16, NewUInt16Value, func(n uint64) uint16 { return uint16(n) }),
+		},
+		{
+			ReceiverType: sema.UInt32Type,
+			Parser:       unsignedIntValueParser(32, NewUInt32Value, func(n uint64) uint32 { return uint32(n) }),
+		},
+		{
+			ReceiverType: sema.UInt64Type,
+			Parser:       unsignedIntValueParser(64, NewUInt64Value, func(n uint64) uint64 { return n }),
+		},
+		{
+			ReceiverType: sema.UInt128Type,
+			Parser: bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
+				if ok = inRange(b, sema.UInt128TypeMinIntBig, sema.UInt128TypeMaxIntBig); ok {
+					v = NewUnmeteredUInt128ValueFromBigInt(b)
+				}
+				return
+			}),
+		},
+		{
+			ReceiverType: sema.UInt256Type,
+			Parser: bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
+				if ok = inRange(b, sema.UInt256TypeMinIntBig, sema.UInt256TypeMaxIntBig); ok {
+					v = NewUnmeteredUInt256ValueFromBigInt(b)
+				}
+				return
+			}),
+		},
+		{
+			ReceiverType: sema.UIntType,
+			Parser: bigIntValueParser(func(b *big.Int) (Value, bool) {
+				return NewUnmeteredUIntValueFromBigInt(b), true
+			}),
+		},
 
 		// Word*
-		{sema.Word8Type, unsignedIntValueParser(8, NewWord8Value, func(n uint64) uint8 { return uint8(n) })},
-		{sema.Word16Type, unsignedIntValueParser(16, NewWord16Value, func(n uint64) uint16 { return uint16(n) })},
-		{sema.Word32Type, unsignedIntValueParser(32, NewWord32Value, func(n uint64) uint32 { return uint32(n) })},
-		{sema.Word64Type, unsignedIntValueParser(64, NewWord64Value, func(n uint64) uint64 { return n })},
-		{sema.Word128Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
-			if ok = inRange(b, sema.Word128TypeMinIntBig, sema.Word128TypeMaxIntBig); ok {
-				v = NewUnmeteredWord128ValueFromBigInt(b)
-			}
-			return
-		})},
-		{sema.Word256Type, bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
-			if ok = inRange(b, sema.Word256TypeMinIntBig, sema.Word256TypeMaxIntBig); ok {
-				v = NewUnmeteredWord256ValueFromBigInt(b)
-			}
-			return
-		})},
+		{
+			ReceiverType: sema.Word8Type,
+			Parser:       unsignedIntValueParser(8, NewWord8Value, func(n uint64) uint8 { return uint8(n) }),
+		},
+		{
+			ReceiverType: sema.Word16Type,
+			Parser:       unsignedIntValueParser(16, NewWord16Value, func(n uint64) uint16 { return uint16(n) }),
+		},
+		{
+			ReceiverType: sema.Word32Type,
+			Parser:       unsignedIntValueParser(32, NewWord32Value, func(n uint64) uint32 { return uint32(n) }),
+		},
+		{
+			ReceiverType: sema.Word64Type,
+			Parser:       unsignedIntValueParser(64, NewWord64Value, func(n uint64) uint64 { return n }),
+		},
+		{
+			ReceiverType: sema.Word128Type,
+			Parser: bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
+				if ok = inRange(b, sema.Word128TypeMinIntBig, sema.Word128TypeMaxIntBig); ok {
+					v = NewUnmeteredWord128ValueFromBigInt(b)
+				}
+				return
+			}),
+		},
+		{
+			ReceiverType: sema.Word256Type,
+			Parser: bigIntValueParser(func(b *big.Int) (v Value, ok bool) {
+				if ok = inRange(b, sema.Word256TypeMinIntBig, sema.Word256TypeMaxIntBig); ok {
+					v = NewUnmeteredWord256ValueFromBigInt(b)
+				}
+				return
+			}),
+		},
 
 		// Fix*
-		{sema.Fix64Type, func(memoryGauge common.MemoryGauge, input string) OptionalValue {
-			n, err := fixedpoint.ParseFix64(input)
-			if err != nil {
-				return NilOptionalValue
-			}
+		{
+			ReceiverType: sema.Fix64Type,
+			Parser: func(memoryGauge common.MemoryGauge, input string) OptionalValue {
+				n, err := fixedpoint.ParseFix64(input)
+				if err != nil {
+					return NilOptionalValue
+				}
 
-			val := NewFix64Value(memoryGauge, n.Int64)
-			return NewSomeValueNonCopying(memoryGauge, val)
+				val := NewFix64Value(memoryGauge, n.Int64)
+				return NewSomeValueNonCopying(memoryGauge, val)
 
-		}},
+			},
+		},
 
 		// UFix*
-		{sema.UFix64Type, func(memoryGauge common.MemoryGauge, input string) OptionalValue {
-			n, err := fixedpoint.ParseUFix64(input)
-			if err != nil {
-				return NilOptionalValue
-			}
-			val := NewUFix64Value(memoryGauge, n.Uint64)
-			return NewSomeValueNonCopying(memoryGauge, val)
-		}},
+		{
+			ReceiverType: sema.UFix64Type,
+			Parser: func(memoryGauge common.MemoryGauge, input string) OptionalValue {
+				n, err := fixedpoint.ParseUFix64(input)
+				if err != nil {
+					return NilOptionalValue
+				}
+				val := NewUFix64Value(memoryGauge, n.Uint64)
+				return NewSomeValueNonCopying(memoryGauge, val)
+			},
+		},
 	} {
 		// index by type name
 		typeName := parser.ReceiverType.String()
@@ -3020,36 +3086,122 @@ var BigEndianBytesConverters = func() map[string]TypedBigEndianBytesConverter {
 
 	for _, converter := range []TypedBigEndianBytesConverter{
 		// Int*
-		{sema.Int8Type, sema.Int8TypeSize, NewInt8ValueFromBigEndianBytes},
-		{sema.Int16Type, sema.Int16TypeSize, NewInt16ValueFromBigEndianBytes},
-		{sema.Int32Type, sema.Int32TypeSize, NewInt32ValueFromBigEndianBytes},
-		{sema.Int64Type, sema.Int64TypeSize, NewInt64ValueFromBigEndianBytes},
-		{sema.Int128Type, sema.Int128TypeSize, NewInt128ValueFromBigEndianBytes},
-		{sema.Int256Type, sema.Int256TypeSize, NewInt256ValueFromBigEndianBytes},
-		{sema.IntType, 0, NewIntValueFromBigEndianBytes},
+		{
+			ReceiverType: sema.Int8Type,
+			ByteLength:   sema.Int8TypeSize,
+			Converter:    NewInt8ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.Int16Type,
+			ByteLength:   sema.Int16TypeSize,
+			Converter:    NewInt16ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.Int32Type,
+			ByteLength:   sema.Int32TypeSize,
+			Converter:    NewInt32ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.Int64Type,
+			ByteLength:   sema.Int64TypeSize,
+			Converter:    NewInt64ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.Int128Type,
+			ByteLength:   sema.Int128TypeSize,
+			Converter:    NewInt128ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.Int256Type,
+			ByteLength:   sema.Int256TypeSize,
+			Converter:    NewInt256ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.IntType,
+			Converter:    NewIntValueFromBigEndianBytes,
+		},
 
 		// UInt*
-		{sema.UInt8Type, sema.UInt8TypeSize, NewUInt8ValueFromBigEndianBytes},
-		{sema.UInt16Type, sema.UInt16TypeSize, NewUInt16ValueFromBigEndianBytes},
-		{sema.UInt32Type, sema.UInt32TypeSize, NewUInt32ValueFromBigEndianBytes},
-		{sema.UInt64Type, sema.UInt64TypeSize, NewUInt64ValueFromBigEndianBytes},
-		{sema.UInt128Type, sema.UInt128TypeSize, NewUInt128ValueFromBigEndianBytes},
-		{sema.UInt256Type, sema.UInt256TypeSize, NewUInt256ValueFromBigEndianBytes},
-		{sema.UIntType, 0, NewUIntValueFromBigEndianBytes},
+		{
+			ReceiverType: sema.UInt8Type,
+			ByteLength:   sema.UInt8TypeSize,
+			Converter:    NewUInt8ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.UInt16Type,
+			ByteLength:   sema.UInt16TypeSize,
+			Converter:    NewUInt16ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.UInt32Type,
+			ByteLength:   sema.UInt32TypeSize,
+			Converter:    NewUInt32ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.UInt64Type,
+			ByteLength:   sema.UInt64TypeSize,
+			Converter:    NewUInt64ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.UInt128Type,
+			ByteLength:   sema.UInt128TypeSize,
+			Converter:    NewUInt128ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.UInt256Type,
+			ByteLength:   sema.UInt256TypeSize,
+			Converter:    NewUInt256ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.UIntType,
+			Converter:    NewUIntValueFromBigEndianBytes,
+		},
 
 		// Word*
-		{sema.Word8Type, sema.Word8TypeSize, NewWord8ValueFromBigEndianBytes},
-		{sema.Word16Type, sema.Word16TypeSize, NewWord16ValueFromBigEndianBytes},
-		{sema.Word32Type, sema.Word32TypeSize, NewWord32ValueFromBigEndianBytes},
-		{sema.Word64Type, sema.Word64TypeSize, NewWord64ValueFromBigEndianBytes},
-		{sema.Word128Type, sema.Word128TypeSize, NewWord128ValueFromBigEndianBytes},
-		{sema.Word256Type, sema.Word256TypeSize, NewWord256ValueFromBigEndianBytes},
+		{
+			ReceiverType: sema.Word8Type,
+			ByteLength:   sema.Word8TypeSize,
+			Converter:    NewWord8ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.Word16Type,
+			ByteLength:   sema.Word16TypeSize,
+			Converter:    NewWord16ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.Word32Type,
+			ByteLength:   sema.Word32TypeSize,
+			Converter:    NewWord32ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.Word64Type,
+			ByteLength:   sema.Word64TypeSize,
+			Converter:    NewWord64ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.Word128Type,
+			ByteLength:   sema.Word128TypeSize,
+			Converter:    NewWord128ValueFromBigEndianBytes,
+		},
+		{
+			ReceiverType: sema.Word256Type,
+			ByteLength:   sema.Word256TypeSize,
+			Converter:    NewWord256ValueFromBigEndianBytes,
+		},
 
 		// Fix*
-		{sema.Fix64Type, sema.Fix64TypeSize, NewFix64ValueFromBigEndianBytes},
+		{
+			ReceiverType: sema.Fix64Type,
+			ByteLength:   sema.Fix64TypeSize,
+			Converter:    NewFix64ValueFromBigEndianBytes,
+		},
 
 		// UFix*
-		{sema.UFix64Type, sema.UFix64TypeSize, NewUFix64ValueFromBigEndianBytes},
+		{
+			ReceiverType: sema.UFix64Type,
+			ByteLength:   sema.UFix64TypeSize,
+			Converter:    NewUFix64ValueFromBigEndianBytes,
+		},
 	} {
 		// index by type name
 		typeName := converter.ReceiverType.String()

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -75,7 +75,7 @@ func NewUnmeteredFix64Value(integer int64) Fix64Value {
 	return Fix64Value(integer)
 }
 
-func NewFix64ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) Fix64Value {
+func NewFix64ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) Value {
 	return NewFix64Value(
 		gauge,
 		func() int64 {

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -96,7 +96,7 @@ func NewUnmeteredInt128ValueFromBigInt(value *big.Int) Int128Value {
 	}
 }
 
-func NewInt128ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) Int128Value {
+func NewInt128ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) Value {
 	return NewInt128ValueFromBigInt(
 		gauge,
 		func() *big.Int {

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -51,7 +51,7 @@ func NewUnmeteredInt16Value(value int16) Int16Value {
 	return Int16Value(value)
 }
 
-func NewInt16ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) Int16Value {
+func NewInt16ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) Value {
 	return NewInt16Value(
 		gauge,
 		func() int16 {

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -50,7 +50,7 @@ func NewUnmeteredInt8Value(value int8) Int8Value {
 	return Int8Value(value)
 }
 
-func NewInt8ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) Int8Value {
+func NewInt8ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) Value {
 	return NewInt8Value(
 		gauge,
 		func() int8 {

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -58,7 +58,7 @@ func NewUnmeteredUInt16Value(value uint16) UInt16Value {
 	return UInt16Value(value)
 }
 
-func NewUInt16ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) UInt16Value {
+func NewUInt16ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) Value {
 	return NewUInt16Value(
 		gauge,
 		func() uint16 {

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -49,7 +49,7 @@ func NewUnmeteredUInt32Value(value uint32) UInt32Value {
 	return UInt32Value(value)
 }
 
-func NewUInt32ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) UInt32Value {
+func NewUInt32ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) Value {
 	return NewUInt32Value(
 		gauge,
 		func() uint32 {

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -58,7 +58,7 @@ func NewUnmeteredUInt8Value(value uint8) UInt8Value {
 	return UInt8Value(value)
 }
 
-func NewUInt8ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) UInt8Value {
+func NewUInt8ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) Value {
 	return NewUInt8Value(
 		gauge,
 		func() uint8 {

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -58,7 +58,7 @@ func NewUnmeteredWord8Value(value uint8) Word8Value {
 	return Word8Value(value)
 }
 
-func NewWord8ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) Word8Value {
+func NewWord8ValueFromBigEndianBytes(gauge common.MemoryGauge, b []byte) Value {
 	return NewWord8Value(
 		gauge,
 		func() uint8 {

--- a/sema/string_type.go
+++ b/sema/string_type.go
@@ -421,7 +421,7 @@ var StringFunctionType = func() *FunctionType {
 		StringTypeAnnotation,
 	)
 
-	functionType.IsConstructor = true
+	functionType.TypeFunctionType = StringType
 
 	addMember := func(member *Member) {
 		if functionType.Members == nil {

--- a/sema/type.go
+++ b/sema/type.go
@@ -3607,6 +3607,11 @@ type FunctionType struct {
 	memberResolvers          map[string]MemberResolver
 	memberResolversOnce      sync.Once
 	IsConstructor            bool
+	// TypeFunctionType indicates that this function type is a "type function",
+	// a function that can have members (in a sense, "static" fields and functions).
+	// This is used for built-in functions like `Int`, `UInt8`, `String`, etc.
+	// which have members like `Int.fromString`, `UInt8.min`, `String.join`, etc.
+	TypeFunctionType Type
 }
 
 func NewSimpleFunctionType(
@@ -4477,7 +4482,8 @@ func init() {
 
 func NumberConversionFunctionType(numberType Type) *FunctionType {
 	return &FunctionType{
-		Purity: FunctionPurityView,
+		Purity:           FunctionPurityView,
+		TypeFunctionType: numberType,
 		Parameters: []Parameter{
 			{
 				Label:          ArgumentLabelNotRequired,
@@ -4511,7 +4517,8 @@ func baseFunctionVariable(name string, ty *FunctionType, docString string) *Vari
 }
 
 var AddressConversionFunctionType = &FunctionType{
-	Purity: FunctionPurityView,
+	Purity:           FunctionPurityView,
+	TypeFunctionType: TheAddressType,
 	Parameters: []Parameter{
 		{
 			Label:          ArgumentLabelNotRequired,


### PR DESCRIPTION
Work towards #3976 

## Description

- Port #3977 to the compiler feature branch
- Improve compilation of method invocations on type functions (e.g. `Int.fromString`)
- Fix invocation of native functions from compiled functions: An invocation like `opt.map(Int)` invokes the native function `Int` from compiled code. Such an invocation was running the VM, which executed unrelated code.
- Implement all `Number` types'
  - `toBigEndianBytes` methods
  - `fromBigEndianBytes` and `fromString` static functions


______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
