### PR TITLE
[Compiler] Meter computation for "entry point" function invocations in interpreter

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -512,6 +512,11 @@ func InvokeFunction(errorHandler ErrorHandler, function FunctionValue, invocatio
 		err = internalErr
 	})
 
+	common.UseComputation(
+		invocation.InvocationContext,
+		common.FunctionInvocationComputationUsage,
+	)
+
 	value = function.Invoke(invocation)
 	return
 }


### PR DESCRIPTION
Work towards #3993 

## Description

Align computation metering of function invocations. Just like the VM, all function invocations should be metered, even "entry point" ones (e.g. contract invocations).

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
