### PR TITLE
[Compiler] Remove environment composite functions handler

### DIFF
--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -36,10 +36,6 @@ type interpretFunc func(inter *interpreter.Interpreter) (interpreter.Value, erro
 type Environment interface {
 	ArgumentDecoder
 
-	SetCompositeValueFunctionsHandler(
-		typeID common.TypeID,
-		handler stdlib.CompositeValueFunctionsHandler,
-	)
 	DeclareValue(
 		valueDeclaration stdlib.StandardLibraryValue,
 		location common.Location,
@@ -173,7 +169,7 @@ func NewBaseInterpreterEnvironment(config Config) *interpreterEnvironment {
 	return env
 }
 
-func NewScriptInterpreterEnvironment(config Config) Environment {
+func NewScriptInterpreterEnvironment(config Config) *interpreterEnvironment {
 	env := NewInterpreterEnvironment(config)
 	for _, valueDeclaration := range stdlib.InterpreterDefaultScriptStandardLibraryValues(env) {
 		env.DeclareValue(valueDeclaration, nil)

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -237,14 +237,6 @@ func (e *vmEnvironment) DeclareType(typeDeclaration stdlib.StandardLibraryType, 
 	e.checkingEnvironment.declareType(typeDeclaration, location)
 }
 
-func (e *vmEnvironment) SetCompositeValueFunctionsHandler(
-	typeID common.TypeID,
-	handler stdlib.CompositeValueFunctionsHandler,
-) {
-	// TODO:
-	panic(errors.NewUnreachableError())
-}
-
 func (e *vmEnvironment) CommitStorageTemporarily(context interpreter.ValueTransferContext) error {
 	const commitContractUpdates = false
 	return e.storage.Commit(context, commitContractUpdates)


### PR DESCRIPTION
Work towards #3804 

## Description

Remove `SetCompositeValueFunctionsHandler` from `Environment`. 

The interpreter composite value functions handler feature is used internally in Cadence for injecting the functions of the `PublicKey` type. In the VM, functions are never part of the value, and are essentially always injected. 

`SetCompositeValueFunctionsHandler` exposes this feature of the interpreter for the embedder (e.g. FVM) so it could inject native functions for certain values. However, the feature is not actually used (https://github.com/search?q=org%3Aonflow+SetCompositeValueFunctionsHandler&type=code), so remove it from `Environment` and the VM environment.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
