### PR TITLE
[Compiler] Fix optional chaining in compiler

### DIFF
--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -6982,7 +6982,7 @@ func TestCompileOptionalChaining(t *testing.T) {
 
 				// Nil check
 				opcode.InstructionGetLocal{Local: optionalValueTempIndex},
-				opcode.InstructionJumpIfNil{Target: 14},
+				opcode.InstructionJumpIfNil{Target: 15},
 
 				// If `foo != nil`
 				// Unwrap the optional. (Loads receiver)
@@ -6992,7 +6992,8 @@ func TestCompileOptionalChaining(t *testing.T) {
 				// Load `Foo.bar` function
 				opcode.InstructionGetMethod{Method: 4},
 				opcode.InstructionInvoke{ArgCount: 0},
-				opcode.InstructionJump{Target: 15},
+				opcode.InstructionWrap{},
+				opcode.InstructionJump{Target: 16},
 
 				// If `foo == nil`
 				opcode.InstructionNil{},
@@ -9109,14 +9110,15 @@ func TestDynamicMethodInvocationViaOptionalChaining(t *testing.T) {
 			opcode.InstructionGetLocal{Local: siIndex},
 			opcode.InstructionSetLocal{Local: tempIndex},
 			opcode.InstructionGetLocal{Local: tempIndex},
-			opcode.InstructionJumpIfNil{Target: 9},
+			opcode.InstructionJumpIfNil{Target: 10},
 			opcode.InstructionGetLocal{Local: tempIndex},
 			opcode.InstructionUnwrap{},
 			opcode.InstructionInvokeDynamic{
 				Name:     0,
 				ArgCount: 0,
 			},
-			opcode.InstructionJump{Target: 10},
+			opcode.InstructionWrap{},
+			opcode.InstructionJump{Target: 11},
 			opcode.InstructionNil{},
 			opcode.InstructionTransferAndConvert{Type: 1},
 			opcode.InstructionReturnValue{},

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -1439,6 +1439,35 @@ func (i InstructionUnwrap) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
 }
 
+// InstructionWrap
+//
+// Pops a value off the stack, wrap it with an optional, and pushes back onto the stack.
+type InstructionWrap struct {
+}
+
+var _ Instruction = InstructionWrap{}
+
+func (InstructionWrap) Opcode() Opcode {
+	return Wrap
+}
+
+func (i InstructionWrap) String() string {
+	return i.Opcode().String()
+}
+
+func (i InstructionWrap) OperandsString(sb *strings.Builder, colorize bool) {}
+
+func (i InstructionWrap) ResolvedOperandsString(sb *strings.Builder,
+	constants []constant.Constant,
+	types []interpreter.StaticType,
+	functionNames []string,
+	colorize bool) {
+}
+
+func (i InstructionWrap) Encode(code *[]byte) {
+	emitOpcode(code, i.Opcode())
+}
+
 // InstructionTransfer
 //
 // Pops a value off the stack, calls transfer, and then pushes it back on to the stack.
@@ -2768,6 +2797,8 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 		return InstructionDestroy{}
 	case Unwrap:
 		return InstructionUnwrap{}
+	case Wrap:
+		return InstructionWrap{}
 	case Transfer:
 		return InstructionTransfer{}
 	case TransferAndConvert:

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -454,6 +454,17 @@
       - name: "value"
         type: "value"
 
+- name: "wrap"
+  description:
+    Pops a value off the stack, wrap it with an optional, and pushes back onto the stack.
+  valueEffects:
+    pop:
+      - name: "value"
+        type: "value"
+    push:
+      - name: "optional"
+        type: "value"
+
 # Conversion instructions
 
 - name: "transfer"

--- a/bbq/opcode/opcode.go
+++ b/bbq/opcode/opcode.go
@@ -77,6 +77,7 @@ const (
 	_
 	_
 	_
+	Wrap
 	Unwrap
 	Destroy
 	TransferAndConvert
@@ -85,7 +86,6 @@ const (
 	ForceCast
 	Deref
 	Transfer
-	_
 	_
 	_
 	_

--- a/bbq/opcode/opcode_string.go
+++ b/bbq/opcode/opcode_string.go
@@ -33,14 +33,15 @@ func _() {
 	_ = x[Equal-30]
 	_ = x[NotEqual-31]
 	_ = x[Not-32]
-	_ = x[Unwrap-36]
-	_ = x[Destroy-37]
-	_ = x[TransferAndConvert-38]
-	_ = x[SimpleCast-39]
-	_ = x[FailableCast-40]
-	_ = x[ForceCast-41]
-	_ = x[Deref-42]
-	_ = x[Transfer-43]
+	_ = x[Wrap-36]
+	_ = x[Unwrap-37]
+	_ = x[Destroy-38]
+	_ = x[TransferAndConvert-39]
+	_ = x[SimpleCast-40]
+	_ = x[FailableCast-41]
+	_ = x[ForceCast-42]
+	_ = x[Deref-43]
+	_ = x[Transfer-44]
 	_ = x[True-49]
 	_ = x[False-50]
 	_ = x[Void-51]
@@ -88,7 +89,7 @@ const (
 	_Opcode_name_1 = "AddSubtractMultiplyDivideModNegate"
 	_Opcode_name_2 = "BitwiseOrBitwiseAndBitwiseXorBitwiseLeftShiftBitwiseRightShift"
 	_Opcode_name_3 = "LessGreaterLessOrEqualGreaterOrEqualEqualNotEqualNot"
-	_Opcode_name_4 = "UnwrapDestroyTransferAndConvertSimpleCastFailableCastForceCastDerefTransfer"
+	_Opcode_name_4 = "WrapUnwrapDestroyTransferAndConvertSimpleCastFailableCastForceCastDerefTransfer"
 	_Opcode_name_5 = "TrueFalseVoidNilNewSimpleCompositeNewCompositeNewCompositeAtNewPathNewArrayNewDictionaryNewRefNewClosure"
 	_Opcode_name_6 = "GetConstantGetLocalSetLocalGetUpvalueSetUpvalueCloseUpvalueGetGlobalSetGlobalGetFieldRemoveFieldSetFieldSetIndexGetIndexRemoveIndexGetMethod"
 	_Opcode_name_7 = "InvokeInvokeDynamic"
@@ -101,7 +102,7 @@ var (
 	_Opcode_index_1 = [...]uint8{0, 3, 11, 19, 25, 28, 34}
 	_Opcode_index_2 = [...]uint8{0, 9, 19, 29, 45, 62}
 	_Opcode_index_3 = [...]uint8{0, 4, 11, 22, 36, 41, 49, 52}
-	_Opcode_index_4 = [...]uint8{0, 6, 13, 31, 41, 53, 62, 67, 75}
+	_Opcode_index_4 = [...]uint8{0, 4, 10, 17, 35, 45, 57, 66, 71, 79}
 	_Opcode_index_5 = [...]uint8{0, 4, 9, 13, 16, 34, 46, 60, 67, 75, 88, 94, 104}
 	_Opcode_index_6 = [...]uint8{0, 11, 19, 27, 37, 47, 59, 68, 77, 85, 96, 104, 112, 120, 131, 140}
 	_Opcode_index_7 = [...]uint8{0, 6, 19}
@@ -122,7 +123,7 @@ func (i Opcode) String() string {
 	case 26 <= i && i <= 32:
 		i -= 26
 		return _Opcode_name_3[_Opcode_index_3[i]:_Opcode_index_3[i+1]]
-	case 36 <= i && i <= 43:
+	case 36 <= i && i <= 44:
 		i -= 36
 		return _Opcode_name_4[_Opcode_index_4[i]:_Opcode_index_4[i+1]]
 	case 49 <= i && i <= 60:

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -223,6 +223,7 @@ func TestPrintInstruction(t *testing.T) {
 		"Equal":    {byte(Equal)},
 		"NotEqual": {byte(NotEqual)},
 
+		"Wrap":    {byte(Wrap)},
 		"Unwrap":  {byte(Unwrap)},
 		"Destroy": {byte(Destroy)},
 		"True":    {byte(True)},

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -1359,6 +1359,12 @@ func opUnwrap(vm *VM) {
 	}
 }
 
+func opWrap(vm *VM) {
+	value := vm.peek()
+	optional := interpreter.NewSomeValueNonCopying(vm.context, value)
+	vm.replaceTop(optional)
+}
+
 func opNewArray(vm *VM, ins opcode.InstructionNewArray) {
 	typeIndex := ins.Type
 	typ := vm.loadType(typeIndex).(interpreter.ArrayStaticType)
@@ -1645,6 +1651,8 @@ func (vm *VM) run() {
 			opNotEqual(vm)
 		case opcode.InstructionNot:
 			opNot(vm)
+		case opcode.InstructionWrap:
+			opWrap(vm)
 		case opcode.InstructionUnwrap:
 			opUnwrap(vm)
 		case opcode.InstructionEmitEvent:

--- a/interpreter/member_test.go
+++ b/interpreter/member_test.go
@@ -1314,3 +1314,57 @@ func TestInterpretNestedReferenceMemberAccess(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestInterpretOptionalChaining(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("method call", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndPrepare(t, `
+            var x: Int? = nil
+
+            struct S {
+                fun getX(): Int? {
+                   return x
+                }
+            }
+
+            fun test(): Int? {
+                var s: S? = S()
+                return s?.getX()!
+            }
+        `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+		AssertValuesEqual(t, inter, interpreter.Nil, value)
+	})
+
+	t.Run("field", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndPrepare(t, `
+            struct S {
+                var x: Int?
+
+                init() {
+                   self.x = nil
+                }
+            }
+
+            fun test(): Int {
+                var s: S? = S()
+                return s?.x!
+            }
+        `)
+
+		_, err := inter.Invoke("test")
+		require.Error(t, err)
+		forceNilError := &interpreter.ForceNilError{}
+		require.ErrorAs(t, err, &forceNilError)
+	})
+}


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/4059

## Description

Address the TODO in compiler for optional chaining, to aligning the compiler/vm behaviour with that of interpreter.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
