### PR TITLE
[Compiler] Enable execution of transactions with VM

### DIFF
--- a/runtime/resourcedictionary_test.go
+++ b/runtime/resourcedictionary_test.go
@@ -1336,7 +1336,7 @@ func BenchmarkRuntimeResourceDictionaryValues(b *testing.B) {
 
      transaction {
 
-         prepare(signer: &Account) {
+         prepare(signer: auth(Storage) &Account) {
              let data: @{Int: Test.R} <- {}
              var i = 0
              while i < 1000 {
@@ -1403,7 +1403,7 @@ func BenchmarkRuntimeResourceDictionaryValues(b *testing.B) {
 
      transaction {
 
-         prepare(signer: &Account) {
+         prepare(signer: auth(Storage) &Account) {
              let ref = signer.storage.borrow<&{Int: Test.R}>(from: /storage/data)!
              assert(ref[50] != nil)
         }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -2260,13 +2260,15 @@ func TestRuntimeScriptReturnSpecial(t *testing.T) {
 			},
 		}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		actual, err := runtime.ExecuteScript(
 			Script{
 				Source: []byte(test.code),
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
 				UseVM:     *compile,
 			},
 		)
@@ -2425,13 +2427,15 @@ func TestRuntimeScriptParameterTypeNotImportableError(t *testing.T) {
 		},
 	}
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	_, err := runtime.ExecuteScript(
 		Script{
 			Source: script,
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
 			UseVM:     *compile,
 		},
 	)
@@ -7179,6 +7183,8 @@ func TestRuntimeExecuteScriptArguments(t *testing.T) {
 				},
 			}
 
+			nextScriptLocation := NewScriptLocationGenerator()
+
 			_, err := runtime.ExecuteScript(
 				Script{
 					Source:    script,
@@ -7186,7 +7192,7 @@ func TestRuntimeExecuteScriptArguments(t *testing.T) {
 				},
 				Context{
 					Interface: runtimeInterface,
-					Location:  common.ScriptLocation{0x1},
+					Location:  nextScriptLocation(),
 					UseVM:     *compile,
 				},
 			)
@@ -7285,13 +7291,15 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
 
 		runtimeInterface := &TestRuntimeInterface{}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
 			},
 		)
 
@@ -7314,13 +7322,15 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
 
 		runtimeInterface := &TestRuntimeInterface{}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
 			},
 		)
 
@@ -7350,13 +7360,15 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
 			Storage: NewTestLedger(nil, nil),
 		}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
 			},
 		)
 		require.NoError(t, err)
@@ -7465,13 +7477,15 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			},
 		}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
 			},
 		)
 
@@ -7499,13 +7513,15 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			},
 		}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
 				UseVM:     *compile,
 			},
 		)
@@ -7538,13 +7554,15 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			},
 		}
 
+		nextTransactionLocation := NewTransactionLocationGenerator()
+
 		err := runtime.ExecuteTransaction(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.TransactionLocation{},
+				Location:  nextTransactionLocation(),
 			},
 		)
 
@@ -7743,13 +7761,15 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			},
 		}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
 				UseVM:     *compile,
 			},
 		)
@@ -7920,6 +7940,8 @@ func TestRuntimeImportAnyStruct(t *testing.T) {
 		},
 	}
 
+	nextTransactionLocation := NewTransactionLocationGenerator()
+
 	err := rt.ExecuteTransaction(
 		Script{
 			Source: []byte(`
@@ -7933,7 +7955,8 @@ func TestRuntimeImportAnyStruct(t *testing.T) {
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.TransactionLocation{},
+			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -7987,12 +8010,7 @@ func BenchmarkRuntimeScriptNoop(b *testing.B) {
 
 	environment := NewScriptInterpreterEnvironment(Config{})
 
-	context := Context{
-		Interface:   runtimeInterface,
-		Location:    common.ScriptLocation{},
-		Environment: environment,
-		UseVM:       *compile,
-	}
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	runtime := NewTestRuntime()
 
@@ -8000,7 +8018,12 @@ func BenchmarkRuntimeScriptNoop(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = runtime.ExecuteScript(script, context)
+		_, _ = runtime.ExecuteScript(script, Context{
+			Interface:   runtimeInterface,
+			Location:    nextScriptLocation(),
+			Environment: environment,
+			UseVM:       *compile,
+		})
 	}
 }
 
@@ -8011,6 +8034,8 @@ func TestRuntimeImportTestStdlib(t *testing.T) {
 	rt := NewTestRuntime()
 
 	runtimeInterface := &TestRuntimeInterface{}
+
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	_, err := rt.ExecuteScript(
 		Script{
@@ -8024,7 +8049,7 @@ func TestRuntimeImportTestStdlib(t *testing.T) {
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
 		},
 	)
 
@@ -8045,6 +8070,8 @@ func TestRuntimeGetCurrentBlockScript(t *testing.T) {
 
 	runtimeInterface := &TestRuntimeInterface{}
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	_, err := rt.ExecuteScript(
 		Script{
 			Source: []byte(`
@@ -8055,7 +8082,7 @@ func TestRuntimeGetCurrentBlockScript(t *testing.T) {
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
 		},
 	)
 
@@ -8210,13 +8237,15 @@ func TestRuntimeErrorExcerpts(t *testing.T) {
 		Storage:                      NewTestLedger(nil, nil),
 	}
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	_, err := rt.ExecuteScript(
 		Script{
 			Source: script,
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
 			UseVM:     *compile,
 		},
 	)
@@ -8224,7 +8253,7 @@ func TestRuntimeErrorExcerpts(t *testing.T) {
 
 	errorString := `Execution failed:
 error: unexpectedly found nil while forcing an Optional value
-  --> 0000000000000000000000000000000000000000000000000000000000000000:9:15
+  --> 0100000000000000000000000000000000000000000000000000000000000000:9:15
    |
  9 |         return a
 10 |             .firstIndex(of: 5)!
@@ -8266,13 +8295,15 @@ func TestRuntimeErrorExcerptsMultiline(t *testing.T) {
 		Storage:                      NewTestLedger(nil, nil),
 	}
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	_, err := rt.ExecuteScript(
 		Script{
 			Source: script,
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
 			UseVM:     *compile,
 		},
 	)
@@ -8280,7 +8311,7 @@ func TestRuntimeErrorExcerptsMultiline(t *testing.T) {
 
 	errorString := `Execution failed:
 error: unexpectedly found nil while forcing an Optional value
-  --> 0000000000000000000000000000000000000000000000000000000000000000:9:15
+  --> 0100000000000000000000000000000000000000000000000000000000000000:9:15
    |
  9 |         return a
 10 |             .firstIndex(of: 5)
@@ -8325,6 +8356,8 @@ func TestRuntimeAccountTypeEquality(t *testing.T) {
 		},
 	}
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	result, err := rt.ExecuteScript(
 		Script{
 			Source: script,
@@ -8334,7 +8367,7 @@ func TestRuntimeAccountTypeEquality(t *testing.T) {
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
 		},
 	)
 	require.NoError(t, err)
@@ -8369,13 +8402,15 @@ func TestRuntimeFlowEventTypes(t *testing.T) {
 		Storage: NewTestLedger(nil, nil),
 	}
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	result, err := rt.ExecuteScript(
 		Script{
 			Source: script,
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
 		},
 	)
 	require.NoError(t, err)
@@ -8796,6 +8831,8 @@ func TestRuntimeOptionalReferenceAttack(t *testing.T) {
 		},
 	}
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	_, err := runtime.ExecuteScript(
 		Script{
 			Source:    []byte(script),
@@ -8803,7 +8840,7 @@ func TestRuntimeOptionalReferenceAttack(t *testing.T) {
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
 			UseVM:     *compile,
 		},
 	)
@@ -8845,6 +8882,8 @@ func TestRuntimeReturnDestroyedOptional(t *testing.T) {
 		Storage: NewTestLedger(nil, nil),
 	}
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	// Test
 
 	_, err := runtime.ExecuteScript(
@@ -8853,7 +8892,7 @@ func TestRuntimeReturnDestroyedOptional(t *testing.T) {
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
 			UseVM:     *compile,
 		},
 	)
@@ -8898,13 +8937,15 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
 			},
 		}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
 				UseVM:     *compile,
 			},
 		)
@@ -8934,13 +8975,15 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
 			},
 		}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
 				UseVM:     *compile,
 			},
 		)
@@ -8973,13 +9016,15 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
 			},
 		}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
 			},
 		)
 
@@ -9020,13 +9065,15 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
 			},
 		}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		_, err := runtime.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
 			},
 		)
 
@@ -9275,6 +9322,7 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
 			Interface:   runtimeInterface,
 			Location:    nextTransactionLocation(),
 			Environment: environment,
+			UseVM:       *compile,
 		},
 	)
 	require.NoError(b, err)
@@ -11047,6 +11095,9 @@ func TestRuntimeContractWithInvalidCapability(t *testing.T) {
 		},
 	}
 
+	nextTransactionLocation := NewTransactionLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	// Deploy contract
 
 	err := runtime.ExecuteTransaction(
@@ -11055,7 +11106,7 @@ func TestRuntimeContractWithInvalidCapability(t *testing.T) {
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.TransactionLocation{},
+			Location:  nextTransactionLocation(),
 		},
 	)
 	require.NoError(t, err)
@@ -11068,7 +11119,7 @@ func TestRuntimeContractWithInvalidCapability(t *testing.T) {
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
 			UseVM:     *compile,
 		},
 	)
@@ -11987,6 +12038,7 @@ func BenchmarkContractFunctionInvocation(b *testing.B) {
 	}
 
 	nextTransactionLocation := NewTransactionLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -12027,7 +12079,7 @@ func BenchmarkContractFunctionInvocation(b *testing.B) {
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
+				Location:  nextScriptLocation(),
 				UseVM:     *compile,
 			},
 		)
@@ -12423,6 +12475,9 @@ func TestRuntimeClosureScopingFunctionExpression(t *testing.T) {
 			return json.Decode(nil, b)
 		},
 	}
+
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	actual, err := rt.ExecuteScript(
 		Script{
 			Source:    []byte(script),
@@ -12430,7 +12485,7 @@ func TestRuntimeClosureScopingFunctionExpression(t *testing.T) {
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
 			UseVM:     *compile,
 		},
 	)
@@ -12453,6 +12508,8 @@ func TestRuntimeClosureScopingInnerFunction(t *testing.T) {
         }
     `
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	actual, err := rt.ExecuteScript(
 		Script{
 			Source:    []byte(script),
@@ -12464,7 +12521,7 @@ func TestRuntimeClosureScopingInnerFunction(t *testing.T) {
 					return json.Decode(nil, b)
 				},
 			},
-			Location: common.ScriptLocation{},
+			Location: nextScriptLocation(),
 			UseVM:    *compile,
 		},
 	)
@@ -12503,19 +12560,23 @@ func TestRuntimeInterfaceConditionDeduplication(t *testing.T) {
 
 	var events []string
 
+	runtimeInterface := &TestRuntimeInterface{
+		OnEmitEvent: func(event cadence.Event) error {
+			events = append(events, event.FieldsMappedByName()["message"].String())
+			return nil
+		},
+	}
+
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	_, err := rt.ExecuteScript(
 		Script{
 			Source: []byte(script),
 		},
 		Context{
-			Interface: &TestRuntimeInterface{
-				OnEmitEvent: func(event cadence.Event) error {
-					events = append(events, event.FieldsMappedByName()["message"].String())
-					return nil
-				},
-			},
-			Location: common.ScriptLocation{},
-			UseVM:    *compile,
+			Interface: runtimeInterface,
+			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -58,8 +58,6 @@ func TestRuntimeExecuteScript(t *testing.T) {
 	runtime := NewTestRuntime()
 
 	script := []byte(`
-      import "imported"
-
       access(all) fun main(): Int {
           let answer = 42
           return answer
@@ -83,6 +81,53 @@ func TestRuntimeExecuteScript(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, cadence.NewInt(42), value)
+}
+
+func TestRuntimeExecuteTransaction(t *testing.T) {
+
+	t.Parallel()
+
+	runtime := NewTestRuntime()
+
+	script := []byte(`
+      transaction {
+		  prepare(signer: &Account) {
+              log(signer.address)
+          }
+          execute {}
+        }
+    `)
+
+	signer := common.MustBytesToAddress([]byte{0x42})
+
+	var messages []string
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetSigningAccounts: func() ([]Address, error) {
+			return []Address{signer}, nil
+		},
+		OnProgramLog: func(message string) {
+			messages = append(messages, message)
+		},
+	}
+
+	nextTransactionLocation := NewTransactionLocationGenerator()
+
+	err := runtime.ExecuteTransaction(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]string{"0x0000000000000042"},
+		messages,
+	)
 }
 
 func TestRuntimeImport(t *testing.T) {
@@ -410,6 +455,7 @@ func TestRuntimeInvalidTransactionArgumentAccount(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)
@@ -452,6 +498,7 @@ func TestRuntimeTransactionWithAccount(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1195,6 +1242,7 @@ func TestRuntimeProgramWithNoTransaction(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)
@@ -1228,6 +1276,7 @@ func TestRuntimeProgramWithMultipleTransaction(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)
@@ -1351,6 +1400,7 @@ func TestRuntimeStorage(t *testing.T) {
 				Context{
 					Interface: runtimeInterface,
 					Location:  nextTransactionLocation(),
+					UseVM:     *compile,
 				},
 			)
 			require.NoError(t, err)
@@ -1461,6 +1511,7 @@ func TestRuntimeStorageMultipleTransactionsResourceWithArray(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1472,6 +1523,7 @@ func TestRuntimeStorageMultipleTransactionsResourceWithArray(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1483,6 +1535,7 @@ func TestRuntimeStorageMultipleTransactionsResourceWithArray(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1562,6 +1615,7 @@ func TestRuntimeStorageMultipleTransactionsResourceFunction(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1573,6 +1627,7 @@ func TestRuntimeStorageMultipleTransactionsResourceFunction(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1653,6 +1708,7 @@ func TestRuntimeStorageMultipleTransactionsResourceField(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1664,6 +1720,7 @@ func TestRuntimeStorageMultipleTransactionsResourceField(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1742,6 +1799,7 @@ func TestRuntimeCompositeFunctionInvocationFromImportingProgram(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1753,6 +1811,7 @@ func TestRuntimeCompositeFunctionInvocationFromImportingProgram(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1891,6 +1950,7 @@ func TestRuntimeResourceContractUseThroughReference(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1902,6 +1962,7 @@ func TestRuntimeResourceContractUseThroughReference(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1986,6 +2047,7 @@ func TestRuntimeResourceContractUseThroughLink(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1997,6 +2059,7 @@ func TestRuntimeResourceContractUseThroughLink(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -2095,6 +2158,7 @@ func TestRuntimeResourceContractWithInterface(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -2106,6 +2170,7 @@ func TestRuntimeResourceContractWithInterface(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -2487,6 +2552,7 @@ func TestRuntimeStorageChanges(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -2498,6 +2564,7 @@ func TestRuntimeStorageChanges(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -2541,6 +2608,7 @@ func TestRuntimeAccountAddress(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -2584,6 +2652,7 @@ func TestRuntimePublicAccountAddress(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -2678,6 +2747,7 @@ func TestRuntimeAccountPublishAndAccess(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -2689,6 +2759,7 @@ func TestRuntimeAccountPublishAndAccess(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -3376,6 +3447,7 @@ func TestRuntimeContractNestedResource(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -4311,6 +4383,7 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -4324,6 +4397,7 @@ func TestRuntimeFungibleTokenUpdateAccountCode(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -4442,6 +4516,7 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -4453,6 +4528,7 @@ func TestRuntimeFungibleTokenCreateAccount(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -4980,6 +5056,7 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -5009,6 +5086,7 @@ func TestRuntimeTransactionTopLevelDeclarations(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
 			},
 		)
 		RequireError(t, err)
@@ -5248,6 +5326,7 @@ func TestRuntimeResourceOwnerFieldUseComposite(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -5269,6 +5348,7 @@ func TestRuntimeResourceOwnerFieldUseComposite(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -5430,6 +5510,7 @@ func TestRuntimeResourceOwnerFieldUseArray(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -5454,6 +5535,7 @@ func TestRuntimeResourceOwnerFieldUseArray(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -5604,6 +5686,7 @@ func TestRuntimeResourceOwnerFieldUseDictionary(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -5628,6 +5711,7 @@ func TestRuntimeResourceOwnerFieldUseDictionary(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -5744,6 +5828,7 @@ func TestRuntimeMetrics(t *testing.T) {
 		Context{
 			Interface: i1,
 			Location:  transactionLocation,
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -5762,12 +5847,14 @@ func TestRuntimeMetrics(t *testing.T) {
 		},
 		r1.programChecked,
 	)
-	assert.Equal(t,
-		map[common.Location]int{
-			transactionLocation: 1,
-		},
-		r1.programInterpreted,
-	)
+	if !*compile {
+		assert.Equal(t,
+			map[common.Location]int{
+				transactionLocation: 1,
+			},
+			r1.programInterpreted,
+		)
+	}
 
 	i2, r2 := newRuntimeInterface()
 
@@ -5780,6 +5867,7 @@ func TestRuntimeMetrics(t *testing.T) {
 		Context{
 			Interface: i2,
 			Location:  transactionLocation,
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -5798,12 +5886,14 @@ func TestRuntimeMetrics(t *testing.T) {
 		},
 		r2.programChecked,
 	)
-	assert.Equal(t,
-		map[common.Location]int{
-			transactionLocation: 1,
-		},
-		r2.programInterpreted,
-	)
+	if !*compile {
+		assert.Equal(t,
+			map[common.Location]int{
+				transactionLocation: 1,
+			},
+			r2.programInterpreted,
+		)
+	}
 }
 
 type ownerKeyPair struct {
@@ -5950,6 +6040,7 @@ func TestRuntimeContractWriteback(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -5965,6 +6056,7 @@ func TestRuntimeContractWriteback(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -6115,6 +6207,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -6163,6 +6256,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -6190,6 +6284,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -6248,6 +6343,7 @@ func TestRuntimeExternalError(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 
@@ -6290,6 +6386,7 @@ func TestRuntimeExternalNonError(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 
@@ -6419,6 +6516,7 @@ func TestRuntimeDeployCodeCaching(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -6636,6 +6734,7 @@ func TestRuntimeUpdateCodeCaching(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -8052,6 +8151,7 @@ func TestRuntimeTypeMismatchErrorMessage(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -9154,6 +9254,7 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
 			Interface:   runtimeInterface,
 			Location:    nextTransactionLocation(),
 			Environment: environment,
+			UseVM:       *compile,
 		},
 	)
 	require.NoError(b, err)
@@ -9205,6 +9306,7 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
 			Interface:   runtimeInterface,
 			Location:    nextTransactionLocation(),
 			Environment: environment,
+			UseVM:       *compile,
 		},
 	)
 	require.NoError(b, err)
@@ -9834,6 +9936,7 @@ func TestRuntimeNestedResourceMoveInTransaction(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 
@@ -11112,6 +11215,7 @@ func TestRuntimeForbidPublicEntitlementBorrow(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -11201,6 +11305,7 @@ func TestRuntimeForbidPublicEntitlementGet(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -11550,6 +11655,7 @@ func TestRuntimeStorageEnumAsDictionaryKey(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -11964,6 +12070,7 @@ func TestRuntimeInvocationReturnTypeInferenceFailure(t *testing.T) {
 		Context{
 			Interface: newRuntimeInterface(),
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)
@@ -12510,6 +12617,7 @@ func TestRuntimeFunctionTypeConfusion(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -9265,7 +9265,7 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
                 import Foo from 0x1
 
                 transaction {
-                    prepare(signer: &Account) {
+                    prepare(signer: auth(Storage) &Account) {
                         signer.storage.save(<- Foo.getResourceArray(), to: /storage/r)
                     }
                 }
@@ -9288,7 +9288,7 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
                 import Foo from 0x1
 
                 transaction {
-                    prepare(signer: &Account) {
+                    prepare(signer: auth(Storage) &Account) {
                         // When the array is loaded from storage, all elements are also loaded.
                         // So all moves of this resource will check for tracking of all elements aas well.
 
@@ -11934,21 +11934,21 @@ func BenchmarkContractFunctionInvocation(b *testing.B) {
 	addressValue := cadence.BytesToAddress([]byte{0x1})
 
 	contract := []byte(`
-      pub contract Test {
-          pub fun helloText(): String {
+      access(all) contract Test {
+          access(all) fun helloText(): String {
               return "global function of the imported program"
           }
 
           init() {}
 
-          pub struct Foo {
-              pub var id : String
+          access(all) struct Foo {
+              access(all) var id: String
 
               init(_ id: String) {
                   self.id = id
               }
 
-              pub fun sayHello(_ id: Int): String {
+              access(all) fun sayHello(_ id: Int): String {
                   // return self.id
                   return Test.helloText()
               }
@@ -12003,7 +12003,7 @@ func BenchmarkContractFunctionInvocation(b *testing.B) {
 	script := `      
       import Test from 0x01
 
-      pub fun main(count: Int): String {
+      access(all) fun main(count: Int): String {
           var i = 0
           var r = Test.Foo("Hello from Foo!")
           while i < count {

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -177,8 +177,12 @@ func (executor *scriptExecutor) preprocess() (err error) {
 		executor.interpret = executor.scriptExecutionFunction()
 
 	case *vmEnvironment:
-		compiledProgram := environment.compileProgram(program, location)
-		executor.vm = environment.newVM(location, compiledProgram.program)
+		var program *Program
+		program, err = environment.loadProgram(location)
+		if err != nil {
+			return newError(err, location, codesAndPrograms)
+		}
+		executor.vm = environment.newVM(location, program.compiledProgram.program)
 
 	default:
 		return errors.NewUnexpectedError("scripts can only be executed with the interpreter")

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/bbq/vm"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
@@ -49,6 +50,8 @@ type transactionExecutor struct {
 	runtime Runtime
 	script  Script
 	transactionExecutorPreparation
+	vm               *vm.VM
+	authorizerValues func(context interpreter.AccountCreationContext) []interpreter.Value
 }
 
 func newTransactionExecutor(
@@ -116,16 +119,10 @@ func (executor *transactionExecutor) preprocess() (err error) {
 	environment := context.Environment
 	if environment == nil {
 		if context.UseVM {
-			return errors.NewUnexpectedError("cannot execute transaction with the VM")
+			environment = NewBaseVMEnvironment(config)
+		} else {
+			environment = NewBaseInterpreterEnvironment(config)
 		}
-		environment = NewBaseInterpreterEnvironment(config)
-	}
-
-	switch environment.(type) {
-	case *interpreterEnvironment:
-		break
-	default:
-		return errors.NewUnexpectedError("transactions can only be executed with the interpreter")
 	}
 
 	environment.Configure(
@@ -188,18 +185,30 @@ func (executor *transactionExecutor) preprocess() (err error) {
 		return newError(err, location, codesAndPrograms)
 	}
 
-	// gather authorizers
+	executor.authorizerValues = func(context interpreter.AccountCreationContext) []interpreter.Value {
+		return authorizerValues(
+			executor.environment,
+			context,
+			authorizerAddresses,
+			prepareParameters,
+		)
+	}
 
-	executor.interpret = executor.transactionExecutionFunction(
-		func(inter *interpreter.Interpreter) []interpreter.Value {
-			return authorizerValues(
-				executor.environment,
-				inter,
-				authorizerAddresses,
-				prepareParameters,
-			)
-		},
-	)
+	switch environment := environment.(type) {
+	case *interpreterEnvironment:
+		executor.interpret = executor.transactionExecutionFunction()
+
+	case *vmEnvironment:
+		var program *Program
+		program, err = environment.loadProgram(location)
+		if err != nil {
+			return newError(err, location, codesAndPrograms)
+		}
+		executor.vm = environment.newVM(location, program.compiledProgram.program)
+
+	default:
+		return errors.NewUnexpectedError("transactions can only be executed with the interpreter")
+	}
 
 	return nil
 }
@@ -226,14 +235,17 @@ func (executor *transactionExecutor) execute() (err error) {
 	switch environment := environment.(type) {
 	case *interpreterEnvironment:
 		err = executor.executeWithInterpreter(environment)
-		if err != nil {
-			return newError(err, executor.context.Location, codesAndPrograms)
-		}
-		return nil
+
+	case *vmEnvironment:
+		err = executor.executeWithVM()
 
 	default:
 		panic(errors.NewUnexpectedError("unsupported environment: %T", environment))
 	}
+	if err != nil {
+		return newError(err, location, codesAndPrograms)
+	}
+	return nil
 }
 
 func (executor *transactionExecutor) executeWithInterpreter(
@@ -257,9 +269,53 @@ func (executor *transactionExecutor) executeWithInterpreter(
 	return nil
 }
 
-func (executor *transactionExecutor) transactionExecutionFunction(
-	authorizerValues func(*interpreter.Interpreter) []interpreter.Value,
-) interpretFunc {
+func (executor *transactionExecutor) executeWithVM() (err error) {
+
+	context := executor.vm.Context()
+	codesAndPrograms := executor.codesAndPrograms
+
+	// Recover internal panics and return them as an error.
+	// For example, the argument validation might attempt to
+	// load contract code for non-existing types
+
+	defer Recover(
+		func(internalErr Error) {
+			err = internalErr
+		},
+		executor.context.Location,
+		codesAndPrograms,
+	)
+
+	environment := executor.environment
+
+	arguments, err := importValidatedArguments(
+		context,
+		environment,
+		interpreter.EmptyLocationRange,
+		executor.script.Arguments,
+		executor.transactionType.Parameters,
+	)
+	if err != nil {
+		return err
+	}
+
+	signers := executor.authorizerValues(context)
+
+	err = executor.vm.InvokeTransaction(arguments, signers...)
+	if err != nil {
+		return err
+	}
+
+	// Write back all stored values, which were actually just cached, back into storage
+	err = environment.commitStorage(context)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (executor *transactionExecutor) transactionExecutionFunction() interpretFunc {
 	return func(inter *interpreter.Interpreter) (value interpreter.Value, err error) {
 
 		// Recover internal panics and return them as an error.
@@ -281,7 +337,7 @@ func (executor *transactionExecutor) transactionExecutionFunction(
 			return nil, err
 		}
 
-		signers := authorizerValues(inter)
+		signers := executor.authorizerValues(inter)
 
 		err = inter.InvokeTransaction(arguments, signers...)
 

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -301,7 +301,7 @@ func (e *vmEnvironment) loadElaboration(location common.Location) (*sema.Elabora
 }
 
 func (e *vmEnvironment) loadType(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
-	elaboration, err := e.loadElaboration(location)
+	program, err := e.loadProgram(location)
 	if err != nil {
 		panic(fmt.Errorf(
 			"cannot load type %s: failed to load elaboration for location %s: %w",
@@ -310,6 +310,8 @@ func (e *vmEnvironment) loadType(location common.Location, typeID interpreter.Ty
 			err,
 		))
 	}
+
+	elaboration := program.compiledProgram.desugaredElaboration
 
 	compositeType := elaboration.CompositeType(typeID)
 	if compositeType != nil {


### PR DESCRIPTION
Work towards #3993 

## Description

- Add support for VM environment in transaction executor
- Fix type loading in VM environment (use desugared elaboration, e.g. to allow lookup of transaction type)
- Cleanups: Fix outdated benchmarks, use location generators

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
