### PR TITLE
[Compiler] Improve native functions

### DIFF
--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -239,6 +239,15 @@ func (c *Context) GetMethod(
 		return nil
 	}
 
+	// If the value is a "type function" (e.g., `String`, `Int`, etc.),
+	// then return the method directly, as the method is essentially "static"
+	// and does not expect a receiver.
+	if functionValue, ok := value.(FunctionValue); ok &&
+		functionValue.FunctionType(c).TypeFunctionType != nil {
+
+		return method
+	}
+
 	return NewBoundFunctionPointerValue(
 		c,
 		value,

--- a/bbq/vm/native_functions.go
+++ b/bbq/vm/native_functions.go
@@ -51,12 +51,12 @@ func NativeFunctions() map[string]*Variable {
 	return funcs
 }
 
-func RegisterFunction(functionValue NativeFunctionValue) {
+func RegisterFunction(functionValue *NativeFunctionValue) {
 	functionName := functionValue.Name
 	registerFunction(functionName, functionValue)
 }
 
-func registerFunction(functionName string, functionValue NativeFunctionValue) {
+func registerFunction(functionName string, functionValue *NativeFunctionValue) {
 	_, ok := nativeFunctions[functionName]
 	if ok {
 		panic(errors.NewUnexpectedError("function already exists: %s", functionName))
@@ -65,7 +65,7 @@ func registerFunction(functionName string, functionValue NativeFunctionValue) {
 	nativeFunctions[functionName] = functionValue
 }
 
-func RegisterTypeBoundFunction(typeName string, functionValue NativeFunctionValue) {
+func RegisterTypeBoundFunction(typeName string, functionValue *NativeFunctionValue) {
 	// Update the name of the function to be type-qualified
 	qualifiedName := commons.QualifiedName(typeName, functionValue.Name)
 	functionValue.Name = qualifiedName
@@ -73,7 +73,7 @@ func RegisterTypeBoundFunction(typeName string, functionValue NativeFunctionValu
 	RegisterFunction(functionValue)
 }
 
-func RegisterTypeBoundCommonFunction(typeName string, functionValue NativeFunctionValue) {
+func RegisterTypeBoundCommonFunction(typeName string, functionValue *NativeFunctionValue) {
 	// Here the function value is common for many types.
 	// Hence, do not update the function name to be type-qualified.
 	// Only the key in the map is type-qualified.
@@ -407,7 +407,7 @@ func registerBuiltinTypeBoundFunctions(
 }
 
 // Built-in functions that are common to all the types.
-var commonBuiltinTypeBoundFunctions = []NativeFunctionValue{
+var commonBuiltinTypeBoundFunctions = []*NativeFunctionValue{
 
 	// `isInstance` function
 	NewNativeFunctionValue(
@@ -438,7 +438,7 @@ var commonBuiltinTypeBoundFunctions = []NativeFunctionValue{
 	// TODO: add remaining functions
 }
 
-var IndexedCommonBuiltinTypeBoundFunctions = map[string]NativeFunctionValue{}
+var IndexedCommonBuiltinTypeBoundFunctions = map[string]*NativeFunctionValue{}
 
 func registerAllSaturatingArithmeticFunctions() {
 	for _, ty := range common.Concat(
@@ -532,7 +532,7 @@ func registerSaturatingArithmeticFunctions(t sema.SaturatingArithmeticType) {
 	}
 }
 
-func newFromStringFunction(typedParser interpreter.TypedStringValueParser) NativeFunctionValue {
+func newFromStringFunction(typedParser interpreter.TypedStringValueParser) *NativeFunctionValue {
 	functionType := sema.FromStringFunctionType(typedParser.ReceiverType)
 	parser := typedParser.Parser
 
@@ -549,7 +549,7 @@ func newFromStringFunction(typedParser interpreter.TypedStringValueParser) Nativ
 	)
 }
 
-func newFromBigEndianBytesFunction(typedConverter interpreter.TypedBigEndianBytesConverter) NativeFunctionValue {
+func newFromBigEndianBytesFunction(typedConverter interpreter.TypedBigEndianBytesConverter) *NativeFunctionValue {
 	functionType := sema.FromBigEndianBytesFunctionType(typedConverter.ReceiverType)
 	byteLength := typedConverter.ByteLength
 	converter := typedConverter.Converter

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -8307,3 +8307,25 @@ func TestUserInvokesNativeFunction(t *testing.T) {
 		result,
 	)
 }
+
+func TestBoundStaticFunction(t *testing.T) {
+
+	t.Parallel()
+
+	result, err := CompileAndInvoke(t,
+		`
+          fun test(): UInt8? {
+              let f = UInt8.fromString
+              return f("1")
+          }
+        `,
+		"test",
+	)
+	require.NoError(t, err)
+	require.Equal(t,
+		interpreter.NewUnmeteredSomeValueNonCopying(
+			interpreter.NewUnmeteredUInt8Value(1),
+		),
+		result,
+	)
+}

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -201,6 +201,7 @@ func NewNativeFunctionValueWithDerivedType(
 
 var _ Value = &NativeFunctionValue{}
 var _ FunctionValue = &NativeFunctionValue{}
+var _ interpreter.MemberAccessibleValue = &NativeFunctionValue{}
 
 func (*NativeFunctionValue) IsValue() {}
 
@@ -336,6 +337,45 @@ func (v *NativeFunctionValue) Invoke(invocation interpreter.Invocation) interpre
 		v,
 		invocation.Arguments,
 	)
+}
+
+func (v *NativeFunctionValue) GetMember(
+	context interpreter.MemberAccessibleContext,
+	locationRange interpreter.LocationRange,
+	name string,
+) interpreter.Value {
+	if function := context.GetMethod(v, name, locationRange); function != nil {
+		return function
+	}
+
+	return nil
+}
+
+func (*NativeFunctionValue) RemoveMember(
+	_ interpreter.ValueTransferContext,
+	_ interpreter.LocationRange,
+	_ string,
+) interpreter.Value {
+	panic(errors.NewUnreachableError())
+}
+
+func (*NativeFunctionValue) SetMember(
+	_ interpreter.ValueTransferContext,
+	_ interpreter.LocationRange,
+	_ string,
+	_ interpreter.Value,
+) bool {
+	panic(errors.NewUnreachableError())
+}
+
+func (v *NativeFunctionValue) GetMethod(
+	_ interpreter.MemberAccessibleContext,
+	_ interpreter.LocationRange,
+	_ string,
+) interpreter.FunctionValue {
+	// Should never be called, VM should not look up method on value.
+	// See `NativeFunctionValue.GetMember`
+	panic(errors.NewUnreachableError())
 }
 
 // BoundFunctionPointerValue is a function-pointer taken for an object-method.

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -173,6 +173,7 @@ type NativeFunctionValue struct {
 	// A function value can only have either one of `functionType` or `functionTypeGetter`.
 	functionType       *sema.FunctionType
 	functionTypeGetter func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType
+	fields             map[string]Value
 }
 
 func NewNativeFunctionValue(
@@ -344,6 +345,11 @@ func (v *NativeFunctionValue) GetMember(
 	locationRange interpreter.LocationRange,
 	name string,
 ) interpreter.Value {
+	value, ok := v.fields[name]
+	if ok {
+		return value
+	}
+
 	if function := context.GetMethod(v, name, locationRange); function != nil {
 		return function
 	}

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -91,7 +91,7 @@ func NewVM(
 	// Delegate the function invocations to the vm.
 	context.invokeFunction = func(function Value, arguments []Value) (Value, error) {
 		// invokeExternally runs the VM, which is incorrect for native functions.
-		if function, ok := function.(NativeFunctionValue); ok {
+		if function, ok := function.(*NativeFunctionValue); ok {
 			result := function.Function(vm.context, nil, arguments...)
 			return result, nil
 		}
@@ -901,7 +901,7 @@ func invokeFunction(
 	case CompiledFunctionValue:
 		vm.pushCallFrame(functionValue, arguments)
 
-	case NativeFunctionValue:
+	case *NativeFunctionValue:
 		result := functionValue.Function(vm.context, typeArguments, arguments...)
 		vm.push(result)
 

--- a/interpreter/fixedpoint_test.go
+++ b/interpreter/fixedpoint_test.go
@@ -321,11 +321,11 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 	t.Run("invalid negative Fix64 to UFix64", func(t *testing.T) {
 
 		inter := parseCheckAndPrepare(t, `
-		  fun test(): UFix64 {
-		      let x: Fix64 = -1.0
-		      return UFix64(x)
-		  }
-		`)
+          fun test(): UFix64 {
+              let x: Fix64 = -1.0
+              return UFix64(x)
+          }
+        `)
 
 		_, err := inter.Invoke("test")
 		RequireError(t, err)
@@ -339,11 +339,11 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 		inter := parseCheckAndPrepare(t,
 			fmt.Sprintf(
 				`
-		          fun test(): Fix64 {
-		              let x: UFix64 = %d.0
-		              return Fix64(x)
-		          }
-		        `,
+                  fun test(): Fix64 {
+                      let x: UFix64 = %d.0
+                      return Fix64(x)
+                  }
+                `,
 				sema.Fix64TypeMaxInt+1,
 			),
 		)
@@ -364,11 +364,11 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
-	                     fun test(): UFix64 {
-	                         let x: %s = -1
-	                         return UFix64(x)
-	                     }
-	                   `,
+                         fun test(): UFix64 {
+                             let x: %s = -1
+                             return UFix64(x)
+                         }
+                       `,
 						integerType,
 					),
 				)
@@ -402,11 +402,11 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
-	                     fun test(): UFix64 {
-	                         let x: %s = %d
-	                         return UFix64(x)
-	                     }
-	                   `,
+                         fun test(): UFix64 {
+                             let x: %s = %d
+                             return UFix64(x)
+                         }
+                       `,
 						integerType,
 						sema.UFix64TypeMaxInt+1,
 					),
@@ -440,11 +440,11 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
-	                     fun test(): UFix64 {
-	                         let x: %s = %d
-	                         return UFix64(x)
-	                     }
-	                   `,
+                         fun test(): UFix64 {
+                             let x: %s = %d
+                             return UFix64(x)
+                         }
+                       `,
 						integerType,
 						testedValue,
 					),
@@ -478,11 +478,11 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
-	                     fun test(): Fix64 {
-	                         let x: %s = %d
-	                         return Fix64(x)
-	                     }
-	                   `,
+                         fun test(): Fix64 {
+                             let x: %s = %d
+                             return Fix64(x)
+                         }
+                       `,
 						integerType,
 						testedValue,
 					),
@@ -516,11 +516,11 @@ func TestInterpretFixedPointConversions(t *testing.T) {
 				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
-	                     fun test(): Fix64 {
-	                         let x: %s = %d
-	                         return Fix64(x)
-	                     }
-	                   `,
+                         fun test(): Fix64 {
+                             let x: %s = %d
+                             return Fix64(x)
+                         }
+                       `,
 						integerType,
 						testedValue,
 					),
@@ -550,9 +550,9 @@ func TestInterpretFixedPointMinMax(t *testing.T) {
 		inter := parseCheckAndInterpret(t,
 			fmt.Sprintf(
 				`
-				  let min = %[1]s.min
-				  let max = %[1]s.max
-				`,
+                  let min = %[1]s.min
+                  let max = %[1]s.max
+                `,
 				ty,
 			),
 		)
@@ -611,7 +611,7 @@ func TestInterpretStringFixedPointConversion(t *testing.T) {
 	}
 
 	type testsuite struct {
-		name         string
+		typeName     string
 		toFixedValue func(isNegative bool, decimal, fractional *big.Int, scale uint) (interpreter.Value, error)
 		intBounds    []*big.Int
 		fracBounds   []*big.Int
@@ -678,14 +678,23 @@ func TestInterpretStringFixedPointConversion(t *testing.T) {
 	}
 
 	test := func(suite testsuite) {
-		t.Run(suite.name, func(t *testing.T) {
+		t.Run(suite.typeName, func(t *testing.T) {
 			t.Parallel()
 
-			code := fmt.Sprintf(`
-				fun fromStringTest(s: String): %s? {
-					return %s.fromString(s)
-				}
-			`, suite.name, suite.name)
+			code := fmt.Sprintf(
+				`
+                    fun fromStringTest(s: String): %[1]s? {
+                        let a = %[1]s.fromString(s)
+                        let f = %[1]s.fromString
+                        let b = f(s)
+                        if a != b {
+                            return nil
+                        }
+                        return b
+                    }
+                `,
+				suite.typeName,
+			)
 
 			inter := parseCheckAndPrepare(t, code)
 

--- a/interpreter/fixedpoint_test.go
+++ b/interpreter/fixedpoint_test.go
@@ -547,7 +547,7 @@ func TestInterpretFixedPointMinMax(t *testing.T) {
 
 	test := func(t *testing.T, ty sema.Type, test testCase) {
 
-		inter := parseCheckAndInterpret(t,
+		inter := parseCheckAndPrepare(t,
 			fmt.Sprintf(
 				`
                   let min = %[1]s.min

--- a/interpreter/integers_test.go
+++ b/interpreter/integers_test.go
@@ -955,7 +955,13 @@ func TestInterpretStringIntegerConversion(t *testing.T) {
 		code := fmt.Sprintf(
 			`
               fun testFromString(_ input: String): Int? {
-                  return %s.fromString(input).map(Int)
+                  let a = %[1]s.fromString(input).map(Int)
+                  let f = %[1]s.fromString
+                  let b = f(input).map(Int)
+                  if a != b {
+                      return nil
+                  }
+                  return b
               }
             `,
 			typ,

--- a/interpreter/integers_test.go
+++ b/interpreter/integers_test.go
@@ -814,7 +814,7 @@ func TestInterpretIntegerMinMax(t *testing.T) {
 
 	test := func(t *testing.T, ty sema.Type, field string, expected interpreter.Value) {
 
-		inter := parseCheckAndInterpret(t,
+		inter := parseCheckAndPrepare(t,
 			fmt.Sprintf(
 				`
                   let x = %s.%s

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -3214,8 +3214,8 @@ var BigEndianBytesConverters = func() map[string]TypedBigEndianBytesConverter {
 }()
 
 type ValueConverterDeclaration struct {
-	min             Value
-	max             Value
+	Min             Value
+	Max             Value
 	Convert         func(common.MemoryGauge, Value, LocationRange) Value
 	nestedVariables []struct {
 		Name  string
@@ -3237,161 +3237,161 @@ var ConverterDeclarations = []ValueConverterDeclaration{
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUInt(gauge, value, locationRange)
 		},
-		min: NewUnmeteredUIntValueFromBigInt(sema.UIntTypeMin),
+		Min: NewUnmeteredUIntValueFromBigInt(sema.UIntTypeMin),
 	},
 	{
 		Name: sema.Int8TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertInt8(gauge, value, locationRange)
 		},
-		min: NewUnmeteredInt8Value(math.MinInt8),
-		max: NewUnmeteredInt8Value(math.MaxInt8),
+		Min: NewUnmeteredInt8Value(math.MinInt8),
+		Max: NewUnmeteredInt8Value(math.MaxInt8),
 	},
 	{
 		Name: sema.Int16TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertInt16(gauge, value, locationRange)
 		},
-		min: NewUnmeteredInt16Value(math.MinInt16),
-		max: NewUnmeteredInt16Value(math.MaxInt16),
+		Min: NewUnmeteredInt16Value(math.MinInt16),
+		Max: NewUnmeteredInt16Value(math.MaxInt16),
 	},
 	{
 		Name: sema.Int32TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertInt32(gauge, value, locationRange)
 		},
-		min: NewUnmeteredInt32Value(math.MinInt32),
-		max: NewUnmeteredInt32Value(math.MaxInt32),
+		Min: NewUnmeteredInt32Value(math.MinInt32),
+		Max: NewUnmeteredInt32Value(math.MaxInt32),
 	},
 	{
 		Name: sema.Int64TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertInt64(gauge, value, locationRange)
 		},
-		min: NewUnmeteredInt64Value(math.MinInt64),
-		max: NewUnmeteredInt64Value(math.MaxInt64),
+		Min: NewUnmeteredInt64Value(math.MinInt64),
+		Max: NewUnmeteredInt64Value(math.MaxInt64),
 	},
 	{
 		Name: sema.Int128TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertInt128(gauge, value, locationRange)
 		},
-		min: NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
-		max: NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+		Min: NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+		Max: NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
 	},
 	{
 		Name: sema.Int256TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertInt256(gauge, value, locationRange)
 		},
-		min: NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
-		max: NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+		Min: NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+		Max: NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
 	},
 	{
 		Name: sema.UInt8TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUInt8(gauge, value, locationRange)
 		},
-		min: NewUnmeteredUInt8Value(0),
-		max: NewUnmeteredUInt8Value(math.MaxUint8),
+		Min: NewUnmeteredUInt8Value(0),
+		Max: NewUnmeteredUInt8Value(math.MaxUint8),
 	},
 	{
 		Name: sema.UInt16TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUInt16(gauge, value, locationRange)
 		},
-		min: NewUnmeteredUInt16Value(0),
-		max: NewUnmeteredUInt16Value(math.MaxUint16),
+		Min: NewUnmeteredUInt16Value(0),
+		Max: NewUnmeteredUInt16Value(math.MaxUint16),
 	},
 	{
 		Name: sema.UInt32TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUInt32(gauge, value, locationRange)
 		},
-		min: NewUnmeteredUInt32Value(0),
-		max: NewUnmeteredUInt32Value(math.MaxUint32),
+		Min: NewUnmeteredUInt32Value(0),
+		Max: NewUnmeteredUInt32Value(math.MaxUint32),
 	},
 	{
 		Name: sema.UInt64TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUInt64(gauge, value, locationRange)
 		},
-		min: NewUnmeteredUInt64Value(0),
-		max: NewUnmeteredUInt64Value(math.MaxUint64),
+		Min: NewUnmeteredUInt64Value(0),
+		Max: NewUnmeteredUInt64Value(math.MaxUint64),
 	},
 	{
 		Name:    sema.UInt128TypeName,
 		Convert: ConvertUInt128,
-		min:     NewUnmeteredUInt128ValueFromUint64(0),
-		max:     NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
+		Min:     NewUnmeteredUInt128ValueFromUint64(0),
+		Max:     NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
 	},
 	{
 		Name: sema.UInt256TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUInt256(gauge, value, locationRange)
 		},
-		min: NewUnmeteredUInt256ValueFromUint64(0),
-		max: NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
+		Min: NewUnmeteredUInt256ValueFromUint64(0),
+		Max: NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
 	},
 	{
 		Name: sema.Word8TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertWord8(gauge, value, locationRange)
 		},
-		min: NewUnmeteredWord8Value(0),
-		max: NewUnmeteredWord8Value(math.MaxUint8),
+		Min: NewUnmeteredWord8Value(0),
+		Max: NewUnmeteredWord8Value(math.MaxUint8),
 	},
 	{
 		Name: sema.Word16TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertWord16(gauge, value, locationRange)
 		},
-		min: NewUnmeteredWord16Value(0),
-		max: NewUnmeteredWord16Value(math.MaxUint16),
+		Min: NewUnmeteredWord16Value(0),
+		Max: NewUnmeteredWord16Value(math.MaxUint16),
 	},
 	{
 		Name: sema.Word32TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertWord32(gauge, value, locationRange)
 		},
-		min: NewUnmeteredWord32Value(0),
-		max: NewUnmeteredWord32Value(math.MaxUint32),
+		Min: NewUnmeteredWord32Value(0),
+		Max: NewUnmeteredWord32Value(math.MaxUint32),
 	},
 	{
 		Name: sema.Word64TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertWord64(gauge, value, locationRange)
 		},
-		min: NewUnmeteredWord64Value(0),
-		max: NewUnmeteredWord64Value(math.MaxUint64),
+		Min: NewUnmeteredWord64Value(0),
+		Max: NewUnmeteredWord64Value(math.MaxUint64),
 	},
 	{
 		Name:    sema.Word128TypeName,
 		Convert: ConvertWord128,
-		min:     NewUnmeteredWord128ValueFromUint64(0),
-		max:     NewUnmeteredWord128ValueFromBigInt(sema.Word128TypeMaxIntBig),
+		Min:     NewUnmeteredWord128ValueFromUint64(0),
+		Max:     NewUnmeteredWord128ValueFromBigInt(sema.Word128TypeMaxIntBig),
 	},
 	{
 		Name:    sema.Word256TypeName,
 		Convert: ConvertWord256,
-		min:     NewUnmeteredWord256ValueFromUint64(0),
-		max:     NewUnmeteredWord256ValueFromBigInt(sema.Word256TypeMaxIntBig),
+		Min:     NewUnmeteredWord256ValueFromUint64(0),
+		Max:     NewUnmeteredWord256ValueFromBigInt(sema.Word256TypeMaxIntBig),
 	},
 	{
 		Name: sema.Fix64TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertFix64(gauge, value, locationRange)
 		},
-		min: NewUnmeteredFix64Value(math.MinInt64),
-		max: NewUnmeteredFix64Value(math.MaxInt64),
+		Min: NewUnmeteredFix64Value(math.MinInt64),
+		Max: NewUnmeteredFix64Value(math.MaxInt64),
 	},
 	{
 		Name: sema.UFix64TypeName,
 		Convert: func(gauge common.MemoryGauge, value Value, locationRange LocationRange) Value {
 			return ConvertUFix64(gauge, value, locationRange)
 		},
-		min: NewUnmeteredUFix64Value(0),
-		max: NewUnmeteredUFix64Value(math.MaxUint64),
+		Min: NewUnmeteredUFix64Value(0),
+		Max: NewUnmeteredUFix64Value(math.MaxUint64),
 	},
 	{
 		Name: sema.AddressTypeName,
@@ -3898,12 +3898,12 @@ var converterFunctionValues = func() []converterFunction {
 			converterFunctionValue.NestedVariables[name] = NewVariableWithValue(nil, value)
 		}
 
-		if declaration.min != nil {
-			addMember(sema.NumberTypeMinFieldName, declaration.min)
+		if declaration.Min != nil {
+			addMember(sema.NumberTypeMinFieldName, declaration.Min)
 		}
 
-		if declaration.max != nil {
-			addMember(sema.NumberTypeMaxFieldName, declaration.max)
+		if declaration.Max != nil {
+			addMember(sema.NumberTypeMaxFieldName, declaration.Max)
 		}
 
 		if stringValueParser, ok := StringValueParsers[declaration.Name]; ok {


### PR DESCRIPTION
Work towards #3976 

## Description

- Make native function values pointer types. They are rather large, so avoid copying
- Fix invocation of bound function pointers (like `Int.fromString`, `String.fromCharacters`, etc.) created from methods of "type functions" (like `Int`, `String`, etc.) by implementing `MemberAccessibleValue`
- Add support for fields to native functions
- Add `min`/`max` fields to type functions of `Number` types (e.g. `Int8.max`)

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
