### PR TITLE
[Compiler] Various improvements

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -271,7 +271,7 @@ func (c *Compiler[_, _]) addImportedGlobal(location common.Location, name string
 	)
 }
 
-func (c *Compiler[E, T]) addFunction(
+func (c *Compiler[E, _]) addFunction(
 	name string,
 	qualifiedName string,
 	parameterCount uint16,
@@ -287,7 +287,7 @@ func (c *Compiler[E, T]) addFunction(
 	return function
 }
 
-func (c *Compiler[E, T]) addGlobalVariableWithGetter(
+func (c *Compiler[E, _]) addGlobalVariableWithGetter(
 	name string,
 	functionType *sema.FunctionType,
 ) *globalVariable[E] {
@@ -308,7 +308,7 @@ func (c *Compiler[E, T]) addGlobalVariableWithGetter(
 	return globalVariable
 }
 
-func (c *Compiler[E, T]) addGlobalVariable(
+func (c *Compiler[E, _]) addGlobalVariable(
 	name string,
 ) *globalVariable[E] {
 	globalVariable := &globalVariable[E]{
@@ -320,7 +320,7 @@ func (c *Compiler[E, T]) addGlobalVariable(
 	return globalVariable
 }
 
-func (c *Compiler[E, T]) newFunction(
+func (c *Compiler[E, _]) newFunction(
 	name string,
 	qualifiedName string,
 	parameterCount uint16,
@@ -337,7 +337,7 @@ func (c *Compiler[E, T]) newFunction(
 	)
 }
 
-func (c *Compiler[E, T]) targetFunction(function *function[E]) {
+func (c *Compiler[E, _]) targetFunction(function *function[E]) {
 	c.currentFunction = function
 
 	var code *[]E
@@ -3318,7 +3318,7 @@ func (c *Compiler[_, _]) emitTransfer() {
 	c.emit(opcode.InstructionTransfer{})
 }
 
-func (c *Compiler[_, T]) getOrAddType(ty sema.Type) uint16 {
+func (c *Compiler[_, _]) getOrAddType(ty sema.Type) uint16 {
 	typeID := ty.ID()
 
 	// Optimization: Re-use types in the pool.
@@ -3345,7 +3345,7 @@ func (c *Compiler[_, T]) addCompiledType(ty sema.Type, data T) uint16 {
 	return uint16(count)
 }
 
-func (c *Compiler[E, T]) declareParameters(paramList *ast.ParameterList, declareReceiver bool) {
+func (c *Compiler[_, _]) declareParameters(paramList *ast.ParameterList, declareReceiver bool) {
 	if declareReceiver {
 		// Declare receiver as `self`.
 		// Receiver is always at the zero-th index of params.

--- a/interpreter/container_mutation_test.go
+++ b/interpreter/container_mutation_test.go
@@ -325,7 +325,7 @@ func TestInterpretArrayMutation(t *testing.T) {
 		baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
 		interpreter.Declare(baseActivation, valueDeclaration)
 
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
             fun test() {
                 let array: [AnyStruct] = [nil] as [(fun(AnyStruct):Void)?]
 
@@ -723,7 +723,7 @@ func TestInterpretDictionaryMutation(t *testing.T) {
 		baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
 		interpreter.Declare(baseActivation, valueDeclaration)
 
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
             fun test() {
                 let dict: {String: AnyStruct} = {}
 

--- a/interpreter/if_test.go
+++ b/interpreter/if_test.go
@@ -39,7 +39,7 @@ func TestInterpretIfStatement(t *testing.T) {
 
 		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
-           access(all) fun testTrue(): Int {
+           fun testTrue(): Int {
                if true {
                    return 2
                } else {
@@ -48,7 +48,7 @@ func TestInterpretIfStatement(t *testing.T) {
                return 4
            }
 
-           access(all) fun testFalse(): Int {
+           fun testFalse(): Int {
                if false {
                    return 2
                } else {
@@ -57,14 +57,14 @@ func TestInterpretIfStatement(t *testing.T) {
                return 4
            }
 
-           access(all) fun testNoElse(): Int {
+           fun testNoElse(): Int {
                if true {
                    return 2
                }
                return 3
            }
 
-           access(all) fun testElseIf(): Int {
+           fun testElseIf(): Int {
                if false {
                    return 2
                } else if true {
@@ -73,7 +73,7 @@ func TestInterpretIfStatement(t *testing.T) {
                return 4
            }
            
-           access(all) fun testElseIfElse(): Int {
+           fun testElseIfElse(): Int {
                if false {
                    return 2
                } else if false {
@@ -124,7 +124,7 @@ func TestInterpretIfStatement(t *testing.T) {
 
 		inter := parseCheckAndPrepare(t,
 			`
-           access(all) fun testTrue(): Int {
+           fun testTrue(): Int {
                if true {
                    return 2
                } else {
@@ -132,7 +132,7 @@ func TestInterpretIfStatement(t *testing.T) {
                }
            }
 
-           access(all) fun testFalse(): Int {
+           fun testFalse(): Int {
                if false {
                    return 2
                } else {
@@ -140,14 +140,14 @@ func TestInterpretIfStatement(t *testing.T) {
                }
            }
 
-           access(all) fun testNoElse(): Int {
+           fun testNoElse(): Int {
                if true {
                    return 2
                }
                return 3
            }
 
-           access(all) fun testElseIf(): Int {
+           fun testElseIf(): Int {
                if false {
                    return 2
                } else if true {
@@ -156,7 +156,7 @@ func TestInterpretIfStatement(t *testing.T) {
                return 4
            }
            
-           access(all) fun testElseIfElse(): Int {
+           fun testElseIfElse(): Int {
                if false {
                    return 2
                } else if false {

--- a/interpreter/switch_test.go
+++ b/interpreter/switch_test.go
@@ -21,13 +21,10 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/interpreter"
-	"github.com/onflow/cadence/sema"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
-	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
 func TestInterpretSwitchStatement(t *testing.T) {
@@ -36,29 +33,20 @@ func TestInterpretSwitchStatement(t *testing.T) {
 
 	t.Run("Bool", func(t *testing.T) {
 
-		inter, err := parseCheckAndInterpretWithOptions(t,
-			`
-              fun test(_ x: Bool): Int {
-                  switch x {
-                  case true:
-                      return 1
-                  case false:
-                      return 2
-                  default:
-                      return 3
-                  }
-                  return 4
-              }
-            `,
-			ParseCheckAndInterpretOptions{
-				HandleCheckerError: func(err error) {
-					errs := RequireCheckerErrors(t, err, 1)
+		t.Parallel()
 
-					assert.IsType(t, &sema.UnreachableStatementError{}, errs[0])
-				},
-			},
-		)
-		require.NoError(t, err)
+		inter := parseCheckAndPrepare(t, `
+          fun test(_ x: Bool): Int {
+              switch x {
+              case true:
+                  return 1
+              case false:
+                  return 2
+              default:
+                  return 3
+              }
+          }
+        `)
 
 		for argument, expected := range map[interpreter.Value]interpreter.Value{
 			interpreter.TrueValue:  interpreter.NewUnmeteredIntValueFromInt64(1),
@@ -74,29 +62,20 @@ func TestInterpretSwitchStatement(t *testing.T) {
 
 	t.Run("Int", func(t *testing.T) {
 
-		inter, err := parseCheckAndInterpretWithOptions(t,
-			`
-              fun test(_ x: Int): String {
-                  switch x {
-                  case 1:
-                      return "1"
-                  case 2:
-                      return "2"
-                  default:
-                      return "3"
-                  }
-                  return "4"
-              }
-            `,
-			ParseCheckAndInterpretOptions{
-				HandleCheckerError: func(err error) {
-					errs := RequireCheckerErrors(t, err, 1)
+		t.Parallel()
 
-					assert.IsType(t, &sema.UnreachableStatementError{}, errs[0])
-				},
-			},
-		)
-		require.NoError(t, err)
+		inter := parseCheckAndPrepare(t, `
+          fun test(_ x: Int): String {
+              switch x {
+              case 1:
+                  return "1"
+              case 2:
+                  return "2"
+              default:
+                  return "3"
+              }
+          }
+        `)
 
 		for argument, expected := range map[interpreter.Value]interpreter.Value{
 			interpreter.NewUnmeteredIntValueFromInt64(1): interpreter.NewUnmeteredStringValue("1"),
@@ -114,30 +93,21 @@ func TestInterpretSwitchStatement(t *testing.T) {
 
 	t.Run("break", func(t *testing.T) {
 
-		inter, err := parseCheckAndInterpretWithOptions(t,
-			`
-              fun test(_ x: Int): String {
-                  switch x {
-                  case 1:
-                      break
-                      return "1"
-                  case 2:
-                      return "2"
-                  default:
-                      return "3"
-                  }
-                  return "4"
-              }
-            `,
-			ParseCheckAndInterpretOptions{
-				HandleCheckerError: func(err error) {
-					errs := RequireCheckerErrors(t, err, 1)
+		t.Parallel()
 
-					assert.IsType(t, &sema.UnreachableStatementError{}, errs[0])
-				},
-			},
-		)
-		require.NoError(t, err)
+		inter := parseCheckAndPrepare(t, `
+          fun test(_ x: Int): String {
+              switch x {
+              case 1:
+                  break
+              case 2:
+                  return "2"
+              default:
+                  return "3"
+              }
+			  return "4"
+          }
+        `)
 
 		for argument, expected := range map[interpreter.Value]interpreter.Value{
 			interpreter.NewUnmeteredIntValueFromInt64(1): interpreter.NewUnmeteredStringValue("4"),
@@ -154,6 +124,8 @@ func TestInterpretSwitchStatement(t *testing.T) {
 	})
 
 	t.Run("no-implicit fallthrough", func(t *testing.T) {
+
+		t.Parallel()
 
 		inter := parseCheckAndPrepare(t, `
           fun test(_ x: Int): [String] {
@@ -202,29 +174,20 @@ func TestInterpretSwitchStatement(t *testing.T) {
 
 	t.Run("optional", func(t *testing.T) {
 
-		inter, err := parseCheckAndInterpretWithOptions(t,
-			`
-              fun test(_ x: Int?, _ y: Int?): String {
-                  switch x {
-                  case y:
-                      return "1"
-                  case nil:
-                      return "2"
-                  default:
-                      return "3"
-                  }
-                  return "4"
-              }
-            `,
-			ParseCheckAndInterpretOptions{
-				HandleCheckerError: func(err error) {
-					errs := RequireCheckerErrors(t, err, 1)
+		t.Parallel()
 
-					assert.IsType(t, &sema.UnreachableStatementError{}, errs[0])
-				},
-			},
-		)
-		require.NoError(t, err)
+		inter := parseCheckAndPrepare(t, `
+          fun test(_ x: Int?, _ y: Int?): String {
+              switch x {
+              case y:
+                  return "1"
+              case nil:
+                  return "2"
+              default:
+                  return "3"
+              }
+          }
+        `)
 
 		type testCase struct {
 			arguments []interpreter.Value

--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1821,6 +1821,8 @@ func exportEventFromScript(t *testing.T, script string) cadence.Event {
 		Context{
 			Interface: inter,
 			Location:  common.ScriptLocation{},
+			// TODO: requires InclusiveRange support in the VM
+			//UseVM:     *compile,
 		},
 	)
 

--- a/runtime/import_test.go
+++ b/runtime/import_test.go
@@ -502,6 +502,7 @@ func TestRuntimeContractImport(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -117,8 +117,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 				Interface:   runtimeInterface,
 				Location:    common.TransactionLocation{},
 				Environment: transactionEnvironment,
-				// TODO: contract deployment with VM
-				// UseVM:     *compile,
+				UseVM:       *compile,
 			},
 		)
 

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -492,7 +492,7 @@ func TestRuntimeStorageReadAndBorrow(t *testing.T) {
 				Identifier: "test",
 			},
 			Context{
-				Location:  TestLocation,
+				// NOTE: no location
 				Interface: runtimeInterface,
 			},
 		)
@@ -519,7 +519,7 @@ func TestRuntimeStorageReadAndBorrow(t *testing.T) {
 				Identifier: "other",
 			},
 			Context{
-				Location:  TestLocation,
+				// NOTE: no location
 				Interface: runtimeInterface,
 			},
 		)

--- a/semgrep-compiler-vm.yaml
+++ b/semgrep-compiler-vm.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: runtime-test-without-usevm
+  languages:
+    - go
+  severity: INFO
+  message: Runtime test not enabled to be run with compiler/VM
+  patterns:
+    - pattern: "Context{..., Location: $Y, ...}"
+    - pattern-not: "Context{..., UseVM: $X, ...}"
+  paths:
+    include:
+      - "runtime/*_test.go"


### PR DESCRIPTION
Work towards #3804 

## Description

- Clean up compiler code, remove unnecessary type parameters from receiver types
- Enable more interpreter tests to be run with compiler/VM, remove unnecessary access modifiers from test code
- Add a semgrep rule to find runtime tests which are not VM enabled yet (passed `Context` lacks `UseVM` field)

  The rule can be used by running:

  ```sh
  $ semgrep scan \
      --config=semgrep-compiler-vm.yaml \
      --exclude runtime/attachments_test.go \
      --exclude runtime/coverage_test.go \
      --exclude runtime/sharedstate_test.go \
      --exclude runtime/debugger_test.go
  ```
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
