### PR TITLE
[Compiler] Refactor method invocation

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -2036,6 +2036,13 @@ func (c *Compiler[_, _]) emitGlobalLoad(name string) {
 	})
 }
 
+func (c *Compiler[_, _]) emitMethodLoad(name string) {
+	global := c.findGlobal(name)
+	c.emit(opcode.InstructionGetMethod{
+		Method: global.Index,
+	})
+}
+
 func (c *Compiler[_, _]) emitVariableStore(name string) {
 	local := c.currentFunction.findLocal(name)
 	if local != nil {
@@ -2083,7 +2090,7 @@ func (c *Compiler[_, _]) VisitInvocationExpression(expression *ast.InvocationExp
 				memberInfo,
 				memberExpression,
 				invocationTypes,
-				argumentCount,
+				uint16(argumentCount),
 			)
 			return
 		}
@@ -2114,7 +2121,7 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 	memberInfo sema.MemberAccessInfo,
 	invokedExpr *ast.MemberExpression,
 	invocationTypes sema.InvocationExpressionTypes,
-	argumentCount int,
+	argumentCount uint16,
 ) {
 	var funcName string
 
@@ -2137,7 +2144,7 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 
 		c.emit(opcode.InstructionInvoke{
 			TypeArgs: typeArgs,
-			ArgCount: uint16(argumentCount),
+			ArgCount: argumentCount,
 		})
 		return
 	}
@@ -2149,8 +2156,6 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 	// Invocations into the interface code, such as default functions and inherited conditions,
 	// that were synthetically added at the desugar phase, must be static calls.
 	isInterfaceInheritedFuncCall := c.DesugaredElaboration.IsInterfaceMethodStaticCall(expression)
-
-	argsCountWithReceiver := uint16(argumentCount) + 1
 
 	// Any invocation on restricted-types must be dynamic
 	if !isInterfaceInheritedFuncCall && isDynamicMethodInvocation(memberInfo.AccessedType) {
@@ -2169,6 +2174,9 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 				c.compileArguments(expression.Arguments, invocationTypes)
 
 				funcNameConst := c.addStringConst(funcName)
+
+				argsCountWithReceiver := argumentCount + 1
+
 				c.emit(
 					opcode.InstructionInvokeMethodDynamic{
 						Name:     funcNameConst.index,
@@ -2207,7 +2215,7 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 		c.compileArguments(expression.Arguments, invocationTypes)
 		c.emit(opcode.InstructionInvoke{
 			TypeArgs: typeArgs,
-			ArgCount: uint16(argumentCount),
+			ArgCount: argumentCount,
 		})
 	} else {
 		c.withOptionalChaining(
@@ -2215,20 +2223,24 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 			isOptional,
 			func(receiverIndex uint16) {
 				// Compile as object-method call.
-
 				// Function must be loaded only if the receiver is non-nil.
-				c.emitGlobalLoad(funcName)
 
 				// The receiver is loaded first.
-				// So 'self' is always the zero-th argument.
 				c.emitGetLocal(receiverIndex)
+
+				// Get the method as a bound function.
+				// This is needed to capture the implicit reference that's get created by bound functions.
+				c.emitMethodLoad(funcName)
 
 				// Compile arguments
 				c.compileArguments(expression.Arguments, invocationTypes)
 
 				c.emit(opcode.InstructionInvokeMethodStatic{
 					TypeArgs: typeArgs,
-					ArgCount: argsCountWithReceiver,
+
+					// Argument count does not include the receiver,
+					// since receiver is already captured by the bound-function.
+					ArgCount: argumentCount,
 				})
 			},
 		)

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -2800,13 +2800,13 @@ func TestCompileMethodInvocation(t *testing.T) {
 				opcode.InstructionStatement{},
 				opcode.InstructionGetLocal{Local: fooIndex},
 				opcode.InstructionSetLocal{Local: tempIndex},
-				opcode.InstructionGetGlobal{Global: fFuncIndex},
 				opcode.InstructionGetLocal{Local: tempIndex},
+				opcode.InstructionGetMethod{Method: fFuncIndex},
 				opcode.InstructionTrue{},
 				opcode.InstructionTransferAndConvert{Type: 2},
 				opcode.InstructionInvokeMethodStatic{
 					TypeArgs: nil,
-					ArgCount: 2,
+					ArgCount: 1,
 				},
 				opcode.InstructionDrop{},
 
@@ -3260,11 +3260,11 @@ func TestCompileDefaultFunction(t *testing.T) {
 			opcode.InstructionSetLocal{Local: tempIndex},
 
 			// self.test()
-			opcode.InstructionGetGlobal{Global: interfaceFunctionIndex}, // must be interface method's index
 			opcode.InstructionGetLocal{Local: tempIndex},
+			opcode.InstructionGetMethod{Method: interfaceFunctionIndex}, // must be interface method's index
 			opcode.InstructionInvokeMethodStatic{
 				TypeArgs: nil,
-				ArgCount: 1,
+				ArgCount: 0,
 			},
 
 			// return
@@ -4078,12 +4078,12 @@ func TestCompileFunctionConditions(t *testing.T) {
 				// Store in temp index
 				opcode.InstructionSetLocal{Local: tempIndex},
 
-				// Get function value `A.TestStruct.test()`
-				opcode.InstructionGetGlobal{Global: 10},
 				// Load receiver at the temp index, as the first argument.
 				opcode.InstructionGetLocal{Local: tempIndex},
+				// Get function value `A.TestStruct.test()`
+				opcode.InstructionGetMethod{Method: 10},
 				opcode.InstructionInvokeMethodStatic{
-					ArgCount: 1,
+					ArgCount: 0,
 				},
 
 				// if !<condition>
@@ -6960,11 +6960,11 @@ func TestCompileOptionalChaining(t *testing.T) {
 				opcode.InstructionUnwrap{},
 				opcode.InstructionSetLocal{Local: unwrappedValueTempIndex},
 
-				// Load `Foo.bar` function
-				opcode.InstructionGetGlobal{Global: 4},
 				// Load receiver
 				opcode.InstructionGetLocal{Local: unwrappedValueTempIndex},
-				opcode.InstructionInvokeMethodStatic{ArgCount: 1},
+				// Load `Foo.bar` function
+				opcode.InstructionGetMethod{Method: 4},
+				opcode.InstructionInvokeMethodStatic{ArgCount: 0},
 				opcode.InstructionJump{Target: 17},
 
 				// If `foo == nil`
@@ -7718,21 +7718,21 @@ func TestCompileOptionalArgument(t *testing.T) {
 		assert.Equal(t,
 			[]opcode.Instruction{
 				opcode.InstructionStatement{},
-				opcode.InstructionGetLocal{Local: 0x0},
-				opcode.InstructionGetField{FieldName: 0x0},
-				opcode.InstructionGetField{FieldName: 0x1},
-				opcode.InstructionNewRef{Type: 0x4, IsImplicit: true},
-				opcode.InstructionSetLocal{Local: 0x1},
-				opcode.InstructionGetGlobal{Global: 0x5},
-				opcode.InstructionGetLocal{Local: 0x1},
-				opcode.InstructionGetConstant{Constant: 0x2},
-				opcode.InstructionTransferAndConvert{Type: 0x5},
-				opcode.InstructionGetConstant{Constant: 0x3},
-				opcode.InstructionGetField{FieldName: 0x4},
-				opcode.InstructionTransferAndConvert{Type: 0x6},
-				opcode.InstructionGetConstant{Constant: 0x5},
+				opcode.InstructionGetLocal{Local: 0},
+				opcode.InstructionGetField{FieldName: 0},
+				opcode.InstructionGetField{FieldName: 1},
+				opcode.InstructionNewRef{Type: 4, IsImplicit: true},
+				opcode.InstructionSetLocal{Local: 1},
+				opcode.InstructionGetLocal{Local: 1},
+				opcode.InstructionGetMethod{Method: 5},
+				opcode.InstructionGetConstant{Constant: 2},
+				opcode.InstructionTransferAndConvert{Type: 5},
+				opcode.InstructionGetConstant{Constant: 3},
+				opcode.InstructionGetField{FieldName: 4},
+				opcode.InstructionTransferAndConvert{Type: 6},
+				opcode.InstructionGetConstant{Constant: 5},
 				opcode.InstructionTransfer{},
-				opcode.InstructionInvokeMethodStatic{TypeArgs: []uint16(nil), ArgCount: 0x4},
+				opcode.InstructionInvokeMethodStatic{ArgCount: 3},
 				opcode.InstructionDrop{},
 				opcode.InstructionReturn{}},
 			functions[3].Code,

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -1207,6 +1207,50 @@ func DecodeInvokeMethodDynamic(ip *uint16, code []byte) (i InstructionInvokeMeth
 	return i
 }
 
+// InstructionGetMethod
+//
+// Pops a value off the stack, the receiver, and then pushes the value of the function at the given index onto the stack.
+type InstructionGetMethod struct {
+	Method uint16
+}
+
+var _ Instruction = InstructionGetMethod{}
+
+func (InstructionGetMethod) Opcode() Opcode {
+	return GetMethod
+}
+
+func (i InstructionGetMethod) String() string {
+	var sb strings.Builder
+	sb.WriteString(i.Opcode().String())
+	i.OperandsString(&sb, false)
+	return sb.String()
+}
+
+func (i InstructionGetMethod) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
+	printfArgument(sb, "method", i.Method, colorize)
+}
+
+func (i InstructionGetMethod) ResolvedOperandsString(sb *strings.Builder,
+	constants []constant.Constant,
+	types []interpreter.StaticType,
+	functionNames []string,
+	colorize bool) {
+	sb.WriteByte(' ')
+	printfArgument(sb, "method", i.Method, colorize)
+}
+
+func (i InstructionGetMethod) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+	emitUint16(code, i.Method)
+}
+
+func DecodeGetMethod(ip *uint16, code []byte) (i InstructionGetMethod) {
+	i.Method = decodeUint16(ip, code)
+	return i
+}
+
 // InstructionDup
 //
 // Pops a value off the stack, duplicates it, and then pushes the original and the copy back on to the stack.
@@ -2640,6 +2684,8 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 		return DecodeInvokeMethodStatic(ip, code)
 	case InvokeMethodDynamic:
 		return DecodeInvokeMethodDynamic(ip, code)
+	case GetMethod:
+		return DecodeGetMethod(ip, code)
 	case Dup:
 		return InstructionDup{}
 	case Drop:

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -376,6 +376,21 @@
   controlEffects:
     - call:
 
+- name: "getMethod"
+  description:
+    Pops a value off the stack, the receiver,
+    and then pushes the value of the function at the given index onto the stack.
+  operands:
+    - name: "method"
+      type: globalIndex
+  valueEffects:
+    pop:
+      - name: "receiver"
+        type: "value"
+    push:
+      - name: "method"
+        type: "function"
+
 # Value stack instructions
 
 - name: "dup"

--- a/bbq/opcode/opcode.go
+++ b/bbq/opcode/opcode.go
@@ -129,7 +129,7 @@ const (
 	SetIndex
 	GetIndex
 	RemoveIndex
-	_
+	GetMethod
 	_
 	_
 	_

--- a/bbq/opcode/opcode_string.go
+++ b/bbq/opcode/opcode_string.go
@@ -65,6 +65,7 @@ func _() {
 	_ = x[SetIndex-81]
 	_ = x[GetIndex-82]
 	_ = x[RemoveIndex-83]
+	_ = x[GetMethod-84]
 	_ = x[Invoke-91]
 	_ = x[InvokeMethodStatic-92]
 	_ = x[InvokeMethodDynamic-93]
@@ -88,7 +89,7 @@ const (
 	_Opcode_name_3 = "LessGreaterLessOrEqualGreaterOrEqualEqualNotEqualNot"
 	_Opcode_name_4 = "UnwrapDestroyTransferAndConvertSimpleCastFailableCastForceCastDerefTransfer"
 	_Opcode_name_5 = "TrueFalseVoidNilNewNewPathNewArrayNewDictionaryNewRefNewClosure"
-	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetUpvalueSetUpvalueCloseUpvalueGetGlobalSetGlobalGetFieldRemoveFieldSetFieldSetIndexGetIndexRemoveIndex"
+	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetUpvalueSetUpvalueCloseUpvalueGetGlobalSetGlobalGetFieldRemoveFieldSetFieldSetIndexGetIndexRemoveIndexGetMethod"
 	_Opcode_name_7 = "InvokeInvokeMethodStaticInvokeMethodDynamic"
 	_Opcode_name_8 = "DropDup"
 	_Opcode_name_9 = "IteratorIteratorHasNextIteratorNextIteratorEndEmitEventLoopStatementTemplateStringOpcodeMax"
@@ -101,7 +102,7 @@ var (
 	_Opcode_index_3 = [...]uint8{0, 4, 11, 22, 36, 41, 49, 52}
 	_Opcode_index_4 = [...]uint8{0, 6, 13, 31, 41, 53, 62, 67, 75}
 	_Opcode_index_5 = [...]uint8{0, 4, 9, 13, 16, 19, 26, 34, 47, 53, 63}
-	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 37, 47, 59, 68, 77, 85, 96, 104, 112, 120, 131}
+	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 37, 47, 59, 68, 77, 85, 96, 104, 112, 120, 131, 140}
 	_Opcode_index_7 = [...]uint8{0, 6, 24, 43}
 	_Opcode_index_8 = [...]uint8{0, 4, 7}
 	_Opcode_index_9 = [...]uint8{0, 8, 23, 35, 46, 55, 59, 68, 82, 91}
@@ -126,7 +127,7 @@ func (i Opcode) String() string {
 	case 49 <= i && i <= 58:
 		i -= 49
 		return _Opcode_name_5[_Opcode_index_5[i]:_Opcode_index_5[i+1]]
-	case 70 <= i && i <= 83:
+	case 70 <= i && i <= 84:
 		i -= 70
 		return _Opcode_name_6[_Opcode_index_6[i]:_Opcode_index_6[i+1]]
 	case 91 <= i && i <= 93:

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -168,6 +168,7 @@ func TestPrintInstruction(t *testing.T) {
 		"CloseUpvalue local:258":   {byte(CloseUpvalue), 1, 2},
 		"GetGlobal global:258":     {byte(GetGlobal), 1, 2},
 		"SetGlobal global:258":     {byte(SetGlobal), 1, 2},
+		"GetMethod method:258":     {byte(GetMethod), 1, 2},
 
 		"Jump target:258":        {byte(Jump), 1, 2},
 		"JumpIfFalse target:258": {byte(JumpIfFalse), 1, 2},

--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -287,7 +287,7 @@ func (c *Context) GetMethod(
 		return method
 	}
 
-	return NewBoundFunctionPointerValue(
+	return NewBoundFunctionValue(
 		c,
 		value,
 		method,

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -1259,7 +1259,11 @@ func TestContractAccessDuringInit(t *testing.T) {
 	t.Run("using contract name", func(t *testing.T) {
 		t.Parallel()
 
-		checker, err := ParseAndCheckWithOptions(t,
+		location := common.NewAddressLocation(nil, common.Address{0x1}, "MyContract")
+
+		programs := CompiledPrograms{}
+
+		program := ParseCheckAndCompile(t,
 			`
               contract MyContract {
                   var status: String
@@ -1273,19 +1277,12 @@ func TestContractAccessDuringInit(t *testing.T) {
                   }
               }
             `,
-			ParseAndCheckOptions{
-				Location: common.NewAddressLocation(nil, common.Address{0x1}, "MyContract"),
-			},
+			location,
+			programs,
 		)
-		require.NoError(t, err)
 
-		comp := compiler.NewInstructionCompiler(
-			interpreter.ProgramFromChecker(checker),
-			checker.Location,
-		)
-		program := comp.Compile()
+		vmConfig := PrepareVMConfig(t, nil, programs)
 
-		vmConfig := &vm.Config{}
 		vmInstance, contractValue := initializeContract(
 			t,
 			scriptLocation(),
@@ -1300,7 +1297,11 @@ func TestContractAccessDuringInit(t *testing.T) {
 	t.Run("using self", func(t *testing.T) {
 		t.Parallel()
 
-		checker, err := ParseAndCheckWithOptions(t,
+		location := common.NewAddressLocation(nil, common.Address{0x1}, "MyContract")
+
+		programs := CompiledPrograms{}
+
+		program := ParseCheckAndCompile(t,
 			`
               contract MyContract {
                   var status: String
@@ -1314,19 +1315,12 @@ func TestContractAccessDuringInit(t *testing.T) {
                   }
               }
             `,
-			ParseAndCheckOptions{
-				Location: common.NewAddressLocation(nil, common.Address{0x1}, "MyContract"),
-			},
+			location,
+			programs,
 		)
-		require.NoError(t, err)
 
-		comp := compiler.NewInstructionCompiler(
-			interpreter.ProgramFromChecker(checker),
-			checker.Location,
-		)
-		program := comp.Compile()
+		vmConfig := PrepareVMConfig(t, nil, programs)
 
-		vmConfig := &vm.Config{}
 		vmInstance, contractValue := initializeContract(
 			t,
 			scriptLocation(),

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -312,7 +312,7 @@ func (v *NativeFunctionValue) IsImportable(
 func (v *NativeFunctionValue) FunctionType(interpreter.ValueStaticTypeContext) *sema.FunctionType {
 	if v.functionTypeGetter != nil {
 		// For native functions where the type is NOT pre-known, This method should never be invoked.
-		// Such functions must always be wrapped with a `BoundFunctionPointerValue`.
+		// Such functions must always be wrapped with a `BoundFunctionValue`.
 		panic(errors.NewUnreachableError())
 	}
 	return v.functionType
@@ -384,8 +384,8 @@ func (v *NativeFunctionValue) GetMethod(
 	panic(errors.NewUnreachableError())
 }
 
-// BoundFunctionPointerValue is a function-pointer taken for an object-method.
-type BoundFunctionPointerValue struct {
+// BoundFunctionValue is a function-wrapper which captures the receivers of an object-method.
+type BoundFunctionValue struct {
 	receiverReference   interpreter.ReferenceValue
 	receiverIsReference bool
 
@@ -393,7 +393,7 @@ type BoundFunctionPointerValue struct {
 	functionType *sema.FunctionType
 }
 
-func NewBoundFunctionPointerValue(
+func NewBoundFunctionValue(
 	context interpreter.ReferenceCreationContext,
 	receiver interpreter.Value,
 	method FunctionValue,
@@ -405,29 +405,29 @@ func NewBoundFunctionPointerValue(
 
 	receiverRef, receiverIsRef := interpreter.ReceiverReference(context, receiver)
 
-	return &BoundFunctionPointerValue{
+	return &BoundFunctionValue{
 		Method:              method,
 		receiverReference:   receiverRef,
 		receiverIsReference: receiverIsRef,
 	}
 }
 
-var _ Value = &BoundFunctionPointerValue{}
-var _ FunctionValue = &BoundFunctionPointerValue{}
+var _ Value = &BoundFunctionValue{}
+var _ FunctionValue = &BoundFunctionValue{}
 
-func (*BoundFunctionPointerValue) IsValue() {}
+func (*BoundFunctionValue) IsValue() {}
 
-func (v *BoundFunctionPointerValue) IsFunctionValue() {}
+func (v *BoundFunctionValue) IsFunctionValue() {}
 
-func (v *BoundFunctionPointerValue) HasGenericType() bool {
+func (v *BoundFunctionValue) HasGenericType() bool {
 	return v.Method.HasGenericType()
 }
 
-func (v *BoundFunctionPointerValue) ResolvedFunctionType(_ Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
+func (v *BoundFunctionValue) ResolvedFunctionType(_ Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 	return v.FunctionType(context)
 }
 
-func (v *BoundFunctionPointerValue) StaticType(context interpreter.ValueStaticTypeContext) bbq.StaticType {
+func (v *BoundFunctionValue) StaticType(context interpreter.ValueStaticTypeContext) bbq.StaticType {
 	if v.functionType == nil {
 		// initialize `v.functionType` field
 		v.initializeFunctionType(context)
@@ -436,7 +436,7 @@ func (v *BoundFunctionPointerValue) StaticType(context interpreter.ValueStaticTy
 	return interpreter.NewFunctionStaticType(context, v.functionType)
 }
 
-func (v *BoundFunctionPointerValue) Transfer(_ interpreter.ValueTransferContext,
+func (v *BoundFunctionValue) Transfer(_ interpreter.ValueTransferContext,
 	_ interpreter.LocationRange,
 	_ atree.Address,
 	_ bool,
@@ -447,15 +447,15 @@ func (v *BoundFunctionPointerValue) Transfer(_ interpreter.ValueTransferContext,
 	return v
 }
 
-func (v *BoundFunctionPointerValue) String() string {
+func (v *BoundFunctionValue) String() string {
 	return v.Method.String()
 }
 
-func (v *BoundFunctionPointerValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v *BoundFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
 	return interpreter.NonStorable{Value: v}, nil
 }
 
-func (v *BoundFunctionPointerValue) Accept(
+func (v *BoundFunctionValue) Accept(
 	_ interpreter.ValueVisitContext,
 	_ interpreter.Visitor,
 	_ interpreter.LocationRange,
@@ -464,7 +464,7 @@ func (v *BoundFunctionPointerValue) Accept(
 	panic(errors.NewUnreachableError())
 }
 
-func (v *BoundFunctionPointerValue) Walk(
+func (v *BoundFunctionValue) Walk(
 	_ interpreter.ValueWalkContext,
 	_ func(interpreter.Value),
 	_ interpreter.LocationRange,
@@ -472,7 +472,7 @@ func (v *BoundFunctionPointerValue) Walk(
 	// NO-OP
 }
 
-func (v *BoundFunctionPointerValue) ConformsToStaticType(
+func (v *BoundFunctionValue) ConformsToStaticType(
 	_ interpreter.ValueStaticTypeConformanceContext,
 	_ interpreter.LocationRange,
 	_ interpreter.TypeConformanceResults,
@@ -480,11 +480,11 @@ func (v *BoundFunctionPointerValue) ConformsToStaticType(
 	return true
 }
 
-func (v *BoundFunctionPointerValue) RecursiveString(_ interpreter.SeenReferences) string {
+func (v *BoundFunctionValue) RecursiveString(_ interpreter.SeenReferences) string {
 	return v.String()
 }
 
-func (v *BoundFunctionPointerValue) MeteredString(
+func (v *BoundFunctionValue) MeteredString(
 	context interpreter.ValueStringContext,
 	_ interpreter.SeenReferences,
 	_ interpreter.LocationRange,
@@ -493,30 +493,30 @@ func (v *BoundFunctionPointerValue) MeteredString(
 	return functionType.MeteredString(context)
 }
 
-func (v *BoundFunctionPointerValue) IsResourceKinded(_ interpreter.ValueStaticTypeContext) bool {
+func (v *BoundFunctionValue) IsResourceKinded(_ interpreter.ValueStaticTypeContext) bool {
 	return false
 }
 
-func (v *BoundFunctionPointerValue) NeedsStoreTo(_ atree.Address) bool {
+func (v *BoundFunctionValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (v *BoundFunctionPointerValue) DeepRemove(_ interpreter.ValueRemoveContext, _ bool) {
+func (v *BoundFunctionValue) DeepRemove(_ interpreter.ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 
-func (v *BoundFunctionPointerValue) Clone(_ interpreter.ValueCloneContext) interpreter.Value {
+func (v *BoundFunctionValue) Clone(_ interpreter.ValueCloneContext) interpreter.Value {
 	return v
 }
 
-func (v *BoundFunctionPointerValue) IsImportable(
+func (v *BoundFunctionValue) IsImportable(
 	_ interpreter.ValueImportableContext,
 	_ interpreter.LocationRange,
 ) bool {
 	return false
 }
 
-func (v *BoundFunctionPointerValue) FunctionType(context interpreter.ValueStaticTypeContext) *sema.FunctionType {
+func (v *BoundFunctionValue) FunctionType(context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 	if v.functionType == nil {
 		v.initializeFunctionType(context)
 	}
@@ -524,7 +524,7 @@ func (v *BoundFunctionPointerValue) FunctionType(context interpreter.ValueStatic
 	return v.functionType
 }
 
-func (v *BoundFunctionPointerValue) initializeFunctionType(context interpreter.ValueStaticTypeContext) {
+func (v *BoundFunctionValue) initializeFunctionType(context interpreter.ValueStaticTypeContext) {
 	method := v.Method
 	// The type of the native function could be either pre-known (e.g: `Integer.toBigEndianBytes()`),
 	// Or would needs to be derived based on the receiver (e.g: `[Int8].append()`).
@@ -538,7 +538,7 @@ func (v *BoundFunctionPointerValue) initializeFunctionType(context interpreter.V
 	}
 }
 
-func (v *BoundFunctionPointerValue) Invoke(invocation interpreter.Invocation) interpreter.Value {
+func (v *BoundFunctionValue) Invoke(invocation interpreter.Invocation) interpreter.Value {
 	context := invocation.InvocationContext
 
 	arguments := make([]Value, 0, 1+len(invocation.Arguments))
@@ -551,7 +551,7 @@ func (v *BoundFunctionPointerValue) Invoke(invocation interpreter.Invocation) in
 	)
 }
 
-func (v *BoundFunctionPointerValue) Receiver(context interpreter.ValueStaticTypeContext) Value {
+func (v *BoundFunctionValue) Receiver(context interpreter.ValueStaticTypeContext) Value {
 	receiver := interpreter.GetReceiver(
 		v.receiverReference,
 		v.receiverIsReference,

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -395,7 +395,7 @@ type BoundFunctionPointerValue struct {
 
 func NewBoundFunctionPointerValue(
 	context interpreter.ReferenceCreationContext,
-	receiver interpreter.MemberAccessibleValue,
+	receiver interpreter.Value,
 	method FunctionValue,
 ) FunctionValue {
 

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -923,8 +923,6 @@ func opInvokeMethodStatic(vm *VM, ins opcode.InstructionInvokeMethodStatic) {
 
 	// Load arguments
 	arguments := vm.popN(int(ins.ArgCount))
-	//receiver := arguments[ReceiverIndex]
-	//arguments[ReceiverIndex] = maybeDereference(vm.context, receiver)
 
 	// Load the invoked value
 	boundFunction := vm.pop().(*BoundFunctionValue)

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -350,7 +350,7 @@ func (vm *VM) InvokeMethodExternally(
 		}
 	}
 
-	boundFunction := NewBoundFunctionPointerValue(context, receiver, functionValue)
+	boundFunction := NewBoundFunctionValue(context, receiver, functionValue)
 
 	return vm.validateAndInvokeExternally(boundFunction, arguments)
 }
@@ -369,7 +369,7 @@ func (vm *VM) validateAndInvokeExternally(functionValue FunctionValue, arguments
 		return nil, err
 	}
 
-	if boundFunction, ok := functionValue.(*BoundFunctionPointerValue); ok {
+	if boundFunction, ok := functionValue.(*BoundFunctionValue); ok {
 		receiver := boundFunction.Receiver(vm.context)
 		preparedArguments = append([]Value{receiver}, preparedArguments...)
 	}
@@ -502,7 +502,7 @@ func (vm *VM) InvokeTransactionPrepare(transaction *interpreter.CompositeValue, 
 
 	prepareValue := prepareVariable.GetValue(context)
 	prepareFunction := prepareValue.(FunctionValue)
-	boundPrepareFunction := NewBoundFunctionPointerValue(
+	boundPrepareFunction := NewBoundFunctionValue(
 		context,
 		transaction,
 		prepareFunction,
@@ -526,7 +526,7 @@ func (vm *VM) InvokeTransactionExecute(transaction *interpreter.CompositeValue) 
 
 	executeValue := executeVariable.GetValue(context)
 	executeFunction := executeValue.(FunctionValue)
-	boundExecuteFunction := NewBoundFunctionPointerValue(
+	boundExecuteFunction := NewBoundFunctionValue(
 		context,
 		transaction,
 		executeFunction,
@@ -885,7 +885,7 @@ func opInvoke(vm *VM, ins opcode.InstructionInvoke) {
 	functionValue := vm.pop()
 
 	// If the function is a pointer to an object-method, then the receiver is implicitly captured.
-	if boundFunction, isBoundFUnction := functionValue.(*BoundFunctionPointerValue); isBoundFUnction {
+	if boundFunction, isBoundFUnction := functionValue.(*BoundFunctionValue); isBoundFUnction {
 		functionValue = boundFunction.Method
 		receiver := boundFunction.Receiver(vm.context)
 		arguments = append([]Value{receiver}, arguments...)
@@ -908,7 +908,7 @@ func opGetMethod(vm *VM, ins opcode.InstructionGetMethod) {
 
 	receiver := vm.pop()
 
-	boundFunction := NewBoundFunctionPointerValue(
+	boundFunction := NewBoundFunctionValue(
 		vm.context,
 		receiver,
 		method,
@@ -927,7 +927,7 @@ func opInvokeMethodStatic(vm *VM, ins opcode.InstructionInvokeMethodStatic) {
 	//arguments[ReceiverIndex] = maybeDereference(vm.context, receiver)
 
 	// Load the invoked value
-	boundFunction := vm.pop().(*BoundFunctionPointerValue)
+	boundFunction := vm.pop().(*BoundFunctionValue)
 
 	functionValue := boundFunction.Method
 	receiver := boundFunction.Receiver(vm.context)
@@ -984,7 +984,7 @@ func invokeFunction(
 
 	// Handle all function types in a single place, so this can be re-used everywhere.
 
-	if boundFunction, ok := functionValue.(*BoundFunctionPointerValue); ok {
+	if boundFunction, ok := functionValue.(*BoundFunctionValue); ok {
 		functionValue = boundFunction.Method
 	}
 

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -8276,7 +8276,7 @@ func TestInterpretOptionalChainingFunctionRead(t *testing.T) {
 
 	var expected interpreter.FunctionValue
 	if *compile {
-		expected = &vm.BoundFunctionPointerValue{}
+		expected = &vm.BoundFunctionValue{}
 	} else {
 		expected = interpreter.BoundFunctionValue{}
 	}

--- a/interpreter/transactions_test.go
+++ b/interpreter/transactions_test.go
@@ -459,7 +459,7 @@ func TestInterpretInvalidRecursiveTransferInExecute(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             transaction {
                 var arr: @[AnyResource]
 
@@ -482,7 +482,7 @@ func TestInterpretInvalidRecursiveTransferInExecute(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             transaction {
                 var dict: @{String: AnyResource}
 
@@ -505,7 +505,7 @@ func TestInterpretInvalidRecursiveTransferInExecute(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndInterpret(t, `
+		inter := parseCheckAndPrepare(t, `
             resource R {
                 fun foo(_ r: @R) {
                     destroy r

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -371,7 +371,12 @@ func (e *vmEnvironment) loadDesugaredElaboration(location common.Location) (*com
 	return program.compiledProgram.desugaredElaboration, nil
 }
 
+// TODO: Maybe split this to four separate methods like in the interpreter.
 func (e *vmEnvironment) loadType(location common.Location, typeID interpreter.TypeID) sema.ContainedType {
+	if location == nil {
+		return stdlib.StandardLibraryTypes[typeID]
+	}
+
 	if _, ok := location.(stdlib.FlowLocation); ok {
 		return stdlib.FlowEventTypes[typeID]
 	}

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -27,18 +27,22 @@ import (
 var StandardLibraryTypes = map[sema.TypeID]sema.ContainedType{}
 
 func init() {
-	stdlibTypes := []sema.Type{
+	stdlibTypesList := []sema.Type{
 		BLSType,
 		RLPType,
 	}
 
-	extractTypes(
-		stdlibTypes,
+	extractNestedTypes(
+		stdlibTypesList,
+		StandardLibraryTypes,
 	)
 }
 
-func extractTypes(
+// extractNestedTypes extract all the types including the nested types,
+// from a list of types to a map.
+func extractNestedTypes(
 	types []sema.Type,
+	extractTo map[sema.TypeID]sema.ContainedType,
 ) {
 	for len(types) > 0 {
 		lastIndex := len(types) - 1
@@ -50,10 +54,10 @@ func extractTypes(
 
 		switch typ := typ.(type) {
 		case *sema.CompositeType:
-			StandardLibraryTypes[typ.ID()] = typ
+			extractTo[typ.ID()] = typ
 			nestedTypes = typ.NestedTypes
 		case *sema.InterfaceType:
-			StandardLibraryTypes[typ.ID()] = typ
+			extractTo[typ.ID()] = typ
 			nestedTypes = typ.NestedTypes
 		default:
 			panic(fmt.Errorf("expected only composite or interface type, found %t", typ))

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -1,0 +1,70 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stdlib
+
+import (
+	"fmt"
+
+	"github.com/onflow/cadence/sema"
+)
+
+var StandardLibraryTypes = map[sema.TypeID]sema.ContainedType{}
+
+func init() {
+	stdlibTypes := []sema.Type{
+		BLSType,
+		RLPType,
+	}
+
+	extractTypes(
+		stdlibTypes,
+	)
+}
+
+func extractTypes(
+	types []sema.Type,
+) {
+	for len(types) > 0 {
+		lastIndex := len(types) - 1
+		typ := types[lastIndex]
+		types[lastIndex] = nil
+		types = types[:lastIndex]
+
+		var nestedTypes *sema.StringTypeOrderedMap
+
+		switch typ := typ.(type) {
+		case *sema.CompositeType:
+			StandardLibraryTypes[typ.ID()] = typ
+			nestedTypes = typ.NestedTypes
+		case *sema.InterfaceType:
+			StandardLibraryTypes[typ.ID()] = typ
+			nestedTypes = typ.NestedTypes
+		default:
+			panic(fmt.Errorf("expected only composite or interface type, found %t", typ))
+		}
+
+		if nestedTypes == nil {
+			continue
+		}
+
+		nestedTypes.Foreach(func(_ string, nestedType sema.Type) {
+			types = append(types, nestedType)
+		})
+	}
+}


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/4015

## Description

Similar to the interpreter, always create a bound-function wrapper before invoking an object-method. Thus introduces a new instruction `GetMethod` (to complement `GetField`) which will assume the receiver to be on stack, and looks-up the function value by **index** (since the method is known at compile time), and creates a bound-function wrapper which creates and captures the implicit-receiver-reference.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
