### PR TITLE
[Compiler] Improve VM config

### DIFF
--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -70,10 +70,9 @@ func NewContext(config *Config) *Context {
 	return &Context{
 		Config:                         config,
 		CapabilityControllerIterations: make(map[interpreter.AddressPath]int),
-		mutationDuringCapabilityControllerIteration: false,
-		referencedResourceKindedValues:              ReferencedResourceKindedValues{},
-		destroyedResources:                          make(map[atree.ValueID]struct{}),
-		semaTypes:                                   make(map[sema.TypeID]sema.Type),
+		referencedResourceKindedValues: ReferencedResourceKindedValues{},
+		destroyedResources:             make(map[atree.ValueID]struct{}),
+		semaTypes:                      make(map[sema.TypeID]sema.Type),
 	}
 }
 

--- a/bbq/vm/test/vm_bench_test.go
+++ b/bbq/vm/test/vm_bench_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
+	. "github.com/onflow/cadence/test_utils/interpreter_utils"
 	"github.com/onflow/cadence/test_utils/runtime_utils"
 	. "github.com/onflow/cadence/test_utils/sema_utils"
 
@@ -50,7 +51,7 @@ func BenchmarkRecursionFib(b *testing.B) {
 	)
 	program := comp.Compile()
 
-	vmConfig := &vm.Config{}
+	vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
 	argument := interpreter.NewUnmeteredIntValueFromInt64(14)
@@ -80,7 +81,7 @@ func BenchmarkImperativeFib(b *testing.B) {
 	)
 	program := comp.Compile()
 
-	vmConfig := &vm.Config{}
+	vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
 	b.ReportAllocs()
@@ -119,7 +120,7 @@ func BenchmarkImperativeFibNewVM(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		vmConfig := &vm.Config{}
+		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
 		_, err := vmInstance.InvokeExternally("main")
@@ -149,7 +150,7 @@ func BenchmarkImperativeFibNewCompilerNewVM(b *testing.B) {
 		)
 		program := comp.Compile()
 
-		vmConfig := &vm.Config{}
+		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmInstance := vm.NewVM(common.ScriptLocation{}, program, vmConfig)
 
 		_, err := vmInstance.InvokeExternally("main")
@@ -188,7 +189,7 @@ func BenchmarkNewStruct(b *testing.B) {
 	)
 	program := comp.Compile()
 
-	vmConfig := &vm.Config{}
+	vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
 	b.ReportAllocs()
@@ -237,7 +238,7 @@ func BenchmarkNewResource(b *testing.B) {
 		)
 		program := comp.Compile()
 
-		vmConfig := &vm.Config{}
+		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 		_, err := vmInstance.InvokeExternally("test", value)
 		require.NoError(b, err)
@@ -330,13 +331,12 @@ func BenchmarkContractImport(b *testing.B) {
 		nil,
 	)
 
-	vmConfig := &vm.Config{
-		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
-			return importedProgram
-		},
-		ContractValueHandler: func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
-			return importedContractValue
-		},
+	vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
+	vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		return importedProgram
+	}
+	vmConfig.ContractValueHandler = func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
+		return importedContractValue
 	}
 
 	b.ResetTimer()
@@ -471,22 +471,21 @@ func BenchmarkMethodCall(b *testing.B) {
 
 		program := comp.Compile()
 
-		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
-				return importedProgram
-			},
-			ContractValueHandler: func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
-				return importedContractValue
-			},
-			TypeLoader: func(location common.Location, typeID interpreter.TypeID) sema.Type {
-				elaboration := importedChecker.Elaboration
-				compositeType := elaboration.CompositeType(typeID)
-				if compositeType != nil {
-					return compositeType
-				}
+		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
+		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			return importedProgram
+		}
+		vmConfig.ContractValueHandler = func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
+			return importedContractValue
+		}
+		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) sema.Type {
+			elaboration := importedChecker.Elaboration
+			compositeType := elaboration.CompositeType(typeID)
+			if compositeType != nil {
+				return compositeType
+			}
 
-				return elaboration.InterfaceType(typeID)
-			},
+			return elaboration.InterfaceType(typeID)
 		}
 
 		scriptLocation := runtime_utils.NewScriptLocationGenerator()
@@ -582,13 +581,12 @@ func BenchmarkMethodCall(b *testing.B) {
 
 		program := comp.Compile()
 
-		vmConfig := &vm.Config{
-			ImportHandler: func(location common.Location) *bbq.InstructionProgram {
-				return importedProgram
-			},
-			ContractValueHandler: func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
-				return importedContractValue
-			},
+		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
+		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			return importedProgram
+		}
+		vmConfig.ContractValueHandler = func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
+			return importedContractValue
 		}
 
 		scriptLocation := runtime_utils.NewScriptLocationGenerator()

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -57,16 +57,8 @@ func NewVM(
 	program *bbq.InstructionProgram,
 	config *Config,
 ) *VM {
-	// TODO: Remove initializing config. Following is for testing purpose only.
-	if config == nil {
-		config = &Config{}
-	}
 
 	context := NewContext(config)
-
-	if context.storage == nil {
-		context.storage = interpreter.NewInMemoryStorage(nil)
-	}
 
 	if context.referencedResourceKindedValues == nil {
 		context.referencedResourceKindedValues = ReferencedResourceKindedValues{}

--- a/bbq/vm/vm_test.go
+++ b/bbq/vm/vm_test.go
@@ -32,7 +32,8 @@ func TestVM_pop(t *testing.T) {
 	t.Parallel()
 
 	program := &bbq.InstructionProgram{}
-	vm := NewVM(nil, program, nil)
+	conf := NewConfig(nil)
+	vm := NewVM(nil, program, conf)
 
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(1))
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(2))
@@ -61,7 +62,8 @@ func TestVM_peekPop(t *testing.T) {
 	t.Parallel()
 
 	program := &bbq.InstructionProgram{}
-	vm := NewVM(nil, program, nil)
+	conf := NewConfig(nil)
+	vm := NewVM(nil, program, conf)
 
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(1))
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(2))
@@ -94,7 +96,8 @@ func TestVM_replaceTop(t *testing.T) {
 	t.Parallel()
 
 	program := &bbq.InstructionProgram{}
-	vm := NewVM(nil, program, nil)
+	conf := NewConfig(nil)
+	vm := NewVM(nil, program, conf)
 
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(1))
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(2))
@@ -122,7 +125,8 @@ func TestVM_pop2(t *testing.T) {
 	t.Parallel()
 
 	program := &bbq.InstructionProgram{}
-	vm := NewVM(nil, program, nil)
+	conf := NewConfig(nil)
+	vm := NewVM(nil, program, conf)
 
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(1))
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(2))
@@ -145,7 +149,8 @@ func TestVM_pop3(t *testing.T) {
 	t.Parallel()
 
 	program := &bbq.InstructionProgram{}
-	vm := NewVM(nil, program, nil)
+	conf := NewConfig(nil)
+	vm := NewVM(nil, program, conf)
 
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(1))
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(2))
@@ -180,7 +185,8 @@ func TestVM_peek(t *testing.T) {
 	t.Parallel()
 
 	program := &bbq.InstructionProgram{}
-	vm := NewVM(nil, program, nil)
+	conf := NewConfig(nil)
+	vm := NewVM(nil, program, conf)
 
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(1))
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(2))
@@ -213,7 +219,8 @@ func TestVM_peekN(t *testing.T) {
 	t.Parallel()
 
 	program := &bbq.InstructionProgram{}
-	vm := NewVM(nil, program, nil)
+	conf := NewConfig(nil)
+	vm := NewVM(nil, program, conf)
 
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(1))
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(2))
@@ -247,7 +254,8 @@ func TestVM_dropN(t *testing.T) {
 	t.Parallel()
 
 	program := &bbq.InstructionProgram{}
-	vm := NewVM(nil, program, nil)
+	conf := NewConfig(nil)
+	vm := NewVM(nil, program, conf)
 
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(1))
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(2))
@@ -267,7 +275,8 @@ func TestVM_popN(t *testing.T) {
 	t.Parallel()
 
 	program := &bbq.InstructionProgram{}
-	vm := NewVM(nil, program, nil)
+	conf := NewConfig(nil)
+	vm := NewVM(nil, program, conf)
 
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(1))
 	vm.push(interpreter.NewUnmeteredIntValueFromInt64(2))

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -613,16 +613,15 @@ func testAccountWithErrorHandlerWithCompiler(
 	var storage interpreter.Storage
 
 	if compilerEnabled && *compile {
-		vmConfig := &vm.Config{
-			BuiltinGlobalsProvider: func(_ common.Location) *activations.Activation[vm.Variable] {
-				activation := activations.NewActivation(nil, vm.DefaultBuiltinGlobals())
+		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
+		vmConfig.BuiltinGlobalsProvider = func(_ common.Location) *activations.Activation[vm.Variable] {
+			activation := activations.NewActivation(nil, vm.DefaultBuiltinGlobals())
 
-				variable := &interpreter.SimpleVariable{}
-				variable.InitializeWithValue(accountValueDeclaration.Value)
-				activation.Set(accountValueDeclaration.Name, variable)
+			variable := &interpreter.SimpleVariable{}
+			variable.InitializeWithValue(accountValueDeclaration.Value)
+			activation.Set(accountValueDeclaration.Name, variable)
 
-				return activation
-			},
+			return activation
 		}
 
 		programs := map[common.Location]*CompiledProgram{}

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -135,20 +135,20 @@ func NewScriptVMEnvironment(config Config) Environment {
 }
 
 func (e *vmEnvironment) newVMConfig() *vm.Config {
-	return &vm.Config{
-		MemoryGauge:                    e,
-		ComputationGauge:               e,
-		TypeLoader:                     e.loadType,
-		BuiltinGlobalsProvider:         e.vmBuiltinGlobals,
-		ContractValueHandler:           e.loadContractValue,
-		ImportHandler:                  e.importProgram,
-		InjectedCompositeFieldsHandler: newInjectedCompositeFieldsHandler(e),
-		UUIDHandler:                    newUUIDHandler(&e.Interface),
-		AccountHandlerFunc:             e.newAccountValue,
-		OnEventEmitted:                 newOnEventEmittedHandler(&e.Interface),
-		CapabilityBorrowHandler:        newCapabilityBorrowHandler(e),
-		CapabilityCheckHandler:         newCapabilityCheckHandler(e),
-	}
+	conf := vm.NewConfig(nil)
+	conf.MemoryGauge = e
+	conf.ComputationGauge = e
+	conf.TypeLoader = e.loadType
+	conf.BuiltinGlobalsProvider = e.vmBuiltinGlobals
+	conf.ContractValueHandler = e.loadContractValue
+	conf.ImportHandler = e.importProgram
+	conf.InjectedCompositeFieldsHandler = newInjectedCompositeFieldsHandler(e)
+	conf.UUIDHandler = newUUIDHandler(&e.Interface)
+	conf.AccountHandlerFunc = e.newAccountValue
+	conf.OnEventEmitted = newOnEventEmittedHandler(&e.Interface)
+	conf.CapabilityBorrowHandler = newCapabilityBorrowHandler(e)
+	conf.CapabilityCheckHandler = newCapabilityCheckHandler(e)
+	return conf
 }
 
 func (e *vmEnvironment) defineValue(name string, value vm.Value) {

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -229,6 +229,9 @@ func ParseCheckAndPrepareWithOptions(
 	if interpreterConfig != nil {
 		storage = interpreterConfig.Storage
 	}
+	if storage == nil {
+		storage = interpreter.NewInMemoryStorage(nil)
+	}
 
 	programs := CompiledPrograms{}
 	var compilerConfig *compiler.Config


### PR DESCRIPTION
Work towards #3804 


## Description

Don't mutate the config when constructing a new VM, don't defensively prepare config and storage.
Assume the config was passed and was constructed correctly.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
