### PR TITLE
[Compiler] Fix `TestRuntimeWrappedErrorHandling` when running with VM

### DIFF
--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -3731,6 +3731,7 @@ func TestRuntimeStorageIteration(t *testing.T) {
 			// So the program needs to be stored when it is loaded for the first time.
 			program, ok := programs[location]
 			if !ok {
+				var err error
 				program, err = load()
 				if err != nil {
 					// Return a wrapped error


### PR DESCRIPTION
Work towards #4059 

## Description

Enable `TestRuntimeWrappedErrorHandling` to be run with the compiler/VM.

This requires fixing the test to treat transaction programs as usual, keeping them in the programs "cache", and only considering contracts as broken.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
