### PR TITLE
[Compiler] Check resource loss in assignments

### DIFF
--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -6439,7 +6439,8 @@ func TestCompileOptionalChaining(t *testing.T) {
 
 		const (
 			fooIndex = iota
-			tempIndex
+			optionalValueTempIndex
+			unwrappedValueTempIndex
 		)
 
 		assert.Equal(t,
@@ -6451,22 +6452,22 @@ func TestCompileOptionalChaining(t *testing.T) {
 
 				// Store the receiver in a temp index for the nil check.
 				opcode.InstructionGetLocal{Local: fooIndex},
-				opcode.InstructionSetLocal{Local: tempIndex},
+				opcode.InstructionSetLocal{Local: optionalValueTempIndex},
 
 				// Nil check
-				opcode.InstructionGetLocal{Local: tempIndex},
+				opcode.InstructionGetLocal{Local: optionalValueTempIndex},
 				opcode.InstructionJumpIfNil{Target: 14},
 
 				// If `foo != nil`
 				// Unwrap the optional
-				opcode.InstructionGetLocal{Local: tempIndex},
+				opcode.InstructionGetLocal{Local: optionalValueTempIndex},
 				opcode.InstructionUnwrap{},
-				opcode.InstructionSetLocal{Local: tempIndex},
+				opcode.InstructionSetLocal{Local: unwrappedValueTempIndex},
 
 				// Load `Foo.bar` function
 				opcode.InstructionGetGlobal{Global: 4},
 				// Load receiver
-				opcode.InstructionGetLocal{Local: tempIndex},
+				opcode.InstructionGetLocal{Local: unwrappedValueTempIndex},
 				opcode.InstructionInvokeMethodStatic{ArgCount: 1},
 				opcode.InstructionJump{Target: 15},
 

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -748,6 +748,12 @@ func opGetLocal(vm *VM, ins opcode.InstructionGetLocal) {
 func opSetLocal(vm *VM, ins opcode.InstructionSetLocal) {
 	localIndex := ins.Local
 	absoluteIndex := vm.callFrame.localsOffset + localIndex
+
+	existingValue := vm.locals[absoluteIndex]
+	if existingValue != nil {
+		interpreter.CheckResourceLoss(vm.context, existingValue, EmptyLocationRange)
+	}
+
 	vm.locals[absoluteIndex] = vm.pop()
 }
 

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5990,7 +5990,7 @@ func (interpreter *Interpreter) WithResourceDestruction(
 	f()
 }
 
-func checkResourceLoss(context ValueStaticTypeContext, value Value, locationRange LocationRange) {
+func CheckResourceLoss(context ValueStaticTypeContext, value Value, locationRange LocationRange) {
 	if !value.IsResourceKinded(context) {
 		return
 	}

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -559,7 +559,7 @@ func (v *ArrayValue) Set(context ContainerMutationContext, locationRange Locatio
 	context.MaybeValidateAtreeStorage()
 
 	existingValue := StoredValue(context, existingStorable, context.Storage())
-	checkResourceLoss(context, existingValue, locationRange)
+	CheckResourceLoss(context, existingValue, locationRange)
 	existingValue.DeepRemove(context, true) // existingValue is standalone because it was overwritten in parent container.
 
 	RemoveReferencedSlab(context, existingStorable)

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -730,7 +730,7 @@ func (v *CompositeValue) SetMemberWithoutTransfer(
 	if existingStorable != nil {
 		existingValue := StoredValue(context, existingStorable, context.Storage())
 
-		checkResourceLoss(context, existingValue, locationRange)
+		CheckResourceLoss(context, existingValue, locationRange)
 
 		existingValue.DeepRemove(context, true) // existingValue is standalone because it was overwritten in parent container.
 
@@ -1593,7 +1593,7 @@ func (v *CompositeValue) RemoveField(
 
 	// Value
 	existingValue := StoredValue(context, existingValueStorable, context.Storage())
-	checkResourceLoss(context, existingValue, locationRange)
+	CheckResourceLoss(context, existingValue, locationRange)
 	existingValue.DeepRemove(context, true) // existingValue is standalone because it was removed from parent container.
 	RemoveReferencedSlab(context, existingValueStorable)
 }

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -674,7 +674,7 @@ func (v *DictionaryValue) SetKey(context ContainerMutationContext, locationRange
 	}
 
 	if existingValue != nil {
-		checkResourceLoss(context, existingValue, locationRange)
+		CheckResourceLoss(context, existingValue, locationRange)
 	}
 }
 

--- a/interpreter/variable.go
+++ b/interpreter/variable.go
@@ -57,7 +57,7 @@ func (v *SimpleVariable) GetValue(ValueStaticTypeContext) Value {
 func (v *SimpleVariable) SetValue(context ValueStaticTypeContext, locationRange LocationRange, value Value) {
 	existingValue := v.value
 	if existingValue != nil {
-		checkResourceLoss(context, existingValue, locationRange)
+		CheckResourceLoss(context, existingValue, locationRange)
 	}
 	v.getter = nil
 	v.value = value


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3976

## Description

Force assignment is also treated as any other assignment. At runtime, all assignments must check for resource-loss. Index assignment, and field assignment already has this check (comping from the interpreter). So the only change needed was to do the same check in local variable assignments (i.e: `SetLocal`).

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
