### PR TITLE
[Compiler] Implement `Capability.check` function, fix `Capability.borrow`

### DIFF
--- a/bbq/vm/value_capability.go
+++ b/bbq/vm/value_capability.go
@@ -67,4 +67,43 @@ func init() {
 			},
 		),
 	)
+
+	// Capability.check
+	RegisterBuiltinTypeBoundFunction(
+		typeName,
+		NewNativeFunctionValueWithDerivedType(
+			sema.CapabilityTypeCheckFunctionName,
+			func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
+				capability := receiver.(*interpreter.IDCapabilityValue)
+				borrowType := interpreter.MustConvertStaticToSemaType(capability.BorrowType, context).(*sema.ReferenceType)
+				return sema.CapabilityTypeCheckFunctionType(borrowType)
+			},
+			func(context *Context, typeArguments []bbq.StaticType, args ...Value) Value {
+				capabilityValue := args[receiverIndex].(*interpreter.IDCapabilityValue)
+				capabilityID := capabilityValue.ID
+
+				if capabilityID == interpreter.InvalidCapabilityID {
+					return interpreter.FalseValue
+				}
+
+				capabilityBorrowType := interpreter.MustConvertStaticToSemaType(capabilityValue.BorrowType, context).(*sema.ReferenceType)
+
+				var typeParameter sema.Type
+				if len(typeArguments) > 0 {
+					typeParameter = interpreter.MustConvertStaticToSemaType(typeArguments[0], context)
+				}
+
+				address := capabilityValue.Address()
+
+				return interpreter.CapabilityCheck(
+					context,
+					typeParameter,
+					address,
+					capabilityID,
+					capabilityBorrowType,
+					EmptyLocationRange,
+				)
+			},
+		),
+	)
 }

--- a/interpreter/idcapability_test.go
+++ b/interpreter/idcapability_test.go
@@ -1,0 +1,229 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/onflow/atree"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/activations"
+	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/interpreter"
+	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/stdlib"
+	"github.com/onflow/cadence/test_utils/common_utils"
+)
+
+type noopReferenceTracker struct{}
+
+func (_ noopReferenceTracker) ClearReferencedResourceKindedValues(_ atree.ValueID) {
+	return
+}
+
+func (_ noopReferenceTracker) ReferencedResourceKindedValues(_ atree.ValueID) map[*interpreter.EphemeralReferenceValue]struct{} {
+	return nil
+}
+
+func (_ noopReferenceTracker) MaybeTrackReferencedResourceKindedValue(_ *interpreter.EphemeralReferenceValue) {
+	return
+}
+
+var _ interpreter.ReferenceTracker = noopReferenceTracker{}
+
+func TestInterpretIDCapability(t *testing.T) {
+
+	t.Parallel()
+
+	const id = 99
+
+	type handlers struct {
+		borrow interpreter.CapabilityBorrowHandlerFunc
+		check  interpreter.CapabilityCheckHandlerFunc
+	}
+
+	test := func(
+		t *testing.T,
+		code string,
+		handlers handlers,
+	) (common_utils.Invokable, error) {
+		borrowType := &sema.ReferenceType{
+			Type:          sema.StringType,
+			Authorization: sema.UnauthorizedAccess,
+		}
+
+		borrowStaticType := interpreter.ConvertSemaToStaticType(nil, borrowType)
+
+		value := stdlib.StandardLibraryValue{
+			Type: &sema.CapabilityType{
+				BorrowType: borrowType,
+			},
+			Value: interpreter.NewUnmeteredCapabilityValue(
+				id,
+				interpreter.AddressValue{0x42},
+				borrowStaticType,
+			),
+			Name: "cap",
+			Kind: common.DeclarationKindConstant,
+		}
+
+		baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+		baseValueActivation.DeclareValue(value)
+
+		baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
+		interpreter.Declare(baseActivation, value)
+
+		return parseCheckAndPrepareWithOptions(
+			t,
+			code,
+			ParseCheckAndInterpretOptions{
+				Config: &interpreter.Config{
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
+					},
+					CapabilityBorrowHandler: handlers.borrow,
+					CapabilityCheckHandler:  handlers.check,
+				},
+				CheckerConfig: &sema.Config{
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
+				},
+				HandleCheckerError: nil,
+			},
+		)
+	}
+
+	t.Run("transfer", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := test(t,
+			`
+              fun f(_ cap: Capability<&String>): Capability<&String>? {
+                  return cap
+              }
+
+	          let capOpt: Capability<&String>? = f(cap)
+            `,
+			handlers{},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("borrow", func(t *testing.T) {
+
+		t.Parallel()
+
+		mockReference := interpreter.NewUnmeteredEphemeralReferenceValue(
+			noopReferenceTracker{},
+			interpreter.UnauthorizedAccess,
+			interpreter.NewUnmeteredStringValue("mock"),
+			sema.NewReferenceType(nil, sema.UnauthorizedAccess, sema.StringType),
+			interpreter.EmptyLocationRange,
+		)
+
+		inter, err := test(t,
+			`
+              fun test(): &String? {
+                  return cap.borrow()
+              }
+            `,
+			handlers{
+				borrow: func(
+					_ interpreter.BorrowCapabilityControllerContext,
+					_ interpreter.LocationRange,
+					address interpreter.AddressValue,
+					capabilityID interpreter.UInt64Value,
+					_ *sema.ReferenceType,
+					_ *sema.ReferenceType,
+				) interpreter.ReferenceValue {
+					assert.Equal(t, interpreter.AddressValue{0x42}, address)
+					assert.Equal(t, interpreter.UInt64Value(id), capabilityID)
+
+					return mockReference
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		res, err := inter.Invoke("test")
+		require.NoError(t, err)
+		require.Equal(t, interpreter.NewUnmeteredSomeValueNonCopying(mockReference), res)
+	})
+
+	t.Run("check", func(t *testing.T) {
+
+		t.Parallel()
+
+		var checked bool
+
+		inter, err := test(t,
+			`
+              fun test(): Bool {
+                  return cap.check()
+              }
+            `,
+			handlers{
+				check: func(
+					_ interpreter.CheckCapabilityControllerContext,
+					_ interpreter.LocationRange,
+					address interpreter.AddressValue,
+					capabilityID interpreter.UInt64Value,
+					_ *sema.ReferenceType,
+					_ *sema.ReferenceType,
+				) interpreter.BoolValue {
+					assert.Equal(t, interpreter.AddressValue{0x42}, address)
+					assert.Equal(t, interpreter.UInt64Value(id), capabilityID)
+
+					checked = true
+
+					return interpreter.TrueValue
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		res, err := inter.Invoke("test")
+		require.NoError(t, err)
+		require.Equal(t, interpreter.TrueValue, res)
+		require.True(t, checked, "check handler was not called")
+	})
+
+	t.Run("id", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter, err := test(t,
+			`
+              fun test(): UInt64 {
+                  return cap.id
+              }
+            `,
+			handlers{},
+		)
+		require.NoError(t, err)
+
+		res, err := inter.Invoke("test")
+		require.NoError(t, err)
+		require.Equal(t, interpreter.UInt64Value(id), res)
+	})
+}

--- a/interpreter/pathcapability_test.go
+++ b/interpreter/pathcapability_test.go
@@ -65,7 +65,7 @@ func TestInterpretPathCapability(t *testing.T) {
 		baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
 		interpreter.Declare(baseActivation, value)
 
-		return parseCheckAndInterpretWithOptions(
+		return parseCheckAndPrepareWithOptions(
 			t,
 			code,
 			ParseCheckAndInterpretOptions{

--- a/runtime/capabilities_test.go
+++ b/runtime/capabilities_test.go
@@ -662,6 +662,7 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 				nil,
 				Context{
 					Interface: runtimeInterface,
+					UseVM:     *compile,
 				},
 			)
 		}
@@ -802,7 +803,9 @@ func TestRuntimeCapability_borrowAndCheck(t *testing.T) {
 				name,
 				nil,
 				nil,
-				Context{Interface: runtimeInterface},
+				Context{
+					Interface: runtimeInterface,
+				},
 			)
 		}
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -3886,6 +3886,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -4263,6 +4264,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 				Context{
 					Interface: runtimeInterface,
 					Location:  nextTransactionLocation(),
+					UseVM:     *compile,
 				},
 			)
 			require.NoError(t, err)

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -154,7 +154,7 @@ func (e *vmEnvironment) Configure(
 	runtimeInterface Interface,
 	codesAndPrograms CodesAndPrograms,
 	storage *Storage,
-	// TODO:
+// TODO:
 	coverageReport *CoverageReport,
 ) {
 	e.Interface = runtimeInterface
@@ -292,10 +292,13 @@ func (e *vmEnvironment) loadProgram(location common.Location) (*Program, error) 
 		return nil, err
 	}
 
-	// If the program is not compiled yet, compile it.
+	// If there is a program, but it is not compiled yet, compile it.
 	// Directly update the program (pointer), which will also update the program "cache" kept by the embedder.
-	if program.compiledProgram == nil {
-		program.compiledProgram = e.compileProgram(program.interpreterProgram, location)
+	if program != nil && program.compiledProgram == nil {
+		program.compiledProgram = e.compileProgram(
+			program.interpreterProgram,
+			location,
+		)
 	}
 
 	return program, nil


### PR DESCRIPTION
Work towards #4015 

## Description

- Implement `Capability.check` in VM
- Fix implementation of `Capability.borrow` in VM to handle path capabilities
- Add interpreter tests for ID capability (similar to existing tests for path capability)
- Enable more tests using `Capability.check` to run with compiler/VM

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
