### PR TITLE
[Compiler] Optimize VM context creation

### DIFF
--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -68,11 +68,7 @@ var _ interpreter.InvocationContext = &Context{}
 
 func NewContext(config *Config) *Context {
 	return &Context{
-		Config:                         config,
-		CapabilityControllerIterations: make(map[interpreter.AddressPath]int),
-		referencedResourceKindedValues: ReferencedResourceKindedValues{},
-		destroyedResources:             make(map[atree.ValueID]struct{}),
-		semaTypes:                      make(map[sema.TypeID]sema.Type),
+		Config: config,
 	}
 }
 
@@ -95,6 +91,9 @@ func (c *Context) SetInStorageIteration(inStorageIteration bool) {
 }
 
 func (c *Context) GetCapabilityControllerIterations() map[interpreter.AddressPath]int {
+	if c.CapabilityControllerIterations == nil {
+		c.CapabilityControllerIterations = make(map[interpreter.AddressPath]int)
+	}
 	return c.CapabilityControllerIterations
 }
 
@@ -220,6 +219,9 @@ func (c *Context) GetMemberAccessContextForLocation(_ common.Location) interpret
 func (c *Context) WithResourceDestruction(valueID atree.ValueID, locationRange interpreter.LocationRange, f func()) {
 	c.EnforceNotResourceDestruction(valueID, locationRange)
 
+	if c.destroyedResources == nil {
+		c.destroyedResources = make(map[atree.ValueID]struct{})
+	}
 	c.destroyedResources[valueID] = struct{}{}
 
 	f()
@@ -359,6 +361,10 @@ func (c *Context) SemaTypeFromStaticType(staticType interpreter.StaticType) sema
 	// TODO: avoid the sema-type conversion
 	semaType = interpreter.MustConvertStaticToSemaType(staticType, c)
 
+	if c.semaTypes == nil {
+		c.semaTypes = make(map[sema.TypeID]sema.Type)
+	}
 	c.semaTypes[typeID] = semaType
+
 	return semaType
 }

--- a/bbq/vm/reference_tracking.go
+++ b/bbq/vm/reference_tracking.go
@@ -37,6 +37,9 @@ func (c *Context) MaybeTrackReferencedResourceKindedValue(referenceValue *interp
 	values := c.referencedResourceKindedValues[id]
 	if values == nil {
 		values = map[*interpreter.EphemeralReferenceValue]struct{}{}
+		if c.referencedResourceKindedValues == nil {
+			c.referencedResourceKindedValues = make(ReferencedResourceKindedValues)
+		}
 		c.referencedResourceKindedValues[id] = values
 	}
 	values[referenceValue] = struct{}{}


### PR DESCRIPTION
Work towards #3804 

## Description

Instead of allocating all maps used for tracking, only allocate them once and if actually needed (i.e. when written to – from the [Go spec](https://go.dev/ref/spec#Map_types): "A nil map is equivalent to an empty map except that no elements may be added.")

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
