### PR TITLE
[Compiler] Allow loading of `flow.*` types in VM environment

### DIFF
--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -8535,6 +8535,7 @@ func TestRuntimeFlowEventTypes(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -357,6 +357,10 @@ func (e *vmEnvironment) loadDesugaredElaboration(location common.Location) (*com
 }
 
 func (e *vmEnvironment) loadType(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
+	if _, ok := location.(stdlib.FlowLocation); ok {
+		return stdlib.FlowEventTypes[typeID]
+	}
+
 	elaboration, err := e.loadDesugaredElaboration(location)
 	if err != nil {
 		panic(fmt.Errorf(


### PR DESCRIPTION
Work towards #4015 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
