### PR TITLE
Improve event emission

### DIFF
--- a/interpreter/interpreter_statement.go
+++ b/interpreter/interpreter_statement.go
@@ -387,9 +387,15 @@ func (interpreter *Interpreter) EmitEvent(
 
 func (interpreter *Interpreter) VisitEmitStatement(statement *ast.EmitStatement) StatementResult {
 
-	event, ok := interpreter.evalExpression(statement.InvocationExpression).(*CompositeValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
+	arguments := statement.InvocationExpression.Arguments
+
+	var eventFields []Value
+	if len(arguments) > 0 {
+		eventFields = make([]Value, len(arguments))
+
+		for i, argument := range arguments {
+			eventFields[i] = interpreter.evalExpression(argument.Expression)
+		}
 	}
 
 	eventType := interpreter.Program.Elaboration.EmitStatementEventType(statement)
@@ -398,8 +404,6 @@ func (interpreter *Interpreter) VisitEmitStatement(statement *ast.EmitStatement)
 		Location:    interpreter.Location,
 		HasPosition: statement,
 	}
-
-	eventFields := extractEventFields(interpreter, event, eventType)
 
 	interpreter.EmitEvent(
 		interpreter,

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -7335,11 +7335,13 @@ func TestInterpretEmitEvent(t *testing.T) {
 		`
           event Transfer(to: Int, from: Int)
           event TransferAmount(to: Int, from: Int, amount: Int)
+          event TransferOptional(to: Int?, from: Int?)
 
           fun test() {
               emit Transfer(to: 1, from: 2)
               emit Transfer(to: 3, from: 4)
               emit TransferAmount(to: 1, from: 2, amount: 100)
+              emit TransferOptional(to: nil, from: 2)
           }
         `,
 		ParseCheckAndInterpretOptions{
@@ -7365,11 +7367,13 @@ func TestInterpretEmitEvent(t *testing.T) {
 
 	transferEventType := RequireGlobalType(t, inter, "Transfer")
 	transferAmountEventType := RequireGlobalType(t, inter, "TransferAmount")
+	transferOptionalEventType := RequireGlobalType(t, inter, "TransferOptional")
 
-	require.Len(t, eventTypes, 3)
+	require.Len(t, eventTypes, 4)
 	require.Equal(t, TestLocation.QualifiedIdentifier(transferEventType.ID()), eventTypes[0].QualifiedIdentifier())
 	require.Equal(t, TestLocation.QualifiedIdentifier(transferEventType.ID()), eventTypes[1].QualifiedIdentifier())
 	require.Equal(t, TestLocation.QualifiedIdentifier(transferAmountEventType.ID()), eventTypes[2].QualifiedIdentifier())
+	require.Equal(t, TestLocation.QualifiedIdentifier(transferOptionalEventType.ID()), eventTypes[3].QualifiedIdentifier())
 
 	require.Equal(t,
 		[][]interpreter.Value{
@@ -7385,6 +7389,12 @@ func TestInterpretEmitEvent(t *testing.T) {
 				interpreter.NewUnmeteredIntValueFromInt64(1),
 				interpreter.NewUnmeteredIntValueFromInt64(2),
 				interpreter.NewUnmeteredIntValueFromInt64(100),
+			},
+			{
+				interpreter.NilValue{},
+				interpreter.NewUnmeteredSomeValueNonCopying(
+					interpreter.NewUnmeteredIntValueFromInt64(2),
+				),
 			},
 		},
 		eventsFields,


### PR DESCRIPTION
Work towards #4059 

## Description

Just like in the VM, only evaluate the arguments of an `emit` statement and avoid creating a temporary composite value.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
