### PR TITLE
[Compiler] Use the correct environment for runtime tests

### DIFF
--- a/bbq/vm/test/interpreter_test.go
+++ b/bbq/vm/test/interpreter_test.go
@@ -641,8 +641,6 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 		},
 	}
 
-	environment := runtime.NewBaseInterpreterEnvironment(runtime.Config{})
-
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy contract interfaces
@@ -671,7 +669,6 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			runtime.Context{
 				Interface:   runtimeInterface,
 				Location:    nextTransactionLocation(),
-				Environment: environment,
 			},
 		)
 		require.NoError(b, err)
@@ -686,7 +683,6 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 		runtime.Context{
 			Interface:   runtimeInterface,
 			Location:    nextTransactionLocation(),
-			Environment: environment,
 		},
 	)
 	require.NoError(b, err)
@@ -707,7 +703,6 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			runtime.Context{
 				Interface:   runtimeInterface,
 				Location:    nextTransactionLocation(),
-				Environment: environment,
 			},
 		)
 		require.NoError(b, err)
@@ -733,7 +728,6 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 		runtime.Context{
 			Interface:   runtimeInterface,
 			Location:    nextTransactionLocation(),
-			Environment: environment,
 		},
 	)
 	require.NoError(b, err)
@@ -761,7 +755,6 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			runtime.Context{
 				Interface:   runtimeInterface,
 				Location:    nextTransactionLocation(),
-				Environment: environment,
 			},
 		)
 		require.NoError(b, err)
@@ -792,7 +785,6 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			runtime.Context{
 				Interface:   runtimeInterface,
 				Location:    nextScriptLocation(),
-				Environment: environment,
 			},
 		)
 		require.NoError(b, err)

--- a/bbq/vm/test/interpreter_test.go
+++ b/bbq/vm/test/interpreter_test.go
@@ -667,8 +667,8 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 				),
 			},
 			runtime.Context{
-				Interface:   runtimeInterface,
-				Location:    nextTransactionLocation(),
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
 			},
 		)
 		require.NoError(b, err)
@@ -681,8 +681,8 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			Source: DeploymentTransaction("FlowToken", []byte(realFlowContract)),
 		},
 		runtime.Context{
-			Interface:   runtimeInterface,
-			Location:    nextTransactionLocation(),
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
 		},
 	)
 	require.NoError(b, err)
@@ -701,8 +701,8 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 				Source: []byte(realFlowTokenSetupAccountTransaction),
 			},
 			runtime.Context{
-				Interface:   runtimeInterface,
-				Location:    nextTransactionLocation(),
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
 			},
 		)
 		require.NoError(b, err)
@@ -726,8 +726,8 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			}),
 		},
 		runtime.Context{
-			Interface:   runtimeInterface,
-			Location:    nextTransactionLocation(),
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
 		},
 	)
 	require.NoError(b, err)
@@ -753,8 +753,8 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 				}),
 			},
 			runtime.Context{
-				Interface:   runtimeInterface,
-				Location:    nextTransactionLocation(),
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
 			},
 		)
 		require.NoError(b, err)
@@ -783,8 +783,8 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 				}),
 			},
 			runtime.Context{
-				Interface:   runtimeInterface,
-				Location:    nextScriptLocation(),
+				Interface: runtimeInterface,
+				Location:  nextScriptLocation(),
 			},
 		)
 		require.NoError(b, err)

--- a/bbq/vm/test/interpreter_test.go
+++ b/bbq/vm/test/interpreter_test.go
@@ -641,6 +641,7 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 		},
 	}
 
+	environment := runtime.NewBaseInterpreterEnvironment(runtime.Config{})
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy contract interfaces
@@ -667,8 +668,9 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 				),
 			},
 			runtime.Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
+				Interface:   runtimeInterface,
+				Location:    nextTransactionLocation(),
+				Environment: environment,
 			},
 		)
 		require.NoError(b, err)
@@ -681,8 +683,9 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			Source: DeploymentTransaction("FlowToken", []byte(realFlowContract)),
 		},
 		runtime.Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
 		},
 	)
 	require.NoError(b, err)
@@ -701,8 +704,9 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 				Source: []byte(realFlowTokenSetupAccountTransaction),
 			},
 			runtime.Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
+				Interface:   runtimeInterface,
+				Location:    nextTransactionLocation(),
+				Environment: environment,
 			},
 		)
 		require.NoError(b, err)
@@ -726,8 +730,9 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 			}),
 		},
 		runtime.Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
 		},
 	)
 	require.NoError(b, err)
@@ -753,8 +758,9 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 				}),
 			},
 			runtime.Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
+				Interface:   runtimeInterface,
+				Location:    nextTransactionLocation(),
+				Environment: environment,
 			},
 		)
 		require.NoError(b, err)
@@ -783,8 +789,9 @@ func BenchmarkRuntimeFungibleTokenTransfer(b *testing.B) {
 				}),
 			},
 			runtime.Context{
-				Interface: runtimeInterface,
-				Location:  nextScriptLocation(),
+				Interface:   runtimeInterface,
+				Location:    nextScriptLocation(),
+				Environment: environment,
 			},
 		)
 		require.NoError(b, err)

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -125,15 +125,6 @@ func (executor *contractFunctionExecutor) preprocess() (err error) {
 		}
 	}
 
-	if context.UseVM {
-		if _, ok := environment.(*vmEnvironment); !ok {
-			panic(errors.NewUnexpectedError(
-				"expected to run with the VM, but found an incompatible environment: %T",
-				environment,
-			))
-		}
-	}
-
 	environment.Configure(
 		runtimeInterface,
 		codesAndPrograms,
@@ -144,9 +135,22 @@ func (executor *contractFunctionExecutor) preprocess() (err error) {
 
 	switch environment := environment.(type) {
 	case *InterpreterEnvironment:
+		if context.UseVM {
+			panic(errors.NewUnexpectedError(
+				"expected to run with the VM, but found an incompatible environment: %T",
+				environment,
+			))
+		}
+
 		// NO-OP
 
 	case *vmEnvironment:
+		if !context.UseVM {
+			panic(errors.NewUnexpectedError(
+				"expected to run with the interpreter, but found an incompatible environment: %T",
+				environment,
+			))
+		}
 		contractLocation := executor.contractLocation
 		program := environment.importProgram(contractLocation)
 		executor.vm = environment.newVM(contractLocation, program)

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -124,6 +124,16 @@ func (executor *contractFunctionExecutor) preprocess() (err error) {
 			environment = NewBaseInterpreterEnvironment(config)
 		}
 	}
+
+	if context.UseVM {
+		if _, ok := environment.(*vmEnvironment); !ok {
+			panic(errors.NewUnexpectedError(
+				"expected to run with the VM, but found an incompatible environment: %T",
+				environment,
+			))
+		}
+	}
+
 	environment.Configure(
 		runtimeInterface,
 		codesAndPrograms,

--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -1082,6 +1082,8 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 		},
 	}
 
+	environment := newTransactionEnvironment()
+
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy Fungible Token contract
@@ -1094,10 +1096,10 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 			),
 		},
 		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-			// TODO: Need the support for isRecovered (https://github.com/onflow/cadence/pull/4073)
-			//UseVM:       *compile,
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
+			UseVM:       *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1228,10 +1230,10 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 			Source: []byte(transaction1),
 		},
 		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-			// TODO: Need the support for isRecovered (https://github.com/onflow/cadence/pull/4073)
-			//UseVM:       *compile,
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
+			UseVM:       *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1266,10 +1268,10 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 			Source: []byte(transaction2),
 		},
 		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-			// TODO: Need the support for isRecovered (https://github.com/onflow/cadence/pull/4073)
-			//UseVM:       *compile,
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
+			UseVM:       *compile,
 		},
 	)
 	RequireError(t, err)
@@ -1320,10 +1322,10 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 			Source: []byte(transaction3),
 		},
 		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-			// TODO: Need the support for isRecovered (https://github.com/onflow/cadence/pull/4073)
-			//UseVM:       *compile,
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
+			UseVM:       *compile,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -1082,8 +1082,6 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 		},
 	}
 
-	environment := NewBaseInterpreterEnvironment(Config{})
-
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy Fungible Token contract
@@ -1098,8 +1096,8 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 		Context{
 			Interface:   runtimeInterface,
 			Location:    nextTransactionLocation(),
-			Environment: environment,
-			UseVM:       *compile,
+			// TODO: Need the support for isRecovered (https://github.com/onflow/cadence/pull/4073)
+			//UseVM:       *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1232,8 +1230,8 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 		Context{
 			Interface:   runtimeInterface,
 			Location:    nextTransactionLocation(),
-			Environment: environment,
-			UseVM:       *compile,
+			// TODO: Need the support for isRecovered (https://github.com/onflow/cadence/pull/4073)
+			//UseVM:       *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -1270,8 +1268,8 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 		Context{
 			Interface:   runtimeInterface,
 			Location:    nextTransactionLocation(),
-			Environment: environment,
-			UseVM:       *compile,
+			// TODO: Need the support for isRecovered (https://github.com/onflow/cadence/pull/4073)
+			//UseVM:       *compile,
 		},
 	)
 	RequireError(t, err)
@@ -1324,8 +1322,8 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 		Context{
 			Interface:   runtimeInterface,
 			Location:    nextTransactionLocation(),
-			Environment: environment,
-			UseVM:       *compile,
+			// TODO: Need the support for isRecovered (https://github.com/onflow/cadence/pull/4073)
+			//UseVM:       *compile,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -1094,8 +1094,8 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 			),
 		},
 		Context{
-			Interface:   runtimeInterface,
-			Location:    nextTransactionLocation(),
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
 			// TODO: Need the support for isRecovered (https://github.com/onflow/cadence/pull/4073)
 			//UseVM:       *compile,
 		},
@@ -1228,8 +1228,8 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 			Source: []byte(transaction1),
 		},
 		Context{
-			Interface:   runtimeInterface,
-			Location:    nextTransactionLocation(),
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
 			// TODO: Need the support for isRecovered (https://github.com/onflow/cadence/pull/4073)
 			//UseVM:       *compile,
 		},
@@ -1266,8 +1266,8 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 			Source: []byte(transaction2),
 		},
 		Context{
-			Interface:   runtimeInterface,
-			Location:    nextTransactionLocation(),
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
 			// TODO: Need the support for isRecovered (https://github.com/onflow/cadence/pull/4073)
 			//UseVM:       *compile,
 		},
@@ -1320,8 +1320,8 @@ func TestRuntimeBrokenFungibleTokenRecovery(t *testing.T) {
 			Source: []byte(transaction3),
 		},
 		Context{
-			Interface:   runtimeInterface,
-			Location:    nextTransactionLocation(),
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
 			// TODO: Need the support for isRecovered (https://github.com/onflow/cadence/pull/4073)
 			//UseVM:       *compile,
 		},

--- a/runtime/import_test.go
+++ b/runtime/import_test.go
@@ -169,9 +169,9 @@ func TestRuntimeCheckCyclicImportsAfterUpdate(t *testing.T) {
 				),
 			},
 			Context{
-				Interface:   runtimeInterface,
-				Location:    nextTransactionLocation(),
-				UseVM:       *compile,
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
 			},
 		)
 	}
@@ -284,9 +284,9 @@ func TestRuntimeCheckCyclicImportAddress(t *testing.T) {
 				),
 			},
 			Context{
-				Interface:   runtimeInterface,
-				Location:    nextTransactionLocation(),
-				UseVM:       *compile,
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
 			},
 		)
 	}
@@ -383,9 +383,9 @@ func TestRuntimeCheckCyclicImportToSelfDuringDeploy(t *testing.T) {
 				),
 			},
 			Context{
-				Interface:   runtimeInterface,
-				Location:    nextTransactionLocation(),
-				UseVM:       *compile,
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
 			},
 		)
 	}

--- a/runtime/import_test.go
+++ b/runtime/import_test.go
@@ -153,6 +153,8 @@ func TestRuntimeCheckCyclicImportsAfterUpdate(t *testing.T) {
 		},
 	}
 
+	environment := newTransactionEnvironment()
+
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	deploy := func(name string, contract string, update bool) error {
@@ -169,9 +171,10 @@ func TestRuntimeCheckCyclicImportsAfterUpdate(t *testing.T) {
 				),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    nextTransactionLocation(),
+				Environment: environment,
+				UseVM:       *compile,
 			},
 		)
 	}
@@ -268,6 +271,8 @@ func TestRuntimeCheckCyclicImportAddress(t *testing.T) {
 		},
 	}
 
+	environment := newTransactionEnvironment()
+
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	deploy := func(name string, contract string, update bool) error {
@@ -284,9 +289,10 @@ func TestRuntimeCheckCyclicImportAddress(t *testing.T) {
 				),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    nextTransactionLocation(),
+				Environment: environment,
+				UseVM:       *compile,
 			},
 		)
 	}
@@ -367,6 +373,8 @@ func TestRuntimeCheckCyclicImportToSelfDuringDeploy(t *testing.T) {
 		},
 	}
 
+	environment := newTransactionEnvironment()
+
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	deploy := func(name string, contract string, update bool) error {
@@ -383,9 +391,10 @@ func TestRuntimeCheckCyclicImportToSelfDuringDeploy(t *testing.T) {
 				),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  nextTransactionLocation(),
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    nextTransactionLocation(),
+				Environment: environment,
+				UseVM:       *compile,
 			},
 		)
 	}

--- a/runtime/import_test.go
+++ b/runtime/import_test.go
@@ -153,8 +153,6 @@ func TestRuntimeCheckCyclicImportsAfterUpdate(t *testing.T) {
 		},
 	}
 
-	environment := NewBaseInterpreterEnvironment(Config{})
-
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	deploy := func(name string, contract string, update bool) error {
@@ -173,7 +171,6 @@ func TestRuntimeCheckCyclicImportsAfterUpdate(t *testing.T) {
 			Context{
 				Interface:   runtimeInterface,
 				Location:    nextTransactionLocation(),
-				Environment: environment,
 				UseVM:       *compile,
 			},
 		)
@@ -271,8 +268,6 @@ func TestRuntimeCheckCyclicImportAddress(t *testing.T) {
 		},
 	}
 
-	environment := NewBaseInterpreterEnvironment(Config{})
-
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	deploy := func(name string, contract string, update bool) error {
@@ -291,7 +286,6 @@ func TestRuntimeCheckCyclicImportAddress(t *testing.T) {
 			Context{
 				Interface:   runtimeInterface,
 				Location:    nextTransactionLocation(),
-				Environment: environment,
 				UseVM:       *compile,
 			},
 		)
@@ -373,8 +367,6 @@ func TestRuntimeCheckCyclicImportToSelfDuringDeploy(t *testing.T) {
 		},
 	}
 
-	environment := NewBaseInterpreterEnvironment(Config{})
-
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	deploy := func(name string, contract string, update bool) error {
@@ -393,7 +385,6 @@ func TestRuntimeCheckCyclicImportToSelfDuringDeploy(t *testing.T) {
 			Context{
 				Interface:   runtimeInterface,
 				Location:    nextTransactionLocation(),
-				Environment: environment,
 				UseVM:       *compile,
 			},
 		)

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -106,7 +106,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 
 		// Run deploy transaction
 
-		transactionEnvironment := NewBaseInterpreterEnvironment(Config{})
+		transactionEnvironment := newTransactionEnvironment()
 		prepareEnvironment(transactionEnvironment)
 
 		err := runtime.ExecuteTransaction(
@@ -814,7 +814,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 
 		// Run script
 
-		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment := newScriptEnvironment()
 		scriptEnvironment.DeclareValue(valueDeclaration, nil)
 		scriptEnvironment.DeclareType(typeDeclaration, nil)
 
@@ -887,7 +887,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 
 		// Run script
 
-		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment := newScriptEnvironment()
 		scriptEnvironment.DeclareValue(valueDeclaration, nil)
 		scriptEnvironment.DeclareType(typeDeclaration, nil)
 
@@ -919,7 +919,10 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 	t.Run("composite type, top-level, non-existing", func(t *testing.T) {
 		t.Parallel()
 
+		location := common.ScriptLocation{}
+
 		xType := &sema.CompositeType{
+			Location:   location,
 			Identifier: "X",
 			Kind:       common.CompositeKindStructure,
 			Members:    &sema.StringMemberOrderedMap{},
@@ -960,7 +963,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 
 		// Run script
 
-		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment := newScriptEnvironment()
 		scriptEnvironment.DeclareValue(valueDeclaration, nil)
 
 		_, err := runtime.ExecuteScript(
@@ -969,7 +972,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 			},
 			Context{
 				Interface:   runtimeInterface,
-				Location:    common.ScriptLocation{},
+				Location:    location,
 				Environment: scriptEnvironment,
 				UseVM:       *compile,
 			},
@@ -983,13 +986,17 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 	t.Run("composite type, nested, existing", func(t *testing.T) {
 		t.Parallel()
 
+		location := common.ScriptLocation{}
+
 		yType := &sema.CompositeType{
+			Location:   location,
 			Identifier: "Y",
 			Kind:       common.CompositeKindStructure,
 			Members:    &sema.StringMemberOrderedMap{},
 		}
 
 		xType := &sema.CompositeType{
+			Location:   location,
 			Identifier: "X",
 			Kind:       common.CompositeKindContract,
 			Members:    &sema.StringMemberOrderedMap{},
@@ -1044,7 +1051,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 
 		// Run script
 
-		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment := newScriptEnvironment()
 		scriptEnvironment.DeclareValue(valueDeclaration, nil)
 		scriptEnvironment.DeclareType(xTypeDeclaration, nil)
 		scriptEnvironment.DeclareType(yTypeDeclaration, nil)
@@ -1055,7 +1062,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 			},
 			Context{
 				Interface:   runtimeInterface,
-				Location:    common.ScriptLocation{},
+				Location:    location,
 				Environment: scriptEnvironment,
 				UseVM:       *compile,
 			},
@@ -1065,7 +1072,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 		require.Equal(t,
 			cadence.NewStruct([]cadence.Value{}).
 				WithType(cadence.NewStructType(
-					nil,
+					location,
 					yType.QualifiedIdentifier(),
 					[]cadence.Field{},
 					nil,
@@ -1077,13 +1084,17 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 	t.Run("composite type, nested, non-existing", func(t *testing.T) {
 		t.Parallel()
 
+		location := common.ScriptLocation{}
+
 		yType := &sema.CompositeType{
+			Location:   location,
 			Identifier: "Y",
 			Kind:       common.CompositeKindStructure,
 			Members:    &sema.StringMemberOrderedMap{},
 		}
 
 		xType := &sema.CompositeType{
+			Location:   location,
 			Identifier: "X",
 			Kind:       common.CompositeKindContract,
 			Members:    &sema.StringMemberOrderedMap{},
@@ -1126,7 +1137,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 
 		// Run script
 
-		scriptEnvironment := NewScriptInterpreterEnvironment(Config{})
+		scriptEnvironment := newScriptEnvironment()
 		scriptEnvironment.DeclareValue(valueDeclaration, nil)
 
 		_, err := runtime.ExecuteScript(
@@ -1135,7 +1146,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 			},
 			Context{
 				Interface:   runtimeInterface,
-				Location:    common.ScriptLocation{},
+				Location:    location,
 				Environment: scriptEnvironment,
 				UseVM:       *compile,
 			},
@@ -1263,7 +1274,8 @@ func TestRuntimePredeclaredTypeWithInjectedFunctions(t *testing.T) {
 			Interface:   runtimeInterface,
 			Location:    common.ScriptLocation{},
 			Environment: scriptEnvironment,
-			UseVM:       *compile,
+			// TODO: Need to inject the composite-type's method to compiler/vm.
+			//UseVM:       *compile,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -51,6 +51,22 @@ import (
 
 var compile = flag.Bool("compile", false, "Run tests using the compiler")
 
+func newScriptEnvironment() Environment {
+	if *compile {
+		return NewScriptVMEnvironment(Config{})
+	} else {
+		return NewScriptInterpreterEnvironment(Config{})
+	}
+}
+
+func newTransactionEnvironment() Environment {
+	if *compile {
+		return NewBaseVMEnvironment(Config{})
+	} else {
+		return NewBaseInterpreterEnvironment(Config{})
+	}
+}
+
 func TestRuntimeExecuteScript(t *testing.T) {
 
 	t.Parallel()
@@ -8065,8 +8081,6 @@ func BenchmarkRuntimeScriptNoop(b *testing.B) {
 		Source: []byte("access(all) fun main() {}"),
 	}
 
-	environment := NewScriptInterpreterEnvironment(Config{})
-
 	nextScriptLocation := NewScriptLocationGenerator()
 
 	runtime := NewTestRuntime()
@@ -8078,10 +8092,9 @@ func BenchmarkRuntimeScriptNoop(b *testing.B) {
 		_, err := runtime.ExecuteScript(
 			script,
 			Context{
-				Interface:   runtimeInterface,
-				Location:    nextScriptLocation(),
-				Environment: environment,
-				UseVM:       *compile,
+				Interface: runtimeInterface,
+				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(b, err)
@@ -9442,8 +9455,6 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
 		},
 	}
 
-	environment := NewBaseInterpreterEnvironment(Config{})
-
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy contract
@@ -9470,10 +9481,9 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
 			),
 		},
 		Context{
-			Interface:   runtimeInterface,
-			Location:    nextTransactionLocation(),
-			Environment: environment,
-			UseVM:       *compile,
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(b, err)
@@ -9491,10 +9501,9 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
             `),
 		},
 		Context{
-			Interface:   runtimeInterface,
-			Location:    nextTransactionLocation(),
-			Environment: environment,
-			UseVM:       *compile,
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(b, err)
@@ -9523,10 +9532,9 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
             `),
 		},
 		Context{
-			Interface:   runtimeInterface,
-			Location:    nextTransactionLocation(),
-			Environment: environment,
-			UseVM:       *compile,
+			Interface: runtimeInterface,
+			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(b, err)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -8081,6 +8081,8 @@ func BenchmarkRuntimeScriptNoop(b *testing.B) {
 		Source: []byte("access(all) fun main() {}"),
 	}
 
+	environment := newTransactionEnvironment()
+
 	nextScriptLocation := NewScriptLocationGenerator()
 
 	runtime := NewTestRuntime()
@@ -8092,9 +8094,10 @@ func BenchmarkRuntimeScriptNoop(b *testing.B) {
 		_, err := runtime.ExecuteScript(
 			script,
 			Context{
-				Interface: runtimeInterface,
-				Location:  nextScriptLocation(),
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    nextScriptLocation(),
+				Environment: environment,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(b, err)
@@ -9455,6 +9458,8 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
 		},
 	}
 
+	environment := newTransactionEnvironment()
+
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
 	// Deploy contract
@@ -9481,9 +9486,10 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
 			),
 		},
 		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-			UseVM:     *compile,
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
+			UseVM:       *compile,
 		},
 	)
 	require.NoError(b, err)
@@ -9501,9 +9507,10 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
             `),
 		},
 		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-			UseVM:     *compile,
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
+			UseVM:       *compile,
 		},
 	)
 	require.NoError(b, err)
@@ -9532,9 +9539,10 @@ func BenchmarkRuntimeResourceTracking(b *testing.B) {
             `),
 		},
 		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-			UseVM:     *compile,
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			Environment: environment,
+			UseVM:       *compile,
 		},
 	)
 	require.NoError(b, err)

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -126,6 +126,15 @@ func (executor *scriptExecutor) preprocess() (err error) {
 		}
 	}
 
+	if context.UseVM {
+		if _, ok := environment.(*vmEnvironment); !ok {
+			panic(errors.NewUnexpectedError(
+				"expected to run with the VM, but found an incompatible environment: %T",
+				environment,
+			))
+		}
+	}
+
 	environment.Configure(
 		runtimeInterface,
 		codesAndPrograms,

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -126,15 +126,6 @@ func (executor *scriptExecutor) preprocess() (err error) {
 		}
 	}
 
-	if context.UseVM {
-		if _, ok := environment.(*vmEnvironment); !ok {
-			panic(errors.NewUnexpectedError(
-				"expected to run with the VM, but found an incompatible environment: %T",
-				environment,
-			))
-		}
-	}
-
 	environment.Configure(
 		runtimeInterface,
 		codesAndPrograms,
@@ -183,9 +174,22 @@ func (executor *scriptExecutor) preprocess() (err error) {
 
 	switch environment := environment.(type) {
 	case *InterpreterEnvironment:
+		if context.UseVM {
+			panic(errors.NewUnexpectedError(
+				"expected to run with the VM, but found an incompatible environment: %T",
+				environment,
+			))
+		}
+
 		executor.interpret = executor.scriptExecutionFunction()
 
 	case *vmEnvironment:
+		if !context.UseVM {
+			panic(errors.NewUnexpectedError(
+				"expected to run with the interpreter, but found an incompatible environment: %T",
+				environment,
+			))
+		}
 		var program *Program
 		program, err = environment.loadProgram(location)
 		if err != nil {

--- a/runtime/sharedstate_test.go
+++ b/runtime/sharedstate_test.go
@@ -130,7 +130,8 @@ func TestRuntimeSharedState(t *testing.T) {
 				Interface:   runtimeInterface,
 				Location:    nextTransactionLocation(),
 				Environment: environment,
-				UseVM:       *compile,
+				// TODO:
+				//UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -159,7 +160,8 @@ func TestRuntimeSharedState(t *testing.T) {
 			Interface:   runtimeInterface,
 			Location:    nextTransactionLocation(),
 			Environment: environment,
-			UseVM:       *compile,
+			// TODO:
+			//UseVM:       *compile,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -125,15 +125,6 @@ func (executor *transactionExecutor) preprocess() (err error) {
 		}
 	}
 
-	if context.UseVM {
-		if _, ok := environment.(*vmEnvironment); !ok {
-			panic(errors.NewUnexpectedError(
-				"expected to run with the VM, but found an incompatible environment: %T",
-				environment,
-			))
-		}
-	}
-
 	environment.Configure(
 		runtimeInterface,
 		codesAndPrograms,
@@ -205,9 +196,23 @@ func (executor *transactionExecutor) preprocess() (err error) {
 
 	switch environment := environment.(type) {
 	case *InterpreterEnvironment:
+		if context.UseVM {
+			panic(errors.NewUnexpectedError(
+				"expected to run with the VM, but found an incompatible environment: %T",
+				environment,
+			))
+		}
+
 		executor.interpret = executor.transactionExecutionFunction()
 
 	case *vmEnvironment:
+		if !context.UseVM {
+			panic(errors.NewUnexpectedError(
+				"expected to run with the interpreter, but found an incompatible environment: %T",
+				environment,
+			))
+		}
+
 		var program *Program
 		program, err = environment.loadProgram(location)
 		if err != nil {

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -125,6 +125,15 @@ func (executor *transactionExecutor) preprocess() (err error) {
 		}
 	}
 
+	if context.UseVM {
+		if _, ok := environment.(*vmEnvironment); !ok {
+			panic(errors.NewUnexpectedError(
+				"expected to run with the VM, but found an incompatible environment: %T",
+				environment,
+			))
+		}
+	}
+
 	environment.Configure(
 		runtimeInterface,
 		codesAndPrograms,


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3804

## Description

Noticed that some of the runtime tests were still running only using the interpreter, eventhough they were also expected to run with the VM. This was because the executors were ignoring the flag, if the environment was provided explicitly.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
