### PR TITLE
[Compiler] Implement getting contract value in VM

### DIFF
--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -212,11 +212,6 @@ func (c *Config) GetAccountHandlerFunc() interpreter.AccountHandlerFunc {
 	return c.AccountHandlerFunc
 }
 
-func (c *Config) GetContractValue(contractLocation common.AddressLocation) (*interpreter.CompositeValue, error) {
-	//TODO
-	return nil, nil
-}
-
 func (c *Config) GetValidateAccountCapabilitiesGetHandler() interpreter.ValidateAccountCapabilitiesGetHandlerFunc {
 	return c.ValidateAccountCapabilitiesGetHandler
 }

--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -362,3 +362,7 @@ func (c *Context) SemaTypeFromStaticType(staticType interpreter.StaticType) sema
 	c.semaTypes[typeID] = semaType
 	return semaType
 }
+
+func (c *Context) GetContractValue(contractLocation common.AddressLocation) *interpreter.CompositeValue {
+	return c.ContractValueHandler(c, contractLocation)
+}

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -503,7 +503,7 @@ var _ AccountContractCreationContext = &Interpreter{}
 
 type AccountContractBorrowContext interface {
 	FunctionCreationContext
-	GetContractValue(contractLocation common.AddressLocation) (*CompositeValue, error)
+	GetContractValue(contractLocation common.AddressLocation) *CompositeValue
 }
 
 var _ AccountContractBorrowContext = &Interpreter{}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5066,31 +5066,24 @@ func (interpreter *Interpreter) AllElaborations() (elaborations map[common.Locat
 	return
 }
 
-func (interpreter *Interpreter) GetContractValue(contractLocation common.AddressLocation) (*CompositeValue, error) {
+func (interpreter *Interpreter) GetContractValue(contractLocation common.AddressLocation) *CompositeValue {
 	inter := interpreter.EnsureLoaded(contractLocation)
 	return inter.GetContractComposite(contractLocation)
 }
 
 // GetContractComposite gets the composite value of the contract at the address location.
-func (interpreter *Interpreter) GetContractComposite(contractLocation common.AddressLocation) (*CompositeValue, error) {
+func (interpreter *Interpreter) GetContractComposite(contractLocation common.AddressLocation) *CompositeValue {
 	contractGlobal := interpreter.Globals.Get(contractLocation.Name)
 	if contractGlobal == nil {
-		return nil, NotDeclaredError{
-			ExpectedKind: common.DeclarationKindContract,
-			Name:         contractLocation.Name,
-		}
+		return nil
 	}
 
-	// get contract value
 	contractValue, ok := contractGlobal.GetValue(interpreter).(*CompositeValue)
 	if !ok {
-		return nil, NotDeclaredError{
-			ExpectedKind: common.DeclarationKindContract,
-			Name:         contractLocation.Name,
-		}
+		return nil
 	}
 
-	return contractValue, nil
+	return contractValue
 }
 
 func GetNativeCompositeValueComputedFields(qualifiedIdentifier string) map[string]ComputedField {

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -2003,8 +2003,7 @@ func TestRuntimeAuthAccountContracts(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
-				// TODO: requires support for contract interface imports
-				//UseVM:     *compile,
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -2098,8 +2097,7 @@ func TestRuntimeAuthAccountContracts(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
-				// TODO: requires support for contract interface imports
-				//UseVM:     *compile,
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -2198,8 +2196,7 @@ func TestRuntimeAuthAccountContracts(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
-				// TODO: requires support for contract interface imports
-				//UseVM:     *compile,
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)

--- a/runtime/contract.go
+++ b/runtime/contract.go
@@ -20,7 +20,6 @@ package runtime
 
 import (
 	"github.com/onflow/cadence/common"
-	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
 )
 
@@ -51,7 +50,7 @@ func loadContractValue(
 	}
 
 	if contractValue == nil {
-		panic(errors.NewDefaultUserError("failed to load contract: %s", location))
+		return nil
 	}
 
 	return contractValue.(*interpreter.CompositeValue)

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -211,9 +211,12 @@ func (executor *contractFunctionExecutor) executeWithInterpreter(
 		return nil, err
 	}
 
-	contractValue, err := inter.GetContractComposite(executor.contractLocation)
-	if err != nil {
-		return nil, err
+	contractValue := inter.GetContractComposite(executor.contractLocation)
+	if contractValue == nil {
+		return nil, interpreter.NotDeclaredError{
+			ExpectedKind: common.DeclarationKindContract,
+			Name:         executor.contractLocation.Name,
+		}
 	}
 
 	var self interpreter.Value = contractValue
@@ -279,6 +282,12 @@ func (executor *contractFunctionExecutor) executeWithVM(
 		contractLocation,
 		environment.storage,
 	)
+	if contractValue == nil {
+		return nil, interpreter.NotDeclaredError{
+			ExpectedKind: common.DeclarationKindContract,
+			Name:         executor.contractLocation.Name,
+		}
+	}
 
 	// receiver + arguments
 	arguments := make([]interpreter.Value, 0, len(executor.arguments))

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -19,7 +19,6 @@
 package stdlib
 
 import (
-	goerrors "errors"
 	"fmt"
 
 	"golang.org/x/crypto/sha3"
@@ -1900,14 +1899,9 @@ func AccountContractsBorrow(
 
 	contractLocation := common.NewAddressLocation(invocationContext, address, name)
 
-	contractValue, err := invocationContext.GetContractValue(contractLocation)
-	if err != nil {
-		var notDeclaredErr interpreter.NotDeclaredError
-		if goerrors.As(err, &notDeclaredErr) {
-			return interpreter.Nil
-		}
-
-		panic(err)
+	contractValue := invocationContext.GetContractValue(contractLocation)
+	if contractValue == nil {
+		return interpreter.Nil
 	}
 
 	// Check the type


### PR DESCRIPTION
Work towards #3804 

## Description

Implement `InvocationContext.GetContractValue`, which enables `Account.Contracts.borrow`.

This requires gracefully handling the composite value for the contract potentially not existing, e.g. when the borrowed contract is a contract interface.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
