### PR TITLE
[Compiler] Close upvalues for locals of for loops

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -450,10 +450,17 @@ func (c *Compiler[_, _]) patchJump(jumpOpcodeOffset int, targetInstructionOffset
 	)
 }
 
-func (c *Compiler[_, _]) pushControlFlow(start int) {
+func (c *Compiler[_, _]) pushControlFlow(start int) *controlFlow {
 	index := len(c.controlFlows)
-	c.controlFlows = append(c.controlFlows, controlFlow{start: start})
-	c.currentControlFlow = &c.controlFlows[index]
+	c.controlFlows = append(
+		c.controlFlows,
+		controlFlow{
+			start: start,
+		},
+	)
+	current := &c.controlFlows[index]
+	c.currentControlFlow = current
+	return current
 }
 
 func (c *Compiler[_, _]) popControlFlow(endOffset int) {
@@ -1127,6 +1134,16 @@ func (c *Compiler[_, _]) VisitBreakStatement(_ *ast.BreakStatement) (_ struct{})
 }
 
 func (c *Compiler[_, _]) VisitContinueStatement(_ *ast.ContinueStatement) (_ struct{}) {
+	c.emitContinue()
+	return
+}
+
+func (c *Compiler[_, _]) emitContinue() {
+	preContinue := c.currentControlFlow.preContinue
+	if preContinue != nil {
+		preContinue()
+	}
+
 	start := c.currentControlFlow.start
 	if start <= 0 {
 		panic(errors.NewUnreachableError())
@@ -1266,18 +1283,31 @@ func (c *Compiler[_, _]) VisitForStatement(statement *ast.ForStatement) (_ struc
 	// Initialize 'index' variable, if needed.
 	index := statement.Index
 	indexNeeded := index != nil
-	var indexLocalVar *local
+	var indexLocal *local
 
 	if indexNeeded {
 		// `var <index> = -1`
 		// Start with -1 and then increment at the start of the loop,
 		// so that we don't have to deal with early exists of the loop.
 		c.emitIntConst(-1)
-		indexLocalVar = c.emitDeclareLocal(index.Identifier)
+		indexLocal = c.emitDeclareLocal(index.Identifier)
 	}
 
+	entryLocal := c.currentFunction.declareLocal(statement.Identifier.Identifier)
+
 	testOffset := c.codeGen.Offset()
-	c.pushControlFlow(testOffset)
+	controlFlow := c.pushControlFlow(testOffset)
+	controlFlow.preContinue = func() {
+		// If the index local (if any) or the entry local are captured,
+		// then we need to close the upvalue for them before continuing the loop.
+
+		if indexLocal != nil && indexLocal.isCaptured {
+			c.emitCloseUpvalue(indexLocal.index)
+		}
+		if entryLocal.isCaptured {
+			c.emitCloseUpvalue(entryLocal.index)
+		}
+	}
 	var endOffset int
 	defer func() {
 		c.popControlFlow(endOffset)
@@ -1298,10 +1328,10 @@ func (c *Compiler[_, _]) VisitForStatement(statement *ast.ForStatement) (_ struc
 	// worry about loop-control statements (e.g: continue, return, break) in the body.
 	if indexNeeded {
 		// <index> = <index> + 1
-		c.emitGetLocal(indexLocalVar.index)
+		c.emitGetLocal(indexLocal.index)
 		c.emitIntConst(1)
 		c.emit(opcode.InstructionAdd{})
-		c.emitSetLocal(indexLocalVar.index)
+		c.emitSetLocal(indexLocal.index)
 	}
 
 	// Get the iterator and call `next()` (value for arrays, key for dictionaries, etc.)
@@ -1326,7 +1356,7 @@ func (c *Compiler[_, _]) VisitForStatement(statement *ast.ForStatement) (_ struc
 
 	// Store it (next entry) in a local var.
 	// `<entry> = iterator.next()`
-	c.emitDeclareLocal(statement.Identifier.Identifier)
+	c.emitSetLocal(entryLocal.index)
 
 	// Compile the for-loop body.
 	c.compileBlock(
@@ -1335,8 +1365,9 @@ func (c *Compiler[_, _]) VisitForStatement(statement *ast.ForStatement) (_ struc
 		nil,
 	)
 
-	// Jump back to the loop test. i.e: `hasNext()`
-	c.emitJump(testOffset)
+	// Jump back to the loop test. i.e: `hasNext()`.
+	// Use a continue to ensure all instructions for the next loop iteration are generated (not just the jump).
+	c.emitContinue()
 
 	endOffset = c.codeGen.Offset()
 	c.patchJump(endJump, endOffset)
@@ -3339,6 +3370,12 @@ func (c *Compiler[E, _]) emitNewClosure(functionIndex uint16, function *function
 	c.emit(opcode.InstructionNewClosure{
 		Function: functionIndex,
 		Upvalues: function.upvalues,
+	})
+}
+
+func (c *Compiler[_, _]) emitCloseUpvalue(localIndex uint16) {
+	c.codeGen.Emit(opcode.InstructionCloseUpvalue{
+		Local: localIndex,
 	})
 }
 

--- a/bbq/compiler/control_flow.go
+++ b/bbq/compiler/control_flow.go
@@ -19,8 +19,9 @@
 package compiler
 
 type controlFlow struct {
-	start  int
-	breaks []int
+	start       int
+	preContinue func()
+	breaks      []int
 }
 
 func (f *controlFlow) appendBreak(offset int) {

--- a/bbq/compiler/function.go
+++ b/bbq/compiler/function.go
@@ -107,6 +107,7 @@ func (f *function[E]) findOrAddUpvalue(name string) (upvalueIndex uint16, ok boo
 
 	enclosingLocal := f.enclosing.findLocal(name)
 	if enclosingLocal != nil {
+		enclosingLocal.isCaptured = true
 		upvalue := opcode.Upvalue{
 			TargetIndex: enclosingLocal.index,
 			IsLocal:     true,

--- a/bbq/compiler/local.go
+++ b/bbq/compiler/local.go
@@ -19,5 +19,6 @@
 package compiler
 
 type local struct {
-	index uint16
+	index      uint16
+	isCaptured bool
 }

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -216,6 +216,50 @@ func DecodeSetUpvalue(ip *uint16, code []byte) (i InstructionSetUpvalue) {
 	return i
 }
 
+// InstructionCloseUpvalue
+//
+// Closes the upvalue for the local at the given index.
+type InstructionCloseUpvalue struct {
+	Local uint16
+}
+
+var _ Instruction = InstructionCloseUpvalue{}
+
+func (InstructionCloseUpvalue) Opcode() Opcode {
+	return CloseUpvalue
+}
+
+func (i InstructionCloseUpvalue) String() string {
+	var sb strings.Builder
+	sb.WriteString(i.Opcode().String())
+	i.OperandsString(&sb, false)
+	return sb.String()
+}
+
+func (i InstructionCloseUpvalue) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
+	printfArgument(sb, "local", i.Local, colorize)
+}
+
+func (i InstructionCloseUpvalue) ResolvedOperandsString(sb *strings.Builder,
+	constants []constant.Constant,
+	types []interpreter.StaticType,
+	functionNames []string,
+	colorize bool) {
+	sb.WriteByte(' ')
+	printfArgument(sb, "local", i.Local, colorize)
+}
+
+func (i InstructionCloseUpvalue) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+	emitUint16(code, i.Local)
+}
+
+func DecodeCloseUpvalue(ip *uint16, code []byte) (i InstructionCloseUpvalue) {
+	i.Local = decodeUint16(ip, code)
+	return i
+}
+
 // InstructionGetGlobal
 //
 // Pushes the value of the global at the given index onto the stack.
@@ -2477,6 +2521,8 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 		return DecodeGetUpvalue(ip, code)
 	case SetUpvalue:
 		return DecodeSetUpvalue(ip, code)
+	case CloseUpvalue:
+		return DecodeCloseUpvalue(ip, code)
 	case GetGlobal:
 		return DecodeGetGlobal(ip, code)
 	case SetGlobal:

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -51,6 +51,13 @@
       - name: "value"
         type: "value"
 
+- name: "closeUpvalue"
+  description:
+    Closes the upvalue for the local at the given index.
+  operands:
+    - name: "local"
+      type: "localIndex"
+
 # Global instructions
 
 - name: "getGlobal"

--- a/bbq/opcode/opcode.go
+++ b/bbq/opcode/opcode.go
@@ -119,6 +119,7 @@ const (
 	SetLocal
 	GetUpvalue
 	SetUpvalue
+	CloseUpvalue
 	GetGlobal
 	SetGlobal
 	GetField

--- a/bbq/opcode/opcode_string.go
+++ b/bbq/opcode/opcode_string.go
@@ -55,27 +55,28 @@ func _() {
 	_ = x[SetLocal-71]
 	_ = x[GetUpvalue-72]
 	_ = x[SetUpvalue-73]
-	_ = x[GetGlobal-74]
-	_ = x[SetGlobal-75]
-	_ = x[GetField-76]
-	_ = x[RemoveField-77]
-	_ = x[SetField-78]
-	_ = x[SetIndex-79]
-	_ = x[GetIndex-80]
-	_ = x[RemoveIndex-81]
-	_ = x[Invoke-89]
-	_ = x[InvokeMethodStatic-90]
-	_ = x[InvokeMethodDynamic-91]
-	_ = x[Drop-99]
-	_ = x[Dup-100]
-	_ = x[Iterator-107]
-	_ = x[IteratorHasNext-108]
-	_ = x[IteratorNext-109]
-	_ = x[IteratorEnd-110]
-	_ = x[EmitEvent-111]
-	_ = x[Loop-112]
-	_ = x[Statement-113]
-	_ = x[OpcodeMax-114]
+	_ = x[CloseUpvalue-74]
+	_ = x[GetGlobal-75]
+	_ = x[SetGlobal-76]
+	_ = x[GetField-77]
+	_ = x[RemoveField-78]
+	_ = x[SetField-79]
+	_ = x[SetIndex-80]
+	_ = x[GetIndex-81]
+	_ = x[RemoveIndex-82]
+	_ = x[Invoke-90]
+	_ = x[InvokeMethodStatic-91]
+	_ = x[InvokeMethodDynamic-92]
+	_ = x[Drop-100]
+	_ = x[Dup-101]
+	_ = x[Iterator-108]
+	_ = x[IteratorHasNext-109]
+	_ = x[IteratorNext-110]
+	_ = x[IteratorEnd-111]
+	_ = x[EmitEvent-112]
+	_ = x[Loop-113]
+	_ = x[Statement-114]
+	_ = x[OpcodeMax-115]
 }
 
 const (
@@ -85,7 +86,7 @@ const (
 	_Opcode_name_3 = "LessGreaterLessOrEqualGreaterOrEqualEqualNotEqualNot"
 	_Opcode_name_4 = "UnwrapDestroyTransferAndConvertSimpleCastFailableCastForceCastDerefTransfer"
 	_Opcode_name_5 = "TrueFalseNilNewNewPathNewArrayNewDictionaryNewRefNewClosure"
-	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetUpvalueSetUpvalueGetGlobalSetGlobalGetFieldRemoveFieldSetFieldSetIndexGetIndexRemoveIndex"
+	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetUpvalueSetUpvalueCloseUpvalueGetGlobalSetGlobalGetFieldRemoveFieldSetFieldSetIndexGetIndexRemoveIndex"
 	_Opcode_name_7 = "InvokeInvokeMethodStaticInvokeMethodDynamic"
 	_Opcode_name_8 = "DropDup"
 	_Opcode_name_9 = "IteratorIteratorHasNextIteratorNextIteratorEndEmitEventLoopStatementOpcodeMax"
@@ -98,7 +99,7 @@ var (
 	_Opcode_index_3 = [...]uint8{0, 4, 11, 22, 36, 41, 49, 52}
 	_Opcode_index_4 = [...]uint8{0, 6, 13, 31, 41, 53, 62, 67, 75}
 	_Opcode_index_5 = [...]uint8{0, 4, 9, 12, 15, 22, 30, 43, 49, 59}
-	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 37, 47, 56, 65, 73, 84, 92, 100, 108, 119}
+	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 37, 47, 59, 68, 77, 85, 96, 104, 112, 120, 131}
 	_Opcode_index_7 = [...]uint8{0, 6, 24, 43}
 	_Opcode_index_8 = [...]uint8{0, 4, 7}
 	_Opcode_index_9 = [...]uint8{0, 8, 23, 35, 46, 55, 59, 68, 77}
@@ -123,17 +124,17 @@ func (i Opcode) String() string {
 	case 49 <= i && i <= 57:
 		i -= 49
 		return _Opcode_name_5[_Opcode_index_5[i]:_Opcode_index_5[i+1]]
-	case 69 <= i && i <= 81:
+	case 69 <= i && i <= 82:
 		i -= 69
 		return _Opcode_name_6[_Opcode_index_6[i]:_Opcode_index_6[i+1]]
-	case 89 <= i && i <= 91:
-		i -= 89
+	case 90 <= i && i <= 92:
+		i -= 90
 		return _Opcode_name_7[_Opcode_index_7[i]:_Opcode_index_7[i+1]]
-	case 99 <= i && i <= 100:
-		i -= 99
+	case 100 <= i && i <= 101:
+		i -= 100
 		return _Opcode_name_8[_Opcode_index_8[i]:_Opcode_index_8[i+1]]
-	case 107 <= i && i <= 114:
-		i -= 107
+	case 108 <= i && i <= 115:
+		i -= 108
 		return _Opcode_name_9[_Opcode_index_9[i]:_Opcode_index_9[i+1]]
 	default:
 		return "Opcode(" + strconv.FormatInt(int64(i), 10) + ")"

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -165,6 +165,7 @@ func TestPrintInstruction(t *testing.T) {
 		"SetLocal local:258":       {byte(SetLocal), 1, 2},
 		"GetUpvalue upvalue:258":   {byte(GetUpvalue), 1, 2},
 		"SetUpvalue upvalue:258":   {byte(SetUpvalue), 1, 2},
+		"CloseUpvalue local:258":   {byte(CloseUpvalue), 1, 2},
 		"GetGlobal global:258":     {byte(GetGlobal), 1, 2},
 		"SetGlobal global:258":     {byte(SetGlobal), 1, 2},
 

--- a/interpreter/for_test.go
+++ b/interpreter/for_test.go
@@ -335,8 +335,7 @@ func TestInterpretForStatementCapturing(t *testing.T) {
 
 	t.Parallel()
 
-	// TODO: Use compiler (parseCheckAndPrepare)
-	inter := parseCheckAndInterpret(t, `
+	inter := parseCheckAndPrepare(t, `
        fun test(): [Int] {
            let fs: [fun(): Int] = []
            for x in [1, 2, 3] {


### PR DESCRIPTION
Work towards #4015

## Description

Closures capturing variables introduced by for loops, e.g. `i` and `x` in `for i, x in ["a", "b", "c"] { ...` should keep the value at the time of the loop iteration, not the final assigned value (each loop iteration re-assigns the current index and current loop element to the variables).

Achieve this by adding a new instruction `CloseUpvalue` which closes an open upvalue for a local index. 
Emit the instruction just before a new iteration starts, i.e. when the loop jumps to the start of the loop because the end of the loop was reached, and when the user explicitly jumps to the start of the loop with a `continue` statement.

This is the same approach as in Lua / in the Lua VM.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
