### PR TITLE
Fix race when array/dictionary entitlement set is used concurrently

### DIFF
--- a/sema/type.go
+++ b/sema/type.go
@@ -3154,6 +3154,7 @@ var arrayDictionaryEntitlements = func() *EntitlementSet {
 	set.Add(MutateType)
 	set.Add(InsertType)
 	set.Add(RemoveType)
+	set.Minimize()
 	return set
 }()
 


### PR DESCRIPTION
## Description

The global `arrayDictionaryEntitlements` might be used concurrently, being converted into an access via `Access()`, which mutates it via `Minimize()`.

Ensure the global is already minimized before it is converted into an access concurrently.

Before the fix `go test -v -run=TestCheckEntitlementConditions -race -count=2` reproduced the race quite easily, with the fix `go test -v -run=TestCheckEntitlementConditions -race -parallel=8 -count=1000` does not report anything.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
