### PR TITLE
[Compiler] Enable more tests to be run with with compiler/VM

### DIFF
--- a/interpreter/function_test.go
+++ b/interpreter/function_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/stdlib"
+	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
 	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
@@ -332,11 +333,11 @@ func TestInterpretGenericFunctionSubtyping(t *testing.T) {
 
 	t.Parallel()
 
-	parseCheckAndInterpretWithGenericFunction := func(
+	parseCheckAndPrepareWithGenericFunction := func(
 		tt *testing.T,
 		code string,
 		boundType sema.Type,
-	) (*interpreter.Interpreter, error) {
+	) (Invokable, error) {
 
 		typeParameter := &sema.TypeParameter{
 			Name:      "T",
@@ -361,7 +362,7 @@ func TestInterpretGenericFunctionSubtyping(t *testing.T) {
 		baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
 		interpreter.Declare(baseActivation, function1)
 
-		return parseCheckAndInterpretWithOptions(t,
+		return parseCheckAndPrepareWithOptions(t,
 			code,
 			ParseCheckAndInterpretOptions{
 				CheckerConfig: &sema.Config{
@@ -381,7 +382,7 @@ func TestInterpretGenericFunctionSubtyping(t *testing.T) {
 	t.Run("generic function as non-generic function", func(t *testing.T) {
 		t.Parallel()
 
-		inter, err := parseCheckAndInterpretWithGenericFunction(t, `
+		inter, err := parseCheckAndPrepareWithGenericFunction(t, `
             fun test() {
                 var boxedFunc: AnyStruct = foo  // fun<T Integer>(): Void
 

--- a/interpreter/member_test.go
+++ b/interpreter/member_test.go
@@ -159,7 +159,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				t.Parallel()
 
-				inter := parseCheckAndInterpret(t, `
+				inter := parseCheckAndPrepare(t, `
                     struct S {
                         let foo: Int
 
@@ -246,7 +246,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				t.Parallel()
 
-				inter := parseCheckAndInterpret(t, `
+				inter := parseCheckAndPrepare(t, `
                     struct interface SI {
                         var foo: Int
                     }
@@ -335,7 +335,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				t.Parallel()
 
-				inter := parseCheckAndInterpret(t, `
+				inter := parseCheckAndPrepare(t, `
                     struct interface SI {
                         let foo: Int
                     }
@@ -387,7 +387,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				t.Parallel()
 
-				inter := parseCheckAndInterpret(t, `
+				inter := parseCheckAndPrepare(t, `
                     struct S {
                         var foo: Int
 
@@ -432,7 +432,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				t.Parallel()
 
-				inter := parseCheckAndInterpret(t, `
+				inter := parseCheckAndPrepare(t, `
                     struct S {
                         var foo: Int
 
@@ -492,7 +492,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				t.Parallel()
 
-				inter := parseCheckAndInterpret(t, `
+				inter := parseCheckAndPrepare(t, `
                     struct S {
                         let foo: Int
 
@@ -535,7 +535,7 @@ func TestInterpretMemberAccessType(t *testing.T) {
 
 				t.Parallel()
 
-				inter := parseCheckAndInterpret(t, `
+				inter := parseCheckAndPrepare(t, `
                     struct S {
                         let foo: Int
 

--- a/interpreter/metatype_test.go
+++ b/interpreter/metatype_test.go
@@ -1040,11 +1040,12 @@ func TestInterpretMetaTypeIsRecovered(t *testing.T) {
 
 		t.Parallel()
 
-		inter, err := parseCheckAndPrepareWithOptions(t, `
-	      fun test(_ type: Type): Bool {
-	          return type.isRecovered
-	      }
-	   `,
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+               fun test(_ type: Type): Bool {
+                   return type.isRecovered
+               }
+            `,
 			ParseCheckAndInterpretOptions{
 				Config: &interpreter.Config{
 					ImportLocationHandler: func(_ *interpreter.Interpreter, _ common.Location) interpreter.Import {
@@ -1080,11 +1081,12 @@ func TestInterpretMetaTypeIsRecovered(t *testing.T) {
 
 		importErr := errors.New("import failure")
 
-		inter, err := parseCheckAndPrepareWithOptions(t, `
-	      fun test(_ type: Type): Bool {
-	          return type.isRecovered
-	      }
-	   `,
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+              fun test(_ type: Type): Bool {
+                  return type.isRecovered
+              }
+           `,
 			ParseCheckAndInterpretOptions{
 				Config: &interpreter.Config{
 					ImportLocationHandler: func(_ *interpreter.Interpreter, _ common.Location) interpreter.Import {

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -12138,7 +12138,7 @@ func TestInterpretCompositeTypeHandler(t *testing.T) {
 
 	testType := interpreter.NewCompositeStaticTypeComputeTypeID(nil, stdlib.FlowLocation{}, "AccountContractAdded")
 
-	inter, err := parseCheckAndInterpretWithOptions(t,
+	inter, err := parseCheckAndPrepareWithOptions(t,
 		`
           fun test(): Type? {
               return CompositeType("flow.AccountContractAdded")

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -1159,6 +1159,7 @@ func TestRuntimePredeclaredTypes(t *testing.T) {
 
 }
 
+// NOTE: This feature is only supported by the interpreter environment, not the VM environment.
 func TestRuntimePredeclaredTypeWithInjectedFunctions(t *testing.T) {
 
 	t.Parallel()
@@ -1274,8 +1275,8 @@ func TestRuntimePredeclaredTypeWithInjectedFunctions(t *testing.T) {
 			Interface:   runtimeInterface,
 			Location:    common.ScriptLocation{},
 			Environment: scriptEnvironment,
-			// TODO: Need to inject the composite-type's method to compiler/vm.
-			//UseVM:       *compile,
+			// NOTE: not supported by VM environment
+			UseVM: false,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/sharedstate_test.go
+++ b/runtime/sharedstate_test.go
@@ -112,7 +112,7 @@ func TestRuntimeSharedState(t *testing.T) {
 		},
 	}
 
-	environment := NewBaseInterpreterEnvironment(config)
+	environment := newTransactionEnvironment()
 
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
@@ -130,8 +130,7 @@ func TestRuntimeSharedState(t *testing.T) {
 				Interface:   runtimeInterface,
 				Location:    nextTransactionLocation(),
 				Environment: environment,
-				// TODO:
-				//UseVM:       *compile,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -160,8 +159,7 @@ func TestRuntimeSharedState(t *testing.T) {
 			Interface:   runtimeInterface,
 			Location:    nextTransactionLocation(),
 			Environment: environment,
-			// TODO:
-			//UseVM:       *compile,
+			UseVM:       *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -184,6 +182,7 @@ func TestRuntimeSharedState(t *testing.T) {
 			Interface:   runtimeInterface,
 			Location:    nextTransactionLocation(),
 			Environment: environment,
+			UseVM:       *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -206,86 +205,204 @@ func TestRuntimeSharedState(t *testing.T) {
 			Interface:   runtimeInterface,
 			Location:    nextTransactionLocation(),
 			Environment: environment,
+			UseVM:       *compile,
 		},
 	)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{`"Hello from C2!"`}, loggedMessages)
 
-	// Assert shared state was used,
-	// i.e. data was not re-read
+	if *compile {
 
-	expectedReads := []ownerKeyPair{
-		// Read account register to check if it is a migrated account
-		// Read returns no value.
-		{
-			owner: signerAddress[:],
-			key:   []byte(AccountStorageKey),
-		},
-		// Read contract domain register.
-		// Read returns no value.
-		{
-			owner: signerAddress[:],
-			key:   []byte(common.StorageDomainContract.Identifier()),
-		},
-		// Read all available domain registers to check if it is a new account
-		// Read returns no value.
-		{
-			owner: signerAddress[:],
-			key:   []byte(common.PathDomainStorage.Identifier()),
-		},
-		{
-			owner: signerAddress[:],
-			key:   []byte(common.PathDomainPrivate.Identifier()),
-		},
-		{
-			owner: signerAddress[:],
-			key:   []byte(common.PathDomainPublic.Identifier()),
-		},
-		{
-			owner: signerAddress[:],
-			key:   []byte(common.StorageDomainContract.Identifier()),
-		},
-		{
-			owner: signerAddress[:],
-			key:   []byte(common.StorageDomainInbox.Identifier()),
-		},
-		{
-			owner: signerAddress[:],
-			key:   []byte(common.StorageDomainCapabilityController.Identifier()),
-		},
-		{
-			owner: signerAddress[:],
-			key:   []byte(common.StorageDomainCapabilityControllerTag.Identifier()),
-		},
-		{
-			owner: signerAddress[:],
-			key:   []byte(common.StorageDomainPathCapability.Identifier()),
-		},
-		{
-			owner: signerAddress[:],
-			key:   []byte(common.StorageDomainAccountCapability.Identifier()),
-		},
-		{
-			owner: signerAddress[:],
-			key:   []byte(AccountStorageKey),
-		},
-		{
-			owner: signerAddress[:],
-			key:   []byte(AccountStorageKey),
-		},
-		{
-			owner: signerAddress[:],
-			key:   []byte(AccountStorageKey),
-		},
-		{
-			owner: signerAddress[:],
-			key:   []byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
-		},
+		// Shared state is ignored in VM environment
+
+		expectedReads := []ownerKeyPair{
+			// Read account register to check if it is a migrated account
+			// Read returns no value.
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			// Read contract domain register.
+			// Read returns no value.
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainContract.Identifier()),
+			},
+			// Read all available domain registers to check if it is a new account
+			// Read returns no value.
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.PathDomainStorage.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.PathDomainPrivate.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.PathDomainPublic.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainContract.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainInbox.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainCapabilityController.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainCapabilityControllerTag.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainPathCapability.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainAccountCapability.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			},
+		}
+
+		require.Equal(t,
+			expectedReads,
+			ledgerReads,
+		)
+
+	} else {
+
+		// Assert shared state was used for interpreter environment,
+		// i.e. data was not re-read
+
+		expectedReads := []ownerKeyPair{
+			// Read account register to check if it is a migrated account
+			// Read returns no value.
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			// Read contract domain register.
+			// Read returns no value.
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainContract.Identifier()),
+			},
+			// Read all available domain registers to check if it is a new account
+			// Read returns no value.
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.PathDomainStorage.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.PathDomainPrivate.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.PathDomainPublic.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainContract.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainInbox.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainCapabilityController.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainCapabilityControllerTag.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainPathCapability.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(common.StorageDomainAccountCapability.Identifier()),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte(AccountStorageKey),
+			},
+			{
+				owner: signerAddress[:],
+				key:   []byte{'$', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+			},
+		}
+
+		require.Equal(t,
+			expectedReads,
+			ledgerReads,
+		)
 	}
-
-	require.Equal(t,
-		expectedReads,
-		ledgerReads,
-	)
 }

--- a/semgrep-compiler-vm.yaml
+++ b/semgrep-compiler-vm.yaml
@@ -10,3 +10,21 @@ rules:
   paths:
     include:
       - "runtime/*_test.go"
+    exclude:
+      - runtime/attachments_test.go
+      - runtime/coverage_test.go
+      - runtime/sharedstate_test.go
+      - runtime/debugger_test.go
+
+- id: interpreter-test-without-vm
+  languages:
+    - go
+  severity: INFO
+  message: Interpreter test not enabled to be run with compiler/VM
+  patterns:
+    - pattern-regex: "parseCheckAndInterpret\\w*\\("
+  paths:
+    include:
+      - "interpreter/*_test.go"
+    exclude:
+      - interpreter/attachments_test.go

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -369,22 +369,6 @@ func ParseCheckAndPrepareWithOptions(
 
 				return nil
 			}
-		}
-
-		if interpreterConfig.CompositeTypeHandler != nil {
-			originalTypeLoader := vmConfig.TypeLoader
-			vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) sema.Type {
-				ty := interpreterConfig.CompositeTypeHandler(location, typeID)
-				if ty != nil {
-					return ty
-				}
-
-				if originalTypeLoader != nil {
-					return originalTypeLoader(location, typeID)
-				}
-
-				return nil
-			}
 
 			vmConfig.ElaborationResolver = func(location common.Location) (*sema.Elaboration, error) {
 				impt := interpreterConfig.ImportLocationHandler(nil, location)
@@ -401,6 +385,22 @@ func ParseCheckAndPrepareWithOptions(
 				}
 
 				return elaboration, nil
+			}
+		}
+
+		if interpreterConfig.CompositeTypeHandler != nil {
+			originalTypeLoader := vmConfig.TypeLoader
+			vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) sema.Type {
+				ty := interpreterConfig.CompositeTypeHandler(location, typeID)
+				if ty != nil {
+					return ty
+				}
+
+				if originalTypeLoader != nil {
+					return originalTypeLoader(location, typeID)
+				}
+
+				return nil
 			}
 		}
 	}


### PR DESCRIPTION
Work towards #4059 

## Description

- Enable more interpreter tests to run with compiler/VM
- Add support for interpreter tests which set the composite type handler of the interpreter config. Use it in the VM config type loader.
- Add a semgrep rule to find remaining interpreter tests that are not enabled yet.
- "Re-enable"/update runtime tests which got disabled with compiler/VM in #4075 / 710e9563e59a84697022c65b1076318b0248ea4a

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
