### PR TITLE
[Compiler] Add corresponding VM tests for missing interpreter test

### DIFF
--- a/bbq/commons/handlers.go
+++ b/bbq/commons/handlers.go
@@ -27,7 +27,7 @@ import (
 
 type ImportHandler func(location common.Location) *bbq.InstructionProgram
 
-type LocationHandler func(identifiers []ast.Identifier, location common.Location) ([]ResolvedLocation, error)
+type LocationHandler = sema.LocationHandlerFunc
 
 type ResolvedLocation = sema.ResolvedLocation
 

--- a/bbq/test_utils/utils.go
+++ b/bbq/test_utils/utils.go
@@ -36,10 +36,7 @@ import (
 	"github.com/onflow/cadence/bbq/compiler"
 )
 
-func SingleIdentifierLocationResolver(t testing.TB) func(
-	identifiers []ast.Identifier,
-	location common.Location,
-) ([]commons.ResolvedLocation, error) {
+func SingleIdentifierLocationResolver(t testing.TB) sema.LocationHandlerFunc {
 	return func(identifiers []ast.Identifier, location common.Location) ([]commons.ResolvedLocation, error) {
 		require.Len(t, identifiers, 1)
 		require.IsType(t, common.AddressLocation{}, location)

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -84,7 +84,7 @@ func compiledFTTransfer(tb testing.TB) {
 	}
 
 	compilerConfig := &compiler.Config{
-		LocationHandler: commons.LocationHandler(locationHandler),
+		LocationHandler: locationHandler,
 		ImportHandler:   importHandler,
 		ElaborationResolver: func(location common.Location) (*compiler.DesugaredElaboration, error) {
 			imported, ok := compiledPrograms[location]

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -567,6 +567,137 @@ func TestImport(t *testing.T) {
 	require.Equal(t, interpreter.NewUnmeteredStringValue("global function of the imported program"), result)
 }
 
+func TestImportError(t *testing.T) {
+
+	t.Parallel()
+
+	importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "Test")
+
+	importedChecker, err := ParseAndCheckWithOptions(t,
+		`
+          fun helloText(): String {
+              return panic("error in helloText")
+          }
+
+          contract Test {
+              struct Foo {
+                  var id : String
+
+                  init(_ id: String) {
+                      self.id = id
+                  }
+
+                  fun sayHello(_ id: Int): String {
+                      self.id
+                      return helloText()
+                  }
+              }
+          }
+        `,
+		ParseAndCheckOptions{
+			Location: importLocation,
+			CheckerConfig: &sema.Config{
+				BaseValueActivationHandler: TestBaseValueActivation,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	importCompConfig := &compiler.Config{
+		BuiltinGlobalsProvider: CompilerDefaultBuiltinGlobalsWithDefaultsAndPanic,
+	}
+
+	importCompiler := compiler.NewInstructionCompilerWithConfig(
+		interpreter.ProgramFromChecker(importedChecker),
+		importedChecker.Location,
+		importCompConfig,
+	)
+	importedProgram := importCompiler.Compile()
+
+	importVMConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
+	importVMConfig.BuiltinGlobalsProvider = VMBuiltinGlobalsProviderWithDefaultsAndPanic
+
+	_, importedContractValue := initializeContract(
+		t,
+		importLocation,
+		importedProgram,
+		importVMConfig,
+	)
+
+	activation := sema.NewVariableActivation(sema.BaseValueActivation)
+	activation.DeclareValue(stdlib.VMPanicFunction)
+
+	checker, err := ParseAndCheckWithOptions(t,
+		`
+          import Test from 0x1
+
+          fun test(): String {
+              var r = Test.Foo("Hello from Foo!")
+              return r.sayHello(1)
+          }
+        `,
+		ParseAndCheckOptions{
+			CheckerConfig: &sema.Config{
+				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
+				BaseValueActivationHandler: func(location common.Location) *sema.VariableActivation {
+					return activation
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	compConfig := &compiler.Config{
+		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
+			return importedProgram
+		},
+		BuiltinGlobalsProvider: CompilerDefaultBuiltinGlobalsWithDefaultsAndPanic,
+	}
+
+	comp := compiler.NewInstructionCompilerWithConfig(
+		interpreter.ProgramFromChecker(checker),
+		checker.Location,
+		compConfig,
+	)
+
+	program := comp.Compile()
+
+	vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
+	vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		return importedProgram
+	}
+	vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+		return importedContractValue
+	}
+	vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+		elaboration := importedChecker.Elaboration
+		compositeType := elaboration.CompositeType(typeID)
+		if compositeType != nil {
+			return compositeType, nil
+		}
+
+		return elaboration.InterfaceType(typeID), nil
+	}
+	vmConfig.BuiltinGlobalsProvider = VMBuiltinGlobalsProviderWithDefaultsAndPanic
+
+	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
+
+	_, err = vmInstance.InvokeExternally("test")
+	RequireError(t, err)
+
+	var panicErr stdlib.PanicError
+	require.ErrorAs(t, err, &panicErr)
+
+	assert.Equal(t,
+		"error in helloText",
+		panicErr.Message,
+	)
+}
+
 func TestContractImport(t *testing.T) {
 
 	t.Parallel()

--- a/interpreter/memory_metering_test.go
+++ b/interpreter/memory_metering_test.go
@@ -8527,7 +8527,11 @@ func TestInterpretFunctionStaticType(t *testing.T) {
 		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindFunctionStaticType))
+		assert.Equal(
+			t,
+			ifCompile[uint64](2, 3),
+			meter.getMemory(common.MemoryKindFunctionStaticType),
+		)
 	})
 }
 


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/4059

## Description

Updated `TestInterpretHostFunction`, `TestInterpretHostFunctionWithVariableArguments` , and `TestInterpretHostFunctionWithOptionalArguments` to also run with the VM.

`TestInterpretImport`, `TestInterpretCompositeFunctionInvocationFromImportingProgram`, and `TestInterpretConformToImportedInterface` already had VM tests.

Added a new VM test for `TestInterpretImportError` 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
