### PR TITLE
[Compiler] Fix nested loops

### DIFF
--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -9163,3 +9163,21 @@ func TestStackDepthLimit(t *testing.T) {
 	var callStackLimitExceededErr *interpreter.CallStackLimitExceededError
 	require.ErrorAs(t, err, &callStackLimitExceededErr)
 }
+
+func TestNestedLoops(t *testing.T) {
+
+	t.Parallel()
+
+	_, err := CompileAndInvoke(t,
+		`
+             fun test() {
+                 for x in [1, 2] {
+                     for y in [1] {}
+                 }
+             }
+        `,
+		"test",
+	)
+	require.NoError(t, err)
+
+}

--- a/bbq/vm/value_iterator.go
+++ b/bbq/vm/value_iterator.go
@@ -104,9 +104,7 @@ func (v IteratorWrapperValue) MeteredString(
 }
 
 func (v IteratorWrapperValue) IsResourceKinded(_ interpreter.ValueStaticTypeContext) bool {
-	// Iterator is an internal-only value.
-	// Hence, this should never be called.
-	panic(errors.NewUnreachableError())
+	return false
 }
 
 func (v IteratorWrapperValue) NeedsStoreTo(_ atree.Address) bool {

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -792,6 +792,7 @@ func TestRuntimeTraversingMerkleProof(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  common.ScriptLocation{},
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
Work towards #3804 

## Description

Iterating loops like `for x in ...` use a temporary local to store the iterator value. When a loop is nested in another, this local is re-assign to on subsequent iterations. Assigning to locals defensively checks for potential resource loss if the local already stores a value (`interpreter.CheckResourceLoss`, which calls `Value.IsResourceKinded`). Implement `IteratorWrapperValue.IsResourceKinded` instead of panicing.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
