### PR TITLE
[v1.6] Port v1.6.4-rc.1: Fix conformance kind mismatch error reporting

### DIFF
--- a/sema/check_composite_declaration.go
+++ b/sema/check_composite_declaration.go
@@ -1497,19 +1497,35 @@ func (checker *Checker) checkConformanceKindMatch(
 		// Otherwise, find the conformance which resulted in the mismatch,
 		// and log the error there.
 		for _, conformance := range conformances {
-			if conformance.Identifier.Identifier == interfaceConformance.Identifier {
+			// If the conformance-type-name is a single identifier, e.g: `A`
+			// (i.e: type is defined in the same contract),
+			// then compare with that single identifier.
+			if len(conformance.NestedIdentifiers) == 0 &&
+				conformance.Identifier.Identifier == interfaceConformance.Identifier {
 				compositeKindMismatchIdentifier = &conformance.Identifier
 				break
+			} else {
+				// Otherwise: If the conformance-type-name has nested identifiers, e.g: `A.B`
+				// (i.e: type is defined in a different contract),
+				// then compare with the nested identifiers.
+				for _, identifier := range conformance.NestedIdentifiers {
+					if identifier.Identifier == interfaceConformance.Identifier {
+						compositeKindMismatchIdentifier = &conformance.Identifier
+						break
+					}
+				}
 			}
 		}
-
-		// If not found, then that means, the mismatching interface is a grandparent.
-		// Then it should have already been reported when checking the parent.
-		// Hence, no need to report an error here again.
 	}
 
+	// For some reason, if it couldn't find the identifier that doesn't match AND,
+	// if there were no previous errors reported either, then report and error to be safe.
 	if compositeKindMismatchIdentifier == nil {
-		return
+		if len(checker.errors) != 0 {
+			return
+		}
+
+		compositeKindMismatchIdentifier = conformingDeclaration.DeclarationIdentifier()
 	}
 
 	checker.report(


### PR DESCRIPTION
## Description

Port the PR from internal [v1.6.4-rc.1](https://github.com/onflow/cadence-internal/releases/tag/v1.6.4-rc.1)
- https://github.com/onflow/cadence-internal/pull/342

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
