### PR TITLE
[Compiler] Recover errors in VM like in interpreter

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -548,7 +548,7 @@ func (interpreter *Interpreter) InvokeTransaction(arguments []Value, signers ...
 func (interpreter *Interpreter) RecoverErrors(onError func(error)) {
 	if r := recover(); r != nil {
 		// Recover all errors, because interpreter can be directly invoked by FVM.
-		err := asCadenceError(r)
+		err := AsCadenceError(r)
 
 		// if the error is not yet an interpreter error, wrap it
 		if _, ok := err.(Error); !ok {
@@ -578,7 +578,7 @@ func (interpreter *Interpreter) RecoverErrors(onError func(error)) {
 	}
 }
 
-func asCadenceError(r any) error {
+func AsCadenceError(r any) error {
 	err, isError := r.(error)
 	if !isError {
 		return errors.NewUnexpectedError("%s", r)

--- a/runtime/contract_test.go
+++ b/runtime/contract_test.go
@@ -1388,14 +1388,8 @@ func TestRuntimeContractTryUpdate(t *testing.T) {
 
 		RequireError(t, err)
 
-		// TODO: requires error recovery in VM
-		if *compile {
-			var externalNonError errors.ExternalNonError
-			require.ErrorAs(t, err, &externalNonError)
-		} else {
-			var unexpectedError errors.UnexpectedError
-			require.ErrorAs(t, err, &unexpectedError)
-		}
+		var unexpectedError errors.UnexpectedError
+		require.ErrorAs(t, err, &unexpectedError)
 
 		assert.True(t, didPanic)
 	})

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -274,6 +274,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 		expectedErrorMessage := "Execution failed:\n" +
 			"error: cannot deploy invalid contract\n"
 
+		// TODO: additional info when using compiler/VM
 		if !*compile {
 			expectedErrorMessage +=
 				" --> 0000000000000000000000000000000000000000000000000000000000000000:5:22\n" +
@@ -313,6 +314,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 		expectedErrorMessage := "Execution failed:\n" +
 			"error: cannot deploy invalid contract\n"
 
+		// TODO: additional info when using compiler/VM
 		if !*compile {
 			expectedErrorMessage +=
 				" --> 0000000000000000000000000000000000000000000000000000000000000000:5:22\n" +
@@ -343,6 +345,7 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 		expectedErrorMessage := "Execution failed:\n" +
 			"error: cannot deploy invalid contract\n"
 
+		// TODO: additional info when using compiler/VM
 		if !*compile {
 			expectedErrorMessage +=
 				" --> 0000000000000000000000000000000000000000000000000000000000000000:5:22\n" +


### PR DESCRIPTION
Work towards #3804 

## Description

Recover and convert errors in the VM like it is done in the interpreter. Export and reuse the error conversion / wrapping function from the interpreter to ensure consistency.

While at it, also add missing TODOs (similar tests already have these TODOs)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
