### PR TITLE
[Compiler] Implement storage and container mutation prevention

### DIFF
--- a/bbq/compiler/function.go
+++ b/bbq/compiler/function.go
@@ -28,17 +28,18 @@ import (
 )
 
 type function[E any] struct {
-	enclosing      *function[E]
-	name           string
-	qualifiedName  string
-	code           []E
-	locals         *activations.Activations[*local]
-	localCount     uint16
-	parameterCount uint16
-	upvalues       []opcode.Upvalue
-	upvalueIndices map[opcode.Upvalue]uint16
-	typeIndex      uint16
-	lineNumbers    bbq.LineNumberTable
+	enclosing                  *function[E]
+	name                       string
+	qualifiedName              string
+	code                       []E
+	locals                     *activations.Activations[*local]
+	localCount                 uint16
+	parameterCount             uint16
+	upvalues                   []opcode.Upvalue
+	upvalueIndices             map[opcode.Upvalue]uint16
+	typeIndex                  uint16
+	lineNumbers                bbq.LineNumberTable
+	activeIteratorLocalIndices []uint16
 }
 
 func newFunction[E any](

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -2300,7 +2300,7 @@ func (i InstructionIteratorHasNext) Encode(code *[]byte) {
 
 // InstructionIteratorNext
 //
-// Pops a value-iterator from stack, calls `next()` method on it, and push the result back onto the stack.
+// Pops a value-iterator from the stack, calls `next()` method on it, and push the result back onto the stack.
 type InstructionIteratorNext struct {
 }
 
@@ -2324,6 +2324,35 @@ func (i InstructionIteratorNext) ResolvedOperandsString(sb *strings.Builder,
 }
 
 func (i InstructionIteratorNext) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+}
+
+// InstructionIteratorEnd
+//
+// Pops a value-iterator from the stack end invalidates it. The iterator may no longer be used after this instruction.
+type InstructionIteratorEnd struct {
+}
+
+var _ Instruction = InstructionIteratorEnd{}
+
+func (InstructionIteratorEnd) Opcode() Opcode {
+	return IteratorEnd
+}
+
+func (i InstructionIteratorEnd) String() string {
+	return i.Opcode().String()
+}
+
+func (i InstructionIteratorEnd) OperandsString(sb *strings.Builder, colorize bool) {}
+
+func (i InstructionIteratorEnd) ResolvedOperandsString(sb *strings.Builder,
+	constants []constant.Constant,
+	types []interpreter.StaticType,
+	functionNames []string,
+	colorize bool) {
+}
+
+func (i InstructionIteratorEnd) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
 }
 
@@ -2564,6 +2593,8 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 		return InstructionIteratorHasNext{}
 	case IteratorNext:
 		return InstructionIteratorNext{}
+	case IteratorEnd:
+		return InstructionIteratorEnd{}
 	case EmitEvent:
 		return DecodeEmitEvent(ip, code)
 	case Loop:

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -846,7 +846,7 @@
 
 - name: "iteratorNext"
   description:
-    Pops a value-iterator from stack, calls `next()` method on it, and push the result back onto the stack.
+    Pops a value-iterator from the stack, calls `next()` method on it, and push the result back onto the stack.
   valueEffects:
     pop:
       - name: "iterator"
@@ -854,6 +854,15 @@
     push:
       - name: "next"
         type: "value"
+
+- name: "iteratorEnd"
+  description:
+    Pops a value-iterator from the stack end invalidates it.
+    The iterator may no longer be used after this instruction.
+  valueEffects:
+    pop:
+      - name: "iterator"
+        type: "iterator"
 
 # Other
 

--- a/bbq/opcode/opcode.go
+++ b/bbq/opcode/opcode.go
@@ -164,6 +164,7 @@ const (
 	Iterator
 	IteratorHasNext
 	IteratorNext
+	IteratorEnd
 
 	// Other
 

--- a/bbq/opcode/opcode_string.go
+++ b/bbq/opcode/opcode_string.go
@@ -71,10 +71,11 @@ func _() {
 	_ = x[Iterator-107]
 	_ = x[IteratorHasNext-108]
 	_ = x[IteratorNext-109]
-	_ = x[EmitEvent-110]
-	_ = x[Loop-111]
-	_ = x[Statement-112]
-	_ = x[OpcodeMax-113]
+	_ = x[IteratorEnd-110]
+	_ = x[EmitEvent-111]
+	_ = x[Loop-112]
+	_ = x[Statement-113]
+	_ = x[OpcodeMax-114]
 }
 
 const (
@@ -87,7 +88,7 @@ const (
 	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetUpvalueSetUpvalueGetGlobalSetGlobalGetFieldRemoveFieldSetFieldSetIndexGetIndexRemoveIndex"
 	_Opcode_name_7 = "InvokeInvokeMethodStaticInvokeMethodDynamic"
 	_Opcode_name_8 = "DropDup"
-	_Opcode_name_9 = "IteratorIteratorHasNextIteratorNextEmitEventLoopStatementOpcodeMax"
+	_Opcode_name_9 = "IteratorIteratorHasNextIteratorNextIteratorEndEmitEventLoopStatementOpcodeMax"
 )
 
 var (
@@ -100,7 +101,7 @@ var (
 	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 37, 47, 56, 65, 73, 84, 92, 100, 108, 119}
 	_Opcode_index_7 = [...]uint8{0, 6, 24, 43}
 	_Opcode_index_8 = [...]uint8{0, 4, 7}
-	_Opcode_index_9 = [...]uint8{0, 8, 23, 35, 44, 48, 57, 66}
+	_Opcode_index_9 = [...]uint8{0, 8, 23, 35, 46, 55, 59, 68, 77}
 )
 
 func (i Opcode) String() string {
@@ -131,7 +132,7 @@ func (i Opcode) String() string {
 	case 99 <= i && i <= 100:
 		i -= 99
 		return _Opcode_name_8[_Opcode_index_8[i]:_Opcode_index_8[i+1]]
-	case 107 <= i && i <= 113:
+	case 107 <= i && i <= 114:
 		i -= 107
 		return _Opcode_name_9[_Opcode_index_9[i]:_Opcode_index_9[i+1]]
 	default:

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -246,6 +246,7 @@ func TestPrintInstruction(t *testing.T) {
 		"Iterator":        {byte(Iterator)},
 		"IteratorHasNext": {byte(IteratorHasNext)},
 		"IteratorNext":    {byte(IteratorNext)},
+		"IteratorEnd":     {byte(IteratorEnd)},
 
 		"EmitEvent type:258 argCount:772": {byte(EmitEvent), 1, 2, 3, 4},
 		"Transfer":                        {byte(Transfer)},

--- a/interpreter/container_mutation_test.go
+++ b/interpreter/container_mutation_test.go
@@ -470,7 +470,7 @@ func TestInterpretArrayMutation(t *testing.T) {
 		baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
 		interpreter.Declare(baseActivation, valueDeclaration)
 
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
                 fun test() {
                     let array: [AnyStruct] = [nil] as [(fun():Void)?]
 
@@ -868,7 +868,7 @@ func TestInterpretDictionaryMutation(t *testing.T) {
 		baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
 		interpreter.Declare(baseActivation, valueDeclaration)
 
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
                fun test() {
                    let dict: {String: AnyStruct} = {} as {String: fun():Void}
 
@@ -978,7 +978,7 @@ func TestInterpretContainerMutationWhileIterating(t *testing.T) {
 	t.Run("array, append", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test(): [String] {
                 let array: [String] = ["foo", "bar"]
 
@@ -1005,7 +1005,7 @@ func TestInterpretContainerMutationWhileIterating(t *testing.T) {
 	t.Run("array, remove", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test() {
                 let array: [String] = ["foo", "bar", "baz"]
 
@@ -1027,7 +1027,7 @@ func TestInterpretContainerMutationWhileIterating(t *testing.T) {
 	t.Run("dictionary, add", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test(): {String: String} {
                 let dictionary: {String: String} = {"a": "foo", "b": "bar"}
 
@@ -1054,7 +1054,7 @@ func TestInterpretContainerMutationWhileIterating(t *testing.T) {
 	t.Run("dictionary, remove", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             fun test(): {String: String} {
                 let dictionary: {String: String} = {"a": "foo", "b": "bar", "c": "baz"}
 
@@ -1079,7 +1079,7 @@ func TestInterpretContainerMutationWhileIterating(t *testing.T) {
 	t.Run("resource dictionary, remove", func(t *testing.T) {
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             resource Foo {}
 
             fun test(): @{String: Foo} {

--- a/interpreter/errors.go
+++ b/interpreter/errors.go
@@ -1026,9 +1026,9 @@ type StorageMutatedDuringIterationError struct {
 var _ errors.UserError = &StorageMutatedDuringIterationError{}
 var _ HasLocationRange = &StorageMutatedDuringIterationError{}
 
-func (StorageMutatedDuringIterationError) IsUserError() {}
+func (*StorageMutatedDuringIterationError) IsUserError() {}
 
-func (StorageMutatedDuringIterationError) Error() string {
+func (*StorageMutatedDuringIterationError) Error() string {
 	return "storage iteration continued after modifying storage"
 }
 

--- a/interpreter/for_test.go
+++ b/interpreter/for_test.go
@@ -548,8 +548,7 @@ func TestInterpretEphemeralReferencesInForLoop(t *testing.T) {
 	t.Run("Mutating reference to resource array", func(t *testing.T) {
 		t.Parallel()
 
-		// TODO: Use compiler (need mutation-while-iterating validation)
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             resource Foo{
                 fun sayHello() {}
             }
@@ -582,8 +581,7 @@ func TestInterpretEphemeralReferencesInForLoop(t *testing.T) {
 	t.Run("Mutating reference to struct array", func(t *testing.T) {
 		t.Parallel()
 
-		// TODO: Use compiler (need mutation-while-iterating validation)
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             struct Foo{
                 fun sayHello() {}
             }

--- a/interpreter/inclusive_range_iterator.go
+++ b/interpreter/inclusive_range_iterator.go
@@ -19,6 +19,8 @@
 package interpreter
 
 import (
+	"github.com/onflow/atree"
+
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/sema"
@@ -87,4 +89,8 @@ func (i *InclusiveRangeIterator) Next(context ValueIteratorContext, locationRang
 func (i *InclusiveRangeIterator) HasNext() bool {
 	// TODO: Not implemented yet
 	panic(errors.NewUnreachableError())
+}
+
+func (*InclusiveRangeIterator) ValueID() (atree.ValueID, bool) {
+	return atree.ValueID{}, false
 }

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -120,8 +120,8 @@ type ValueTransferContext interface {
 		newOwner common.Address,
 	)
 
-	WithMutationPrevention(valueID atree.ValueID, f func())
-	ValidateMutation(valueID atree.ValueID, locationRange LocationRange)
+	WithContainerMutationPrevention(valueID atree.ValueID, f func())
+	ValidateContainerMutation(valueID atree.ValueID, locationRange LocationRange)
 
 	EnforceNotResourceDestruction(
 		valueID atree.ValueID,
@@ -537,11 +537,11 @@ func (ctx NoOpStringContext) MeterComputation(_ common.ComputationUsage) error {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) WithMutationPrevention(_ atree.ValueID, f func()) {
+func (ctx NoOpStringContext) WithContainerMutationPrevention(_ atree.ValueID, f func()) {
 	f()
 }
 
-func (ctx NoOpStringContext) ValidateMutation(_ atree.ValueID, _ LocationRange) {
+func (ctx NoOpStringContext) ValidateContainerMutation(_ atree.ValueID, _ LocationRange) {
 	panic(errors.NewUnreachableError())
 }
 

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -4366,11 +4366,9 @@ func AccountStorageIterate(
 	}
 	storageIterator := storageMap.Iterator(invocationContext)
 
-	inIteration := invocationContext.InStorageIteration()
+	wasInIteration := invocationContext.InStorageIteration()
 	invocationContext.SetInStorageIteration(true)
-	defer func() {
-		invocationContext.SetInStorageIteration(inIteration)
-	}()
+	defer invocationContext.SetInStorageIteration(wasInIteration)
 
 	for key, value := storageIterator.Next(); key != nil && value != nil; key, value = storageIterator.Next() {
 
@@ -5944,7 +5942,7 @@ func capabilityCheckFunction(
 	)
 }
 
-func (interpreter *Interpreter) ValidateMutation(valueID atree.ValueID, locationRange LocationRange) {
+func (interpreter *Interpreter) ValidateContainerMutation(valueID atree.ValueID, locationRange LocationRange) {
 	_, present := interpreter.SharedState.containerValueIteration[valueID]
 	if !present {
 		return
@@ -5954,7 +5952,7 @@ func (interpreter *Interpreter) ValidateMutation(valueID atree.ValueID, location
 	})
 }
 
-func (interpreter *Interpreter) WithMutationPrevention(valueID atree.ValueID, f func()) {
+func (interpreter *Interpreter) WithContainerMutationPrevention(valueID atree.ValueID, f func()) {
 	if interpreter == nil {
 		f()
 		return

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -260,6 +260,7 @@ type ValueIteratorContext interface {
 type ValueIterator interface {
 	HasNext() bool
 	Next(context ValueIteratorContext, locationRange LocationRange) Value
+	ValueID() (atree.ValueID, bool)
 }
 
 // atreeContainerBackedValue is an interface for values using atree containers

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -319,7 +319,7 @@ func (v *DictionaryValue) iterateKeys(
 		}
 	}
 
-	interpreter.WithMutationPrevention(v.ValueID(), iterate)
+	interpreter.WithContainerMutationPrevention(v.ValueID(), iterate)
 }
 
 func (v *DictionaryValue) IterateReadOnly(
@@ -396,7 +396,7 @@ func (v *DictionaryValue) iterate(
 		}
 	}
 
-	context.WithMutationPrevention(v.ValueID(), iterate)
+	context.WithContainerMutationPrevention(v.ValueID(), iterate)
 }
 
 type DictionaryKeyIterator struct {
@@ -587,7 +587,7 @@ func (v *DictionaryValue) ForEachKey(
 		}
 	}
 
-	context.WithMutationPrevention(v.ValueID(), iterate)
+	context.WithContainerMutationPrevention(v.ValueID(), iterate)
 }
 
 func (v *DictionaryValue) ContainsKey(
@@ -645,7 +645,7 @@ func (v *DictionaryValue) GetKey(context ValueComparisonContext, locationRange L
 }
 
 func (v *DictionaryValue) SetKey(context ContainerMutationContext, locationRange LocationRange, keyValue Value, value Value) {
-	context.ValidateMutation(v.ValueID(), locationRange)
+	context.ValidateContainerMutation(v.ValueID(), locationRange)
 
 	checkContainerMutation(context, v.Type.KeyType, keyValue, locationRange)
 	checkContainerMutation(
@@ -940,7 +940,7 @@ func (v *DictionaryValue) RemoveWithoutTransfer(
 	existingValueStorable atree.Storable,
 ) {
 
-	context.ValidateMutation(v.ValueID(), locationRange)
+	context.ValidateContainerMutation(v.ValueID(), locationRange)
 
 	valueComparator := newValueComparator(context, locationRange)
 	hashInputProvider := newHashInputProvider(context, locationRange)
@@ -1013,7 +1013,7 @@ func (v *DictionaryValue) InsertWithoutTransfer(
 	keyValue, value atree.Value,
 ) (existingValueStorable atree.Storable) {
 
-	context.ValidateMutation(v.ValueID(), locationRange)
+	context.ValidateContainerMutation(v.ValueID(), locationRange)
 
 	// length increases by 1
 	dataSlabs, metaDataSlabs := common.AdditionalAtreeMemoryUsage(v.dictionary.Count(), v.elementSize, false)

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -372,3 +372,7 @@ func (i *ReferenceValueIterator) Next(context ValueIteratorContext, locationRang
 func (i *ReferenceValueIterator) HasNext() bool {
 	return i.iterator.HasNext()
 }
+
+func (i *ReferenceValueIterator) ValueID() (atree.ValueID, bool) {
+	return i.iterator.ValueID()
+}

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -1146,6 +1146,10 @@ func (i *StringValueIterator) HasNext() bool {
 	return *i.hasNext
 }
 
+func (*StringValueIterator) ValueID() (atree.ValueID, bool) {
+	return atree.ValueID{}, false
+}
+
 func stringFunctionEncodeHex(invocation Invocation) Value {
 	argument, ok := invocation.Arguments[0].(*ArrayValue)
 	if !ok {

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -4408,17 +4408,17 @@ func TestRuntimeStorageIteration2(t *testing.T) {
           contract Test {
               access(all)
               fun saveStorage() {
-                  self.account.storage.save(0, to:/storage/foo)
+                  self.account.storage.save(0, to: /storage/foo)
               }
 
               access(all)
               fun saveOtherStorage() {
-                  self.account.storage.save(0, to:/storage/bar)
+                  self.account.storage.save(0, to: /storage/bar)
               }
 
               access(all)
               fun loadStorage() {
-                  self.account.storage.load<Int>(from:/storage/foo)
+                  self.account.storage.load<Int>(from: /storage/foo)
               }
 
               access(all)


### PR DESCRIPTION
Work towards #3993 

## Description

While iterating storage and containers, mutations of them are not allowed. 

Implement storage mutation prevention (`StorageMutationTracker` and `StorageIterationTracker`), and container mutation prevention (`WithContainerMutationPrevention` and `ValidateContainerMutation`) in `vm.Context`.

Container mutation prevention requires knowing the end of an iterator, so introduce a new `IteratorEnd` instruction, and ensure iterators are always ended, even on function return. Untracking the iterated value requires knowing it's value ID, so keep it in the iterator, if available (zero/no ID is OK for immutable values, like `String`s and `InclusiveRange`s)

Finally, enable the interpreter tests.

The tests for storage mutation prevention all rely on the `getAuthAccount` function which is not implemented yet. I've added enabling those tests as a TODO to #3804.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
