### PR TITLE
Improve API for test framework

### DIFF
--- a/runtime/checking_environment.go
+++ b/runtime/checking_environment.go
@@ -31,17 +31,17 @@ import (
 	"github.com/onflow/cadence/stdlib"
 )
 
-// checkingEnvironmentReconfigured is the portion of checkingEnvironment
+// checkingEnvironmentReconfigured is the portion of CheckingEnvironment
 // that gets reconfigured by checkingEnvironment.Configure
 type checkingEnvironmentReconfigured struct {
 	runtimeInterface Interface
 	codesAndPrograms CodesAndPrograms
 }
 
-type checkingEnvironment struct {
+type CheckingEnvironment struct {
 	checkingEnvironmentReconfigured
 
-	config *sema.Config
+	Config *sema.Config
 
 	checkedImports importResolutionResults
 
@@ -66,18 +66,18 @@ type checkingEnvironment struct {
 	baseValueActivationsByLocation map[common.Location]*sema.VariableActivation
 }
 
-func newCheckingEnvironment() *checkingEnvironment {
+func newCheckingEnvironment() *CheckingEnvironment {
 	defaultBaseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
 	defaultBaseTypeActivation := sema.NewVariableActivation(sema.BaseTypeActivation)
-	env := &checkingEnvironment{
+	env := &CheckingEnvironment{
 		defaultBaseValueActivation: defaultBaseValueActivation,
 		defaultBaseTypeActivation:  defaultBaseTypeActivation,
 	}
-	env.config = env.newConfig()
+	env.Config = env.newConfig()
 	return env
 }
 
-func (e *checkingEnvironment) newConfig() *sema.Config {
+func (e *CheckingEnvironment) newConfig() *sema.Config {
 	return &sema.Config{
 		AccessCheckMode:                  sema.AccessCheckModeStrict,
 		BaseValueActivationHandler:       e.getBaseValueActivation,
@@ -89,7 +89,7 @@ func (e *checkingEnvironment) newConfig() *sema.Config {
 	}
 }
 
-func (e *checkingEnvironment) configure(runtimeInterface Interface, codesAndPrograms CodesAndPrograms) {
+func (e *CheckingEnvironment) configure(runtimeInterface Interface, codesAndPrograms CodesAndPrograms) {
 	e.runtimeInterface = runtimeInterface
 	e.codesAndPrograms = codesAndPrograms
 }
@@ -98,7 +98,7 @@ func (e *checkingEnvironment) configure(runtimeInterface Interface, codesAndProg
 // If a value was declared for the location (using DeclareValue),
 // then the specific base value activation for this location is returned.
 // Otherwise, the default base activation that applies for all locations is returned.
-func (e *checkingEnvironment) getBaseValueActivation(
+func (e *CheckingEnvironment) getBaseValueActivation(
 	location common.Location,
 ) (
 	baseValueActivation *sema.VariableActivation,
@@ -121,7 +121,7 @@ func (e *checkingEnvironment) getBaseValueActivation(
 // If a type was declared for the location (using DeclareType),
 // then the specific base type activation for this location is returned.
 // Otherwise, the default base activation that applies for all locations is returned.
-func (e *checkingEnvironment) getBaseTypeActivation(
+func (e *CheckingEnvironment) getBaseTypeActivation(
 	location common.Location,
 ) (
 	baseTypeActivation *sema.VariableActivation,
@@ -139,7 +139,7 @@ func (e *checkingEnvironment) getBaseTypeActivation(
 	return
 }
 
-func (e *checkingEnvironment) semaBaseActivationFor(
+func (e *CheckingEnvironment) semaBaseActivationFor(
 	location common.Location,
 	baseActivationsByLocation *map[Location]*sema.VariableActivation,
 	defaultBaseActivation *sema.VariableActivation,
@@ -160,7 +160,7 @@ func (e *checkingEnvironment) semaBaseActivationFor(
 	return baseActivation
 }
 
-func (e *checkingEnvironment) declareValue(valueDeclaration stdlib.StandardLibraryValue, location common.Location) {
+func (e *CheckingEnvironment) declareValue(valueDeclaration stdlib.StandardLibraryValue, location common.Location) {
 	e.semaBaseActivationFor(
 		location,
 		&e.baseValueActivationsByLocation,
@@ -168,7 +168,7 @@ func (e *checkingEnvironment) declareValue(valueDeclaration stdlib.StandardLibra
 	).DeclareValue(valueDeclaration)
 }
 
-func (e *checkingEnvironment) declareType(typeDeclaration stdlib.StandardLibraryType, location common.Location) {
+func (e *CheckingEnvironment) declareType(typeDeclaration stdlib.StandardLibraryType, location common.Location) {
 	e.semaBaseActivationFor(
 		location,
 		&e.baseTypeActivationsByLocation,
@@ -176,7 +176,7 @@ func (e *checkingEnvironment) declareType(typeDeclaration stdlib.StandardLibrary
 	).DeclareType(typeDeclaration)
 }
 
-func (e *checkingEnvironment) resolveLocation(
+func (e *CheckingEnvironment) resolveLocation(
 	identifiers []Identifier,
 	location Location,
 ) (
@@ -190,7 +190,7 @@ func (e *checkingEnvironment) resolveLocation(
 	)
 }
 
-func (e *checkingEnvironment) resolveImport(
+func (e *CheckingEnvironment) resolveImport(
 	_ *sema.Checker,
 	importedLocation common.Location,
 	importRange ast.Range,
@@ -222,7 +222,7 @@ func (e *checkingEnvironment) resolveImport(
 	}, nil
 }
 
-func (e *checkingEnvironment) check(
+func (e *CheckingEnvironment) check(
 	location common.Location,
 	program *ast.Program,
 	checkedImports importResolutionResults,
@@ -236,7 +236,7 @@ func (e *checkingEnvironment) check(
 		program,
 		location,
 		e,
-		e.config,
+		e.Config,
 	)
 	if err != nil {
 		return nil, err
@@ -252,11 +252,11 @@ func (e *checkingEnvironment) check(
 	return elaboration, nil
 }
 
-func (e *checkingEnvironment) MeterMemory(usage common.MemoryUsage) error {
+func (e *CheckingEnvironment) MeterMemory(usage common.MemoryUsage) error {
 	return e.runtimeInterface.MeterMemory(usage)
 }
 
-func (e *checkingEnvironment) ParseAndCheckProgram(
+func (e *CheckingEnvironment) ParseAndCheckProgram(
 	code []byte,
 	location common.Location,
 	getAndSetProgram bool,
@@ -283,7 +283,7 @@ func (e *checkingEnvironment) ParseAndCheckProgram(
 }
 
 // parseAndCheckProgram parses and checks the given program.
-func (e *checkingEnvironment) parseAndCheckProgram(
+func (e *CheckingEnvironment) parseAndCheckProgram(
 	code []byte,
 	location common.Location,
 	checkedImports importResolutionResults,
@@ -330,7 +330,7 @@ func (e *checkingEnvironment) parseAndCheckProgram(
 	return program, elaboration, nil
 }
 
-func (e *checkingEnvironment) GetProgram(
+func (e *CheckingEnvironment) GetProgram(
 	location Location,
 	storeProgram bool,
 	checkedImports importResolutionResults,
@@ -350,7 +350,7 @@ func (e *checkingEnvironment) GetProgram(
 
 // getProgram returns the existing program at the given location, if available.
 // If it is not available, it loads the code, and then parses and checks it.
-func (e *checkingEnvironment) getProgram(
+func (e *CheckingEnvironment) getProgram(
 	location Location,
 	getCode func() ([]byte, error),
 	getAndSetProgram bool,
@@ -423,7 +423,7 @@ func (e *checkingEnvironment) getProgram(
 // Recovery attempts to parse the contract with the old parser,
 // and if it succeeds, uses the program recovery handler
 // to produce an elaboration for the old program.
-func (e *checkingEnvironment) parseAndCheckProgramWithRecovery(
+func (e *CheckingEnvironment) parseAndCheckProgramWithRecovery(
 	code []byte,
 	location common.Location,
 	checkedImports importResolutionResults,
@@ -463,7 +463,7 @@ func (e *checkingEnvironment) parseAndCheckProgramWithRecovery(
 
 // recoverProgram parses and checks the given program with the old parser,
 // and recovers the elaboration from the old program.
-func (e *checkingEnvironment) recoverProgram(
+func (e *CheckingEnvironment) recoverProgram(
 	oldCode []byte,
 	location common.Location,
 	checkedImports importResolutionResults,
@@ -514,6 +514,6 @@ func (e *checkingEnvironment) recoverProgram(
 	return program, elaboration
 }
 
-func (e *checkingEnvironment) temporarilyRecordCode(location common.AddressLocation, code []byte) {
+func (e *CheckingEnvironment) temporarilyRecordCode(location common.AddressLocation, code []byte) {
 	e.codesAndPrograms.setCode(location, code)
 }

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -133,7 +133,7 @@ func (executor *contractFunctionExecutor) preprocess() (err error) {
 	executor.environment = environment
 
 	switch environment := environment.(type) {
-	case *interpreterEnvironment:
+	case *InterpreterEnvironment:
 		// NO-OP
 
 	// TODO: Uncomment once the compiler branch is merged to master.
@@ -167,7 +167,7 @@ func (executor *contractFunctionExecutor) execute() (val cadence.Value, err erro
 	)
 
 	switch environment := environment.(type) {
-	case *interpreterEnvironment:
+	case *InterpreterEnvironment:
 		value, err := executor.executeWithInterpreter(environment)
 		if err != nil {
 			return nil, newError(err, executor.context.Location, codesAndPrograms)
@@ -188,13 +188,13 @@ func (executor *contractFunctionExecutor) execute() (val cadence.Value, err erro
 }
 
 func (executor *contractFunctionExecutor) executeWithInterpreter(
-	environment *interpreterEnvironment,
+	environment *InterpreterEnvironment,
 ) (val cadence.Value, err error) {
 
 	location := executor.context.Location
 
 	// create interpreter
-	_, inter, err := environment.interpret(
+	_, inter, err := environment.Interpret(
 		location,
 		nil,
 		nil,

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -66,18 +66,18 @@ type Environment interface {
 	newAccountValue(context interpreter.AccountCreationContext, address interpreter.AddressValue) interpreter.Value
 }
 
-// interpreterEnvironmentReconfigured is the portion of interpreterEnvironment
-// that gets reconfigured by interpreterEnvironment.Configure
+// interpreterEnvironmentReconfigured is the portion of InterpreterEnvironment
+// that gets reconfigured by InterpreterEnvironment.Configure
 type interpreterEnvironmentReconfigured struct {
 	Interface
 	storage        *Storage
 	coverageReport *CoverageReport
 }
 
-type interpreterEnvironment struct {
+type InterpreterEnvironment struct {
 	interpreterEnvironmentReconfigured
 
-	checkingEnvironment *checkingEnvironment
+	CheckingEnvironment *CheckingEnvironment
 
 	// defaultBaseActivation is the base activation that applies to all locations by default
 	defaultBaseActivation *interpreter.VariableActivation
@@ -98,30 +98,30 @@ type interpreterEnvironment struct {
 	*stdlib.SimpleContractAdditionTracker
 }
 
-var _ Environment = &interpreterEnvironment{}
-var _ stdlib.Logger = &interpreterEnvironment{}
-var _ stdlib.RandomGenerator = &interpreterEnvironment{}
-var _ stdlib.BlockAtHeightProvider = &interpreterEnvironment{}
-var _ stdlib.CurrentBlockProvider = &interpreterEnvironment{}
-var _ stdlib.AccountHandler = &interpreterEnvironment{}
-var _ stdlib.AccountCreator = &interpreterEnvironment{}
-var _ stdlib.EventEmitter = &interpreterEnvironment{}
-var _ stdlib.PublicKeyValidator = &interpreterEnvironment{}
-var _ stdlib.PublicKeySignatureVerifier = &interpreterEnvironment{}
-var _ stdlib.BLSPoPVerifier = &interpreterEnvironment{}
-var _ stdlib.BLSPublicKeyAggregator = &interpreterEnvironment{}
-var _ stdlib.BLSSignatureAggregator = &interpreterEnvironment{}
-var _ stdlib.Hasher = &interpreterEnvironment{}
-var _ ArgumentDecoder = &interpreterEnvironment{}
-var _ common.MemoryGauge = &interpreterEnvironment{}
-var _ common.ComputationGauge = &interpreterEnvironment{}
+var _ Environment = &InterpreterEnvironment{}
+var _ stdlib.Logger = &InterpreterEnvironment{}
+var _ stdlib.RandomGenerator = &InterpreterEnvironment{}
+var _ stdlib.BlockAtHeightProvider = &InterpreterEnvironment{}
+var _ stdlib.CurrentBlockProvider = &InterpreterEnvironment{}
+var _ stdlib.AccountHandler = &InterpreterEnvironment{}
+var _ stdlib.AccountCreator = &InterpreterEnvironment{}
+var _ stdlib.EventEmitter = &InterpreterEnvironment{}
+var _ stdlib.PublicKeyValidator = &InterpreterEnvironment{}
+var _ stdlib.PublicKeySignatureVerifier = &InterpreterEnvironment{}
+var _ stdlib.BLSPoPVerifier = &InterpreterEnvironment{}
+var _ stdlib.BLSPublicKeyAggregator = &InterpreterEnvironment{}
+var _ stdlib.BLSSignatureAggregator = &InterpreterEnvironment{}
+var _ stdlib.Hasher = &InterpreterEnvironment{}
+var _ ArgumentDecoder = &InterpreterEnvironment{}
+var _ common.MemoryGauge = &InterpreterEnvironment{}
+var _ common.ComputationGauge = &InterpreterEnvironment{}
 
-func NewInterpreterEnvironment(config Config) *interpreterEnvironment {
+func NewInterpreterEnvironment(config Config) *InterpreterEnvironment {
 	defaultBaseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
 
-	env := &interpreterEnvironment{
+	env := &InterpreterEnvironment{
 		config:                        config,
-		checkingEnvironment:           newCheckingEnvironment(),
+		CheckingEnvironment:           newCheckingEnvironment(),
 		defaultBaseActivation:         defaultBaseActivation,
 		stackDepthLimiter:             newStackDepthLimiter(config.StackDepthLimit),
 		SimpleContractAdditionTracker: stdlib.NewSimpleContractAdditionTracker(),
@@ -132,7 +132,7 @@ func NewInterpreterEnvironment(config Config) *interpreterEnvironment {
 	return env
 }
 
-func (e *interpreterEnvironment) NewInterpreterConfig() *interpreter.Config {
+func (e *InterpreterEnvironment) NewInterpreterConfig() *interpreter.Config {
 	return &interpreter.Config{
 		MemoryGauge:                    e,
 		ComputationGauge:               e,
@@ -165,7 +165,7 @@ func (e *interpreterEnvironment) NewInterpreterConfig() *interpreter.Config {
 	}
 }
 
-func NewBaseInterpreterEnvironment(config Config) *interpreterEnvironment {
+func NewBaseInterpreterEnvironment(config Config) *InterpreterEnvironment {
 	env := NewInterpreterEnvironment(config)
 	for _, valueDeclaration := range stdlib.DefaultStandardLibraryValues(env) {
 		env.DeclareValue(valueDeclaration, nil)
@@ -181,7 +181,7 @@ func NewScriptInterpreterEnvironment(config Config) Environment {
 	return env
 }
 
-func (e *interpreterEnvironment) Configure(
+func (e *InterpreterEnvironment) Configure(
 	runtimeInterface Interface,
 	codesAndPrograms CodesAndPrograms,
 	storage *Storage,
@@ -193,7 +193,7 @@ func (e *interpreterEnvironment) Configure(
 	e.coverageReport = coverageReport
 	e.stackDepthLimiter.depth = 0
 
-	e.checkingEnvironment.configure(
+	e.CheckingEnvironment.configure(
 		runtimeInterface,
 		codesAndPrograms,
 	)
@@ -201,18 +201,18 @@ func (e *interpreterEnvironment) Configure(
 	configureVersionedFeatures(runtimeInterface)
 }
 
-func (e *interpreterEnvironment) DeclareValue(valueDeclaration stdlib.StandardLibraryValue, location common.Location) {
-	e.checkingEnvironment.declareValue(valueDeclaration, location)
+func (e *InterpreterEnvironment) DeclareValue(valueDeclaration stdlib.StandardLibraryValue, location common.Location) {
+	e.CheckingEnvironment.declareValue(valueDeclaration, location)
 
 	activation := e.interpreterBaseActivationFor(location)
 	interpreter.Declare(activation, valueDeclaration)
 }
 
-func (e *interpreterEnvironment) DeclareType(typeDeclaration stdlib.StandardLibraryType, location common.Location) {
-	e.checkingEnvironment.declareType(typeDeclaration, location)
+func (e *InterpreterEnvironment) DeclareType(typeDeclaration stdlib.StandardLibraryType, location common.Location) {
+	e.CheckingEnvironment.declareType(typeDeclaration, location)
 }
 
-func (e *interpreterEnvironment) interpreterBaseActivationFor(
+func (e *InterpreterEnvironment) interpreterBaseActivationFor(
 	location common.Location,
 ) *interpreter.VariableActivation {
 	defaultBaseActivation := e.defaultBaseActivation
@@ -231,19 +231,19 @@ func (e *interpreterEnvironment) interpreterBaseActivationFor(
 	return baseActivation
 }
 
-func (e *interpreterEnvironment) SetCompositeValueFunctionsHandler(
+func (e *InterpreterEnvironment) SetCompositeValueFunctionsHandler(
 	typeID common.TypeID,
 	handler stdlib.CompositeValueFunctionsHandler,
 ) {
 	e.compositeValueFunctionsHandlers[typeID] = handler
 }
 
-func (e *interpreterEnvironment) CommitStorageTemporarily(context interpreter.ValueTransferContext) error {
+func (e *InterpreterEnvironment) CommitStorageTemporarily(context interpreter.ValueTransferContext) error {
 	const commitContractUpdates = false
 	return e.storage.Commit(context, commitContractUpdates)
 }
 
-func (e *interpreterEnvironment) EmitEvent(
+func (e *InterpreterEnvironment) EmitEvent(
 	context interpreter.ValueExportContext,
 	locationRange interpreter.LocationRange,
 	eventType *sema.CompositeType,
@@ -258,26 +258,26 @@ func (e *interpreterEnvironment) EmitEvent(
 	)
 }
 
-func (e *interpreterEnvironment) RecordContractRemoval(location common.AddressLocation) {
+func (e *InterpreterEnvironment) RecordContractRemoval(location common.AddressLocation) {
 	e.storage.recordContractUpdate(location, nil)
 }
 
-func (e *interpreterEnvironment) RecordContractUpdate(
+func (e *InterpreterEnvironment) RecordContractUpdate(
 	location common.AddressLocation,
 	contractValue *interpreter.CompositeValue,
 ) {
 	e.storage.recordContractUpdate(location, contractValue)
 }
 
-func (e *interpreterEnvironment) ContractUpdateRecorded(location common.AddressLocation) bool {
+func (e *InterpreterEnvironment) ContractUpdateRecorded(location common.AddressLocation) bool {
 	return e.storage.contractUpdateRecorded(location)
 }
 
-func (e *interpreterEnvironment) TemporarilyRecordCode(location common.AddressLocation, code []byte) {
-	e.checkingEnvironment.temporarilyRecordCode(location, code)
+func (e *InterpreterEnvironment) TemporarilyRecordCode(location common.AddressLocation, code []byte) {
+	e.CheckingEnvironment.temporarilyRecordCode(location, code)
 }
 
-func (e *interpreterEnvironment) ParseAndCheckProgram(
+func (e *InterpreterEnvironment) ParseAndCheckProgram(
 	code []byte,
 	location common.Location,
 	getAndSetProgram bool,
@@ -285,20 +285,20 @@ func (e *interpreterEnvironment) ParseAndCheckProgram(
 	*interpreter.Program,
 	error,
 ) {
-	return e.checkingEnvironment.ParseAndCheckProgram(code, location, getAndSetProgram)
+	return e.CheckingEnvironment.ParseAndCheckProgram(code, location, getAndSetProgram)
 }
 
-func (e *interpreterEnvironment) ResolveLocation(
+func (e *InterpreterEnvironment) ResolveLocation(
 	identifiers []Identifier,
 	location Location,
 ) (
 	res []ResolvedLocation,
 	err error,
 ) {
-	return e.checkingEnvironment.resolveLocation(identifiers, location)
+	return e.CheckingEnvironment.resolveLocation(identifiers, location)
 }
 
-func (e *interpreterEnvironment) newInterpreter(
+func (e *InterpreterEnvironment) newInterpreter(
 	location common.Location,
 	program *interpreter.Program,
 ) (*interpreter.Interpreter, error) {
@@ -331,7 +331,7 @@ func (e *interpreterEnvironment) newInterpreter(
 	return inter, nil
 }
 
-func (e *interpreterEnvironment) newOnStatementHandler() interpreter.OnStatementFunc {
+func (e *InterpreterEnvironment) newOnStatementHandler() interpreter.OnStatementFunc {
 	if e.config.CoverageReport == nil {
 		return nil
 	}
@@ -348,14 +348,14 @@ func (e *interpreterEnvironment) newOnStatementHandler() interpreter.OnStatement
 	}
 }
 
-func (e *interpreterEnvironment) newAccountValue(
+func (e *InterpreterEnvironment) newAccountValue(
 	context interpreter.AccountCreationContext,
 	address interpreter.AddressValue,
 ) interpreter.Value {
 	return stdlib.NewAccountValue(context, e, address)
 }
 
-func (e *interpreterEnvironment) newContractValueHandler() interpreter.ContractValueHandlerFunc {
+func (e *InterpreterEnvironment) newContractValueHandler() interpreter.ContractValueHandlerFunc {
 	return func(
 		inter *interpreter.Interpreter,
 		compositeType *sema.CompositeType,
@@ -401,11 +401,11 @@ func (e *interpreterEnvironment) newContractValueHandler() interpreter.ContractV
 	}
 }
 
-func (e *interpreterEnvironment) newImportLocationHandler() interpreter.ImportLocationHandlerFunc {
+func (e *InterpreterEnvironment) newImportLocationHandler() interpreter.ImportLocationHandlerFunc {
 	return func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 
 		const getAndSetProgram = true
-		program, err := e.checkingEnvironment.GetProgram(
+		program, err := e.CheckingEnvironment.GetProgram(
 			location,
 			getAndSetProgram,
 			importResolutionResults{},
@@ -432,7 +432,7 @@ func (e *interpreterEnvironment) newImportLocationHandler() interpreter.ImportLo
 	}
 }
 
-func (e *interpreterEnvironment) newCompositeTypeHandler() interpreter.CompositeTypeHandlerFunc {
+func (e *InterpreterEnvironment) newCompositeTypeHandler() interpreter.CompositeTypeHandlerFunc {
 	return func(location common.Location, typeID common.TypeID) *sema.CompositeType {
 
 		switch location.(type) {
@@ -441,7 +441,7 @@ func (e *interpreterEnvironment) newCompositeTypeHandler() interpreter.Composite
 
 		case nil:
 			qualifiedIdentifier := string(typeID)
-			baseTypeActivation := e.checkingEnvironment.getBaseTypeActivation(location)
+			baseTypeActivation := e.CheckingEnvironment.getBaseTypeActivation(location)
 			ty := sema.TypeActivationNestedType(baseTypeActivation, qualifiedIdentifier)
 			if ty == nil {
 				return nil
@@ -456,7 +456,7 @@ func (e *interpreterEnvironment) newCompositeTypeHandler() interpreter.Composite
 	}
 }
 
-func (e *interpreterEnvironment) newCompositeValueFunctionsHandler() interpreter.CompositeValueFunctionsHandlerFunc {
+func (e *InterpreterEnvironment) newCompositeValueFunctionsHandler() interpreter.CompositeValueFunctionsHandlerFunc {
 	return func(
 		inter *interpreter.Interpreter,
 		locationRange interpreter.LocationRange,
@@ -472,19 +472,19 @@ func (e *interpreterEnvironment) newCompositeValueFunctionsHandler() interpreter
 	}
 }
 
-func (e *interpreterEnvironment) newOnFunctionInvocationHandler() func(_ *interpreter.Interpreter) {
+func (e *InterpreterEnvironment) newOnFunctionInvocationHandler() func(_ *interpreter.Interpreter) {
 	return func(_ *interpreter.Interpreter) {
 		e.stackDepthLimiter.OnFunctionInvocation()
 	}
 }
 
-func (e *interpreterEnvironment) newOnInvokedFunctionReturnHandler() func(_ *interpreter.Interpreter) {
+func (e *InterpreterEnvironment) newOnInvokedFunctionReturnHandler() func(_ *interpreter.Interpreter) {
 	return func(_ *interpreter.Interpreter) {
 		e.stackDepthLimiter.OnInvokedFunctionReturn()
 	}
 }
 
-func (e *interpreterEnvironment) LoadContractValue(
+func (e *InterpreterEnvironment) LoadContractValue(
 	location common.AddressLocation,
 	program *interpreter.Program,
 	name string,
@@ -498,7 +498,7 @@ func (e *interpreterEnvironment) LoadContractValue(
 		e.deployedContractConstructorInvocation = nil
 	}()
 
-	_, inter, err := e.interpret(location, program, nil)
+	_, inter, err := e.Interpret(location, program, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -516,7 +516,7 @@ func (e *interpreterEnvironment) LoadContractValue(
 	return
 }
 
-func (e *interpreterEnvironment) interpret(
+func (e *InterpreterEnvironment) Interpret(
 	location common.Location,
 	program *interpreter.Program,
 	f interpretFunc,
@@ -552,7 +552,7 @@ func (e *interpreterEnvironment) interpret(
 	return result, inter, nil
 }
 
-func (e *interpreterEnvironment) newResourceOwnerChangedHandler() interpreter.OnResourceOwnerChangeFunc {
+func (e *InterpreterEnvironment) newResourceOwnerChangedHandler() interpreter.OnResourceOwnerChangeFunc {
 	if !e.config.ResourceOwnerChangeHandlerEnabled {
 		return nil
 	}
@@ -560,7 +560,7 @@ func (e *interpreterEnvironment) newResourceOwnerChangedHandler() interpreter.On
 	return newResourceOwnerChangedHandler(&e.Interface)
 }
 
-func (e *interpreterEnvironment) commitStorage(context interpreter.ValueTransferContext) error {
+func (e *InterpreterEnvironment) commitStorage(context interpreter.ValueTransferContext) error {
 	checkStorageHealth := e.config.AtreeValidationEnabled
 	return CommitStorage(context, e.storage, checkStorageHealth)
 }
@@ -569,7 +569,7 @@ func (e *interpreterEnvironment) commitStorage(context interpreter.ValueTransfer
 // If a value was declared for the location (using DeclareValue),
 // then the specific base activation for this location is returned.
 // Otherwise, the default base activation that applies for all locations is returned.
-func (e *interpreterEnvironment) getBaseActivation(
+func (e *InterpreterEnvironment) getBaseActivation(
 	location common.Location,
 ) (
 	baseActivation *interpreter.VariableActivation,
@@ -587,6 +587,6 @@ func (e *interpreterEnvironment) getBaseActivation(
 	return
 }
 
-func (e *interpreterEnvironment) ProgramLog(message string, _ interpreter.LocationRange) error {
+func (e *InterpreterEnvironment) ProgramLog(message string, _ interpreter.LocationRange) error {
 	return e.Interface.ProgramLog(message)
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -374,12 +374,12 @@ func (r *runtime) Storage(context Context) (*Storage, *interpreter.Interpreter, 
 		context.CoverageReport,
 	)
 
-	interpreterEnv, ok := environment.(*interpreterEnvironment)
+	interpreterEnv, ok := environment.(*InterpreterEnvironment)
 	if !ok {
 		panic(errors.NewUnexpectedError("unsupported environment: %T", environment))
 	}
 
-	_, inter, err := interpreterEnv.interpret(
+	_, inter, err := interpreterEnv.Interpret(
 		location,
 		nil,
 		nil,

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -124,7 +124,7 @@ func (executor *scriptExecutor) preprocess() (err error) {
 	}
 
 	switch environment.(type) {
-	case *interpreterEnvironment:
+	case *InterpreterEnvironment:
 		break
 	default:
 		return errors.NewUnexpectedError("scripts can only be executed with the interpreter")
@@ -201,7 +201,7 @@ func (executor *scriptExecutor) execute() (val cadence.Value, err error) {
 	)
 
 	switch environment := environment.(type) {
-	case *interpreterEnvironment:
+	case *InterpreterEnvironment:
 		value, err := executor.executeWithInterpreter(environment)
 		if err != nil {
 			return nil, newError(err, executor.context.Location, codesAndPrograms)
@@ -214,10 +214,10 @@ func (executor *scriptExecutor) execute() (val cadence.Value, err error) {
 }
 
 func (executor *scriptExecutor) executeWithInterpreter(
-	environment *interpreterEnvironment,
+	environment *InterpreterEnvironment,
 ) (val cadence.Value, err error) {
 
-	value, inter, err := environment.interpret(
+	value, inter, err := environment.Interpret(
 		executor.context.Location,
 		executor.program,
 		executor.interpret,

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -122,7 +122,7 @@ func (executor *transactionExecutor) preprocess() (err error) {
 	}
 
 	switch environment.(type) {
-	case *interpreterEnvironment:
+	case *InterpreterEnvironment:
 		break
 	default:
 		return errors.NewUnexpectedError("transactions can only be executed with the interpreter")
@@ -224,7 +224,7 @@ func (executor *transactionExecutor) execute() (err error) {
 	)
 
 	switch environment := environment.(type) {
-	case *interpreterEnvironment:
+	case *InterpreterEnvironment:
 		err = executor.executeWithInterpreter(environment)
 		if err != nil {
 			return newError(err, executor.context.Location, codesAndPrograms)
@@ -237,9 +237,9 @@ func (executor *transactionExecutor) execute() (err error) {
 }
 
 func (executor *transactionExecutor) executeWithInterpreter(
-	environment *interpreterEnvironment,
+	environment *InterpreterEnvironment,
 ) error {
-	_, inter, err := environment.interpret(
+	_, inter, err := environment.Interpret(
 		executor.context.Location,
 		executor.program,
 		executor.interpret,

--- a/stdlib/test-framework.go
+++ b/stdlib/test-framework.go
@@ -96,35 +96,29 @@ type Account struct {
 	Address   common.Address
 }
 
-// TODO: This is used by the test-framework.
-//
-//	Check and the functionalities needed.
 type TestFrameworkScriptExecutionContext interface {
+	interpreter.ValueExportContext
 }
 
 var _ TestFrameworkScriptExecutionContext = &interpreter.Interpreter{}
 
-// TODO: This is used by the test-framework.
-//
-//	Check and the functionalities needed.
 type TestFrameworkAddTransactionContext interface {
+	interpreter.ValueExportContext
 }
 
 var _ TestFrameworkAddTransactionContext = &interpreter.Interpreter{}
 
-// TODO: This is used by the test-framework.
-//
-//	Check and the functionalities needed.
 type TestFrameworkContractDeploymentContext interface {
+	interpreter.ValueExportContext
 }
 
 var _ TestFrameworkContractDeploymentContext = &interpreter.Interpreter{}
 
-// TODO: This is used by the test-framework.
-//
-//	Check and the functionalities needed.
 type TestFrameworkEventsContext interface {
+	common.MemoryGauge
 	interpreter.ArrayCreationContext
+	interpreter.ArrayCreationContext
+	interpreter.MemberAccessibleContext
 }
 
 var _ TestFrameworkEventsContext = &interpreter.Interpreter{}


### PR DESCRIPTION

## Description

onflow/cadence-tools#470 updates the test framework to Cadence v1.6.0.

However, recent changes to Cadence, mostly for adding the compiler/VM, removed functionality needed for the test framework.

Bring back the required functionality that was accessible before:

- Exporting the checking environment and its config
- Export the interpreter environment and its `interpret` function
- Resolve TODOs and add the functionality used by the test framework to the new context interfaces

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
