### PR TITLE
[Compiler] Implement RLP and BLS functions for VM

### DIFF
--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -498,13 +498,16 @@ func TestRuntimeBLSAggregateSignatures(t *testing.T) {
 		},
 	}
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	result, err := runtime.ExecuteScript(
 		Script{
 			Source: script,
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -574,13 +577,15 @@ func TestRuntimeBLSAggregatePublicKeys(t *testing.T) {
 	}
 	addPublicKeyValidation(runtimeInterface, nil)
 
+	nextScriptLocation := NewScriptLocationGenerator()
+
 	result, err := runtime.ExecuteScript(
 		Script{
 			Source: script,
 		},
 		Context{
 			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
+			Location:  nextScriptLocation(),
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/rlp_test.go
+++ b/runtime/rlp_test.go
@@ -147,6 +147,7 @@ func TestRuntimeRLPDecodeString(t *testing.T) {
 				Context{
 					Interface: runtimeInterface,
 					Location:  common.ScriptLocation{},
+					UseVM:     *compile,
 				},
 			)
 			if len(test.expectedErrMsg) > 0 {
@@ -303,6 +304,7 @@ func TestRuntimeRLPDecodeList(t *testing.T) {
 				Context{
 					Interface: runtimeInterface,
 					Location:  common.ScriptLocation{},
+					UseVM:     *compile,
 				},
 			)
 			if len(test.expectedErrMsg) > 0 {

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -103,6 +103,15 @@ func newVMEnvironment(config Config) *vmEnvironment {
 			qualifiedName,
 			variable,
 		)
+
+		if env.defaultCompilerBuiltinGlobals.Find(qualifiedName) == (compiler.GlobalImport{}) {
+			env.defaultCompilerBuiltinGlobals.Set(
+				qualifiedName,
+				compiler.GlobalImport{
+					Name: qualifiedName,
+				},
+			)
+		}
 	}
 
 	return env

--- a/stdlib/bls.go
+++ b/stdlib/bls.go
@@ -21,6 +21,8 @@ package stdlib
 //go:generate go run ../sema/gen -p stdlib bls.cdc bls.gen.go
 
 import (
+	"github.com/onflow/cadence/bbq"
+	"github.com/onflow/cadence/bbq/vm"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
@@ -34,7 +36,7 @@ type BLSPublicKeyAggregator interface {
 	BLSAggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error)
 }
 
-func newBLSAggregatePublicKeysFunction(
+func newInterpreterBLSAggregatePublicKeysFunction(
 	gauge common.MemoryGauge,
 	aggregator BLSPublicKeyAggregator,
 ) *interpreter.HostFunctionValue {
@@ -44,62 +46,106 @@ func newBLSAggregatePublicKeysFunction(
 		gauge,
 		BLSTypeAggregatePublicKeysFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.InvocationContext
+			locationRange := invocation.LocationRange
+
 			publicKeysValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.InvocationContext
-			locationRange := invocation.LocationRange
-
-			interpreter.ExpectType(
+			return BLSAggregatePublicKeys(
 				inter,
 				publicKeysValue,
-				sema.PublicKeyArrayType,
 				locationRange,
-			)
-
-			publicKeys := make([]*PublicKey, 0, publicKeysValue.Count())
-			publicKeysValue.Iterate(
-				inter,
-				func(element interpreter.Value) (resume bool) {
-					publicKeyValue, ok := element.(*interpreter.CompositeValue)
-					if !ok {
-						panic(errors.NewUnreachableError())
-					}
-
-					publicKey, err := NewPublicKeyFromValue(inter, locationRange, publicKeyValue)
-					if err != nil {
-						panic(err)
-					}
-
-					publicKeys = append(publicKeys, publicKey)
-
-					// Continue iteration
-					return true
-				},
-				false,
-				locationRange,
-			)
-
-			aggregatedPublicKey, err := aggregator.BLSAggregatePublicKeys(publicKeys)
-
-			// If the crypto layer produces an error, we have invalid input, return nil
-			if err != nil {
-				return interpreter.NilOptionalValue
-			}
-
-			aggregatedPublicKeyValue := NewPublicKeyValue(
-				inter,
-				locationRange,
-				aggregatedPublicKey,
-			)
-
-			return interpreter.NewSomeValueNonCopying(
-				inter,
-				aggregatedPublicKeyValue,
+				aggregator,
 			)
 		},
+	)
+}
+
+func NewVMBLSAggregatePublicKeysFunction(
+	aggregator BLSPublicKeyAggregator,
+) VMFunction {
+	return VMFunction{
+		BaseType: BLSType,
+		FunctionValue: vm.NewNativeFunctionValue(
+			BLSTypeAggregatePublicKeysFunctionName,
+			BLSTypeAggregatePublicKeysFunctionType,
+			func(context *vm.Context, _ []bbq.StaticType, args ...vm.Value) vm.Value {
+
+				// arg[0] is the receiver. Actual arguments starts from 1.
+				args = args[vm.TypeBoundFunctionArgumentOffset:]
+
+				publicKeysValue, ok := args[0].(*interpreter.ArrayValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				return BLSAggregatePublicKeys(
+					context,
+					publicKeysValue,
+					interpreter.EmptyLocationRange,
+					aggregator,
+				)
+			},
+		),
+	}
+}
+
+func BLSAggregatePublicKeys(
+	context interpreter.InvocationContext,
+	publicKeysValue *interpreter.ArrayValue,
+	locationRange interpreter.LocationRange,
+	aggregator BLSPublicKeyAggregator,
+) interpreter.Value {
+
+	interpreter.ExpectType(
+		context,
+		publicKeysValue,
+		sema.PublicKeyArrayType,
+		locationRange,
+	)
+
+	publicKeys := make([]*PublicKey, 0, publicKeysValue.Count())
+	publicKeysValue.Iterate(
+		context,
+		func(element interpreter.Value) (resume bool) {
+			publicKeyValue, ok := element.(*interpreter.CompositeValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			publicKey, err := NewPublicKeyFromValue(context, locationRange, publicKeyValue)
+			if err != nil {
+				panic(err)
+			}
+
+			publicKeys = append(publicKeys, publicKey)
+
+			// Continue iteration
+			return true
+		},
+		false,
+		locationRange,
+	)
+
+	aggregatedPublicKey, err := aggregator.BLSAggregatePublicKeys(publicKeys)
+
+	// If the crypto layer produces an error, we have invalid input, return nil
+	if err != nil {
+		return interpreter.NilOptionalValue
+	}
+
+	aggregatedPublicKeyValue := NewPublicKeyValue(
+		context,
+		locationRange,
+		aggregatedPublicKey,
+	)
+
+	return interpreter.NewSomeValueNonCopying(
+		context,
+		aggregatedPublicKeyValue,
 	)
 }
 
@@ -108,7 +154,7 @@ type BLSSignatureAggregator interface {
 	BLSAggregateSignatures(signatures [][]byte) ([]byte, error)
 }
 
-func newBLSAggregateSignaturesFunction(
+func newInterpreterBLSAggregateSignaturesFunction(
 	gauge common.MemoryGauge,
 	aggregator BLSSignatureAggregator,
 ) *interpreter.HostFunctionValue {
@@ -118,58 +164,102 @@ func newBLSAggregateSignaturesFunction(
 		gauge,
 		BLSTypeAggregateSignaturesFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.InvocationContext
+			locationRange := invocation.LocationRange
+
 			signaturesValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
 			if !ok {
 				panic(errors.NewUnreachableError())
 			}
 
-			inter := invocation.InvocationContext
-			locationRange := invocation.LocationRange
-
-			interpreter.ExpectType(
+			return BLSAggregateSignatures(
 				inter,
 				signaturesValue,
-				sema.ByteArrayArrayType,
 				locationRange,
-			)
-
-			bytesArray := make([][]byte, 0, signaturesValue.Count())
-			signaturesValue.Iterate(
-				inter,
-				func(element interpreter.Value) (resume bool) {
-					signature, ok := element.(*interpreter.ArrayValue)
-					if !ok {
-						panic(errors.NewUnreachableError())
-					}
-
-					bytes, err := interpreter.ByteArrayValueToByteSlice(inter, signature, invocation.LocationRange)
-					if err != nil {
-						panic(err)
-					}
-
-					bytesArray = append(bytesArray, bytes)
-
-					// Continue iteration
-					return true
-				},
-				false,
-				locationRange,
-			)
-
-			aggregatedSignature, err := aggregator.BLSAggregateSignatures(bytesArray)
-
-			// If the crypto layer produces an error, we have invalid input, return nil
-			if err != nil {
-				return interpreter.NilOptionalValue
-			}
-
-			aggregatedSignatureValue := interpreter.ByteSliceToByteArrayValue(inter, aggregatedSignature)
-
-			return interpreter.NewSomeValueNonCopying(
-				inter,
-				aggregatedSignatureValue,
+				aggregator,
 			)
 		},
+	)
+}
+
+func NewVMBLSAggregateSignaturesFunction(
+	aggregator BLSSignatureAggregator,
+) VMFunction {
+	return VMFunction{
+		BaseType: BLSType,
+		FunctionValue: vm.NewNativeFunctionValue(
+			BLSTypeAggregateSignaturesFunctionName,
+			BLSTypeAggregateSignaturesFunctionType,
+			func(context *vm.Context, _ []bbq.StaticType, args ...vm.Value) vm.Value {
+
+				// arg[0] is the receiver. Actual arguments starts from 1.
+				args = args[vm.TypeBoundFunctionArgumentOffset:]
+
+				signaturesValue, ok := args[0].(*interpreter.ArrayValue)
+				if !ok {
+					panic(errors.NewUnreachableError())
+				}
+
+				return BLSAggregateSignatures(
+					context,
+					signaturesValue,
+					interpreter.EmptyLocationRange,
+					aggregator,
+				)
+			},
+		),
+	}
+}
+
+func BLSAggregateSignatures(
+	context interpreter.InvocationContext,
+	signaturesValue *interpreter.ArrayValue,
+	locationRange interpreter.LocationRange,
+	aggregator BLSSignatureAggregator,
+) interpreter.Value {
+
+	interpreter.ExpectType(
+		context,
+		signaturesValue,
+		sema.ByteArrayArrayType,
+		locationRange,
+	)
+
+	bytesArray := make([][]byte, 0, signaturesValue.Count())
+	signaturesValue.Iterate(
+		context,
+		func(element interpreter.Value) (resume bool) {
+			signature, ok := element.(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			bytes, err := interpreter.ByteArrayValueToByteSlice(context, signature, locationRange)
+			if err != nil {
+				panic(err)
+			}
+
+			bytesArray = append(bytesArray, bytes)
+
+			// Continue iteration
+			return true
+		},
+		false,
+		locationRange,
+	)
+
+	aggregatedSignature, err := aggregator.BLSAggregateSignatures(bytesArray)
+
+	// If the crypto layer produces an error, we have invalid input, return nil
+	if err != nil {
+		return interpreter.NilOptionalValue
+	}
+
+	aggregatedSignatureValue := interpreter.ByteSliceToByteArrayValue(context, aggregatedSignature)
+
+	return interpreter.NewSomeValueNonCopying(
+		context,
+		aggregatedSignatureValue,
 	)
 }
 
@@ -192,9 +282,9 @@ func NewBLSContract(
 	computeLazyStoredMethod := func(name string) interpreter.FunctionValue {
 		switch name {
 		case BLSTypeAggregatePublicKeysFunctionName:
-			return newBLSAggregatePublicKeysFunction(gauge, handler)
+			return newInterpreterBLSAggregatePublicKeysFunction(gauge, handler)
 		case BLSTypeAggregateSignaturesFunctionName:
-			return newBLSAggregateSignaturesFunction(gauge, handler)
+			return newInterpreterBLSAggregateSignaturesFunction(gauge, handler)
 		default:
 			return nil
 		}

--- a/stdlib/builtin.go
+++ b/stdlib/builtin.go
@@ -73,7 +73,7 @@ func VMDefaultStandardLibraryValues(handler StandardLibraryHandler) []StandardLi
 		// TODO: PublicKeyConstructor
 		// TODO: HashAlgorithmConstructor
 		RLPContract,
-		// TODO: NewBLSContract(nil, handler),
+		NewBLSContract(nil, handler),
 	}
 }
 
@@ -114,6 +114,8 @@ func VMFunctions(handler StandardLibraryHandler) []VMFunction {
 		VMRLPDecodeStringFunction,
 		VMRLPDecodeListFunction,
 
+		NewVMBLSAggregatePublicKeysFunction(handler),
+		NewVMBLSAggregateSignaturesFunction(handler),
 	}
 }
 

--- a/stdlib/builtin.go
+++ b/stdlib/builtin.go
@@ -111,8 +111,9 @@ func VMFunctions(handler StandardLibraryHandler) []VMFunction {
 		NewVMAccountAccountCapabilitiesIssueFunction(handler),
 		NewVMAccountAccountCapabilitiesIssueWithTypeFunction(handler),
 
-		vmRLPDecodeStringFunction,
-		vmRLPDecodeListFunction,
+		VMRLPDecodeStringFunction,
+		VMRLPDecodeListFunction,
+
 	}
 }
 

--- a/stdlib/builtin.go
+++ b/stdlib/builtin.go
@@ -72,8 +72,8 @@ func VMDefaultStandardLibraryValues(handler StandardLibraryHandler) []StandardLi
 		NewVMAccountConstructor(handler),
 		// TODO: PublicKeyConstructor
 		// TODO: HashAlgorithmConstructor
-		// TODO: RLPContract,
-		// TODO: BLSContract
+		RLPContract,
+		// TODO: NewBLSContract(nil, handler),
 	}
 }
 
@@ -110,6 +110,9 @@ func VMFunctions(handler StandardLibraryHandler) []VMFunction {
 		NewVMAccountAccountCapabilitiesForEachControllerFunction(handler),
 		NewVMAccountAccountCapabilitiesIssueFunction(handler),
 		NewVMAccountAccountCapabilitiesIssueWithTypeFunction(handler),
+
+		vmRLPDecodeStringFunction,
+		vmRLPDecodeListFunction,
 	}
 }
 

--- a/stdlib/rlp.go
+++ b/stdlib/rlp.go
@@ -23,6 +23,8 @@ package stdlib
 import (
 	"fmt"
 
+	"github.com/onflow/cadence/bbq"
+	"github.com/onflow/cadence/bbq/vm"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
@@ -44,8 +46,8 @@ func (e RLPDecodeStringError) Error() string {
 
 const rlpErrMsgInputContainsExtraBytes = "input data is expected to be RLP-encoded of a single string or a single list but it seems it contains extra trailing bytes."
 
-// rlpDecodeStringFunction is a static function
-var rlpDecodeStringFunction = interpreter.NewUnmeteredStaticHostFunctionValue(
+// interpreterRLPDecodeStringFunction is a static function
+var interpreterRLPDecodeStringFunction = interpreter.NewUnmeteredStaticHostFunctionValue(
 	RLPTypeDecodeStringFunctionType,
 	func(invocation interpreter.Invocation) interpreter.Value {
 		context := invocation.InvocationContext
@@ -56,40 +58,76 @@ var rlpDecodeStringFunction = interpreter.NewUnmeteredStaticHostFunctionValue(
 			panic(errors.NewUnreachableError())
 		}
 
-		convertedInput, err := interpreter.ByteArrayValueToByteSlice(context, input, locationRange)
-		if err != nil {
-			panic(RLPDecodeStringError{
-				Msg:           err.Error(),
-				LocationRange: locationRange,
-			})
-		}
-
-		common.UseComputation(
+		return RLPDecodeString(
+			input,
 			context,
-			common.ComputationUsage{
-				Kind:      common.ComputationKindSTDLIBRLPDecodeString,
-				Intensity: uint64(input.Count()),
-			},
+			locationRange,
 		)
-
-		output, bytesRead, err := rlp.DecodeString(convertedInput, 0)
-		if err != nil {
-			panic(RLPDecodeStringError{
-				Msg:           err.Error(),
-				LocationRange: locationRange,
-			})
-		}
-
-		if bytesRead != len(convertedInput) {
-			panic(RLPDecodeStringError{
-				Msg:           rlpErrMsgInputContainsExtraBytes,
-				LocationRange: locationRange,
-			})
-		}
-
-		return interpreter.ByteSliceToByteArrayValue(context, output)
 	},
 )
+
+var vmRLPDecodeStringFunction = VMFunction{
+	BaseType: RLPType,
+	FunctionValue: vm.NewNativeFunctionValue(
+		RLPTypeDecodeStringFunctionName,
+		RLPTypeDecodeStringFunctionType,
+		func(context *vm.Context, _ []bbq.StaticType, args ...vm.Value) vm.Value {
+
+			// arg[0] is the receiver. Actual arguments starts from 1.
+			_, args = args[vm.ReceiverIndex], args[vm.TypeBoundFunctionArgumentOffset:]
+
+			input, ok := args[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			return RLPDecodeString(
+				input,
+				context,
+				interpreter.EmptyLocationRange,
+			)
+		},
+	),
+}
+
+func RLPDecodeString(
+	input *interpreter.ArrayValue,
+	context interpreter.InvocationContext,
+	locationRange interpreter.LocationRange,
+) interpreter.Value {
+	convertedInput, err := interpreter.ByteArrayValueToByteSlice(context, input, locationRange)
+	if err != nil {
+		panic(RLPDecodeStringError{
+			Msg:           err.Error(),
+			LocationRange: locationRange,
+		})
+	}
+
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindSTDLIBRLPDecodeString,
+			Intensity: uint64(input.Count()),
+		},
+	)
+
+	output, bytesRead, err := rlp.DecodeString(convertedInput, 0)
+	if err != nil {
+		panic(RLPDecodeStringError{
+			Msg:           err.Error(),
+			LocationRange: locationRange,
+		})
+	}
+
+	if bytesRead != len(convertedInput) {
+		panic(RLPDecodeStringError{
+			Msg:           rlpErrMsgInputContainsExtraBytes,
+			LocationRange: locationRange,
+		})
+	}
+
+	return interpreter.ByteSliceToByteArrayValue(context, output)
+}
 
 type RLPDecodeListError struct {
 	interpreter.LocationRange
@@ -104,8 +142,8 @@ func (e RLPDecodeListError) Error() string {
 	return fmt.Sprintf("failed to RLP-decode list: %s", e.Msg)
 }
 
-// rlpDecodeListFunction is a static function
-var rlpDecodeListFunction = interpreter.NewUnmeteredStaticHostFunctionValue(
+// interpreterRLPDecodeListFunction is a static function
+var interpreterRLPDecodeListFunction = interpreter.NewUnmeteredStaticHostFunctionValue(
 	RLPTypeDecodeListFunctionType,
 	func(invocation interpreter.Invocation) interpreter.Value {
 		context := invocation.InvocationContext
@@ -116,59 +154,95 @@ var rlpDecodeListFunction = interpreter.NewUnmeteredStaticHostFunctionValue(
 			panic(errors.NewUnreachableError())
 		}
 
-		convertedInput, err := interpreter.ByteArrayValueToByteSlice(context, input, locationRange)
-		if err != nil {
-			panic(RLPDecodeListError{
-				Msg:           err.Error(),
-				LocationRange: locationRange,
-			})
-		}
-
-		common.UseComputation(
-			context,
-			common.ComputationUsage{
-				Kind:      common.ComputationKindSTDLIBRLPDecodeList,
-				Intensity: uint64(input.Count()),
-			},
-		)
-
-		output, bytesRead, err := rlp.DecodeList(convertedInput, 0)
-
-		if err != nil {
-			panic(RLPDecodeListError{
-				Msg:           err.Error(),
-				LocationRange: locationRange,
-			})
-		}
-
-		if bytesRead != len(convertedInput) {
-			panic(RLPDecodeListError{
-				Msg:           rlpErrMsgInputContainsExtraBytes,
-				LocationRange: locationRange,
-			})
-		}
-
-		values := make([]interpreter.Value, len(output))
-		for i, b := range output {
-			values[i] = interpreter.ByteSliceToByteArrayValue(context, b)
-		}
-
-		return interpreter.NewArrayValue(
+		return RLPDecodeList(
+			input,
 			context,
 			locationRange,
-			interpreter.NewVariableSizedStaticType(
-				context,
-				interpreter.ByteArrayStaticType,
-			),
-			common.ZeroAddress,
-			values...,
 		)
 	},
 )
 
+var vmRLPDecodeListFunction = VMFunction{
+	BaseType: RLPType,
+	FunctionValue: vm.NewNativeFunctionValue(
+		RLPTypeDecodeListFunctionName,
+		RLPTypeDecodeListFunctionType,
+		func(context *vm.Context, _ []bbq.StaticType, args ...vm.Value) vm.Value {
+
+			// arg[0] is the receiver. Actual arguments starts from 1.
+			_, args = args[vm.ReceiverIndex], args[vm.TypeBoundFunctionArgumentOffset:]
+
+			input, ok := args[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			return RLPDecodeList(
+				input,
+				context,
+				interpreter.EmptyLocationRange,
+			)
+		},
+	),
+}
+
+func RLPDecodeList(
+	input *interpreter.ArrayValue,
+	context interpreter.InvocationContext,
+	locationRange interpreter.LocationRange,
+) interpreter.Value {
+	convertedInput, err := interpreter.ByteArrayValueToByteSlice(context, input, locationRange)
+	if err != nil {
+		panic(RLPDecodeListError{
+			Msg:           err.Error(),
+			LocationRange: locationRange,
+		})
+	}
+
+	common.UseComputation(
+		context,
+		common.ComputationUsage{
+			Kind:      common.ComputationKindSTDLIBRLPDecodeList,
+			Intensity: uint64(input.Count()),
+		},
+	)
+
+	output, bytesRead, err := rlp.DecodeList(convertedInput, 0)
+
+	if err != nil {
+		panic(RLPDecodeListError{
+			Msg:           err.Error(),
+			LocationRange: locationRange,
+		})
+	}
+
+	if bytesRead != len(convertedInput) {
+		panic(RLPDecodeListError{
+			Msg:           rlpErrMsgInputContainsExtraBytes,
+			LocationRange: locationRange,
+		})
+	}
+
+	values := make([]interpreter.Value, len(output))
+	for i, b := range output {
+		values[i] = interpreter.ByteSliceToByteArrayValue(context, b)
+	}
+
+	return interpreter.NewArrayValue(
+		context,
+		locationRange,
+		interpreter.NewVariableSizedStaticType(
+			context,
+			interpreter.ByteArrayStaticType,
+		),
+		common.ZeroAddress,
+		values...,
+	)
+}
+
 var rlpContractFields = map[string]interpreter.Value{
-	RLPTypeDecodeListFunctionName:   rlpDecodeListFunction,
-	RLPTypeDecodeStringFunctionName: rlpDecodeStringFunction,
+	RLPTypeDecodeListFunctionName:   interpreterRLPDecodeListFunction,
+	RLPTypeDecodeStringFunctionName: interpreterRLPDecodeStringFunction,
 }
 
 var RLPTypeStaticType = interpreter.ConvertSemaToStaticType(nil, RLPType)

--- a/stdlib/rlp.go
+++ b/stdlib/rlp.go
@@ -66,7 +66,7 @@ var interpreterRLPDecodeStringFunction = interpreter.NewUnmeteredStaticHostFunct
 	},
 )
 
-var vmRLPDecodeStringFunction = VMFunction{
+var VMRLPDecodeStringFunction = VMFunction{
 	BaseType: RLPType,
 	FunctionValue: vm.NewNativeFunctionValue(
 		RLPTypeDecodeStringFunctionName,
@@ -74,7 +74,7 @@ var vmRLPDecodeStringFunction = VMFunction{
 		func(context *vm.Context, _ []bbq.StaticType, args ...vm.Value) vm.Value {
 
 			// arg[0] is the receiver. Actual arguments starts from 1.
-			_, args = args[vm.ReceiverIndex], args[vm.TypeBoundFunctionArgumentOffset:]
+			args = args[vm.TypeBoundFunctionArgumentOffset:]
 
 			input, ok := args[0].(*interpreter.ArrayValue)
 			if !ok {
@@ -162,7 +162,7 @@ var interpreterRLPDecodeListFunction = interpreter.NewUnmeteredStaticHostFunctio
 	},
 )
 
-var vmRLPDecodeListFunction = VMFunction{
+var VMRLPDecodeListFunction = VMFunction{
 	BaseType: RLPType,
 	FunctionValue: vm.NewNativeFunctionValue(
 		RLPTypeDecodeListFunctionName,
@@ -170,7 +170,7 @@ var vmRLPDecodeListFunction = VMFunction{
 		func(context *vm.Context, _ []bbq.StaticType, args ...vm.Value) vm.Value {
 
 			// arg[0] is the receiver. Actual arguments starts from 1.
-			_, args = args[vm.ReceiverIndex], args[vm.TypeBoundFunctionArgumentOffset:]
+			args = args[vm.TypeBoundFunctionArgumentOffset:]
 
 			input, ok := args[0].(*interpreter.ArrayValue)
 			if !ok {


### PR DESCRIPTION
Work towards #4015
⚠️ Depends on #4034

### Description

The `BLS.aggregatePublicKeys` tests cannot be enabled yet, because they rely on the types `PublicKey` and `SignatureAlgorithm`, which are not implemented yet in the compiler/VM.

Also: the compiler package already registers global imports for the methods of all built-in types. However, the stdlib might define more methods (like for the `BLS` and `RLP` contract types). Register the methods of these types also with the compiler, not just the VM.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
