### PR TITLE
[Compiler] Enable more runtime tests to be run with compiler/VM

### DIFF
--- a/runtime/capabilities_test.go
+++ b/runtime/capabilities_test.go
@@ -335,7 +335,9 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 				name,
 				nil,
 				nil,
-				Context{Interface: runtimeInterface},
+				Context{
+					Interface: runtimeInterface,
+				},
 			)
 		}
 
@@ -658,7 +660,9 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 				name,
 				nil,
 				nil,
-				Context{Interface: runtimeInterface},
+				Context{
+					Interface: runtimeInterface,
+				},
 			)
 		}
 

--- a/runtime/deployedcontract_test.go
+++ b/runtime/deployedcontract_test.go
@@ -96,16 +96,16 @@ func TestRuntimeDeployedContracts(t *testing.T) {
 	}
 
 	nextTransactionLocation := NewTransactionLocationGenerator()
-	newContext := func() Context {
-		return Context{Interface: runtimeInterface, Location: nextTransactionLocation()}
-	}
 
 	// deploy the contract
 	err := rt.ExecuteTransaction(
 		Script{
 			Source: DeploymentTransaction("Test", []byte(contractCode)),
 		},
-		newContext(),
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
 	)
 	require.NoError(t, err)
 
@@ -114,7 +114,10 @@ func TestRuntimeDeployedContracts(t *testing.T) {
 		Script{
 			Source: []byte(script),
 		},
-		newContext(),
+		Context{
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+		},
 	)
 
 	require.NoError(t, err)

--- a/runtime/import_test.go
+++ b/runtime/import_test.go
@@ -73,13 +73,16 @@ func TestRuntimeCyclicImport(t *testing.T) {
 		},
 	}
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	_, err := runtime.ExecuteScript(
 		Script{
 			Source: script,
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3555,7 +3555,9 @@ func TestRuntimeStorageLoadedDestructionConcreteType(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
-		})
+			UseVM:     *compile,
+		},
+	)
 	require.NoError(t, err)
 
 	require.Len(t, events, 2)
@@ -4065,6 +4067,7 @@ func TestRuntimeStorageLoadedDestructionAnyResource(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -4179,6 +4182,7 @@ func TestRuntimeStorageLoadedDestructionAfterRemoval(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)
@@ -4836,6 +4840,11 @@ func TestRuntimeRandom(t *testing.T) {
 			// example "modulo: UInt8(77)"
 			moduloArgument = fmt.Sprintf("modulo: %s(%s)", ty.String(), moduloArgument)
 		}
+
+		runtimeInterface := &TestRuntimeInterface{
+			OnReadRandom: randomGenerator,
+		}
+
 		return runtime.ExecuteScript(
 			Script{
 				Source: []byte(
@@ -4845,10 +4854,8 @@ func TestRuntimeRandom(t *testing.T) {
 					)),
 			},
 			Context{
-				Interface: &TestRuntimeInterface{
-					OnReadRandom: randomGenerator,
-				},
-				Location: nextScriptLocation(),
+				Interface: runtimeInterface,
+				Location:  nextScriptLocation(),
 			},
 		)
 	}
@@ -7333,6 +7340,7 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 
@@ -7371,6 +7379,7 @@ func TestRuntimeAccountsInDictionary(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -8020,12 +8029,15 @@ func BenchmarkRuntimeScriptNoop(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := runtime.ExecuteScript(script, Context{
-			Interface:   runtimeInterface,
-			Location:    nextScriptLocation(),
-			Environment: environment,
-			UseVM:       *compile,
-		})
+		_, err := runtime.ExecuteScript(
+			script,
+			Context{
+				Interface:   runtimeInterface,
+				Location:    nextScriptLocation(),
+				Environment: environment,
+				UseVM:       *compile,
+			},
+		)
 		require.NoError(b, err)
 	}
 }
@@ -11454,7 +11466,7 @@ func TestRuntimeForbidPublicEntitlementGet(t *testing.T) {
 	}
 
 	nextTransactionLocation := NewTransactionLocationGenerator()
-	nexScriptLocation := NewScriptLocationGenerator()
+	nextScriptLocation := NewScriptLocationGenerator()
 
 	err := runtime.ExecuteTransaction(
 		Script{
@@ -11474,7 +11486,7 @@ func TestRuntimeForbidPublicEntitlementGet(t *testing.T) {
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  nexScriptLocation(),
+			Location:  nextScriptLocation(),
 		},
 	)
 	require.NoError(t, err)
@@ -11856,6 +11868,7 @@ func TestResultRedeclared(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -11904,6 +11917,7 @@ func TestResultRedeclared(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -191,6 +191,7 @@ func TestRuntimeStorageWrite(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -267,6 +268,7 @@ func TestRuntimeAccountStorage(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -392,6 +394,7 @@ func TestRuntimePublicCapabilityBorrowTypeConfusion(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 
@@ -440,6 +443,7 @@ func TestRuntimeStorageReadAndBorrow(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/type_test.go
+++ b/runtime/type_test.go
@@ -76,6 +76,7 @@ func TestRuntimeTypeStorage(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -87,6 +88,7 @@ func TestRuntimeTypeStorage(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
Depends on #4013 

## Description

Went over remaining runtime tests not yet enabled to be run with the compiler/VM and enabled what is possible, and added TODOs to #3804 for tests that can't be enabled yet due to missing or broken features in the compiler/VM.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
