### PR TITLE
Clean up test utils

### DIFF
--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -3934,7 +3934,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 			aLocation,
 			ParseCheckAndCompileOptions{
 				ParseAndCheckOptions: &ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 							return baseValueActivation
 						},
@@ -7610,7 +7610,7 @@ func TestCompileOptionalArgument(t *testing.T) {
             }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},
@@ -9046,7 +9046,7 @@ func TestCompileInjectedContract(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			Location: TestLocation,
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 					assert.Equal(t, TestLocation, location)
 					return baseValueActivation

--- a/bbq/test_utils/utils.go
+++ b/bbq/test_utils/utils.go
@@ -80,9 +80,9 @@ type CompiledProgram struct {
 }
 
 type ParseCheckAndCompileOptions struct {
-	*ParseAndCheckOptions
-	CompilerConfig      *compiler.Config
-	CheckerErrorHandler func(error)
+	ParseAndCheckOptions *ParseAndCheckOptions
+	CompilerConfig       *compiler.Config
+	CheckerErrorHandler  func(error)
 }
 
 func ParseCheckAndCompile(
@@ -161,7 +161,7 @@ func parseAndCheckWithOptions(
 	} else {
 		parseAndCheckOptions = ParseAndCheckOptions{
 			Location: location,
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				LocationHandler:            SingleIdentifierLocationResolver(t),
 				BaseValueActivationHandler: TestBaseValueActivation,
 			},
@@ -170,10 +170,10 @@ func parseAndCheckWithOptions(
 
 	parseAndCheckOptions.Location = location
 
-	semaConfig := parseAndCheckOptions.Config
+	semaConfig := parseAndCheckOptions.CheckerConfig
 
 	if semaConfig != nil && semaConfig.ImportHandler == nil {
-		parseAndCheckOptions.Config.ImportHandler = func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+		parseAndCheckOptions.CheckerConfig.ImportHandler = func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 			imported, ok := programs[location]
 			if !ok {
 				return nil, fmt.Errorf("cannot find contract in location %s", location)

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -138,8 +138,8 @@ func compiledFTTransfer(tb testing.TB) {
 			location,
 			ParseCheckAndCompileOptions{
 				ParseAndCheckOptions: &ParseAndCheckOptions{
-					Location: location,
-					Config:   semaConfig,
+					Location:      location,
+					CheckerConfig: semaConfig,
 				},
 				CompilerConfig: compilerConfig,
 			},
@@ -307,8 +307,8 @@ func compiledFTTransfer(tb testing.TB) {
 			txLocation,
 			ParseCheckAndCompileOptions{
 				ParseAndCheckOptions: &ParseAndCheckOptions{
-					Location: txLocation,
-					Config:   semaConfig,
+					Location:      txLocation,
+					CheckerConfig: semaConfig,
 				},
 				CompilerConfig: compilerConfig,
 			},
@@ -339,8 +339,8 @@ func compiledFTTransfer(tb testing.TB) {
 		txLocation,
 		ParseCheckAndCompileOptions{
 			ParseAndCheckOptions: &ParseAndCheckOptions{
-				Location: txLocation,
-				Config:   semaConfig,
+				Location:      txLocation,
+				CheckerConfig: semaConfig,
 			},
 			CompilerConfig: compilerConfig,
 		},
@@ -387,8 +387,8 @@ func compiledFTTransfer(tb testing.TB) {
 		txLocation,
 		ParseCheckAndCompileOptions{
 			ParseAndCheckOptions: &ParseAndCheckOptions{
-				Location: txLocation,
-				Config:   semaConfig,
+				Location:      txLocation,
+				CheckerConfig: semaConfig,
 			},
 			CompilerConfig: compilerConfig,
 		},
@@ -459,8 +459,8 @@ func compiledFTTransfer(tb testing.TB) {
 			scriptLocation,
 			ParseCheckAndCompileOptions{
 				ParseAndCheckOptions: &ParseAndCheckOptions{
-					Location: scriptLocation,
-					Config:   semaConfig,
+					Location:      scriptLocation,
+					CheckerConfig: semaConfig,
 				},
 				CompilerConfig: compilerConfig,
 			},

--- a/bbq/vm/test/interpreter_test.go
+++ b/bbq/vm/test/interpreter_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/onflow/cadence/pretty"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
 	. "github.com/onflow/cadence/test_utils/runtime_utils"
 	. "github.com/onflow/cadence/test_utils/sema_utils"
@@ -38,16 +39,15 @@ import (
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/interpreter"
-	"github.com/onflow/cadence/pretty"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/stdlib"
 )
 
 type ParseCheckAndInterpretOptions struct {
-	Config             *interpreter.Config
-	CheckerConfig      *sema.Config
-	HandleCheckerError func(error)
+	ParseAndCheckOptions *ParseAndCheckOptions
+	InterpreterConfig    *interpreter.Config
+	HandleCheckerError   func(error)
 }
 
 func parseCheckAndInterpretWithOptions(
@@ -59,27 +59,26 @@ func parseCheckAndInterpretWithOptions(
 	inter *interpreter.Interpreter,
 	err error,
 ) {
-	return parseCheckAndInterpretWithOptionsAndMemoryMetering(t, code, location, options, nil)
-}
 
-func parseCheckAndInterpretWithOptionsAndMemoryMetering(
-	t testing.TB,
-	code string,
-	location common.Location,
-	options ParseCheckAndInterpretOptions,
-	memoryGauge common.MemoryGauge,
-) (
-	inter *interpreter.Interpreter,
-	err error,
-) {
+	var memoryGauge common.MemoryGauge
+	if options.InterpreterConfig != nil {
+		memoryGauge = options.InterpreterConfig.MemoryGauge
+	}
+	if memoryGauge == nil && options.ParseAndCheckOptions != nil {
+		memoryGauge = options.ParseAndCheckOptions.MemoryGauge
+	}
 
-	checker, err := ParseAndCheckWithOptionsAndMemoryMetering(t,
+	var parseAndCheckOptions ParseAndCheckOptions
+	if options.ParseAndCheckOptions != nil {
+		parseAndCheckOptions = *options.ParseAndCheckOptions
+	}
+	if parseAndCheckOptions.Location == nil {
+		parseAndCheckOptions.Location = location
+	}
+
+	checker, err := ParseAndCheckWithOptions(t,
 		code,
-		ParseAndCheckOptions{
-			Location: location,
-			Config:   options.CheckerConfig,
-		},
-		memoryGauge,
+		parseAndCheckOptions,
 	)
 
 	if options.HandleCheckerError != nil {
@@ -99,8 +98,8 @@ func parseCheckAndInterpretWithOptionsAndMemoryMetering(
 	var uuid uint64 = 0
 
 	var config interpreter.Config
-	if options.Config != nil {
-		config = *options.Config
+	if options.InterpreterConfig != nil {
+		config = *options.InterpreterConfig
 	}
 
 	if config.UUIDHandler == nil {
@@ -111,10 +110,6 @@ func parseCheckAndInterpretWithOptionsAndMemoryMetering(
 	}
 	if config.Storage == nil {
 		config.Storage = interpreter.NewInMemoryStorage(memoryGauge)
-	}
-
-	if memoryGauge != nil && config.MemoryGauge == nil {
-		config.MemoryGauge = memoryGauge
 	}
 
 	inter, err = interpreter.NewInterpreter(
@@ -375,8 +370,10 @@ func interpreterFTTransfer(tb testing.TB) {
 			code,
 			location,
 			ParseCheckAndInterpretOptions{
-				Config:        interConfig,
-				CheckerConfig: checkerConfig,
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: checkerConfig,
+				},
+				InterpreterConfig: interConfig,
 			},
 		)
 
@@ -822,8 +819,6 @@ func TestInterpreterImperativeFib(t *testing.T) {
 
 	t.Parallel()
 
-	scriptLocation := NewScriptLocationGenerator()
-
 	inter, err := parseCheckAndInterpretWithOptions(
 		t,
 		imperativeFib,
@@ -832,7 +827,7 @@ func TestInterpreterImperativeFib(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	var value interpreter.Value = interpreter.NewUnmeteredIntValueFromInt64(7)
+	value := interpreter.NewUnmeteredIntValueFromInt64(7)
 
 	result, err := inter.Invoke("fib", value)
 	require.NoError(t, err)
@@ -840,8 +835,6 @@ func TestInterpreterImperativeFib(t *testing.T) {
 }
 
 func BenchmarkInterpreterImperativeFib(b *testing.B) {
-
-	scriptLocation := NewScriptLocationGenerator()
 
 	inter, err := parseCheckAndInterpretWithOptions(
 		b,
@@ -851,7 +844,7 @@ func BenchmarkInterpreterImperativeFib(b *testing.B) {
 	)
 	require.NoError(b, err)
 
-	var value interpreter.Value = interpreter.NewUnmeteredIntValueFromInt64(14)
+	value := interpreter.NewUnmeteredIntValueFromInt64(14)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -864,26 +857,25 @@ func BenchmarkInterpreterImperativeFib(b *testing.B) {
 
 func BenchmarkInterpreterNewStruct(b *testing.B) {
 
-	scriptLocation := NewScriptLocationGenerator()
-
 	inter, err := parseCheckAndInterpretWithOptions(
 		b,
 		`
-        struct Foo {
-            var id : Int
+          struct Foo {
+              var id : Int
 
-            init(_ id: Int) {
-                self.id = id
-            }
-        }
+              init(_ id: Int) {
+                  self.id = id
+              }
+          }
 
-        fun test(count: Int) {
-            var i = 0
-            while i < count {
-                Foo(i)
-                i = i + 1
-            }
-        }`,
+          fun test(count: Int) {
+              var i = 0
+              while i < count {
+                  Foo(i)
+                  i = i + 1
+              }
+          }
+        `,
 		scriptLocation(),
 		ParseCheckAndInterpretOptions{},
 	)

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -516,7 +516,7 @@ func CompileAndInvokeWithLogs(
 		CompilerAndVMOptions{
 			ParseCheckAndCompileOptions: ParseCheckAndCompileOptions{
 				ParseAndCheckOptions: &ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						LocationHandler: SingleIdentifierLocationResolver(t),
 						BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 							return activation
@@ -590,7 +590,7 @@ func CompileAndInvokeWithConditionLogs(
 		CompilerAndVMOptions{
 			ParseCheckAndCompileOptions: ParseCheckAndCompileOptions{
 				ParseAndCheckOptions: &ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						LocationHandler: SingleIdentifierLocationResolver(t),
 						BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 							return activation

--- a/bbq/vm/test/vm_bench_test.go
+++ b/bbq/vm/test/vm_bench_test.go
@@ -361,7 +361,7 @@ func BenchmarkContractImport(b *testing.B) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
@@ -450,7 +450,7 @@ func BenchmarkMethodCall(b *testing.B) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
@@ -560,7 +560,7 @@ func BenchmarkMethodCall(b *testing.B) {
         }`,
 
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -523,7 +523,7 @@ func TestImport(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
@@ -630,7 +630,7 @@ func TestContractImport(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
@@ -745,7 +745,7 @@ func TestContractImport(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
@@ -862,7 +862,7 @@ func TestContractImport(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				Location: barLocation,
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.Equal(t, fooLocation, location)
 						return sema.ElaborationImport{
@@ -905,7 +905,7 @@ func TestContractImport(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.IsType(t, common.AddressLocation{}, location)
 						addressLocation := location.(common.AddressLocation)
@@ -1056,7 +1056,7 @@ func TestContractImport(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				Location: barLocation,
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.Equal(t, fooLocation, location)
 						return sema.ElaborationImport{
@@ -1117,7 +1117,7 @@ func TestContractImport(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.IsType(t, common.AddressLocation{}, location)
 						addressLocation := location.(common.AddressLocation)
@@ -1241,7 +1241,7 @@ func TestContractImport(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				Location: importLocation,
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 						return activation
 					},
@@ -1296,7 +1296,7 @@ func TestContractImport(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
@@ -1641,7 +1641,7 @@ func TestContractField(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
@@ -1735,7 +1735,7 @@ func TestContractField(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
@@ -1789,7 +1789,7 @@ func TestNativeFunctions(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},
@@ -1861,7 +1861,7 @@ func TestNativeFunctions(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},
@@ -2062,7 +2062,7 @@ func TestTransaction(t *testing.T) {
 
 		parseAndCheckOptions := &ParseAndCheckOptions{
 			Location: location,
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				LocationHandler: SingleIdentifierLocationResolver(t),
 				BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 					return activation
@@ -2131,7 +2131,7 @@ func TestTransaction(t *testing.T) {
 
 		parseAndCheckOptions := &ParseAndCheckOptions{
 			Location: location,
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				LocationHandler: SingleIdentifierLocationResolver(t),
 				BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 					return activation
@@ -2196,7 +2196,7 @@ func TestTransaction(t *testing.T) {
 
 		parseAndCheckOptions := &ParseAndCheckOptions{
 			Location: location,
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				LocationHandler: SingleIdentifierLocationResolver(t),
 				BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 					return activation
@@ -2278,7 +2278,7 @@ func TestTransaction(t *testing.T) {
 
 		parseAndCheckOptions := &ParseAndCheckOptions{
 			Location: location,
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				LocationHandler: SingleIdentifierLocationResolver(t),
 				BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 					return activation
@@ -2428,7 +2428,7 @@ func TestInterfaceMethodCall(t *testing.T) {
             `,
 
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
@@ -2532,7 +2532,7 @@ func TestInterfaceMethodCall(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 				Location: barLocation,
@@ -2575,7 +2575,7 @@ func TestInterfaceMethodCall(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						var elaboration *sema.Elaboration
 						switch location {
@@ -2680,7 +2680,7 @@ func TestInterfaceMethodCall(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						var elaboration *sema.Elaboration
 						switch location {
@@ -2782,7 +2782,7 @@ func TestInterfaceMethodCall(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						var elaboration *sema.Elaboration
 						switch location {
@@ -3954,7 +3954,7 @@ func TestFunctionPreConditions(t *testing.T) {
 				CompilerConfig: compilerConfig,
 				ParseAndCheckOptions: &ParseAndCheckOptions{
 					Location: barLocation,
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						LocationHandler: SingleIdentifierLocationResolver(t),
 						BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 							return activation
@@ -4008,7 +4008,7 @@ func TestFunctionPreConditions(t *testing.T) {
 				CompilerConfig: compilerConfig,
 				ParseAndCheckOptions: &ParseAndCheckOptions{
 					Location: fooLocation,
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						LocationHandler: SingleIdentifierLocationResolver(t),
 						BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 							return activation
@@ -4058,7 +4058,7 @@ func TestFunctionPreConditions(t *testing.T) {
 					CompilerConfig: compilerConfig,
 					ParseAndCheckOptions: &ParseAndCheckOptions{
 						Location: location,
-						Config: &sema.Config{
+						CheckerConfig: &sema.Config{
 							LocationHandler: SingleIdentifierLocationResolver(t),
 							BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 								return activation
@@ -6096,7 +6096,7 @@ func TestContractAccount(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
@@ -6217,7 +6217,7 @@ func TestResourceOwner(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
@@ -6351,7 +6351,7 @@ func TestResourceUUID(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
@@ -6747,7 +6747,7 @@ func TestContractClosure(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
@@ -7509,7 +7509,7 @@ func TestInheritedConditions(t *testing.T) {
 			ParseCheckAndCompileOptions{
 				CompilerConfig: compilerConfig,
 				ParseAndCheckOptions: &ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 							return baseValueActivation
 						},
@@ -8169,7 +8169,7 @@ func TestGlobalVariables(t *testing.T) {
 			CompilerAndVMOptions{
 				ParseCheckAndCompileOptions: ParseCheckAndCompileOptions{
 					ParseAndCheckOptions: &ParseAndCheckOptions{
-						Config: &sema.Config{
+						CheckerConfig: &sema.Config{
 							LocationHandler: SingleIdentifierLocationResolver(t),
 							BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 								return activation
@@ -8534,7 +8534,7 @@ func TestFunctionInvocationWithOptionalArgs(t *testing.T) {
 			ParseCheckAndCompileOptions: ParseCheckAndCompileOptions{
 				CompilerConfig: compilerConfig,
 				ParseAndCheckOptions: &ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 							return activation
 						},
@@ -8860,7 +8860,7 @@ func TestGetAuthAccount(t *testing.T) {
 					CompilerConfig: compilerConfig,
 					ParseAndCheckOptions: &ParseAndCheckOptions{
 						Location: location,
-						Config: &sema.Config{
+						CheckerConfig: &sema.Config{
 							LocationHandler: SingleIdentifierLocationResolver(t),
 							BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 								return activation
@@ -8913,7 +8913,7 @@ func TestGetAuthAccount(t *testing.T) {
 					CompilerConfig: compilerConfig,
 					ParseAndCheckOptions: &ParseAndCheckOptions{
 						Location: location,
-						Config: &sema.Config{
+						CheckerConfig: &sema.Config{
 							LocationHandler: SingleIdentifierLocationResolver(t),
 							BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 								return activation
@@ -9149,7 +9149,7 @@ func TestInjectedContract(t *testing.T) {
 				CompilerConfig: compilerConfig,
 				ParseAndCheckOptions: &ParseAndCheckOptions{
 					Location: TestLocation,
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 							assert.Equal(t, TestLocation, location)
 							return baseValueActivation
@@ -9269,7 +9269,7 @@ func TestInheritedDefaultDestroyEvent(t *testing.T) {
 			CompilerConfig: compilerConfig,
 			ParseAndCheckOptions: &ParseAndCheckOptions{
 				Location: barLocation,
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					LocationHandler: SingleIdentifierLocationResolver(t),
 					BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 						return activation
@@ -9311,7 +9311,7 @@ func TestInheritedDefaultDestroyEvent(t *testing.T) {
 			CompilerConfig: compilerConfig,
 			ParseAndCheckOptions: &ParseAndCheckOptions{
 				Location: fooLocation,
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					LocationHandler: SingleIdentifierLocationResolver(t),
 					BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 						return activation
@@ -9381,7 +9381,7 @@ func TestInheritedDefaultDestroyEvent(t *testing.T) {
 				CompilerConfig: compilerConfig,
 				ParseAndCheckOptions: &ParseAndCheckOptions{
 					Location: location,
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						LocationHandler: SingleIdentifierLocationResolver(t),
 						BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
 							return activation

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -626,7 +626,7 @@ func testAccountWithErrorHandlerWithCompiler(
 
 		programs := map[common.Location]*CompiledProgram{}
 		parseAndCheckOptions := &ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				LocationHandler: NewSingleIdentifierLocationResolver(t),
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
@@ -680,11 +680,14 @@ func testAccountWithErrorHandlerWithCompiler(
 		storage = vmConfig.Storage()
 	} else {
 
+		// NOTE: test code for VM above
 		inter, err := parseCheckAndInterpretWithOptions(t,
 			code,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &checkerConfig,
-				Config: &interpreter.Config{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &checkerConfig,
+				},
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},

--- a/interpreter/attachments_test.go
+++ b/interpreter/attachments_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/onflow/cadence/stdlib"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
+	. "github.com/onflow/cadence/test_utils/sema_utils"
 
 	"github.com/stretchr/testify/require"
 )
@@ -1261,7 +1262,7 @@ func TestInterpretAttachmentDestructor(t *testing.T) {
                 }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					OnEventEmitted: func(
 						_ interpreter.ValueExportContext,
 						_ interpreter.LocationRange,
@@ -1315,7 +1316,7 @@ func TestInterpretAttachmentDestructor(t *testing.T) {
                 }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					OnEventEmitted: func(
 						_ interpreter.ValueExportContext,
 						_ interpreter.LocationRange,
@@ -1362,7 +1363,7 @@ func TestInterpretAttachmentDestructor(t *testing.T) {
                 }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					OnEventEmitted: func(
 						_ interpreter.ValueExportContext,
 						_ interpreter.LocationRange,
@@ -1416,7 +1417,7 @@ func TestInterpretAttachmentDestructor(t *testing.T) {
                 }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					OnEventEmitted: func(
 						_ interpreter.ValueExportContext,
 						_ interpreter.LocationRange,
@@ -1474,7 +1475,7 @@ func TestInterpretAttachmentDestructor(t *testing.T) {
                 }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					OnEventEmitted: func(
 						_ interpreter.ValueExportContext,
 						_ interpreter.LocationRange,
@@ -1543,7 +1544,7 @@ func TestInterpretAttachmentDestructor(t *testing.T) {
                 }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					OnEventEmitted: func(
 						_ interpreter.ValueExportContext,
 						_ interpreter.LocationRange,
@@ -2577,12 +2578,14 @@ func TestInterpretBuiltinCompositeAttachment(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			CheckerConfig: &sema.Config{
-				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-					return baseValueActivation
+			ParseAndCheckOptions: &ParseAndCheckOptions{
+				CheckerConfig: &sema.Config{
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 					return baseActivation
 				},

--- a/interpreter/composite_value_test.go
+++ b/interpreter/composite_value_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/onflow/cadence/stdlib"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
+	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
 func TestInterpretCompositeValue(t *testing.T) {
@@ -145,24 +146,26 @@ func testCompositeValue(t *testing.T, code string) Invokable {
 	inter, err := parseCheckAndPrepareWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{
-			CheckerConfig: &sema.Config{
-				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-					return baseValueActivation
-				},
-				BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
-					return baseTypeActivation
-				},
-				CheckHandler: func(checker *sema.Checker, check func()) {
-					if checker.Location == TestLocation {
-						checker.Elaboration.SetCompositeType(
-							fruitType.ID(),
-							fruitType,
-						)
-					}
-					check()
+			ParseAndCheckOptions: &ParseAndCheckOptions{
+				CheckerConfig: &sema.Config{
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
+					BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseTypeActivation
+					},
+					CheckHandler: func(checker *sema.Checker, check func()) {
+						if checker.Location == TestLocation {
+							checker.Elaboration.SetCompositeType(
+								fruitType.ID(),
+								fruitType,
+							)
+						}
+						check()
+					},
 				},
 			},
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				Storage: storage,
 				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 					return baseActivation

--- a/interpreter/condition_test.go
+++ b/interpreter/condition_test.go
@@ -663,7 +663,7 @@ func TestInterpretInterfaceFunctionUseWithPreCondition(t *testing.T) {
 					tearDownCode,
 				),
 				ParseCheckAndInterpretOptions{
-					Config: &interpreter.Config{
+					InterpreterConfig: &interpreter.Config{
 						ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 						OnEventEmitted: func(
 							_ interpreter.ValueExportContext,
@@ -1235,7 +1235,7 @@ func TestInterpretIsInstanceCheckInPreCondition(t *testing.T) {
 				condition,
 			),
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},
@@ -1345,12 +1345,14 @@ func TestInterpretFunctionWithPostConditionAndResourceResult(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			CheckerConfig: &sema.Config{
-				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-					return baseValueActivation
+			ParseAndCheckOptions: &ParseAndCheckOptions{
+				CheckerConfig: &sema.Config{
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 					return baseActivation
 				},

--- a/interpreter/container_mutation_test.go
+++ b/interpreter/container_mutation_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/onflow/cadence/stdlib"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
+	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
 func TestInterpretArrayMutation(t *testing.T) {
@@ -335,12 +336,14 @@ func TestInterpretArrayMutation(t *testing.T) {
                 logger("hello")
             }`,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
@@ -478,12 +481,14 @@ func TestInterpretArrayMutation(t *testing.T) {
                 }
             `,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
@@ -733,12 +738,14 @@ func TestInterpretDictionaryMutation(t *testing.T) {
                 logger("hello")
             }`,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
@@ -876,12 +883,14 @@ func TestInterpretDictionaryMutation(t *testing.T) {
                }
            `,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},

--- a/interpreter/contract_test.go
+++ b/interpreter/contract_test.go
@@ -55,7 +55,7 @@ func TestInterpretContractUseBeforeInitializationComplete(t *testing.T) {
               }
 	        `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},
@@ -86,7 +86,7 @@ func TestInterpretContractUseBeforeInitializationComplete(t *testing.T) {
               }
 	        `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},
@@ -117,7 +117,7 @@ func TestInterpretContractUseBeforeInitializationComplete(t *testing.T) {
               }
 	        `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},
@@ -150,7 +150,7 @@ func TestInterpretContractUseBeforeInitializationComplete(t *testing.T) {
               }
 	        `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},

--- a/interpreter/dynamic_casting_test.go
+++ b/interpreter/dynamic_casting_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/onflow/cadence/stdlib"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
+	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
 // dynamic casting operation -> returns optional
@@ -1483,12 +1484,14 @@ func TestInterpretDynamicCastingInclusiveRange(t *testing.T) {
 	interpreter.Declare(baseActivation, stdlib.InterpreterInclusiveRangeConstructor)
 
 	options := ParseCheckAndInterpretOptions{
-		CheckerConfig: &sema.Config{
-			BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
-				return baseValueActivation
+		ParseAndCheckOptions: &ParseAndCheckOptions{
+			CheckerConfig: &sema.Config{
+				BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
+					return baseValueActivation
+				},
 			},
 		},
-		Config: &interpreter.Config{
+		InterpreterConfig: &interpreter.Config{
 			BaseActivationHandler: func(common.Location) *interpreter.VariableActivation {
 				return baseActivation
 			},
@@ -3457,12 +3460,14 @@ func TestInterpretDynamicCastingCapability(t *testing.T) {
 			interpreter.Declare(baseActivation, capabilityValueDeclaration)
 
 			options := ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},

--- a/interpreter/entitlements_test.go
+++ b/interpreter/entitlements_test.go
@@ -1412,6 +1412,7 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             entitlement Y
             entitlement Z
@@ -1446,6 +1447,7 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             entitlement Y
             entitlement Z
@@ -1485,6 +1487,7 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             entitlement Y
             entitlement Z
@@ -1523,6 +1526,7 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             entitlement Y
             entitlement Z
@@ -1562,6 +1566,7 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             entitlement Y
             entitlement Z
@@ -1601,6 +1606,7 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             entitlement X
             entitlement E
@@ -1637,6 +1643,7 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             entitlement X
             entitlement E
@@ -1677,6 +1684,7 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             entitlement X
             entitlement E
@@ -1717,6 +1725,7 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             entitlement X
             entitlement E
@@ -1757,6 +1766,7 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             entitlement X
             entitlement E
@@ -1931,6 +1941,7 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             entitlement X
             entitlement E
@@ -1962,6 +1973,7 @@ func TestInterpretEntitledAttachments(t *testing.T) {
 
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             entitlement Z
             entitlement Y

--- a/interpreter/enum_test.go
+++ b/interpreter/enum_test.go
@@ -245,7 +245,7 @@ func TestInterpretEnumInContract(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 		},

--- a/interpreter/equality_test.go
+++ b/interpreter/equality_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/stdlib"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
+	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
 func TestInterpretEquality(t *testing.T) {
@@ -67,14 +68,16 @@ func TestInterpretEquality(t *testing.T) {
               let res2 = maybeCapNil == nil
 		    `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
-					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
-						return baseActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				InterpreterConfig: &interpreter.Config{
+					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
+						return baseActivation
 					},
 				},
 			},

--- a/interpreter/for_test.go
+++ b/interpreter/for_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/onflow/cadence/stdlib"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
+	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
 func TestInterpretForStatement(t *testing.T) {
@@ -843,12 +844,14 @@ func TestInclusiveRangeForInLoop(t *testing.T) {
 
 			inter, err := parseCheckAndPrepareWithOptions(t, code,
 				ParseCheckAndInterpretOptions{
-					CheckerConfig: &sema.Config{
-						BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
-							return baseValueActivation
+					ParseAndCheckOptions: &ParseAndCheckOptions{
+						CheckerConfig: &sema.Config{
+							BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
+								return baseValueActivation
+							},
 						},
 					},
-					Config: &interpreter.Config{
+					InterpreterConfig: &interpreter.Config{
 						BaseActivationHandler: func(common.Location) *interpreter.VariableActivation {
 							return baseActivation
 						},

--- a/interpreter/function_test.go
+++ b/interpreter/function_test.go
@@ -365,12 +365,14 @@ func TestInterpretGenericFunctionSubtyping(t *testing.T) {
 		return parseCheckAndPrepareWithOptions(t,
 			code,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},

--- a/interpreter/idcapability_test.go
+++ b/interpreter/idcapability_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/stdlib"
 	"github.com/onflow/cadence/test_utils/common_utils"
+	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
 type noopReferenceTracker struct{}
@@ -96,19 +97,20 @@ func TestInterpretIDCapability(t *testing.T) {
 			t,
 			code,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
+					},
+				},
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
 					CapabilityBorrowHandler: handlers.borrow,
 					CapabilityCheckHandler:  handlers.check,
 				},
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
-					},
-				},
-				HandleCheckerError: nil,
 			},
 		)
 	}

--- a/interpreter/if_test.go
+++ b/interpreter/if_test.go
@@ -37,6 +37,8 @@ func TestInterpretIfStatement(t *testing.T) {
 	t.Run("with errors", func(t *testing.T) {
 		t.Parallel()
 
+		// NOTE: invalid code not supported by compiler,
+		// tests without errors are in the next subtest "without errors"
 		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
            fun testTrue(): Int {

--- a/interpreter/import_test.go
+++ b/interpreter/import_test.go
@@ -72,6 +72,7 @@ func TestInterpretVirtualImport(t *testing.T) {
 		Type:            fooType,
 	})
 
+	// NOTE: virtual imports are not supported by the compiler/VM
 	inter, err := parseCheckAndInterpretWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{

--- a/interpreter/import_test.go
+++ b/interpreter/import_test.go
@@ -75,7 +75,16 @@ func TestInterpretVirtualImport(t *testing.T) {
 	inter, err := parseCheckAndInterpretWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			ParseAndCheckOptions: &ParseAndCheckOptions{
+				CheckerConfig: &sema.Config{
+					ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+						return sema.VirtualImport{
+							ValueElements: valueElements,
+						}, nil
+					},
+				},
+			},
+			InterpreterConfig: &interpreter.Config{
 				ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 
 					assert.Equal(t,
@@ -121,13 +130,6 @@ func TestInterpretVirtualImport(t *testing.T) {
 						},
 						Elaboration: elaboration,
 					}
-				},
-			},
-			CheckerConfig: &sema.Config{
-				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-					return sema.VirtualImport{
-						ValueElements: valueElements,
-					}, nil
 				},
 			},
 		},
@@ -206,7 +208,7 @@ func TestInterpretImportMultipleProgramsFromLocation(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				LocationHandler: func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
 
 					require.Equal(t,
@@ -339,7 +341,7 @@ func TestInterpretResourceConstructionThroughIndirectImport(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 					require.IsType(t, common.AddressLocation{}, importedLocation)
 					addressLocation := importedLocation.(common.AddressLocation)

--- a/interpreter/interface_test.go
+++ b/interpreter/interface_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/stdlib"
 	. "github.com/onflow/cadence/test_utils/common_utils"
+	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
 func parseCheckAndPrepareWithConditionLogs(
@@ -75,12 +76,14 @@ func parseCheckAndPrepareWithConditionLogs(
 	invokable, err = parseCheckAndPrepareWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{
-			CheckerConfig: &sema.Config{
-				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-					return baseValueActivation
+			ParseAndCheckOptions: &ParseAndCheckOptions{
+				CheckerConfig: &sema.Config{
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				BaseActivationHandler: func(common.Location) *interpreter.VariableActivation {
 					return baseActivation
 				},
@@ -1272,8 +1275,7 @@ func TestInterpretNestedInterfaceCast(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			CheckerConfig: &sema.Config{},
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 		},

--- a/interpreter/invocation_test.go
+++ b/interpreter/invocation_test.go
@@ -19,6 +19,7 @@
 package interpreter_test
 
 import (
+	goruntime "runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -177,7 +178,7 @@ func TestInterpretRejectUnboxedInvocation(t *testing.T) {
 		func() {
 			defer func() {
 				recoverErr := recover()
-				require.IsType(t, &runtime.TypeAssertionError{}, recoverErr)
+				require.IsType(t, &goruntime.TypeAssertionError{}, recoverErr)
 				require.ErrorContains(
 					t,
 					recoverErr.(error),

--- a/interpreter/invocation_test.go
+++ b/interpreter/invocation_test.go
@@ -19,7 +19,6 @@
 package interpreter_test
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/interpreter/member_test.go
+++ b/interpreter/member_test.go
@@ -1064,6 +1064,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("resource reference, attachment", func(t *testing.T) {
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             resource R {}
 
@@ -1085,6 +1086,7 @@ func TestInterpretMemberAccess(t *testing.T) {
 	t.Run("attachment nested member", func(t *testing.T) {
 		t.Parallel()
 
+		// TODO: requires support for attachments in the VM
 		inter := parseCheckAndInterpret(t, `
             resource R {}
 

--- a/interpreter/memory_metering_test.go
+++ b/interpreter/memory_metering_test.go
@@ -63,6 +63,25 @@ func (g *testMemoryGauge) getMemory(kind common.MemoryKind) uint64 {
 	return g.meter[kind]
 }
 
+func parseCheckAndInterpretWithMemoryMetering(
+	t *testing.T,
+	code string,
+	gauge common.MemoryGauge,
+) (Invokable, error) {
+	return parseCheckAndInterpretWithOptions(
+		t,
+		code,
+		ParseCheckAndInterpretOptions{
+			ParseAndCheckOptions: &ParseAndCheckOptions{
+				MemoryGauge: gauge,
+			},
+			InterpreterConfig: &interpreter.Config{
+				MemoryGauge: gauge,
+			},
+		},
+	)
+}
+
 func TestInterpretArrayMetering(t *testing.T) {
 
 	t.Parallel()
@@ -79,17 +98,18 @@ func TestInterpretArrayMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(25), meter.getMemory(common.MemoryKindArrayValueBase))
 		assert.Equal(t, uint64(20), meter.getMemory(common.MemoryKindAtreeArrayDataSlab))
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindAtreeArrayMetaDataSlab))
 		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindAtreeArrayElementOverhead))
-		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindVariable))
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindElaboration))
+		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindVariable))
 		// 1 Int8 for type
 		// 2 String: 1 for type, 1 for value
 		// 3 Bool: 1 for type, 2 for value
@@ -110,9 +130,10 @@ func TestInterpretArrayMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(26), meter.getMemory(common.MemoryKindArrayValueBase))
@@ -137,9 +158,10 @@ func TestInterpretArrayMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayValueBase))
@@ -161,9 +183,10 @@ func TestInterpretArrayMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayValueBase))
@@ -191,9 +214,10 @@ func TestInterpretArrayMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayValueBase))
@@ -217,9 +241,10 @@ func TestInterpretArrayMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayValueBase))
@@ -239,9 +264,10 @@ func TestInterpretArrayMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayValueBase))
@@ -261,9 +287,10 @@ func TestInterpretArrayMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayValueBase))
@@ -285,9 +312,10 @@ func TestInterpretArrayMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayValueBase))
@@ -307,9 +335,10 @@ func TestInterpretArrayMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayValueBase))
@@ -332,9 +361,10 @@ func TestInterpretArrayMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(37), meter.getMemory(common.MemoryKindArrayValueBase))
@@ -363,9 +393,10 @@ func TestInterpretArrayMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindArrayValueBase))
@@ -396,9 +427,10 @@ func TestInterpretDictionaryMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(9), meter.getMemory(common.MemoryKindDictionaryValueBase))
@@ -424,9 +456,10 @@ func TestInterpretDictionaryMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindDictionaryValueBase))
@@ -451,9 +484,10 @@ func TestInterpretDictionaryMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindPrimitiveStaticType))
@@ -471,9 +505,10 @@ func TestInterpretDictionaryMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindDictionaryValueBase))
@@ -504,9 +539,10 @@ func TestInterpretDictionaryMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindDictionaryValueBase))
@@ -535,9 +571,10 @@ func TestInterpretDictionaryMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindDictionaryValueBase))
@@ -560,9 +597,10 @@ func TestInterpretDictionaryMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindDictionaryValueBase))
@@ -585,9 +623,10 @@ func TestInterpretDictionaryMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindDictionaryValueBase))
@@ -623,9 +662,10 @@ func TestInterpretCompositeMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindStringValue))
@@ -657,9 +697,10 @@ func TestInterpretCompositeMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(24), meter.getMemory(common.MemoryKindCompositeValueBase))
@@ -686,7 +727,8 @@ func TestInterpretSimpleCompositeMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
 		address := common.MustBytesToAddress([]byte{0x1})
 
@@ -698,7 +740,7 @@ func TestInterpretSimpleCompositeMetering(t *testing.T) {
 			interpreter.EmptyLocationRange,
 		)
 
-		_, err := inter.Invoke("main", account)
+		_, err = inter.Invoke("main", account)
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindSimpleCompositeValueBase))
@@ -721,9 +763,10 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindRawString))
@@ -751,9 +794,10 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindRawString))
@@ -784,9 +828,10 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindRawString))
@@ -809,9 +854,10 @@ func TestInterpretInterpretedFunctionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindInterpretedFunctionValue))
@@ -830,9 +876,10 @@ func TestInterpretInterpretedFunctionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// 1 for the main, and 1 for the anon-func
@@ -856,9 +903,10 @@ func TestInterpretInterpretedFunctionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// 1 for the main, and 1 for the anon-func.
@@ -880,9 +928,10 @@ func TestInterpretInterpretedFunctionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// 1 for the main, and 1 for the struct method.
@@ -901,9 +950,10 @@ func TestInterpretInterpretedFunctionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// 1 for the main, and 1 for the struct init.
@@ -924,9 +974,10 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindHostFunctionValue))
 	})
@@ -948,9 +999,10 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindHostFunctionValue))
 	})
@@ -967,9 +1019,10 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// 1 for the struct method.
@@ -988,9 +1041,10 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// 1 for the struct init.
@@ -1009,9 +1063,10 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// builtin functions are not metered
@@ -1038,22 +1093,26 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 			interpreter.Declare(baseActivation, valueDeclaration)
 		}
 
-		inter, err := parseCheckAndInterpretWithOptionsAndMemoryMetering(
+		// TODO: requires standard library values for VM
+		inter, err := parseCheckAndInterpretWithOptions(
 			t,
 			script,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					MemoryGauge: meter,
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
+					MemoryGauge: meter,
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
 				},
 			},
-			meter,
 		)
 		require.NoError(t, err)
 
@@ -1089,22 +1148,26 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 		}
 
 		meter := newTestMemoryGauge()
-		inter, err := parseCheckAndInterpretWithOptionsAndMemoryMetering(
+		// TODO: requires standard library values for VM
+		inter, err := parseCheckAndInterpretWithOptions(
 			t,
 			script,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					MemoryGauge: meter,
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
+					MemoryGauge: meter,
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
 				},
 			},
-			meter,
 		)
 		require.NoError(t, err)
 
@@ -1145,22 +1208,26 @@ func TestInterpretHostFunctionMetering(t *testing.T) {
 		}
 
 		meter := newTestMemoryGauge()
-		inter, err := parseCheckAndInterpretWithOptionsAndMemoryMetering(
+		// TODO: requires standard library values for VM
+		inter, err := parseCheckAndInterpretWithOptions(
 			t,
 			script,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					MemoryGauge: meter,
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
+					MemoryGauge: meter,
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
 				},
 			},
-			meter,
 		)
 		require.NoError(t, err)
 
@@ -1187,9 +1254,10 @@ func TestInterpretBoundFunctionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// No bound functions are created without usages.
@@ -1208,9 +1276,10 @@ func TestInterpretBoundFunctionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// No bound functions are created without usages.
@@ -1234,9 +1303,10 @@ func TestInterpretBoundFunctionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// 3 bound functions are created for the 3 invocations of 'bar()'.
@@ -1258,9 +1328,10 @@ func TestInterpretOptionalValueMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindOptionalValue))
@@ -1278,9 +1349,10 @@ func TestInterpretOptionalValueMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// 2 for `z`
@@ -1303,9 +1375,10 @@ func TestInterpretOptionalValueMetering(t *testing.T) {
 
 		meter := newTestMemoryGauge()
 
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// 1 from creating new entry by setting x[0]
@@ -1324,9 +1397,10 @@ func TestInterpretOptionalValueMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// 0: optional type is created here, not an optional value
@@ -1351,9 +1425,10 @@ func TestInterpretIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindBigInt))
@@ -1370,9 +1445,10 @@ func TestInterpretIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(64), meter.getMemory(common.MemoryKindBigInt))
@@ -1389,9 +1465,10 @@ func TestInterpretIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1408,9 +1485,10 @@ func TestInterpretIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(64), meter.getMemory(common.MemoryKindBigInt))
@@ -1427,9 +1505,10 @@ func TestInterpretIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1446,9 +1525,10 @@ func TestInterpretIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1465,9 +1545,10 @@ func TestInterpretIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1484,9 +1565,10 @@ func TestInterpretIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1503,9 +1585,10 @@ func TestInterpretIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1522,9 +1605,10 @@ func TestInterpretIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(64), meter.getMemory(common.MemoryKindBigInt))
@@ -1541,9 +1625,10 @@ func TestInterpretIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1561,9 +1646,10 @@ func TestInterpretIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(48), meter.getMemory(common.MemoryKindBigInt))
@@ -1585,9 +1671,10 @@ func TestInterpretUIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8
@@ -1605,9 +1692,10 @@ func TestInterpretUIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(64), meter.getMemory(common.MemoryKindBigInt))
@@ -1624,9 +1712,10 @@ func TestInterpretUIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1643,9 +1732,10 @@ func TestInterpretUIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1662,9 +1752,10 @@ func TestInterpretUIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(64), meter.getMemory(common.MemoryKindBigInt))
@@ -1681,9 +1772,10 @@ func TestInterpretUIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1700,9 +1792,10 @@ func TestInterpretUIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1719,9 +1812,10 @@ func TestInterpretUIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1738,9 +1832,10 @@ func TestInterpretUIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1757,9 +1852,10 @@ func TestInterpretUIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1776,9 +1872,10 @@ func TestInterpretUIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(64), meter.getMemory(common.MemoryKindBigInt))
@@ -1795,9 +1892,10 @@ func TestInterpretUIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(56), meter.getMemory(common.MemoryKindBigInt))
@@ -1815,9 +1913,10 @@ func TestInterpretUIntMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(48), meter.getMemory(common.MemoryKindBigInt))
@@ -1839,9 +1938,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1
@@ -1859,9 +1959,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -1880,9 +1981,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -1901,9 +2003,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -1922,9 +2025,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -1943,9 +2047,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -1964,9 +2069,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -1985,9 +2091,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -2006,9 +2113,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -2027,9 +2135,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -2048,9 +2157,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -2069,9 +2179,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -2091,9 +2202,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -2112,9 +2224,10 @@ func TestInterpretUInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -2138,9 +2251,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2
@@ -2158,9 +2272,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -2179,9 +2294,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -2200,9 +2316,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -2221,9 +2338,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -2242,9 +2360,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -2263,9 +2382,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -2284,9 +2404,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -2305,9 +2426,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -2326,9 +2448,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -2347,9 +2470,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -2368,9 +2492,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -2389,9 +2514,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -2410,9 +2536,10 @@ func TestInterpretUInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -2436,9 +2563,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4
@@ -2456,9 +2584,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -2477,9 +2606,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -2498,9 +2628,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -2519,9 +2650,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -2540,9 +2672,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -2561,9 +2694,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -2582,9 +2716,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -2603,9 +2738,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -2624,9 +2760,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -2645,9 +2782,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -2666,9 +2804,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -2687,9 +2826,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -2708,9 +2848,10 @@ func TestInterpretUInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -2734,9 +2875,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8
@@ -2754,9 +2896,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -2775,9 +2918,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -2796,9 +2940,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -2817,9 +2962,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -2838,9 +2984,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -2859,9 +3006,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -2880,9 +3028,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -2901,9 +3050,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -2922,9 +3072,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -2943,9 +3094,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -2964,9 +3116,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -2985,9 +3138,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3006,9 +3160,10 @@ func TestInterpretUInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3032,9 +3187,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8
@@ -3052,9 +3208,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3073,9 +3230,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3094,9 +3252,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3115,9 +3274,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3137,9 +3297,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3158,9 +3319,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3179,9 +3341,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3200,9 +3363,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3221,9 +3385,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3242,9 +3407,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3263,9 +3429,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3284,9 +3451,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8 + 16
@@ -3305,9 +3473,10 @@ func TestInterpretUInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3331,9 +3500,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8
@@ -3351,9 +3521,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3372,9 +3543,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3393,9 +3565,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3414,9 +3587,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3435,9 +3609,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3456,9 +3631,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3477,9 +3653,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3498,9 +3675,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3519,9 +3697,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3540,9 +3719,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3561,9 +3741,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3582,9 +3763,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8 + 32
@@ -3603,9 +3785,10 @@ func TestInterpretUInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -3629,9 +3812,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindNumberValue))
@@ -3648,9 +3832,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two operands (literals): 1 + 1
@@ -3670,9 +3855,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 1 + 1
@@ -3691,9 +3877,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two operands (literals): 1 + 1
@@ -3713,9 +3900,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 1 + 1
@@ -3734,9 +3922,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two operands (literals): 1 + 1
@@ -3756,9 +3945,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 1 + 1
@@ -3777,9 +3967,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two operands (literals): 1 + 1
@@ -3799,9 +3990,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 1 + 1
@@ -3820,9 +4012,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 1 + 1
@@ -3842,9 +4035,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// x: 1
@@ -3863,9 +4057,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 1 + 1
@@ -3884,9 +4079,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 1 + 1
@@ -3905,9 +4101,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 1 + 1
@@ -3926,9 +4123,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 1 + 1
@@ -3947,9 +4145,10 @@ func TestInterpretInt8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 1 + 1
@@ -3974,9 +4173,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindNumberValue))
@@ -3993,9 +4193,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4015,9 +4216,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4036,9 +4238,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4058,9 +4261,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4079,9 +4283,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4101,9 +4306,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4122,9 +4328,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4144,9 +4351,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4165,9 +4373,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4187,9 +4396,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// x: 2
@@ -4208,9 +4418,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4229,9 +4440,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4250,9 +4462,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4271,9 +4484,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4292,9 +4506,10 @@ func TestInterpretInt16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 2 + 2
@@ -4318,9 +4533,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindNumberValue))
@@ -4337,9 +4553,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4359,9 +4576,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4380,9 +4598,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4402,9 +4621,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4423,9 +4643,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4445,9 +4666,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4466,9 +4688,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4488,9 +4711,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4509,9 +4733,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4531,9 +4756,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// x: 4
@@ -4552,9 +4778,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4573,9 +4800,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4594,9 +4822,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4615,9 +4844,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4636,9 +4866,10 @@ func TestInterpretInt32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 4 + 4
@@ -4662,9 +4893,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindNumberValue))
@@ -4681,9 +4913,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -4703,9 +4936,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -4724,9 +4958,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -4746,9 +4981,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -4767,9 +5003,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -4789,9 +5026,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -4810,9 +5048,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -4832,9 +5071,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -4853,9 +5093,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -4875,9 +5116,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// x: 8
@@ -4896,9 +5138,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -4917,9 +5160,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -4938,9 +5182,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -4959,9 +5204,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -4980,9 +5226,10 @@ func TestInterpretInt64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5006,9 +5253,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindBigInt))
@@ -5025,9 +5273,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5047,9 +5296,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5068,9 +5318,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5090,9 +5341,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5111,9 +5363,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5133,9 +5386,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5154,9 +5408,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5176,9 +5431,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5197,9 +5453,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5219,9 +5476,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// x: 16
@@ -5240,9 +5498,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5261,9 +5520,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5282,9 +5542,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5303,9 +5564,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8 + 16
@@ -5324,9 +5586,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5351,9 +5614,10 @@ func TestInterpretInt128Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindElaboration))
@@ -5375,9 +5639,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindBigInt))
@@ -5394,9 +5659,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5416,9 +5682,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5437,9 +5704,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5459,9 +5727,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5480,9 +5749,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5502,9 +5772,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5523,9 +5794,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5545,9 +5817,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5566,9 +5839,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5588,9 +5862,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// x: 32
@@ -5609,9 +5884,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5630,9 +5906,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5651,9 +5928,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5672,9 +5950,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8 + 32
@@ -5693,9 +5972,10 @@ func TestInterpretInt256Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -5719,9 +5999,10 @@ func TestInterpretWord8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1
@@ -5740,9 +6021,10 @@ func TestInterpretWord8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -5761,9 +6043,10 @@ func TestInterpretWord8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -5782,9 +6065,10 @@ func TestInterpretWord8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -5803,9 +6087,10 @@ func TestInterpretWord8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -5824,9 +6109,10 @@ func TestInterpretWord8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -5845,9 +6131,10 @@ func TestInterpretWord8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -5866,9 +6153,10 @@ func TestInterpretWord8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -5887,9 +6175,10 @@ func TestInterpretWord8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -5908,9 +6197,10 @@ func TestInterpretWord8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -5929,9 +6219,10 @@ func TestInterpretWord8Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 1 + 1
@@ -5955,9 +6246,10 @@ func TestInterpretWord16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2
@@ -5975,9 +6267,10 @@ func TestInterpretWord16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -5996,9 +6289,10 @@ func TestInterpretWord16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -6017,9 +6311,10 @@ func TestInterpretWord16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -6038,9 +6333,10 @@ func TestInterpretWord16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -6059,9 +6355,10 @@ func TestInterpretWord16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -6080,9 +6377,10 @@ func TestInterpretWord16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -6101,9 +6399,10 @@ func TestInterpretWord16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -6122,9 +6421,10 @@ func TestInterpretWord16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -6143,9 +6443,10 @@ func TestInterpretWord16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -6164,9 +6465,10 @@ func TestInterpretWord16Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 2 + 2
@@ -6190,9 +6492,10 @@ func TestInterpretWord32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4
@@ -6210,9 +6513,10 @@ func TestInterpretWord32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -6231,9 +6535,10 @@ func TestInterpretWord32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -6252,9 +6557,10 @@ func TestInterpretWord32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -6273,9 +6579,10 @@ func TestInterpretWord32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -6294,9 +6601,10 @@ func TestInterpretWord32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -6315,9 +6623,10 @@ func TestInterpretWord32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -6336,9 +6645,10 @@ func TestInterpretWord32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -6357,9 +6667,10 @@ func TestInterpretWord32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -6378,9 +6689,10 @@ func TestInterpretWord32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -6399,9 +6711,10 @@ func TestInterpretWord32Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 4 + 4
@@ -6425,9 +6738,10 @@ func TestInterpretWord64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8
@@ -6445,9 +6759,10 @@ func TestInterpretWord64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -6466,9 +6781,10 @@ func TestInterpretWord64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -6487,9 +6803,10 @@ func TestInterpretWord64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -6508,9 +6825,10 @@ func TestInterpretWord64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -6529,9 +6847,10 @@ func TestInterpretWord64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -6550,9 +6869,10 @@ func TestInterpretWord64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -6571,9 +6891,10 @@ func TestInterpretWord64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -6592,9 +6913,10 @@ func TestInterpretWord64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -6613,9 +6935,10 @@ func TestInterpretWord64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -6634,9 +6957,10 @@ func TestInterpretWord64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// creation: 8 + 8
@@ -6660,7 +6984,8 @@ func TestInterpretStorageReferenceValueMetering(t *testing.T) {
           `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
 		address := common.MustBytesToAddress([]byte{0x1})
 		authorization := interpreter.NewEntitlementSetAuthorization(
@@ -6673,9 +6998,15 @@ func TestInterpretStorageReferenceValueMetering(t *testing.T) {
 			1,
 			sema.Conjunction,
 		)
-		account := stdlib.NewAccountReferenceValue(inter, nil, interpreter.AddressValue(address), authorization, interpreter.EmptyLocationRange)
+		account := stdlib.NewAccountReferenceValue(
+			inter,
+			nil,
+			interpreter.AddressValue(address),
+			authorization,
+			interpreter.EmptyLocationRange,
+		)
 
-		_, err := inter.Invoke("main", account)
+		_, err = inter.Invoke("main", account)
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindStorageReferenceValue))
@@ -6699,9 +7030,10 @@ func TestInterpretEphemeralReferenceValueMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindEphemeralReferenceValue))
@@ -6721,9 +7053,10 @@ func TestInterpretEphemeralReferenceValueMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindEphemeralReferenceValue))
@@ -6744,9 +7077,10 @@ func TestInterpretStringMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindStringValue))
@@ -6763,9 +7097,10 @@ func TestInterpretStringMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindStringValue))
@@ -6781,9 +7116,10 @@ func TestInterpretStringMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindStringValue))
@@ -6799,9 +7135,10 @@ func TestInterpretStringMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// 1 + 3 (abc)
@@ -6818,9 +7155,10 @@ func TestInterpretStringMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// 1 + 4 (max UTF8 encoding)
@@ -6840,9 +7178,10 @@ func TestInterpretCharacterMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindCharacterValue))
@@ -6859,9 +7198,10 @@ func TestInterpretCharacterMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindCharacterValue))
@@ -6878,9 +7218,10 @@ func TestInterpretCharacterMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindCharacterValue))
@@ -6899,9 +7240,10 @@ func TestInterpretAddressValueMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindAddressValue))
@@ -6916,9 +7258,10 @@ func TestInterpretAddressValueMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindAddressValue))
@@ -6937,9 +7280,10 @@ func TestInterpretPathValueMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindPathValue))
@@ -6954,9 +7298,10 @@ func TestInterpretPathValueMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindPathValue))
@@ -6989,9 +7334,10 @@ func TestInterpretTypeValueMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindTypeValue))
@@ -7007,9 +7353,10 @@ func TestInterpretTypeValueMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindTypeValue))
@@ -7025,9 +7372,10 @@ func TestInterpretTypeValueMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindTypeValue))
@@ -7049,9 +7397,10 @@ func TestInterpretVariableMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindVariable))
@@ -7066,9 +7415,10 @@ func TestInterpretVariableMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke(
+		_, err = inter.Invoke(
 			"main",
 			interpreter.NewUnmeteredStringValue(""),
 			interpreter.FalseValue,
@@ -7087,9 +7437,10 @@ func TestInterpretVariableMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindVariable))
@@ -7105,9 +7456,10 @@ func TestInterpretVariableMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindVariable))
@@ -7129,9 +7481,10 @@ func TestInterpretFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindNumberValue))
@@ -7149,9 +7502,10 @@ func TestInterpretFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7172,9 +7526,10 @@ func TestInterpretFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7194,9 +7549,10 @@ func TestInterpretFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7217,9 +7573,10 @@ func TestInterpretFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7239,9 +7596,10 @@ func TestInterpretFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7262,9 +7620,10 @@ func TestInterpretFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7284,9 +7643,10 @@ func TestInterpretFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7307,9 +7667,10 @@ func TestInterpretFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7329,9 +7690,10 @@ func TestInterpretFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7355,9 +7717,10 @@ func TestInterpretFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// x: 8
@@ -7378,9 +7741,10 @@ func TestInterpretFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindNumberValue))
@@ -7404,9 +7768,10 @@ func TestInterpretFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(224), meter.getMemory(common.MemoryKindBigInt))
@@ -7428,9 +7793,10 @@ func TestInterpretUFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindNumberValue))
@@ -7448,9 +7814,10 @@ func TestInterpretUFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7471,9 +7838,10 @@ func TestInterpretUFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7493,9 +7861,10 @@ func TestInterpretUFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7516,9 +7885,10 @@ func TestInterpretUFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7538,9 +7908,10 @@ func TestInterpretUFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7561,9 +7932,10 @@ func TestInterpretUFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7583,9 +7955,10 @@ func TestInterpretUFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7606,9 +7979,10 @@ func TestInterpretUFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7628,9 +8002,10 @@ func TestInterpretUFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// two literals: 8 + 8
@@ -7653,9 +8028,10 @@ func TestInterpretUFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindNumberValue))
@@ -7679,9 +8055,10 @@ func TestInterpretUFix64Metering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(224), meter.getMemory(common.MemoryKindBigInt))
@@ -7708,9 +8085,10 @@ func TestInterpretTokenMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(30), meter.getMemory(common.MemoryKindTypeToken))
@@ -7730,9 +8108,10 @@ func TestInterpretTokenMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 		assert.Equal(t, uint64(35), meter.getMemory(common.MemoryKindTypeToken))
 		assert.Equal(t, uint64(30), meter.getMemory(common.MemoryKindSpaceToken))
@@ -7751,9 +8130,10 @@ func TestInterpretTokenMetering(t *testing.T) {
           fun main() {}
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 		assert.Equal(t, uint64(10), meter.getMemory(common.MemoryKindTypeToken))
 		assert.Equal(t, uint64(6), meter.getMemory(common.MemoryKindSpaceToken))
@@ -7773,9 +8153,10 @@ func TestInterpretTokenMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 		assert.Equal(t, uint64(26), meter.getMemory(common.MemoryKindTypeToken))
 		assert.Equal(t, uint64(25), meter.getMemory(common.MemoryKindSpaceToken))
@@ -7799,9 +8180,10 @@ func TestInterpreterStringLocationMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		emptyLocationStringCount := meter.getMemory(common.MemoryKindRawString)
@@ -7817,7 +8199,8 @@ func TestInterpreterStringLocationMetering(t *testing.T) {
         `
 
 		meter = newTestMemoryGauge()
-		inter = parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err = parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
 		_, err = inter.Invoke("main")
 		require.NoError(t, err)
@@ -7846,9 +8229,10 @@ func TestInterpretIdentifierMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		// 'main', 'foo', 'bar', empty-return-type
@@ -7863,9 +8247,10 @@ func TestInterpretIdentifierMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke(
+		_, err = inter.Invoke(
 			"main",
 			interpreter.NewUnmeteredStringValue("x"),
 			interpreter.NewUnmeteredStringValue("y"),
@@ -7896,9 +8281,10 @@ func TestInterpretIdentifierMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 		assert.Equal(t, uint64(15), meter.getMemory(common.MemoryKindIdentifier))
 	})
@@ -7917,9 +8303,10 @@ func TestInterpretIdentifierMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 		assert.Equal(t, uint64(14), meter.getMemory(common.MemoryKindIdentifier))
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindPrimitiveStaticType))
@@ -7945,9 +8332,10 @@ func TestInterpretInterfaceStaticType(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindInterfaceStaticType))
@@ -7968,9 +8356,10 @@ func TestInterpretFunctionStaticType(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindFunctionStaticType))
@@ -7988,9 +8377,10 @@ func TestInterpretFunctionStaticType(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindFunctionStaticType))
@@ -8011,9 +8401,10 @@ func TestInterpretFunctionStaticType(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindFunctionStaticType))
@@ -8034,9 +8425,10 @@ func TestInterpretFunctionStaticType(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindFunctionStaticType))
@@ -8062,9 +8454,10 @@ func TestInterpretASTMetering(t *testing.T) {
           }
         `
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindArgument))
@@ -8095,9 +8488,10 @@ func TestInterpretASTMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 		assert.Equal(t, uint64(7), meter.getMemory(common.MemoryKindBlock))
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindFunctionBlock))
@@ -8158,18 +8552,23 @@ func TestInterpretASTMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		meter := newTestMemoryGauge()
-		inter, err := parseCheckAndInterpretWithOptionsAndMemoryMetering(
+		// TODO: provide import for VM
+		inter, err := parseCheckAndInterpretWithOptions(
 			t,
 			script,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					MemoryGauge: meter,
+					CheckerConfig: &sema.Config{
+						ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+							return sema.ElaborationImport{
+								Elaboration: importedChecker.Elaboration,
+							}, nil
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
+					MemoryGauge: meter,
 					ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 						require.IsType(t, common.AddressLocation{}, location)
 						program := interpreter.ProgramFromChecker(importedChecker)
@@ -8184,7 +8583,6 @@ func TestInterpretASTMetering(t *testing.T) {
 					},
 				},
 			},
-			meter,
 		)
 		require.NoError(t, err)
 
@@ -8257,11 +8655,15 @@ func TestInterpretASTMetering(t *testing.T) {
         `
 		meter := newTestMemoryGauge()
 
-		inter, err := parseCheckAndInterpretWithOptionsAndMemoryMetering(
+		inter, err := parseCheckAndInterpretWithOptions(
 			t,
 			script,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					MemoryGauge: meter,
+				},
+				InterpreterConfig: &interpreter.Config{
+					MemoryGauge: meter,
 					ContractValueHandler: func(
 						inter *interpreter.Interpreter,
 						compositeType *sema.CompositeType,
@@ -8273,7 +8675,6 @@ func TestInterpretASTMetering(t *testing.T) {
 					},
 				},
 			},
-			meter,
 		)
 		require.NoError(t, err)
 
@@ -8331,9 +8732,10 @@ func TestInterpretASTMetering(t *testing.T) {
         `
 		meter := newTestMemoryGauge()
 
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindBooleanExpression))
@@ -8387,9 +8789,10 @@ func TestInterpretASTMetering(t *testing.T) {
         `
 		meter := newTestMemoryGauge()
 
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindConstantSizedType))
@@ -8429,9 +8832,10 @@ func TestInterpretASTMetering(t *testing.T) {
 
 		meter := newTestMemoryGauge()
 
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(200), meter.getMemory(common.MemoryKindPosition))
@@ -8456,18 +8860,23 @@ func TestInterpretASTMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		meter := newTestMemoryGauge()
-		_, err = parseCheckAndInterpretWithOptionsAndMemoryMetering(
+		// TODO: provide import for VM
+		_, err = parseCheckAndInterpretWithOptions(
 			t,
 			script,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
-						return sema.ElaborationImport{
-							Elaboration: importedChecker.Elaboration,
-						}, nil
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					MemoryGauge: meter,
+					CheckerConfig: &sema.Config{
+						ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+							return sema.ElaborationImport{
+								Elaboration: importedChecker.Elaboration,
+							}, nil
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
+					MemoryGauge: meter,
 					ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
 						program := interpreter.ProgramFromChecker(importedChecker)
 						subInterpreter, err := inter.NewSubInterpreter(program, location)
@@ -8481,7 +8890,6 @@ func TestInterpretASTMetering(t *testing.T) {
 					},
 				},
 			},
-			meter,
 		)
 		require.NoError(t, err)
 
@@ -8502,9 +8910,10 @@ func TestInterpretVariableActivationMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindActivation))
@@ -8525,9 +8934,10 @@ func TestInterpretVariableActivationMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(5), meter.getMemory(common.MemoryKindActivation))
@@ -8547,9 +8957,10 @@ func TestInterpretVariableActivationMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindActivation))
@@ -8577,9 +8988,10 @@ func TestInterpretStaticTypeConversionMetering(t *testing.T) {
         `
 
 		meter := newTestMemoryGauge()
-		inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+		require.NoError(t, err)
 
-		_, err := inter.Invoke("main")
+		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindDictionarySemaType))
@@ -8605,7 +9017,8 @@ func TestInterpretStorageMapMetering(t *testing.T) {
     `
 
 	meter := newTestMemoryGauge()
-	inter := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+	inter, err := parseCheckAndInterpretWithMemoryMetering(t, script, meter)
+	require.NoError(t, err)
 
 	address := interpreter.AddressValue(common.MustBytesToAddress([]byte{0x1}))
 	authorization := interpreter.NewEntitlementSetAuthorization(
@@ -8626,7 +9039,7 @@ func TestInterpretStorageMapMetering(t *testing.T) {
 		interpreter.EmptyLocationRange,
 	)
 
-	_, err := inter.Invoke("main", account)
+	_, err = inter.Invoke("main", account)
 	require.NoError(t, err)
 
 	assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindStorageMap))
@@ -8673,20 +9086,25 @@ func TestInterpretValueStringConversion(t *testing.T) {
 		baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
 		interpreter.Declare(baseActivation, logFunction)
 
-		inter, err := parseCheckAndInterpretWithOptionsAndMemoryMetering(t, script,
+		inter, err := parseCheckAndInterpretWithOptions(
+			t,
+			script,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
+					MemoryGauge: meter,
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
 				},
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					MemoryGauge: meter,
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
 			},
-			meter,
 		)
 		require.NoError(t, err)
 
@@ -9017,20 +9435,25 @@ func TestInterpretStaticTypeStringConversion(t *testing.T) {
 		baseActivation := activations.NewActivation(nil, interpreter.BaseActivation)
 		interpreter.Declare(baseActivation, logFunction)
 
-		inter, err := parseCheckAndInterpretWithOptionsAndMemoryMetering(t, script,
+		inter, err := parseCheckAndInterpretWithOptions(
+			t,
+			script,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					MemoryGauge: meter,
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
+					},
+				},
+				InterpreterConfig: &interpreter.Config{
+					MemoryGauge: meter,
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
 				},
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
-					},
-				},
 			},
-			meter,
 		)
 		require.NoError(t, err)
 
@@ -9191,11 +9614,12 @@ func TestInterpretBytesMetering(t *testing.T) {
     `
 
 	meter := newTestMemoryGauge()
-	inter := parseCheckAndInterpretWithMemoryMetering(t, code, meter)
+	inter, err := parseCheckAndInterpretWithMemoryMetering(t, code, meter)
+	require.NoError(t, err)
 
 	stringValue := interpreter.NewUnmeteredStringValue("abc")
 
-	_, err := inter.Invoke("test", stringValue)
+	_, err = inter.Invoke("test", stringValue)
 	require.NoError(t, err)
 
 	// 1 + 3

--- a/interpreter/metatype_test.go
+++ b/interpreter/metatype_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/onflow/cadence/stdlib"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
+	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
 func TestInterpretMetaTypeEquality(t *testing.T) {
@@ -142,12 +143,14 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
               let result = Type<Int>() == unknownType
             `,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
@@ -202,12 +205,14 @@ func TestInterpretMetaTypeEquality(t *testing.T) {
               let result = unknownType1 == unknownType2
             `,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
@@ -295,12 +300,14 @@ func TestInterpretMetaTypeIdentifier(t *testing.T) {
               let identifier = unknownType.identifier
             `,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
@@ -454,12 +461,14 @@ func TestInterpretIsInstance(t *testing.T) {
 			inter, err := parseCheckAndPrepareWithOptions(t,
 				testCase.code,
 				ParseCheckAndInterpretOptions{
-					CheckerConfig: &sema.Config{
-						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-							return baseValueActivation
+					ParseAndCheckOptions: &ParseAndCheckOptions{
+						CheckerConfig: &sema.Config{
+							BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+								return baseValueActivation
+							},
 						},
 					},
-					Config: &interpreter.Config{
+					InterpreterConfig: &interpreter.Config{
 						BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 							return baseActivation
 						},
@@ -601,12 +610,14 @@ func TestInterpretMetaTypeIsSubtype(t *testing.T) {
 			inter, err := parseCheckAndPrepareWithOptions(t,
 				testCase.code,
 				ParseCheckAndInterpretOptions{
-					CheckerConfig: &sema.Config{
-						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-							return baseValueActivation
+					ParseAndCheckOptions: &ParseAndCheckOptions{
+						CheckerConfig: &sema.Config{
+							BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+								return baseValueActivation
+							},
 						},
 					},
-					Config: &interpreter.Config{
+					InterpreterConfig: &interpreter.Config{
 						BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 							return baseActivation
 						},
@@ -1014,12 +1025,14 @@ func TestInterpretMetaTypeIsRecovered(t *testing.T) {
 	         let isRecovered = unknownType.isRecovered
 	       `,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
@@ -1047,7 +1060,7 @@ func TestInterpretMetaTypeIsRecovered(t *testing.T) {
                }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ImportLocationHandler: func(_ *interpreter.Interpreter, _ common.Location) interpreter.Import {
 						elaboration := sema.NewElaboration(nil)
 						elaboration.IsRecovered = true
@@ -1088,7 +1101,7 @@ func TestInterpretMetaTypeIsRecovered(t *testing.T) {
               }
            `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ImportLocationHandler: func(_ *interpreter.Interpreter, _ common.Location) interpreter.Import {
 						panic(importErr)
 					},
@@ -1144,7 +1157,7 @@ func TestInterpretMetaTypeAddress(t *testing.T) {
               }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ImportLocationHandler: func(_ *interpreter.Interpreter, _ common.Location) interpreter.Import {
 						elaboration := sema.NewElaboration(nil)
 						elaboration.SetCompositeType(
@@ -1189,7 +1202,7 @@ func TestInterpretMetaTypeAddress(t *testing.T) {
               }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ImportLocationHandler: func(_ *interpreter.Interpreter, _ common.Location) interpreter.Import {
 						elaboration := sema.NewElaboration(nil)
 						elaboration.SetCompositeType(
@@ -1249,12 +1262,14 @@ func TestInterpretMetaTypeAddress(t *testing.T) {
 	         let address = unknownType.address
 	       `,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
@@ -1322,7 +1337,7 @@ func TestInterpretMetaTypeContractName(t *testing.T) {
               }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ImportLocationHandler: func(_ *interpreter.Interpreter, _ common.Location) interpreter.Import {
 						elaboration := sema.NewElaboration(nil)
 						elaboration.SetCompositeType(
@@ -1381,7 +1396,7 @@ func TestInterpretMetaTypeContractName(t *testing.T) {
           }
         `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ImportLocationHandler: func(_ *interpreter.Interpreter, _ common.Location) interpreter.Import {
 						elaboration := sema.NewElaboration(nil)
 						elaboration.SetCompositeType(
@@ -1444,12 +1459,14 @@ func TestInterpretMetaTypeContractName(t *testing.T) {
 	         let contractName = unknownType.contractName
 	       `,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},

--- a/interpreter/metering_test.go
+++ b/interpreter/metering_test.go
@@ -415,7 +415,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
 
 		computationMeteredValues := make(map[common.ComputationKind]uint64)
 
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
             fun main() {
                 let x = [1, 2, 3]
                 let y = x.reverse()
@@ -442,7 +442,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
 
 		computationMeteredValues := make(map[common.ComputationKind]uint64)
 
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
             fun main() {
                 let x = [1, 2, 3, 4]
 			    let trueForEven = fun (_ x: Int): Bool {
@@ -472,7 +472,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
 
 		computationMeteredValues := make(map[common.ComputationKind]uint64)
 
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
             fun main() {
                 let x = [1, 2, 3, 4, 5]
 			    let onlyEven = view fun (_ x: Int): Bool {
@@ -501,7 +501,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
 		t.Parallel()
 
 		computationMeteredValues := make(map[common.ComputationKind]uint64)
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
             fun main() {
                 let x = [1, 2, 3, 4, 5, 6]
                 let y = x.slice(from: 1, upTo: 4)
@@ -527,7 +527,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
 		t.Parallel()
 
 		computationMeteredValues := make(map[common.ComputationKind]uint64)
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
             fun main() {
                 let x = [1, 2, 3]
                 let y = x.concat([4, 5, 6])
@@ -561,7 +561,7 @@ func TestInterpretStdlibComputationMetering(t *testing.T) {
 
 		computationMeteredValues := make(map[common.ComputationKind]uint64)
 
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
             fun main() {
                 let s = String.join(["one", "two", "three", "four"], separator: ", ")
             }`,
@@ -587,7 +587,7 @@ func TestInterpretStdlibComputationMetering(t *testing.T) {
 
 		computationMeteredValues := make(map[common.ComputationKind]uint64)
 
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
             fun main() {
                 let s = "a b c".concat("1 2 3")
             }`,
@@ -613,7 +613,7 @@ func TestInterpretStdlibComputationMetering(t *testing.T) {
 
 		computationMeteredValues := make(map[common.ComputationKind]uint64)
 
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
             fun main() {
                 let s = "abcadeaf".replaceAll(of: "a", with: "z")
             }`,
@@ -639,7 +639,7 @@ func TestInterpretStdlibComputationMetering(t *testing.T) {
 
 		computationMeteredValues := make(map[common.ComputationKind]uint64)
 
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
             fun main() {
                 let s = "ABCdef".toLower()
             }`,
@@ -665,7 +665,7 @@ func TestInterpretStdlibComputationMetering(t *testing.T) {
 
 		computationMeteredValues := make(map[common.ComputationKind]uint64)
 
-		inter, err := parseCheckAndInterpretWithOptions(t, `
+		inter, err := parseCheckAndPrepareWithOptions(t, `
             fun main() {
                 let s = "abc/d/ef//".split(separator: "/")
             }`,

--- a/interpreter/metering_test.go
+++ b/interpreter/metering_test.go
@@ -70,7 +70,7 @@ func TestInterpretStatementHandler(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 					assert.Equal(t,
 						ImportedLocation,
@@ -194,7 +194,7 @@ func TestInterpretLoopIterationHandler(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 					assert.Equal(t,
 						ImportedLocation,
@@ -329,7 +329,7 @@ func TestInterpretFunctionInvocationHandler(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 					assert.Equal(t,
 						ImportedLocation,
@@ -421,7 +421,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
                 let y = x.reverse()
             }`,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ComputationGauge: computationGaugeFunc(func(usage common.ComputationUsage) error {
 						computationMeteredValues[usage.Kind] += usage.Intensity
 						return nil
@@ -451,7 +451,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
                 let y = x.map(trueForEven)
             }`,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ComputationGauge: computationGaugeFunc(func(usage common.ComputationUsage) error {
 						computationMeteredValues[usage.Kind] += usage.Intensity
 						return nil
@@ -481,7 +481,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
                 let y = x.filter(onlyEven)
             }`,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ComputationGauge: computationGaugeFunc(func(usage common.ComputationUsage) error {
 						computationMeteredValues[usage.Kind] += usage.Intensity
 						return nil
@@ -507,7 +507,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
                 let y = x.slice(from: 1, upTo: 4)
             }`,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ComputationGauge: computationGaugeFunc(func(usage common.ComputationUsage) error {
 						computationMeteredValues[usage.Kind] += usage.Intensity
 						return nil
@@ -533,7 +533,7 @@ func TestInterpretArrayFunctionsComputationMetering(t *testing.T) {
                 let y = x.concat([4, 5, 6])
             }`,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ComputationGauge: computationGaugeFunc(func(usage common.ComputationUsage) error {
 						computationMeteredValues[usage.Kind] += usage.Intensity
 						return nil
@@ -566,7 +566,7 @@ func TestInterpretStdlibComputationMetering(t *testing.T) {
                 let s = String.join(["one", "two", "three", "four"], separator: ", ")
             }`,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ComputationGauge: computationGaugeFunc(func(usage common.ComputationUsage) error {
 						computationMeteredValues[usage.Kind] += usage.Intensity
 						return nil
@@ -592,7 +592,7 @@ func TestInterpretStdlibComputationMetering(t *testing.T) {
                 let s = "a b c".concat("1 2 3")
             }`,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ComputationGauge: computationGaugeFunc(func(usage common.ComputationUsage) error {
 						computationMeteredValues[usage.Kind] += usage.Intensity
 						return nil
@@ -618,7 +618,7 @@ func TestInterpretStdlibComputationMetering(t *testing.T) {
                 let s = "abcadeaf".replaceAll(of: "a", with: "z")
             }`,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ComputationGauge: computationGaugeFunc(func(usage common.ComputationUsage) error {
 						computationMeteredValues[usage.Kind] += usage.Intensity
 						return nil
@@ -644,7 +644,7 @@ func TestInterpretStdlibComputationMetering(t *testing.T) {
                 let s = "ABCdef".toLower()
             }`,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ComputationGauge: computationGaugeFunc(func(usage common.ComputationUsage) error {
 						computationMeteredValues[usage.Kind] += usage.Intensity
 						return nil
@@ -670,7 +670,7 @@ func TestInterpretStdlibComputationMetering(t *testing.T) {
                 let s = "abc/d/ef//".split(separator: "/")
             }`,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ComputationGauge: computationGaugeFunc(func(usage common.ComputationUsage) error {
 						computationMeteredValues[usage.Kind] += usage.Intensity
 						return nil

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -53,10 +53,6 @@ var parseCheckAndInterpret = test_utils.ParseCheckAndInterpret
 
 var parseCheckAndInterpretWithOptions = test_utils.ParseCheckAndInterpretWithOptions
 
-var parseCheckAndInterpretWithMemoryMetering = test_utils.ParseCheckAndInterpretWithMemoryMetering
-
-var parseCheckAndInterpretWithOptionsAndMemoryMetering = test_utils.ParseCheckAndInterpretWithOptionsAndMemoryMetering
-
 type testEvent = test_utils.TestEvent
 
 func newUnmeteredInMemoryStorage() interpreter.InMemoryStorage {
@@ -2092,7 +2088,7 @@ func TestInterpretCompositeDeclaration(t *testing.T) {
 					constructorArguments(compositeKind, ""),
 				),
 				ParseCheckAndInterpretOptions{
-					Config: &interpreter.Config{
+					InterpreterConfig: &interpreter.Config{
 						ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 					},
 				},
@@ -3758,7 +3754,7 @@ func TestInterpretCompositeNilEquality(t *testing.T) {
 					identifier,
 				),
 				ParseCheckAndInterpretOptions{
-					Config: &interpreter.Config{
+					InterpreterConfig: &interpreter.Config{
 						ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 					},
 				},
@@ -3900,7 +3896,7 @@ func TestInterpretInterfaceFieldUse(t *testing.T) {
 					teardownCode,
 				),
 				ParseCheckAndInterpretOptions{
-					Config: &interpreter.Config{
+					InterpreterConfig: &interpreter.Config{
 						ContractValueHandler: makeContractValueHandler(
 							[]interpreter.Value{
 								argument,
@@ -3989,7 +3985,7 @@ func TestInterpretInterfaceFunctionUse(t *testing.T) {
 					identifier,
 				),
 				ParseCheckAndInterpretOptions{
-					Config: &interpreter.Config{
+					InterpreterConfig: &interpreter.Config{
 						ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 					},
 				},
@@ -4031,7 +4027,7 @@ func TestInterpretImport(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 					assert.Equal(t,
 						ImportedLocation,
@@ -4105,7 +4101,7 @@ func TestInterpretImportError(t *testing.T) {
 			code,
 			ParseAndCheckOptions{
 				Location: location,
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},
@@ -5123,12 +5119,14 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 	              }
 	            `,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					Storage: storage,
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
@@ -6503,7 +6501,7 @@ func TestInterpretResourceMoveInArrayAndDestroy(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -6575,7 +6573,7 @@ func TestInterpretResourceMoveInDictionaryAndDestroy(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -6903,7 +6901,7 @@ func TestInterpretCompositeFunctionInvocationFromImportingProgram(t *testing.T) 
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 					assert.Equal(t,
 						ImportedLocation,
@@ -7063,7 +7061,7 @@ func TestInterpretResourceDestroyExpressionDestructor(t *testing.T) {
            }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -7127,7 +7125,7 @@ func TestInterpretResourceDestroyExpressionNestedResources(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -7181,7 +7179,7 @@ func TestInterpretResourceDestroyArray(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -7224,7 +7222,7 @@ func TestInterpretResourceDestroyDictionary(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -7267,7 +7265,7 @@ func TestInterpretResourceDestroyOptionalSome(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -7309,7 +7307,7 @@ func TestInterpretResourceDestroyOptionalNil(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -7381,7 +7379,7 @@ func TestInterpretEmitEvent(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -7444,7 +7442,7 @@ func TestInterpretReferenceEventParameter(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -7787,16 +7785,20 @@ func TestInterpretEmitEventParameterTypes(t *testing.T) {
 			var eventsFields [][]interpreter.Value
 
 			inter, err := parseCheckAndPrepareWithOptions(
-				t, code, ParseCheckAndInterpretOptions{
-					CheckerConfig: &sema.Config{
-						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-							return baseValueActivation
-						},
-						BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
-							return baseTypeActivation
+				t,
+				code,
+				ParseCheckAndInterpretOptions{
+					ParseAndCheckOptions: &ParseAndCheckOptions{
+						CheckerConfig: &sema.Config{
+							BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+								return baseValueActivation
+							},
+							BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
+								return baseTypeActivation
+							},
 						},
 					},
-					Config: &interpreter.Config{
+					InterpreterConfig: &interpreter.Config{
 						Storage: storage,
 						OnEventEmitted: func(
 							_ interpreter.ValueExportContext,
@@ -8369,12 +8371,14 @@ func TestInterpretOptionalChainingFieldReadAndNilCoalescing(t *testing.T) {
           let x = test?.x ?? panic("nil")
         `,
 		ParseCheckAndInterpretOptions{
-			CheckerConfig: &sema.Config{
-				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-					return baseValueActivation
+			ParseAndCheckOptions: &ParseAndCheckOptions{
+				CheckerConfig: &sema.Config{
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 					return baseActivation
 				},
@@ -8413,12 +8417,14 @@ func TestInterpretOptionalChainingFunctionCallAndNilCoalescing(t *testing.T) {
           let x = test?.x() ?? panic("nil")
         `,
 		ParseCheckAndInterpretOptions{
-			CheckerConfig: &sema.Config{
-				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-					return baseValueActivation
+			ParseAndCheckOptions: &ParseAndCheckOptions{
+				CheckerConfig: &sema.Config{
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 					return baseActivation
 				},
@@ -8510,7 +8516,7 @@ func TestInterpretCompositeDeclarationNestedTypeScopingOuterInner(t *testing.T) 
           access(all) let x2 = x1.test()
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 		},
@@ -8555,7 +8561,7 @@ func TestInterpretCompositeDeclarationNestedConstructor(t *testing.T) {
           access(all) let x = Test.X()
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 		},
@@ -8603,7 +8609,7 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 		inter, err := parseCheckAndPrepareWithOptions(t,
 			code,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 					InjectedCompositeFieldsHandler: func(
 						context interpreter.AccountCreationContext,
@@ -8648,7 +8654,7 @@ func TestInterpretContractAccountFieldUse(t *testing.T) {
 		env := runtime.NewBaseInterpreterEnvironment(runtime.Config{})
 		_, err := parseCheckAndInterpretWithOptions(t, code,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ContractValueHandler:           makeContractValueHandler(nil, nil, nil),
 					InjectedCompositeFieldsHandler: env.InterpreterConfig.InjectedCompositeFieldsHandler,
 				},
@@ -8693,7 +8699,7 @@ func TestInterpretConformToImportedInterface(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 					assert.Equal(t,
 						ImportedLocation,
@@ -8776,7 +8782,7 @@ func TestInterpretContractUseInNestedDeclaration(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 		},
@@ -9015,12 +9021,14 @@ func TestInterpretHexDecode(t *testing.T) {
               }
             `,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
@@ -9191,12 +9199,14 @@ func TestInterpretResourceOwnerFieldUse(t *testing.T) {
 	inter, err := parseCheckAndPrepareWithOptions(t,
 		code,
 		ParseCheckAndInterpretOptions{
-			CheckerConfig: &sema.Config{
-				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-					return baseValueActivation
+			ParseAndCheckOptions: &ParseAndCheckOptions{
+				CheckerConfig: &sema.Config{
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 					return baseActivation
 				},
@@ -9478,7 +9488,7 @@ func TestInterpretEphemeralReferenceToOptional(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 		},
@@ -9516,7 +9526,7 @@ func TestInterpretNestedDeclarationOrder(t *testing.T) {
               }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},
@@ -9550,7 +9560,7 @@ func TestInterpretNestedDeclarationOrder(t *testing.T) {
               }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},
@@ -9657,7 +9667,7 @@ func TestInterpretFailableCastingCompositeTypeConfusion(t *testing.T) {
           let s = A.S() as? B.S
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 		},
@@ -9722,7 +9732,7 @@ func TestInterpretNestedDestroy(t *testing.T) {
             }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -11791,12 +11801,14 @@ func TestInterpretArrayToConstantSized(t *testing.T) {
                }
             `,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
@@ -11897,12 +11909,14 @@ func TestInterpretNilCoalesceReference(t *testing.T) {
           let ref = &xs["a"] as &Int? ?? panic("no a")
         `,
 		ParseCheckAndInterpretOptions{
-			CheckerConfig: &sema.Config{
-				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-					return baseValueActivation
+			ParseAndCheckOptions: &ParseAndCheckOptions{
+				CheckerConfig: &sema.Config{
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 					return baseActivation
 				},
@@ -11946,12 +11960,14 @@ func TestInterpretNilCoalesceAnyResourceAndPanic(t *testing.T) {
           let y <- f() ?? panic("no R")
         `,
 		ParseCheckAndInterpretOptions{
-			CheckerConfig: &sema.Config{
-				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-					return baseValueActivation
+			ParseAndCheckOptions: &ParseAndCheckOptions{
+				CheckerConfig: &sema.Config{
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
 				},
 			},
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 					return baseActivation
 				},
@@ -12166,7 +12182,7 @@ func TestInterpretCompositeTypeHandler(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				CompositeTypeHandler: func(location common.Location, typeID common.TypeID) *sema.CompositeType {
 					if _, ok := location.(stdlib.FlowLocation); ok {
 						return stdlib.FlowEventTypes[typeID]
@@ -12774,7 +12790,7 @@ func TestInterpretSomeValueChildContainerMutation(t *testing.T) {
 			inter, err := parseCheckAndPrepareWithOptions(t,
 				code,
 				ParseCheckAndInterpretOptions{
-					Config: &interpreter.Config{
+					InterpreterConfig: &interpreter.Config{
 						Storage: runtime.NewStorage(ledger, nil, runtime.StorageConfig{}),
 					},
 				},

--- a/interpreter/nesting_test.go
+++ b/interpreter/nesting_test.go
@@ -42,7 +42,7 @@ func TestInterpretContractWithNestedDeclaration(t *testing.T) {
 	      }
 	    `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 			},
 		},

--- a/interpreter/pathcapability_test.go
+++ b/interpreter/pathcapability_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/stdlib"
 	"github.com/onflow/cadence/test_utils/common_utils"
+	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
 func TestInterpretPathCapability(t *testing.T) {
@@ -69,17 +70,18 @@ func TestInterpretPathCapability(t *testing.T) {
 			t,
 			code,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
+					},
+				},
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
 				},
-				CheckerConfig: &sema.Config{
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
-					},
-				},
-				HandleCheckerError: nil,
 			},
 		)
 	}

--- a/interpreter/range_value_test.go
+++ b/interpreter/range_value_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/onflow/cadence/stdlib"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
+	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
 type containsTestCase struct {
@@ -394,12 +395,14 @@ func TestInclusiveRange(t *testing.T) {
 
 			inter, err := parseCheckAndPrepareWithOptions(t, code,
 				ParseCheckAndInterpretOptions{
-					CheckerConfig: &sema.Config{
-						BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
-							return baseValueActivation
+					ParseAndCheckOptions: &ParseAndCheckOptions{
+						CheckerConfig: &sema.Config{
+							BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
+								return baseValueActivation
+							},
 						},
 					},
-					Config: &interpreter.Config{
+					InterpreterConfig: &interpreter.Config{
 						BaseActivationHandler: func(common.Location) *interpreter.VariableActivation {
 							return baseActivation
 						},
@@ -509,12 +512,14 @@ func TestInclusiveRangeConstructionInvalid(t *testing.T) {
 
 			_, err := parseCheckAndPrepareWithOptions(t, code,
 				ParseCheckAndInterpretOptions{
-					CheckerConfig: &sema.Config{
-						BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
-							return baseValueActivation
+					ParseAndCheckOptions: &ParseAndCheckOptions{
+						CheckerConfig: &sema.Config{
+							BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
+								return baseValueActivation
+							},
 						},
 					},
-					Config: &interpreter.Config{
+					InterpreterConfig: &interpreter.Config{
 						BaseActivationHandler: func(common.Location) *interpreter.VariableActivation {
 							return baseActivation
 						},

--- a/interpreter/resources_test.go
+++ b/interpreter/resources_test.go
@@ -2638,6 +2638,7 @@ func TestInterpreterDefaultDestroyEventBaseShadowing(t *testing.T) {
 		var eventTypes []*sema.CompositeType
 		var eventsFields [][]interpreter.Value
 
+		// TODO: requires support for attachments in the VM
 		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
                 resource R {
@@ -2711,6 +2712,7 @@ func TestInterpreterDefaultDestroyEventBaseShadowing(t *testing.T) {
 		var eventTypes []*sema.CompositeType
 		var eventsFields [][]interpreter.Value
 
+		// TODO: requires support for attachments in the VM
 		inter, err := parseCheckAndInterpretWithOptions(t,
 			`
                 contract base {
@@ -3434,6 +3436,7 @@ func TestInterpretInvalidatingAttachmentLoopedReference(t *testing.T) {
 
 	t.Parallel()
 
+	// TODO: requires support for attachments in the VM
 	inter := parseCheckAndInterpret(t, `
 		// Victim code starts
 		resource Vault {

--- a/interpreter/resources_test.go
+++ b/interpreter/resources_test.go
@@ -2366,7 +2366,7 @@ func TestInterpretResourceInterfaceDefaultDestroyEvent(t *testing.T) {
             }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -2445,7 +2445,7 @@ func TestInterpretResourceInterfaceDefaultDestroyEventMultipleInheritance(t *tes
             }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -2522,7 +2522,7 @@ func TestInterpretResourceInterfaceDefaultDestroyEventIndirectInheritance(t *tes
             }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -2595,7 +2595,7 @@ func TestInterpretResourceInterfaceDefaultDestroyEventNoCompositeEvent(t *testin
             }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,
@@ -2671,7 +2671,7 @@ func TestInterpreterDefaultDestroyEventBaseShadowing(t *testing.T) {
                 }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					OnEventEmitted: func(
 						_ interpreter.ValueExportContext,
 						_ interpreter.LocationRange,
@@ -2737,7 +2737,7 @@ func TestInterpreterDefaultDestroyEventBaseShadowing(t *testing.T) {
                 }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					OnEventEmitted: func(
 						_ interpreter.ValueExportContext,
 						_ interpreter.LocationRange,
@@ -2793,7 +2793,7 @@ func TestInterpretDefaultDestroyEventArgumentScoping(t *testing.T) {
             }
         `,
 		ParseCheckAndInterpretOptions{
-			Config: &interpreter.Config{
+			InterpreterConfig: &interpreter.Config{
 				OnEventEmitted: func(
 					_ interpreter.ValueExportContext,
 					_ interpreter.LocationRange,

--- a/interpreter/transactions_test.go
+++ b/interpreter/transactions_test.go
@@ -403,6 +403,7 @@ func TestInterpretInvalidTransferInExecute(t *testing.T) {
 
 	t.Parallel()
 
+	// TODO: requires improved swap in VM
 	inter, _ := parseCheckAndInterpretWithOptions(t,
 		`
           resource Dummy {}

--- a/interpreter/transfer_test.go
+++ b/interpreter/transfer_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/stdlib"
 	. "github.com/onflow/cadence/test_utils/common_utils"
+	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
 func TestInterpretTransferCheck(t *testing.T) {
@@ -74,15 +75,17 @@ func TestInterpretTransferCheck(t *testing.T) {
               }
             `,
 			ParseCheckAndInterpretOptions{
-				CheckerConfig: &sema.Config{
-					BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseTypeActivation
-					},
-					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
-						return baseValueActivation
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseTypeActivation
+						},
+						BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+							return baseValueActivation
+						},
 					},
 				},
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					BaseActivationHandler: func(_ common.Location) *interpreter.VariableActivation {
 						return baseActivation
 					},
@@ -124,7 +127,7 @@ func TestInterpretTransferCheck(t *testing.T) {
               }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},
@@ -161,7 +164,7 @@ func TestInterpretTransferCheck(t *testing.T) {
               }
             `,
 			ParseCheckAndInterpretOptions{
-				Config: &interpreter.Config{
+				InterpreterConfig: &interpreter.Config{
 					ContractValueHandler: makeContractValueHandler(nil, nil, nil),
 				},
 			},

--- a/interpreter/uuid_test.go
+++ b/interpreter/uuid_test.go
@@ -65,7 +65,7 @@ func TestInterpretResourceUUID(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 					assert.Equal(t,
 						ImportedLocation,

--- a/runtime/error_test.go
+++ b/runtime/error_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/onflow/cadence/interpreter"
 	. "github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/sema"
-	"github.com/onflow/cadence/stdlib"
 	. "github.com/onflow/cadence/test_utils/runtime_utils"
 )
 
@@ -57,6 +56,7 @@ func TestRuntimeError(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  location,
+				UseVM:     *compile,
 			},
 		)
 
@@ -91,6 +91,7 @@ func TestRuntimeError(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  location,
+				UseVM:     *compile,
 			},
 		)
 		require.ErrorContains(
@@ -131,6 +132,7 @@ func TestRuntimeError(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  location,
+				UseVM:     *compile,
 			},
 		)
 		require.ErrorContains(
@@ -169,6 +171,7 @@ func TestRuntimeError(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  location,
+				UseVM:     *compile,
 			},
 		)
 		require.ErrorContains(
@@ -218,29 +221,39 @@ func TestRuntimeError(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  location,
+				UseVM:     *compile,
 			},
 		)
 
-		require.ErrorContains(t, err,
-			"Execution failed:\n"+
-				"  --> 0100000000000000000000000000000000000000000000000000000000000000:15:12\n"+
-				"   |\n"+
-				"15 | 				destroy createResource()\n"+
-				"   | 				        ^^^^^^^^^^^^^^^^\n"+
-				"\n"+
-				"  --> 0100000000000000000000000000000000000000000000000000000000000000:9:21\n"+
-				"   |\n"+
-				" 9 | 				return <- create Resource(\n"+
-				"10 | 					s: \"argument\"\n"+
-				"11 | 				)\n"+
-				"   | 				^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"+
-				"\n"+
-				"error: panic: 42\n"+
-				" --> 0100000000000000000000000000000000000000000000000000000000000000:4:5\n"+
-				"  |\n"+
-				"4 | 					panic(\"42\")\n"+
-				"  | 					^^^^^^^^^^^\n",
-		)
+		// TODO: improve error locations in the VM
+		if *compile {
+			require.ErrorContains(t, err,
+				"Execution failed:\n"+
+					"error: panic: 42\n"+
+					" --> 0100000000000000000000000000000000000000000000000000000000000000:0:0\n",
+			)
+		} else {
+			require.ErrorContains(t, err,
+				"Execution failed:\n"+
+					"  --> 0100000000000000000000000000000000000000000000000000000000000000:15:12\n"+
+					"   |\n"+
+					"15 | 				destroy createResource()\n"+
+					"   | 				        ^^^^^^^^^^^^^^^^\n"+
+					"\n"+
+					"  --> 0100000000000000000000000000000000000000000000000000000000000000:9:21\n"+
+					"   |\n"+
+					" 9 | 				return <- create Resource(\n"+
+					"10 | 					s: \"argument\"\n"+
+					"11 | 				)\n"+
+					"   | 				^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"+
+					"\n"+
+					"error: panic: 42\n"+
+					" --> 0100000000000000000000000000000000000000000000000000000000000000:4:5\n"+
+					"  |\n"+
+					"4 | 					panic(\"42\")\n"+
+					"  | 					^^^^^^^^^^^\n",
+			)
+		}
 	})
 
 	t.Run("parse error in import", func(t *testing.T) {
@@ -273,6 +286,7 @@ func TestRuntimeError(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  location,
+				UseVM:     *compile,
 			},
 		)
 		require.ErrorContains(
@@ -316,6 +330,7 @@ func TestRuntimeError(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  location,
+				UseVM:     *compile,
 			},
 		)
 		require.ErrorContains(
@@ -373,24 +388,41 @@ func TestRuntimeError(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  location,
+				UseVM:     *compile,
 			},
 		)
-		require.ErrorContains(
-			t,
-			err,
-			"Execution failed:\n"+
-				" --> 0100000000000000000000000000000000000000000000000000000000000000:5:16\n"+
-				"  |\n"+
-				"5 |                 add()\n"+
-				"  |                 ^^^^^\n"+
-				"\n"+
-				"error: overflow\n"+
-				" --> imported:6:16\n"+
-				"  |\n"+
-				"6 |                 a + b\n"+
-				"  |                 ^^^^^\n"+
-				"",
-		)
+
+		// TODO: improve error locations in the VM
+		if *compile {
+			require.ErrorContains(
+				t,
+				err,
+				"Execution failed:\n"+
+					"error: overflow\n"+
+					" --> imported:6:16\n"+
+					"  |\n"+
+					"6 |                 a + b\n"+
+					"  |                 ^^^^^\n"+
+					"",
+			)
+		} else {
+			require.ErrorContains(
+				t,
+				err,
+				"Execution failed:\n"+
+					" --> 0100000000000000000000000000000000000000000000000000000000000000:5:16\n"+
+					"  |\n"+
+					"5 |                 add()\n"+
+					"  |                 ^^^^^\n"+
+					"\n"+
+					"error: overflow\n"+
+					" --> imported:6:16\n"+
+					"  |\n"+
+					"6 |                 a + b\n"+
+					"  |                 ^^^^^\n"+
+					"",
+			)
+		}
 	})
 
 	t.Run("nested errors", func(t *testing.T) {
@@ -454,6 +486,7 @@ func TestRuntimeError(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  location,
+				UseVM:     *compile,
 			},
 		)
 		require.ErrorContains(t, err,
@@ -581,6 +614,7 @@ func TestRuntimeMultipleInterfaceDefaultImplementationsError(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -593,19 +627,14 @@ func TestRuntimeMultipleInterfaceDefaultImplementationsError(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "access(all) resource R: TestInterfaces.A, TestInterfaces.B {}")
 
-	var errType *sema.CheckerError
-	require.ErrorAs(t, err, &errType)
-
-	checkerErr := err.(Error).
-		Err.(interpreter.Error).
-		Err.(*stdlib.InvalidContractDeploymentError).
-		Err.(*ParsingCheckingError).
-		Err.(*sema.CheckerError)
+	var checkerErr *sema.CheckerError
+	require.ErrorAs(t, err, &checkerErr)
 
 	var specificErrType *sema.MultipleInterfaceDefaultImplementationsError
 	require.ErrorAs(t, checkerErr.Errors[0], &specificErrType)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -9430,6 +9430,8 @@ func TestRuntimeWrappedErrorHandling(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			// TODO: fix running with VM
+			//UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -9446,6 +9448,8 @@ func TestRuntimeWrappedErrorHandling(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			// TODO: fix running with VM
+			//UseVM:     *compile,
 		},
 	)
 
@@ -10922,6 +10926,8 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			// TODO: fix VM
+			//UseVM: *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -10984,6 +10990,8 @@ func TestResourceLossViaSelfRugPull(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			// TODO: fix VM
+			//UseVM:     *compile,
 		},
 	)
 	RequireError(t, err)
@@ -11073,43 +11081,45 @@ func TestRuntimeValueTransferResourceLoss(t *testing.T) {
 
 	nextScriptLocation := NewScriptLocationGenerator()
 
-	script := []byte(fmt.Sprintf(`
-        import Foo from %[1]s
+	script := []byte(fmt.Sprintf(
+		`
+          import Foo from %[1]s
 
-    access(all) struct IndexSwitcher {
-        access(self) var counter: Int
-        init() {
-            self.counter = 0
-        }
-        access(all) fun callback(): Int {
-            self.counter = self.counter + 1
-            if self.counter == 1 {
-                // Which key we want to be read?
-                // Let's point it to a non-existent key
-                return 123
-            } else {
-                // Which key we want to be assigned to?
-                // We point it to 0 to overwrite the victim value
-                return 0
-            }
-        }
-    }
+          access(all) struct IndexSwitcher {
+              access(self) var counter: Int
+              init() {
+                  self.counter = 0
+              }
+              access(all) fun callback(): Int {
+                  self.counter = self.counter + 1
+                  if self.counter == 1 {
+                      // Which key we want to be read?
+                      // Let's point it to a non-existent key
+                      return 123
+                  } else {
+                      // Which key we want to be assigned to?
+                      // We point it to 0 to overwrite the victim value
+                      return 0
+                  }
+              }
+          }
 
-    access(all) fun loseResource(victim: @Foo.R) {
-       var a <- Foo.createR("dummy resource")
-       var dict: @{Int: Foo.R} <- { 0: <- victim }
-       var indexSwitcher = IndexSwitcher()
-       
-       // this callback should only be evaluated once, rather than twice
-       var b <- dict[indexSwitcher.callback()] <- a
-       destroy b
-       destroy dict
-    }
+          access(all) fun loseResource(victim: @Foo.R) {
+             var a <- Foo.createR("dummy resource")
+             var dict: @{Int: Foo.R} <- { 0: <- victim }
+             var indexSwitcher = IndexSwitcher()
+             
+             // this callback should only be evaluated once, rather than twice
+             var b <- dict[indexSwitcher.callback()] <- a
+             destroy b
+             destroy dict
+          }
 
-    access(all) fun main(): Void {
-       var victim <- Foo.createR("victim resource")
-       loseResource(victim: <- victim)
-    }`,
+          access(all) fun main(): Void {
+             var victim <- Foo.createR("victim resource")
+             loseResource(victim: <- victim)
+          }
+        `,
 		address.HexWithPrefix(),
 	))
 
@@ -11120,6 +11130,8 @@ func TestRuntimeValueTransferResourceLoss(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			// TODO: fix VM
+			//UseVM:     *compile,
 		},
 	)
 
@@ -11516,6 +11528,7 @@ func TestRuntimeForbidPublicEntitlementBorrow(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nexScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -11606,6 +11619,7 @@ func TestRuntimeForbidPublicEntitlementGet(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextScriptLocation(),
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -11678,6 +11692,7 @@ func TestRuntimeForbidPublicEntitlementPublish(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
 			},
 		)
 
@@ -11794,6 +11809,7 @@ func TestRuntimeForbidPublicEntitlementPublish(t *testing.T) {
 			Context{
 				Interface: runtimeInterface,
 				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
 			},
 		)
 
@@ -13280,6 +13296,8 @@ func TestRuntimeStorageReferenceBoundFunctionConfusion(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
+			// TODO: fix VM
+			//UseVM:     *compile,
 		},
 	)
 

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -51,7 +51,7 @@ type vmEnvironment struct {
 	checkingEnvironment *CheckingEnvironment
 
 	config         Config
-	vmConfig       *vm.Config
+	VMConfig       *vm.Config
 	compilerConfig *compiler.Config
 
 	defaultCompilerBuiltinGlobals *activations.Activation[compiler.GlobalImport]
@@ -90,7 +90,7 @@ func newVMEnvironment(config Config) *vmEnvironment {
 		SimpleContractAdditionTracker: stdlib.NewSimpleContractAdditionTracker(),
 	}
 	env.checkingEnvironment = newCheckingEnvironment()
-	env.vmConfig = env.newVMConfig()
+	env.VMConfig = env.newVMConfig()
 	env.compilerConfig = env.newCompilerConfig()
 
 	env.defaultCompilerBuiltinGlobals = activations.NewActivation(nil, compiler.DefaultBuiltinGlobals())
@@ -148,6 +148,8 @@ func (e *vmEnvironment) newVMConfig() *vm.Config {
 	conf.OnEventEmitted = newOnEventEmittedHandler(&e.Interface)
 	conf.CapabilityBorrowHandler = newCapabilityBorrowHandler(e)
 	conf.CapabilityCheckHandler = newCapabilityCheckHandler(e)
+	conf.ValidateAccountCapabilitiesGetHandler = newValidateAccountCapabilitiesGetHandler(&e.Interface)
+	conf.ValidateAccountCapabilitiesPublishHandler = newValidateAccountCapabilitiesPublishHandler(&e.Interface)
 	conf.ElaborationResolver = e.resolveElaboration
 	conf.StackDepthLimit = defaultStackDepthLimit
 	return conf
@@ -202,7 +204,7 @@ func (e *vmEnvironment) Configure(
 ) {
 	e.Interface = runtimeInterface
 	e.storage = storage
-	e.vmConfig.SetStorage(storage)
+	e.VMConfig.SetStorage(storage)
 
 	e.checkingEnvironment.configure(
 		runtimeInterface,
@@ -525,7 +527,7 @@ func (e *vmEnvironment) newVM(
 	return vm.NewVM(
 		location,
 		program,
-		e.vmConfig,
+		e.VMConfig,
 	)
 }
 

--- a/sema/accesses_test.go
+++ b/sema/accesses_test.go
@@ -196,7 +196,7 @@ func TestCheckAccessModifierInterfaceFunctionDeclaration(t *testing.T) {
 							access.Keyword(),
 						),
 						ParseAndCheckOptions{
-							Config: &sema.Config{
+							CheckerConfig: &sema.Config{
 								AccessCheckMode: checkMode,
 							},
 						},
@@ -603,7 +603,7 @@ func TestCheckAccessModifierGlobalCompositeDeclaration(t *testing.T) {
 								baseType,
 							),
 							ParseAndCheckOptions{
-								Config: &sema.Config{
+								CheckerConfig: &sema.Config{
 									AccessCheckMode: checkMode,
 								},
 							},
@@ -707,7 +707,7 @@ func TestCheckAccessCompositeFunction(t *testing.T) {
 							tearDownCode,
 						),
 						ParseAndCheckOptions{
-							Config: &sema.Config{
+							CheckerConfig: &sema.Config{
 								AccessCheckMode: checkMode,
 							},
 						},
@@ -818,7 +818,7 @@ func TestCheckAccessInterfaceFunction(t *testing.T) {
 							tearDownCode,
 						),
 						ParseAndCheckOptions{
-							Config: &sema.Config{
+							CheckerConfig: &sema.Config{
 								AccessCheckMode: checkMode,
 							},
 						},
@@ -925,7 +925,7 @@ func TestCheckAccessCompositeFieldRead(t *testing.T) {
 							tearDownCode,
 						),
 						ParseAndCheckOptions{
-							Config: &sema.Config{
+							CheckerConfig: &sema.Config{
 								AccessCheckMode: checkMode,
 							},
 						},
@@ -1040,7 +1040,7 @@ func TestCheckAccessInterfaceFieldRead(t *testing.T) {
 							tearDownCode,
 						),
 						ParseAndCheckOptions{
-							Config: &sema.Config{
+							CheckerConfig: &sema.Config{
 								AccessCheckMode: checkMode,
 							},
 						},
@@ -1152,7 +1152,7 @@ func TestCheckAccessCompositeFieldAssignmentAndSwap(t *testing.T) {
 							tearDownCode,
 						),
 						ParseAndCheckOptions{
-							Config: &sema.Config{
+							CheckerConfig: &sema.Config{
 								AccessCheckMode: checkMode,
 							},
 						},
@@ -1291,7 +1291,7 @@ func TestCheckAccessInterfaceFieldWrite(t *testing.T) {
 							tearDownCode,
 						),
 						ParseAndCheckOptions{
-							Config: &sema.Config{
+							CheckerConfig: &sema.Config{
 								AccessCheckMode: checkMode,
 							},
 						},
@@ -1378,7 +1378,7 @@ func TestCheckAccessCompositeFieldVariableDeclarationWithSecondValue(t *testing.
 						access.Keyword(),
 					),
 					ParseAndCheckOptions{
-						Config: &sema.Config{
+						CheckerConfig: &sema.Config{
 							AccessCheckMode: checkMode,
 						},
 					},
@@ -1482,7 +1482,7 @@ func TestCheckAccessInterfaceFieldVariableDeclarationWithSecondValue(t *testing.
 						access.Keyword(),
 					),
 					ParseAndCheckOptions{
-						Config: &sema.Config{
+						CheckerConfig: &sema.Config{
 							AccessCheckMode: checkMode,
 						},
 					},
@@ -1589,7 +1589,7 @@ func TestCheckAccessImportGlobalValue(t *testing.T) {
                     `,
 					ParseAndCheckOptions{
 
-						Config: &sema.Config{
+						CheckerConfig: &sema.Config{
 							AccessCheckMode: checkMode,
 							ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 								return sema.ElaborationImport{
@@ -1794,7 +1794,7 @@ func TestCheckAccessImportGlobalValueAssignmentAndSwap(t *testing.T) {
                   }
                 `,
 				ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						AccessCheckMode: checkMode,
 						ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 							return sema.ElaborationImport{
@@ -1840,7 +1840,7 @@ func TestCheckAccessImportGlobalValueVariableDeclarationWithSecondValue(t *testi
            }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 					return sema.ElaborationImport{
 						Elaboration: imported.Elaboration,
@@ -2296,7 +2296,7 @@ func TestCheckAccountAccess(t *testing.T) {
 								importingCode,
 								ParseAndCheckOptions{
 									Location: test.location,
-									Config: &sema.Config{
+									CheckerConfig: &sema.Config{
 										AccessCheckMode: checkMode,
 										ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 											return sema.ElaborationImport{

--- a/sema/assert_test.go
+++ b/sema/assert_test.go
@@ -43,7 +43,7 @@ func TestCheckAssertWithoutMessage(t *testing.T) {
             }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -68,7 +68,7 @@ func TestCheckAssertWithMessage(t *testing.T) {
             }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},

--- a/sema/attachments_test.go
+++ b/sema/attachments_test.go
@@ -3517,7 +3517,7 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 					destroy r
 				}
 				`,
-			ParseAndCheckOptions{Config: &sema.Config{
+			ParseAndCheckOptions{CheckerConfig: &sema.Config{
 				SuggestionsEnabled: true,
 			}},
 		)
@@ -3596,7 +3596,7 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 				}
 				
 				`,
-			ParseAndCheckOptions{Config: &sema.Config{
+			ParseAndCheckOptions{CheckerConfig: &sema.Config{
 				SuggestionsEnabled: true,
 			}},
 		)
@@ -3669,7 +3669,7 @@ func TestCheckAttachmentsExternalMutation(t *testing.T) {
 				}
 				
 				`,
-			ParseAndCheckOptions{Config: &sema.Config{
+			ParseAndCheckOptions{CheckerConfig: &sema.Config{
 				SuggestionsEnabled: true,
 			}},
 		)

--- a/sema/builtinfunctions_test.go
+++ b/sema/builtinfunctions_test.go
@@ -285,7 +285,7 @@ func TestCheckRevertibleRandom(t *testing.T) {
 		baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
 		baseValueActivation.DeclareValue(stdlib.NewInterpreterRevertibleRandomFunction(&testRandomGenerator{}))
 		return ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},

--- a/sema/capability_controller_test.go
+++ b/sema/capability_controller_test.go
@@ -44,7 +44,7 @@ func TestCheckStorageCapabilityController(t *testing.T) {
 			t,
 			code,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 						return baseActivation
 					},
@@ -107,7 +107,7 @@ func TestCheckAccountCapabilityController(t *testing.T) {
 			t,
 			code,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 						return baseActivation
 					},

--- a/sema/contract_test.go
+++ b/sema/contract_test.go
@@ -782,7 +782,7 @@ func TestCheckContractEnumAccessRestricted(t *testing.T) {
             let x = foo.bar()!
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				AccessCheckMode: sema.AccessCheckModeStrict,
 			},
 		},

--- a/sema/crypto_test.go
+++ b/sema/crypto_test.go
@@ -49,7 +49,7 @@ func TestCheckHashAlgorithmCases(t *testing.T) {
 				algorithm.Name(),
 			),
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},
@@ -77,7 +77,7 @@ func TestCheckHashAlgorithmConstructor(t *testing.T) {
            let algo = HashAlgorithm(rawValue: 0)
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -102,7 +102,7 @@ func TestCheckHashAlgorithmHashFunctions(t *testing.T) {
            let result2: [UInt8] = HashAlgorithm.SHA2_256.hashWithTag(data, tag: "tag")
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -130,7 +130,7 @@ func TestCheckSignatureAlgorithmCases(t *testing.T) {
 				algorithm.Name(),
 			),
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},
@@ -158,7 +158,7 @@ func TestCheckSignatureAlgorithmConstructor(t *testing.T) {
            let algo = SignatureAlgorithm(rawValue: 0)
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -187,7 +187,7 @@ func TestCheckVerifyPoP(t *testing.T) {
            let x: Bool = key.verifyPoP([1, 2, 3])
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -216,7 +216,7 @@ func TestCheckVerifyPoPInvalidArgument(t *testing.T) {
            let x: Int = key.verifyPoP([1 as Int32, 2, 3])
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -242,7 +242,7 @@ func TestCheckBLSAggregateSignatures(t *testing.T) {
            let r: [UInt8] = BLS.aggregateSignatures([[1 as UInt8, 2, 3], []])!
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -265,7 +265,7 @@ func TestCheckInvalidBLSAggregateSignatures(t *testing.T) {
            let r: [UInt16] = BLS.aggregateSignatures([[1 as UInt32, 2, 3], []])!
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -298,7 +298,7 @@ func TestCheckBLSAggregatePublicKeys(t *testing.T) {
            ])!
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -323,7 +323,7 @@ func TestCheckInvalidBLSAggregatePublicKeys(t *testing.T) {
            let r: [PublicKey] = BLS.aggregatePublicKeys([1])!
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},

--- a/sema/declaration_test.go
+++ b/sema/declaration_test.go
@@ -473,7 +473,7 @@ func TestCheckTopLevelContractRestriction(t *testing.T) {
           contract C {}
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ValidTopLevelDeclarationsHandler: func(_ common.Location) common.DeclarationKindSet {
 					return common.NewDeclarationKindSet(
 						common.DeclarationKindContract,
@@ -508,7 +508,7 @@ func TestCheckInvalidTopLevelContractRestriction(t *testing.T) {
 			_, err := ParseAndCheckWithOptions(t,
 				code,
 				ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						ValidTopLevelDeclarationsHandler: func(_ common.Location) common.DeclarationKindSet {
 							return common.NewDeclarationKindSet(
 								common.DeclarationKindContractInterface,

--- a/sema/entitlements_test.go
+++ b/sema/entitlements_test.go
@@ -4408,7 +4408,7 @@ func TestCheckEntitlementConditions(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					SuggestionsEnabled: true,
 				},
 			},
@@ -4486,7 +4486,7 @@ func TestCheckEntitlementConditions(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					SuggestionsEnabled: true,
 				},
 			},
@@ -4926,7 +4926,7 @@ func TestCheckEntitledWriteAndMutateNotAllowed(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					SuggestionsEnabled: true,
 				},
 			},
@@ -5888,7 +5888,7 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
                 }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					SuggestionsEnabled: true,
 				},
 			},
@@ -5946,7 +5946,7 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					SuggestionsEnabled: true,
 				},
 			},
@@ -6005,7 +6005,7 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					SuggestionsEnabled: true,
 				},
 			},
@@ -6062,7 +6062,7 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					SuggestionsEnabled: true,
 				},
 			},
@@ -6118,7 +6118,7 @@ func TestCheckEntitlementErrorReporting(t *testing.T) {
                 }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					SuggestionsEnabled: true,
 				},
 			},

--- a/sema/error_handling_test.go
+++ b/sema/error_handling_test.go
@@ -44,7 +44,7 @@ func TestCheckErrorShortCircuiting(t *testing.T) {
               let x: Type<X<X<X>>>? = nil
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ErrorShortCircuitingEnabled: true,
 				},
 			},
@@ -72,7 +72,7 @@ func TestCheckErrorShortCircuiting(t *testing.T) {
                let b = B
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ErrorShortCircuitingEnabled: true,
 					ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 
@@ -83,7 +83,7 @@ func TestCheckErrorShortCircuiting(t *testing.T) {
                             `,
 							ParseAndCheckOptions{
 								Location: ImportedLocation,
-								Config: &sema.Config{
+								CheckerConfig: &sema.Config{
 									ErrorShortCircuitingEnabled: true,
 								},
 							},

--- a/sema/events_test.go
+++ b/sema/events_test.go
@@ -308,7 +308,7 @@ func TestCheckEmitEvent(t *testing.T) {
               }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,

--- a/sema/for_test.go
+++ b/sema/for_test.go
@@ -110,7 +110,7 @@ func TestCheckForInclusiveRange(t *testing.T) {
 
 			_, err := ParseAndCheckWithOptions(t, code,
 				ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
 							return baseValueActivation
 						},

--- a/sema/function_test.go
+++ b/sema/function_test.go
@@ -461,7 +461,7 @@ func TestCheckNativeFunctionDeclaration(t *testing.T) {
 				ParseOptions: parser.Config{
 					NativeModifierEnabled: true,
 				},
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					AllowNativeDeclarations: false,
 				},
 			},
@@ -484,7 +484,7 @@ func TestCheckNativeFunctionDeclaration(t *testing.T) {
 				ParseOptions: parser.Config{
 					NativeModifierEnabled: true,
 				},
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					AllowNativeDeclarations: true,
 				},
 			},
@@ -507,7 +507,7 @@ func TestCheckNativeFunctionDeclaration(t *testing.T) {
 				ParseOptions: parser.Config{
 					NativeModifierEnabled: true,
 				},
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					AllowNativeDeclarations: true,
 				},
 			},
@@ -532,7 +532,7 @@ func TestCheckNativeFunctionDeclaration(t *testing.T) {
 				ParseOptions: parser.Config{
 					NativeModifierEnabled: true,
 				},
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					AllowNativeDeclarations: true,
 				},
 			},
@@ -726,7 +726,7 @@ func TestCheckGenericFunctionSubtyping(t *testing.T) {
 		return ParseAndCheckWithOptions(tt,
 			code,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},
@@ -917,7 +917,7 @@ func TestCheckGenericFunctionSubtyping(t *testing.T) {
                 func = bar      // fun<T>(): Path
 		    }`,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},

--- a/sema/gen/golden_test.go
+++ b/sema/gen/golden_test.go
@@ -61,7 +61,7 @@ func TestConstructor(t *testing.T) {
           let x = Foo(bar: 1)
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -87,7 +87,7 @@ func TestContract(t *testing.T) {
           let x = Test.Foo(bar: 1)
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},

--- a/sema/genericfunction_test.go
+++ b/sema/genericfunction_test.go
@@ -45,7 +45,7 @@ func parseAndCheckWithTestValue(t *testing.T, code string, ty sema.Type) (*sema.
 	return ParseAndCheckWithOptions(t,
 		code,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -928,7 +928,7 @@ func TestCheckGenericFunctionDeclaration(t *testing.T) {
               let x: Int? = head([1, 2, 3])
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					AllowNativeDeclarations: false,
 				},
 				ParseOptions: parser.Config{
@@ -953,7 +953,7 @@ func TestCheckGenericFunctionDeclaration(t *testing.T) {
               let x: Int? = head([1, 2, 3])
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					AllowNativeDeclarations: true,
 				},
 				ParseOptions: parser.Config{
@@ -978,7 +978,7 @@ func TestCheckGenericFunctionDeclaration(t *testing.T) {
 	          let x: Int? = S().head([1, 2, 3])
 	        `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					AllowNativeDeclarations: false,
 				},
 				ParseOptions: parser.Config{
@@ -1005,7 +1005,7 @@ func TestCheckGenericFunctionDeclaration(t *testing.T) {
 	          let x: Int? = S().head([1, 2, 3])
 	        `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					AllowNativeDeclarations: true,
 				},
 				ParseOptions: parser.Config{
@@ -1029,7 +1029,7 @@ func TestCheckGenericFunctionDeclaration(t *testing.T) {
 	          let x = test<Int, Bool>()
 	        `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					AllowNativeDeclarations: true,
 				},
 				ParseOptions: parser.Config{
@@ -1055,7 +1055,7 @@ func TestCheckGenericFunctionDeclaration(t *testing.T) {
 	          let x = test<Int>()
 	        `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					AllowNativeDeclarations: true,
 				},
 				ParseOptions: parser.Config{
@@ -1079,7 +1079,7 @@ func TestCheckGenericFunctionDeclaration(t *testing.T) {
 	          native fun test<T, U: T>(_ u: U): U {}
 	        `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					AllowNativeDeclarations: true,
 				},
 				ParseOptions: parser.Config{
@@ -1105,7 +1105,7 @@ func TestCheckGenericFunctionDeclaration(t *testing.T) {
 	          let x = test<Int>()
 	        `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					AllowNativeDeclarations: true,
 				},
 				ParseOptions: parser.Config{

--- a/sema/import_test.go
+++ b/sema/import_test.go
@@ -68,7 +68,7 @@ func TestCheckRepeatedImport(t *testing.T) {
            import y from "imported"
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
@@ -126,7 +126,7 @@ func TestCheckRepeatedImportResolution(t *testing.T) {
            import y from 0x1
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				LocationHandler: func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
 					for _, identifier := range identifiers {
 						result = append(result, sema.ResolvedLocation{
@@ -182,7 +182,7 @@ func TestCheckInvalidRepeatedImport(t *testing.T) {
            import x from "imported"
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
@@ -242,7 +242,7 @@ func TestCheckImportResolutionSplit(t *testing.T) {
            import x, y from 0x1
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				LocationHandler: func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
 					for _, identifier := range identifiers {
 						result = append(result, sema.ResolvedLocation{
@@ -301,7 +301,7 @@ func TestCheckImportAll(t *testing.T) {
           access(all) let x = answer()
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
@@ -336,7 +336,7 @@ func TestCheckInvalidImportUnexported(t *testing.T) {
            access(all) let x = answer()
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
@@ -377,7 +377,7 @@ func TestCheckImportSome(t *testing.T) {
           access(all) let x = answer()
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
@@ -406,7 +406,7 @@ func TestCheckInvalidImportedError(t *testing.T) {
            import x from "imported"
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 					return nil, importedErr
 				},
@@ -477,7 +477,7 @@ func TestCheckImportTypes(t *testing.T) {
 					useCode,
 				),
 				ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 							return sema.ElaborationImport{
 								Elaboration: importedChecker.Elaboration,
@@ -526,7 +526,7 @@ func TestCheckInvalidImportCycleSelf(t *testing.T) {
 			code,
 			ParseAndCheckOptions{
 				Location: location,
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 
 						elaboration, ok := elaborations[importedLocation]
@@ -617,7 +617,7 @@ func TestCheckInvalidImportCycleTwoLocations(t *testing.T) {
 		codeEven,
 		ParseAndCheckOptions{
 			Location: common.StringLocation("even"),
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
 					importedProgram := getProgram(importedLocation)
 
@@ -705,7 +705,7 @@ func TestCheckImportVirtual(t *testing.T) {
 	_, err := ParseAndCheckWithOptions(t,
 		code,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 					return sema.VirtualImport{
 						ValueElements: valueElements,
@@ -757,7 +757,7 @@ func TestCheckImportContract(t *testing.T) {
             }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
@@ -804,7 +804,7 @@ func TestCheckImportContract(t *testing.T) {
             }
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,

--- a/sema/invalid_test.go
+++ b/sema/invalid_test.go
@@ -238,7 +238,7 @@ func TestCheckInvalidInvocationFunctionReturnType(t *testing.T) {
           let res = [f].reverse()
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -273,7 +273,7 @@ func TestCheckInvalidTypeDefensiveCheck(t *testing.T) {
                   let res = invalid
                 `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},

--- a/sema/invocation_test.go
+++ b/sema/invocation_test.go
@@ -333,7 +333,7 @@ func TestCheckInvocationWithOnlyVarargs(t *testing.T) {
             }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -388,7 +388,7 @@ func TestCheckArgumentLabels(t *testing.T) {
                   let t = test(x: 1, "2")
                 `,
 				ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 							return sema.ElaborationImport{
 								Elaboration: importedChecker.Elaboration,
@@ -449,7 +449,7 @@ func TestCheckArgumentLabels(t *testing.T) {
                   let t = Test().test(x: 1, "2")
                 `,
 				ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 							return sema.ElaborationImport{
 								Elaboration: importedChecker.Elaboration,
@@ -510,7 +510,7 @@ func TestCheckArgumentLabels(t *testing.T) {
                   let t = Test(x: 1, "2")
                 `,
 				ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 							return sema.ElaborationImport{
 								Elaboration: importedChecker.Elaboration,
@@ -575,7 +575,7 @@ func TestCheckArgumentLabels(t *testing.T) {
                   let t = C.S(x: 1, "2")
                 `,
 				ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 							return sema.ElaborationImport{
 								Elaboration: importedChecker.Elaboration,
@@ -640,7 +640,7 @@ func TestCheckInvocationWithIncorrectTypeParameter(t *testing.T) {
             }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},

--- a/sema/member_test.go
+++ b/sema/member_test.go
@@ -315,7 +315,7 @@ func TestCheckMemberNotDeclaredSecondaryError(t *testing.T) {
             let test: Test = Test()
             let x = test.foop()
         `, ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				SuggestionsEnabled: true,
 			},
 		})
@@ -361,7 +361,7 @@ func TestCheckMemberNotDeclaredSecondaryError(t *testing.T) {
             let test: Test = Test()
             let x = test.foop()
         `, ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				SuggestionsEnabled: true,
 			},
 		})
@@ -385,7 +385,7 @@ func TestCheckMemberNotDeclaredSecondaryError(t *testing.T) {
             let test: Test = Test()
             let x = test.foop()
         `, ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				SuggestionsEnabled: true,
 			},
 		})
@@ -409,7 +409,7 @@ func TestCheckMemberNotDeclaredSecondaryError(t *testing.T) {
             let test: Test = Test()
             let x = test.foop()
         `, ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				SuggestionsEnabled: true,
 			},
 		})

--- a/sema/nesting_test.go
+++ b/sema/nesting_test.go
@@ -331,7 +331,7 @@ func TestCheckNestedTypeInvalidChildType(t *testing.T) {
 			_, err := ParseAndCheckWithOptions(t,
 				`let u: T.U = nil`,
 				ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
 							return baseTypeActivation
 						},

--- a/sema/occurrences_test.go
+++ b/sema/occurrences_test.go
@@ -41,7 +41,7 @@ func TestCheckOccurrencesVariableDeclarations(t *testing.T) {
         var y = x
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				PositionInfoEnabled: true,
 			},
 		},
@@ -113,7 +113,7 @@ func TestCheckOccurrencesFunction(t *testing.T) {
         }
 		`,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				PositionInfoEnabled: true,
 			},
 		},
@@ -254,7 +254,7 @@ func TestCheckOccurrencesStructAndInterface(t *testing.T) {
 	    }
 		`,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				PositionInfoEnabled: true,
 			},
 		},

--- a/sema/operations_test.go
+++ b/sema/operations_test.go
@@ -403,7 +403,7 @@ func TestCheckNonIntegerComparisonOperations(t *testing.T) {
 							test.ty, test.leftType, test.left, test.rightType, test.right, operation.Symbol(),
 						),
 						ParseAndCheckOptions{
-							Config: &sema.Config{
+							CheckerConfig: &sema.Config{
 								BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
 									return baseValueActivation
 								},

--- a/sema/predeclaredvalues_test.go
+++ b/sema/predeclaredvalues_test.go
@@ -52,7 +52,7 @@ func TestCheckPredeclaredValues(t *testing.T) {
             }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},

--- a/sema/range_test.go
+++ b/sema/range_test.go
@@ -64,7 +64,7 @@ func TestCheckRange(t *testing.T) {
           resource _TEST_Baz {}
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				PositionInfoEnabled: true,
 			},
 		},

--- a/sema/range_value_test.go
+++ b/sema/range_value_test.go
@@ -248,7 +248,7 @@ func TestCheckInclusiveRangeConstructionValid(t *testing.T) {
 
 			checker, err := ParseAndCheckWithOptions(t, code,
 				ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
 							return baseValueActivation
 						},
@@ -292,7 +292,7 @@ func TestCheckInclusiveRangeConstructionInvalid(t *testing.T) {
 
 			_, err := ParseAndCheckWithOptions(t, code,
 				ParseAndCheckOptions{
-					Config: &sema.Config{
+					CheckerConfig: &sema.Config{
 						BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
 							return baseValueActivation
 						},
@@ -424,7 +424,7 @@ func TestInclusiveRangeNonLeafIntegerTypes(t *testing.T) {
 		baseValueActivation.DeclareValue(stdlib.InterpreterInclusiveRangeConstructor)
 
 		return ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},

--- a/sema/reference_test.go
+++ b/sema/reference_test.go
@@ -1947,7 +1947,7 @@ func TestCheckInvalidatedReferenceUse(t *testing.T) {
             }
         `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,

--- a/sema/resource_test.go
+++ b/sema/resource_test.go
@@ -1667,7 +1667,7 @@ func TestCheckInvalidCreateImportedResource(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,

--- a/sema/return_test.go
+++ b/sema/return_test.go
@@ -210,7 +210,7 @@ func testExits(t *testing.T, test exitTest) {
 		t,
 		code,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},

--- a/sema/rlp_test.go
+++ b/sema/rlp_test.go
@@ -41,7 +41,7 @@ func TestCheckRLPDecodeString(t *testing.T) {
            let l: [UInt8] = RLP.decodeString([0, 1, 2])
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -63,7 +63,7 @@ func TestCheckInvalidRLPDecodeString(t *testing.T) {
            let l: String = RLP.decodeString("string")
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -89,7 +89,7 @@ func TestCheckRLPDecodeList(t *testing.T) {
            let l: [[UInt8]] = RLP.decodeList([0, 1, 2])
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -111,7 +111,7 @@ func TestCheckInvalidRLPDecodeList(t *testing.T) {
            let l: String = RLP.decodeList("string")
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},

--- a/sema/storable_test.go
+++ b/sema/storable_test.go
@@ -44,7 +44,7 @@ func TestCheckStorable(t *testing.T) {
 		_, err := ParseAndCheckWithOptions(t,
 			code,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},

--- a/sema/transactions_test.go
+++ b/sema/transactions_test.go
@@ -415,7 +415,7 @@ func TestCheckTransactionExecuteScope(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				AccessCheckMode: sema.AccessCheckModeStrict,
 			},
 		},

--- a/sema/typeargument_test.go
+++ b/sema/typeargument_test.go
@@ -68,7 +68,7 @@ func TestCheckTypeArguments(t *testing.T) {
               let inclusiveRange: InclusiveRange<Int, String> = InclusiveRange(1, 10)
             `,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},
@@ -169,7 +169,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 		baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
 		baseValueActivation.DeclareValue(stdlib.InterpreterInclusiveRangeConstructor)
 		options := ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -822,7 +822,7 @@ func TestCheckParameterizedTypeIsInstantiated(t *testing.T) {
 		})
 
 		options := ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseTypeActivation
 				},

--- a/sema/utils_test.go
+++ b/sema/utils_test.go
@@ -35,7 +35,7 @@ func ParseAndCheckWithPanic(t *testing.T, code string) (*sema.Checker, error) {
 	return ParseAndCheckWithOptions(t,
 		code,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseValueActivation
 				},
@@ -56,7 +56,7 @@ func ParseAndCheckWithAny(t *testing.T, code string) (*sema.Checker, error) {
 	return ParseAndCheckWithOptions(t,
 		code,
 		ParseAndCheckOptions{
-			Config: &sema.Config{
+			CheckerConfig: &sema.Config{
 				BaseTypeActivationHandler: func(_ common.Location) *sema.VariableActivation {
 					return baseTypeActivation
 				},

--- a/stdlib/builtin_test.go
+++ b/stdlib/builtin_test.go
@@ -102,7 +102,7 @@ func TestCheckAssert(t *testing.T) {
 		return ParseAndCheckWithOptions(t,
 			code,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},
@@ -220,7 +220,7 @@ func TestCheckPanic(t *testing.T) {
 		return ParseAndCheckWithOptions(t,
 			code,
 			ParseAndCheckOptions{
-				Config: &sema.Config{
+				CheckerConfig: &sema.Config{
 					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
 						return baseValueActivation
 					},

--- a/test_utils/sema_utils/utils.go
+++ b/test_utils/sema_utils/utils.go
@@ -40,8 +40,9 @@ func ParseAndCheck(t testing.TB, code string) (*sema.Checker, error) {
 }
 
 type ParseAndCheckOptions struct {
+	MemoryGauge      common.MemoryGauge
 	Location         common.Location
-	Config           *sema.Config
+	CheckerConfig    *sema.Config
 	ParseOptions     parser.Config
 	IgnoreParseError bool
 }
@@ -57,21 +58,12 @@ func ParseAndCheckWithOptions(
 	code string,
 	options ParseAndCheckOptions,
 ) (*sema.Checker, error) {
-	return ParseAndCheckWithOptionsAndMemoryMetering(t, code, options, nil)
-}
-
-func ParseAndCheckWithOptionsAndMemoryMetering(
-	t testing.TB,
-	code string,
-	options ParseAndCheckOptions,
-	memoryGauge common.MemoryGauge,
-) (*sema.Checker, error) {
 
 	if options.Location == nil {
 		options.Location = TestLocation
 	}
 
-	program, err := parser.ParseProgram(memoryGauge, []byte(code), options.ParseOptions)
+	program, err := parser.ParseProgram(options.MemoryGauge, []byte(code), options.ParseOptions)
 	if !options.IgnoreParseError && !assert.NoError(t, err) {
 		var sb strings.Builder
 		location := options.Location
@@ -86,7 +78,7 @@ func ParseAndCheckWithOptionsAndMemoryMetering(
 
 	check := func() (*sema.Checker, error) {
 
-		config := options.Config
+		config := options.CheckerConfig
 		if config == nil {
 			config = &sema.Config{}
 		}
@@ -99,7 +91,7 @@ func ParseAndCheckWithOptionsAndMemoryMetering(
 		checker, err := sema.NewChecker(
 			program,
 			options.Location,
-			memoryGauge,
+			options.MemoryGauge,
 			config,
 		)
 		if err != nil {


### PR DESCRIPTION
Work towards #3804 

## Description

We currently have a lot of different "variants" of test utils, including variants with memory metering (e.g. `parseCheckAndInterprerWithMemoryMetering`).

Make it easier configuration of the memory gauge for the parser, checker, and interpreter (reused for compiler and VM in the `prepare` variant).

Also:
- Follow the pattern of `ParseCheckAndCompileOptions` in `ParseCheckAndInterpretOptions` and include the existing `ParseAndCheckOptions`.
- Improve naming (`Config` -> `CheckerConfig` / `InterpreterConfig`)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
