### PR TITLE
Re-use static-type to sema-type conversion results

### DIFF
--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -48,6 +48,12 @@ type Context struct {
 	containerValueIteration       map[atree.ValueID]int
 	destroyedResources            map[atree.ValueID]struct{}
 
+	// semaTypeCache is a cache-alike for temporary storing sema-types by their ID,
+	// to avoid repeated conversions from static-types to sema-types.
+	// This cache-alike is maintained per execution.
+	// TODO: Maybe extend/share this between executions.
+	semaTypeCache                 map[sema.TypeID]sema.Type
+
 	// TODO: stack-trace, location, etc.
 }
 
@@ -66,6 +72,7 @@ func NewContext(config *Config) *Context {
 		mutationDuringCapabilityControllerIteration: false,
 		referencedResourceKindedValues:              ReferencedResourceKindedValues{},
 		destroyedResources:                          make(map[atree.ValueID]struct{}),
+		semaTypeCache:                               make(map[sema.TypeID]sema.Type),
 	}
 }
 
@@ -263,8 +270,7 @@ func (c *Context) GetMethod(
 ) interpreter.FunctionValue {
 	staticType := value.StaticType(c)
 
-	// TODO: avoid the sema-type conversion
-	semaType := interpreter.MustConvertStaticToSemaType(staticType, c)
+	semaType := c.SemaTypeFromStaticType(staticType)
 
 	var location common.Location
 	if locatedType, ok := semaType.(sema.LocatedType); ok {
@@ -341,4 +347,18 @@ func (c *Context) DefaultDestroyEvents(
 	)
 
 	return eventValues
+}
+
+func (c *Context) SemaTypeFromStaticType(staticType interpreter.StaticType) sema.Type {
+	typeID := staticType.ID()
+	semaType, ok := c.semaTypeCache[typeID]
+	if ok {
+		return semaType
+	}
+
+	// TODO: avoid the sema-type conversion
+	semaType = interpreter.MustConvertStaticToSemaType(staticType, c)
+
+	c.semaTypeCache[typeID] = semaType
+	return semaType
 }

--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -48,11 +48,12 @@ type Context struct {
 	containerValueIteration       map[atree.ValueID]int
 	destroyedResources            map[atree.ValueID]struct{}
 
-	// semaTypeCache is a cache-alike for temporary storing sema-types by their ID,
+	// semaTypes is a cache-alike for temporary storing sema-types by their ID,
 	// to avoid repeated conversions from static-types to sema-types.
 	// This cache-alike is maintained per execution.
+	// TODO: Re-use the conversions from the compiler.
 	// TODO: Maybe extend/share this between executions.
-	semaTypeCache                 map[sema.TypeID]sema.Type
+	semaTypes map[sema.TypeID]sema.Type
 
 	// TODO: stack-trace, location, etc.
 }
@@ -72,7 +73,7 @@ func NewContext(config *Config) *Context {
 		mutationDuringCapabilityControllerIteration: false,
 		referencedResourceKindedValues:              ReferencedResourceKindedValues{},
 		destroyedResources:                          make(map[atree.ValueID]struct{}),
-		semaTypeCache:                               make(map[sema.TypeID]sema.Type),
+		semaTypes:                                   make(map[sema.TypeID]sema.Type),
 	}
 }
 
@@ -351,7 +352,7 @@ func (c *Context) DefaultDestroyEvents(
 
 func (c *Context) SemaTypeFromStaticType(staticType interpreter.StaticType) sema.Type {
 	typeID := staticType.ID()
-	semaType, ok := c.semaTypeCache[typeID]
+	semaType, ok := c.semaTypes[typeID]
 	if ok {
 		return semaType
 	}
@@ -359,6 +360,6 @@ func (c *Context) SemaTypeFromStaticType(staticType interpreter.StaticType) sema
 	// TODO: avoid the sema-type conversion
 	semaType = interpreter.MustConvertStaticToSemaType(staticType, c)
 
-	c.semaTypeCache[typeID] = semaType
+	c.semaTypes[typeID] = semaType
 	return semaType
 }

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -429,6 +429,8 @@ func compiledFTTransfer(tb testing.TB) {
 		require.NoError(tb, err)
 		require.Equal(tb, 0, tokenTransferTxVM.StackSize())
 
+		tokenTransferTxVM.Reset()
+
 		transferCount++
 	}
 

--- a/bbq/vm/value.go
+++ b/bbq/vm/value.go
@@ -31,8 +31,8 @@ func ConvertAndBox(
 	value Value,
 	valueType, targetType bbq.StaticType,
 ) Value {
-	valueSemaType := interpreter.MustConvertStaticToSemaType(valueType, context)
-	targetSemaType := interpreter.MustConvertStaticToSemaType(targetType, context)
+	valueSemaType := context.SemaTypeFromStaticType(valueType)
+	targetSemaType := context.SemaTypeFromStaticType(targetType)
 
 	return interpreter.ConvertAndBox(
 		context,

--- a/bbq/vm/value_account_storage.go
+++ b/bbq/vm/value_account_storage.go
@@ -68,7 +68,7 @@ func init() {
 				arguments := args[TypeBoundFunctionArgumentOffset:]
 
 				borrowType := typeArguments[0]
-				semaBorrowType := interpreter.MustConvertStaticToSemaType(borrowType, context)
+				semaBorrowType := context.SemaTypeFromStaticType(borrowType)
 
 				return interpreter.AccountStorageBorrow(
 					context,
@@ -166,7 +166,7 @@ func init() {
 				arguments := args[TypeBoundFunctionArgumentOffset:]
 
 				borrowType := typeArguments[0]
-				semaBorrowType := interpreter.MustConvertStaticToSemaType(borrowType, context)
+				semaBorrowType := context.SemaTypeFromStaticType(borrowType)
 
 				return interpreter.AccountStorageRead(
 					context,
@@ -193,7 +193,7 @@ func init() {
 				arguments := args[TypeBoundFunctionArgumentOffset:]
 
 				borrowType := typeArguments[0]
-				semaBorrowType := interpreter.MustConvertStaticToSemaType(borrowType, context)
+				semaBorrowType := context.SemaTypeFromStaticType(borrowType)
 
 				return interpreter.AccountStorageRead(
 					context,
@@ -220,7 +220,7 @@ func init() {
 				arguments := args[TypeBoundFunctionArgumentOffset:]
 
 				borrowType := typeArguments[0]
-				semaBorrowType := interpreter.MustConvertStaticToSemaType(borrowType, context)
+				semaBorrowType := context.SemaTypeFromStaticType(borrowType)
 
 				return interpreter.AccountStorageCheck(
 					context,

--- a/bbq/vm/value_capability.go
+++ b/bbq/vm/value_capability.go
@@ -37,7 +37,7 @@ func init() {
 			sema.CapabilityTypeBorrowFunctionName,
 			func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 				capability := receiver.(*interpreter.IDCapabilityValue)
-				borrowType := interpreter.MustConvertStaticToSemaType(capability.BorrowType, context).(*sema.ReferenceType)
+				borrowType := context.SemaTypeFromStaticType(capability.BorrowType).(*sema.ReferenceType)
 				return sema.CapabilityTypeBorrowFunctionType(borrowType)
 			},
 			func(context *Context, typeArguments []bbq.StaticType, args ...Value) Value {
@@ -63,11 +63,11 @@ func init() {
 					return interpreter.Nil
 				}
 
-				capabilityBorrowType := interpreter.MustConvertStaticToSemaType(idCapabilityValue.BorrowType, context).(*sema.ReferenceType)
+				capabilityBorrowType := context.SemaTypeFromStaticType(idCapabilityValue.BorrowType).(*sema.ReferenceType)
 
 				var typeParameter sema.Type
 				if len(typeArguments) > 0 {
-					typeParameter = interpreter.MustConvertStaticToSemaType(typeArguments[0], context)
+					typeParameter = context.SemaTypeFromStaticType(typeArguments[0])
 				}
 
 				address := idCapabilityValue.Address()
@@ -91,7 +91,7 @@ func init() {
 			sema.CapabilityTypeCheckFunctionName,
 			func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 				capability := receiver.(*interpreter.IDCapabilityValue)
-				borrowType := interpreter.MustConvertStaticToSemaType(capability.BorrowType, context).(*sema.ReferenceType)
+				borrowType := context.SemaTypeFromStaticType(capability.BorrowType).(*sema.ReferenceType)
 				return sema.CapabilityTypeCheckFunctionType(borrowType)
 			},
 			func(context *Context, typeArguments []bbq.StaticType, args ...Value) Value {
@@ -118,11 +118,11 @@ func init() {
 					return interpreter.FalseValue
 				}
 
-				capabilityBorrowType := interpreter.MustConvertStaticToSemaType(idCapabilityValue.BorrowType, context).(*sema.ReferenceType)
+				capabilityBorrowType := context.SemaTypeFromStaticType(idCapabilityValue.BorrowType).(*sema.ReferenceType)
 
 				var typeParameter sema.Type
 				if len(typeArguments) > 0 {
-					typeParameter = interpreter.MustConvertStaticToSemaType(typeArguments[0], context)
+					typeParameter = context.SemaTypeFromStaticType(typeArguments[0])
 				}
 
 				address := idCapabilityValue.Address()

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -477,6 +477,11 @@ func (n NoOpReferenceCreationContext) IsTypeInfoRecovered(location common.Locati
 	return false
 }
 
+func (n NoOpReferenceCreationContext) SemaTypeFromStaticType(staticType interpreter.StaticType) sema.Type {
+	// NO-OP
+	return nil
+}
+
 type NoOpFunctionCreationContext struct {
 	//Just to make the compiler happy
 	interpreter.ResourceDestructionContext

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -31,6 +31,7 @@ import (
 type TypeConverter interface {
 	common.MemoryGauge
 	StaticTypeConversionHandler
+	SemaTypeFromStaticType(staticType StaticType) sema.Type
 }
 
 var _ TypeConverter = &Interpreter{}
@@ -74,7 +75,6 @@ type ValueStaticTypeContext interface {
 	StorageReader
 	TypeConverter
 	IsTypeInfoRecovered(location common.Location) bool
-	SemaTypeFromStaticType(staticType StaticType) sema.Type
 }
 
 var _ ValueStaticTypeContext = &Interpreter{}

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -74,6 +74,7 @@ type ValueStaticTypeContext interface {
 	StorageReader
 	TypeConverter
 	IsTypeInfoRecovered(location common.Location) bool
+	SemaTypeFromStaticType(staticType StaticType) sema.Type
 }
 
 var _ ValueStaticTypeContext = &Interpreter{}
@@ -723,5 +724,9 @@ func (ctx NoOpStringContext) GetCompositeType(_ common.Location, _ string, _ Typ
 }
 
 func (ctx NoOpStringContext) IsTypeInfoRecovered(_ common.Location) bool {
+	panic(errors.NewUnreachableError())
+}
+
+func (ctx NoOpStringContext) SemaTypeFromStaticType(staticType StaticType) sema.Type {
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -6170,3 +6170,7 @@ func (interpreter *Interpreter) DefaultDestroyEvents(
 ) []*CompositeValue {
 	return resourceValue.DefaultDestroyEvents(interpreter, locationRange)
 }
+
+func (interpreter *Interpreter) SemaTypeFromStaticType(staticType StaticType) sema.Type {
+	return MustConvertStaticToSemaType(staticType, interpreter)
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1923,7 +1923,7 @@ func TransferAndConvert(
 	if targetType != nil &&
 		!IsSubTypeOfSemaType(context, resultStaticType, targetType) {
 
-		resultSemaType := MustConvertStaticToSemaType(resultStaticType, context)
+		resultSemaType := context.SemaTypeFromStaticType(resultStaticType)
 
 		panic(&ValueTransferTypeError{
 			ExpectedType:  targetType,
@@ -2201,7 +2201,7 @@ func convert(
 				return value
 			}
 
-			targetElementType := MustConvertStaticToSemaType(arrayStaticType.ElementType(), context)
+			targetElementType := context.SemaTypeFromStaticType(arrayStaticType.ElementType())
 
 			array := arrayValue.array
 
@@ -2225,7 +2225,7 @@ func convert(
 					}
 
 					value := MustConvertStoredValue(context, element)
-					valueType := MustConvertStaticToSemaType(value.StaticType(context), context)
+					valueType := context.SemaTypeFromStaticType(value.StaticType(context))
 					return convert(context, value, valueType, targetElementType, locationRange)
 				},
 			)
@@ -2241,8 +2241,8 @@ func convert(
 				return value
 			}
 
-			targetKeyType := MustConvertStaticToSemaType(dictStaticType.KeyType, context)
-			targetValueType := MustConvertStaticToSemaType(dictStaticType.ValueType, context)
+			targetKeyType := context.SemaTypeFromStaticType(dictStaticType.KeyType)
+			targetValueType := context.SemaTypeFromStaticType(dictStaticType.ValueType)
 
 			dictionary := dictValue.dictionary
 
@@ -2271,8 +2271,8 @@ func convert(
 					key := MustConvertStoredValue(context, k)
 					value := MustConvertStoredValue(context, v)
 
-					keyType := MustConvertStaticToSemaType(key.StaticType(context), context)
-					valueType := MustConvertStaticToSemaType(value.StaticType(context), context)
+					keyType := context.SemaTypeFromStaticType(key.StaticType(context))
+					valueType := context.SemaTypeFromStaticType(value.StaticType(context))
 
 					convertedKey := convert(context, key, keyType, targetKeyType, locationRange)
 					convertedValue := convert(context, value, valueType, targetValueType, locationRange)
@@ -4215,7 +4215,7 @@ func IsSubType(typeConverter TypeConverter, subType StaticType, superType Static
 		return true
 	}
 
-	semaType := MustConvertStaticToSemaType(superType, typeConverter)
+	semaType := typeConverter.SemaTypeFromStaticType(superType)
 
 	return IsSubTypeOfSemaType(typeConverter, subType, semaType)
 }
@@ -4242,7 +4242,7 @@ func IsSubTypeOfSemaType(typeConverter TypeConverter, staticSubType StaticType, 
 		return superType == sema.AnyStructType
 	}
 
-	semaSubType := MustConvertStaticToSemaType(staticSubType, typeConverter)
+	semaSubType := typeConverter.SemaTypeFromStaticType(staticSubType)
 
 	return sema.IsSubType(semaSubType, superType)
 }
@@ -5404,7 +5404,7 @@ func ExpectType(
 	valueStaticType := value.StaticType(context)
 
 	if !IsSubTypeOfSemaType(context, valueStaticType, expectedType) {
-		valueSemaType := MustConvertStaticToSemaType(valueStaticType, context)
+		valueSemaType := context.SemaTypeFromStaticType(valueStaticType)
 
 		panic(TypeMismatchError{
 			ExpectedType:  expectedType,

--- a/interpreter/statictype.go
+++ b/interpreter/statictype.go
@@ -556,6 +556,8 @@ var NilStaticType = &OptionalStaticType{
 type IntersectionStaticType struct {
 	Types      []*InterfaceStaticType
 	LegacyType StaticType
+
+	typeID *TypeID
 }
 
 var _ StaticType = &IntersectionStaticType{}
@@ -628,8 +630,12 @@ outer:
 }
 
 func (t *IntersectionStaticType) ID() TypeID {
-	var interfaceTypeIDs []TypeID
 	typeCount := len(t.Types)
+	if typeCount == 1 {
+		return sema.FormatIntersectionTypeIDWithSingleInterface(t.Types[0].ID())
+	}
+
+	var interfaceTypeIDs []TypeID
 	if typeCount > 0 {
 		interfaceTypeIDs = make([]TypeID, 0, typeCount)
 		for _, ty := range t.Types {

--- a/interpreter/statictype.go
+++ b/interpreter/statictype.go
@@ -556,8 +556,6 @@ var NilStaticType = &OptionalStaticType{
 type IntersectionStaticType struct {
 	Types      []*InterfaceStaticType
 	LegacyType StaticType
-
-	typeID *TypeID
 }
 
 var _ StaticType = &IntersectionStaticType{}

--- a/interpreter/statictype_test.go
+++ b/interpreter/statictype_test.go
@@ -1762,6 +1762,10 @@ func (s staticTypeConversionHandler) MeterMemory(_ common.MemoryUsage) error {
 	return nil
 }
 
+func (s staticTypeConversionHandler) SemaTypeFromStaticType(staticType StaticType) sema.Type {
+	return MustConvertStaticToSemaType(staticType, s)
+}
+
 func TestIntersectionStaticType_ID(t *testing.T) {
 	t.Parallel()
 

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -144,7 +144,7 @@ func (v *StorageReferenceValue) dereference(context ValueStaticTypeContext, loca
 		staticType := referenced.StaticType(context)
 
 		if !IsSubTypeOfSemaType(context, staticType, v.BorrowedType) {
-			semaType := MustConvertStaticToSemaType(staticType, context)
+			semaType := context.SemaTypeFromStaticType(staticType)
 
 			return nil, &ForceCastTypeMismatchError{
 				ExpectedType:  v.BorrowedType,
@@ -239,7 +239,7 @@ func (v *StorageReferenceValue) GetMember(context MemberAccessibleContext, locat
 			v.Authorization,
 			v.TargetStorageAddress,
 			v.TargetPath,
-			MustConvertStaticToSemaType(referencedValueStaticType, context),
+			context.SemaTypeFromStaticType(referencedValueStaticType),
 		)
 		return boundFunction
 	}

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -289,7 +289,7 @@ func (executor *contractFunctionExecutor) executeWithVM(
 	}
 
 	staticType := contractValue.StaticType(context)
-	semaType := interpreter.MustConvertStaticToSemaType(staticType, context)
+	semaType := context.SemaTypeFromStaticType(staticType)
 	qualifiedFuncName := commons.TypeQualifiedName(semaType, executor.functionName)
 
 	value, err := executor.vm.InvokeMethodExternally(

--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -950,9 +950,10 @@ func TestRuntimeFungibleTokenTransferInterpreter(t *testing.T) {
 	testRuntimeFungibleTokenTransfer(t, false)
 }
 
-func TestRuntimeFungibleTokenTransferVM(t *testing.T) {
-	testRuntimeFungibleTokenTransfer(t, true)
-}
+// TODO:
+//func TestRuntimeFungibleTokenTransferVM(t *testing.T) {
+//	testRuntimeFungibleTokenTransfer(t, true)
+//}
 
 func BenchmarkRuntimeFungibleTokenTransferInterpreter(b *testing.B) {
 	testRuntimeFungibleTokenTransfer(b, false)

--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -950,10 +950,9 @@ func TestRuntimeFungibleTokenTransferInterpreter(t *testing.T) {
 	testRuntimeFungibleTokenTransfer(t, false)
 }
 
-// TODO:
-//func TestRuntimeFungibleTokenTransferVM(t *testing.T) {
-//	testRuntimeFungibleTokenTransfer(t, true)
-//}
+func TestRuntimeFungibleTokenTransferVM(t *testing.T) {
+	testRuntimeFungibleTokenTransfer(t, true)
+}
 
 func BenchmarkRuntimeFungibleTokenTransferInterpreter(b *testing.B) {
 	testRuntimeFungibleTokenTransfer(b, false)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -49,7 +49,7 @@ import (
 	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
-var compile = flag.Bool("compile", true, "Run tests using the compiler")
+var compile = flag.Bool("compile", false, "Run tests using the compiler")
 
 func TestRuntimeExecuteScript(t *testing.T) {
 

--- a/sema/type.go
+++ b/sema/type.go
@@ -8271,9 +8271,21 @@ func formatIntersectionType[T ~string](separator string, interfaceStrings []T) s
 	return result.String()
 }
 
+func formatIntersectionTypeWithSingleInterface[T ~string](interfaceString T) string {
+	var result strings.Builder
+	result.WriteByte('{')
+	result.WriteString(string(interfaceString))
+	result.WriteByte('}')
+	return result.String()
+}
+
 func FormatIntersectionTypeID[T ~string](interfaceTypeIDs []T) T {
 	slices.Sort(interfaceTypeIDs)
 	return T(formatIntersectionType("", interfaceTypeIDs))
+}
+
+func FormatIntersectionTypeIDWithSingleInterface[T ~string](interfaceTypeID T) T {
+	return T(formatIntersectionTypeWithSingleInterface(interfaceTypeID))
 }
 
 func (t *IntersectionType) string(separator string, typeFormatter func(Type) string) string {


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3804

## Description

```
             │ without_caching.txt │          with_caching.txt          │
             │       sec/op        │   sec/op     vs base               │
FTTransfer-8           90.51µ ± 3%   77.88µ ± 2%  -13.95% (p=0.002 n=6)

             │ without_caching.txt │          with_caching.txt           │
             │        B/op         │     B/op      vs base               │
FTTransfer-8          54.78Ki ± 0%   47.85Ki ± 0%  -12.65% (p=0.002 n=6)

             │ without_caching.txt │          with_caching.txt          │
             │      allocs/op      │  allocs/op   vs base               │
FTTransfer-8           1.430k ± 0%   1.201k ± 0%  -16.01% (p=0.002 n=6)
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
