### PR TITLE
[v1.6] Port v1.6.1-rc.1

### DIFF
--- a/interpreter/div_mod_test.go
+++ b/interpreter/div_mod_test.go
@@ -3286,28 +3286,28 @@ func TestDivModUFix64(t *testing.T) {
 		{1, ufix64Zero, "division by zero"},
 		{2, ufix64Zero, "division by zero"},
 		{ufix64MaxIntDividend, ufix64Zero, "division by zero"},
-		{ufix64MaxIntDividend + 1, ufix64Zero, OverflowError{}},
+		{ufix64MaxIntDividend + 1, ufix64Zero, &OverflowError{}},
 
 		// 0.1
 		{0, ufix64ZeroDotOne, nil},
 		{1, ufix64ZeroDotOne, nil},
 		{2, ufix64ZeroDotOne, nil},
 		{ufix64MaxIntDividend, ufix64ZeroDotOne, values.OverflowError{}},
-		{ufix64MaxIntDividend + 1, ufix64ZeroDotOne, OverflowError{}},
+		{ufix64MaxIntDividend + 1, ufix64ZeroDotOne, &OverflowError{}},
 
 		// 1.0
 		{0, ufix64One, nil},
 		{1, ufix64One, nil},
 		{2, ufix64One, nil},
 		{ufix64MaxIntDividend, ufix64One, nil},
-		{ufix64MaxIntDividend + 1, ufix64One, OverflowError{}},
+		{ufix64MaxIntDividend + 1, ufix64One, &OverflowError{}},
 
 		// 2.0
 		{0, ufix64Two, nil},
 		{1, ufix64Two, nil},
 		{2, ufix64Two, nil},
 		{ufix64MaxIntDividend, ufix64Two, nil},
-		{ufix64MaxIntDividend + 1, ufix64Two, OverflowError{}},
+		{ufix64MaxIntDividend + 1, ufix64Two, &OverflowError{}},
 	}
 
 	inter, err := NewInterpreter(nil, nil, &Config{})
@@ -3332,7 +3332,19 @@ func TestDivModUFix64(t *testing.T) {
 			if test.panic == nil {
 				assert.NotPanics(t, f)
 			} else {
-				assert.PanicsWithValue(t, test.panic, f)
+				var paniced bool
+				func() {
+					defer func() {
+						recovered := recover()
+						if recovered != nil {
+							paniced = true
+						}
+						assert.Equal(t, test.panic, recovered)
+					}()
+					f()
+				}()
+
+				assert.True(t, paniced, "expected panic but did not panic")
 			}
 		}
 	}

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -343,20 +343,9 @@ func (v UFix64Value) Div(context NumberValueArithmeticContext, other NumberValue
 	return UFix64Value{UFix64Value: result}
 }
 
-func (v UFix64Value) SaturatingDiv(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {
-	defer func() {
-		r := recover()
-		if _, ok := r.(*InvalidOperandsError); ok {
-			panic(&InvalidOperandsError{
-				FunctionName:  sema.NumericTypeSaturatingDivideFunctionName,
-				LeftType:      v.StaticType(context),
-				RightType:     other.StaticType(context),
-				LocationRange: locationRange,
-			})
-		}
-	}()
-
-	return v.Div(context, other, locationRange)
+func (v UFix64Value) SaturatingDiv(_ NumberValueArithmeticContext, _ NumberValue, _ LocationRange) NumberValue {
+	// UFix64 does not have a saturating division operation, see sema.UFix64Type
+	panic(errors.NewUnreachableError())
 }
 
 func (v UFix64Value) Mod(context NumberValueArithmeticContext, other NumberValue, locationRange LocationRange) NumberValue {

--- a/parser/lexer/lexer.go
+++ b/parser/lexer/lexer.go
@@ -314,8 +314,15 @@ func (l *lexer) endPos() position {
 
 	var w int
 	for offset := startOffset; offset < endOffset-1; offset += w {
+
 		var r rune
-		r, w = utf8.DecodeRune(l.input[offset:])
+		b := l.input[offset:]
+		r, w = utf8.DecodeRune(b)
+
+		// fallback to 1 byte width if decoding fails
+		if w <= 0 {
+			w = 1
+		}
 
 		if r == '\n' {
 			endPos.line++

--- a/parser/lexer/lexer_test.go
+++ b/parser/lexer/lexer_test.go
@@ -3133,3 +3133,20 @@ func TestLimit(t *testing.T) {
 	_, err := Lex([]byte(code), nil)
 	require.ErrorAs(t, err, &TokenLimitReachedError{})
 }
+
+func TestLexInvalidRune(t *testing.T) {
+
+	t.Parallel()
+
+	code := `"\(FFFF\`
+
+	tokens, err := Lex([]byte(code), nil)
+	require.NoError(t, err)
+
+	for {
+		token := tokens.Next()
+		if token.Type == TokenEOF {
+			break
+		}
+	}
+}

--- a/values/value_ufix64.go
+++ b/values/value_ufix64.go
@@ -192,8 +192,9 @@ func (v UFix64Value) Div(gauge common.MemoryGauge, other UFix64Value) (UFix64Val
 	return NewUFix64Value(gauge, valueGetter)
 }
 
-func (v UFix64Value) SaturatingDiv(gauge common.MemoryGauge, other UFix64Value) (UFix64Value, error) {
-	return v.Div(gauge, other)
+func (v UFix64Value) SaturatingDiv(_ common.MemoryGauge, _ UFix64Value) (UFix64Value, error) {
+	// UFix64 does not have a saturating division operation, see sema.UFix64Type
+	panic(errors.NewUnreachableError())
 }
 
 func (v UFix64Value) Mod(gauge common.MemoryGauge, other UFix64Value) (UFix64Value, error) {

--- a/values/value_ufix64.go
+++ b/values/value_ufix64.go
@@ -182,6 +182,10 @@ func (v UFix64Value) Div(gauge common.MemoryGauge, other UFix64Value) (UFix64Val
 		result := new(big.Int).Mul(a, sema.Fix64FactorBig)
 		result.Div(result, b)
 
+		if !result.IsUint64() {
+			return 0, OverflowError{}
+		}
+
 		return result.Uint64(), nil
 	}
 


### PR DESCRIPTION


## Description

Port internal PRs of v1.6.1-rc.1 to v1.6:

- https://github.com/onflow/cadence-internal/pull/339
- https://github.com/onflow/cadence-internal/pull/341

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
