### PR TITLE
[Compiler] Register common built-in type bound functions for values injected into VM environment

### DIFF
--- a/bbq/compiler/builtin_globals.go
+++ b/bbq/compiler/builtin_globals.go
@@ -32,26 +32,26 @@ func DefaultBuiltinGlobals() *activations.Activation[GlobalImport] {
 	return defaultBuiltinGlobals
 }
 
-type builtinFunction struct {
-	name string
-	typ  *sema.FunctionType
+type BuiltinFunction struct {
+	Name string
+	Type *sema.FunctionType
 }
 
-var commonBuiltinTypeBoundFunctions = []builtinFunction{
+var CommonBuiltinTypeBoundFunctions = []BuiltinFunction{
 	{
-		name: sema.GetTypeFunctionName,
-		typ:  sema.GetTypeFunctionType,
+		Name: sema.GetTypeFunctionName,
+		Type: sema.GetTypeFunctionType,
 	},
 	{
-		name: sema.IsInstanceFunctionName,
-		typ:  sema.IsInstanceFunctionType,
+		Name: sema.IsInstanceFunctionName,
+		Type: sema.IsInstanceFunctionType,
 	},
 }
 
-var valueConstructorFunctions = []builtinFunction{
+var valueConstructorFunctions = []BuiltinFunction{
 	{
-		name: sema.StringType.Name,
-		typ:  sema.StringFunctionType,
+		Name: sema.StringType.Name,
+		Type: sema.StringFunctionType,
 	},
 }
 
@@ -66,10 +66,10 @@ func init() {
 
 	for _, constructor := range valueConstructorFunctions {
 		// Register the constructor. e.g: `String()`
-		registerDefaultBuiltinGlobal(constructor.name)
+		registerDefaultBuiltinGlobal(constructor.Name)
 
 		// Register the members of the constructor/type. e.g: `String.join()`
-		registerBoundFunctions(constructor.typ)
+		registerBoundFunctions(constructor.Type)
 	}
 
 	// The panic function is needed for conditions.

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -700,8 +700,8 @@ func (c *Compiler[_, _]) reserveFunctionGlobals(
 	// Add natively provided methods as globals.
 	// Only do it for user-defined types (i.e: `compositeTypeName` is not empty).
 	if enclosingType != nil {
-		for _, boundFunction := range commonBuiltinTypeBoundFunctions {
-			functionName := boundFunction.name
+		for _, boundFunction := range CommonBuiltinTypeBoundFunctions {
+			functionName := boundFunction.Name
 			qualifiedName := commons.TypeQualifiedName(enclosingType, functionName)
 			c.addGlobal(qualifiedName)
 		}
@@ -3102,14 +3102,14 @@ func (c *Compiler[_, _]) VisitInterfaceDeclaration(declaration *ast.InterfaceDec
 }
 
 func (c *Compiler[_, _]) addBuiltinMethods(typ sema.Type) {
-	for _, boundFunction := range commonBuiltinTypeBoundFunctions {
-		name := boundFunction.name
+	for _, boundFunction := range CommonBuiltinTypeBoundFunctions {
+		name := boundFunction.Name
 		qualifiedName := commons.TypeQualifiedName(typ, name)
 		c.addFunction(
 			name,
 			qualifiedName,
-			uint16(len(boundFunction.typ.Parameters)+1),
-			boundFunction.typ,
+			uint16(len(boundFunction.Type.Parameters)+1),
+			boundFunction.Type,
 		)
 	}
 }

--- a/bbq/vm/builtin_globals.go
+++ b/bbq/vm/builtin_globals.go
@@ -41,7 +41,7 @@ func DefaultBuiltinGlobals() *activations.Activation[Variable] {
 	return defaultBuiltinGlobals
 }
 
-func RegisterBuiltinFunction(functionValue *NativeFunctionValue) {
+func registerBuiltinFunction(functionValue *NativeFunctionValue) {
 	registerGlobalFunction(
 		functionValue.Name,
 		functionValue,
@@ -63,12 +63,12 @@ func registerGlobalFunction(
 	activation.Set(functionName, variable)
 }
 
-func RegisterBuiltinTypeBoundFunction(typeName string, functionValue *NativeFunctionValue) {
+func registerBuiltinTypeBoundFunction(typeName string, functionValue *NativeFunctionValue) {
 	// Update the name of the function to be type-qualified
 	qualifiedName := commons.QualifiedName(typeName, functionValue.Name)
 	functionValue.Name = qualifiedName
 
-	RegisterBuiltinFunction(functionValue)
+	registerBuiltinFunction(functionValue)
 }
 
 func registerBuiltinTypeBoundCommonFunction(typeName string, functionValue *NativeFunctionValue) {
@@ -87,7 +87,7 @@ func init() {
 
 	// Type constructors
 
-	RegisterBuiltinFunction(
+	registerBuiltinFunction(
 		NewNativeFunctionValue(
 			sema.MetaTypeName,
 			sema.MetaTypeFunctionType,
@@ -100,7 +100,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinFunction(
+	registerBuiltinFunction(
 		NewNativeFunctionValue(
 			sema.OptionalTypeFunctionName,
 			sema.OptionalTypeFunctionType,
@@ -113,7 +113,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinFunction(
+	registerBuiltinFunction(
 		NewNativeFunctionValue(
 			sema.VariableSizedArrayTypeFunctionName,
 			sema.VariableSizedArrayTypeFunctionType,
@@ -129,7 +129,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinFunction(
+	registerBuiltinFunction(
 		NewNativeFunctionValue(
 			sema.ConstantSizedArrayTypeFunctionName,
 			sema.ConstantSizedArrayTypeFunctionType,
@@ -148,7 +148,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinFunction(
+	registerBuiltinFunction(
 		NewNativeFunctionValue(
 			sema.DictionaryTypeFunctionName,
 			sema.DictionaryTypeFunctionType,
@@ -166,7 +166,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinFunction(
+	registerBuiltinFunction(
 		NewNativeFunctionValue(
 			sema.CompositeTypeFunctionName,
 			sema.CompositeTypeFunctionType,
@@ -179,7 +179,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinFunction(
+	registerBuiltinFunction(
 		NewNativeFunctionValue(
 			sema.FunctionTypeFunctionName,
 			sema.FunctionTypeFunctionType,
@@ -198,7 +198,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinFunction(
+	registerBuiltinFunction(
 		NewNativeFunctionValue(
 			sema.ReferenceTypeFunctionName,
 			sema.ReferenceTypeFunctionType,
@@ -217,7 +217,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinFunction(
+	registerBuiltinFunction(
 		NewNativeFunctionValue(
 			sema.IntersectionTypeFunctionName,
 			sema.IntersectionTypeFunctionType,
@@ -234,7 +234,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinFunction(
+	registerBuiltinFunction(
 		NewNativeFunctionValue(
 			sema.CapabilityTypeFunctionName,
 			sema.CapabilityTypeFunctionType,
@@ -247,7 +247,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinFunction(
+	registerBuiltinFunction(
 		NewNativeFunctionValue(
 			sema.InclusiveRangeTypeFunctionName,
 			sema.InclusiveRangeTypeFunctionType,
@@ -278,7 +278,7 @@ func init() {
 				)
 			},
 		)
-		RegisterBuiltinFunction(function)
+		registerBuiltinFunction(function)
 
 		addMember := func(name string, value interpreter.Value) {
 			if function.fields == nil {
@@ -299,14 +299,14 @@ func init() {
 		}
 
 		if stringValueParser, ok := interpreter.StringValueParsers[declaration.Name]; ok {
-			RegisterBuiltinTypeBoundFunction(
+			registerBuiltinTypeBoundFunction(
 				commons.TypeQualifier(stringValueParser.ReceiverType),
 				newFromStringFunction(stringValueParser),
 			)
 		}
 
 		if bigEndianBytesConverter, ok := interpreter.BigEndianBytesConverters[declaration.Name]; ok {
-			RegisterBuiltinTypeBoundFunction(
+			registerBuiltinTypeBoundFunction(
 				commons.TypeQualifier(bigEndianBytesConverter.ReceiverType),
 				newFromBigEndianBytesFunction(bigEndianBytesConverter),
 			)
@@ -315,7 +315,7 @@ func init() {
 
 	// Value constructors
 
-	RegisterBuiltinFunction(
+	registerBuiltinFunction(
 		NewNativeFunctionValue(
 			sema.StringType.String(),
 			sema.StringFunctionType,
@@ -404,7 +404,7 @@ func registerBuiltinTypeSaturatingArithmeticFunctions(t sema.SaturatingArithmeti
 		functionName string,
 		op func(context *Context, v, other interpreter.NumberValue) interpreter.NumberValue,
 	) {
-		RegisterBuiltinTypeBoundFunction(
+		registerBuiltinTypeBoundFunction(
 			commons.TypeQualifier(t),
 			NewNativeFunctionValue(
 				functionName,

--- a/bbq/vm/builtin_globals.go
+++ b/bbq/vm/builtin_globals.go
@@ -71,7 +71,7 @@ func RegisterBuiltinTypeBoundFunction(typeName string, functionValue *NativeFunc
 	RegisterBuiltinFunction(functionValue)
 }
 
-func RegisterBuiltinTypeBoundCommonFunction(typeName string, functionValue *NativeFunctionValue) {
+func registerBuiltinTypeBoundCommonFunction(typeName string, functionValue *NativeFunctionValue) {
 	// Here the function value is common for many types.
 	// Hence, do not update the function name to be type-qualified.
 	// Only the key in the map is type-qualified.
@@ -337,7 +337,7 @@ func registerBuiltinCommonTypeBoundFunctions() {
 		registerBuiltinTypeBoundFunctions(typeQualifier)
 	}
 
-	for _, function := range commonBuiltinTypeBoundFunctions {
+	for _, function := range CommonBuiltinTypeBoundFunctions {
 		IndexedCommonBuiltinTypeBoundFunctions[function.Name] = function
 	}
 }
@@ -345,16 +345,16 @@ func registerBuiltinCommonTypeBoundFunctions() {
 func registerBuiltinTypeBoundFunctions(
 	typeQualifier string,
 ) {
-	for _, boundFunction := range commonBuiltinTypeBoundFunctions {
-		RegisterBuiltinTypeBoundCommonFunction(
+	for _, boundFunction := range CommonBuiltinTypeBoundFunctions {
+		registerBuiltinTypeBoundCommonFunction(
 			typeQualifier,
 			boundFunction,
 		)
 	}
 }
 
-// Built-in functions that are common to all the types.
-var commonBuiltinTypeBoundFunctions = []*NativeFunctionValue{
+// CommonBuiltinTypeBoundFunctions are the built-in functions that are common to all the types.
+var CommonBuiltinTypeBoundFunctions = []*NativeFunctionValue{
 
 	// `isInstance` function
 	NewNativeFunctionValue(

--- a/bbq/vm/value_account_contracts.go
+++ b/bbq/vm/value_account_contracts.go
@@ -34,7 +34,7 @@ func init() {
 
 	// Methods on `Account.Contracts` value.
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		accountContractsTypeName,
 		NewNativeFunctionValue(
 			sema.Account_ContractsTypeAddFunctionName,

--- a/bbq/vm/value_account_storage.go
+++ b/bbq/vm/value_account_storage.go
@@ -33,7 +33,7 @@ func init() {
 	accountStorageTypeName := commons.TypeQualifier(sema.Account_StorageType)
 
 	// Account.Storage.save
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeSaveFunctionName,
@@ -56,7 +56,7 @@ func init() {
 	)
 
 	// Account.Storage.borrow
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeBorrowFunctionName,
@@ -82,7 +82,7 @@ func init() {
 	)
 
 	// Account.Storage.forEachPublic
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeForEachPublicFunctionName,
@@ -107,7 +107,7 @@ func init() {
 	)
 
 	// Account.Storage.forEachStored
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeForEachStoredFunctionName,
@@ -132,7 +132,7 @@ func init() {
 	)
 
 	// Account.Storage.type
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeTypeFunctionName,
@@ -154,7 +154,7 @@ func init() {
 	)
 
 	// Account.Storage.load
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeLoadFunctionName,
@@ -181,7 +181,7 @@ func init() {
 	)
 
 	// Account.Storage.copy
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeCopyFunctionName,
@@ -208,7 +208,7 @@ func init() {
 	)
 
 	// Account.Storage.check
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		accountStorageTypeName,
 		NewNativeFunctionValue(
 			sema.Account_StorageTypeCheckFunctionName,

--- a/bbq/vm/value_accountcapabilitycontroller.go
+++ b/bbq/vm/value_accountcapabilitycontroller.go
@@ -31,7 +31,7 @@ import (
 func init() {
 	accountCapabilityControllerTypeName := commons.TypeQualifier(sema.AccountCapabilityControllerType)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		accountCapabilityControllerTypeName,
 		NewNativeFunctionValue(
 			sema.AccountCapabilityControllerTypeSetTagFunctionName,
@@ -57,7 +57,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		accountCapabilityControllerTypeName,
 		NewNativeFunctionValue(
 			sema.AccountCapabilityControllerTypeDeleteFunctionName,

--- a/bbq/vm/value_address.go
+++ b/bbq/vm/value_address.go
@@ -32,7 +32,7 @@ func init() {
 
 	typeName := commons.TypeQualifier(sema.TheAddressType)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.ToStringFunctionName,
@@ -48,7 +48,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.AddressTypeToBytesFunctionName,
@@ -61,7 +61,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.AddressTypeFromBytesFunctionName,
@@ -77,7 +77,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.AddressTypeFromStringFunctionName,

--- a/bbq/vm/value_array.go
+++ b/bbq/vm/value_array.go
@@ -35,7 +35,7 @@ func init() {
 		commons.TypeQualifierArrayVariableSized,
 		commons.TypeQualifierArrayConstantSized,
 	} {
-		RegisterBuiltinTypeBoundFunction(
+		registerBuiltinTypeBoundFunction(
 			typeQualifier,
 			NewNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeFirstIndexFunctionName,
@@ -52,7 +52,7 @@ func init() {
 			),
 		)
 
-		RegisterBuiltinTypeBoundFunction(
+		registerBuiltinTypeBoundFunction(
 			typeQualifier,
 			NewNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeContainsFunctionName,
@@ -69,7 +69,7 @@ func init() {
 			),
 		)
 
-		RegisterBuiltinTypeBoundFunction(
+		registerBuiltinTypeBoundFunction(
 			typeQualifier,
 			NewNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeReverseFunctionName,
@@ -85,7 +85,7 @@ func init() {
 			),
 		)
 
-		RegisterBuiltinTypeBoundFunction(
+		registerBuiltinTypeBoundFunction(
 			typeQualifier,
 			NewNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeFilterFunctionName,
@@ -102,7 +102,7 @@ func init() {
 			),
 		)
 
-		RegisterBuiltinTypeBoundFunction(
+		registerBuiltinTypeBoundFunction(
 			typeQualifier,
 			NewNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeMapFunctionName,
@@ -122,7 +122,7 @@ func init() {
 
 	// Functions available only for variable-sized arrays.
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeAppendFunctionName,
@@ -140,7 +140,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeAppendAllFunctionName,
@@ -163,7 +163,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeConcatFunctionName,
@@ -180,7 +180,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeInsertFunctionName,
@@ -209,7 +209,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeRemoveFunctionName,
@@ -234,7 +234,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeRemoveFirstFunctionName,
@@ -250,7 +250,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeRemoveLastFunctionName,
@@ -266,7 +266,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeSliceFunctionName,
@@ -289,7 +289,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeToConstantSizedFunctionName,
@@ -312,7 +312,7 @@ func init() {
 
 	// Methods available only for constant-sized arrays.
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayConstantSized,
 		NewNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeToVariableSizedFunctionName,

--- a/bbq/vm/value_capability.go
+++ b/bbq/vm/value_capability.go
@@ -31,7 +31,7 @@ func init() {
 	typeName := interpreter.PrimitiveStaticTypeCapability.String()
 
 	// Capability.borrow
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValueWithDerivedType(
 			sema.CapabilityTypeBorrowFunctionName,
@@ -85,7 +85,7 @@ func init() {
 	)
 
 	// Capability.check
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValueWithDerivedType(
 			sema.CapabilityTypeCheckFunctionName,

--- a/bbq/vm/value_character.go
+++ b/bbq/vm/value_character.go
@@ -31,7 +31,7 @@ func init() {
 
 	typeName := commons.TypeQualifier(sema.CharacterType)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.ToStringFunctionName,

--- a/bbq/vm/value_deployedcontract.go
+++ b/bbq/vm/value_deployedcontract.go
@@ -35,7 +35,7 @@ func init() {
 
 	// Methods on `DeployedContract` value.
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		deployedContractTypeName,
 		NewNativeFunctionValue(
 			sema.DeployedContractTypePublicTypesFunctionName,

--- a/bbq/vm/value_dictionary.go
+++ b/bbq/vm/value_dictionary.go
@@ -29,7 +29,7 @@ import (
 
 func init() {
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierDictionary,
 		NewNativeFunctionValueWithDerivedType(
 			sema.DictionaryTypeRemoveFunctionName,
@@ -46,7 +46,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierDictionary,
 		NewNativeFunctionValueWithDerivedType(
 			sema.DictionaryTypeInsertFunctionName,
@@ -70,7 +70,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierDictionary,
 		NewNativeFunctionValueWithDerivedType(
 			sema.DictionaryTypeContainsKeyFunctionName,
@@ -91,7 +91,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierDictionary,
 		NewNativeFunctionValueWithDerivedType(
 			sema.DictionaryTypeForEachKeyFunctionName,

--- a/bbq/vm/value_number.go
+++ b/bbq/vm/value_number.go
@@ -31,7 +31,7 @@ func init() {
 	for _, pathType := range sema.AllNumberTypes {
 		typeName := commons.TypeQualifier(pathType)
 
-		RegisterBuiltinTypeBoundFunction(
+		registerBuiltinTypeBoundFunction(
 			typeName,
 			NewNativeFunctionValue(
 				sema.ToStringFunctionName,
@@ -46,7 +46,7 @@ func init() {
 			),
 		)
 
-		RegisterBuiltinTypeBoundFunction(
+		registerBuiltinTypeBoundFunction(
 			typeName,
 			NewNativeFunctionValue(
 				sema.ToBigEndianBytesFunctionName,

--- a/bbq/vm/value_optional.go
+++ b/bbq/vm/value_optional.go
@@ -29,7 +29,7 @@ import (
 
 func init() {
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierOptional,
 		NewNativeFunctionValueWithDerivedType(
 			sema.OptionalTypeMapFunctionName,

--- a/bbq/vm/value_path.go
+++ b/bbq/vm/value_path.go
@@ -38,7 +38,7 @@ func init() {
 	} {
 		typeName := commons.TypeQualifier(pathType)
 
-		RegisterBuiltinTypeBoundFunction(
+		registerBuiltinTypeBoundFunction(
 			typeName,
 			NewNativeFunctionValue(
 				sema.ToStringFunctionName,

--- a/bbq/vm/value_storagecapabilitycontroller.go
+++ b/bbq/vm/value_storagecapabilitycontroller.go
@@ -32,7 +32,7 @@ import (
 func init() {
 	storageCapabilityControllerTypeName := commons.TypeQualifier(sema.StorageCapabilityControllerType)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		storageCapabilityControllerTypeName,
 		NewNativeFunctionValue(
 			sema.StorageCapabilityControllerTypeSetTagFunctionName,
@@ -58,7 +58,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		storageCapabilityControllerTypeName,
 		NewNativeFunctionValue(
 			sema.StorageCapabilityControllerTypeDeleteFunctionName,
@@ -81,7 +81,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		storageCapabilityControllerTypeName,
 		NewNativeFunctionValue(
 			sema.StorageCapabilityControllerTypeTargetFunctionName,
@@ -100,7 +100,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		storageCapabilityControllerTypeName,
 		NewNativeFunctionValue(
 			sema.StorageCapabilityControllerTypeRetargetFunctionName,

--- a/bbq/vm/value_string.go
+++ b/bbq/vm/value_string.go
@@ -32,7 +32,7 @@ func init() {
 
 	// Methods on `String` value.
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeConcatFunctionName,
@@ -50,7 +50,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeSliceFunctionName,
@@ -64,7 +64,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeContainsFunctionName,
@@ -77,7 +77,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeIndexFunctionName,
@@ -90,7 +90,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeCountFunctionName,
@@ -103,7 +103,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeDecodeHexFunctionName,
@@ -115,7 +115,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeToLowerFunctionName,
@@ -127,7 +127,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeSplitFunctionName,
@@ -144,7 +144,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeReplaceAllFunctionName,
@@ -165,7 +165,7 @@ func init() {
 
 	// Methods on `String` type.
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeEncodeHexFunctionName,
@@ -181,7 +181,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeFromUtf8FunctionName,
@@ -197,7 +197,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeFromCharactersFunctionName,
@@ -213,7 +213,7 @@ func init() {
 		),
 	)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.StringTypeJoinFunctionName,

--- a/bbq/vm/value_type.go
+++ b/bbq/vm/value_type.go
@@ -31,7 +31,7 @@ import (
 func init() {
 	typeName := commons.TypeQualifier(sema.MetaType)
 
-	RegisterBuiltinTypeBoundFunction(
+	registerBuiltinTypeBoundFunction(
 		typeName,
 		NewNativeFunctionValue(
 			sema.MetaTypeIsSubtypeFunctionName,

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -466,7 +466,7 @@ func TestRuntimeBLSVerifyPoP(t *testing.T) {
 	assert.True(t, called)
 }
 
-func TestRuntimeBLSGetType(t *testing.T) {
+func TestRuntimeBLSGetTypeAndIsInstance(t *testing.T) {
 
 	t.Parallel()
 
@@ -475,6 +475,7 @@ func TestRuntimeBLSGetType(t *testing.T) {
 	script := []byte(`
 
 	  access(all) fun main(): Type {
+        assert(BLS.isInstance(Type<BLS>()))
 		return BLS.getType()
 	  }
 	`)

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -488,8 +488,7 @@ func TestRuntimeBLSGetType(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  common.ScriptLocation{},
-			// TODO: add support for getType and isInstance for stdlib values
-			//UseVM:     *compile,
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/rlp_test.go
+++ b/runtime/rlp_test.go
@@ -343,7 +343,7 @@ func TestRuntimeRLPDecodeList(t *testing.T) {
 	}
 }
 
-func TestRuntimeRLPGetType(t *testing.T) {
+func TestRuntimeRLPGetTypeAndIsInstance(t *testing.T) {
 
 	t.Parallel()
 
@@ -352,6 +352,7 @@ func TestRuntimeRLPGetType(t *testing.T) {
 	script := []byte(`
 
 	  access(all) fun main(): Type {
+        assert(RLP.isInstance(Type<RLP>()))
 		return RLP.getType()
 	  }
 	`)

--- a/runtime/rlp_test.go
+++ b/runtime/rlp_test.go
@@ -365,8 +365,7 @@ func TestRuntimeRLPGetType(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  common.ScriptLocation{},
-			// TODO: add support for getType and isInstance for stdlib values
-			//UseVM:     *compile,
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -233,6 +233,19 @@ func (e *vmEnvironment) declareCompilerValue(valueDeclaration stdlib.StandardLib
 			Name: name,
 		},
 	)
+
+	for _, function := range compiler.CommonBuiltinTypeBoundFunctions {
+		qualifiedFunctionName := commons.TypeQualifiedName(
+			valueDeclaration.Type,
+			function.Name,
+		)
+		compilerBuiltinGlobals.Set(
+			qualifiedFunctionName,
+			compiler.GlobalImport{
+				Name: qualifiedFunctionName,
+			},
+		)
+	}
 }
 
 func (e *vmEnvironment) declareVMValue(valueDeclaration stdlib.StandardLibraryValue, location common.Location) {
@@ -247,6 +260,21 @@ func (e *vmEnvironment) declareVMValue(valueDeclaration stdlib.StandardLibraryVa
 		valueDeclaration.Name,
 		variable,
 	)
+
+	for _, function := range vm.CommonBuiltinTypeBoundFunctions {
+		qualifiedFunctionName := commons.TypeQualifiedName(
+			valueDeclaration.Type,
+			function.Name,
+		)
+		variable := interpreter.NewVariableWithValue(
+			nil,
+			function,
+		)
+		vmBuiltinGlobals.Set(
+			qualifiedFunctionName,
+			variable,
+		)
+	}
 
 }
 func (e *vmEnvironment) DeclareType(typeDeclaration stdlib.StandardLibraryType, location common.Location) {


### PR DESCRIPTION
Work towards #3804 

## Description

Also, unexport the registration functions for VM built-in globals. The default built-in globals should never be modified, and additional (or different) built-ins should be provided using the built-in globals provider instead.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
