### PR TITLE
[Compiler] Fix compilation of dynamic method invocation via optional chaining

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -2180,7 +2180,9 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 	isInterfaceInheritedFuncCall := c.DesugaredElaboration.IsInterfaceMethodStaticCall(expression)
 
 	// Any invocation on restricted-types must be dynamic
-	if !isInterfaceInheritedFuncCall && isDynamicMethodInvocation(memberInfo.AccessedType) {
+	if !isInterfaceInheritedFuncCall &&
+		isDynamicMethodInvocation(memberInfo.AccessedType) {
+
 		funcName = invokedExpr.Identifier.Identifier
 		if len(funcName) >= math.MaxUint16 {
 			panic(errors.NewDefaultUserError("invalid function name"))
@@ -2326,11 +2328,10 @@ func isDynamicMethodInvocation(accessedType sema.Type) bool {
 	switch typ := accessedType.(type) {
 	case *sema.ReferenceType:
 		return isDynamicMethodInvocation(typ.Type)
+	case *sema.OptionalType:
+		return isDynamicMethodInvocation(typ.Type)
 	case *sema.IntersectionType:
 		return true
-
-		// TODO: Optional type?
-
 	case *sema.InterfaceType:
 		return true
 	default:

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -8999,3 +8999,39 @@ func TestStringTemplate(t *testing.T) {
 		require.Equal(t, interpreter.NewUnmeteredStringValue("A + B = 4"), result)
 	})
 }
+
+func TestDynamicMethodInvocationViaOptionalChaining(t *testing.T) {
+
+	t.Parallel()
+
+	actual, err := CompileAndInvoke(t,
+		`
+          struct interface SI {
+              fun answer(): Int
+          }
+
+          struct S: SI {
+              fun answer(): Int {
+                  return 42
+              }
+          }
+
+          fun answer(_ si: {SI}?): Int? {
+              return si?.answer()
+          }
+
+          fun test(): Int? {
+              return answer(S())
+          }
+        `,
+		"test",
+	)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		interpreter.NewUnmeteredSomeValueNonCopying(
+			interpreter.NewUnmeteredIntValueFromInt64(42),
+		),
+		actual,
+	)
+}


### PR DESCRIPTION
Work towards #3804 

## Description

Encountered while working on https://github.com/onflow/flow-go/pull/7559, getting the EVM contract to work with the Cadence VM: compilation of the method `EVM.borrowBridgeAccessor` failed with: 
```
internal error: unexpected: cannot find global declaration 'EVM.BridgeRouter.borrowBridgeAccessor'
```
Issue was that the compiler was not considering the method invocation to be a dynamic method invocation due to the optional type. 

Add support for method invocations of interface methods via optional chaining by resolving the TODO which already hinted at the missing handling of this case.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
