### PR TITLE
[Compiler] Add call stack depth limit to VM 

### DIFF
--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -62,7 +62,7 @@ type Config struct {
 	// AtreeValueValidationEnabled determines if the validation of atree values is enabled
 	AtreeValueValidationEnabled bool
 	// StackDepthLimit is the maximum depth of the call stack
-	StackDepthLimit int
+	StackDepthLimit uint64
 
 	debugEnabled bool
 }

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -19,6 +19,8 @@
 package vm
 
 import (
+	"math"
+
 	"github.com/onflow/cadence/bbq/commons"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
@@ -59,13 +61,16 @@ type Config struct {
 	AtreeStorageValidationEnabled bool
 	// AtreeValueValidationEnabled determines if the validation of atree values is enabled
 	AtreeValueValidationEnabled bool
+	// StackDepthLimit is the maximum depth of the call stack
+	StackDepthLimit int
 
 	debugEnabled bool
 }
 
 func NewConfig(storage interpreter.Storage) *Config {
 	return &Config{
-		storage: storage,
+		storage:         storage,
+		StackDepthLimit: math.MaxInt,
 	}
 }
 

--- a/bbq/vm/errors.go
+++ b/bbq/vm/errors.go
@@ -50,20 +50,3 @@ func (UnknownFunctionError) IsUserError() {}
 func (e UnknownFunctionError) Error() string {
 	return fmt.Sprintf("unknown function `%s`", e.name)
 }
-
-// CallStackLimitExceededError
-
-type CallStackLimitExceededError struct {
-	Limit int
-}
-
-var _ errors.UserError = CallStackLimitExceededError{}
-
-func (CallStackLimitExceededError) IsUserError() {}
-
-func (e CallStackLimitExceededError) Error() string {
-	return fmt.Sprintf(
-		"call stack limit exceeded: %d",
-		e.Limit,
-	)
-}

--- a/bbq/vm/errors.go
+++ b/bbq/vm/errors.go
@@ -50,3 +50,20 @@ func (UnknownFunctionError) IsUserError() {}
 func (e UnknownFunctionError) Error() string {
 	return fmt.Sprintf("unknown function `%s`", e.name)
 }
+
+// CallStackLimitExceededError
+
+type CallStackLimitExceededError struct {
+	Limit int
+}
+
+var _ errors.UserError = CallStackLimitExceededError{}
+
+func (CallStackLimitExceededError) IsUserError() {}
+
+func (e CallStackLimitExceededError) Error() string {
+	return fmt.Sprintf(
+		"call stack limit exceeded: %d",
+		e.Limit,
+	)
+}

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -2242,7 +2242,7 @@ func TestTransaction(t *testing.T) {
 		)
 
 		err := vmInstance.InvokeTransaction(nil)
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "pre/post condition failed")
 
 		assert.Equal(t, []string{"2"}, logs)
@@ -2311,7 +2311,7 @@ func TestTransaction(t *testing.T) {
 		)
 
 		err := vmInstance.InvokeTransaction(nil)
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "pre/post condition failed")
 
 		assert.Equal(t, []string{"2", "10"}, logs)
@@ -3621,7 +3621,7 @@ func TestFunctionPreConditions(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(3),
 		)
 
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "pre/post condition failed")
 	})
 
@@ -3642,7 +3642,7 @@ func TestFunctionPreConditions(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(3),
 		)
 
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "x must be zero")
 	})
 
@@ -3698,7 +3698,7 @@ func TestFunctionPreConditions(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(4),
 		)
 
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "a must be larger than 10")
 	})
 
@@ -3733,7 +3733,7 @@ func TestFunctionPreConditions(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(4),
 		)
 
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "a must be larger than 10")
 	})
 
@@ -3778,7 +3778,7 @@ func TestFunctionPreConditions(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(4),
 		)
 
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "a must be larger than 10")
 	})
 
@@ -4073,7 +4073,7 @@ func TestFunctionPostConditions(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(3),
 		)
 
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "pre/post condition failed")
 	})
 
@@ -4094,7 +4094,7 @@ func TestFunctionPostConditions(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(3),
 		)
 
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "x must be zero")
 	})
 
@@ -4159,7 +4159,7 @@ func TestFunctionPostConditions(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(4),
 		)
 
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "x must be 5")
 	})
 
@@ -4237,7 +4237,7 @@ func TestFunctionPostConditions(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(3),
 		)
 
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "x must be zero")
 	})
 
@@ -4293,7 +4293,7 @@ func TestFunctionPostConditions(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(4),
 		)
 
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "result must be larger than 10")
 	})
 
@@ -4350,7 +4350,7 @@ func TestFunctionPostConditions(t *testing.T) {
 			"main",
 		)
 
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "pre/post condition failed")
 	})
 
@@ -4385,7 +4385,7 @@ func TestFunctionPostConditions(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(4),
 		)
 
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.ErrorContains(t, err, "a must be larger than 10")
 	})
 }
@@ -4942,7 +4942,7 @@ func TestCasting(t *testing.T) {
 			"test",
 			interpreter.TrueValue,
 		)
-		require.Error(t, err)
+		RequireError(t, err)
 		assert.Equal(
 			t,
 			&interpreter.ForceCastTypeMismatchError{
@@ -5703,7 +5703,7 @@ func TestCompileForce(t *testing.T) {
 			"test",
 			interpreter.Nil,
 		)
-		require.Error(t, err)
+		RequireError(t, err)
 
 		var forceNilError *interpreter.ForceNilError
 		require.ErrorAs(t, err, &forceNilError)
@@ -5722,7 +5722,7 @@ func TestCompileForce(t *testing.T) {
 			"test",
 			interpreter.Nil,
 		)
-		require.Error(t, err)
+		RequireError(t, err)
 		var forceNilError *interpreter.ForceNilError
 		require.ErrorAs(t, err, &forceNilError)
 	})
@@ -9137,4 +9137,29 @@ func TestInjectedContract(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(2), result)
+}
+
+func TestStackDepthLimit(t *testing.T) {
+
+	t.Parallel()
+
+	vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
+	vmConfig.StackDepthLimit = 10
+
+	_, err := CompileAndInvokeWithOptions(t,
+		`
+
+            fun test() {
+                test()
+            }
+        `,
+		"test",
+		CompilerAndVMOptions{
+			VMConfig: vmConfig,
+		},
+	)
+	RequireError(t, err)
+
+	var callStackLimitExceededErr vm.CallStackLimitExceededError
+	require.ErrorAs(t, err, &callStackLimitExceededErr)
 }

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -9160,6 +9160,6 @@ func TestStackDepthLimit(t *testing.T) {
 	)
 	RequireError(t, err)
 
-	var callStackLimitExceededErr vm.CallStackLimitExceededError
+	var callStackLimitExceededErr *interpreter.CallStackLimitExceededError
 	require.ErrorAs(t, err, &callStackLimitExceededErr)
 }

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -208,6 +208,12 @@ func fill(slice []Value, n int) []Value {
 }
 
 func (vm *VM) pushCallFrame(functionValue CompiledFunctionValue, arguments []Value) {
+	if len(vm.callstack) == vm.context.StackDepthLimit {
+		panic(CallStackLimitExceededError{
+			Limit: vm.context.StackDepthLimit,
+		})
+	}
+
 	localsCount := functionValue.Function.LocalCount
 
 	vm.locals = append(vm.locals, arguments...)

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -208,8 +208,8 @@ func fill(slice []Value, n int) []Value {
 }
 
 func (vm *VM) pushCallFrame(functionValue CompiledFunctionValue, arguments []Value) {
-	if len(vm.callstack) == vm.context.StackDepthLimit {
-		panic(CallStackLimitExceededError{
+	if uint64(len(vm.callstack)) == vm.context.StackDepthLimit {
+		panic(&interpreter.CallStackLimitExceededError{
 			Limit: vm.context.StackDepthLimit,
 		})
 	}

--- a/interpreter/errors.go
+++ b/interpreter/errors.go
@@ -1445,3 +1445,25 @@ func (e *GetCapabilityError) Error() string {
 func (e *GetCapabilityError) SetLocationRange(locationRange LocationRange) {
 	e.LocationRange = locationRange
 }
+
+// CallStackLimitExceededError
+
+type CallStackLimitExceededError struct {
+	Limit uint64
+	LocationRange
+}
+
+var _ errors.UserError = &CallStackLimitExceededError{}
+
+func (*CallStackLimitExceededError) IsUserError() {}
+
+func (e *CallStackLimitExceededError) Error() string {
+	return fmt.Sprintf(
+		"call stack limit exceeded: %d",
+		e.Limit,
+	)
+}
+
+func (e *CallStackLimitExceededError) SetLocationRange(locationRange LocationRange) {
+	e.LocationRange = locationRange
+}

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -62,23 +62,6 @@ func (e Error) Error() string {
 	return sb.String()
 }
 
-// CallStackLimitExceededError
-
-type CallStackLimitExceededError struct {
-	Limit uint64
-}
-
-var _ errors.UserError = CallStackLimitExceededError{}
-
-func (CallStackLimitExceededError) IsUserError() {}
-
-func (e CallStackLimitExceededError) Error() string {
-	return fmt.Sprintf(
-		"call stack limit exceeded: %d",
-		e.Limit,
-	)
-}
-
 // InvalidTransactionCountError
 
 type InvalidTransactionCountError struct {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/bbq/vm"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/encoding/json"
 	runtimeErrors "github.com/onflow/cadence/errors"
@@ -7498,14 +7499,20 @@ func TestRuntimeStackOverflow(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)
 
 	assertRuntimeErrorIsUserError(t, err)
 
-	var callStackLimitExceededErr CallStackLimitExceededError
-	require.ErrorAs(t, err, &callStackLimitExceededErr)
+	if *compile {
+		var callStackLimitExceededErr vm.CallStackLimitExceededError
+		require.ErrorAs(t, err, &callStackLimitExceededErr)
+	} else {
+		var callStackLimitExceededErr CallStackLimitExceededError
+		require.ErrorAs(t, err, &callStackLimitExceededErr)
+	}
 }
 
 func TestRuntimeInternalErrors(t *testing.T) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/ast"
-	"github.com/onflow/cadence/bbq/vm"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/encoding/json"
 	runtimeErrors "github.com/onflow/cadence/errors"
@@ -7506,13 +7505,8 @@ func TestRuntimeStackOverflow(t *testing.T) {
 
 	assertRuntimeErrorIsUserError(t, err)
 
-	if *compile {
-		var callStackLimitExceededErr vm.CallStackLimitExceededError
-		require.ErrorAs(t, err, &callStackLimitExceededErr)
-	} else {
-		var callStackLimitExceededErr CallStackLimitExceededError
-		require.ErrorAs(t, err, &callStackLimitExceededErr)
-	}
+	var callStackLimitExceededErr *interpreter.CallStackLimitExceededError
+	require.ErrorAs(t, err, &callStackLimitExceededErr)
 }
 
 func TestRuntimeInternalErrors(t *testing.T) {

--- a/runtime/stackdepth.go
+++ b/runtime/stackdepth.go
@@ -18,6 +18,8 @@
 
 package runtime
 
+import "github.com/onflow/cadence/interpreter"
+
 const defaultStackDepthLimit = 2000
 
 type stackDepthLimiter struct {
@@ -41,7 +43,7 @@ func (limiter *stackDepthLimiter) OnFunctionInvocation() {
 		return
 	}
 
-	panic(CallStackLimitExceededError{
+	panic(&interpreter.CallStackLimitExceededError{
 		Limit: limiter.limit,
 	})
 }

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -148,6 +148,7 @@ func (e *vmEnvironment) newVMConfig() *vm.Config {
 	conf.OnEventEmitted = newOnEventEmittedHandler(&e.Interface)
 	conf.CapabilityBorrowHandler = newCapabilityBorrowHandler(e)
 	conf.CapabilityCheckHandler = newCapabilityCheckHandler(e)
+	conf.StackDepthLimit = defaultStackDepthLimit
 	return conf
 }
 


### PR DESCRIPTION
Work towards #3804 

## Description

Add direct support for limiting the call stack depth to the VM.

In the interpreter this is implemented through callbacks, which the interpreter environment configures and uses to limit the call stack depth.

Also improve error assertion for existing VM tests.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
