### PR TITLE
[Compiler] Create `SimpleCompositeValue`s for transactions

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -2991,12 +2991,21 @@ func (c *Compiler[_, _]) compileInitializer(declaration *ast.SpecialFunctionDecl
 	}
 
 	if address == common.ZeroAddress {
-		c.emit(
-			opcode.InstructionNewComposite{
-				Kind: kind,
-				Type: typeIndex,
-			},
-		)
+		if typeName == commons.TransactionWrapperCompositeName {
+			c.emit(
+				opcode.InstructionNewSimpleComposite{
+					Kind: kind,
+					Type: typeIndex,
+				},
+			)
+		} else {
+			c.emit(
+				opcode.InstructionNewComposite{
+					Kind: kind,
+					Type: typeIndex,
+				},
+			)
+		}
 	} else {
 		addressConstant := c.addConstant(constant.Address, address.Bytes())
 		c.emit(

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -2991,7 +2991,11 @@ func (c *Compiler[_, _]) compileInitializer(declaration *ast.SpecialFunctionDecl
 	}
 
 	if address == common.ZeroAddress {
-		if typeName == commons.TransactionWrapperCompositeName {
+
+		// Transaction wrapper composite values are simple composite values.
+		if _, ok := enclosingType.GetLocation().(common.TransactionLocation); ok &&
+			typeName == commons.TransactionWrapperCompositeName {
+
 			c.emit(
 				opcode.InstructionNewSimpleComposite{
 					Kind: kind,

--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -2117,11 +2117,9 @@ func simpleFunctionDeclaration(
 
 func (d *Desugar) transactionCompositeType() *sema.CompositeType {
 	return &sema.CompositeType{
-		Location:    d.location,
-		Identifier:  commons.TransactionWrapperCompositeName,
-		Kind:        common.CompositeKindStructure,
-		NestedTypes: &sema.StringTypeOrderedMap{},
-		Members:     &sema.StringMemberOrderedMap{},
+		Location:   d.location,
+		Identifier: commons.TransactionWrapperCompositeName,
+		Kind:       common.CompositeKindStructure,
 	}
 }
 

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -697,6 +697,57 @@ func (i InstructionNil) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
 }
 
+// InstructionNewSimpleComposite
+//
+// Creates a new instance of a simple composite value of given kind and type, at address 0x0, and then pushes it onto the stack.
+type InstructionNewSimpleComposite struct {
+	Kind common.CompositeKind
+	Type uint16
+}
+
+var _ Instruction = InstructionNewSimpleComposite{}
+
+func (InstructionNewSimpleComposite) Opcode() Opcode {
+	return NewSimpleComposite
+}
+
+func (i InstructionNewSimpleComposite) String() string {
+	var sb strings.Builder
+	sb.WriteString(i.Opcode().String())
+	i.OperandsString(&sb, false)
+	return sb.String()
+}
+
+func (i InstructionNewSimpleComposite) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
+	printfArgument(sb, "kind", i.Kind, colorize)
+	sb.WriteByte(' ')
+	printfArgument(sb, "type", i.Type, colorize)
+}
+
+func (i InstructionNewSimpleComposite) ResolvedOperandsString(sb *strings.Builder,
+	constants []constant.Constant,
+	types []interpreter.StaticType,
+	functionNames []string,
+	colorize bool) {
+	sb.WriteByte(' ')
+	printfArgument(sb, "kind", i.Kind, colorize)
+	sb.WriteByte(' ')
+	printfTypeArgument(sb, "type", types[i.Type], colorize)
+}
+
+func (i InstructionNewSimpleComposite) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+	emitCompositeKind(code, i.Kind)
+	emitUint16(code, i.Type)
+}
+
+func DecodeNewSimpleComposite(ip *uint16, code []byte) (i InstructionNewSimpleComposite) {
+	i.Kind = decodeCompositeKind(ip, code)
+	i.Type = decodeUint16(ip, code)
+	return i
+}
+
 // InstructionNewComposite
 //
 // Creates a new instance of the given composite kind and type, at address 0x0, and then pushes it onto the stack.
@@ -2685,6 +2736,8 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 		return InstructionFalse{}
 	case Nil:
 		return InstructionNil{}
+	case NewSimpleComposite:
+		return DecodeNewSimpleComposite(ip, code)
 	case NewComposite:
 		return DecodeNewComposite(ip, code)
 	case NewCompositeAt:

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -206,6 +206,20 @@
       - name: "value"
         type: "value"
 
+- name: "newSimpleComposite"
+  description:
+    Creates a new instance of a simple composite value of given kind and type, at address 0x0,
+    and then pushes it onto the stack.
+  operands:
+    - name: "kind"
+      type: "compositeKind"
+    - name: "type"
+      type: "typeIndex"
+  valueEffects:
+    push:
+      - name: "value"
+        type: "value"
+
 - name: "newComposite"
   description:
     Creates a new instance of the given composite kind and type, at address 0x0,

--- a/bbq/opcode/opcode.go
+++ b/bbq/opcode/opcode.go
@@ -97,6 +97,7 @@ const (
 	False
 	Void
 	Nil
+	NewSimpleComposite
 	NewComposite
 	NewCompositeAt
 	NewPath
@@ -104,7 +105,6 @@ const (
 	NewDictionary
 	NewRef
 	NewClosure
-	_
 	_
 	_
 	_

--- a/bbq/opcode/opcode_string.go
+++ b/bbq/opcode/opcode_string.go
@@ -45,13 +45,14 @@ func _() {
 	_ = x[False-50]
 	_ = x[Void-51]
 	_ = x[Nil-52]
-	_ = x[NewComposite-53]
-	_ = x[NewCompositeAt-54]
-	_ = x[NewPath-55]
-	_ = x[NewArray-56]
-	_ = x[NewDictionary-57]
-	_ = x[NewRef-58]
-	_ = x[NewClosure-59]
+	_ = x[NewSimpleComposite-53]
+	_ = x[NewComposite-54]
+	_ = x[NewCompositeAt-55]
+	_ = x[NewPath-56]
+	_ = x[NewArray-57]
+	_ = x[NewDictionary-58]
+	_ = x[NewRef-59]
+	_ = x[NewClosure-60]
 	_ = x[GetConstant-71]
 	_ = x[GetLocal-72]
 	_ = x[SetLocal-73]
@@ -88,7 +89,7 @@ const (
 	_Opcode_name_2 = "BitwiseOrBitwiseAndBitwiseXorBitwiseLeftShiftBitwiseRightShift"
 	_Opcode_name_3 = "LessGreaterLessOrEqualGreaterOrEqualEqualNotEqualNot"
 	_Opcode_name_4 = "UnwrapDestroyTransferAndConvertSimpleCastFailableCastForceCastDerefTransfer"
-	_Opcode_name_5 = "TrueFalseVoidNilNewCompositeNewCompositeAtNewPathNewArrayNewDictionaryNewRefNewClosure"
+	_Opcode_name_5 = "TrueFalseVoidNilNewSimpleCompositeNewCompositeNewCompositeAtNewPathNewArrayNewDictionaryNewRefNewClosure"
 	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetUpvalueSetUpvalueCloseUpvalueGetGlobalSetGlobalGetFieldRemoveFieldSetFieldSetIndexGetIndexRemoveIndexGetMethod"
 	_Opcode_name_7 = "InvokeInvokeDynamic"
 	_Opcode_name_8 = "DropDup"
@@ -101,7 +102,7 @@ var (
 	_Opcode_index_2 = [...]uint8{0, 9, 19, 29, 45, 62}
 	_Opcode_index_3 = [...]uint8{0, 4, 11, 22, 36, 41, 49, 52}
 	_Opcode_index_4 = [...]uint8{0, 6, 13, 31, 41, 53, 62, 67, 75}
-	_Opcode_index_5 = [...]uint8{0, 4, 9, 13, 16, 28, 42, 49, 57, 70, 76, 86}
+	_Opcode_index_5 = [...]uint8{0, 4, 9, 13, 16, 34, 46, 60, 67, 75, 88, 94, 104}
 	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 37, 47, 59, 68, 77, 85, 96, 104, 112, 120, 131, 140}
 	_Opcode_index_7 = [...]uint8{0, 6, 19}
 	_Opcode_index_8 = [...]uint8{0, 4, 7}
@@ -124,7 +125,7 @@ func (i Opcode) String() string {
 	case 36 <= i && i <= 43:
 		i -= 36
 		return _Opcode_name_4[_Opcode_index_4[i]:_Opcode_index_4[i+1]]
-	case 49 <= i && i <= 59:
+	case 49 <= i && i <= 60:
 		i -= 49
 		return _Opcode_name_5[_Opcode_index_5[i]:_Opcode_index_5[i+1]]
 	case 71 <= i && i <= 85:

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -177,6 +177,7 @@ func TestPrintInstruction(t *testing.T) {
 
 		"TransferAndConvert type:258": {byte(TransferAndConvert), 1, 2},
 
+		"NewSimpleComposite kind:CompositeKind(258) type:772":          {byte(NewSimpleComposite), 1, 2, 3, 4},
 		"NewComposite kind:CompositeKind(258) type:772":                {byte(NewComposite), 1, 2, 3, 4},
 		"NewCompositeAt kind:CompositeKind(258) type:772 address:1286": {byte(NewCompositeAt), 1, 2, 3, 4, 5, 6},
 

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -2065,6 +2065,11 @@ func TestTransaction(t *testing.T) {
             `,
 			CompilerAndVMOptions{
 				VMConfig: vmConfig,
+				ParseCheckAndCompileOptions: ParseCheckAndCompileOptions{
+					ParseAndCheckOptions: &ParseAndCheckOptions{
+						Location: common.TransactionLocation{},
+					},
+				},
 			},
 		)
 		require.NoError(t, err)
@@ -2132,6 +2137,11 @@ func TestTransaction(t *testing.T) {
             `,
 			CompilerAndVMOptions{
 				VMConfig: vmConfig,
+				ParseCheckAndCompileOptions: ParseCheckAndCompileOptions{
+					ParseAndCheckOptions: &ParseAndCheckOptions{
+						Location: common.TransactionLocation{},
+					},
+				},
 			},
 		)
 		require.NoError(t, err)

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -158,7 +158,7 @@ func (v *SimpleCompositeValue) GetMember(context MemberAccessibleContext, locati
 
 func (v *SimpleCompositeValue) GetMethod(
 	context MemberAccessibleContext,
-	locationRange LocationRange,
+	_ LocationRange,
 	name string,
 ) FunctionValue {
 	if v.FunctionMemberGetter == nil {

--- a/interpreter/transactions_test.go
+++ b/interpreter/transactions_test.go
@@ -448,21 +448,8 @@ func TestInterpretInvalidTransferInExecute(t *testing.T) {
 
 	err := inter.InvokeTransaction(nil, signer1)
 
-	// The interpreter gives a InvalidatedResourceError, because there, transaction
-	// gets created as a SimpleCompositeValue.
-	// Thus getting `self.vaults` twice (in LHS and RHS of the assignment) would return the same value instance.
-	// So moving the RHS would automatically invalidate the LHS.
-	// But in compiler/vm, transactions are created as a `CompositeValue`.
-	// There, given the composite-value is backed by atree, the two values returned for `self.vaults`,
-	// are two different instances (which is correct).
-	// Thus, moving one of them wouldn't invalidate the other.
-	if *compile {
-		var recursiveTransferError *interpreter.RecursiveTransferError
-		require.ErrorAs(t, err, &recursiveTransferError)
-	} else {
-		var invalidatedResourceError *interpreter.InvalidatedResourceError
-		require.ErrorAs(t, err, &invalidatedResourceError)
-	}
+	var invalidatedResourceError *interpreter.InvalidatedResourceError
+	require.ErrorAs(t, err, &invalidatedResourceError)
 }
 
 func TestInterpretInvalidRecursiveTransferInExecute(t *testing.T) {

--- a/interpreter/transactions_test.go
+++ b/interpreter/transactions_test.go
@@ -42,15 +42,23 @@ func TestInterpretTransactions(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-          transaction {
-            execute {
-              let x = 1 + 2
-            }
-          }
-        `)
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+              transaction {
+                execute {
+                  let x = 1 + 2
+                }
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
 
-		err := inter.InvokeTransaction(nil)
+		err = inter.InvokeTransaction(nil)
 		assert.NoError(t, err)
 	})
 
@@ -58,22 +66,30 @@ func TestInterpretTransactions(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-          transaction {
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+              transaction {
 
-            var x: Int
+                var x: Int
 
-            prepare() {
-              self.x = 5
-            }
+                prepare() {
+                  self.x = 5
+                }
 
-            execute {
-              let y = self.x + 1
-            }
-          }
-        `)
+                execute {
+                  let y = self.x + 1
+                }
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
 
-		err := inter.InvokeTransaction(nil)
+		err = inter.InvokeTransaction(nil)
 		assert.NoError(t, err)
 	})
 
@@ -81,22 +97,30 @@ func TestInterpretTransactions(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-          transaction {
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+              transaction {
 
-            var x: Int
+                var x: Int
 
-            prepare() {
-              self.x = 5
-            }
+                prepare() {
+                  self.x = 5
+                }
 
-            pre {
-              self.x > 1
-            }
-          }
-        `)
+                pre {
+                  self.x > 1
+                }
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
 
-		err := inter.InvokeTransaction(nil)
+		err = inter.InvokeTransaction(nil)
 		assert.NoError(t, err)
 	})
 
@@ -104,22 +128,30 @@ func TestInterpretTransactions(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-          transaction {
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+              transaction {
 
-            var x: Int
+                var x: Int
 
-            prepare() {
-              self.x = 5
-            }
+                prepare() {
+                  self.x = 5
+                }
 
-            pre {
-              self.x > 10
-            }
-          }
-        `)
+                pre {
+                  self.x > 10
+                }
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
 
-		err := inter.InvokeTransaction(nil)
+		err = inter.InvokeTransaction(nil)
 		RequireError(t, err)
 
 		assertConditionError(
@@ -133,26 +165,34 @@ func TestInterpretTransactions(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-          transaction {
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+              transaction {
 
-            var x: Int
+                var x: Int
 
-            prepare() {
-              self.x = 5
-            }
+                prepare() {
+                  self.x = 5
+                }
 
-            execute {
-              self.x = 10
-            }
+                execute {
+                  self.x = 10
+                }
 
-            post {
-              self.x == 10
-            }
-          }
-        `)
+                post {
+                  self.x == 10
+                }
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
 
-		err := inter.InvokeTransaction(nil)
+		err = inter.InvokeTransaction(nil)
 		assert.NoError(t, err)
 	})
 
@@ -160,26 +200,34 @@ func TestInterpretTransactions(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-          transaction {
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+              transaction {
 
-            var x: Int
+                var x: Int
 
-            prepare() {
-              self.x = 5
-            }
+                prepare() {
+                  self.x = 5
+                }
 
-            execute {
-              self.x = 10
-            }
+                execute {
+                  self.x = 10
+                }
 
-            post {
-              self.x == 5
-            }
-          }
-        `)
+                post {
+                  self.x == 5
+                }
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
 
-		err := inter.InvokeTransaction(nil)
+		err = inter.InvokeTransaction(nil)
 		RequireError(t, err)
 
 		assertConditionError(
@@ -193,11 +241,19 @@ func TestInterpretTransactions(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-          transaction {
-            prepare(signer: &Account) {}
-          }
-        `)
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+              transaction {
+                prepare(signer: &Account) {}
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
 
 		signer := stdlib.NewAccountReferenceValue(
 			inter,
@@ -207,7 +263,7 @@ func TestInterpretTransactions(t *testing.T) {
 			interpreter.EmptyLocationRange,
 		)
 
-		err := inter.InvokeTransaction(nil)
+		err = inter.InvokeTransaction(nil)
 		assert.IsType(t, interpreter.ArgumentCountError{}, err)
 
 		err = inter.InvokeTransaction(nil, signer)
@@ -218,11 +274,19 @@ func TestInterpretTransactions(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-          transaction {
-            execute {}
-          }
-        `)
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+              transaction {
+                execute {}
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
 
 		signer1 := stdlib.NewAccountReferenceValue(
 			inter,
@@ -240,7 +304,7 @@ func TestInterpretTransactions(t *testing.T) {
 			interpreter.EmptyLocationRange,
 		)
 
-		err := inter.InvokeTransaction(nil)
+		err = inter.InvokeTransaction(nil)
 		assert.NoError(t, err)
 
 		err = inter.InvokeTransaction(nil, signer1)
@@ -254,13 +318,21 @@ func TestInterpretTransactions(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-          transaction {
-            prepare(signer: &Account) {}
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+              transaction {
+                prepare(signer: &Account) {}
 
-            execute {}
-          }
-        `)
+                execute {}
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
 
 		signer1 := stdlib.NewAccountReferenceValue(
 			inter,
@@ -278,7 +350,7 @@ func TestInterpretTransactions(t *testing.T) {
 			interpreter.EmptyLocationRange,
 		)
 
-		err := inter.InvokeTransaction(nil, signer1)
+		err = inter.InvokeTransaction(nil, signer1)
 		require.NoError(t, err)
 
 		err = inter.InvokeTransaction(nil, signer1, signer2)
@@ -289,18 +361,26 @@ func TestInterpretTransactions(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-          let values: [AnyStruct] = []
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+              let values: [AnyStruct] = []
 
-          transaction(x: Int, y: Bool) {
+              transaction(x: Int, y: Bool) {
 
-            prepare(signer: &Account) {
-              values.append(signer.address)
-              values.append(y)
-              values.append(x)
-            }
-          }
-        `)
+                prepare(signer: &Account) {
+                  values.append(signer.address)
+                  values.append(y)
+                  values.append(x)
+                }
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
 
 		arguments := []interpreter.Value{
 			interpreter.NewUnmeteredIntValueFromInt64(1),
@@ -317,7 +397,7 @@ func TestInterpretTransactions(t *testing.T) {
 			interpreter.EmptyLocationRange,
 		)
 
-		err := inter.InvokeTransaction(arguments, signer)
+		err = inter.InvokeTransaction(arguments, signer)
 		require.NoError(t, err)
 
 		values := inter.GetGlobal("values")
@@ -340,30 +420,38 @@ func TestInterpretTransactions(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-            enum Alpha: Int {
-                case A
-                case B
-            }
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+                enum Alpha: Int {
+                    case A
+                    case B
+                }
 
-            let a = Alpha.A
-            let b = Alpha.B
+                let a = Alpha.A
+                let b = Alpha.B
 
-            let values: [AnyStruct] = []
+                let values: [AnyStruct] = []
 
-            transaction(x: Alpha) {
+                transaction(x: Alpha) {
 
-                prepare(signer: &Account) {
-                    values.append(signer.address)
-                    values.append(x)
-                    if x == Alpha.A {
-                        values.append(Alpha.B)
-                    } else {
-                        values.append(-1)
+                    prepare(signer: &Account) {
+                        values.append(signer.address)
+                        values.append(x)
+                        if x == Alpha.A {
+                            values.append(Alpha.B)
+                        } else {
+                            values.append(-1)
+                        }
                     }
                 }
-            }
-        `)
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
 
 		arguments := []interpreter.Value{
 			inter.GetGlobal("a"),
@@ -379,7 +467,7 @@ func TestInterpretTransactions(t *testing.T) {
 			interpreter.EmptyLocationRange,
 		)
 
-		err := inter.InvokeTransaction(arguments, signer)
+		err = inter.InvokeTransaction(arguments, signer)
 		require.NoError(t, err)
 
 		values := inter.GetGlobal("values")
@@ -429,6 +517,9 @@ func TestInterpretInvalidTransferInExecute(t *testing.T) {
           }
         `,
 		ParseCheckAndInterpretOptions{
+			ParseAndCheckOptions: &ParseAndCheckOptions{
+				Location: common.TransactionLocation{},
+			},
 			HandleCheckerError: func(err error) {
 				errs := RequireCheckerErrors(t, err, 3)
 				require.IsType(t, &sema.ResourceCapturingError{}, errs[0])
@@ -460,21 +551,29 @@ func TestInterpretInvalidRecursiveTransferInExecute(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-            transaction {
-                var arr: @[AnyResource]
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+                transaction {
+                    var arr: @[AnyResource]
 
-                prepare() {
-                    self.arr <- []
+                    prepare() {
+                        self.arr <- []
+                    }
+
+                    execute {
+                        self.arr.append(<-self.arr)
+                    }
                 }
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
 
-                execute {
-                    self.arr.append(<-self.arr)
-                }
-            }
-        `)
-
-		err := inter.InvokeTransaction(nil)
+		err = inter.InvokeTransaction(nil)
 		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
 		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
@@ -483,21 +582,29 @@ func TestInterpretInvalidRecursiveTransferInExecute(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-            transaction {
-                var dict: @{String: AnyResource}
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+                transaction {
+                    var dict: @{String: AnyResource}
 
-                prepare() {
-                    self.dict <- {}
+                    prepare() {
+                        self.dict <- {}
+                    }
+
+                    execute {
+                        destroy self.dict.insert(key: "", <-self.dict)
+                    }
                 }
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
 
-                execute {
-                    destroy self.dict.insert(key: "", <-self.dict)
-                }
-            }
-        `)
-
-		err := inter.InvokeTransaction(nil)
+		err = inter.InvokeTransaction(nil)
 		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
 		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})
@@ -506,27 +613,35 @@ func TestInterpretInvalidRecursiveTransferInExecute(t *testing.T) {
 
 		t.Parallel()
 
-		inter := parseCheckAndPrepare(t, `
-            resource R {
-                fun foo(_ r: @R) {
-                    destroy r
-                }
-            }
-
-            transaction {
-                var r: @R
-
-                prepare() {
-                    self.r <- create R()
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+                resource R {
+                    fun foo(_ r: @R) {
+                        destroy r
+                    }
                 }
 
-                execute {
-                    self.r.foo(<-self.r)
-                }
-            }
-        `)
+                transaction {
+                    var r: @R
 
-		err := inter.InvokeTransaction(nil)
+                    prepare() {
+                        self.r <- create R()
+                    }
+
+                    execute {
+                        self.r.foo(<-self.r)
+                    }
+                }
+            `,
+			ParseCheckAndInterpretOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					Location: common.TransactionLocation{},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		err = inter.InvokeTransaction(nil)
 		var invalidatedResourceReferenceError *interpreter.InvalidatedResourceReferenceError
 		require.ErrorAs(t, err, &invalidatedResourceReferenceError)
 	})

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -9784,3 +9784,35 @@ func TestParseKeywordsAsFieldNames(t *testing.T) {
 		})
 	}
 }
+
+func TestParseStructNamedTransaction(t *testing.T) {
+	t.Parallel()
+
+	code := `
+        struct transaction {}
+
+        fun test(): transaction {
+            return transaction()
+        }
+    `
+
+	_, errs := testParseProgram(code)
+
+	// The compiler relies on the type-name `transaction`,
+	// to distinguish between constructing a transaction value vs any other composite value.
+	// So defining composite types with the name `transaction` must not be allwoed.
+	AssertEqualWithDiff(
+		t,
+		Error{
+			Code: []uint8(code),
+			Errors: []error{
+				&SyntaxError{
+					Pos:     ast.Position{Line: 2, Column: 15, Offset: 16},
+					Message: "expected identifier following struct declaration, got keyword transaction",
+				},
+			},
+		},
+		errs,
+	)
+
+}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -8005,8 +8005,8 @@ func TestRuntimeComputationMetering(t *testing.T) {
               for i in [1, 2] {}
             `,
 			ok:        true,
-			hits:      ifCompile[uint](7, 4),
-			intensity: ifCompile[uint64](7, 4),
+			hits:      ifCompile[uint](6, 4),
+			intensity: ifCompile[uint64](6, 4),
 		},
 		{
 			name: "statement + functionInvocation + encoding",
@@ -8014,8 +8014,8 @@ func TestRuntimeComputationMetering(t *testing.T) {
               acc.storage.save("A quick brown fox jumps over the lazy dog", to:/storage/some_path)
             `,
 			ok:        true,
-			hits:      ifCompile[uint](6, 3),
-			intensity: ifCompile[uint64](111, 108),
+			hits:      ifCompile[uint](5, 3),
+			intensity: ifCompile[uint64](110, 108),
 		},
 	}
 


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/4059

## Description

Create `SimpleCompositeValue`s for transactions, instead of a `CompositeValue` which is backed by atree.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
