### PR TITLE
Fix Array.map and Array.filter

### DIFF
--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -1700,7 +1700,7 @@ func (v *ArrayValue) Filter(
 	procedure FunctionValue,
 ) Value {
 
-	elementType := v.semaType.ElementType(false)
+	elementType := v.SemaType(context).ElementType(false)
 
 	argumentTypes := []sema.Type{elementType}
 
@@ -1787,7 +1787,7 @@ func (v *ArrayValue) Map(
 	procedure FunctionValue,
 ) Value {
 
-	elementType := v.semaType.ElementType(false)
+	elementType := v.SemaType(context).ElementType(false)
 
 	argumentTypes := []sema.Type{elementType}
 


### PR DESCRIPTION
Work towards #3804 

## Description

Use the getter function to get the sema type instead of directly accessing the field storing the cached type. It might not be initialized yet

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
