### PR TITLE
[Compiler] Transaction pre/post conditions are already executed

### DIFF
--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -408,9 +408,10 @@ func (vm *VM) InvokeTransaction(arguments []Value, signers ...Value) (err error)
 		return err
 	}
 
-	// TODO: Invoke pre/post conditions
-
 	// Invoke 'execute', if exists.
+	// NOTE: pre and post conditions of the transaction were already
+	// desugared into the execution function.
+	// If no `execute` function was defined, a synthetic one was created.
 	err = vm.InvokeTransactionExecute(transaction)
 	if err != nil {
 		return err


### PR DESCRIPTION
Work towards #4059 

## Description

Resolve the TODO, as the functionality is already done: Transaction pre/post conditions are desugared into the `execute` function. This is tested in the VM test `TestTransaction`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
