### PR TITLE
[Compiler] Implement Account.Keys functions for VM

### DIFF
--- a/stdlib/builtin.go
+++ b/stdlib/builtin.go
@@ -90,6 +90,11 @@ func VMFunctions(handler StandardLibraryHandler) []VMFunction {
 		NewVMAccountCapabilitiesPublishFunction(handler),
 		NewVMAccountCapabilitiesUnpublishFunction(handler),
 
+		NewVMAccountKeysAddFunction(handler),
+		NewVMAccountKeysGetFunction(handler),
+		NewVMAccountKeysRevokeFunction(handler),
+		NewVMAccountKeysForEachFunction(handler),
+
 		NewVMAccountStorageCapabilitiesGetControllersFunction(handler),
 		NewVMAccountStorageCapabilitiesGetControllerFunction(handler),
 		NewVMAccountStorageCapabilitiesForEachControllerFunction(handler),


### PR DESCRIPTION
Work towards #4015 

### Description

Cannot be tested yet, as the tests depend on the `PublicKey` and `HashAlgorithm` types, which are not implemented for the compiler/VM yet.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
