### PR TITLE
[Compiler] Fix use of imported enum cases

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -3133,6 +3133,10 @@ func (c *Compiler[_, _]) addGlobalsFromImportedProgram(location common.Location)
 		c.addImportedGlobal(location, contract.Name)
 	}
 
+	for _, variable := range importedProgram.Variables {
+		c.addImportedGlobal(location, variable.Name)
+	}
+
 	for _, function := range importedProgram.Functions {
 		name := function.QualifiedName
 

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -6679,19 +6679,25 @@ func TestCompileImports(t *testing.T) {
 
 		// Deploy a second contract.
 
-		bContract := fmt.Sprintf(`
-          import A from %[1]s
+		bContract := fmt.Sprintf(
+			`
+              import A from %[1]s
 
-          contract B {
-              fun test() {
-                  return A.test()
+              contract B {
+                  fun test() {
+                      return A.test()
+                  }
               }
-          }
-        `,
+            `,
 			contractsAddress.HexWithPrefix(),
 		)
 
-		bProgram := ParseCheckAndCompile(t, bContract, bLocation, programs)
+		bProgram := ParseCheckAndCompile(
+			t,
+			bContract,
+			bLocation,
+			programs,
+		)
 
 		// Should have import for contract value `A` and the method `A.test`.
 		assert.Equal(
@@ -8844,4 +8850,68 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 		)
 	})
 
+}
+
+func TestCompileImportEnumCase(t *testing.T) {
+
+	t.Parallel()
+
+	aContract := `
+        contract A {
+            enum E: UInt8 {
+                case X
+            }
+        }
+    `
+
+	programs := CompiledPrograms{}
+
+	contractsAddress := common.MustBytesToAddress([]byte{0x1})
+
+	aLocation := common.NewAddressLocation(nil, contractsAddress, "A")
+	bLocation := common.NewAddressLocation(nil, contractsAddress, "B")
+
+	aProgram := ParseCheckAndCompile(
+		t,
+		aContract,
+		aLocation,
+		programs,
+	)
+
+	// Should have no imports
+	assert.Empty(t, aProgram.Imports)
+
+	// Deploy a second contract.
+
+	bContract := fmt.Sprintf(
+		`
+          import A from %[1]s
+
+          contract B {
+              fun test(): A.E {
+                  return A.E.X
+              }
+          }
+        `,
+		contractsAddress.HexWithPrefix(),
+	)
+
+	bProgram := ParseCheckAndCompile(
+		t,
+		bContract,
+		bLocation,
+		programs,
+	)
+
+	// Should have import for the enum case `A.E.X`.
+	assert.Equal(
+		t,
+		[]bbq.Import{
+			{
+				Location: aLocation,
+				Name:     "A.E.X",
+			},
+		},
+		bProgram.Imports,
+	)
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -11796,6 +11796,7 @@ func TestRuntimeStorageEnumAsDictionaryKey(t *testing.T) {
 		Script{
 			Source: []byte(`
               import C from 0x1
+
               transaction {
                   prepare(signer: auth(Storage) &Account) {
                       signer.storage.save(<-C.createEmptyCollection(), to: /storage/collection)
@@ -11808,6 +11809,7 @@ func TestRuntimeStorageEnumAsDictionaryKey(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
Work towards #3804 

## Description

When importing a program in the compiler, also import the imported program's variables.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
