### PR TITLE
[Compiler] Enable execution of scripts with VM

### DIFF
--- a/bbq/vm/test/interpreter_test.go
+++ b/bbq/vm/test/interpreter_test.go
@@ -604,7 +604,7 @@ func BenchmarkInterpreterFTTransfer(b *testing.B) {
 
 func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 
-	interpreterRuntime := NewTestInterpreterRuntime()
+	interpreterRuntime := NewTestRuntime()
 
 	contractsAddress := common.MustBytesToAddress([]byte{0x1})
 	senderAddress := common.MustBytesToAddress([]byte{0x2})

--- a/bbq/vm/test/runtime_test.go
+++ b/bbq/vm/test/runtime_test.go
@@ -496,7 +496,7 @@ func TestFTContractInvocation(t *testing.T) {
 
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	// Deploy contracts
 

--- a/encoding/ccf/ccf_test.go
+++ b/encoding/ccf/ccf_test.go
@@ -17146,7 +17146,7 @@ func TestEncodeEventWithAttachment(t *testing.T) {
 }
 
 func exportEventFromScript(t *testing.T, script string) cadence.Event {
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var events []cadence.Event
 

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -46,7 +46,7 @@ func TestRuntimeAccountKeyConstructor(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	script := []byte(`
         access(all) fun main(): AccountKey {
@@ -91,7 +91,7 @@ func TestRuntimeReturnPublicAccount(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	script := []byte(`
         access(all) fun main(): &Account {
@@ -124,7 +124,7 @@ func TestRuntimeReturnAuthAccount(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	script := []byte(`
         access(all) fun main(): auth(Storage) &Account {
@@ -164,7 +164,7 @@ func TestRuntimeStoreAccountAPITypes(t *testing.T) {
 		sema.PublicKeyType,
 	} {
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(fmt.Sprintf(`
             transaction {
@@ -229,7 +229,7 @@ type accountTestEnvironment struct {
 
 func newAccountTestEnv() accountTestEnvironment {
 	storage := newTestAccountKeyStorage()
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	rtInterface := newAccountKeyTestRuntimeInterface(storage)
 
 	addPublicKeyValidation(rtInterface, nil)
@@ -594,7 +594,7 @@ func TestRuntimeAuthAccountKeysAdd(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	pubKey1 := []byte{1, 2, 3}
 	pubKey1Value := newBytesValue(pubKey1)
@@ -1061,7 +1061,7 @@ func TestRuntimeHashAlgorithm(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	script := []byte(`
         access(all) fun main(): [HashAlgorithm?] {
@@ -1136,7 +1136,7 @@ func TestRuntimeSignatureAlgorithm(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	script := []byte(`
         access(all) fun main(): [SignatureAlgorithm?] {
@@ -1457,7 +1457,7 @@ func TestRuntimePublicKey(t *testing.T) {
 	t.Parallel()
 
 	executeScript := func(code string, runtimeInterface Interface) (cadence.Value, error) {
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		value, err := rt.ExecuteScript(
 			Script{
@@ -1816,7 +1816,7 @@ func TestRuntimeAuthAccountContracts(t *testing.T) {
 	t.Run("get existing contract", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(`
             transaction {
@@ -1858,7 +1858,7 @@ func TestRuntimeAuthAccountContracts(t *testing.T) {
 	t.Run("get non-existing contract", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(`
             transaction {
@@ -1900,7 +1900,7 @@ func TestRuntimeAuthAccountContracts(t *testing.T) {
 	t.Run("borrow existing contract", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		accountCodes := map[Location][]byte{}
 		var events []cadence.Event
@@ -1993,7 +1993,7 @@ func TestRuntimeAuthAccountContracts(t *testing.T) {
 	t.Run("borrow existing contract with incorrect type", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		accountCodes := map[Location][]byte{}
 		var events []cadence.Event
@@ -2084,7 +2084,7 @@ func TestRuntimeAuthAccountContracts(t *testing.T) {
 	t.Run("borrow existing contract interface", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		accountCodes := map[Location][]byte{}
 		var events []cadence.Event
@@ -2180,7 +2180,7 @@ func TestRuntimeAuthAccountContracts(t *testing.T) {
 	t.Run("borrow existing contract with entitlement authorization", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		accountCodes := map[Location][]byte{}
 		var events []cadence.Event
@@ -2258,7 +2258,7 @@ func TestRuntimeAuthAccountContracts(t *testing.T) {
 	t.Run("borrow non-existing contract", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: NewTestLedger(nil, nil),
@@ -2294,7 +2294,7 @@ func TestRuntimeAuthAccountContracts(t *testing.T) {
 	t.Run("get names", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(`
             transaction {
@@ -2338,7 +2338,7 @@ func TestRuntimeAuthAccountContracts(t *testing.T) {
 	t.Run("update names", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(`
             transaction {
@@ -2377,7 +2377,7 @@ func TestRuntimeAuthAccountContracts(t *testing.T) {
 	t.Run("update names through reference", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(`
             transaction {
@@ -2425,7 +2425,7 @@ func TestRuntimePublicAccountContracts(t *testing.T) {
 	t.Run("get existing contract", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(`
             access(all) fun main(): [AnyStruct] {
@@ -2483,7 +2483,7 @@ func TestRuntimePublicAccountContracts(t *testing.T) {
 	t.Run("get non-existing contract", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(`
             access(all) fun main() {
@@ -2521,7 +2521,7 @@ func TestRuntimePublicAccountContracts(t *testing.T) {
 	t.Run("get names", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(`
             access(all) fun main(): &[String] {
@@ -2571,7 +2571,7 @@ func TestRuntimeGetAuthAccount(t *testing.T) {
 	t.Run("script", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(`
             access(all) fun main(): UInt64 {
@@ -2603,7 +2603,7 @@ func TestRuntimeGetAuthAccount(t *testing.T) {
 	t.Run("incorrect arg type", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(`
             access(all) fun main() {
@@ -2631,7 +2631,7 @@ func TestRuntimeGetAuthAccount(t *testing.T) {
 	t.Run("no args", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(`
             access(all) fun main() {
@@ -2659,7 +2659,7 @@ func TestRuntimeGetAuthAccount(t *testing.T) {
 	t.Run("too many args", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(`
             access(all) fun main() {
@@ -2686,7 +2686,7 @@ func TestRuntimeGetAuthAccount(t *testing.T) {
 	t.Run("transaction", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		script := []byte(`
             transaction {

--- a/runtime/attachments_test.go
+++ b/runtime/attachments_test.go
@@ -35,7 +35,7 @@ func TestRuntimeAccountAttachmentSaveAndLoad(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -146,7 +146,7 @@ func TestRuntimeAccountAttachmentExportFailure(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	logs := make([]string, 0)
 	events := make([]string, 0)
@@ -238,7 +238,7 @@ func TestRuntimeAccountAttachmentExport(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -323,7 +323,7 @@ func TestRuntimeAccountAttachedExport(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -411,7 +411,7 @@ func TestRuntimeAccountAttachmentSaveAndBorrow(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -525,7 +525,7 @@ func TestRuntimeAccountAttachmentCapability(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -665,8 +665,8 @@ func TestRuntimeAttachmentStorage(t *testing.T) {
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
-	newRuntime := func() (TestInterpreterRuntime, *TestRuntimeInterface) {
-		runtime := NewTestInterpreterRuntime()
+	newRuntime := func() (TestRuntime, *TestRuntimeInterface) {
+		runtime := NewTestRuntime()
 
 		accountCodes := map[common.Location][]byte{}
 

--- a/runtime/capabilities_test.go
+++ b/runtime/capabilities_test.go
@@ -37,8 +37,8 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
-	newRuntime := func() (TestInterpreterRuntime, *TestRuntimeInterface) {
-		runtime := NewTestInterpreterRuntime()
+	newRuntime := func() (TestRuntime, *TestRuntimeInterface) {
+		runtime := NewTestRuntime()
 		accountCodes := map[common.Location][]byte{}
 
 		runtimeInterface := &TestRuntimeInterface{

--- a/runtime/capabilitycontrollers_test.go
+++ b/runtime/capabilitycontrollers_test.go
@@ -45,7 +45,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 		err error,
 	) {
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		accountCodes := map[Location][]byte{}
 
@@ -3554,7 +3554,7 @@ func TestRuntimeCapabilityBorrowAsInheritedInterface(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contract := []byte(`
         access(all) contract Test {
@@ -3666,7 +3666,7 @@ func TestRuntimeCapabilityControllerOperationAfterDeletion(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			rt := NewTestInterpreterRuntime()
+			rt := NewTestRuntime()
 
 			tx := []byte(fmt.Sprintf(
 				`
@@ -3834,7 +3834,7 @@ func TestRuntimeCapabilitiesGetBackwardCompatibility(t *testing.T) {
 
 	test := func(t *testing.T, value interpreter.Value) {
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: NewTestLedger(nil, nil),
@@ -3936,7 +3936,7 @@ func TestRuntimeCapabilitiesPublishBackwardCompatibility(t *testing.T) {
 
 	test := func(t *testing.T, value interpreter.Value) {
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		var events []cadence.Event
 
@@ -4027,7 +4027,7 @@ func TestRuntimeCapabilitiesUnpublishBackwardCompatibility(t *testing.T) {
 
 	test := func(t *testing.T, value interpreter.Value) {
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		var events []cadence.Event
 

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -54,7 +54,7 @@ func TestRuntimeContract(t *testing.T) {
 	runTest := func(t *testing.T, tc testCase) {
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		var loggedMessages []string
 
@@ -698,7 +698,7 @@ func TestRuntimeImportMultipleContracts(t *testing.T) {
 		},
 	}
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
@@ -799,7 +799,7 @@ func TestRuntimeContractInterfaceEventEmission(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployInterfaceTx := DeploymentTransaction("TestInterface", []byte(`
@@ -935,7 +935,7 @@ func TestRuntimeContractInterfaceConditionEventEmission(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployInterfaceTx := DeploymentTransaction("TestInterface", []byte(`
@@ -1112,7 +1112,7 @@ func TestRuntimeContractTryUpdate(t *testing.T) {
 
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		deployTx := DeploymentTransaction("Foo", []byte(`access(all) contract Foo {}`))
 
@@ -1188,7 +1188,7 @@ func TestRuntimeContractTryUpdate(t *testing.T) {
 
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		updateTx := []byte(`
 			transaction {
@@ -1251,7 +1251,7 @@ func TestRuntimeContractTryUpdate(t *testing.T) {
 
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		deployTx := DeploymentTransaction("Foo", []byte(`access(all) contract Foo {}`))
 
@@ -1306,7 +1306,7 @@ func TestRuntimeContractTryUpdate(t *testing.T) {
 
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		deployTx := DeploymentTransaction("Foo", []byte(`access(all) contract Foo {}`))
 

--- a/runtime/contract_update_test.go
+++ b/runtime/contract_update_test.go
@@ -35,7 +35,7 @@ import (
 func TestRuntimeContractUpdateWithDependencies(t *testing.T) {
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 	accountCodes := map[common.Location][]byte{}
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 	fooLocation := common.AddressLocation{
@@ -217,7 +217,7 @@ func TestRuntimeContractUpdateWithDependencies(t *testing.T) {
 func TestRuntimeContractUpdateWithPrecedingIdentifiers(t *testing.T) {
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -347,7 +347,7 @@ func TestRuntimeContractRedeployInSameTransaction(t *testing.T) {
             }
         `)
 
-		runtime := NewTestInterpreterRuntimeWithConfig(Config{
+		runtime := NewTestRuntimeWithConfig(Config{
 			AtreeValidationEnabled: false,
 		})
 
@@ -422,7 +422,7 @@ func TestRuntimeNestedContractDeployment(t *testing.T) {
             }
         `)
 
-		runtime := NewTestInterpreterRuntimeWithConfig(Config{
+		runtime := NewTestRuntimeWithConfig(Config{
 			AtreeValidationEnabled: false,
 		})
 
@@ -487,7 +487,7 @@ func TestRuntimeNestedContractDeployment(t *testing.T) {
             }
         `)
 
-		runtime := NewTestInterpreterRuntimeWithConfig(Config{
+		runtime := NewTestRuntimeWithConfig(Config{
 			AtreeValidationEnabled: false,
 		})
 
@@ -561,7 +561,7 @@ func TestRuntimeNestedContractDeployment(t *testing.T) {
             }
         `)
 
-		runtime := NewTestInterpreterRuntimeWithConfig(Config{
+		runtime := NewTestRuntimeWithConfig(Config{
 			AtreeValidationEnabled: false,
 		})
 
@@ -620,7 +620,7 @@ func TestRuntimeContractRedeploymentInSeparateTransactions(t *testing.T) {
             }
         `)
 
-	runtime := NewTestInterpreterRuntimeWithConfig(Config{
+	runtime := NewTestRuntimeWithConfig(Config{
 		AtreeValidationEnabled: false,
 	})
 
@@ -684,7 +684,7 @@ func TestRuntimeContractRedeploymentInSeparateTransactions(t *testing.T) {
 func TestRuntimeContractUpdateWithOldProgramError(t *testing.T) {
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	accountCodes := map[common.Location][]byte{}
 	signerAccount := common.MustBytesToAddress([]byte{0x1})

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -88,7 +88,7 @@ func newContractDeploymentTransactor(t *testing.T, config Config) func(code stri
 
 func newContractDeploymentTransactorWithVersion(t *testing.T, config Config, version string) func(code string) error {
 
-	rt := NewTestInterpreterRuntimeWithConfig(config)
+	rt := NewTestRuntimeWithConfig(config)
 
 	accountCodes := map[Location][]byte{}
 	var events []cadence.Event
@@ -667,7 +667,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 	testWithValidators(t, "change imported field nominal type location", func(t *testing.T, config Config) {
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		makeDeployTransaction := func(name, code string) []byte {
 			return []byte(fmt.Sprintf(
@@ -831,7 +831,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 	testWithValidators(t, "change imported non-field nominal type location", func(t *testing.T, config Config) {
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		makeDeployTransaction := func(name, code string) []byte {
 			return []byte(fmt.Sprintf(
@@ -987,7 +987,7 @@ func TestRuntimeContractUpdateValidation(t *testing.T) {
 
 	testWithValidators(t, "change imported field nominal type location implicitly", func(t *testing.T, config Config) {
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		makeDeployTransaction := func(name, code string) []byte {
 			return []byte(fmt.Sprintf(
@@ -2864,7 +2864,7 @@ func TestRuntimeContractUpdateConformanceChanges(t *testing.T) {
           }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		contractLocation := common.AddressLocation{
 			Address: address,
@@ -2942,7 +2942,7 @@ func TestRuntimeContractUpdateProgramCaching(t *testing.T) {
 		programGets locationAccessCounts,
 		programSets locationAccessCounts,
 	) {
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		accountCodes := map[Location][]byte{}
 		var events []cadence.Event
@@ -3615,7 +3615,7 @@ func TestRuntimeContractUpdateErrorsInOldProgram(t *testing.T) {
 
 	testWithValidators(t, "invalid old program", func(t *testing.T, config Config) {
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		var events []cadence.Event
 

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1803,7 +1803,7 @@ func TestRuntimeExportEventValue(t *testing.T) {
 }
 
 func exportEventFromScript(t *testing.T, script string) cadence.Event {
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var events []cadence.Event
 
@@ -1833,7 +1833,7 @@ func exportEventFromScript(t *testing.T, script string) cadence.Event {
 }
 
 func exportValueFromScript(t *testing.T, script string) cadence.Value {
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	value, err := rt.ExecuteScript(
 		Script{
@@ -1961,7 +1961,7 @@ func TestRuntimeExportReferenceValue(t *testing.T) {
 
 		// Arrange
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		transaction := `
             transaction {
@@ -2043,7 +2043,7 @@ func TestRuntimeExportReferenceValue(t *testing.T) {
             }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: NewTestLedger(nil, nil),
@@ -2080,7 +2080,7 @@ func TestRuntimeExportReferenceValue(t *testing.T) {
             }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: NewTestLedger(nil, nil),
@@ -2527,7 +2527,7 @@ func TestRuntimeEnumValue(t *testing.T) {
 }
 
 func executeTestScript(t *testing.T, script string, arg cadence.Value) (cadence.Value, error) {
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	runtimeInterface := &TestRuntimeInterface{
 		Storage: NewTestLedger(nil, nil),
@@ -4059,7 +4059,7 @@ func TestRuntimeStringValueImport(t *testing.T) {
 		encodedArg, err := json.Encode(stringValue)
 		require.NoError(t, err)
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		var validated bool
 
@@ -4109,7 +4109,7 @@ func TestRuntimeTypeValueImport(t *testing.T) {
 		encodedArg, err := json.Encode(typeValue)
 		require.NoError(t, err)
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		var ok bool
 
@@ -4157,7 +4157,7 @@ func TestRuntimeTypeValueImport(t *testing.T) {
 		encodedArg, err := json.Encode(typeValue)
 		require.NoError(t, err)
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
@@ -4204,7 +4204,7 @@ func TestRuntimeCapabilityValueImport(t *testing.T) {
 		encodedArg, err := json.Encode(capabilityValue)
 		require.NoError(t, err)
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
@@ -4245,7 +4245,7 @@ func TestRuntimeCapabilityValueImport(t *testing.T) {
 		encodedArg, err := json.Encode(capabilityValue)
 		require.NoError(t, err)
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
@@ -4293,7 +4293,7 @@ func TestRuntimeCapabilityValueImport(t *testing.T) {
 		encodedArg, err := json.Encode(capabilityValue)
 		require.NoError(t, err)
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
@@ -4331,7 +4331,7 @@ func TestRuntimePublicKeyImport(t *testing.T) {
 		encodedArg, err := json.Encode(arg)
 		require.NoError(t, err)
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		return rt.ExecuteScript(
 			Script{
@@ -4681,7 +4681,7 @@ func TestRuntimePublicKeyImport(t *testing.T) {
             }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		storage := NewTestLedger(nil, nil)
 
@@ -4747,7 +4747,7 @@ func TestRuntimePublicKeyImport(t *testing.T) {
             }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		storage := NewTestLedger(nil, nil)
 
@@ -4811,7 +4811,7 @@ func TestRuntimePublicKeyImport(t *testing.T) {
             }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		var publicKeyValidated bool
 
@@ -4882,7 +4882,7 @@ func TestRuntimePublicKeyImport(t *testing.T) {
             }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		var publicKeyValidated bool
 
@@ -5229,7 +5229,7 @@ func TestRuntimeNestedStructArgPassing(t *testing.T) {
           }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		storage := NewTestLedger(nil, nil)
 
@@ -5292,7 +5292,7 @@ func TestRuntimeNestedStructArgPassing(t *testing.T) {
           }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		storage := NewTestLedger(nil, nil)
 
@@ -5327,7 +5327,7 @@ func TestRuntimeNestedStructArgPassing(t *testing.T) {
 func TestRuntimeDestroyedResourceReferenceExport(t *testing.T) {
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	script := []byte(`
         access(all) resource S {}
@@ -5378,7 +5378,7 @@ func TestRuntimeDeploymentResultValueImportExport(t *testing.T) {
             access(all) fun main(v: DeploymentResult) {}
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 		runtimeInterface := &TestRuntimeInterface{}
 
 		_, err := rt.ExecuteScript(
@@ -5407,7 +5407,7 @@ func TestRuntimeDeploymentResultValueImportExport(t *testing.T) {
             }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 		runtimeInterface := &TestRuntimeInterface{}
 
 		_, err := rt.ExecuteScript(
@@ -5441,7 +5441,7 @@ func TestRuntimeDeploymentResultTypeImportExport(t *testing.T) {
             }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		typeValue := cadence.NewTypeValue(cadence.NewStructType(
 			nil,
@@ -5488,7 +5488,7 @@ func TestRuntimeDeploymentResultTypeImportExport(t *testing.T) {
             }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 		runtimeInterface := &TestRuntimeInterface{}
 
 		result, err := rt.ExecuteScript(
@@ -5569,7 +5569,7 @@ func TestRuntimeExportInterfaceType(t *testing.T) {
             }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		_, err := rt.ExecuteScript(
 			Script{
@@ -5607,7 +5607,7 @@ func TestRuntimeExportInterfaceType(t *testing.T) {
             }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		_, err := rt.ExecuteScript(
 			Script{

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -1409,7 +1409,7 @@ func TestRuntimeCoverage(t *testing.T) {
 
 	config := DefaultTestInterpreterConfig
 	config.CoverageReport = coverageReport
-	runtime := NewTestInterpreterRuntimeWithConfig(config)
+	runtime := NewTestRuntimeWithConfig(config)
 
 	value, err := runtime.ExecuteScript(
 		Script{
@@ -1567,7 +1567,7 @@ func TestRuntimeCoverageWithExcludedLocation(t *testing.T) {
 
 	config := DefaultTestInterpreterConfig
 	config.CoverageReport = coverageReport
-	runtime := NewTestInterpreterRuntimeWithConfig(config)
+	runtime := NewTestRuntimeWithConfig(config)
 
 	value, err := runtime.ExecuteScript(
 		Script{
@@ -1951,7 +1951,7 @@ func TestRuntimeCoverageReportLCOVFormat(t *testing.T) {
 
 		config := DefaultTestInterpreterConfig
 		config.CoverageReport = coverageReport
-		runtime := NewTestInterpreterRuntimeWithConfig(config)
+		runtime := NewTestRuntimeWithConfig(config)
 
 		value, err := runtime.ExecuteScript(
 			Script{
@@ -2022,7 +2022,7 @@ end_of_record
 
 		config := DefaultTestInterpreterConfig
 		config.CoverageReport = coverageReport
-		runtime := NewTestInterpreterRuntimeWithConfig(config)
+		runtime := NewTestRuntimeWithConfig(config)
 
 		value, err := runtime.ExecuteScript(
 			Script{

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -41,7 +41,7 @@ func TestRuntimeHashAlgorithm_hash(t *testing.T) {
 	t.Parallel()
 
 	executeScript := func(code string, inter Interface) (cadence.Value, error) {
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 		return runtime.ExecuteScript(
 			Script{
 				Source: []byte(code),
@@ -166,7 +166,7 @@ func TestRuntimeHashingAlgorithmExport(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 	runtimeInterface := &TestRuntimeInterface{}
 	nextScriptLocation := NewScriptLocationGenerator()
 
@@ -211,7 +211,7 @@ func TestRuntimeSignatureAlgorithmExport(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 	runtimeInterface := &TestRuntimeInterface{}
 	nextScriptLocation := NewScriptLocationGenerator()
 
@@ -256,7 +256,7 @@ func TestRuntimeSignatureAlgorithmImport(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 	runtimeInterface := &TestRuntimeInterface{
 		OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 			return json.Decode(nil, b)
@@ -333,7 +333,7 @@ func TestRuntimeHashAlgorithmImport(t *testing.T) {
 
 		storage := NewTestLedger(nil, nil)
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: storage,
 			OnHash: func(data []byte, tag string, hashAlgorithm HashAlgorithm) ([]byte, error) {
@@ -405,7 +405,7 @@ func TestRuntimeBLSVerifyPoP(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
 
@@ -464,7 +464,7 @@ func TestRuntimeBLSAggregateSignatures(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
 
@@ -529,7 +529,7 @@ func TestRuntimeBLSAggregatePublicKeys(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
 
@@ -624,7 +624,7 @@ func TestRuntimeTraversingMerkleProof(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
         access(all) fun main(rootHash: [UInt8], address: [UInt8], accountProof: [[UInt8]]){

--- a/runtime/debugger_test.go
+++ b/runtime/debugger_test.go
@@ -56,7 +56,7 @@ func TestRuntimeDebugger(t *testing.T) {
 
 		config := DefaultTestInterpreterConfig
 		config.Debugger = debugger
-		runtime := NewTestInterpreterRuntimeWithConfig(config)
+		runtime := NewTestRuntimeWithConfig(config)
 
 		address := common.MustBytesToAddress([]byte{0x1})
 
@@ -149,7 +149,7 @@ func TestRuntimeDebuggerBreakpoints(t *testing.T) {
 
 		config := DefaultTestInterpreterConfig
 		config.Debugger = debugger
-		runtime := NewTestInterpreterRuntimeWithConfig(config)
+		runtime := NewTestRuntimeWithConfig(config)
 
 		address := common.MustBytesToAddress([]byte{0x1})
 

--- a/runtime/deployedcontract_test.go
+++ b/runtime/deployedcontract_test.go
@@ -64,7 +64,7 @@ func TestRuntimeDeployedContracts(t *testing.T) {
 		}
 		`
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
 
 	runtimeInterface := &TestRuntimeInterface{

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -148,7 +148,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 			argumentCode,
 		))
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		var accountCode []byte
 		var events []cadence.Event

--- a/runtime/entitlements_test.go
+++ b/runtime/entitlements_test.go
@@ -36,7 +36,7 @@ func TestRuntimeAccountEntitlementSaveAndLoadSuccess(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -128,7 +128,7 @@ func TestRuntimeAccountEntitlementSaveAndLoadFail(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -221,7 +221,7 @@ func TestRuntimeAccountEntitlementAttachment(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -327,7 +327,7 @@ func TestRuntimeAccountExportEntitledRef(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -404,7 +404,7 @@ func TestRuntimeAccountEntitlementNamingConflict(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -507,7 +507,7 @@ func TestRuntimeAccountEntitlementCapabilityCasting(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -608,7 +608,7 @@ func TestRuntimeAccountEntitlementCapabilityDictionary(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -724,7 +724,7 @@ func TestRuntimeAccountEntitlementGenericCapabilityDictionary(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
 
 	deployTx := DeploymentTransaction("Test", []byte(`
@@ -842,7 +842,7 @@ func TestRuntimeCapabilityEntitlements(t *testing.T) {
 	address := common.MustBytesToAddress([]byte{0x1})
 
 	test := func(t *testing.T, script string) {
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		accountCodes := map[common.Location][]byte{}
 
@@ -1121,7 +1121,7 @@ func TestRuntimeImportedEntitlementMapInclude(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
 
 	furtherUpstreamDeployTx := DeploymentTransaction("FurtherUpstream", []byte(`
@@ -1299,7 +1299,7 @@ func TestRuntimeEntitlementMapIncludeDeduped(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
 
 	script := []byte(`

--- a/runtime/error_test.go
+++ b/runtime/error_test.go
@@ -42,7 +42,7 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`X`)
 
@@ -76,7 +76,7 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`fun test() {}`)
 
@@ -109,7 +109,7 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
             access(all) fun main() {
@@ -149,7 +149,7 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
 			access(all) fun main() {
@@ -187,7 +187,7 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
 			access(all) resource Resource {
@@ -247,7 +247,7 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		importedScript := []byte(`X`)
 
@@ -290,7 +290,7 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		importedScript := []byte(`fun test() {}`)
 
@@ -334,7 +334,7 @@ func TestRuntimeError(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		importedScript := []byte(`
             access(all) fun add() {
@@ -446,7 +446,7 @@ func TestRuntimeError(t *testing.T) {
 			},
 		}
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 		err = rt.ExecuteTransaction(
 			Script{
 				Source: []byte(codes[location]),
@@ -489,7 +489,7 @@ func TestRuntimeError(t *testing.T) {
 func TestRuntimeMultipleInterfaceDefaultImplementationsError(t *testing.T) {
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	makeDeployTransaction := func(name, code string) []byte {
 		return []byte(fmt.Sprintf(

--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -583,7 +583,7 @@ access(all) fun main(account: Address): UFix64 {
 
 func testRuntimeFungibleTokenTransfer(tb testing.TB, useVM bool) {
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contractsAddress := common.MustBytesToAddress([]byte{0x1})
 	senderAddress := common.MustBytesToAddress([]byte{0x2})
@@ -976,7 +976,7 @@ func getField(declaration *ast.CompositeDeclaration, name string) *ast.FieldDecl
 
 func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contractsAddress := common.MustBytesToAddress([]byte{0x1})
 	userAddress := common.MustBytesToAddress([]byte{0x2})

--- a/runtime/import_test.go
+++ b/runtime/import_test.go
@@ -39,7 +39,7 @@ func TestRuntimeCyclicImport(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	imported1 := []byte(`
       import p2
@@ -118,7 +118,7 @@ func TestRuntimeCyclicImport(t *testing.T) {
 
 func TestRuntimeCheckCyclicImportsAfterUpdate(t *testing.T) {
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contractsAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -215,7 +215,7 @@ func TestRuntimeCheckCyclicImportsAfterUpdate(t *testing.T) {
 
 func TestRuntimeCheckCyclicImportAddress(t *testing.T) {
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contractsAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -326,7 +326,7 @@ func TestRuntimeCheckCyclicImportAddress(t *testing.T) {
 
 func TestRuntimeCheckCyclicImportToSelfDuringDeploy(t *testing.T) {
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contractsAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -415,7 +415,7 @@ func TestRuntimeContractImport(t *testing.T) {
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
 	}
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contract := []byte(`
         access(all) contract Foo {

--- a/runtime/imported_values_memory_metering_test.go
+++ b/runtime/imported_values_memory_metering_test.go
@@ -46,7 +46,7 @@ func TestRuntimeImportedValueMemoryMetering(t *testing.T) {
 
 	executeScript := func(t *testing.T, script []byte, meter map[common.MemoryKind]uint64, args ...cadence.Value) {
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			OnMeterMemory: testUseMemory(meter),
@@ -524,7 +524,7 @@ func TestRuntimeImportedValueMemoryMeteringForSimpleTypes(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runtime := NewTestInterpreterRuntime()
+			runtime := NewTestRuntime()
 
 			meter := make(map[common.MemoryKind]uint64)
 			runtimeInterface := &TestRuntimeInterface{
@@ -596,7 +596,7 @@ func TestRuntimeScriptDecodedLocationMetering(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
 
-			runtime := NewTestInterpreterRuntime()
+			runtime := NewTestRuntime()
 
 			meter := make(map[common.MemoryKind]uint64)
 			runtimeInterface := &TestRuntimeInterface{

--- a/runtime/inbox_test.go
+++ b/runtime/inbox_test.go
@@ -37,7 +37,7 @@ func TestRuntimeAccountInboxPublishUnpublish(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -127,7 +127,7 @@ func TestRuntimeAccountInboxUnpublishWrongType(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -207,7 +207,7 @@ func TestRuntimeAccountInboxUnpublishAbsent(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -297,7 +297,7 @@ func TestRuntimeAccountInboxUnpublishRemove(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -410,7 +410,7 @@ func TestRuntimeAccountInboxUnpublishWrongAccount(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -542,7 +542,7 @@ func TestRuntimeAccountInboxPublishClaim(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -652,7 +652,7 @@ func TestRuntimeAccountInboxPublishClaimWrongType(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -754,7 +754,7 @@ func TestRuntimeAccountInboxPublishClaimWrongName(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -857,7 +857,7 @@ func TestRuntimeAccountInboxPublishClaimRemove(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string
@@ -985,7 +985,7 @@ func TestRuntimeAccountInboxPublishClaimWrongAccount(t *testing.T) {
 	t.Parallel()
 
 	storage := NewTestLedger(nil, nil)
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var logs []string
 	var events []string

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -58,7 +58,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 		checkScript func(result cadence.Value, err error),
 	) {
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		deploy := DeploymentTransaction(contractName, []byte(contract))
 
@@ -285,7 +285,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
           }
 	    `)
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: NewTestLedger(nil, nil),
@@ -357,7 +357,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
           }
 	    `)
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: NewTestLedger(nil, nil),
@@ -429,7 +429,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
           }
 	    `)
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: NewTestLedger(nil, nil),
@@ -506,7 +506,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
           }
 	    `)
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: NewTestLedger(nil, nil),
@@ -586,7 +586,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
           }
 	    `)
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: NewTestLedger(nil, nil),
@@ -687,7 +687,7 @@ func TestRuntimePredeclaredTypeWithInjectedFunctions(t *testing.T) {
       }
 	`)
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	runtimeInterface := &TestRuntimeInterface{
 		Storage: NewTestLedger(nil, nil),

--- a/runtime/program_params_validation_test.go
+++ b/runtime/program_params_validation_test.go
@@ -82,7 +82,7 @@ func TestRuntimeScriptParameterTypeValidation(t *testing.T) {
 		encodedArg, err = json.Encode(arg)
 		require.NoError(t, err)
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		storage := NewTestLedger(nil, nil)
 
@@ -700,7 +700,7 @@ func TestRuntimeTransactionParameterTypeValidation(t *testing.T) {
 		encodedArg, err = json.Encode(arg)
 		require.NoError(t, err)
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		storage := NewTestLedger(nil, nil)
 

--- a/runtime/resource_duplicate_test.go
+++ b/runtime/resource_duplicate_test.go
@@ -37,7 +37,7 @@ func TestRuntimeResourceDuplicationWithContractTransferInTransaction(t *testing.
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	accountCodes := map[common.Location][]byte{}
 
@@ -205,7 +205,7 @@ func TestRuntimeResourceDuplicationWithContractTransferInSameContract(t *testing
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	accountCodes := map[common.Location][]byte{}
 

--- a/runtime/resourcedictionary_test.go
+++ b/runtime/resourcedictionary_test.go
@@ -87,7 +87,7 @@ func TestRuntimeResourceDictionaryValues(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
@@ -385,7 +385,7 @@ func TestRuntimeResourceDictionaryValues_Nested(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
@@ -582,7 +582,7 @@ func TestRuntimeResourceDictionaryValues_DictionaryTransfer(t *testing.T) {
 	signer1 := common.MustBytesToAddress([]byte{0x1})
 	signer2 := common.MustBytesToAddress([]byte{0x2})
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contract := []byte(`
      access(all) contract Test {
@@ -749,7 +749,7 @@ func TestRuntimeResourceDictionaryValues_Removal(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contract := []byte(resourceDictionaryContract)
 
@@ -878,7 +878,7 @@ func TestRuntimeResourceDictionaryValues_Destruction(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contract := []byte(resourceDictionaryContract)
 
@@ -991,7 +991,7 @@ func TestRuntimeResourceDictionaryValues_Insertion(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contract := []byte(resourceDictionaryContract)
 
@@ -1132,7 +1132,7 @@ func TestRuntimeResourceDictionaryValues_ValueTransferAndDestroy(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contract := []byte(resourceDictionaryContract)
 
@@ -1314,7 +1314,7 @@ func TestRuntimeResourceDictionaryValues_ValueTransferAndDestroy(t *testing.T) {
 
 func BenchmarkRuntimeResourceDictionaryValues(b *testing.B) {
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 

--- a/runtime/rlp_test.go
+++ b/runtime/rlp_test.go
@@ -36,7 +36,7 @@ func TestRuntimeRLPDecodeString(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
 
@@ -176,7 +176,7 @@ func TestRuntimeRLPDecodeList(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
 

--- a/runtime/runtime_memory_metering_test.go
+++ b/runtime/runtime_memory_metering_test.go
@@ -81,7 +81,7 @@ func TestRuntimeInterpreterAddressLocationMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -129,7 +129,7 @@ func TestRuntimeInterpreterElaborationImportMetering(t *testing.T) {
 				script = importExpressions[j] + script
 			}
 
-			runtime := NewTestInterpreterRuntime()
+			runtime := NewTestRuntime()
 
 			meter := newTestMemoryGauge()
 
@@ -220,7 +220,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -254,7 +254,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		largeBigInt := &big.Int{}
 		largeBigInt.Exp(big.NewInt(2<<33), big.NewInt(6), nil)
@@ -293,7 +293,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -327,7 +327,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -361,7 +361,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -395,7 +395,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -429,7 +429,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -463,7 +463,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -499,7 +499,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -533,7 +533,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -562,7 +562,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -591,7 +591,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -620,7 +620,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -649,7 +649,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -678,7 +678,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -707,7 +707,7 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -759,7 +759,7 @@ func TestRuntimeLogFunctionStringConversionMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -821,7 +821,7 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -859,7 +859,7 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 			OnMeterMemory: meter.MeterMemory,
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -913,7 +913,7 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 			},
 		}
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		err := runtime.ExecuteTransaction(
 			Script{
@@ -938,7 +938,7 @@ func TestRuntimeMemoryMeteringErrors(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	type memoryMeter map[common.MemoryKind]uint64
 
@@ -1050,7 +1050,7 @@ func TestRuntimeMeterEncoding(t *testing.T) {
 
 		config := DefaultTestInterpreterConfig
 		config.AtreeValidationEnabled = false
-		rt := NewTestInterpreterRuntimeWithConfig(config)
+		rt := NewTestRuntimeWithConfig(config)
 
 		address := common.MustBytesToAddress([]byte{0x1})
 		storage := NewTestLedger(nil, nil)
@@ -1099,7 +1099,7 @@ func TestRuntimeMeterEncoding(t *testing.T) {
 
 		config := DefaultTestInterpreterConfig
 		config.AtreeValidationEnabled = false
-		rt := NewTestInterpreterRuntimeWithConfig(config)
+		rt := NewTestRuntimeWithConfig(config)
 
 		address := common.MustBytesToAddress([]byte{0x1})
 		storage := NewTestLedger(nil, nil)
@@ -1153,7 +1153,7 @@ func TestRuntimeMeterEncoding(t *testing.T) {
 
 		config := DefaultTestInterpreterConfig
 		config.AtreeValidationEnabled = false
-		rt := NewTestInterpreterRuntimeWithConfig(config)
+		rt := NewTestRuntimeWithConfig(config)
 
 		address := common.MustBytesToAddress([]byte{0x1})
 		storage := NewTestLedger(nil, nil)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -51,11 +51,45 @@ import (
 
 var compile = flag.Bool("compile", false, "Run tests using the compiler")
 
+func TestRuntimeExecuteScript(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := NewTestRuntime()
+
+	script := []byte(`
+      import "imported"
+
+      access(all) fun main(): Int {
+          let answer = 42
+          return answer
+        }
+    `)
+
+	runtimeInterface := &TestRuntimeInterface{}
+
+	nextScriptLocation := NewScriptLocationGenerator()
+
+	value, err := runtime.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextScriptLocation(),
+			UseVM:     *compile,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, cadence.NewInt(42), value)
+}
+
 func TestRuntimeImport(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	importedScript := []byte(`
       access(all) fun answer(): Int {
@@ -103,6 +137,7 @@ func TestRuntimeImport(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -116,7 +151,7 @@ func TestRuntimeConcurrentImport(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	importedScript := []byte(`
       access(all) fun answer(): Int {
@@ -195,6 +230,7 @@ func TestRuntimeConcurrentImport(t *testing.T) {
 				Context{
 					Interface: runtimeInterface,
 					Location:  location,
+					UseVM:     *compile,
 				},
 			)
 			require.NoError(t, err)
@@ -229,7 +265,7 @@ func TestRuntimeProgramSetAndGet(t *testing.T) {
 	importedScriptLocation := common.StringLocation("imported")
 	scriptLocation := common.StringLocation("placeholder")
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 	runtimeInterface := &TestRuntimeInterface{
 		OnGetOrLoadProgram: func(
 			location Location,
@@ -350,7 +386,7 @@ func TestRuntimeInvalidTransactionArgumentAccount(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
       transaction {
@@ -384,7 +420,7 @@ func TestRuntimeTransactionWithAccount(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
       transaction {
@@ -716,7 +752,7 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 
 		t.Run(tc.label, func(t *testing.T) {
 			t.Parallel()
-			rt := NewTestInterpreterRuntime()
+			rt := NewTestRuntime()
 
 			var loggedMessages []string
 
@@ -1096,7 +1132,7 @@ func TestRuntimeScriptArguments(t *testing.T) {
 
 			t.Parallel()
 
-			rt := NewTestInterpreterRuntime()
+			rt := NewTestRuntime()
 
 			var loggedMessages []string
 
@@ -1120,6 +1156,7 @@ func TestRuntimeScriptArguments(t *testing.T) {
 				Context{
 					Interface: runtimeInterface,
 					Location:  common.ScriptLocation{},
+					UseVM:     *compile,
 				},
 			)
 
@@ -1141,7 +1178,7 @@ func TestRuntimeProgramWithNoTransaction(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
       access(all) fun main() {}
@@ -1169,7 +1206,7 @@ func TestRuntimeProgramWithMultipleTransaction(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
       transaction {
@@ -1261,7 +1298,7 @@ func TestRuntimeStorage(t *testing.T) {
 
 	for name, code := range tests {
 		t.Run(name, func(t *testing.T) {
-			runtime := NewTestInterpreterRuntime()
+			runtime := NewTestRuntime()
 
 			imported := []byte(`
               access(all) resource R {}
@@ -1327,7 +1364,7 @@ func TestRuntimeStorageMultipleTransactionsResourceWithArray(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	container := []byte(`
       access(all) resource Container {
@@ -1457,7 +1494,7 @@ func TestRuntimeStorageMultipleTransactionsResourceFunction(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	deepThought := []byte(`
       access(all) resource DeepThought {
@@ -1549,7 +1586,7 @@ func TestRuntimeStorageMultipleTransactionsResourceField(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	imported := []byte(`
       access(all) resource SomeNumber {
@@ -1641,7 +1678,7 @@ func TestRuntimeCompositeFunctionInvocationFromImportingProgram(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	imported := []byte(`
       // function must have arguments
@@ -1725,7 +1762,7 @@ func TestRuntimeStorageMultipleTransactionsInclusiveRangeFunction(t *testing.T) 
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	inclusiveRangeCreation := []byte(`
       access(all) fun createInclusiveRange(): InclusiveRange<Int> {
@@ -1788,7 +1825,7 @@ func TestRuntimeResourceContractUseThroughReference(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	imported := []byte(`
       access(all) resource R {
@@ -1876,7 +1913,7 @@ func TestRuntimeResourceContractUseThroughLink(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	imported := []byte(`
       access(all) resource R {
@@ -1971,7 +2008,7 @@ func TestRuntimeResourceContractWithInterface(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	imported1 := []byte(`
       access(all) resource interface RI {
@@ -2081,7 +2118,7 @@ func TestRuntimeParseAndCheckProgram(t *testing.T) {
 	t.Parallel()
 
 	t.Run("ValidProgram", func(t *testing.T) {
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte("access(all) fun test(): Int { return 42 }")
 		runtimeInterface := &TestRuntimeInterface{}
@@ -2099,7 +2136,7 @@ func TestRuntimeParseAndCheckProgram(t *testing.T) {
 	})
 
 	t.Run("InvalidSyntax", func(t *testing.T) {
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte("invalid syntax")
 		runtimeInterface := &TestRuntimeInterface{}
@@ -2117,7 +2154,7 @@ func TestRuntimeParseAndCheckProgram(t *testing.T) {
 	})
 
 	t.Run("InvalidSemantics", func(t *testing.T) {
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`access(all) let a: Int = "b"`)
 		runtimeInterface := &TestRuntimeInterface{}
@@ -2147,7 +2184,7 @@ func TestRuntimeScriptReturnSpecial(t *testing.T) {
 
 	test := func(t *testing.T, test testCase) {
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		storage := NewTestLedger(nil, nil)
 
@@ -2165,6 +2202,7 @@ func TestRuntimeScriptReturnSpecial(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  common.ScriptLocation{},
+				UseVM:     *compile,
 			},
 		)
 
@@ -2308,7 +2346,7 @@ func TestRuntimeScriptParameterTypeNotImportableError(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
       access(all) fun main(x: fun(): Int) {
@@ -2329,6 +2367,7 @@ func TestRuntimeScriptParameterTypeNotImportableError(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  common.ScriptLocation{},
+			UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)
@@ -2341,7 +2380,7 @@ func TestRuntimeSyntaxError(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
       access(all) fun main(): String {
@@ -2364,6 +2403,7 @@ func TestRuntimeSyntaxError(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)
@@ -2374,7 +2414,7 @@ func TestRuntimeStorageChanges(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	imported := []byte(`
       access(all) resource X {
@@ -2469,7 +2509,7 @@ func TestRuntimeAccountAddress(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
       transaction {
@@ -2512,7 +2552,7 @@ func TestRuntimePublicAccountAddress(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
       transaction {
@@ -2560,7 +2600,7 @@ func TestRuntimeAccountPublishAndAccess(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	imported := []byte(`
       access(all) resource R {
@@ -2660,7 +2700,7 @@ func TestRuntimeTransaction_CreateAccount(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
       transaction {
@@ -2722,7 +2762,7 @@ func TestRuntimeContractAccount(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
@@ -2812,6 +2852,7 @@ func TestRuntimeContractAccount(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -2827,6 +2868,7 @@ func TestRuntimeContractAccount(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -2843,7 +2885,7 @@ func TestRuntimeInvokeContractFunction(t *testing.T) {
 	}
 
 	newRuntime := func(testing *testing.T) (Runtime, Interface, func() []string, func() common.TransactionLocation) {
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		contract := []byte(`
             access(all) contract Test {
@@ -3249,7 +3291,7 @@ func TestRuntimeContractNestedResource(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -3345,7 +3387,7 @@ func TestRuntimeStorageLoadedDestructionConcreteType(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -3448,7 +3490,7 @@ func TestRuntimeStorageLoadedDestructionConcreteTypeWithAttachment(t *testing.T)
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -3578,7 +3620,7 @@ func TestRuntimeStorageLoadedDestructionConcreteTypeWithAttachmentUnloadedContra
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -3712,7 +3754,7 @@ func TestRuntimeStorageLoadedDestructionConcreteTypeSameNamedInterface(t *testin
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -3865,7 +3907,7 @@ func TestRuntimeStorageLoadedDestructionAnyResource(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -3959,7 +4001,7 @@ func TestRuntimeStorageLoadedDestructionAfterRemoval(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -4172,7 +4214,7 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	address1Value := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -4291,7 +4333,7 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	address1Value := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -4420,7 +4462,7 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	makeDeployToNewAccountTransaction := func(name, code string) []byte {
 		return []byte(fmt.Sprintf(
@@ -4607,7 +4649,7 @@ func TestRuntimeBlock(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
       transaction {
@@ -4707,7 +4749,7 @@ func TestRuntimeRandom(t *testing.T) {
 	) (cadence.Value, error) {
 
 		nextScriptLocation := NewScriptLocationGenerator()
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		if moduloArgument != "" {
 			// example "modulo: UInt8(77)"
@@ -4779,7 +4821,7 @@ func TestRuntimeRandom(t *testing.T) {
 				},
 			}
 
-			runtime := NewTestInterpreterRuntime()
+			runtime := NewTestRuntime()
 
 			nextTransactionLocation := NewTransactionLocationGenerator()
 			err := runtime.ExecuteTransaction(
@@ -4915,7 +4957,7 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 	t.Parallel()
 
 	t.Run("transaction with function", func(t *testing.T) {
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
           access(all) fun test() {}
@@ -4944,7 +4986,7 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 	})
 
 	t.Run("transaction with resource", func(t *testing.T) {
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
           access(all) resource R {}
@@ -4986,7 +5028,7 @@ func TestRuntimeStoreIntegerTypes(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := interpreter.AddressValue{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xCA, 0xDE,
@@ -5062,7 +5104,7 @@ func TestRuntimeResourceOwnerFieldUseComposite(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	address := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -5257,7 +5299,7 @@ func TestRuntimeResourceOwnerFieldUseArray(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	address := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -5431,7 +5473,7 @@ func TestRuntimeResourceOwnerFieldUseDictionary(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	address := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -5605,7 +5647,7 @@ func TestRuntimeMetrics(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	imported1Location := common.StringLocation("imported1")
 
@@ -5778,7 +5820,7 @@ func TestRuntimeContractWriteback(t *testing.T) {
 
 	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contract := []byte(`
       access(all) contract Test {
@@ -5948,7 +5990,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 
 	addressValue := cadence.BytesToAddress([]byte{0xCA, 0xDE})
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contract := []byte(`
       access(all) contract Test {
@@ -6178,7 +6220,7 @@ func TestRuntimeExternalError(t *testing.T) {
 
 	t.Parallel()
 
-	interpreterRuntime := NewTestInterpreterRuntime()
+	interpreterRuntime := NewTestRuntime()
 
 	script := []byte(`
       transaction {
@@ -6218,7 +6260,7 @@ func TestRuntimeExternalNonError(t *testing.T) {
 
 	t.Parallel()
 
-	interpreterRuntime := NewTestInterpreterRuntime()
+	interpreterRuntime := NewTestRuntime()
 
 	script := []byte(`
       transaction {
@@ -6299,7 +6341,7 @@ func TestRuntimeDeployCodeCaching(t *testing.T) {
 
 	deployTx := DeploymentTransaction("HelloWorld", []byte(helloWorldContract))
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	accountCodes := map[common.Location][]byte{}
 	var events []cadence.Event
@@ -6433,7 +6475,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 	deployTx := DeploymentTransaction("HelloWorld", []byte(helloWorldContract1))
 	updateTx := UpdateTransaction("HelloWorld", []byte(helloWorldContract2))
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	accountCodes := map[common.Location][]byte{}
 	var events []cadence.Event
@@ -6528,6 +6570,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -6574,6 +6617,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -6643,7 +6687,7 @@ func TestRuntimeProgramsHitForToplevelPrograms(t *testing.T) {
 
 	deployTx := DeploymentTransaction("HelloWorld", []byte(helloWorldContract))
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	accountCodes := map[common.Location][]byte{}
 	var events []cadence.Event
@@ -6782,7 +6826,7 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	const contract1 = `
       access(all) contract Test {
@@ -6937,6 +6981,7 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -6998,6 +7043,7 @@ func TestRuntimeTransaction_ContractUpdate(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -7007,7 +7053,7 @@ func TestRuntimeExecuteScriptArguments(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
       access(all) fun main(num: Int) {}
@@ -7042,6 +7088,7 @@ func TestRuntimeExecuteScriptArguments(t *testing.T) {
 				Context{
 					Interface: runtimeInterface,
 					Location:  common.ScriptLocation{0x1},
+					UseVM:     *compile,
 				},
 			)
 
@@ -7087,7 +7134,7 @@ func TestRuntimePanics(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
       access(all) fun main() {
@@ -7113,6 +7160,7 @@ func TestRuntimePanics(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)
@@ -7126,7 +7174,7 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
 	t.Run("store auth account reference", func(t *testing.T) {
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
           access(all) fun main() {
@@ -7155,7 +7203,7 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
           access(all) fun main() {
@@ -7189,7 +7237,7 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
           access(all) fun main() {
@@ -7224,7 +7272,7 @@ func TestRuntimeStackOverflow(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	const contract = `
 
@@ -7308,7 +7356,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
           }
         `)
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			OnProgramLog: func(message string) {
@@ -7343,7 +7391,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
           }
         `)
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			OnProgramLog: func(message string) {
@@ -7359,6 +7407,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  common.ScriptLocation{},
+				UseVM:     *compile,
 			},
 		)
 
@@ -7380,7 +7429,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
           }
         `)
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			OnProgramLog: func(message string) {
@@ -7425,7 +7474,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 
 		storage := NewTestLedger(nil, nil)
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: storage,
@@ -7491,7 +7540,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 
 		script := []byte("access(all) fun test() {}")
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			OnGetOrLoadProgram: func(_ Location, _ func() (*Program, error)) (*Program, error) {
@@ -7518,7 +7567,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: TestLedger{
@@ -7551,7 +7600,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: TestLedger{
@@ -7586,7 +7635,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 
 		script := []byte(`access(all) fun main() {}`)
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			OnMeterMemory: func(usage common.MemoryUsage) error {
@@ -7602,6 +7651,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  common.ScriptLocation{},
+				UseVM:     *compile,
 			},
 		)
 
@@ -7693,7 +7743,7 @@ func TestRuntimeComputationMetring(t *testing.T) {
 				),
 			)
 
-			runtime := NewTestInterpreterRuntime()
+			runtime := NewTestRuntime()
 
 			var hits uint
 			var totalIntensity uint64
@@ -7750,7 +7800,7 @@ func TestRuntimeImportAnyStruct(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var loggedMessages []string
 
@@ -7842,9 +7892,10 @@ func BenchmarkRuntimeScriptNoop(b *testing.B) {
 		Interface:   runtimeInterface,
 		Location:    common.ScriptLocation{},
 		Environment: environment,
+		UseVM:       *compile,
 	}
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -7858,7 +7909,7 @@ func TestRuntimeImportTestStdlib(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	runtimeInterface := &TestRuntimeInterface{}
 
@@ -7891,7 +7942,7 @@ func TestRuntimeGetCurrentBlockScript(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	runtimeInterface := &TestRuntimeInterface{}
 
@@ -7919,7 +7970,7 @@ func TestRuntimeTypeMismatchErrorMessage(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	address1 := common.MustBytesToAddress([]byte{0x1})
 	address2 := common.MustBytesToAddress([]byte{0x2})
@@ -8035,7 +8086,7 @@ func TestRuntimeErrorExcerpts(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	script := []byte(`
     access(all) fun main(): Int {
@@ -8066,6 +8117,7 @@ func TestRuntimeErrorExcerpts(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  common.ScriptLocation{},
+			UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)
@@ -8089,7 +8141,7 @@ func TestRuntimeErrorExcerptsMultiline(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	script := []byte(`
     access(all) fun main(): String {
@@ -8121,6 +8173,7 @@ func TestRuntimeErrorExcerptsMultiline(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  common.ScriptLocation{},
+			UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)
@@ -8146,7 +8199,7 @@ func TestRuntimeAccountTypeEquality(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	script := []byte(`
       access(all) fun main(address: Address): AnyStruct {
@@ -8204,7 +8257,7 @@ func TestRuntimeFlowEventTypes(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	script := []byte(`
       access(all) fun main(): Type? {
@@ -8246,7 +8299,7 @@ func TestRuntimeInvalidatedResourceUse(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -8433,7 +8486,7 @@ func TestRuntimeInvalidatedResourceUse2(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -8605,7 +8658,7 @@ func TestRuntimeOptionalReferenceAttack(t *testing.T) {
       }
     `
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	accountCodes := map[common.Location][]byte{}
 
@@ -8651,6 +8704,7 @@ func TestRuntimeOptionalReferenceAttack(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  common.ScriptLocation{},
+			UseVM:     *compile,
 		},
 	)
 
@@ -8668,7 +8722,7 @@ func TestRuntimeReturnDestroyedOptional(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script := []byte(`
       access(all) resource Foo {}
@@ -8700,6 +8754,7 @@ func TestRuntimeReturnDestroyedOptional(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  common.ScriptLocation{},
+			UseVM:     *compile,
 		},
 	)
 
@@ -8723,7 +8778,7 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	t.Run("regular error returned", func(t *testing.T) {
 		t.Parallel()
@@ -8750,6 +8805,7 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  common.ScriptLocation{},
+				UseVM:     *compile,
 			},
 		)
 
@@ -8785,6 +8841,7 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  common.ScriptLocation{},
+				UseVM:     *compile,
 			},
 		)
 
@@ -8937,7 +8994,7 @@ func TestRuntimeWrappedErrorHandling(t *testing.T) {
         }
     `)
 
-	runtime := NewTestInterpreterRuntimeWithConfig(Config{
+	runtime := NewTestRuntimeWithConfig(Config{
 		AtreeValidationEnabled: false,
 	})
 
@@ -9034,7 +9091,7 @@ func TestRuntimeWrappedErrorHandling(t *testing.T) {
 
 func BenchmarkRuntimeResourceTracking(b *testing.B) {
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contractsAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -9219,7 +9276,7 @@ func TestRuntimeEventEmission(t *testing.T) {
 	t.Run("primitive", func(t *testing.T) {
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
           access(all)
@@ -9252,6 +9309,7 @@ func TestRuntimeEventEmission(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  location,
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -9278,7 +9336,7 @@ func TestRuntimeEventEmission(t *testing.T) {
 	t.Run("reference", func(t *testing.T) {
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
           access(all)
@@ -9311,6 +9369,7 @@ func TestRuntimeEventEmission(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  location,
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -9339,7 +9398,7 @@ func TestRuntimeInvalidWrappedPrivateCapability(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntimeWithConfig(Config{
+	runtime := NewTestRuntimeWithConfig(Config{
 		AtreeValidationEnabled: false,
 	})
 
@@ -9470,7 +9529,7 @@ func TestRuntimeNestedResourceMoveInDestructor(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -9580,7 +9639,7 @@ func TestRuntimeNestedResourceMoveWithSecondTransferInDestructor(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -9692,7 +9751,7 @@ func TestRuntimeNestedResourceMoveInTransaction(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -9785,7 +9844,7 @@ func TestRuntimePreconditionDuplication(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -9989,7 +10048,7 @@ func TestRuntimeStorageReferenceStaticTypeSpoofing(t *testing.T) {
 	t.Run("force cast", func(t *testing.T) {
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -10142,7 +10201,7 @@ func TestRuntimeStorageReferenceStaticTypeSpoofing(t *testing.T) {
 	t.Run("optional cast", func(t *testing.T) {
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -10297,7 +10356,7 @@ func TestRuntimeIfLetElseBranchConfusion(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -10401,7 +10460,7 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	signerAccount := common.MustBytesToAddress([]byte{0x1})
 
@@ -10574,7 +10633,7 @@ func TestRuntimeValueTransferResourceLoss(t *testing.T) {
         }
     `)
 
-	runtime := NewTestInterpreterRuntimeWithConfig(Config{
+	runtime := NewTestRuntimeWithConfig(Config{
 		AtreeValidationEnabled: false,
 	})
 
@@ -10694,7 +10753,7 @@ func TestRuntimeNonPublicAccessModifierInInterface(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	address1 := common.MustBytesToAddress([]byte{0x1})
 	address2 := common.MustBytesToAddress([]byte{0x2})
@@ -10827,7 +10886,7 @@ func TestRuntimeContractWithInvalidCapability(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
@@ -10907,6 +10966,7 @@ func TestRuntimeContractWithInvalidCapability(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  common.ScriptLocation{},
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -10929,7 +10989,7 @@ func TestRuntimeAccountStorageBorrowEphemeralReferenceValue(t *testing.T) {
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
 	}
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contract := []byte(`
         access(all) contract C {
@@ -10993,7 +11053,7 @@ func TestRuntimeForbidPublicEntitlementBorrow(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script1 := []byte(`
       transaction {
@@ -11082,7 +11142,7 @@ func TestRuntimeForbidPublicEntitlementGet(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	script1 := []byte(`
       transaction {
@@ -11171,7 +11231,7 @@ func TestRuntimeForbidPublicEntitlementPublish(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	t.Run("entitled capability", func(t *testing.T) {
 
@@ -11352,7 +11412,7 @@ func TestRuntimeStorageEnumAsDictionaryKey(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
@@ -11512,7 +11572,7 @@ func TestResultRedeclared(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
           access(all) fun main(): Int {
@@ -11541,7 +11601,7 @@ func TestResultRedeclared(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
           access(all)
@@ -11649,7 +11709,7 @@ func TestRuntimeIdentifierLocationToAddressLocationRewrite(t *testing.T) {
 		},
 	}
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	nextTransactionLocation := NewTransactionLocationGenerator()
 	nextScriptLocation := NewScriptLocationGenerator()
@@ -11685,6 +11745,7 @@ func TestRuntimeIdentifierLocationToAddressLocationRewrite(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -11738,7 +11799,7 @@ func TestRuntimeBuiltInFunctionConfusion(t *testing.T) {
 		}
 	}
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
@@ -11762,7 +11823,7 @@ func TestRuntimeBuiltInFunctionConfusion(t *testing.T) {
 
 func BenchmarkContractFunctionInvocation(b *testing.B) {
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := cadence.BytesToAddress([]byte{0x1})
 
@@ -11861,6 +11922,7 @@ func BenchmarkContractFunctionInvocation(b *testing.B) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(b, err)
@@ -11883,7 +11945,7 @@ func TestRuntimeInvocationReturnTypeInferenceFailure(t *testing.T) {
 		}
 	}
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
@@ -11934,7 +11996,7 @@ func TestRuntimeSomeValueChildContainerMutation(t *testing.T) {
 		runTransaction func(tx []byte) (logs []string),
 	) {
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		accountCodes := map[Location][]byte{}
 
@@ -12237,7 +12299,7 @@ func TestRuntimeSomeValueChildContainerMutation(t *testing.T) {
 func TestRuntimeClosureScopingFunctionExpression(t *testing.T) {
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	script := `
         access(all) fun main(a: Int): Int {
@@ -12249,29 +12311,30 @@ func TestRuntimeClosureScopingFunctionExpression(t *testing.T) {
         }
     `
 
+	runtimeInterface := &TestRuntimeInterface{
+		OnDecodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
+			return json.Decode(nil, b)
+		},
+	}
 	actual, err := rt.ExecuteScript(
 		Script{
 			Source:    []byte(script),
 			Arguments: encodeArgs([]cadence.Value{cadence.NewInt(1)}),
 		},
 		Context{
-			Interface: &TestRuntimeInterface{
-				OnDecodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
-					return json.Decode(nil, b)
-				},
-			},
-			Location: common.ScriptLocation{},
+			Interface: runtimeInterface,
+			Location:  common.ScriptLocation{},
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
 	require.Equal(t, cadence.NewInt(1), actual)
-
 }
 
 func TestRuntimeClosureScopingInnerFunction(t *testing.T) {
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	script := `
         access(all) fun main(a: Int): Int {
@@ -12295,6 +12358,7 @@ func TestRuntimeClosureScopingInnerFunction(t *testing.T) {
 				},
 			},
 			Location: common.ScriptLocation{},
+			UseVM:    *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -12328,7 +12392,7 @@ func TestRuntimeInterfaceConditionDeduplication(t *testing.T) {
         }
     `
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	var events []string
 
@@ -12344,6 +12408,7 @@ func TestRuntimeInterfaceConditionDeduplication(t *testing.T) {
 				},
 			},
 			Location: common.ScriptLocation{},
+			UseVM:    *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -12363,7 +12428,7 @@ func TestRuntimeFunctionTypeConfusion(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	imported := []byte(`
         access(all) resource interface Receiver {
@@ -12458,7 +12523,7 @@ func TestRuntimeInvokeContractFunctionImported(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	addressValue := Address{
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
@@ -12764,7 +12829,7 @@ func TestRuntimeStorageReferenceBoundFunctionConfusion(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	transaction := []byte(`
       transaction {
@@ -12833,7 +12898,7 @@ func TestRuntimeMetering(t *testing.T) {
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
 	}
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	contract := []byte(`
         access(all) contract Test {

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/bbq/vm"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
@@ -50,6 +51,7 @@ type scriptExecutor struct {
 	runtime Runtime
 	scriptExecutorPreparation
 	script Script
+	vm     *vm.VM
 }
 
 func newScriptExecutor(
@@ -118,16 +120,10 @@ func (executor *scriptExecutor) preprocess() (err error) {
 	environment := context.Environment
 	if environment == nil {
 		if context.UseVM {
-			return errors.NewUnexpectedError("cannot execute script with the VM")
+			environment = NewScriptVMEnvironment(config)
+		} else {
+			environment = NewScriptInterpreterEnvironment(config)
 		}
-		environment = NewScriptInterpreterEnvironment(config)
-	}
-
-	switch environment.(type) {
-	case *interpreterEnvironment:
-		break
-	default:
-		return errors.NewUnexpectedError("scripts can only be executed with the interpreter")
 	}
 
 	environment.Configure(
@@ -176,7 +172,17 @@ func (executor *scriptExecutor) preprocess() (err error) {
 		return newError(err, location, codesAndPrograms)
 	}
 
-	executor.interpret = executor.scriptExecutionFunction()
+	switch environment := environment.(type) {
+	case *interpreterEnvironment:
+		executor.interpret = executor.scriptExecutionFunction()
+
+	case *vmEnvironment:
+		compiledProgram := environment.compileProgram(program, location)
+		executor.vm = environment.newVM(location, compiledProgram.program)
+
+	default:
+		return errors.NewUnexpectedError("scripts can only be executed with the interpreter")
+	}
 
 	return nil
 }
@@ -200,17 +206,23 @@ func (executor *scriptExecutor) execute() (val cadence.Value, err error) {
 		codesAndPrograms,
 	)
 
+	var result cadence.Value
+
 	switch environment := environment.(type) {
 	case *interpreterEnvironment:
-		value, err := executor.executeWithInterpreter(environment)
-		if err != nil {
-			return nil, newError(err, executor.context.Location, codesAndPrograms)
-		}
-		return value, nil
+		result, err = executor.executeWithInterpreter(environment)
+
+	case *vmEnvironment:
+		result, err = executor.executeWithVM(environment)
 
 	default:
 		panic(errors.NewUnexpectedError("unsupported environment: %T", environment))
 	}
+
+	if err != nil {
+		return nil, newError(err, executor.context.Location, codesAndPrograms)
+	}
+	return result, nil
 }
 
 func (executor *scriptExecutor) executeWithInterpreter(
@@ -248,6 +260,59 @@ func (executor *scriptExecutor) executeWithInterpreter(
 	}
 
 	return result, nil
+}
+
+func (executor *scriptExecutor) executeWithVM(
+	environment *vmEnvironment,
+) (val cadence.Value, err error) {
+
+	context := executor.vm.Context()
+	codesAndPrograms := executor.codesAndPrograms
+
+	// Recover internal panics and return them as an error.
+	// For example, the argument validation might attempt to
+	// load contract code for non-existing types
+
+	defer Recover(
+		func(internalErr Error) {
+			err = internalErr
+		},
+		executor.context.Location,
+		codesAndPrograms,
+	)
+
+	values, err := importValidatedArguments(
+		context,
+		executor.environment,
+		interpreter.EmptyLocationRange,
+		executor.script.Arguments,
+		executor.functionEntryPointType.Parameters,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	value, err := executor.vm.InvokeExternally(
+		sema.FunctionEntryPointName,
+		values...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Write back all stored values, which were actually just cached, back into storage
+	err = environment.commitStorage(context)
+	if err != nil {
+		return nil, err
+	}
+
+	var exportedValue cadence.Value
+	exportedValue, err = ExportValue(value, context, interpreter.EmptyLocationRange)
+	if err != nil {
+		return nil, err
+	}
+
+	return exportedValue, nil
 }
 
 func (executor *scriptExecutor) scriptExecutionFunction() interpretFunc {

--- a/runtime/sharedstate_test.go
+++ b/runtime/sharedstate_test.go
@@ -39,7 +39,7 @@ func TestRuntimeSharedState(t *testing.T) {
 
 	config := DefaultTestInterpreterConfig
 	config.AtreeValidationEnabled = false
-	runtime := NewTestInterpreterRuntimeWithConfig(config)
+	runtime := NewTestRuntimeWithConfig(config)
 
 	deploy1 := DeploymentTransaction("C1", []byte(`
         access(all) contract C1 {

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -154,7 +154,7 @@ func TestRuntimeStorageWrite(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
@@ -222,7 +222,7 @@ func TestRuntimeAccountStorage(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	script := []byte(`
       transaction {
@@ -281,7 +281,7 @@ func TestRuntimePublicCapabilityBorrowTypeConfusion(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	addressString, err := hex.DecodeString("aad3e26e406987c2")
 	require.NoError(t, err)
@@ -402,7 +402,7 @@ func TestRuntimeStorageReadAndBorrow(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	storage := NewTestLedger(nil, nil)
 
@@ -527,7 +527,7 @@ func TestRuntimeTopShotContractDeployment(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	testAddress, err := common.HexToAddress("0x0b2a3299cc857e29")
 	require.NoError(t, err)
@@ -616,7 +616,7 @@ func TestRuntimeTopShotBatchTransfer(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	nftAddress, err := common.HexToAddress("0x1d7e57aa55817448")
 	require.NoError(t, err)
@@ -806,7 +806,7 @@ func TestRuntimeBatchMintAndTransfer(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	const contract = `
       access(all) contract Test {
@@ -1055,7 +1055,7 @@ func TestRuntimeStoragePublishAndUnpublish(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	storage := NewTestLedger(nil, nil)
 
@@ -1145,7 +1145,7 @@ func TestRuntimeStorageSaveCapability(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	storage := NewTestLedger(nil, nil)
 
@@ -1231,7 +1231,7 @@ func TestRuntimeStorageReferenceCast(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	signerAddress := common.MustBytesToAddress([]byte{0x42})
 
@@ -1327,7 +1327,7 @@ func TestRuntimeStorageReferenceDowncast(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	signerAddress := common.MustBytesToAddress([]byte{0x42})
 
@@ -1425,7 +1425,7 @@ func TestRuntimeStorageNonStorable(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
@@ -1487,7 +1487,7 @@ func TestRuntimeStorageRecursiveReference(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
@@ -1528,7 +1528,7 @@ func TestRuntimeStorageTransfer(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	address1 := common.MustBytesToAddress([]byte{0x1})
 	address2 := common.MustBytesToAddress([]byte{0x2})
@@ -1618,7 +1618,7 @@ func TestRuntimeResourceOwnerChange(t *testing.T) {
 
 	config := DefaultTestInterpreterConfig
 	config.ResourceOwnerChangeHandlerEnabled = true
-	rt := NewTestInterpreterRuntimeWithConfig(config)
+	rt := NewTestRuntimeWithConfig(config)
 
 	address1 := common.MustBytesToAddress([]byte{0x1})
 	address2 := common.MustBytesToAddress([]byte{0x2})
@@ -1834,7 +1834,7 @@ func TestRuntimeStorageUsed(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	ledger := NewTestLedger(nil, nil)
 
@@ -2048,7 +2048,7 @@ transaction {
 }
 `
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	testAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -2177,7 +2177,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
           }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		accountCodes := map[Location][]byte{}
 
@@ -2305,7 +2305,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
           }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		testAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -2435,7 +2435,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
           }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		testAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -2558,7 +2558,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
           }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		testAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -2680,7 +2680,7 @@ func TestRuntimeReferenceOwnerAccess(t *testing.T) {
           }
         `
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		testAddress := common.MustBytesToAddress([]byte{0x1})
 
@@ -2770,7 +2770,7 @@ func TestRuntimeNoAtreeSendOnClosedChannelDuringCommit(t *testing.T) {
 
 		for i := 0; i < 1000; i++ {
 
-			rt := NewTestInterpreterRuntime()
+			rt := NewTestRuntime()
 
 			address := common.MustBytesToAddress([]byte{0x1})
 
@@ -2815,7 +2815,7 @@ func TestRuntimeStorageEnumCase(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
@@ -2974,7 +2974,7 @@ func TestRuntimeStorageReadNoImplicitWrite(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	address, err := common.HexToAddress("0x1")
 	require.NoError(t, err)
@@ -3011,7 +3011,7 @@ func TestRuntimeStorageInternalAccess(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
@@ -3155,7 +3155,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 		address := common.MustBytesToAddress([]byte{0x1})
 		accountCodes := map[common.Location][]byte{}
 		ledger := NewTestLedger(nil, nil)
@@ -3283,7 +3283,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 		address := common.MustBytesToAddress([]byte{0x1})
 		accountCodes := map[common.Location][]byte{}
 		ledger := NewTestLedger(nil, nil)
@@ -3416,7 +3416,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 		address := common.MustBytesToAddress([]byte{0x1})
 		accountCodes := map[common.Location][]byte{}
 		ledger := NewTestLedger(nil, nil)
@@ -3548,7 +3548,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 		address := common.MustBytesToAddress([]byte{0x1})
 		accountCodes := map[common.Location][]byte{}
 		ledger := NewTestLedger(nil, nil)
@@ -3693,7 +3693,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 		address := common.MustBytesToAddress([]byte{0x1})
 		accountCodes := map[common.Location][]byte{}
 		ledger := NewTestLedger(nil, nil)
@@ -3889,7 +3889,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 		address := common.MustBytesToAddress([]byte{0x1})
 		accountCodes := map[common.Location][]byte{}
 		ledger := NewTestLedger(nil, nil)
@@ -4095,7 +4095,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 
 		test := func(brokenType bool, t *testing.T) {
 
-			rt := NewTestInterpreterRuntime()
+			rt := NewTestRuntime()
 			address := common.MustBytesToAddress([]byte{0x1})
 			accountCodes := map[common.Location][]byte{}
 			ledger := NewTestLedger(nil, nil)
@@ -4274,7 +4274,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 	t.Run("box and convert arguments, forEachStored", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: NewTestLedger(nil, nil),
@@ -4320,7 +4320,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 	t.Run("box and convert arguments, forEachPublic", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: NewTestLedger(nil, nil),
@@ -4374,8 +4374,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
-	newRuntime := func() (TestInterpreterRuntime, *TestRuntimeInterface) {
-		rt := NewTestInterpreterRuntime()
+	newRuntime := func() (TestRuntime, *TestRuntimeInterface) {
+		rt := NewTestRuntime()
 		accountCodes := map[common.Location][]byte{}
 
 		runtimeInterface := &TestRuntimeInterface{
@@ -5125,8 +5125,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
-	newRuntime := func() (TestInterpreterRuntime, *TestRuntimeInterface) {
-		rt := NewTestInterpreterRuntime()
+	newRuntime := func() (TestRuntime, *TestRuntimeInterface) {
+		rt := NewTestRuntime()
 		accountCodes := map[common.Location][]byte{}
 
 		runtimeInterface := &TestRuntimeInterface{
@@ -5707,8 +5707,8 @@ func TestRuntimeTypeOrderInsignificance(t *testing.T) {
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
-	newRuntime := func() (TestInterpreterRuntime, *TestRuntimeInterface) {
-		rt := NewTestInterpreterRuntime()
+	newRuntime := func() (TestRuntime, *TestRuntimeInterface) {
+		rt := NewTestRuntime()
 		accountCodes := map[common.Location][]byte{}
 
 		runtimeInterface := &TestRuntimeInterface{
@@ -5883,7 +5883,7 @@ func TestRuntimeStorageReferenceBoundFunction(t *testing.T) {
 
 	t.Run("resource", func(t *testing.T) {
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		signerAddress := common.MustBytesToAddress([]byte{0x42})
 
@@ -5983,7 +5983,7 @@ func TestRuntimeStorageReferenceBoundFunction(t *testing.T) {
 	t.Run("struct", func(t *testing.T) {
 		t.Parallel()
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		tx := []byte(`
             transaction {
@@ -6035,7 +6035,7 @@ func TestRuntimeStorageReferenceBoundFunction(t *testing.T) {
 
 	t.Run("replace resource", func(t *testing.T) {
 
-		rt := NewTestInterpreterRuntime()
+		rt := NewTestRuntime()
 
 		signerAddress := common.MustBytesToAddress([]byte{0x42})
 
@@ -6150,7 +6150,7 @@ func TestRuntimeStorageReferenceAccess(t *testing.T) {
 
 	t.Parallel()
 
-	rt := NewTestInterpreterRuntime()
+	rt := NewTestRuntime()
 
 	address := common.MustBytesToAddress([]byte{0x1})
 

--- a/runtime/type_test.go
+++ b/runtime/type_test.go
@@ -34,7 +34,7 @@ func TestRuntimeTypeStorage(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestInterpreterRuntime()
+	runtime := NewTestRuntime()
 
 	tx1 := []byte(`
       transaction {
@@ -102,7 +102,7 @@ func TestRuntimeBlockFieldTypes(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
             transaction {
@@ -162,7 +162,7 @@ func TestRuntimeBlockFieldTypes(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
             access(all) fun main(): [UFix64] {

--- a/runtime/validation_test.go
+++ b/runtime/validation_test.go
@@ -44,7 +44,7 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
           transaction(value: AnyStruct) {}
@@ -91,7 +91,7 @@ func TestRuntimeArgumentImportMissingType(t *testing.T) {
 
 		t.Parallel()
 
-		runtime := NewTestInterpreterRuntime()
+		runtime := NewTestRuntime()
 
 		script := []byte(`
           access(all) fun main(value: AnyStruct) {}

--- a/test_utils/runtime_utils/testruntime.go
+++ b/test_utils/runtime_utils/testruntime.go
@@ -24,14 +24,14 @@ import (
 	"github.com/onflow/cadence/runtime"
 )
 
-type TestInterpreterRuntime struct {
+type TestRuntime struct {
 	runtime.Runtime
 }
 
-var _ runtime.Runtime = TestInterpreterRuntime{}
+var _ runtime.Runtime = TestRuntime{}
 
-func NewTestInterpreterRuntimeWithConfig(config runtime.Config) TestInterpreterRuntime {
-	return TestInterpreterRuntime{
+func NewTestRuntimeWithConfig(config runtime.Config) TestRuntime {
+	return TestRuntime{
 		Runtime: runtime.NewRuntime(config),
 	}
 }
@@ -40,17 +40,17 @@ var DefaultTestInterpreterConfig = runtime.Config{
 	AtreeValidationEnabled: true,
 }
 
-func NewTestInterpreterRuntime() TestInterpreterRuntime {
-	return NewTestInterpreterRuntimeWithConfig(DefaultTestInterpreterConfig)
+func NewTestRuntime() TestRuntime {
+	return NewTestRuntimeWithConfig(DefaultTestInterpreterConfig)
 }
 
-func (r TestInterpreterRuntime) ExecuteTransaction(script runtime.Script, context runtime.Context) error {
+func (r TestRuntime) ExecuteTransaction(script runtime.Script, context runtime.Context) error {
 	i := context.Interface.(*TestRuntimeInterface)
 	i.onTransactionExecutionStart()
 	return r.Runtime.ExecuteTransaction(script, context)
 }
 
-func (r TestInterpreterRuntime) ExecuteScript(script runtime.Script, context runtime.Context) (cadence.Value, error) {
+func (r TestRuntime) ExecuteScript(script runtime.Script, context runtime.Context) (cadence.Value, error) {
 	i := context.Interface.(*TestRuntimeInterface)
 	i.onScriptExecutionStart()
 	value, err := r.Runtime.ExecuteScript(script, context)


### PR DESCRIPTION
Work towards #3993 

## Description

- Enable VM support in script executor
- Enable script execution with VM for most runtime tests
- Rename test runtime, it is no longer limited to using the interpreter

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
