### PR TITLE
[Compiler] Fix contract deployment / initialization

### DIFF
--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -206,13 +206,31 @@
       - name: "value"
         type: "value"
 
-- name: "new"
-  description: Creates a new instance of the given kind and type and then pushes it onto the stack.
+- name: "newComposite"
+  description:
+    Creates a new instance of the given composite kind and type, at address 0x0,
+    and then pushes it onto the stack.
   operands:
     - name: "kind"
       type: "compositeKind"
     - name: "type"
       type: "typeIndex"
+  valueEffects:
+    push:
+      - name: "value"
+        type: "value"
+
+- name: "newCompositeAt"
+  description:
+    Creates a new instance of the given composite kind and type, at the given address,
+    and then pushes it onto the stack.
+  operands:
+    - name: "kind"
+      type: "compositeKind"
+    - name: "type"
+      type: "typeIndex"
+    - name: "address"
+      type: "constantIndex"
   valueEffects:
     push:
       - name: "value"

--- a/bbq/opcode/opcode.go
+++ b/bbq/opcode/opcode.go
@@ -97,7 +97,8 @@ const (
 	False
 	Void
 	Nil
-	New
+	NewComposite
+	NewCompositeAt
 	NewPath
 	NewArray
 	NewDictionary

--- a/bbq/opcode/opcode_string.go
+++ b/bbq/opcode/opcode_string.go
@@ -45,41 +45,42 @@ func _() {
 	_ = x[False-50]
 	_ = x[Void-51]
 	_ = x[Nil-52]
-	_ = x[New-53]
-	_ = x[NewPath-54]
-	_ = x[NewArray-55]
-	_ = x[NewDictionary-56]
-	_ = x[NewRef-57]
-	_ = x[NewClosure-58]
-	_ = x[GetConstant-70]
-	_ = x[GetLocal-71]
-	_ = x[SetLocal-72]
-	_ = x[GetUpvalue-73]
-	_ = x[SetUpvalue-74]
-	_ = x[CloseUpvalue-75]
-	_ = x[GetGlobal-76]
-	_ = x[SetGlobal-77]
-	_ = x[GetField-78]
-	_ = x[RemoveField-79]
-	_ = x[SetField-80]
-	_ = x[SetIndex-81]
-	_ = x[GetIndex-82]
-	_ = x[RemoveIndex-83]
-	_ = x[GetMethod-84]
-	_ = x[Invoke-91]
-	_ = x[InvokeMethodStatic-92]
-	_ = x[InvokeMethodDynamic-93]
-	_ = x[Drop-101]
-	_ = x[Dup-102]
-	_ = x[Iterator-109]
-	_ = x[IteratorHasNext-110]
-	_ = x[IteratorNext-111]
-	_ = x[IteratorEnd-112]
-	_ = x[EmitEvent-113]
-	_ = x[Loop-114]
-	_ = x[Statement-115]
-	_ = x[TemplateString-116]
-	_ = x[OpcodeMax-117]
+	_ = x[NewComposite-53]
+	_ = x[NewCompositeAt-54]
+	_ = x[NewPath-55]
+	_ = x[NewArray-56]
+	_ = x[NewDictionary-57]
+	_ = x[NewRef-58]
+	_ = x[NewClosure-59]
+	_ = x[GetConstant-71]
+	_ = x[GetLocal-72]
+	_ = x[SetLocal-73]
+	_ = x[GetUpvalue-74]
+	_ = x[SetUpvalue-75]
+	_ = x[CloseUpvalue-76]
+	_ = x[GetGlobal-77]
+	_ = x[SetGlobal-78]
+	_ = x[GetField-79]
+	_ = x[RemoveField-80]
+	_ = x[SetField-81]
+	_ = x[SetIndex-82]
+	_ = x[GetIndex-83]
+	_ = x[RemoveIndex-84]
+	_ = x[GetMethod-85]
+	_ = x[Invoke-92]
+	_ = x[InvokeMethodStatic-93]
+	_ = x[InvokeMethodDynamic-94]
+	_ = x[Drop-102]
+	_ = x[Dup-103]
+	_ = x[Iterator-110]
+	_ = x[IteratorHasNext-111]
+	_ = x[IteratorNext-112]
+	_ = x[IteratorEnd-113]
+	_ = x[EmitEvent-114]
+	_ = x[Loop-115]
+	_ = x[Statement-116]
+	_ = x[TemplateString-117]
+	_ = x[OpcodeMax-118]
 }
 
 const (
@@ -88,7 +89,7 @@ const (
 	_Opcode_name_2 = "BitwiseOrBitwiseAndBitwiseXorBitwiseLeftShiftBitwiseRightShift"
 	_Opcode_name_3 = "LessGreaterLessOrEqualGreaterOrEqualEqualNotEqualNot"
 	_Opcode_name_4 = "UnwrapDestroyTransferAndConvertSimpleCastFailableCastForceCastDerefTransfer"
-	_Opcode_name_5 = "TrueFalseVoidNilNewNewPathNewArrayNewDictionaryNewRefNewClosure"
+	_Opcode_name_5 = "TrueFalseVoidNilNewCompositeNewCompositeAtNewPathNewArrayNewDictionaryNewRefNewClosure"
 	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetUpvalueSetUpvalueCloseUpvalueGetGlobalSetGlobalGetFieldRemoveFieldSetFieldSetIndexGetIndexRemoveIndexGetMethod"
 	_Opcode_name_7 = "InvokeInvokeMethodStaticInvokeMethodDynamic"
 	_Opcode_name_8 = "DropDup"
@@ -101,7 +102,7 @@ var (
 	_Opcode_index_2 = [...]uint8{0, 9, 19, 29, 45, 62}
 	_Opcode_index_3 = [...]uint8{0, 4, 11, 22, 36, 41, 49, 52}
 	_Opcode_index_4 = [...]uint8{0, 6, 13, 31, 41, 53, 62, 67, 75}
-	_Opcode_index_5 = [...]uint8{0, 4, 9, 13, 16, 19, 26, 34, 47, 53, 63}
+	_Opcode_index_5 = [...]uint8{0, 4, 9, 13, 16, 28, 42, 49, 57, 70, 76, 86}
 	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 37, 47, 59, 68, 77, 85, 96, 104, 112, 120, 131, 140}
 	_Opcode_index_7 = [...]uint8{0, 6, 24, 43}
 	_Opcode_index_8 = [...]uint8{0, 4, 7}
@@ -124,20 +125,20 @@ func (i Opcode) String() string {
 	case 36 <= i && i <= 43:
 		i -= 36
 		return _Opcode_name_4[_Opcode_index_4[i]:_Opcode_index_4[i+1]]
-	case 49 <= i && i <= 58:
+	case 49 <= i && i <= 59:
 		i -= 49
 		return _Opcode_name_5[_Opcode_index_5[i]:_Opcode_index_5[i+1]]
-	case 70 <= i && i <= 84:
-		i -= 70
+	case 71 <= i && i <= 85:
+		i -= 71
 		return _Opcode_name_6[_Opcode_index_6[i]:_Opcode_index_6[i+1]]
-	case 91 <= i && i <= 93:
-		i -= 91
+	case 92 <= i && i <= 94:
+		i -= 92
 		return _Opcode_name_7[_Opcode_index_7[i]:_Opcode_index_7[i+1]]
-	case 101 <= i && i <= 102:
-		i -= 101
+	case 102 <= i && i <= 103:
+		i -= 102
 		return _Opcode_name_8[_Opcode_index_8[i]:_Opcode_index_8[i+1]]
-	case 109 <= i && i <= 117:
-		i -= 109
+	case 110 <= i && i <= 118:
+		i -= 110
 		return _Opcode_name_9[_Opcode_index_9[i]:_Opcode_index_9[i+1]]
 	default:
 		return "Opcode(" + strconv.FormatInt(int64(i), 10) + ")"

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -177,7 +177,8 @@ func TestPrintInstruction(t *testing.T) {
 
 		"TransferAndConvert type:258": {byte(TransferAndConvert), 1, 2},
 
-		"New kind:CompositeKind(258) type:772": {byte(New), 1, 2, 3, 4},
+		"NewComposite kind:CompositeKind(258) type:772":                {byte(NewComposite), 1, 2, 3, 4},
+		"NewCompositeAt kind:CompositeKind(258) type:772 address:1286": {byte(NewCompositeAt), 1, 2, 3, 4, 5, 6},
 
 		"SimpleCast type:258":   {byte(SimpleCast), 1, 2, 3},
 		"FailableCast type:258": {byte(FailableCast), 1, 2, 3},

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -734,11 +734,12 @@ func opFalse(vm *VM) {
 
 func opGetConstant(vm *VM, ins opcode.InstructionGetConstant) {
 	constantIndex := ins.Constant
-	constant := vm.callFrame.function.Executable.Constants[constantIndex]
-	if constant == nil {
-		constant = vm.initializeConstant(constantIndex)
+	executable := vm.callFrame.function.Executable
+	c := executable.Constants[constantIndex]
+	if c == nil {
+		c = vm.initializeConstant(constantIndex)
 	}
-	vm.push(constant)
+	vm.push(c)
 }
 
 func opGetLocal(vm *VM, ins opcode.InstructionGetLocal) {
@@ -1012,11 +1013,36 @@ func opDup(vm *VM) {
 	vm.push(top)
 }
 
-func opNew(vm *VM, ins opcode.InstructionNew) {
-	compositeKind := ins.Kind
+func opNewComposite(vm *VM, ins opcode.InstructionNewComposite) {
+	compositeValue := newCompositeValue(
+		vm,
+		ins.Kind,
+		ins.Type,
+		common.ZeroAddress,
+	)
+	vm.push(compositeValue)
+}
 
+func opNewCompositeAt(vm *VM, ins opcode.InstructionNewCompositeAt) {
+	executable := vm.callFrame.function.Executable
+	c := executable.Program.Constants[ins.Address]
+
+	compositeValue := newCompositeValue(
+		vm,
+		ins.Kind,
+		ins.Type,
+		common.MustBytesToAddress(c.Data),
+	)
+	vm.push(compositeValue)
+}
+
+func newCompositeValue(
+	vm *VM,
+	compositeKind common.CompositeKind,
+	typeIndex uint16,
+	address common.Address,
+) *interpreter.CompositeValue {
 	// decode location
-	typeIndex := ins.Type
 	staticType := vm.loadType(typeIndex)
 
 	// TODO: Support inclusive-range type
@@ -1026,18 +1052,15 @@ func opNew(vm *VM, ins opcode.InstructionNew) {
 
 	compositeFields := newCompositeValueFields(config, compositeKind)
 
-	value := interpreter.NewCompositeValue(
+	return interpreter.NewCompositeValue(
 		config,
 		EmptyLocationRange,
 		compositeStaticType.Location,
 		compositeStaticType.QualifiedIdentifier,
 		compositeKind,
 		compositeFields,
-		// Newly created values are always on stack.
-		// Need to 'Transfer' if needed to be stored in an account.
-		common.ZeroAddress,
+		address,
 	)
-	vm.push(value)
 }
 
 func opSetField(vm *VM, ins opcode.InstructionSetField) {
@@ -1123,8 +1146,9 @@ func opRemoveField(vm *VM, ins opcode.InstructionRemoveField) {
 }
 
 func getStringConstant(vm *VM, index uint16) string {
-	constant := vm.callFrame.function.Executable.Program.Constants[index]
-	return string(constant.Data)
+	executable := vm.callFrame.function.Executable
+	c := executable.Program.Constants[index]
+	return string(c.Data)
 }
 
 func opTransferAndConvert(vm *VM, ins opcode.InstructionTransferAndConvert) {
@@ -1574,8 +1598,10 @@ func (vm *VM) run() {
 			opDrop(vm)
 		case opcode.InstructionDup:
 			opDup(vm)
-		case opcode.InstructionNew:
-			opNew(vm, ins)
+		case opcode.InstructionNewComposite:
+			opNewComposite(vm, ins)
+		case opcode.InstructionNewCompositeAt:
+			opNewCompositeAt(vm, ins)
 		case opcode.InstructionNewArray:
 			opNewArray(vm, ins)
 		case opcode.InstructionNewDictionary:
@@ -1723,8 +1749,8 @@ func opStatement(vm *VM) {
 
 func (vm *VM) initializeConstant(index uint16) (value Value) {
 	executable := vm.callFrame.function.Executable
-
 	c := executable.Program.Constants[index]
+
 	memoryGauge := vm.context.MemoryGauge
 
 	switch c.Kind {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -6070,8 +6070,7 @@ func TestRuntimeContractWriteback(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
-			// TODO: VM produces different writes
-			//UseVM:     *compile,
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)
@@ -6230,8 +6229,7 @@ func TestRuntimeStorageWriteback(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  nextTransactionLocation(),
-			// TODO: VM produces different writes
-			//UseVM:     *compile,
+			UseVM:     *compile,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -375,6 +375,8 @@ func (e *vmEnvironment) LoadContractValue(
 
 	vm := e.newVM(location, compiledProgram.program)
 
+	// NOTE: invocation.Address is not needed here, as the initializer of the contract
+	// instantiates a new contract value with the address of the contract already (newCompositeAt)
 	contract, err = vm.InitializeContract(name, invocation.ConstructorArguments...)
 
 	return


### PR DESCRIPTION
Work toward #4059 

## Description

- Rename the `new` instruction to `newComposite` to make it clearer that only composite values can be allocated with the instruction
- Add a new instruction `newCompositeAt` which is the same as `newComposite`, but it has an address operand. `newComposite` is now an optimization for a very common case
- Emit `newCompositeAt` instead of `newComposite` when allocating the composite value in a contract initializer of a contract deployed to an address location. This creates the composite value immediately in the account, like the interpreter does. Currently the value was allocated on the stack (address 0x0) and the writes were lost
- Implement the `newCompositeAt` instruction in the VM: It has the same behaviour as `newComposite`, but the given address is used instead of the implicit zero address
- Add a dedicated test case for compiling contracts with initializers. This was so far only tested implicitly/partially through other tests
- Enable both failing test cases which now work as expected

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
