### PR TITLE
Show migration note and documentation link in pretty error printer

### DIFF
--- a/pretty/print.go
+++ b/pretty/print.go
@@ -231,7 +231,8 @@ func (p ErrorPrettyPrinter) prettyPrintError(err error, location common.Location
 
 	if errorNotes, ok := err.(errors.ErrorNotes); ok {
 		for _, errorNote := range errorNotes.ErrorNotes() {
-			excerpts = append(excerpts,
+			excerpts = append(
+				excerpts,
 				newExcerpt(errorNote, errorNote.Message(), false),
 			)
 		}
@@ -240,6 +241,32 @@ func (p ErrorPrettyPrinter) prettyPrintError(err error, location common.Location
 	sortExcerpts(excerpts)
 
 	p.writeCodeExcerpts(excerpts, location, code)
+
+	if hasMigrationNote, ok := err.(errors.HasMigrationNote); ok {
+		migrationNote := hasMigrationNote.MigrationNote()
+		if migrationNote != "" {
+			p.writeString("\n  Migration note: ")
+			if p.useColor {
+				p.writeString(colorizeNote(migrationNote))
+			} else {
+				p.writeString(migrationNote)
+			}
+			p.writeString("\n")
+		}
+	}
+
+	if hasDocumentationLink, ok := err.(errors.HasDocumentationLink); ok {
+		documentationLink := hasDocumentationLink.DocumentationLink()
+		if documentationLink != "" {
+			p.writeString("\n  See documentation at: ")
+			if p.useColor {
+				p.writeString(aurora.Hyperlink(documentationLink, documentationLink).String())
+			} else {
+				p.writeString(documentationLink)
+			}
+			p.writeString("\n")
+		}
+	}
 }
 
 func (p ErrorPrettyPrinter) writeCodeExcerpts(


### PR DESCRIPTION
Work towards #4062 

## Description

Show migration node and documentation link (if any) at end of pretty error output. The documentation link is a hyperlink (clickable).

For example:

<img width="954" height="255" alt="Screenshot 2025-08-06 at 1 09 05 PM" src="https://github.com/user-attachments/assets/6ae310a1-4dfc-4d2c-ad11-59ecc092873b" />

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
