### PR TITLE
[Compiler] Fix second-value assignment for index-expressions

### DIFF
--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -837,7 +837,9 @@ func opRemoveIndex(vm *VM) {
 		EmptyLocationRange,
 		index,
 	)
-	containerValue.SetKey(
+
+	// Note: Must use `InsertKey` here, not `SetKey`.
+	containerValue.InsertKey(
 		context,
 		EmptyLocationRange,
 		index,

--- a/interpreter/resources_test.go
+++ b/interpreter/resources_test.go
@@ -3983,3 +3983,43 @@ func TestForceAssignment(t *testing.T) {
 		assert.ErrorAs(t, err, &resourceLossError)
 	})
 }
+
+func TestInterpretRecursiveTransfers(t *testing.T) {
+
+	t.Parallel()
+
+	inter, _ := parseCheckAndPrepareWithOptions(t,
+		`
+        resource Dummy {}
+
+        resource Wrapper {
+            var vaults: @[AnyResource]
+            init(_ vaults: @[AnyResource]) {
+                self.vaults <- vaults
+            }
+        }
+
+        fun main() {
+            var vaultsWrapper <- create Wrapper( <- [
+                <-create Dummy(),
+                <-create Dummy()
+            ])
+
+            var r <- vaultsWrapper.vaults[0] <- vaultsWrapper.vaults
+            destroy r
+            destroy vaultsWrapper
+        }
+        `,
+		ParseCheckAndInterpretOptions{
+			HandleCheckerError: func(err error) {
+				errs := RequireCheckerErrors(t, err, 1)
+				require.IsType(t, &sema.InvalidNestedResourceMoveError{}, errs[0])
+			},
+		},
+	)
+
+	_, err := inter.Invoke("main")
+
+	var recursiveTransferError *interpreter.RecursiveTransferError
+	require.ErrorAs(t, err, &recursiveTransferError)
+}

--- a/interpreter/transactions_test.go
+++ b/interpreter/transactions_test.go
@@ -403,7 +403,7 @@ func TestInterpretInvalidTransferInExecute(t *testing.T) {
 
 	t.Parallel()
 
-	inter, _ := parseCheckAndInterpretWithOptions(t,
+	inter, _ := parseCheckAndPrepareWithOptions(t,
 		`
           resource Dummy {}
 
@@ -447,8 +447,22 @@ func TestInterpretInvalidTransferInExecute(t *testing.T) {
 	)
 
 	err := inter.InvokeTransaction(nil, signer1)
-	var invalidatedResourceError *interpreter.InvalidatedResourceError
-	require.ErrorAs(t, err, &invalidatedResourceError)
+
+	// The interpreter gives a InvalidatedResourceError, because there, transaction
+	// gets created as a SimpleCompositeValue.
+	// Thus getting `self.vaults` twice (in LHS and RHS of the assignment) would return the same value instance.
+	// So moving the RHS would automatically invalidate the LHS.
+	// But in compiler/vm, transactions are created as a `CompositeValue`.
+	// There, given the composite-value is backed by atree, the two values returned for `self.vaults`,
+	// are two different instances (which is correct).
+	// Thus, moving one of them wouldn't invalidate the other.
+	if *compile {
+		var recursiveTransferError *interpreter.RecursiveTransferError
+		require.ErrorAs(t, err, &recursiveTransferError)
+	} else {
+		var invalidatedResourceError *interpreter.InvalidatedResourceError
+		require.ErrorAs(t, err, &invalidatedResourceError)
+	}
 }
 
 func TestInterpretInvalidRecursiveTransferInExecute(t *testing.T) {


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/4059

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
