### PR TITLE
[Compiler] Improve scripts

### DIFF
--- a/bbq/commons/constants.go
+++ b/bbq/commons/constants.go
@@ -30,6 +30,7 @@ const (
 	AssertFunctionName              = "assert"
 	PanicFunctionName               = "panic"
 	GetAccountFunctionName          = "getAccount"
+	GetAuthAccountFunctionName      = "getAuthAccount"
 
 	GeneratedNameQualifier              = "$"
 	ResourceDestroyedEventsFunctionName = GeneratedNameQualifier + ast.ResourceDestructionDefaultEventName

--- a/bbq/compiler/builtin_globals.go
+++ b/bbq/compiler/builtin_globals.go
@@ -26,10 +26,17 @@ import (
 	"github.com/onflow/cadence/bbq/commons"
 )
 
-var nativeFunctions *activations.Activation[GlobalImport]
+var (
+	defaultBuiltinGlobals       = activations.NewActivation[GlobalImport](nil, nil)
+	defaultBuiltinScriptGlobals = activations.NewActivation[GlobalImport](nil, defaultBuiltinGlobals)
+)
 
-func NativeFunctions() *activations.Activation[GlobalImport] {
-	return nativeFunctions
+func DefaultBuiltinGlobals() *activations.Activation[GlobalImport] {
+	return defaultBuiltinGlobals
+}
+
+func DefaultBuiltinScriptGlobals() *activations.Activation[GlobalImport] {
+	return defaultBuiltinScriptGlobals
 }
 
 var stdlibFunctions = []string{
@@ -37,6 +44,9 @@ var stdlibFunctions = []string{
 	commons.AssertFunctionName,
 	commons.PanicFunctionName,
 	commons.GetAccountFunctionName,
+}
+
+var scriptStdlibFunctions = []string{
 }
 
 type builtinFunction struct {
@@ -73,33 +83,38 @@ func init() {
 
 	for _, constructor := range valueConstructorFunctions {
 		// Register the constructor. e.g: `String()`
-		addNativeFunction(constructor.name)
+		registerDefaultBuiltinGlobal(constructor.name)
 
 		// Register the members of the constructor/type. e.g: `String.join()`
 		registerBoundFunctions(constructor.typ)
 	}
 
 	for _, funcName := range stdlibFunctions {
-		addNativeFunction(funcName)
+		registerDefaultBuiltinGlobal(funcName)
 	}
 
 	// Type constructors
 	for _, typeConstructor := range sema.RuntimeTypeConstructors {
-		addNativeFunction(typeConstructor.Name)
+		registerDefaultBuiltinGlobal(typeConstructor.Name)
 	}
 
 	// Value conversion functions
 	for _, declaration := range interpreter.ConverterDeclarations {
-		addNativeFunction(declaration.Name)
+		registerDefaultBuiltinGlobal(declaration.Name)
 		declarationVariable := sema.BaseValueActivation.Find(declaration.Name)
 		registerBoundFunctions(declarationVariable.Type)
+	}
+
+	// Script globals
+	for _, funcName := range scriptStdlibFunctions {
+		registerDefaultBuiltinScriptGlobal(funcName)
 	}
 }
 
 func registerBoundFunctions(typ sema.Type) {
 	for name := range typ.GetMembers() { //nolint:maprange
 		funcName := commons.TypeQualifiedName(typ, name)
-		addNativeFunction(funcName)
+		registerDefaultBuiltinGlobal(funcName)
 	}
 
 	compositeType, ok := typ.(*sema.CompositeType)
@@ -110,12 +125,8 @@ func registerBoundFunctions(typ sema.Type) {
 	}
 }
 
-func addNativeFunction(name string) {
-	if nativeFunctions == nil {
-		nativeFunctions = activations.NewActivation[GlobalImport](nil, nil)
-	}
-
-	nativeFunctions.Set(
+func registerGlobalImport(name string, activation *activations.Activation[GlobalImport]) {
+	activation.Set(
 		name,
 		GlobalImport{
 			// This is a native function, so the location is nil.
@@ -123,4 +134,12 @@ func addNativeFunction(name string) {
 			Name:     name,
 		},
 	)
+}
+
+func registerDefaultBuiltinGlobal(name string) {
+	registerGlobalImport(name, defaultBuiltinGlobals)
+}
+
+func registerDefaultBuiltinScriptGlobal(name string) {
+	registerGlobalImport(name, defaultBuiltinScriptGlobals)
 }

--- a/bbq/compiler/builtin_globals.go
+++ b/bbq/compiler/builtin_globals.go
@@ -47,6 +47,7 @@ var stdlibFunctions = []string{
 }
 
 var scriptStdlibFunctions = []string{
+	commons.GetAuthAccountFunctionName,
 }
 
 type builtinFunction struct {

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -151,7 +151,7 @@ func newCompiler[E, T any](
 	if config.BuiltinGlobalsProvider != nil {
 		globalImports = config.BuiltinGlobalsProvider()
 	} else {
-		globalImports = NativeFunctions()
+		globalImports = DefaultBuiltinGlobals()
 	}
 	globalImports = activations.NewActivation[GlobalImport](config.MemoryGauge, globalImports)
 

--- a/bbq/vm/builtin_globals.go
+++ b/bbq/vm/builtin_globals.go
@@ -177,6 +177,32 @@ func init() {
 		),
 	)
 
+	RegisterBuiltinScriptFunction(
+		NewNativeFunctionValue(
+			commons.GetAuthAccountFunctionName,
+			stdlib.GetAuthAccountFunctionType,
+			func(context *Context, typeArguments []bbq.StaticType, arguments ...Value) Value {
+				accountAddress, ok := arguments[0].(interpreter.AddressValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				referenceType, ok := typeArguments[0].(*interpreter.ReferenceStaticType)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				return stdlib.NewAccountReferenceValue(
+					context,
+					context.AccountHandler,
+					accountAddress,
+					referenceType.Authorization,
+					EmptyLocationRange,
+				)
+			},
+		),
+	)
+
 	// Type constructors
 
 	RegisterBuiltinFunction(

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -384,7 +384,7 @@ func CompileAndInvoke(
 
 func NativeFunctionsWithLogAndPanic(logs *[]string) vm.BuiltinGlobalsProvider {
 	return func() *activations.Activation[*vm.Variable] {
-		baseActivation := vm.NativeFunctions()
+		baseActivation := vm.DefaultBuiltinGlobals()
 
 		activation := activations.NewActivation[*vm.Variable](nil, baseActivation)
 

--- a/bbq/vm/value_account.go
+++ b/bbq/vm/value_account.go
@@ -69,7 +69,7 @@ func init() {
 
 	// Methods on `Account.Contracts` value.
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountContractsTypeName,
 		NewNativeFunctionValue(
 			sema.Account_ContractsTypeAddFunctionName,

--- a/bbq/vm/value_account_capabilities.go
+++ b/bbq/vm/value_account_capabilities.go
@@ -33,7 +33,7 @@ func init() {
 	accountCapabilitiesTypeName := commons.TypeQualifier(sema.Account_CapabilitiesType)
 
 	// Account.Capabilities.get
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountCapabilitiesTypeName,
 		NewNativeFunctionValue(
 			sema.Account_CapabilitiesTypeGetFunctionName,
@@ -64,7 +64,7 @@ func init() {
 	)
 
 	// Account.Capabilities.borrow
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountCapabilitiesTypeName,
 		NewNativeFunctionValue(
 			sema.Account_CapabilitiesTypeBorrowFunctionName,
@@ -96,7 +96,7 @@ func init() {
 	)
 
 	// Account.Capabilities.publish
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountCapabilitiesTypeName,
 		NewNativeFunctionValue(
 			sema.Account_CapabilitiesTypePublishFunctionName,
@@ -133,7 +133,7 @@ func init() {
 	)
 
 	// Account.Capabilities.unpublish
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountCapabilitiesTypeName,
 		NewNativeFunctionValue(
 			sema.Account_CapabilitiesTypeUnpublishFunctionName,
@@ -160,7 +160,7 @@ func init() {
 	)
 
 	// Account.Capabilities.exist
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountCapabilitiesTypeName,
 		NewNativeFunctionValue(
 			sema.Account_CapabilitiesTypeExistsFunctionName,

--- a/bbq/vm/value_account_storage.go
+++ b/bbq/vm/value_account_storage.go
@@ -33,7 +33,7 @@ func init() {
 	accountStorageTypeName := commons.TypeQualifier(sema.Account_StorageType)
 
 	// Account.Storage.save
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeSaveFunctionName,
@@ -56,7 +56,7 @@ func init() {
 	)
 
 	// Account.Storage.borrow
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeBorrowFunctionName,
@@ -82,7 +82,7 @@ func init() {
 	)
 
 	// Account.Storage.forEachPublic
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeForEachPublicFunctionName,
@@ -107,7 +107,7 @@ func init() {
 	)
 
 	// Account.Storage.forEachStored
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeForEachStoredFunctionName,
@@ -132,7 +132,7 @@ func init() {
 	)
 
 	// Account.Storage.type
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeTypeFunctionName,
@@ -154,7 +154,7 @@ func init() {
 	)
 
 	// Account.Storage.load
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeLoadFunctionName,
@@ -181,7 +181,7 @@ func init() {
 	)
 
 	// Account.Storage.copy
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeCopyFunctionName,
@@ -208,7 +208,7 @@ func init() {
 	)
 
 	// Account.Storage.check
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeCheckFunctionName,

--- a/bbq/vm/value_account_storagecapabilities.go
+++ b/bbq/vm/value_account_storagecapabilities.go
@@ -33,7 +33,7 @@ func init() {
 	accountStorageCapabilitiesTypeName := commons.TypeQualifier(sema.Account_StorageCapabilitiesType)
 
 	// Account.StorageCapabilities.issue
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageCapabilitiesTypeIssueFunctionName,
@@ -62,7 +62,7 @@ func init() {
 	)
 
 	// Account.StorageCapabilities.issueWithType
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageCapabilitiesTypeIssueWithTypeFunctionName,
@@ -99,7 +99,7 @@ func init() {
 	)
 
 	// Account.StorageCapabilities.getController
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageCapabilitiesTypeGetControllerFunctionName,
@@ -126,7 +126,7 @@ func init() {
 	)
 
 	// Account.StorageCapabilities.getControllers
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageCapabilitiesTypeGetControllersFunctionName,
@@ -153,7 +153,7 @@ func init() {
 	)
 
 	// Account.StorageCapabilities.forEachController
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		accountStorageCapabilitiesTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageCapabilitiesTypeForEachControllerFunctionName,

--- a/bbq/vm/value_address.go
+++ b/bbq/vm/value_address.go
@@ -32,7 +32,7 @@ func init() {
 
 	typeName := commons.TypeQualifier(sema.TheAddressType)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.ToStringFunctionName,
@@ -48,7 +48,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.AddressTypeToBytesFunctionName,
@@ -61,7 +61,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.AddressTypeFromBytesFunctionName,
@@ -77,7 +77,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.AddressTypeFromStringFunctionName,

--- a/bbq/vm/value_array.go
+++ b/bbq/vm/value_array.go
@@ -35,7 +35,7 @@ func init() {
 		commons.TypeQualifierArrayVariableSized,
 		commons.TypeQualifierArrayConstantSized,
 	} {
-		RegisterTypeBoundFunction(
+		RegisterBuiltinTypeBoundFunction(
 			typeQualifier,
 			NewNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeFirstIndexFunctionName,
@@ -52,7 +52,7 @@ func init() {
 			),
 		)
 
-		RegisterTypeBoundFunction(
+		RegisterBuiltinTypeBoundFunction(
 			typeQualifier,
 			NewNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeContainsFunctionName,
@@ -69,7 +69,7 @@ func init() {
 			),
 		)
 
-		RegisterTypeBoundFunction(
+		RegisterBuiltinTypeBoundFunction(
 			typeQualifier,
 			NewNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeReverseFunctionName,
@@ -85,7 +85,7 @@ func init() {
 			),
 		)
 
-		RegisterTypeBoundFunction(
+		RegisterBuiltinTypeBoundFunction(
 			typeQualifier,
 			NewNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeFilterFunctionName,
@@ -102,7 +102,7 @@ func init() {
 			),
 		)
 
-		RegisterTypeBoundFunction(
+		RegisterBuiltinTypeBoundFunction(
 			typeQualifier,
 			NewNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeMapFunctionName,
@@ -122,7 +122,7 @@ func init() {
 
 	// Functions available only for variable-sized arrays.
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeAppendFunctionName,
@@ -140,7 +140,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeAppendAllFunctionName,
@@ -163,7 +163,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeConcatFunctionName,
@@ -180,7 +180,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeInsertFunctionName,
@@ -209,7 +209,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeRemoveFunctionName,
@@ -234,7 +234,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeRemoveFirstFunctionName,
@@ -250,7 +250,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeRemoveLastFunctionName,
@@ -266,7 +266,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeSliceFunctionName,
@@ -289,7 +289,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeToConstantSizedFunctionName,
@@ -312,7 +312,7 @@ func init() {
 
 	// Methods available only for constant-sized arrays.
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayConstantSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeToVariableSizedFunctionName,

--- a/bbq/vm/value_capability.go
+++ b/bbq/vm/value_capability.go
@@ -30,7 +30,7 @@ func init() {
 	typeName := interpreter.PrimitiveStaticTypeCapability.String()
 
 	// Capability.borrow
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValueWithDerivedType(
 			sema.CapabilityTypeBorrowFunctionName,

--- a/bbq/vm/value_capability_controller.go
+++ b/bbq/vm/value_capability_controller.go
@@ -24,7 +24,7 @@ package vm
 //	typeName := sema.StorageCapabilityControllerType.QualifiedName
 //
 //	// Capability.borrow
-//	RegisterTypeBoundFunction(
+//	RegisterBuiltinTypeBoundFunction(
 //		typeName,
 //		sema.StorageCapabilityControllerTypeSetTagFunctionName,
 //		NativeFunctionValue{

--- a/bbq/vm/value_character.go
+++ b/bbq/vm/value_character.go
@@ -31,7 +31,7 @@ func init() {
 
 	typeName := commons.TypeQualifier(sema.CharacterType)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.ToStringFunctionName,

--- a/bbq/vm/value_dictionary.go
+++ b/bbq/vm/value_dictionary.go
@@ -29,7 +29,7 @@ import (
 
 func init() {
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierDictionary,
 		NewNativeFunctionValueWithDerivedType(
 			sema.DictionaryTypeRemoveFunctionName,
@@ -46,7 +46,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierDictionary,
 		NewNativeFunctionValueWithDerivedType(
 			sema.DictionaryTypeInsertFunctionName,
@@ -70,7 +70,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierDictionary,
 		NewNativeFunctionValueWithDerivedType(
 			sema.DictionaryTypeContainsKeyFunctionName,
@@ -91,7 +91,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierDictionary,
 		NewNativeFunctionValueWithDerivedType(
 			sema.DictionaryTypeForEachKeyFunctionName,

--- a/bbq/vm/value_number.go
+++ b/bbq/vm/value_number.go
@@ -31,7 +31,7 @@ func init() {
 	for _, pathType := range sema.AllNumberTypes {
 		typeName := commons.TypeQualifier(pathType)
 
-		RegisterTypeBoundFunction(
+		RegisterBuiltinTypeBoundFunction(
 			typeName,
 			NewNativeFunctionValue(
 				sema.ToStringFunctionName,
@@ -46,7 +46,7 @@ func init() {
 			),
 		)
 
-		RegisterTypeBoundFunction(
+		RegisterBuiltinTypeBoundFunction(
 			typeName,
 			NewNativeFunctionValue(
 				sema.ToBigEndianBytesFunctionName,

--- a/bbq/vm/value_optional.go
+++ b/bbq/vm/value_optional.go
@@ -29,7 +29,7 @@ import (
 
 func init() {
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		commons.TypeQualifierOptional,
 		NewNativeFunctionValueWithDerivedType(
 			sema.OptionalTypeMapFunctionName,

--- a/bbq/vm/value_path.go
+++ b/bbq/vm/value_path.go
@@ -38,7 +38,7 @@ func init() {
 	} {
 		typeName := commons.TypeQualifier(pathType)
 
-		RegisterTypeBoundFunction(
+		RegisterBuiltinTypeBoundFunction(
 			typeName,
 			NewNativeFunctionValue(
 				sema.ToStringFunctionName,

--- a/bbq/vm/value_string.go
+++ b/bbq/vm/value_string.go
@@ -32,7 +32,7 @@ func init() {
 
 	// Methods on `String` value.
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeConcatFunctionName,
@@ -50,7 +50,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeSliceFunctionName,
@@ -64,7 +64,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeContainsFunctionName,
@@ -77,7 +77,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeIndexFunctionName,
@@ -90,7 +90,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeCountFunctionName,
@@ -103,7 +103,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeDecodeHexFunctionName,
@@ -115,7 +115,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeToLowerFunctionName,
@@ -127,7 +127,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeSplitFunctionName,
@@ -144,7 +144,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeReplaceAllFunctionName,
@@ -165,7 +165,7 @@ func init() {
 
 	// Methods on `String` type.
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeEncodeHexFunctionName,
@@ -181,7 +181,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeFromUtf8FunctionName,
@@ -197,7 +197,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeFromCharactersFunctionName,
@@ -213,7 +213,7 @@ func init() {
 		),
 	)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeJoinFunctionName,

--- a/bbq/vm/value_type.go
+++ b/bbq/vm/value_type.go
@@ -31,7 +31,7 @@ import (
 func init() {
 	typeName := commons.TypeQualifier(sema.MetaType)
 
-	RegisterTypeBoundFunction(
+	RegisterBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.MetaTypeIsSubtypeFunctionName,

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -69,7 +69,7 @@ func NewVM(
 	}
 
 	if context.BuiltinGlobalsProvider == nil {
-		context.BuiltinGlobalsProvider = NativeFunctions
+		context.BuiltinGlobalsProvider = DefaultBuiltinGlobals
 	}
 
 	if context.referencedResourceKindedValues == nil {

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -610,7 +610,7 @@ func testAccountWithErrorHandlerWithCompiler(
 	if compilerEnabled && *compile {
 		vmConfig := &vm.Config{
 			BuiltinGlobalsProvider: func() *activations.Activation[*vm.Variable] {
-				baseActivation := vm.NativeFunctions()
+				baseActivation := vm.DefaultBuiltinGlobals()
 				activation := activations.NewActivation[*vm.Variable](nil, baseActivation)
 				variable := &interpreter.SimpleVariable{}
 				variable.InitializeWithValue(accountValueDeclaration.Value)
@@ -637,7 +637,7 @@ func testAccountWithErrorHandlerWithCompiler(
 					ParseAndCheckOptions: parseAndCheckOptions,
 					CompilerConfig: &compiler.Config{
 						BuiltinGlobalsProvider: func() *activations.Activation[compiler.GlobalImport] {
-							baseActivation := compiler.NativeFunctions()
+							baseActivation := compiler.DefaultBuiltinGlobals()
 							activation := activations.NewActivation[compiler.GlobalImport](nil, baseActivation)
 							for _, valueDeclaration := range valueDeclarations {
 								name := valueDeclaration.Name

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -108,13 +108,16 @@ func TestRuntimeReturnPublicAccount(t *testing.T) {
 		Storage:                      NewTestLedger(nil, nil),
 	}
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	_, err := rt.ExecuteScript(
 		Script{
 			Source: script,
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -141,13 +144,16 @@ func TestRuntimeReturnAuthAccount(t *testing.T) {
 		Storage:                      NewTestLedger(nil, nil),
 	}
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	_, err := rt.ExecuteScript(
 		Script{
 			Source: script,
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -2575,7 +2581,7 @@ func TestRuntimeGetAuthAccount(t *testing.T) {
 
 		script := []byte(`
             access(all) fun main(): UInt64 {
-                let acc = getAccount(0x02)
+                let acc = getAuthAccount<&Account>(0x02)
                 return acc.storage.used
             }
         `)
@@ -2586,13 +2592,16 @@ func TestRuntimeGetAuthAccount(t *testing.T) {
 			},
 		}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		result, err := rt.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{0x1},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 
@@ -2613,13 +2622,16 @@ func TestRuntimeGetAuthAccount(t *testing.T) {
 
 		runtimeInterface := &TestRuntimeInterface{}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		_, err := rt.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{0x1},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 
@@ -2641,13 +2653,16 @@ func TestRuntimeGetAuthAccount(t *testing.T) {
 
 		runtimeInterface := &TestRuntimeInterface{}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		_, err := rt.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{0x1},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 
@@ -2669,13 +2684,16 @@ func TestRuntimeGetAuthAccount(t *testing.T) {
 
 		runtimeInterface := &TestRuntimeInterface{}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		_, err := rt.ExecuteScript(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{0x1},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		errs := RequireCheckerErrors(t, err, 1)
@@ -2703,13 +2721,16 @@ func TestRuntimeGetAuthAccount(t *testing.T) {
 			},
 		}
 
+		nextTransactionLocation := NewTransactionLocationGenerator()
+
 		err := rt.ExecuteTransaction(
 			Script{
 				Source: script,
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.TransactionLocation{0x1},
+				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
 			},
 		)
 

--- a/runtime/capabilitycontrollers_test.go
+++ b/runtime/capabilitycontrollers_test.go
@@ -3984,6 +3984,7 @@ func TestRuntimeCapabilitiesPublishBackwardCompatibility(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -4075,6 +4076,7 @@ func TestRuntimeCapabilitiesUnpublishBackwardCompatibility(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -858,6 +858,7 @@ func TestRuntimeTransactionWithArguments(t *testing.T) {
 				Context{
 					Interface: runtimeInterface,
 					Location:  transactionLocation(),
+					UseVM:     *compile,
 				},
 			)
 
@@ -7300,6 +7301,7 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 
@@ -8305,6 +8307,7 @@ func TestRuntimeTypeMismatchErrorMessage(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -1845,6 +1845,8 @@ func TestRuntimeStorageUsed(t *testing.T) {
 		},
 	}
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	// NOTE: do NOT change the contents of this script,
 	// it matters how the array is constructed,
 	// ESPECIALLY the value of the addresses and the number of elements!
@@ -1890,7 +1892,7 @@ func TestRuntimeStorageUsed(t *testing.T) {
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
 		},
 	)
 	require.NoError(t, err)
@@ -4280,6 +4282,8 @@ func TestRuntimeStorageIteration(t *testing.T) {
 			Storage: NewTestLedger(nil, nil),
 		}
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		const script = `
           access(all)
 		  fun main(): String? {
@@ -4306,7 +4310,8 @@ func TestRuntimeStorageIteration(t *testing.T) {
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -4328,6 +4333,8 @@ func TestRuntimeStorageIteration(t *testing.T) {
 				return nil
 			},
 		}
+
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		const script = `
           access(all)
@@ -4356,7 +4363,8 @@ func TestRuntimeStorageIteration(t *testing.T) {
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -4593,6 +4601,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 
 		rt, runtimeInterface := newRuntime()
 
+		nextScriptLocation := NewScriptLocationGenerator()
+
 		const script = `
           access(all)
           struct S {
@@ -4640,7 +4650,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -4657,6 +4668,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 		t.Parallel()
 
 		rt, runtimeInterface := newRuntime()
+
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		const script = `
           access(all)
@@ -4703,7 +4716,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -4720,6 +4734,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 		t.Parallel()
 
 		rt, runtimeInterface := newRuntime()
+
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		const script = `
           access(all)
@@ -4768,7 +4784,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -4785,6 +4802,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 		t.Parallel()
 
 		rt, runtimeInterface := newRuntime()
+
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		const script = `
           access(all)
@@ -4825,7 +4844,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -4881,6 +4901,7 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -4912,6 +4933,7 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -4927,6 +4949,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 		t.Parallel()
 
 		rt, runtimeInterface := newRuntime()
+
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		const script = `
           access(all)
@@ -4978,7 +5002,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -4995,6 +5020,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 		t.Parallel()
 
 		rt, runtimeInterface := newRuntime()
+
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		const script = `
           access(all)
@@ -5044,7 +5071,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		RequireError(t, err)
@@ -5058,6 +5086,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 		t.Parallel()
 
 		rt, runtimeInterface := newRuntime()
+
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		const script = `
           access(all)
@@ -5106,7 +5136,8 @@ func TestRuntimeStorageIteration2(t *testing.T) {
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -5157,6 +5188,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 
 			rt, runtimeInterface := newRuntime()
 
+			nextScriptLocation := NewScriptLocationGenerator()
+
 			script := fmt.Sprintf(
 				`
                   access(all)
@@ -5186,7 +5219,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 				},
 				Context{
 					Interface: runtimeInterface,
-					Location:  common.ScriptLocation{},
+					Location:  nextScriptLocation(),
+					UseVM:     *compile,
 				},
 			)
 
@@ -5204,6 +5238,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			t.Parallel()
 
 			rt, runtimeInterface := newRuntime()
+
+			nextScriptLocation := NewScriptLocationGenerator()
 
 			script := fmt.Sprintf(
 				`
@@ -5239,7 +5275,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 				},
 				Context{
 					Interface: runtimeInterface,
-					Location:  common.ScriptLocation{},
+					Location:  nextScriptLocation(),
+					UseVM:     *compile,
 				},
 			)
 
@@ -5258,6 +5295,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 
 			rt, runtimeInterface := newRuntime()
 
+			nextScriptLocation := NewScriptLocationGenerator()
+
 			script := fmt.Sprintf(
 				`
                   access(all)
@@ -5294,7 +5333,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 				},
 				Context{
 					Interface: runtimeInterface,
-					Location:  common.ScriptLocation{},
+					Location:  nextScriptLocation(),
+					UseVM:     *compile,
 				},
 			)
 
@@ -5313,6 +5353,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 
 			rt, runtimeInterface := newRuntime()
 
+			nextScriptLocation := NewScriptLocationGenerator()
+
 			script := fmt.Sprintf(
 				`
                   access(all)
@@ -5352,7 +5394,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 				},
 				Context{
 					Interface: runtimeInterface,
-					Location:  common.ScriptLocation{},
+					Location:  nextScriptLocation(),
+					UseVM:     *compile,
 				},
 			)
 
@@ -5370,6 +5413,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			t.Parallel()
 
 			rt, runtimeInterface := newRuntime()
+
+			nextScriptLocation := NewScriptLocationGenerator()
 
 			script := fmt.Sprintf(
 				`
@@ -5400,7 +5445,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 				},
 				Context{
 					Interface: runtimeInterface,
-					Location:  common.ScriptLocation{},
+					Location:  nextScriptLocation(),
+					UseVM:     *compile,
 				},
 			)
 			if continueAfterMutation {
@@ -5417,6 +5463,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			t.Parallel()
 
 			rt, runtimeInterface := newRuntime()
+
+			nextScriptLocation := NewScriptLocationGenerator()
 
 			script := fmt.Sprintf(
 				`
@@ -5449,7 +5497,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 				},
 				Context{
 					Interface: runtimeInterface,
-					Location:  common.ScriptLocation{},
+					Location:  nextScriptLocation(),
+					UseVM:     *compile,
 				},
 			)
 			if continueAfterMutation {
@@ -5466,6 +5515,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			t.Parallel()
 
 			rt, runtimeInterface := newRuntime()
+
+			nextScriptLocation := NewScriptLocationGenerator()
 
 			script := fmt.Sprintf(
 				`
@@ -5498,7 +5549,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 				},
 				Context{
 					Interface: runtimeInterface,
-					Location:  common.ScriptLocation{},
+					Location:  nextScriptLocation(),
+					UseVM:     *compile,
 				},
 			)
 			if continueAfterMutation {
@@ -5515,6 +5567,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			t.Parallel()
 
 			rt, runtimeInterface := newRuntime()
+
+			nextScriptLocation := NewScriptLocationGenerator()
 
 			// Deploy contract
 
@@ -5574,7 +5628,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 				},
 				Context{
 					Interface: runtimeInterface,
-					Location:  common.ScriptLocation{},
+					Location:  nextScriptLocation(),
+					UseVM:     *compile,
 				},
 			)
 			if continueAfterMutation {
@@ -5595,6 +5650,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 		t.Parallel()
 
 		rt, runtimeInterface := newRuntime()
+
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		const script = `
           access(all)
@@ -5627,7 +5684,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -5637,6 +5695,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 		t.Parallel()
 
 		rt, runtimeInterface := newRuntime()
+
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		const script = `
           access(all)
@@ -5658,7 +5718,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -5668,6 +5729,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 		t.Parallel()
 
 		rt, runtimeInterface := newRuntime()
+
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		const script = `
           access(all)
@@ -5694,7 +5757,8 @@ func TestRuntimeAccountIterationMutation(t *testing.T) {
 			},
 			Context{
 				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -6329,7 +6393,7 @@ func TestRuntimeStorageForNewAccount(t *testing.T) {
 	//  - account register
 	//  - account storage map
 	//  - zero or more non-inlined domain storage map
-	// migration: no migraiton for new account.
+	// migration: no migration for new account.
 	createDomainTestCases := []struct {
 		name                  string
 		newDomains            []common.StorageDomain
@@ -8450,7 +8514,7 @@ func createAndWriteAccountStorageMap(
 		require.NotNil(t, domainStorageMap)
 		require.Equal(t, uint64(0), domainStorageMap.Count())
 
-		// Write to to domain storage map
+		// Write to domain storage map
 		accountValues[domain] = writeToDomainStorageMap(inter, domainStorageMap, count, random)
 	}
 

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -120,6 +120,8 @@ func (e *vmEnvironment) newVMConfig() *vm.Config {
 		AccountHandlerFunc:             e.newAccountValue,
 		OnEventEmitted:                 newOnEventEmittedHandler(&e.Interface),
 		AccountHandler:                 e,
+		CapabilityBorrowHandler:        newCapabilityBorrowHandler(e),
+		CapabilityCheckHandler:         newCapabilityCheckHandler(e),
 	}
 }
 

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -187,10 +187,10 @@ const getAuthAccountFunctionDocString = `
 Returns the account for the given address. Only available in scripts
 `
 
-// getAuthAccountFunctionType represents the type
+// GetAuthAccountFunctionType represents the type
 //
 //	fun getAuthAccount<T: &Account>(_ address: Address): T
-var getAuthAccountFunctionType = func() *sema.FunctionType {
+var GetAuthAccountFunctionType = func() *sema.FunctionType {
 
 	typeParam := &sema.TypeParameter{
 		Name:      "T",
@@ -218,7 +218,7 @@ var getAuthAccountFunctionType = func() *sema.FunctionType {
 func NewGetAuthAccountFunction(handler AccountHandler) StandardLibraryValue {
 	return NewStandardLibraryStaticFunction(
 		getAuthAccountFunctionName,
-		getAuthAccountFunctionType,
+		GetAuthAccountFunctionType,
 		getAuthAccountFunctionDocString,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			accountAddress, ok := invocation.Arguments[0].(interpreter.AddressValue)

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -283,7 +283,7 @@ func ParseCheckAndPrepareWithOptions(
 			interpreterBaseActivationVariables := interpreterBaseActivation.ValuesInCurrentLevel()
 
 			vmConfig.BuiltinGlobalsProvider = func() *activations.Activation[*vm.Variable] {
-				baseActivation := vm.NativeFunctions()
+				baseActivation := vm.DefaultBuiltinGlobals()
 
 				activation := activations.NewActivation[*vm.Variable](nil, baseActivation)
 
@@ -326,7 +326,7 @@ func ParseCheckAndPrepareWithOptions(
 			// Register externally provided globals in compiler.
 			compilerConfig = &compiler.Config{
 				BuiltinGlobalsProvider: func() *activations.Activation[compiler.GlobalImport] {
-					baseActivation := compiler.NativeFunctions()
+					baseActivation := compiler.DefaultBuiltinGlobals()
 					activation := activations.NewActivation[compiler.GlobalImport](nil, baseActivation)
 					for name := range interpreterBaseActivationVariables { //nolint:maprange
 						existing := activation.Find(name)


### PR DESCRIPTION
Work towards #3993 and #3804 

## Description

- Rename "native functions" to "builtin globals" in compiler/VM
- Add support for script-specific globals in compiler/VM
- Implement the widely used `getAuthAccount` function for scripts in the compiler/VM
- Use the script-specific compiler/VM globals in the VM environment for scripts
- Configure the capability borrow and capability check handlers of the environment's VM
- Enable ~all runtime tests which use getAuthAccount, including the runtime storage tests of #4007 which couldn't be enabled back then

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
