### PR TITLE
[Compiler] Test construction of InclusiveRange with VM, resolve TODO

### DIFF
--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -9396,3 +9396,57 @@ func TestInheritedDefaultDestroyEvent(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, eventEmitted)
 }
+
+func TestFunctionInclusiveRangeConstruction(t *testing.T) {
+
+	t.Parallel()
+
+	activation := sema.NewVariableActivation(sema.BaseValueActivation)
+	activation.DeclareValue(stdlib.VMInclusiveRangeConstructor)
+
+	compilerConfig := &compiler.Config{
+		BuiltinGlobalsProvider: func(_ common.Location) *activations.Activation[compiler.GlobalImport] {
+			activation := activations.NewActivation[compiler.GlobalImport](nil, compiler.DefaultBuiltinGlobals())
+			activation.Set(
+				stdlib.VMInclusiveRangeConstructor.Name,
+				compiler.GlobalImport{
+					Name: stdlib.VMInclusiveRangeConstructor.Name,
+				},
+			)
+			return activation
+		},
+	}
+	vmConfig := vm.NewConfig(interpreter.NewInMemoryStorage(nil))
+	vmConfig.BuiltinGlobalsProvider = func(_ common.Location) *activations.Activation[vm.Variable] {
+		activation := activations.NewActivation[vm.Variable](nil, vm.DefaultBuiltinGlobals())
+		variable := &interpreter.SimpleVariable{}
+		variable.InitializeWithValue(stdlib.VMInclusiveRangeConstructor.Value)
+		activation.Set(stdlib.VMInclusiveRangeConstructor.Name, variable)
+		return activation
+	}
+
+	result, err := CompileAndInvokeWithOptions(
+		t,
+		`
+          fun test(): InclusiveRange<Int> {
+              return InclusiveRange(5, 10)
+          }
+        `,
+		"test",
+		CompilerAndVMOptions{
+			ParseCheckAndCompileOptions: ParseCheckAndCompileOptions{
+				CompilerConfig: compilerConfig,
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
+							return activation
+						},
+					},
+				},
+			},
+			VMConfig: vmConfig,
+		},
+	)
+	require.NoError(t, err)
+	require.IsType(t, &interpreter.CompositeValue{}, result)
+}

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -1020,7 +1020,6 @@ func opNew(vm *VM, ins opcode.InstructionNew) {
 	typeIndex := ins.Type
 	staticType := vm.loadType(typeIndex)
 
-	// TODO: Support inclusive-range type
 	compositeStaticType := staticType.(*interpreter.CompositeStaticType)
 
 	config := vm.context


### PR DESCRIPTION
Work towards #4059 

## Description

Remove the incorrect TODO to add support for `InclusiveRange` in the `newComposite`/`newCompositeAt` instruction implementations in the VM, as `InclusiveRange` values are constructed using a native constructor function defined in the VM.

Add a test by injecting the constructor function defined in the stdlib, `InclusiveRange` values can be constructed and returned to Go.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
