### PR TITLE
[Compiler] Refactor function invocation

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -2295,13 +2295,11 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 
 				funcNameConst := c.addStringConst(funcName)
 
-				argsCountWithReceiver := argumentCount + 1
-
 				c.emit(
 					opcode.InstructionInvokeMethodDynamic{
 						Name:     funcNameConst.index,
 						TypeArgs: typeArgs,
-						ArgCount: argsCountWithReceiver,
+						ArgCount: argumentCount,
 					},
 				)
 			},

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -2296,7 +2296,7 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 				funcNameConst := c.addStringConst(funcName)
 
 				c.emit(
-					opcode.InstructionInvokeMethodDynamic{
+					opcode.InstructionInvokeDynamic{
 						Name:     funcNameConst.index,
 						TypeArgs: typeArgs,
 						ArgCount: argumentCount,
@@ -2351,7 +2351,7 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 				// Compile arguments
 				c.compileArguments(expression.Arguments, invocationTypes)
 
-				c.emit(opcode.InstructionInvokeMethodStatic{
+				c.emit(opcode.InstructionInvoke{
 					TypeArgs: typeArgs,
 
 					// Argument count does not include the receiver,

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -2802,7 +2802,7 @@ func TestCompileMethodInvocation(t *testing.T) {
 				opcode.InstructionGetMethod{Method: fFuncIndex},
 				opcode.InstructionTrue{},
 				opcode.InstructionTransferAndConvert{Type: 2},
-				opcode.InstructionInvokeMethodStatic{
+				opcode.InstructionInvoke{
 					TypeArgs: nil,
 					ArgCount: 1,
 				},
@@ -3256,7 +3256,7 @@ func TestCompileDefaultFunction(t *testing.T) {
 			// self.test()
 			opcode.InstructionGetLocal{Local: selfIndex},
 			opcode.InstructionGetMethod{Method: interfaceFunctionIndex}, // must be interface method's index
-			opcode.InstructionInvokeMethodStatic{
+			opcode.InstructionInvoke{
 				TypeArgs: nil,
 				ArgCount: 0,
 			},
@@ -4072,7 +4072,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 
 				// Get function value `A.TestStruct.test()`
 				opcode.InstructionGetMethod{Method: 10},
-				opcode.InstructionInvokeMethodStatic{
+				opcode.InstructionInvoke{
 					ArgCount: 0,
 				},
 
@@ -6961,7 +6961,7 @@ func TestCompileOptionalChaining(t *testing.T) {
 
 				// Load `Foo.bar` function
 				opcode.InstructionGetMethod{Method: 4},
-				opcode.InstructionInvokeMethodStatic{ArgCount: 0},
+				opcode.InstructionInvoke{ArgCount: 0},
 				opcode.InstructionJump{Target: 15},
 
 				// If `foo == nil`
@@ -7779,7 +7779,7 @@ func TestCompileOptionalArgument(t *testing.T) {
 				opcode.InstructionGetConstant{Constant: optionalArgIndex},
 				opcode.InstructionTransfer{},
 
-				opcode.InstructionInvokeMethodStatic{ArgCount: 3},
+				opcode.InstructionInvoke{ArgCount: 3},
 				opcode.InstructionDrop{},
 
 				opcode.InstructionReturn{}},
@@ -9083,9 +9083,9 @@ func TestDynamicMethodInvocationViaOptionalChaining(t *testing.T) {
 			opcode.InstructionJumpIfNil{Target: 9},
 			opcode.InstructionGetLocal{Local: tempIndex},
 			opcode.InstructionUnwrap{},
-			opcode.InstructionInvokeMethodDynamic{
+			opcode.InstructionInvokeDynamic{
 				Name:     0,
-				ArgCount: 1,
+				ArgCount: 0,
 			},
 			opcode.InstructionJump{Target: 10},
 			opcode.InstructionNil{},
@@ -9234,7 +9234,7 @@ func TestCompileInjectedContract(t *testing.T) {
 				AccessedType: 5,
 			},
 			opcode.InstructionTransferAndConvert{Type: 6},
-			opcode.InstructionInvokeMethodStatic{ArgCount: 1},
+			opcode.InstructionInvoke{ArgCount: 1},
 			opcode.InstructionTransferAndConvert{Type: 6},
 			// return
 			opcode.InstructionReturnValue{},

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -1170,80 +1170,29 @@ func DecodeInvoke(ip *uint16, code []byte) (i InstructionInvoke) {
 	return i
 }
 
-// InstructionInvokeMethodStatic
+// InstructionInvokeDynamic
 //
-// Pops the method and arguments off the stack, invokes the method with the arguments, and then pushes the result back on to the stack. The first argument is the receiver of the method.
-type InstructionInvokeMethodStatic struct {
-	TypeArgs []uint16
-	ArgCount uint16
-}
-
-var _ Instruction = InstructionInvokeMethodStatic{}
-
-func (InstructionInvokeMethodStatic) Opcode() Opcode {
-	return InvokeMethodStatic
-}
-
-func (i InstructionInvokeMethodStatic) String() string {
-	var sb strings.Builder
-	sb.WriteString(i.Opcode().String())
-	i.OperandsString(&sb, false)
-	return sb.String()
-}
-
-func (i InstructionInvokeMethodStatic) OperandsString(sb *strings.Builder, colorize bool) {
-	sb.WriteByte(' ')
-	printfUInt16ArrayArgument(sb, "typeArgs", i.TypeArgs, colorize)
-	sb.WriteByte(' ')
-	printfArgument(sb, "argCount", i.ArgCount, colorize)
-}
-
-func (i InstructionInvokeMethodStatic) ResolvedOperandsString(sb *strings.Builder,
-	constants []constant.Constant,
-	types []interpreter.StaticType,
-	functionNames []string,
-	colorize bool) {
-	sb.WriteByte(' ')
-	printfTypeArrayArgument(sb, "typeArgs", i.TypeArgs, colorize, types)
-	sb.WriteByte(' ')
-	printfArgument(sb, "argCount", i.ArgCount, colorize)
-}
-
-func (i InstructionInvokeMethodStatic) Encode(code *[]byte) {
-	emitOpcode(code, i.Opcode())
-	emitUint16Array(code, i.TypeArgs)
-	emitUint16(code, i.ArgCount)
-}
-
-func DecodeInvokeMethodStatic(ip *uint16, code []byte) (i InstructionInvokeMethodStatic) {
-	i.TypeArgs = decodeUint16Array(ip, code)
-	i.ArgCount = decodeUint16(ip, code)
-	return i
-}
-
-// InstructionInvokeMethodDynamic
-//
-// Pops the arguments off the stack, invokes the method with the given name and argument count, and then pushes the result back on to the stack. The first argument is the receiver of the method.
-type InstructionInvokeMethodDynamic struct {
+// Invokes a method with the given name dynamically. Pops the receiver and the arguments off the stack, invokes the function with the arguments, and then pushes the result back on to the stack.
+type InstructionInvokeDynamic struct {
 	Name     uint16
 	TypeArgs []uint16
 	ArgCount uint16
 }
 
-var _ Instruction = InstructionInvokeMethodDynamic{}
+var _ Instruction = InstructionInvokeDynamic{}
 
-func (InstructionInvokeMethodDynamic) Opcode() Opcode {
-	return InvokeMethodDynamic
+func (InstructionInvokeDynamic) Opcode() Opcode {
+	return InvokeDynamic
 }
 
-func (i InstructionInvokeMethodDynamic) String() string {
+func (i InstructionInvokeDynamic) String() string {
 	var sb strings.Builder
 	sb.WriteString(i.Opcode().String())
 	i.OperandsString(&sb, false)
 	return sb.String()
 }
 
-func (i InstructionInvokeMethodDynamic) OperandsString(sb *strings.Builder, colorize bool) {
+func (i InstructionInvokeDynamic) OperandsString(sb *strings.Builder, colorize bool) {
 	sb.WriteByte(' ')
 	printfArgument(sb, "name", i.Name, colorize)
 	sb.WriteByte(' ')
@@ -1252,7 +1201,7 @@ func (i InstructionInvokeMethodDynamic) OperandsString(sb *strings.Builder, colo
 	printfArgument(sb, "argCount", i.ArgCount, colorize)
 }
 
-func (i InstructionInvokeMethodDynamic) ResolvedOperandsString(sb *strings.Builder,
+func (i InstructionInvokeDynamic) ResolvedOperandsString(sb *strings.Builder,
 	constants []constant.Constant,
 	types []interpreter.StaticType,
 	functionNames []string,
@@ -1265,14 +1214,14 @@ func (i InstructionInvokeMethodDynamic) ResolvedOperandsString(sb *strings.Build
 	printfArgument(sb, "argCount", i.ArgCount, colorize)
 }
 
-func (i InstructionInvokeMethodDynamic) Encode(code *[]byte) {
+func (i InstructionInvokeDynamic) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
 	emitUint16(code, i.Name)
 	emitUint16Array(code, i.TypeArgs)
 	emitUint16(code, i.ArgCount)
 }
 
-func DecodeInvokeMethodDynamic(ip *uint16, code []byte) (i InstructionInvokeMethodDynamic) {
+func DecodeInvokeDynamic(ip *uint16, code []byte) (i InstructionInvokeDynamic) {
 	i.Name = decodeUint16(ip, code)
 	i.TypeArgs = decodeUint16Array(ip, code)
 	i.ArgCount = decodeUint16(ip, code)
@@ -2754,10 +2703,8 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 		return DecodeNewClosure(ip, code)
 	case Invoke:
 		return DecodeInvoke(ip, code)
-	case InvokeMethodStatic:
-		return DecodeInvokeMethodStatic(ip, code)
-	case InvokeMethodDynamic:
-		return DecodeInvokeMethodDynamic(ip, code)
+	case InvokeDynamic:
+		return DecodeInvokeDynamic(ip, code)
 	case GetMethod:
 		return DecodeGetMethod(ip, code)
 	case Dup:

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -354,33 +354,11 @@
   controlEffects:
     - call:
 
-- name: "invokeMethodStatic"
+- name: "invokeDynamic"
   description:
-    Pops the method and arguments off the stack, invokes the method with the arguments,
+    Invokes a method with the given name dynamically. 
+    Pops the receiver and the arguments off the stack, invokes the function with the arguments,
     and then pushes the result back on to the stack.
-    The first argument is the receiver of the method.
-  operands:
-    - name: "typeArgs"
-      type: "typeIndices"
-    - name: "argCount"
-      type: "size"
-  valueEffects:
-    pop:
-      - name: "arguments"
-        # TODO: count
-      - name: "method"
-        type: "function"
-    push:
-      - name: "result"
-        type: "value"
-  controlEffects:
-    - call:
-
-- name: "invokeMethodDynamic"
-  description:
-    Pops the arguments off the stack, invokes the method with the given name and argument count,
-    and then pushes the result back on to the stack.
-    The first argument is the receiver of the method.
   operands:
     - name: "name"
       type: "constantIndex"

--- a/bbq/opcode/opcode.go
+++ b/bbq/opcode/opcode.go
@@ -141,8 +141,8 @@ const (
 	// Invocations
 
 	Invoke
-	InvokeMethodStatic
-	InvokeMethodDynamic
+	InvokeDynamic
+	_
 	_
 	_
 	_
@@ -189,8 +189,7 @@ func (i Opcode) IsControlFlow() bool {
 		JumpIfTrue,
 		JumpIfNil,
 		Invoke,
-		InvokeMethodStatic,
-		InvokeMethodDynamic:
+		InvokeDynamic:
 
 		return true
 

--- a/bbq/opcode/opcode_string.go
+++ b/bbq/opcode/opcode_string.go
@@ -68,8 +68,7 @@ func _() {
 	_ = x[RemoveIndex-84]
 	_ = x[GetMethod-85]
 	_ = x[Invoke-92]
-	_ = x[InvokeMethodStatic-93]
-	_ = x[InvokeMethodDynamic-94]
+	_ = x[InvokeDynamic-93]
 	_ = x[Drop-102]
 	_ = x[Dup-103]
 	_ = x[Iterator-110]
@@ -91,7 +90,7 @@ const (
 	_Opcode_name_4 = "UnwrapDestroyTransferAndConvertSimpleCastFailableCastForceCastDerefTransfer"
 	_Opcode_name_5 = "TrueFalseVoidNilNewCompositeNewCompositeAtNewPathNewArrayNewDictionaryNewRefNewClosure"
 	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetUpvalueSetUpvalueCloseUpvalueGetGlobalSetGlobalGetFieldRemoveFieldSetFieldSetIndexGetIndexRemoveIndexGetMethod"
-	_Opcode_name_7 = "InvokeInvokeMethodStaticInvokeMethodDynamic"
+	_Opcode_name_7 = "InvokeInvokeDynamic"
 	_Opcode_name_8 = "DropDup"
 	_Opcode_name_9 = "IteratorIteratorHasNextIteratorNextIteratorEndEmitEventLoopStatementTemplateStringOpcodeMax"
 )
@@ -104,7 +103,7 @@ var (
 	_Opcode_index_4 = [...]uint8{0, 6, 13, 31, 41, 53, 62, 67, 75}
 	_Opcode_index_5 = [...]uint8{0, 4, 9, 13, 16, 28, 42, 49, 57, 70, 76, 86}
 	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 37, 47, 59, 68, 77, 85, 96, 104, 112, 120, 131, 140}
-	_Opcode_index_7 = [...]uint8{0, 6, 24, 43}
+	_Opcode_index_7 = [...]uint8{0, 6, 19}
 	_Opcode_index_8 = [...]uint8{0, 4, 7}
 	_Opcode_index_9 = [...]uint8{0, 8, 23, 35, 46, 55, 59, 68, 82, 91}
 )
@@ -131,7 +130,7 @@ func (i Opcode) String() string {
 	case 71 <= i && i <= 85:
 		i -= 71
 		return _Opcode_name_6[_Opcode_index_6[i]:_Opcode_index_6[i+1]]
-	case 92 <= i && i <= 94:
+	case 92 <= i && i <= 93:
 		i -= 92
 		return _Opcode_name_7[_Opcode_index_7[i]:_Opcode_index_7[i+1]]
 	case 102 <= i && i <= 103:

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -189,11 +189,8 @@ func TestPrintInstruction(t *testing.T) {
 		"Invoke typeArgs:[772, 1286] argCount:1": {
 			byte(Invoke), 0, 2, 3, 4, 5, 6, 0, 1,
 		},
-		"InvokeMethodStatic typeArgs:[772, 1286] argCount:1": {
-			byte(InvokeMethodStatic), 0, 2, 3, 4, 5, 6, 0, 1,
-		},
-		`InvokeMethodDynamic name:1 typeArgs:[772, 1286] argCount:1800`: {
-			byte(InvokeMethodDynamic), 0, 1, 0, 2, 3, 4, 5, 6, 7, 8,
+		`InvokeDynamic name:1 typeArgs:[772, 1286] argCount:1800`: {
+			byte(InvokeDynamic), 0, 1, 0, 2, 3, 4, 5, 6, 7, 8,
 		},
 
 		"NewRef type:258 isImplicit:true": {byte(NewRef), 1, 2, 1},

--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -327,10 +327,10 @@ func (c *Context) DefaultDestroyEvents(
 		return nil
 	}
 
-	// Always have the receiver as the first argument.
-	arguments := []Value{resourceValue}
+	//Always have the receiver as the first argument.
+	//arguments := []Value{resourceValue}
 
-	events := c.InvokeFunction(method, arguments)
+	events := c.InvokeFunction(method, nil)
 	eventsArray, ok := events.(*interpreter.ArrayValue)
 	if !ok {
 		panic(errors.NewUnreachableError())

--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -327,9 +327,7 @@ func (c *Context) DefaultDestroyEvents(
 		return nil
 	}
 
-	//Always have the receiver as the first argument.
-	//arguments := []Value{resourceValue}
-
+	// The generated function takes no arguments.
 	events := c.InvokeFunction(method, nil)
 	eventsArray, ok := events.(*interpreter.ArrayValue)
 	if !ok {

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -899,25 +899,7 @@ func opGetMethod(vm *VM, ins opcode.InstructionGetMethod) {
 	vm.push(boundFunction)
 }
 
-func opInvokeMethodStatic(vm *VM, ins opcode.InstructionInvokeMethodStatic) {
-	// Load type arguments
-	typeArguments := loadTypeArguments(vm, ins.TypeArgs)
-
-	// Load arguments
-	arguments := vm.popN(int(ins.ArgCount))
-
-	// Load the invoked value
-	functionValue := vm.pop()
-
-	invokeFunction(
-		vm,
-		functionValue,
-		arguments,
-		typeArguments,
-	)
-}
-
-func opInvokeMethodDynamic(vm *VM, ins opcode.InstructionInvokeMethodDynamic) {
+func opInvokeMethodDynamic(vm *VM, ins opcode.InstructionInvokeDynamic) {
 	// TODO: This method is now equivalent to: `GetField` + `Invoke` instructions.
 	// See if it can be replaced. That will reduce the complexity of `invokeFunction` method below.
 
@@ -973,6 +955,7 @@ func invokeFunction(
 
 	case *NativeFunctionValue:
 		// TODO: pass the receiver separately.
+		//  That will reduce the argument confusion/mistakes in builtin functions.
 		if receiver != nil {
 			arguments = append([]Value{receiver}, arguments...)
 		}
@@ -1601,9 +1584,7 @@ func (vm *VM) run() {
 			opGetMethod(vm, ins)
 		case opcode.InstructionInvoke:
 			opInvoke(vm, ins)
-		case opcode.InstructionInvokeMethodStatic:
-			opInvokeMethodStatic(vm, ins)
-		case opcode.InstructionInvokeMethodDynamic:
+		case opcode.InstructionInvokeDynamic:
 			opInvokeMethodDynamic(vm, ins)
 		case opcode.InstructionDrop:
 			opDrop(vm)

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -351,11 +351,6 @@ func (vm *VM) validateAndInvokeExternally(functionValue FunctionValue, arguments
 		return nil, err
 	}
 
-	//if boundFunction, ok := functionValue.(*BoundFunctionValue); ok {
-	//	receiver := boundFunction.Receiver(vm.context)
-	//	preparedArguments = append([]Value{receiver}, preparedArguments...)
-	//}
-
 	return vm.invokeExternally(functionValue, preparedArguments)
 }
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -49,7 +49,7 @@ import (
 	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
-var compile = flag.Bool("compile", true, "Run tests using the compiler")
+var compile = flag.Bool("compile", false, "Run tests using the compiler")
 
 func newScriptEnvironment() Environment {
 	if *compile {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -49,7 +49,7 @@ import (
 	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
-var compile = flag.Bool("compile", false, "Run tests using the compiler")
+var compile = flag.Bool("compile", true, "Run tests using the compiler")
 
 func newScriptEnvironment() Environment {
 	if *compile {


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3804

## Description

Simplify the invocations by:
- Moving the handling of bound-functions and receiver to a single location (now handled in `invokeFunction`)
- When ^is done, it simplified and made the instructions `Invoke` and `InvokeMethodStatic` identical. Hence remove `InvokeMethodStatic`, and use `Invoke` instead.
- Now that there are only two invocation methods, renamed `InvokeMethodDynamic` to simply `InvokeDynamic`
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
