### PR TITLE
[Compiler] Produce ConditionError for pre/post condition failures in VM

### DIFF
--- a/bbq/commons/constants.go
+++ b/bbq/commons/constants.go
@@ -28,9 +28,9 @@ const (
 	TransactionPrepareFunctionName  = "transaction.prepare"
 
 	// FailPreConditionFunctionName is the name of the function which is used for failing pre-conditions
-	FailPreConditionFunctionName = "failPreCondition"
+	FailPreConditionFunctionName = "$failPreCondition"
 	// FailPostConditionFunctionName is the name  of the function which is used for failing post-conditions
-	FailPostConditionFunctionName = "failPostCondition"
+	FailPostConditionFunctionName = "$failPostCondition"
 
 	GeneratedNameQualifier              = "$"
 	ResourceDestroyedEventsFunctionName = GeneratedNameQualifier + ast.ResourceDestructionDefaultEventName

--- a/bbq/commons/constants.go
+++ b/bbq/commons/constants.go
@@ -26,8 +26,11 @@ const (
 	TransactionWrapperCompositeName = "transaction"
 	TransactionExecuteFunctionName  = "transaction.execute"
 	TransactionPrepareFunctionName  = "transaction.prepare"
-	// PanicFunctionName is the name of the panic function, which is needed for conditions
-	PanicFunctionName = "panic"
+
+	// FailPreConditionFunctionName is the name of the function which is used for failing pre-conditions
+	FailPreConditionFunctionName = "failPreCondition"
+	// FailPostConditionFunctionName is the name  of the function which is used for failing post-conditions
+	FailPostConditionFunctionName = "failPostCondition"
 
 	GeneratedNameQualifier              = "$"
 	ResourceDestroyedEventsFunctionName = GeneratedNameQualifier + ast.ResourceDestructionDefaultEventName

--- a/bbq/compiler/builtin_globals.go
+++ b/bbq/compiler/builtin_globals.go
@@ -72,8 +72,9 @@ func init() {
 		registerBoundFunctions(constructor.Type)
 	}
 
-	// The panic function is needed for conditions.
-	registerDefaultBuiltinGlobal(commons.PanicFunctionName)
+	// The panic function is needed for pre/post conditions.
+	registerDefaultBuiltinGlobal(commons.FailPreConditionFunctionName)
+	registerDefaultBuiltinGlobal(commons.FailPostConditionFunctionName)
 
 	// Type constructors
 	for _, typeConstructor := range sema.RuntimeTypeConstructors {

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -3318,7 +3318,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 		checker, err := ParseAndCheck(t, `
         fun test(x: Int): Int {
-            pre {x > 0}
+            pre { x > 0 }
             return 5
         }
     `)
@@ -3340,7 +3340,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 		// Would be equivalent to:
 		// fun test(x: Int): Int {
 		//    if !(x > 0) {
-		//        panic("pre/post condition failed")
+		//        failPreCondition("")
 		//    }
 		//    return 5
 		// }
@@ -3357,7 +3357,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 12},
 
-				// panic("pre/post condition failed")
+				// failPreCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 1}, // error message
@@ -3382,7 +3382,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 		checker, err := ParseAndCheck(t, `
         fun test(x: Int): Int {
-            post {x > 0}
+            post { x > 0 }
             return 5
         }
     `)
@@ -3409,7 +3409,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 		//    $_result = 5
 		//    let result = $_result
 		//    if !(x > 0) {
-		//        panic("pre/post condition failed")
+		//        failPostCondition("")
 		//    }
 		//    return $_result
 		// }
@@ -3442,7 +3442,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 21},
 
-				// panic("pre/post condition failed")
+				// failPostCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 2}, // error message
@@ -3466,7 +3466,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 		checker, err := ParseAndCheck(t, `
         fun test(x: @AnyResource?): @AnyResource? {
-            post {result != nil}
+            post { result != nil }
             return <- x
         }
     `)
@@ -3493,7 +3493,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 		//    var $_result <-x
 		//    let result = &$_result
 		//    if !(result != nil) {
-		//        panic("pre/post condition failed")
+		//        failPostCondition("")
 		//    }
 		//    return <-$_result
 		//}
@@ -3529,7 +3529,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 23},
 
-				// panic("pre/post condition failed")
+				// failPostCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 0}, // error message
@@ -3553,8 +3553,8 @@ func TestCompileFunctionConditions(t *testing.T) {
 		checker, err := ParseAndCheck(t, `
             struct interface IA {
                 fun test(x: Int, y: Int): Int {
-                    pre {x > 0}
-                    post {y > 0}
+                    pre { x > 0 }
+                    post { y > 0 }
                 }
             }
 
@@ -3594,7 +3594,8 @@ func TestCompileFunctionConditions(t *testing.T) {
 			// Next two indexes are for builtin methods (i.e: getType, isInstance) for interface type
 			_
 			_
-			panicFunctionIndex
+			failPreConditionFunctionIndex
+			failPostConditionFunctionIndex
 		)
 
 		// 	`Test` type's constructor
@@ -3634,14 +3635,14 @@ func TestCompileFunctionConditions(t *testing.T) {
 		// ```
 		//     fun test(x: Int, y: Int): Int {
 		//        if !(x > 0) {
-		//            panic("pre/post condition failed")
+		//            failPreCondition("")
 		//        }
 		//
 		//        var $_result = 42
 		//        let result = $_result
 		//
 		//        if !(y > 0) {
-		//            panic("pre/post condition failed")
+		//            failPostCondition("")
 		//        }
 		//
 		//        return $_result
@@ -3662,9 +3663,9 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 12},
 
-				// panic("pre/post condition failed")
+				// failPreCondition("")
 				opcode.InstructionStatement{},
-				opcode.InstructionGetGlobal{Global: panicFunctionIndex},
+				opcode.InstructionGetGlobal{Global: failPreConditionFunctionIndex},
 				opcode.InstructionGetConstant{Constant: constPanicMessageIndex},
 				opcode.InstructionTransferAndConvert{Type: 5},
 				opcode.InstructionInvoke{ArgCount: 1},
@@ -3703,9 +3704,9 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 33},
 
-				// panic("pre/post condition failed")
+				// failPostCondition("")
 				opcode.InstructionStatement{},
-				opcode.InstructionGetGlobal{Global: panicFunctionIndex},
+				opcode.InstructionGetGlobal{Global: failPostConditionFunctionIndex},
 				opcode.InstructionGetConstant{Constant: constPanicMessageIndex},
 				opcode.InstructionTransferAndConvert{Type: 5},
 				opcode.InstructionInvoke{ArgCount: 1},
@@ -3727,7 +3728,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 		checker, err := ParseAndCheck(t, `
             struct interface IA {
                 fun test(x: Int): Int {
-                    post {before(x) < x}
+                    post { before(x) < x }
                 }
             }
 
@@ -3767,7 +3768,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 			// Next two indexes are for builtin methods (i.e: getType, isInstance) for interface type
 			_
 			_
-			panicFunctionIndex
+			failPostConditionFunctionIndex
 		)
 
 		// 	`Test` type's constructor
@@ -3811,7 +3812,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 		//        var $_result = 42
 		//        let result = $_result
 		//        if !($before_0 < x) {
-		//            panic("pre/post condition failed")
+		//            failPostCondition("")
 		//        }
 		//        return $_result
 		//    }
@@ -3859,9 +3860,9 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 25},
 
-				// panic("pre/post condition failed")
+				// failPostCondition("")
 				opcode.InstructionStatement{},
-				opcode.InstructionGetGlobal{Global: panicFunctionIndex},
+				opcode.InstructionGetGlobal{Global: failPostConditionFunctionIndex},
 				opcode.InstructionGetConstant{Constant: constPanicMessageIndex},
 				opcode.InstructionTransferAndConvert{Type: 6},
 				opcode.InstructionInvoke{ArgCount: 1},
@@ -4030,8 +4031,8 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 		// Function indexes
 		const (
-			concreteTypeFunctionIndex = 7
-			panicFunctionIndex        = 11
+			concreteTypeFunctionIndex     = 7
+			failPreConditionFunctionIndex = 11
 		)
 
 		// `D.Vault` type's `getBalance` function.
@@ -4054,7 +4055,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 		// ```
 		//  fun getBalance(): Int {
 		//	  if !A.TestStruct().test() {
-		//	    panic("pre/post condition failed")
+		//	    failPreCondition("")
 		//    }
 		//	  return self.balance
 		//  }
@@ -4078,9 +4079,9 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 13},
 
-				// panic("pre/post condition failed")
+				// failPreCondition("")
 				opcode.InstructionStatement{},
-				opcode.InstructionGetGlobal{Global: panicFunctionIndex},
+				opcode.InstructionGetGlobal{Global: failPreConditionFunctionIndex},
 				opcode.InstructionGetConstant{Constant: panicMessageIndex},
 				opcode.InstructionTransferAndConvert{Type: 9},
 				opcode.InstructionInvoke{ArgCount: 1},
@@ -4114,7 +4115,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 				},
 				{
 					Location: nil,
-					Name:     "panic",
+					Name:     "failPreCondition",
 				},
 			},
 			dProgram.Imports,
@@ -4810,7 +4811,8 @@ func TestCompileTransaction(t *testing.T) {
 		_
 		prepareFunctionIndex
 		executeFunctionIndex
-		panicFunctionIndex
+		failPreConditionFunctionIndex
+		failPostConditionFunctionIndex
 	)
 
 	// Transaction constructor
@@ -4861,14 +4863,14 @@ func TestCompileTransaction(t *testing.T) {
 	// Would be equivalent to:
 	//    fun execute {
 	//        if !(self.count == 2) {
-	//            panic("pre/post condition failed")
+	//            failPreCondition("")
 	//        }
 	//
 	//        var $_result
 	//        self.count = 10
 	//
 	//        if !(self.count == 10) {
-	//            panic("pre/post condition failed")
+	//            failPostCondition("")
 	//        }
 	//        return
 	//    }
@@ -4893,9 +4895,9 @@ func TestCompileTransaction(t *testing.T) {
 			opcode.InstructionNot{},
 			opcode.InstructionJumpIfFalse{Target: 13},
 
-			// panic("pre/post condition failed")
+			// failPreCondition("")
 			opcode.InstructionStatement{},
-			opcode.InstructionGetGlobal{Global: panicFunctionIndex},
+			opcode.InstructionGetGlobal{Global: failPreConditionFunctionIndex},
 			opcode.InstructionGetConstant{Constant: constErrorMsgIndex},
 			opcode.InstructionTransferAndConvert{Type: 5},
 			opcode.InstructionInvoke{ArgCount: 1},
@@ -4922,9 +4924,9 @@ func TestCompileTransaction(t *testing.T) {
 			opcode.InstructionNot{},
 			opcode.InstructionJumpIfFalse{Target: 31},
 
-			// panic("pre/post condition failed")
+			// failPostCondition("")
 			opcode.InstructionStatement{},
-			opcode.InstructionGetGlobal{Global: panicFunctionIndex},
+			opcode.InstructionGetGlobal{Global: failPostConditionFunctionIndex},
 			opcode.InstructionGetConstant{Constant: constErrorMsgIndex},
 			opcode.InstructionTransferAndConvert{Type: 5},
 			opcode.InstructionInvoke{ArgCount: 1},
@@ -8383,7 +8385,7 @@ func TestCompileFunctionExpressionConditions(t *testing.T) {
 		checker, err := ParseAndCheck(t, `
         fun test() {
             var foo = fun(x: Int): Int {
-                pre {x > 0}
+                pre { x > 0 }
                 return 5
             }
         }
@@ -8419,7 +8421,7 @@ func TestCompileFunctionExpressionConditions(t *testing.T) {
 		// Function expression. Would be equivalent to:
 		// fun foo(x: Int): Int {
 		//    if !(x > 0) {
-		//        panic("pre/post condition failed")
+		//        failPreCondition("")
 		//    }
 		//    return 5
 		// }
@@ -8441,7 +8443,7 @@ func TestCompileFunctionExpressionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 12},
 
-				// panic("pre/post condition failed")
+				// failPreCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 1}, // error message
@@ -8467,7 +8469,7 @@ func TestCompileFunctionExpressionConditions(t *testing.T) {
 		checker, err := ParseAndCheck(t, `
         fun test() {
             var foo = fun(x: Int): Int {
-                post {x > 0}
+                post { x > 0 }
                 return 5
             }
         }
@@ -8512,7 +8514,7 @@ func TestCompileFunctionExpressionConditions(t *testing.T) {
 		//    $_result = 5
 		//    let result = $_result
 		//    if !(x > 0) {
-		//        panic("pre/post condition failed")
+		//        failPostCondition("")
 		//    }
 		//    return $_result
 		// }
@@ -8545,7 +8547,7 @@ func TestCompileFunctionExpressionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 21},
 
-				// panic("pre/post condition failed")
+				// failPostCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 2}, // error message
@@ -8575,7 +8577,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 		checker, err := ParseAndCheck(t, `
             fun test() {
                 fun foo(x: Int): Int {
-                    pre {x > 0}
+                    pre { x > 0 }
                     return 5
                 }
             }
@@ -8610,7 +8612,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 		// Function expression. Would be equivalent to:
 		// fun foo(x: Int): Int {
 		//    if !(x > 0) {
-		//        panic("pre/post condition failed")
+		//        failPreCondition("")
 		//    }
 		//    return 5
 		// }
@@ -8632,7 +8634,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 12},
 
-				// panic("pre/post condition failed")
+				// failPreCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 1}, // error message
@@ -8658,7 +8660,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 		checker, err := ParseAndCheck(t, `
             fun test() {
                 fun foo(x: Int): Int {
-                    post {x > 0}
+                    post { x > 0 }
                     return 5
                 }
             }
@@ -8702,7 +8704,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 		//    $_result = 5
 		//    let result = $_result
 		//    if !(x > 0) {
-		//        panic("pre/post condition failed")
+		//        failPostCondition("")
 		//    }
 		//    return $_result
 		// }
@@ -8735,7 +8737,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 21},
 
-				// panic("pre/post condition failed")
+				// failPostCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 2}, // error message
@@ -8762,7 +8764,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
             if true {
                 if true {
                     fun foo(x: Int): Int {
-                        pre {x > 0}
+                        pre { x > 0 }
                         return 5
                     }
                 }
@@ -8805,7 +8807,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 		// Function expression. Would be equivalent to:
 		// fun foo(x: Int): Int {
 		//    if !(x > 0) {
-		//        panic("pre/post condition failed")
+		//        failPreCondition("")
 		//    }
 		//    return 5
 		// }
@@ -8827,7 +8829,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 12},
 
-				// panic("pre/post condition failed")
+				// failPreCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 1}, // error message

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -3340,7 +3340,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 		// Would be equivalent to:
 		// fun test(x: Int): Int {
 		//    if !(x > 0) {
-		//        failPreCondition("")
+		//        $failPreCondition("")
 		//    }
 		//    return 5
 		// }
@@ -3357,7 +3357,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 12},
 
-				// failPreCondition("")
+				// $failPreCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 1}, // error message
@@ -3409,7 +3409,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 		//    $_result = 5
 		//    let result = $_result
 		//    if !(x > 0) {
-		//        failPostCondition("")
+		//       $failPostCondition("")
 		//    }
 		//    return $_result
 		// }
@@ -3442,7 +3442,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 21},
 
-				// failPostCondition("")
+				// $failPostCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 2}, // error message
@@ -3493,7 +3493,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 		//    var $_result <-x
 		//    let result = &$_result
 		//    if !(result != nil) {
-		//        failPostCondition("")
+		//        $failPostCondition("")
 		//    }
 		//    return <-$_result
 		//}
@@ -3529,7 +3529,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 23},
 
-				// failPostCondition("")
+				// $failPostCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 0}, // error message
@@ -3635,14 +3635,14 @@ func TestCompileFunctionConditions(t *testing.T) {
 		// ```
 		//     fun test(x: Int, y: Int): Int {
 		//        if !(x > 0) {
-		//            failPreCondition("")
+		//            $failPreCondition("")
 		//        }
 		//
 		//        var $_result = 42
 		//        let result = $_result
 		//
 		//        if !(y > 0) {
-		//            failPostCondition("")
+		//            $failPostCondition("")
 		//        }
 		//
 		//        return $_result
@@ -3663,7 +3663,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 12},
 
-				// failPreCondition("")
+				// $failPreCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: failPreConditionFunctionIndex},
 				opcode.InstructionGetConstant{Constant: constPanicMessageIndex},
@@ -3704,7 +3704,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 33},
 
-				// failPostCondition("")
+				// $failPostCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: failPostConditionFunctionIndex},
 				opcode.InstructionGetConstant{Constant: constPanicMessageIndex},
@@ -3812,7 +3812,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 		//        var $_result = 42
 		//        let result = $_result
 		//        if !($before_0 < x) {
-		//            failPostCondition("")
+		//            $failPostCondition("")
 		//        }
 		//        return $_result
 		//    }
@@ -3860,7 +3860,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 25},
 
-				// failPostCondition("")
+				// $failPostCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: failPostConditionFunctionIndex},
 				opcode.InstructionGetConstant{Constant: constPanicMessageIndex},
@@ -4055,7 +4055,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 		// ```
 		//  fun getBalance(): Int {
 		//	  if !A.TestStruct().test() {
-		//	    failPreCondition("")
+		//	    $failPreCondition("")
 		//    }
 		//	  return self.balance
 		//  }
@@ -4079,7 +4079,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 13},
 
-				// failPreCondition("")
+				// $failPreCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: failPreConditionFunctionIndex},
 				opcode.InstructionGetConstant{Constant: panicMessageIndex},
@@ -4115,7 +4115,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 				},
 				{
 					Location: nil,
-					Name:     "failPreCondition",
+					Name:     "$failPreCondition",
 				},
 			},
 			dProgram.Imports,
@@ -4863,14 +4863,14 @@ func TestCompileTransaction(t *testing.T) {
 	// Would be equivalent to:
 	//    fun execute {
 	//        if !(self.count == 2) {
-	//            failPreCondition("")
+	//            $failPreCondition("")
 	//        }
 	//
 	//        var $_result
 	//        self.count = 10
 	//
 	//        if !(self.count == 10) {
-	//            failPostCondition("")
+	//            $failPostCondition("")
 	//        }
 	//        return
 	//    }
@@ -4895,7 +4895,7 @@ func TestCompileTransaction(t *testing.T) {
 			opcode.InstructionNot{},
 			opcode.InstructionJumpIfFalse{Target: 13},
 
-			// failPreCondition("")
+			// $failPreCondition("")
 			opcode.InstructionStatement{},
 			opcode.InstructionGetGlobal{Global: failPreConditionFunctionIndex},
 			opcode.InstructionGetConstant{Constant: constErrorMsgIndex},
@@ -4924,7 +4924,7 @@ func TestCompileTransaction(t *testing.T) {
 			opcode.InstructionNot{},
 			opcode.InstructionJumpIfFalse{Target: 31},
 
-			// failPostCondition("")
+			// $failPostCondition("")
 			opcode.InstructionStatement{},
 			opcode.InstructionGetGlobal{Global: failPostConditionFunctionIndex},
 			opcode.InstructionGetConstant{Constant: constErrorMsgIndex},
@@ -8421,7 +8421,7 @@ func TestCompileFunctionExpressionConditions(t *testing.T) {
 		// Function expression. Would be equivalent to:
 		// fun foo(x: Int): Int {
 		//    if !(x > 0) {
-		//        failPreCondition("")
+		//        $failPreCondition("")
 		//    }
 		//    return 5
 		// }
@@ -8443,7 +8443,7 @@ func TestCompileFunctionExpressionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 12},
 
-				// failPreCondition("")
+				// $failPreCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 1}, // error message
@@ -8514,7 +8514,7 @@ func TestCompileFunctionExpressionConditions(t *testing.T) {
 		//    $_result = 5
 		//    let result = $_result
 		//    if !(x > 0) {
-		//        failPostCondition("")
+		//        $failPostCondition("")
 		//    }
 		//    return $_result
 		// }
@@ -8547,7 +8547,7 @@ func TestCompileFunctionExpressionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 21},
 
-				// failPostCondition("")
+				// $failPostCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 2}, // error message
@@ -8612,7 +8612,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 		// Function expression. Would be equivalent to:
 		// fun foo(x: Int): Int {
 		//    if !(x > 0) {
-		//        failPreCondition("")
+		//        $failPreCondition("")
 		//    }
 		//    return 5
 		// }
@@ -8634,7 +8634,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 12},
 
-				// failPreCondition("")
+				// $failPreCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 1}, // error message
@@ -8704,7 +8704,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 		//    $_result = 5
 		//    let result = $_result
 		//    if !(x > 0) {
-		//        failPostCondition("")
+		//        $failPostCondition("")
 		//    }
 		//    return $_result
 		// }
@@ -8737,7 +8737,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 21},
 
-				// failPostCondition("")
+				// $failPostCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 2}, // error message
@@ -8807,7 +8807,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 		// Function expression. Would be equivalent to:
 		// fun foo(x: Int): Int {
 		//    if !(x > 0) {
-		//        failPreCondition("")
+		//        $failPreCondition("")
 		//    }
 		//    return 5
 		// }
@@ -8829,7 +8829,7 @@ func TestCompileInnerFunctionConditions(t *testing.T) {
 				opcode.InstructionNot{},
 				opcode.InstructionJumpIfFalse{Target: 12},
 
-				// failPreCondition("")
+				// $failPreCondition("")
 				opcode.InstructionStatement{},
 				opcode.InstructionGetGlobal{Global: 1},     // global index 1 is 'panic' function
 				opcode.InstructionGetConstant{Constant: 1}, // error message

--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -669,7 +669,7 @@ func (d *Desugar) desugarCondition(
 		// is converted to:
 		// ```
 		//   if !(x > 0) {
-		//     failPreCondition("x must be larger than zero")
+		//     $failPreCondition("x must be larger than zero")
 		//   }
 		// ```
 		//
@@ -681,7 +681,7 @@ func (d *Desugar) desugarCondition(
 		// is converted to:
 		// ```
 		//   if !(x > 0) {
-		//     failPreCondition("")
+		//     $failPreCondition("")
 		//   }
 		// ```
 

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -110,6 +110,13 @@ func compiledFTTransfer(tb testing.TB) {
 				},
 			)
 
+			activation.Set(
+				stdlib.PanicFunctionName,
+				compiler.GlobalImport{
+					Name: stdlib.PanicFunctionName,
+				},
+			)
+
 			return activation
 		},
 	}

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -397,6 +397,19 @@ func CompilerDefaultBuiltinGlobalsWithDefaultsAndLog(_ common.Location) *activat
 	return activation
 }
 
+func CompilerDefaultBuiltinGlobalsWithDefaultsAndPanic(_ common.Location) *activations.Activation[compiler.GlobalImport] {
+	activation := activations.NewActivation(nil, compiler.DefaultBuiltinGlobals())
+
+	activation.Set(
+		stdlib.PanicFunctionName,
+		compiler.GlobalImport{
+			Name: stdlib.PanicFunctionName,
+		},
+	)
+
+	return activation
+}
+
 func CompilerDefaultBuiltinGlobalsWithDefaultsAndConditionLog(_ common.Location) *activations.Activation[compiler.GlobalImport] {
 	activation := activations.NewActivation(nil, compiler.DefaultBuiltinGlobals())
 
@@ -414,10 +427,10 @@ func VMBuiltinGlobalsProviderWithDefaultsAndPanic(_ common.Location) *activation
 	activation := activations.NewActivation(nil, vm.DefaultBuiltinGlobals())
 
 	panicFunctionVariable := &interpreter.SimpleVariable{}
-	activation.Set(commons.PanicFunctionName, panicFunctionVariable)
+	activation.Set(stdlib.PanicFunctionName, panicFunctionVariable)
 	panicFunctionVariable.InitializeWithValue(
 		vm.NewNativeFunctionValue(
-			commons.PanicFunctionName,
+			stdlib.PanicFunctionName,
 			stdlib.PanicFunctionType,
 			func(context *vm.Context, _ []interpreter.StaticType, arguments ...vm.Value) vm.Value {
 				messageValue, ok := arguments[0].(*interpreter.StringValue)

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -2243,7 +2243,19 @@ func TestTransaction(t *testing.T) {
 
 		err := vmInstance.InvokeTransaction(nil)
 		RequireError(t, err)
-		assert.ErrorContains(t, err, "pre/post condition failed")
+
+		var conditionError *interpreter.ConditionError
+		assert.ErrorAs(t, err, &conditionError)
+		assert.Equal(
+			t,
+			ast.ConditionKindPre,
+			conditionError.ConditionKind,
+		)
+		assert.Equal(
+			t,
+			"",
+			conditionError.Message,
+		)
 
 		assert.Equal(t, []string{"2"}, logs)
 	})
@@ -2312,7 +2324,19 @@ func TestTransaction(t *testing.T) {
 
 		err := vmInstance.InvokeTransaction(nil)
 		RequireError(t, err)
-		assert.ErrorContains(t, err, "pre/post condition failed")
+
+		var conditionError *interpreter.ConditionError
+		assert.ErrorAs(t, err, &conditionError)
+		assert.Equal(
+			t,
+			ast.ConditionKindPost,
+			conditionError.ConditionKind,
+		)
+		assert.Equal(
+			t,
+			"",
+			conditionError.Message,
+		)
 
 		assert.Equal(t, []string{"2", "10"}, logs)
 	})
@@ -3622,7 +3646,19 @@ func TestFunctionPreConditions(t *testing.T) {
 		)
 
 		RequireError(t, err)
-		assert.ErrorContains(t, err, "pre/post condition failed")
+
+		var conditionError *interpreter.ConditionError
+		assert.ErrorAs(t, err, &conditionError)
+		assert.Equal(
+			t,
+			ast.ConditionKindPre,
+			conditionError.ConditionKind,
+		)
+		assert.Equal(
+			t,
+			"",
+			conditionError.Message,
+		)
 	})
 
 	t.Run("failed with message", func(t *testing.T) {
@@ -3643,7 +3679,19 @@ func TestFunctionPreConditions(t *testing.T) {
 		)
 
 		RequireError(t, err)
-		assert.ErrorContains(t, err, "x must be zero")
+
+		var conditionError *interpreter.ConditionError
+		assert.ErrorAs(t, err, &conditionError)
+		assert.Equal(
+			t,
+			ast.ConditionKindPre,
+			conditionError.ConditionKind,
+		)
+		assert.Equal(
+			t,
+			"x must be zero",
+			conditionError.Message,
+		)
 	})
 
 	t.Run("passed", func(t *testing.T) {
@@ -4074,7 +4122,19 @@ func TestFunctionPostConditions(t *testing.T) {
 		)
 
 		RequireError(t, err)
-		assert.ErrorContains(t, err, "pre/post condition failed")
+
+		var conditionError *interpreter.ConditionError
+		assert.ErrorAs(t, err, &conditionError)
+		assert.Equal(
+			t,
+			ast.ConditionKindPost,
+			conditionError.ConditionKind,
+		)
+		assert.Equal(
+			t,
+			"",
+			conditionError.Message,
+		)
 	})
 
 	t.Run("failed with message", func(t *testing.T) {
@@ -4351,7 +4411,19 @@ func TestFunctionPostConditions(t *testing.T) {
 		)
 
 		RequireError(t, err)
-		assert.ErrorContains(t, err, "pre/post condition failed")
+
+		var conditionError *interpreter.ConditionError
+		assert.ErrorAs(t, err, &conditionError)
+		assert.Equal(
+			t,
+			ast.ConditionKindPost,
+			conditionError.ConditionKind,
+		)
+		assert.Equal(
+			t,
+			"",
+			conditionError.Message,
+		)
 	})
 
 	t.Run("inherited with different param names", func(t *testing.T) {
@@ -6714,13 +6786,18 @@ func TestContractClosure(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	comp := compiler.NewInstructionCompiler(
+	compConfig := &compiler.Config{
+		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
+			return importedProgram
+		},
+		BuiltinGlobalsProvider: CompilerDefaultBuiltinGlobalsWithDefaultsAndPanic,
+	}
+
+	comp := compiler.NewInstructionCompilerWithConfig(
 		interpreter.ProgramFromChecker(checker),
 		checker.Location,
+		compConfig,
 	)
-	comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
-		return importedProgram
-	}
 
 	program := comp.Compile()
 

--- a/interpreter/condition_test.go
+++ b/interpreter/condition_test.go
@@ -210,13 +210,6 @@ func assertConditionError(
 ) {
 	RequireError(t, err)
 
-	if *compile {
-		var conditionErr stdlib.PanicError
-		require.ErrorAs(t, err, &conditionErr)
-		require.ErrorContains(t, err, "pre/post condition failed")
-		return
-	}
-
 	var conditionErr *interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)
 
@@ -233,13 +226,6 @@ func assertConditionErrorWithMessage(
 	message string,
 ) {
 	RequireError(t, err)
-
-	if *compile {
-		var conditionErr stdlib.PanicError
-		require.ErrorAs(t, err, &conditionErr)
-		require.ErrorContains(t, err, message)
-		return
-	}
 
 	var conditionErr *interpreter.ConditionError
 	require.ErrorAs(t, err, &conditionErr)

--- a/interpreter/entitlements_test.go
+++ b/interpreter/entitlements_test.go
@@ -27,8 +27,6 @@ import (
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
-	"github.com/onflow/cadence/stdlib"
-	"github.com/onflow/cadence/test_utils"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
 )
@@ -1111,13 +1109,8 @@ func TestInterpretEntitledResult(t *testing.T) {
 		_, err := invokable.Invoke("test")
 		RequireError(t, err)
 
-		if _, compiled := invokable.(*test_utils.VMInvokable); compiled {
-			var panicError stdlib.PanicError
-			require.ErrorAs(t, err, &panicError)
-		} else {
-			var conditionError *interpreter.ConditionError
-			require.ErrorAs(t, err, &conditionError)
-		}
+		var conditionError *interpreter.ConditionError
+		require.ErrorAs(t, err, &conditionError)
 	})
 }
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -4756,8 +4756,7 @@ func TestRuntimeInvokeStoredInterfaceFunction(t *testing.T) {
 					Context{
 						Interface: runtimeInterface,
 						Location:  nextTransactionLocation(),
-						// TODO: requires support for ConditionError in the VM
-						//UseVM:     *compile,
+						UseVM:     *compile,
 					},
 				)
 


### PR DESCRIPTION
Work towards #3804 

## Description

Instead of declaring the stdlib function `panic` as a default compiler built-in global, and using it for failing pre and post conditions, define two new global functions `$failPreCondition` and `$failPostCondition`, which produce a `ConditionError`, just like the interpreter.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
