### PR TITLE
[Compiler] Implement built-in methods and functions for `Address`

### DIFF
--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -86,11 +86,12 @@ func init() {
 		NewNativeFunctionValue(
 			commons.LogFunctionName,
 			stdlib.LogFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+				value := arguments[0]
 				return stdlib.Log(
 					context,
 					context,
-					arguments[0],
+					value,
 					EmptyLocationRange,
 				)
 			},
@@ -101,7 +102,7 @@ func init() {
 		NewNativeFunctionValue(
 			commons.AssertFunctionName,
 			stdlib.AssertFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				result, ok := arguments[0].(interpreter.BoolValue)
 				if !ok {
 					panic(errors.NewUnreachableError())
@@ -129,9 +130,10 @@ func init() {
 		NewNativeFunctionValue(
 			commons.PanicFunctionName,
 			stdlib.PanicFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+				message := arguments[0]
 				return stdlib.PanicWithError(
-					arguments[0],
+					message,
 					EmptyLocationRange,
 				)
 			},
@@ -142,7 +144,7 @@ func init() {
 		NewNativeFunctionValue(
 			commons.GetAccountFunctionName,
 			stdlib.GetAccountFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				address := arguments[0].(interpreter.AddressValue)
 				return NewAccountReferenceValue(
 					context,
@@ -339,7 +341,7 @@ func init() {
 			NewNativeFunctionValue(
 				declaration.Name,
 				functionType,
-				func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 					return convert(
 						context.MemoryGauge,
 						arguments[0],
@@ -411,7 +413,7 @@ var commonBuiltinTypeBoundFunctions = []NativeFunctionValue{
 	NewNativeFunctionValue(
 		sema.IsInstanceFunctionName,
 		sema.IsInstanceFunctionType,
-		func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+		func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 			value := arguments[receiverIndex]
 
 			typeValue, ok := arguments[typeBoundFunctionArgumentOffset].(interpreter.TypeValue)
@@ -427,7 +429,7 @@ var commonBuiltinTypeBoundFunctions = []NativeFunctionValue{
 	NewNativeFunctionValue(
 		sema.GetTypeFunctionName,
 		sema.GetTypeFunctionType,
-		func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+		func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 			value := arguments[receiverIndex]
 			return interpreter.ValueGetType(context, value)
 		},
@@ -460,7 +462,7 @@ func registerSaturatingArithmeticFunctions(t sema.SaturatingArithmeticType) {
 			NewNativeFunctionValue(
 				functionName,
 				sema.SaturatingArithmeticTypeFunctionTypes[t],
-				func(context *Context, typeArguments []bbq.StaticType, args ...Value) Value {
+				func(context *Context, _ []bbq.StaticType, args ...Value) Value {
 					v, ok := args[receiverIndex].(interpreter.NumberValue)
 					if !ok {
 						panic(errors.NewUnreachableError())

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -405,7 +405,7 @@ func NativeFunctionsWithLogAndPanic(logs *[]string) vm.BuiltinGlobalsProvider {
 			vm.NewNativeFunctionValue(
 				commons.PanicFunctionName,
 				stdlib.PanicFunctionType,
-				func(context *vm.Context, typeArguments []interpreter.StaticType, arguments ...vm.Value) vm.Value {
+				func(context *vm.Context, _ []interpreter.StaticType, arguments ...vm.Value) vm.Value {
 					messageValue, ok := arguments[0].(*interpreter.StringValue)
 					if !ok {
 						panic(errors.NewUnreachableError())

--- a/bbq/vm/value_account_capabilities.go
+++ b/bbq/vm/value_account_capabilities.go
@@ -101,7 +101,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.Account_CapabilitiesTypePublishFunctionName,
 			sema.Account_CapabilitiesTypePublishFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, args ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.Capabilities)
 				accountAddress := getAccountTypePrivateAddressValue(args[receiverIndex])
 
@@ -138,7 +138,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.Account_CapabilitiesTypeUnpublishFunctionName,
 			sema.Account_CapabilitiesTypeUnpublishFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, args ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.Capabilities)
 				accountAddress := getAccountTypePrivateAddressValue(args[receiverIndex])
 
@@ -165,7 +165,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.Account_CapabilitiesTypeExistsFunctionName,
 			sema.Account_CapabilitiesTypeExistsFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, args ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, args ...Value) Value {
 				// Get address field from the receiver (Account.Capabilities)
 				accountAddress := getAccountTypePrivateAddressValue(args[receiverIndex])
 

--- a/bbq/vm/value_account_storage.go
+++ b/bbq/vm/value_account_storage.go
@@ -38,7 +38,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeSaveFunctionName,
 			sema.Account_StorageTypeSaveFunctionType,
-			func(context *Context, typeArs []bbq.StaticType, args ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, args ...Value) Value {
 
 				address := getAccountTypePrivateAddressValue(args[receiverIndex])
 
@@ -61,13 +61,13 @@ func init() {
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeBorrowFunctionName,
 			sema.Account_StorageTypeBorrowFunctionType,
-			func(context *Context, typeArgs []bbq.StaticType, args ...Value) Value {
+			func(context *Context, typeArguments []bbq.StaticType, args ...Value) Value {
 				address := getAccountTypePrivateAddressValue(args[receiverIndex])
 
 				// arg[0] is the receiver. Actual arguments starts from 1.
 				arguments := args[typeBoundFunctionArgumentOffset:]
 
-				borrowType := typeArgs[0]
+				borrowType := typeArguments[0]
 				semaBorrowType := interpreter.MustConvertStaticToSemaType(borrowType, context)
 
 				return interpreter.AccountStorageBorrow(
@@ -87,7 +87,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeForEachPublicFunctionName,
 			sema.Account_StorageTypeForEachPublicFunctionType,
-			func(context *Context, typeArs []bbq.StaticType, args ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, args ...Value) Value {
 
 				address := getAccountTypePrivateAddressValue(args[receiverIndex])
 
@@ -112,7 +112,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeForEachStoredFunctionName,
 			sema.Account_StorageTypeForEachPublicFunctionType,
-			func(context *Context, typeArs []bbq.StaticType, args ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, args ...Value) Value {
 
 				address := getAccountTypePrivateAddressValue(args[receiverIndex])
 
@@ -137,7 +137,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeTypeFunctionName,
 			sema.Account_StorageTypeTypeFunctionType,
-			func(context *Context, typeArs []bbq.StaticType, args ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, args ...Value) Value {
 
 				address := getAccountTypePrivateAddressValue(args[receiverIndex])
 
@@ -159,13 +159,13 @@ func init() {
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeLoadFunctionName,
 			sema.Account_StorageTypeLoadFunctionType,
-			func(context *Context, typeArgs []bbq.StaticType, args ...Value) Value {
+			func(context *Context, typeArguments []bbq.StaticType, args ...Value) Value {
 				address := getAccountTypePrivateAddressValue(args[receiverIndex])
 
 				// arg[0] is the receiver. Actual arguments starts from 1.
 				arguments := args[typeBoundFunctionArgumentOffset:]
 
-				borrowType := typeArgs[0]
+				borrowType := typeArguments[0]
 				semaBorrowType := interpreter.MustConvertStaticToSemaType(borrowType, context)
 
 				return interpreter.AccountStorageRead(
@@ -186,13 +186,13 @@ func init() {
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeCopyFunctionName,
 			sema.Account_StorageTypeCopyFunctionType,
-			func(context *Context, typeArgs []bbq.StaticType, args ...Value) Value {
+			func(context *Context, typeArguments []bbq.StaticType, args ...Value) Value {
 				address := getAccountTypePrivateAddressValue(args[receiverIndex]).ToAddress()
 
 				// arg[0] is the receiver. Actual arguments starts from 1.
 				arguments := args[typeBoundFunctionArgumentOffset:]
 
-				borrowType := typeArgs[0]
+				borrowType := typeArguments[0]
 				semaBorrowType := interpreter.MustConvertStaticToSemaType(borrowType, context)
 
 				return interpreter.AccountStorageRead(
@@ -213,13 +213,13 @@ func init() {
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeCheckFunctionName,
 			sema.Account_StorageTypeCheckFunctionType,
-			func(context *Context, typeArgs []bbq.StaticType, args ...Value) Value {
+			func(context *Context, typeArguments []bbq.StaticType, args ...Value) Value {
 				address := getAccountTypePrivateAddressValue(args[receiverIndex]).ToAddress()
 
 				// arg[0] is the receiver. Actual arguments starts from 1.
 				arguments := args[typeBoundFunctionArgumentOffset:]
 
-				borrowType := typeArgs[0]
+				borrowType := typeArguments[0]
 				semaBorrowType := interpreter.MustConvertStaticToSemaType(borrowType, context)
 
 				return interpreter.AccountStorageCheck(

--- a/bbq/vm/value_address.go
+++ b/bbq/vm/value_address.go
@@ -21,6 +21,7 @@ package vm
 import (
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/bbq/commons"
+	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 )
@@ -36,13 +37,54 @@ func init() {
 		NewNativeFunctionValue(
 			sema.ToStringFunctionName,
 			sema.ToStringFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				address := arguments[receiverIndex].(interpreter.AddressValue)
 				return interpreter.AddressValueToStringFunction(
 					context,
 					address,
 					EmptyLocationRange,
 				)
+			},
+		),
+	)
+
+	RegisterTypeBoundFunction(
+		typeName,
+		NewNativeFunctionValue(
+			sema.AddressTypeToBytesFunctionName,
+			sema.AddressTypeToBytesFunctionType,
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+				addressValue := arguments[receiverIndex].(interpreter.AddressValue)
+				address := common.Address(addressValue)
+				return interpreter.ByteSliceToByteArrayValue(context, address[:])
+			},
+		),
+	)
+
+	RegisterTypeBoundFunction(
+		typeName,
+		NewNativeFunctionValue(
+			sema.AddressTypeFromBytesFunctionName,
+			sema.AddressTypeFromBytesFunctionType,
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+				byteArrayValue := arguments[0].(*interpreter.ArrayValue)
+				return interpreter.AddressValueFromByteArray(
+					context,
+					byteArrayValue,
+					EmptyLocationRange,
+				)
+			},
+		),
+	)
+
+	RegisterTypeBoundFunction(
+		typeName,
+		NewNativeFunctionValue(
+			sema.AddressTypeFromStringFunctionName,
+			sema.AddressTypeFromStringFunctionType,
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
+				stringValue := arguments[0].(*interpreter.StringValue)
+				return interpreter.AddressValueFromString(context, stringValue)
 			},
 		),
 	)

--- a/bbq/vm/value_array.go
+++ b/bbq/vm/value_array.go
@@ -43,7 +43,7 @@ func init() {
 					elementType := arrayElementTypeFromValue(receiver, context)
 					return sema.ArrayFirstIndexFunctionType(elementType)
 				},
-				func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 					value := arguments[receiverIndex]
 					array := value.(*interpreter.ArrayValue)
 					element := arguments[1]
@@ -60,7 +60,7 @@ func init() {
 					elementType := arrayElementTypeFromValue(receiver, context)
 					return sema.ArrayContainsFunctionType(elementType)
 				},
-				func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 					value := arguments[receiverIndex]
 					array := value.(*interpreter.ArrayValue)
 					element := arguments[1]
@@ -77,7 +77,7 @@ func init() {
 					arrayType := arrayTypeFromValue(receiver, context)
 					return sema.ArrayReverseFunctionType(arrayType)
 				},
-				func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 					value := arguments[receiverIndex]
 					array := value.(*interpreter.ArrayValue)
 					return array.Reverse(context, EmptyLocationRange)
@@ -93,7 +93,7 @@ func init() {
 					elementType := arrayElementTypeFromValue(receiver, context)
 					return sema.ArrayFilterFunctionType(context, elementType)
 				},
-				func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 					value := arguments[receiverIndex]
 					array := value.(*interpreter.ArrayValue)
 					funcArgument := arguments[1].(FunctionValue)
@@ -110,7 +110,7 @@ func init() {
 					arrayType := arrayTypeFromValue(receiver, context)
 					return sema.ArrayMapFunctionType(context, arrayType)
 				},
-				func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 					value := arguments[receiverIndex]
 					array := value.(*interpreter.ArrayValue)
 					funcArgument := arguments[1].(FunctionValue)
@@ -130,7 +130,7 @@ func init() {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArrayAppendFunctionType(elementType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				array := value.(*interpreter.ArrayValue)
 				element := arguments[1]
@@ -148,7 +148,7 @@ func init() {
 				arrayType := arrayTypeFromValue(receiver, context)
 				return sema.ArrayAppendAllFunctionType(arrayType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				array := value.(*interpreter.ArrayValue)
 				otherArray := arguments[1].(*interpreter.ArrayValue)
@@ -171,7 +171,7 @@ func init() {
 				arrayType := arrayTypeFromValue(receiver, context)
 				return sema.ArrayConcatFunctionType(arrayType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				array := value.(*interpreter.ArrayValue)
 				otherArray := arguments[1].(*interpreter.ArrayValue)
@@ -188,7 +188,7 @@ func init() {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArrayInsertFunctionType(elementType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				array := value.(*interpreter.ArrayValue)
 				indexValue := arguments[1].(interpreter.NumberValue)
@@ -217,7 +217,7 @@ func init() {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArrayRemoveFunctionType(elementType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				array := value.(*interpreter.ArrayValue)
 				indexValue := arguments[1].(interpreter.NumberValue)
@@ -242,7 +242,7 @@ func init() {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArrayRemoveFirstFunctionType(elementType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				array := value.(*interpreter.ArrayValue)
 				return array.RemoveFirst(context, EmptyLocationRange)
@@ -258,7 +258,7 @@ func init() {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArrayRemoveLastFunctionType(elementType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				array := value.(*interpreter.ArrayValue)
 				return array.RemoveLast(context, EmptyLocationRange)
@@ -274,7 +274,7 @@ func init() {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArraySliceFunctionType(elementType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				array := value.(*interpreter.ArrayValue)
 				from := arguments[1].(interpreter.IntValue)
@@ -320,7 +320,7 @@ func init() {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArrayToVariableSizedFunctionType(elementType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				array := value.(*interpreter.ArrayValue)
 				return array.ToVariableSized(context, EmptyLocationRange)

--- a/bbq/vm/value_character.go
+++ b/bbq/vm/value_character.go
@@ -36,7 +36,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.ToStringFunctionName,
 			sema.ToStringFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				address := arguments[receiverIndex].(interpreter.CharacterValue)
 				return interpreter.CharacterValueToString(
 					context,

--- a/bbq/vm/value_dictionary.go
+++ b/bbq/vm/value_dictionary.go
@@ -37,7 +37,7 @@ func init() {
 				dictionaryType := dictionaryType(receiver, context)
 				return sema.DictionaryRemoveFunctionType(dictionaryType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				dictionary := value.(*interpreter.DictionaryValue)
 				key := arguments[1]
@@ -54,7 +54,7 @@ func init() {
 				dictionaryType := dictionaryType(receiver, context)
 				return sema.DictionaryInsertFunctionType(dictionaryType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				dictionary := value.(*interpreter.DictionaryValue)
 				keyValue := arguments[1]
@@ -78,7 +78,7 @@ func init() {
 				dictionaryType := dictionaryType(receiver, context)
 				return sema.DictionaryContainsKeyFunctionType(dictionaryType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				dictionary := value.(*interpreter.DictionaryValue)
 				key := arguments[1]
@@ -100,7 +100,7 @@ func init() {
 				dictionaryType := dictionaryValue.SemaType(context)
 				return sema.DictionaryRemoveFunctionType(dictionaryType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				dictionary := value.(*interpreter.DictionaryValue)
 				funcArgument := arguments[1].(FunctionValue)

--- a/bbq/vm/value_number.go
+++ b/bbq/vm/value_number.go
@@ -36,7 +36,7 @@ func init() {
 			NewNativeFunctionValue(
 				sema.ToStringFunctionName,
 				sema.ToStringFunctionType,
-				func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 					number := arguments[receiverIndex].(interpreter.NumberValue)
 					return interpreter.NumberValueToString(
 						context,
@@ -51,7 +51,7 @@ func init() {
 			NewNativeFunctionValue(
 				sema.ToBigEndianBytesFunctionName,
 				sema.ToBigEndianBytesFunctionType,
-				func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 					number := arguments[receiverIndex].(interpreter.NumberValue)
 					return interpreter.ByteSliceToByteArrayValue(
 						context,

--- a/bbq/vm/value_optional.go
+++ b/bbq/vm/value_optional.go
@@ -41,7 +41,7 @@ func init() {
 					innerValueType,
 				)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				value := arguments[receiverIndex]
 				optionalValue := value.(interpreter.OptionalValue)
 				innerValueType := optionalValue.InnerValueType(context)

--- a/bbq/vm/value_path.go
+++ b/bbq/vm/value_path.go
@@ -43,7 +43,7 @@ func init() {
 			NewNativeFunctionValue(
 				sema.ToStringFunctionName,
 				sema.ToStringFunctionType,
-				func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 					address := arguments[receiverIndex].(interpreter.PathValue)
 					return interpreter.PathValueToStringFunction(
 						context,

--- a/bbq/vm/value_string.go
+++ b/bbq/vm/value_string.go
@@ -37,7 +37,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.StringTypeConcatFunctionName,
 			sema.StringTypeConcatFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				this := arguments[receiverIndex].(*interpreter.StringValue)
 				other := arguments[typeBoundFunctionArgumentOffset]
 				return interpreter.StringConcat(
@@ -55,7 +55,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.StringTypeSliceFunctionName,
 			sema.StringTypeSliceFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				this := arguments[receiverIndex].(*interpreter.StringValue)
 				from := arguments[1].(interpreter.IntValue)
 				to := arguments[2].(interpreter.IntValue)
@@ -69,7 +69,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.StringTypeContainsFunctionName,
 			sema.StringTypeContainsFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				this := arguments[receiverIndex].(*interpreter.StringValue)
 				other := arguments[1].(*interpreter.StringValue)
 				return this.Contains(context, other)
@@ -82,7 +82,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.StringTypeIndexFunctionName,
 			sema.StringTypeIndexFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				this := arguments[receiverIndex].(*interpreter.StringValue)
 				other := arguments[1].(*interpreter.StringValue)
 				return this.IndexOf(context, other)
@@ -95,7 +95,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.StringTypeCountFunctionName,
 			sema.StringTypeCountFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				this := arguments[receiverIndex].(*interpreter.StringValue)
 				other := arguments[1].(*interpreter.StringValue)
 				return this.Count(context, EmptyLocationRange, other)
@@ -108,7 +108,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.StringTypeDecodeHexFunctionName,
 			sema.StringTypeDecodeHexFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				this := arguments[receiverIndex].(*interpreter.StringValue)
 				return this.DecodeHex(context, EmptyLocationRange)
 			},
@@ -120,7 +120,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.StringTypeToLowerFunctionName,
 			sema.StringTypeToLowerFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				this := arguments[receiverIndex].(*interpreter.StringValue)
 				return this.ToLower(context)
 			},
@@ -132,7 +132,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.StringTypeSplitFunctionName,
 			sema.StringTypeSplitFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				this := arguments[receiverIndex].(*interpreter.StringValue)
 				separator := arguments[1].(*interpreter.StringValue)
 				return this.Split(
@@ -149,7 +149,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.StringTypeReplaceAllFunctionName,
 			sema.StringTypeReplaceAllFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				this := arguments[receiverIndex].(*interpreter.StringValue)
 				original := arguments[1].(*interpreter.StringValue)
 				replacement := arguments[2].(*interpreter.StringValue)
@@ -170,7 +170,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.StringTypeEncodeHexFunctionName,
 			sema.StringTypeEncodeHexFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				byteArray := arguments[0].(*interpreter.ArrayValue)
 				return interpreter.StringFunctionEncodeHex(
 					context,
@@ -186,7 +186,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.StringTypeFromUtf8FunctionName,
 			sema.StringTypeFromUtf8FunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				byteArray := arguments[0].(*interpreter.ArrayValue)
 				return interpreter.StringFunctionFromUtf8(
 					context,
@@ -202,7 +202,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.StringTypeFromCharactersFunctionName,
 			sema.StringTypeFromCharactersFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				charactersArray := arguments[0].(*interpreter.ArrayValue)
 				return interpreter.StringFunctionFromCharacters(
 					context,
@@ -218,7 +218,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.StringTypeJoinFunctionName,
 			sema.StringTypeJoinFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				stringArray := arguments[0].(*interpreter.ArrayValue)
 				separator := arguments[1].(*interpreter.StringValue)
 

--- a/bbq/vm/value_type.go
+++ b/bbq/vm/value_type.go
@@ -36,7 +36,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.MetaTypeIsSubtypeFunctionName,
 			sema.MetaTypeIsSubtypeFunctionType,
-			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+			func(context *Context, _ []bbq.StaticType, arguments ...Value) Value {
 				typeValue := arguments[receiverIndex].(interpreter.TypeValue)
 
 				otherTypeValue, ok := arguments[typeBoundFunctionArgumentOffset].(interpreter.TypeValue)

--- a/interpreter/builtinfunctions_test.go
+++ b/interpreter/builtinfunctions_test.go
@@ -123,7 +123,7 @@ func TestInterpretToBytes(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
           let x: Address = 0x123456
           let y = x.toBytes()
         `)
@@ -168,7 +168,7 @@ func TestInterpretAddressFromBytes(t *testing.T) {
 				innerCode,
 			)
 
-			inter := parseCheckAndInterpret(t, code)
+			inter := parseCheckAndPrepare(t, code)
 			res, err := inter.Invoke("test")
 
 			require.NoError(t, err)
@@ -186,14 +186,14 @@ func TestInterpretAddressFromBytes(t *testing.T) {
 
 			code := fmt.Sprintf(`
                   fun test(): Bool {
-                    let address : Address = %s;
+                    let address: Address = %s;
 					return address == Address.fromBytes(address.toBytes());
                   }
             	`,
 				innerCode,
 			)
 
-			inter := parseCheckAndInterpret(t, code)
+			inter := parseCheckAndPrepare(t, code)
 			res, err := inter.Invoke("test")
 
 			require.NoError(t, err)
@@ -217,7 +217,7 @@ func TestInterpretAddressFromBytes(t *testing.T) {
 				innerCode,
 			)
 
-			inter := parseCheckAndInterpret(t, code)
+			inter := parseCheckAndPrepare(t, code)
 			_, err := inter.Invoke("test")
 
 			RequireError(t, err)
@@ -254,7 +254,7 @@ func TestInterpretAddressFromString(t *testing.T) {
 				innerCode,
 			)
 
-			inter := parseCheckAndInterpret(t, code)
+			inter := parseCheckAndPrepare(t, code)
 			res, err := inter.Invoke("test")
 
 			require.NoError(t, err)
@@ -275,14 +275,14 @@ func TestInterpretAddressFromString(t *testing.T) {
 
 			code := fmt.Sprintf(`
 	              fun test(): Bool {
-	                let address : Address? = %s;
+	                let address: Address? = %s;
 					return address == Address.fromString(address!.toString());
 	              }
 	        	`,
 				innerCode,
 			)
 
-			inter := parseCheckAndInterpret(t, code)
+			inter := parseCheckAndPrepare(t, code)
 			res, err := inter.Invoke("test")
 
 			require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestInterpretAddressFromString(t *testing.T) {
 				innerCode,
 			)
 
-			inter := parseCheckAndInterpret(t, code)
+			inter := parseCheckAndPrepare(t, code)
 			res, err := inter.Invoke("test")
 			require.NoError(t, err)
 

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -3407,14 +3407,37 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 				Name: sema.AddressTypeFromBytesFunctionName,
 				Value: NewUnmeteredStaticHostFunctionValue(
 					sema.AddressTypeFromBytesFunctionType,
-					AddressFromBytes,
+					func(invocation Invocation) Value {
+						context := invocation.InvocationContext
+						locationRange := invocation.LocationRange
+
+						byteArray, ok := invocation.Arguments[0].(*ArrayValue)
+						if !ok {
+							panic(errors.NewUnreachableError())
+						}
+
+						return AddressValueFromByteArray(
+							context,
+							byteArray,
+							locationRange,
+						)
+					},
 				),
 			},
 			{
 				Name: sema.AddressTypeFromStringFunctionName,
 				Value: NewUnmeteredStaticHostFunctionValue(
 					sema.AddressTypeFromStringFunctionType,
-					AddressFromString,
+					func(invocation Invocation) Value {
+						context := invocation.InvocationContext
+
+						string, ok := invocation.Arguments[0].(*StringValue)
+						if !ok {
+							panic(errors.NewUnreachableError())
+						}
+
+						return AddressValueFromString(context, string)
+					},
 				),
 			},
 		},

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -285,15 +285,6 @@ func (AddressValue) ChildStorables() []atree.Storable {
 	return nil
 }
 
-func AddressValueFromString(gauge common.MemoryGauge, string *StringValue) Value {
-	addr, err := common.HexToAddressAssertPrefix(string.Str)
-	if err != nil {
-		return Nil
-	}
-
-	return NewSomeValueNonCopying(gauge, NewAddressValue(gauge, addr))
-}
-
 func AddressValueFromByteArray(context ContainerMutationContext, byteArray *ArrayValue, locationRange LocationRange) AddressValue {
 	bytes, err := ByteArrayValueToByteSlice(context, byteArray, locationRange)
 	if err != nil {
@@ -301,4 +292,13 @@ func AddressValueFromByteArray(context ContainerMutationContext, byteArray *Arra
 	}
 
 	return NewAddressValue(context, common.MustBytesToAddress(bytes))
+}
+
+func AddressValueFromString(gauge common.MemoryGauge, string *StringValue) Value {
+	addr, err := common.HexToAddressAssertPrefix(string.Str)
+	if err != nil {
+		return Nil
+	}
+
+	return NewSomeValueNonCopying(gauge, NewAddressValue(gauge, addr))
 }

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -285,33 +285,20 @@ func (AddressValue) ChildStorables() []atree.Storable {
 	return nil
 }
 
-func AddressFromBytes(invocation Invocation) Value {
-	argument, ok := invocation.Arguments[0].(*ArrayValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-
-	inter := invocation.InvocationContext
-
-	bytes, err := ByteArrayValueToByteSlice(inter, argument, invocation.LocationRange)
-	if err != nil {
-		panic(err)
-	}
-
-	return NewAddressValue(invocation.InvocationContext, common.MustBytesToAddress(bytes))
-}
-
-func AddressFromString(invocation Invocation) Value {
-	argument, ok := invocation.Arguments[0].(*StringValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-
-	addr, err := common.HexToAddressAssertPrefix(argument.Str)
+func AddressValueFromString(gauge common.MemoryGauge, string *StringValue) Value {
+	addr, err := common.HexToAddressAssertPrefix(string.Str)
 	if err != nil {
 		return Nil
 	}
 
-	inter := invocation.InvocationContext
-	return NewSomeValueNonCopying(inter, NewAddressValue(inter, addr))
+	return NewSomeValueNonCopying(gauge, NewAddressValue(gauge, addr))
+}
+
+func AddressValueFromByteArray(context ContainerMutationContext, byteArray *ArrayValue, locationRange LocationRange) AddressValue {
+	bytes, err := ByteArrayValueToByteSlice(context, byteArray, locationRange)
+	if err != nil {
+		panic(err)
+	}
+
+	return NewAddressValue(context, common.MustBytesToAddress(bytes))
 }


### PR DESCRIPTION
Work towards #3976 

## Description

Implement `Address` `toBytes` method, and `fromBytes` and `fromString` static functions.
Also clean up type argument parameters of native functions.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
