### PR TITLE
[Compiler] Implement contract removal and recoverable contract update for VM environment

### DIFF
--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -1183,8 +1183,7 @@ func TestRuntimeContractTryUpdate(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
-				// TODO: requires support for tryUpdate in VM
-				//UseVM:     *compile,
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -1243,8 +1242,7 @@ func TestRuntimeContractTryUpdate(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
-				// TODO: requires support for tryUpdate in VM
-				//UseVM:     *compile,
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -1319,8 +1317,7 @@ func TestRuntimeContractTryUpdate(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
-				// TODO: requires support for tryUpdate in VM
-				//UseVM:     *compile,
+				UseVM:     *compile,
 			},
 		)
 
@@ -1385,14 +1382,20 @@ func TestRuntimeContractTryUpdate(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
-				// TODO: requires support for tryUpdate in VM
-				//UseVM:     *compile,
+				UseVM:     *compile,
 			},
 		)
 
 		RequireError(t, err)
-		var unexpectedError errors.UnexpectedError
-		require.ErrorAs(t, err, &unexpectedError)
+
+		// TODO: requires error recovery in VM
+		if *compile {
+			var externalNonError errors.ExternalNonError
+			require.ErrorAs(t, err, &externalNonError)
+		} else {
+			var unexpectedError errors.UnexpectedError
+			require.ErrorAs(t, err, &unexpectedError)
+		}
 
 		assert.True(t, didPanic)
 	})

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -388,8 +388,7 @@ func TestRuntimeContract(t *testing.T) {
 				Context{
 					Interface: runtimeInterface,
 					Location:  nextTransactionLocation(),
-					// TODO: requires support for contract removal in VM
-					//UseVM: *compile,
+					UseVM:     *compile,
 				},
 			)
 			require.NoError(t, err)
@@ -490,8 +489,7 @@ func TestRuntimeContract(t *testing.T) {
 				Context{
 					Interface: runtimeInterface,
 					Location:  nextTransactionLocation(),
-					// TODO: requires support for contract removal in VM
-					//UseVM: *compile,
+					UseVM:     *compile,
 				},
 			)
 			RequireError(t, err)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -4189,8 +4189,7 @@ func TestRuntimeStorageLoadedDestructionAfterRemoval(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
-			// TODO: requires support for contract removal in the VM
-			//UseVM: *compile,
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)

--- a/stdlib/builtin.go
+++ b/stdlib/builtin.go
@@ -104,7 +104,7 @@ func VMFunctions(handler StandardLibraryHandler) []VMFunction {
 
 		newVMAccountContractsChangeFunction(handler, true),
 		newVMAccountContractsChangeFunction(handler, false),
-		// TODO: tryUpdate
+		newVMAccountContractsTryUpdateFunction(handler),
 		newVMAccountContractsRemoveFunction(handler),
 
 		NewVMAccountStorageCapabilitiesGetControllersFunction(handler),

--- a/stdlib/builtin.go
+++ b/stdlib/builtin.go
@@ -104,7 +104,8 @@ func VMFunctions(handler StandardLibraryHandler) []VMFunction {
 
 		newVMAccountContractsChangeFunction(handler, true),
 		newVMAccountContractsChangeFunction(handler, false),
-		// TODO: tryUpdate, remove
+		// TODO: tryUpdate
+		newVMAccountContractsRemoveFunction(handler),
 
 		NewVMAccountStorageCapabilitiesGetControllersFunction(handler),
 		NewVMAccountStorageCapabilitiesGetControllerFunction(handler),


### PR DESCRIPTION
Work towards #3804 

## Description

Implement `Account.Contracts.remove` and `Account.Contracts.tryUpdate` for the VM environment.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
