### PR TITLE
[Compiler] Fix compilation of for loops over non-reference array with reference values

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1349,9 +1349,10 @@ func (c *Compiler[_, _]) VisitForStatement(statement *ast.ForStatement) (_ struc
 
 	forStmtTypes := c.DesugaredElaboration.ForStatementType(statement)
 	loopVarType := forStmtTypes.ValueVariableType
-	_, isResultReference := sema.MaybeReferenceType(loopVarType)
+	_, isContainerReference := sema.MaybeReferenceType(forStmtTypes.ContainerType)
+	_, isValueReference := sema.MaybeReferenceType(loopVarType)
 
-	if isResultReference {
+	if isContainerReference && isValueReference {
 		index := c.getOrAddType(loopVarType)
 		c.emit(opcode.InstructionNewRef{
 			Type:       index,

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -3317,11 +3317,11 @@ func TestCompileFunctionConditions(t *testing.T) {
 		t.Parallel()
 
 		checker, err := ParseAndCheck(t, `
-        fun test(x: Int): Int {
-            pre { x > 0 }
-            return 5
-        }
-    `)
+            fun test(x: Int): Int {
+                pre { x > 0 }
+                return 5
+            }
+        `)
 		require.NoError(t, err)
 
 		comp := compiler.NewInstructionCompiler(
@@ -3381,11 +3381,11 @@ func TestCompileFunctionConditions(t *testing.T) {
 		t.Parallel()
 
 		checker, err := ParseAndCheck(t, `
-        fun test(x: Int): Int {
-            post { x > 0 }
-            return 5
-        }
-    `)
+            fun test(x: Int): Int {
+                post { x > 0 }
+                return 5
+            }
+        `)
 		require.NoError(t, err)
 
 		comp := compiler.NewInstructionCompiler(
@@ -3465,11 +3465,11 @@ func TestCompileFunctionConditions(t *testing.T) {
 		t.Parallel()
 
 		checker, err := ParseAndCheck(t, `
-        fun test(x: @AnyResource?): @AnyResource? {
-            post { result != nil }
-            return <- x
-        }
-    `)
+            fun test(x: @AnyResource?): @AnyResource? {
+                post { result != nil }
+                return <- x
+            }
+        `)
 		require.NoError(t, err)
 
 		comp := compiler.NewInstructionCompiler(

--- a/sema/check_for.go
+++ b/sema/check_for.go
@@ -90,6 +90,7 @@ func (checker *Checker) VisitForStatement(statement *ast.ForStatement) (_ struct
 	checker.Elaboration.SetForStatementType(statement, ForStatementTypes{
 		IndexVariableType: indexType,
 		ValueVariableType: loopVariableType,
+		ContainerType:     valueType,
 	})
 
 	// The body of the loop will maybe be evaluated.

--- a/sema/elaboration.go
+++ b/sema/elaboration.go
@@ -114,6 +114,7 @@ type ExpressionTypes struct {
 type ForStatementTypes struct {
 	IndexVariableType Type
 	ValueVariableType Type
+	ContainerType     Type
 }
 
 type Elaboration struct {


### PR DESCRIPTION
Work towards #4059 

## Description

Fix compiling of for loops when the element type is a reference, but the container is not, e.g. 

```cadence
let x = 1
let refs = [&x] 
for ref in refs { ... }
```

Currently this is miscompiled to creating a reference for each element. However, a reference should only be created if the value that is iterated over ("container") is a reference.

Found while enabling FVM tests, in particular https://github.com/onflow/flow-go/blob/432c6a857484df96629c4bfc88b35738769719aa/fvm/blueprints/scripts/setupStorageForServiceAccountsTemplate.cdc#L17-L24.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
