### PR TITLE
[Compiler] Enable more tests for VM or add TODO

### DIFF
--- a/runtime/convertValues_test.go
+++ b/runtime/convertValues_test.go
@@ -1757,7 +1757,7 @@ func TestRuntimeExportEventValue(t *testing.T) {
 			nil,
 		)
 
-		actual := exportEventFromScript(t, script)
+		actual := exportEventFromScript(t, script, *compile)
 		expected := cadence.NewEvent([]cadence.Value{
 			cadence.NewInt(42),
 		}).WithType(fooEventType)
@@ -1793,7 +1793,7 @@ func TestRuntimeExportEventValue(t *testing.T) {
 			nil,
 		)
 
-		actual := exportEventFromScript(t, script)
+		actual := exportEventFromScript(t, script, *compile)
 		expected := cadence.NewEvent([]cadence.Value{
 			cadence.NewInt(42),
 		}).WithType(fooEventType)
@@ -1802,7 +1802,7 @@ func TestRuntimeExportEventValue(t *testing.T) {
 	})
 }
 
-func exportEventFromScript(t *testing.T, script string) cadence.Event {
+func exportEventFromScript(t *testing.T, script string, useVM bool) cadence.Event {
 	rt := NewTestRuntime()
 
 	var events []cadence.Event
@@ -1821,8 +1821,7 @@ func exportEventFromScript(t *testing.T, script string) cadence.Event {
 		Context{
 			Interface: inter,
 			Location:  common.ScriptLocation{},
-			// TODO: requires InclusiveRange support in the VM
-			//UseVM:     *compile,
+			UseVM:     useVM,
 		},
 	)
 
@@ -1844,8 +1843,7 @@ func exportValueFromScript(t *testing.T, script string) cadence.Value {
 		Context{
 			Interface: &TestRuntimeInterface{},
 			Location:  common.ScriptLocation{},
-			// TODO: requires InclusiveRange support in the VM
-			//UseVM:     *compile,
+			UseVM:     *compile,
 		},
 	)
 
@@ -2477,7 +2475,7 @@ var exportJsonDeterministicExpected string
 func TestRuntimeExportJsonDeterministic(t *testing.T) {
 	t.Parallel()
 
-	// exported order of field in a dictionary depends on the execution ,
+	// exported order of field in a dictionary depends on the execution,
 	// however the deterministic code should generate deterministic type
 
 	script := `
@@ -2515,7 +2513,8 @@ func TestRuntimeExportJsonDeterministic(t *testing.T) {
         }
     `
 
-	event := exportEventFromScript(t, script)
+	// TODO: investigate why execution with VM does not produce the same order
+	event := exportEventFromScript(t, script, false)
 
 	bytes, err := json.Encode(event)
 
@@ -2646,8 +2645,7 @@ func executeTestScript(t *testing.T, script string, arg cadence.Value) (cadence.
 		Context{
 			Interface: runtimeInterface,
 			Location:  common.ScriptLocation{},
-			// TODO: requires InclusiveRange support in the VM
-			//UseVM:     *compile,
+			UseVM:     *compile,
 		},
 	)
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -380,6 +380,7 @@ func TestRuntimeProgramSetAndGet(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  scriptLocation,
+				// NOTE: UseVM is ignored for parsing/checking
 			},
 		)
 		assert.NoError(t, err)
@@ -410,6 +411,7 @@ func TestRuntimeProgramSetAndGet(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  scriptLocation,
+				// NOTE: UseVM is ignored for parsing/checking
 			},
 		)
 		assert.NoError(t, err)
@@ -434,6 +436,7 @@ func TestRuntimeProgramSetAndGet(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  scriptLocation,
+				// NOTE: UseVM is ignored for parsing/checking
 			},
 		)
 		assert.NoError(t, err)
@@ -2214,6 +2217,7 @@ func TestRuntimeParseAndCheckProgram(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
+				// NOTE: UseVM is ignored for parsing/checking
 			},
 		)
 		assert.NoError(t, err)
@@ -2232,6 +2236,7 @@ func TestRuntimeParseAndCheckProgram(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
+				// NOTE: UseVM is ignored for parsing/checking
 			},
 		)
 		assert.NotNil(t, err)
@@ -2250,6 +2255,7 @@ func TestRuntimeParseAndCheckProgram(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
+				// NOTE: UseVM is ignored for parsing/checking
 			},
 		)
 		assert.NotNil(t, err)
@@ -6064,6 +6070,8 @@ func TestRuntimeContractWriteback(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			// TODO: VM produces different writes
+			//UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -6222,6 +6230,8 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			// TODO: VM produces different writes
+			//UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -6934,6 +6944,8 @@ func TestRuntimeProgramsHitForToplevelPrograms(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			// TODO: VM produces different hits
+			//UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -6947,6 +6959,8 @@ func TestRuntimeProgramsHitForToplevelPrograms(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			// TODO: VM produces different hits
+			//UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -6962,6 +6976,8 @@ func TestRuntimeProgramsHitForToplevelPrograms(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			// TODO: VM produces different hits
+			//UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -7560,6 +7576,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 
@@ -7637,6 +7654,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
 			},
 		)
 
@@ -7700,6 +7718,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -7717,6 +7736,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
 			},
 		)
 
@@ -7746,7 +7766,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
-				UseVM:     *compile,
+				// NOTE: UseVM is ignored for parsing/checking
 			},
 		)
 
@@ -7973,6 +7993,8 @@ func TestRuntimeComputationMetring(t *testing.T) {
 				Context{
 					Interface: runtimeInterface,
 					Location:  nextTransactionLocation(),
+					// TODO: VM has different computation metering
+					//UseVM:     *compile,
 				},
 			)
 			if testCase.ok {
@@ -8233,6 +8255,8 @@ func TestRuntimeImportTestStdlib(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			// TODO: test framework is not supported in VM yet
+			//UseVM:     *compile,
 		},
 	)
 
@@ -8266,6 +8290,7 @@ func TestRuntimeGetCurrentBlockScript(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 
@@ -8553,6 +8578,7 @@ func TestRuntimeAccountTypeEquality(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -9215,6 +9241,7 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 
@@ -9264,6 +9291,7 @@ func TestRuntimeComputationMeteringError(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextScriptLocation(),
+				UseVM:     *compile,
 			},
 		)
 
@@ -9387,6 +9415,8 @@ func TestRuntimeWrappedErrorHandling(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			// TODO: fix running with VM
+			//UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
Work towards #4059 

## Description

Now that `InclusiveRange` got implemented in #4081, all built-in / standard library values are implemented, and we can enable the value conversion tests to be run with the VM.

Also some other recently implemented features and bugfixes allow running more tests with the VM.

In cases where not possible, leave a TODO and track it in #4059.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
