### PR TITLE
Improve errors

### DIFF
--- a/ast/expression.go
+++ b/ast/expression.go
@@ -878,10 +878,10 @@ type AccessExpression interface {
 type MemberExpression struct {
 	Expression Expression
 	Identifier Identifier
-	// The position of the token (`.`, `?.`) that separates the accessed expression
+	// The end position of the token (`.`, `?.`) that separates the accessed expression
 	// and the identifier of the member
-	AccessPos Position
-	Optional  bool
+	AccessEndPos Position
+	Optional     bool
 }
 
 var _ Element = &MemberExpression{}
@@ -891,16 +891,16 @@ func NewMemberExpression(
 	gauge common.MemoryGauge,
 	expression Expression,
 	optional bool,
-	accessPos Position,
+	accessEndPos Position,
 	identifier Identifier,
 ) *MemberExpression {
 	common.UseMemory(gauge, common.MemberExpressionMemoryUsage)
 
 	return &MemberExpression{
-		Expression: expression,
-		Optional:   optional,
-		AccessPos:  accessPos,
-		Identifier: identifier,
+		Expression:   expression,
+		Optional:     optional,
+		AccessEndPos: accessEndPos,
+		Identifier:   identifier,
 	}
 }
 
@@ -960,7 +960,7 @@ func (e *MemberExpression) StartPosition() Position {
 
 func (e *MemberExpression) EndPosition(memoryGauge common.MemoryGauge) Position {
 	if e.Identifier.Identifier == "" {
-		return e.AccessPos
+		return e.AccessEndPos
 	} else {
 		return e.Identifier.EndPosition(memoryGauge)
 	}

--- a/ast/expression_test.go
+++ b/ast/expression_test.go
@@ -967,8 +967,8 @@ func TestMemberExpression_MarshalJSON(t *testing.T) {
 				EndPos:   Position{Offset: 4, Line: 5, Column: 6},
 			},
 		},
-		Optional:  true,
-		AccessPos: Position{Offset: 7, Line: 8, Column: 9},
+		Optional:     true,
+		AccessEndPos: Position{Offset: 7, Line: 8, Column: 9},
 		Identifier: Identifier{
 			Identifier: "foobar",
 			Pos:        Position{Offset: 10, Line: 11, Column: 12},

--- a/old_parser/declaration_test.go
+++ b/old_parser/declaration_test.go
@@ -2718,7 +2718,7 @@ func TestParseCompositeDeclaration(t *testing.T) {
 																Pos:        ast.Position{Offset: 111, Line: 6, Column: 18},
 															},
 														},
-														AccessPos: ast.Position{Offset: 115, Line: 6, Column: 22},
+														AccessEndPos: ast.Position{Offset: 115, Line: 6, Column: 22},
 														Identifier: ast.Identifier{
 															Identifier: "foo",
 															Pos:        ast.Position{Offset: 116, Line: 6, Column: 23},
@@ -2778,7 +2778,7 @@ func TestParseCompositeDeclaration(t *testing.T) {
 															Pos:        ast.Position{Offset: 206, Line: 10, Column: 25},
 														},
 													},
-													AccessPos: ast.Position{Offset: 210, Line: 10, Column: 29},
+													AccessEndPos: ast.Position{Offset: 210, Line: 10, Column: 29},
 													Identifier: ast.Identifier{
 														Identifier: "foo",
 														Pos:        ast.Position{Offset: 211, Line: 10, Column: 30},
@@ -4501,7 +4501,7 @@ func TestParseStructure(t *testing.T) {
 															Pos:        ast.Position{Offset: 103, Line: 6, Column: 16},
 														},
 													},
-													AccessPos: ast.Position{Offset: 107, Line: 6, Column: 20},
+													AccessEndPos: ast.Position{Offset: 107, Line: 6, Column: 20},
 													Identifier: ast.Identifier{
 														Identifier: "foo",
 														Pos:        ast.Position{Offset: 108, Line: 6, Column: 21},
@@ -4561,7 +4561,7 @@ func TestParseStructure(t *testing.T) {
 														Pos:        ast.Position{Offset: 192, Line: 10, Column: 23},
 													},
 												},
-												AccessPos: ast.Position{Offset: 196, Line: 10, Column: 27},
+												AccessEndPos: ast.Position{Offset: 196, Line: 10, Column: 27},
 												Identifier: ast.Identifier{
 													Identifier: "foo",
 													Pos:        ast.Position{Offset: 197, Line: 10, Column: 28},
@@ -5997,7 +5997,7 @@ func TestParseCompositeDeclarationWithSemicolonSeparatedMembers(t *testing.T) {
 															Pos:        ast.Position{Offset: 54, Line: 2, Column: 53},
 														},
 													},
-													AccessPos: ast.Position{Offset: 58, Line: 2, Column: 57},
+													AccessEndPos: ast.Position{Offset: 58, Line: 2, Column: 57},
 													Identifier: ast.Identifier{
 														Identifier: "id",
 														Pos:        ast.Position{Offset: 59, Line: 2, Column: 58},

--- a/old_parser/expression_test.go
+++ b/old_parser/expression_test.go
@@ -1801,7 +1801,7 @@ func TestParseMemberExpression(t *testing.T) {
 						Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
 					},
 				},
-				AccessPos: ast.Position{Offset: 1, Line: 1, Column: 1},
+				AccessEndPos: ast.Position{Offset: 1, Line: 1, Column: 1},
 				Identifier: ast.Identifier{
 					Identifier: "n",
 					Pos:        ast.Position{Offset: 2, Line: 1, Column: 2},
@@ -1826,7 +1826,7 @@ func TestParseMemberExpression(t *testing.T) {
 						Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
 					},
 				},
-				AccessPos: ast.Position{Offset: 2, Line: 1, Column: 2},
+				AccessEndPos: ast.Position{Offset: 2, Line: 1, Column: 2},
 				Identifier: ast.Identifier{
 					Identifier: "n",
 					Pos:        ast.Position{Offset: 3, Line: 1, Column: 3},
@@ -1859,7 +1859,7 @@ func TestParseMemberExpression(t *testing.T) {
 						Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
 					},
 				},
-				AccessPos: ast.Position{Offset: 1, Line: 1, Column: 1},
+				AccessEndPos: ast.Position{Offset: 1, Line: 1, Column: 1},
 			},
 			result,
 		)
@@ -1882,7 +1882,7 @@ func TestParseMemberExpression(t *testing.T) {
 							Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
 						},
 					},
-					AccessPos: ast.Position{Offset: 1, Line: 1, Column: 1},
+					AccessEndPos: ast.Position{Offset: 1, Line: 1, Column: 1},
 					Identifier: ast.Identifier{
 						Identifier: "n",
 						Pos:        ast.Position{Offset: 2, Line: 1, Column: 2},
@@ -1928,7 +1928,7 @@ func TestParseMemberExpression(t *testing.T) {
 							Pos:        ast.Position{Offset: 4, Line: 1, Column: 4},
 						},
 					},
-					AccessPos: ast.Position{Offset: 5, Line: 1, Column: 5},
+					AccessEndPos: ast.Position{Offset: 5, Line: 1, Column: 5},
 					Identifier: ast.Identifier{
 						Identifier: "n",
 						Pos:        ast.Position{Offset: 6, Line: 1, Column: 6},
@@ -1955,7 +1955,7 @@ func TestParseMemberExpression(t *testing.T) {
 						Pos:        ast.Position{Offset: 0, Line: 1, Column: 0},
 					},
 				},
-				AccessPos: ast.Position{Offset: 2, Line: 1, Column: 2},
+				AccessEndPos: ast.Position{Offset: 2, Line: 1, Column: 2},
 				Identifier: ast.Identifier{
 					Identifier: "n",
 					Pos:        ast.Position{Offset: 3, Line: 1, Column: 3},
@@ -1999,7 +1999,7 @@ func TestParseMemberExpression(t *testing.T) {
 							Identifier: "c",
 							Pos:        ast.Position{Offset: 21, Line: 2, Column: 20},
 						},
-						AccessPos: ast.Position{Offset: 20, Line: 2, Column: 19},
+						AccessEndPos: ast.Position{Offset: 20, Line: 2, Column: 19},
 					},
 					StartPos: ast.Position{Offset: 11, Line: 2, Column: 10},
 				},
@@ -2634,7 +2634,7 @@ func TestParseForceExpression(t *testing.T) {
 									Pos:        ast.Position{Line: 1, Column: 0, Offset: 0},
 								},
 							},
-							AccessPos: ast.Position{Line: 2, Column: 0, Offset: 2},
+							AccessEndPos: ast.Position{Line: 2, Column: 0, Offset: 2},
 							Identifier: ast.Identifier{
 								Identifier: "y",
 								Pos:        ast.Position{Line: 2, Column: 1, Offset: 3},
@@ -2673,7 +2673,7 @@ func TestParseForceExpression(t *testing.T) {
 								Pos:        ast.Position{Line: 1, Column: 0, Offset: 0},
 							},
 						},
-						AccessPos: ast.Position{Line: 1, Column: 1, Offset: 1},
+						AccessEndPos: ast.Position{Line: 1, Column: 1, Offset: 1},
 						Identifier: ast.Identifier{
 							Identifier: "y",
 							Pos:        ast.Position{Line: 1, Column: 3, Offset: 3},
@@ -4729,7 +4729,7 @@ func TestParseOptionalMemberExpression(t *testing.T) {
 						Identifier: "c",
 						Pos:        ast.Position{Offset: 17, Line: 2, Column: 16},
 					},
-					AccessPos: ast.Position{Offset: 16, Line: 2, Column: 15},
+					AccessEndPos: ast.Position{Offset: 16, Line: 2, Column: 15},
 				},
 				StartPos: ast.Position{Offset: 6, Line: 2, Column: 5},
 			},
@@ -6149,7 +6149,7 @@ func TestParseReferenceInVariableDeclaration(t *testing.T) {
 									Pos:        ast.Position{Offset: 17, Line: 2, Column: 16},
 								},
 							},
-							AccessPos: ast.Position{Offset: 24, Line: 2, Column: 23},
+							AccessEndPos: ast.Position{Offset: 24, Line: 2, Column: 23},
 							Identifier: ast.Identifier{
 								Identifier: "storage",
 								Pos:        ast.Position{Offset: 25, Line: 2, Column: 24},

--- a/old_parser/statement_test.go
+++ b/old_parser/statement_test.go
@@ -1957,13 +1957,13 @@ func TestParseAccessAssignment(t *testing.T) {
 															Pos:        ast.Position{Offset: 31, Line: 3, Column: 12},
 														},
 													},
-													AccessPos: ast.Position{Offset: 32, Line: 3, Column: 13},
+													AccessEndPos: ast.Position{Offset: 32, Line: 3, Column: 13},
 													Identifier: ast.Identifier{
 														Identifier: "foo",
 														Pos:        ast.Position{Offset: 33, Line: 3, Column: 14},
 													},
 												},
-												AccessPos: ast.Position{Offset: 36, Line: 3, Column: 17},
+												AccessEndPos: ast.Position{Offset: 36, Line: 3, Column: 17},
 												Identifier: ast.Identifier{
 													Identifier: "bar",
 													Pos:        ast.Position{Offset: 37, Line: 3, Column: 18},
@@ -1997,7 +1997,7 @@ func TestParseAccessAssignment(t *testing.T) {
 											EndPos:   ast.Position{Offset: 45, Line: 3, Column: 26},
 										},
 									},
-									AccessPos: ast.Position{Offset: 46, Line: 3, Column: 27},
+									AccessEndPos: ast.Position{Offset: 46, Line: 3, Column: 27},
 									Identifier: ast.Identifier{
 										Identifier: "baz",
 										Pos:        ast.Position{Offset: 47, Line: 3, Column: 28},
@@ -2070,13 +2070,13 @@ func TestParseExpressionStatementWithAccess(t *testing.T) {
 															Pos:        ast.Position{Offset: 19, Line: 2, Column: 18},
 														},
 													},
-													AccessPos: ast.Position{Offset: 20, Line: 2, Column: 19},
+													AccessEndPos: ast.Position{Offset: 20, Line: 2, Column: 19},
 													Identifier: ast.Identifier{
 														Identifier: "foo",
 														Pos:        ast.Position{Offset: 21, Line: 2, Column: 20},
 													},
 												},
-												AccessPos: ast.Position{Offset: 24, Line: 2, Column: 23},
+												AccessEndPos: ast.Position{Offset: 24, Line: 2, Column: 23},
 												Identifier: ast.Identifier{
 													Identifier: "bar",
 													Pos:        ast.Position{Offset: 25, Line: 2, Column: 24},
@@ -2110,7 +2110,7 @@ func TestParseExpressionStatementWithAccess(t *testing.T) {
 											EndPos:   ast.Position{Offset: 33, Line: 2, Column: 32},
 										},
 									},
-									AccessPos: ast.Position{Offset: 34, Line: 2, Column: 33},
+									AccessEndPos: ast.Position{Offset: 34, Line: 2, Column: 33},
 									Identifier: ast.Identifier{
 										Identifier: "baz",
 										Pos:        ast.Position{Offset: 35, Line: 2, Column: 34},
@@ -2415,7 +2415,7 @@ func TestParseSwapStatementInFunctionDeclaration(t *testing.T) {
 											Pos:        ast.Position{Offset: 41, Line: 3, Column: 21},
 										},
 									},
-									AccessPos: ast.Position{Offset: 44, Line: 3, Column: 24},
+									AccessEndPos: ast.Position{Offset: 44, Line: 3, Column: 24},
 									Identifier: ast.Identifier{
 										Identifier: "baz",
 										Pos:        ast.Position{Offset: 45, Line: 3, Column: 25},

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -1956,9 +1956,9 @@ func parseEnumCase(
 	// Skip the `enum` keyword
 	p.nextSemanticToken()
 	if !p.current.Is(lexer.TokenIdentifier) {
-		return nil, p.newSyntaxError("expected identifier after start of enum case declaration, got %s", p.current.Type).
-			WithSecondary("provide a name for the enum case after the `case` keyword").
-			WithDocumentation("https://cadence-lang.org/docs/language/enumerations")
+		return nil, &MissingEnumCaseNameError{
+			GotToken: p.current,
+		}
 	}
 
 	identifier := p.tokenToIdentifier(p.current)

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -339,10 +339,9 @@ func parseEntitlementList(p *parser) (ast.EntitlementSet, error) {
 		// Luckily, however, the former two are just equivalent, and the latter we can disambiguate in the type checker.
 		return ast.NewConjunctiveEntitlementSet(entitlements), nil
 	default:
-		return nil, p.newSyntaxError("unexpected entitlement separator %s", p.current.Type.String()).
-			WithSecondary("use a comma (,) for conjunctive entitlements " +
-				"or a vertical bar (|) for disjunctive entitlements").
-			WithDocumentation("https://cadence-lang.org/docs/language/access-control#entitlements")
+		return nil, &InvalidEntitlementSeparatorError{
+			Token: p.current,
+		}
 	}
 
 	remainingEntitlements, _, err := parseNominalTypes(p, lexer.TokenParenClose, separator)

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -310,15 +310,11 @@ var enumeratedAccessModifierKeywords = common.EnumerateWords(
 
 func rejectAccessKeywordEntitlementType(p *parser, ty *ast.NominalType) {
 	switch ty.Identifier.Identifier {
-	case KeywordAll, KeywordAccess, KeywordAccount, KeywordSelf:
-		p.report(
-			NewSyntaxError(
-				ty.StartPosition(),
-				"unexpected non-nominal type: %s",
-				ty,
-			).WithSecondary("use an entitlement name instead of access control keywords").
-				WithDocumentation("https://cadence-lang.org/docs/language/access-control#entitlements"),
-		)
+	case KeywordAll, KeywordAccess, KeywordAccount, KeywordSelf, KeywordContract:
+		p.report(&AccessKeywordEntitlementNameError{
+			Keyword: ty.Identifier.Identifier,
+			Range:   ast.NewRangeFromPositioned(p.memoryGauge, ty),
+		})
 	}
 }
 

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -1903,19 +1903,10 @@ func parseSpecialFunctionDeclaration(
 	}
 
 	if returnTypeAnnotation != nil {
-		var kindDescription string
-		if declarationKind != common.DeclarationKindUnknown {
-			kindDescription = declarationKind.Name()
-		} else {
-			kindDescription = "special function"
-		}
-
-		p.report(NewSyntaxError(
-			returnTypeAnnotation.StartPos,
-			"invalid return type for %s",
-			kindDescription,
-		).WithSecondary("special functions like `init` or `prepare` cannot have return types").
-			WithDocumentation("https://cadence-lang.org/docs/language/functions"))
+		p.report(&SpecialFunctionReturnTypeError{
+			DeclarationKind: declarationKind,
+			Range:           ast.NewRangeFromPositioned(p.memoryGauge, returnTypeAnnotation),
+		})
 	}
 
 	return ast.NewSpecialFunctionDeclaration(

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -174,9 +174,9 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 			case KeywordAccess:
 				if access != ast.AccessNotSpecified {
 					p.report(
-						p.newSyntaxError("invalid second access modifier").
-							WithSecondary("only one access modifier can be used per declaration").
-							WithDocumentation("https://cadence-lang.org/docs/language/access-control"),
+						&DuplicateAccessModifierError{
+							Range: p.current.Range,
+						},
 					)
 				}
 				if staticModifierEnabled && staticPos != nil {
@@ -1656,11 +1656,9 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 
 			case KeywordAccess:
 				if access != ast.AccessNotSpecified {
-					p.report(
-						p.newSyntaxError("invalid second access modifier").
-							WithSecondary("only one access modifier can be used per declaration").
-							WithDocumentation("https://cadence-lang.org/docs/language/access-control"),
-					)
+					p.report(&DuplicateAccessModifierError{
+						Range: p.current.Range,
+					})
 				}
 				if staticModifierEnabled && staticPos != nil {
 					p.reportSyntaxError("invalid access modifier after `static` modifier")

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -150,14 +150,9 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 
 			case KeywordView:
 				if purity != ast.FunctionPurityUnspecified {
-					p.report(
-						NewSyntaxErrorWithSuggestedReplacement(
-							p.current.Range,
-							"invalid second `view` modifier",
-							"",
-						).WithSecondary("the `view` modifier can only be used once per function declaration").
-							WithDocumentation("https://cadence-lang.org/docs/language/functions#view-functions"),
-					)
+					p.report(&DuplicateViewModifierError{
+						Range: p.current.Range,
+					})
 				}
 
 				pos := p.current.StartPos
@@ -1639,14 +1634,9 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 
 			case KeywordView:
 				if purity != ast.FunctionPurityUnspecified {
-					p.report(
-						NewSyntaxErrorWithSuggestedReplacement(
-							p.current.Range,
-							"invalid second `view` modifier",
-							"",
-						).WithSecondary("the `view` modifier can only be used once per function declaration").
-							WithDocumentation("https://cadence-lang.org/docs/language/functions#view-functions"),
-					)
+					p.report(&DuplicateViewModifierError{
+						Range: p.current.Range,
+					})
 				}
 				pos := p.current.StartPos
 				purityPos = &pos

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -1238,10 +1238,9 @@ func parseConformances(p *parser) ([]*ast.NominalType, error) {
 		}
 
 		if len(conformances) < 1 {
-			return nil, p.newSyntaxError("expected at least one conformance after %s", lexer.TokenColon).
-				WithSecondary("provide at least one interface or type to conform to, " +
-					"or remove the colon if no conformances are needed").
-				WithDocumentation("https://cadence-lang.org/docs/language/interfaces")
+			p.report(&MissingConformanceError{
+				Pos: p.current.StartPos,
+			})
 		}
 	}
 

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -233,15 +233,9 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 }
 
 func handlePriv(p *parser) {
-	p.report(
-		NewSyntaxErrorWithSuggestedReplacement(
-			p.current.Range,
-			"`priv` is no longer a valid access modifier",
-			"access(self)",
-		).WithSecondary("use `access(self)` instead").
-			WithMigration("This is pre-Cadence 1.0 syntax. The `priv` modifier was replaced with `access(self)`").
-			WithDocumentation("https://cadence-lang.org/docs/language/access-control"),
-	)
+	p.report(&PrivAccessError{
+		Range: p.current.Range,
+	})
 	p.next()
 }
 
@@ -252,15 +246,9 @@ func handlePub(p *parser) error {
 
 	// Try to parse `(set)` if given
 	if !p.current.Is(lexer.TokenParenOpen) {
-		p.report(
-			NewSyntaxErrorWithSuggestedReplacement(
-				pubToken.Range,
-				"`pub` is no longer a valid access modifier",
-				"access(all)",
-			).WithSecondary("use `access(all)` instead").
-				WithMigration("This is pre-Cadence 1.0 syntax. The `pub` modifier was replaced with `access(all)`").
-				WithDocumentation("https://cadence-lang.org/docs/language/access-control"),
-		)
+		p.report(&PubAccessError{
+			Range: pubToken.Range,
+		})
 		return nil
 	}
 

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -1145,11 +1145,7 @@ func TestParseFunctionDeclaration(t *testing.T) {
 		_, errs := testParseDeclarations("view view fun foo (): X { }")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxErrorWithSuggestedReplacement{
-					Message:       "invalid second `view` modifier",
-					Replacement:   "",
-					Secondary:     "the `view` modifier can only be used once per function declaration",
-					Documentation: "https://cadence-lang.org/docs/language/functions#view-functions",
+				&DuplicateViewModifierError{
 					Range: ast.Range{
 						StartPos: ast.Position{Offset: 5, Line: 1, Column: 5},
 						EndPos:   ast.Position{Offset: 8, Line: 1, Column: 8},

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -2063,11 +2063,14 @@ func TestParseAccess(t *testing.T) {
 		result, errs := parse("access ( foo bar )")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected entitlement separator identifier",
-					Secondary:     "use a comma (,) for conjunctive entitlements or a vertical bar (|) for disjunctive entitlements",
-					Documentation: "https://cadence-lang.org/docs/language/access-control#entitlements",
-					Pos:           ast.Position{Offset: 13, Line: 1, Column: 13},
+				&InvalidEntitlementSeparatorError{
+					Token: lexer.Token{
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 13, Line: 1, Column: 13},
+							EndPos:   ast.Position{Offset: 15, Line: 1, Column: 15},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -2086,11 +2089,14 @@ func TestParseAccess(t *testing.T) {
 		result, errs := parse("access ( foo & bar )")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected entitlement separator '&'",
-					Secondary:     "use a comma (,) for conjunctive entitlements or a vertical bar (|) for disjunctive entitlements",
-					Documentation: "https://cadence-lang.org/docs/language/access-control#entitlements",
-					Pos:           ast.Position{Offset: 13, Line: 1, Column: 13},
+				&InvalidEntitlementSeparatorError{
+					Token: lexer.Token{
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 13, Line: 1, Column: 13},
+							EndPos:   ast.Position{Offset: 13, Line: 1, Column: 13},
+						},
+						Type: lexer.TokenAmpersand,
+					},
 				},
 			},
 			errs,

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -6281,11 +6281,8 @@ func TestParseInvalidConformances(t *testing.T) {
 	_, errs := testParseDeclarations("struct Test: {}")
 	AssertEqualWithDiff(t,
 		[]error{
-			&SyntaxError{
-				Message:       "expected at least one conformance after ':'",
-				Secondary:     "provide at least one interface or type to conform to, or remove the colon if no conformances are needed",
-				Documentation: "https://cadence-lang.org/docs/language/interfaces",
-				Pos:           ast.Position{Offset: 13, Line: 1, Column: 13},
+			&MissingConformanceError{
+				Pos: ast.Position{Offset: 13, Line: 1, Column: 13},
 			},
 		},
 		errs,

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -9899,16 +9899,11 @@ func TestParseDeprecatedAccessModifiers(t *testing.T) {
 		_, errs := testParseDeclarations(" pub fun foo ( ) { }")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxErrorWithSuggestedReplacement{
-					Message: "`pub` is no longer a valid access modifier",
+				&PubAccessError{
 					Range: ast.Range{
 						StartPos: ast.Position{Offset: 1, Line: 1, Column: 1},
 						EndPos:   ast.Position{Offset: 3, Line: 1, Column: 3},
 					},
-					Replacement:   "access(all)",
-					Secondary:     "use `access(all)` instead",
-					Documentation: "https://cadence-lang.org/docs/language/access-control",
-					Migration:     "This is pre-Cadence 1.0 syntax. The `pub` modifier was replaced with `access(all)`",
 				},
 			},
 			errs,
@@ -9923,16 +9918,11 @@ func TestParseDeprecatedAccessModifiers(t *testing.T) {
 		_, errs := testParseDeclarations(" priv fun foo ( ) { }")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxErrorWithSuggestedReplacement{
-					Message: "`priv` is no longer a valid access modifier",
+				&PrivAccessError{
 					Range: ast.Range{
 						StartPos: ast.Position{Offset: 1, Line: 1, Column: 1},
 						EndPos:   ast.Position{Offset: 4, Line: 1, Column: 4},
 					},
-					Replacement:   "access(self)",
-					Secondary:     "use `access(self)` instead",
-					Documentation: "https://cadence-lang.org/docs/language/access-control",
-					Migration:     "This is pre-Cadence 1.0 syntax. The `priv` modifier was replaced with `access(self)`",
 				},
 			},
 			errs,

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -9897,11 +9897,12 @@ func TestParseInvalidSpecialFunctionReturnTypeAnnotation(t *testing.T) {
 	`)
 	AssertEqualWithDiff(t,
 		[]error{
-			&SyntaxError{
-				Message:       "invalid return type for initializer",
-				Secondary:     "special functions like `init` or `prepare` cannot have return types",
-				Documentation: "https://cadence-lang.org/docs/language/functions",
-				Pos:           ast.Position{Offset: 40, Line: 4, Column: 18},
+			&SpecialFunctionReturnTypeError{
+				DeclarationKind: common.DeclarationKindInitializer,
+				Range: ast.Range{
+					StartPos: ast.Position{Offset: 40, Line: 4, Column: 18},
+					EndPos:   ast.Position{Offset: 42, Line: 4, Column: 20},
+				},
 			},
 		},
 		errs,

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -8322,11 +8322,11 @@ func TestParseInvalidAccessModifiers(t *testing.T) {
 		_, errs := testParseDeclarations("access(all) access(self) let x = 1")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "invalid second access modifier",
-					Secondary:     "only one access modifier can be used per declaration",
-					Documentation: "https://cadence-lang.org/docs/language/access-control",
-					Pos:           ast.Position{Offset: 12, Line: 1, Column: 12},
+				&DuplicateAccessModifierError{
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 12, Line: 1, Column: 12},
+						EndPos:   ast.Position{Offset: 17, Line: 1, Column: 17},
+					},
 				},
 			},
 			errs,

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -4938,11 +4938,14 @@ func TestParseEnumDeclaration(t *testing.T) {
 		_, errs := testParseDeclarations("enum E { case }")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "expected identifier after start of enum case declaration, got '}'",
-					Secondary:     "provide a name for the enum case after the `case` keyword",
-					Documentation: "https://cadence-lang.org/docs/language/enumerations",
-					Pos:           ast.Position{Offset: 14, Line: 1, Column: 14},
+				&MissingEnumCaseNameError{
+					GotToken: lexer.Token{
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 14, Line: 1, Column: 14},
+							EndPos:   ast.Position{Offset: 14, Line: 1, Column: 14},
+						},
+						Type: lexer.TokenBraceClose,
+					},
 				},
 			},
 			errs,

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -1981,11 +1981,12 @@ func TestParseAccess(t *testing.T) {
 		result, errs := parse("access ( foo , self )")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected non-nominal type: self",
-					Secondary:     "use an entitlement name instead of access control keywords",
-					Documentation: "https://cadence-lang.org/docs/language/access-control#entitlements",
-					Pos:           ast.Position{Offset: 15, Line: 1, Column: 15},
+				&AccessKeywordEntitlementNameError{
+					Keyword: "self",
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 15, Line: 1, Column: 15},
+						EndPos:   ast.Position{Offset: 18, Line: 1, Column: 18},
+					},
 				},
 			},
 			errs,
@@ -2021,11 +2022,12 @@ func TestParseAccess(t *testing.T) {
 		result, errs := parse("access ( foo | self )")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected non-nominal type: self",
-					Secondary:     "use an entitlement name instead of access control keywords",
-					Documentation: "https://cadence-lang.org/docs/language/access-control#entitlements",
-					Pos:           ast.Position{Offset: 15, Line: 1, Column: 15},
+				&AccessKeywordEntitlementNameError{
+					Keyword: "self",
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 15, Line: 1, Column: 15},
+						EndPos:   ast.Position{Offset: 18, Line: 1, Column: 18},
+					},
 				},
 			},
 			errs,

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/parser/lexer"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 )
 
@@ -332,11 +333,15 @@ func TestParseVariableDeclaration(t *testing.T) {
 		_, errs := testParseDeclarations("static var x = 1")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 0, Line: 1, Column: 0},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+							EndPos:   ast.Position{Offset: 5, Line: 1, Column: 5},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -371,11 +376,15 @@ func TestParseVariableDeclaration(t *testing.T) {
 		_, errs := testParseDeclarations("native var x = 1")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 0, Line: 1, Column: 0},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+							EndPos:   ast.Position{Offset: 5, Line: 1, Column: 5},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -1164,11 +1173,15 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 0, Line: 1, Column: 0},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+							EndPos:   ast.Position{Offset: 5, Line: 1, Column: 5},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -1226,11 +1239,15 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 0, Line: 1, Column: 0},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+							EndPos:   ast.Position{Offset: 5, Line: 1, Column: 5},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -1289,11 +1306,15 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 0, Line: 1, Column: 0},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+							EndPos:   ast.Position{Offset: 5, Line: 1, Column: 5},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -1330,11 +1351,15 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 0, Line: 1, Column: 0},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+							EndPos:   ast.Position{Offset: 5, Line: 1, Column: 5},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -1422,14 +1447,14 @@ func TestParseFunctionDeclaration(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos: ast.Position{
-						Offset: 12,
-						Line:   1,
-						Column: 12,
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 12, Line: 1, Column: 12},
+							EndPos:   ast.Position{Offset: 17, Line: 1, Column: 17},
+						},
+						Type: lexer.TokenIdentifier,
 					},
 				},
 			},
@@ -7007,11 +7032,15 @@ func TestParsePragmaNoArguments(t *testing.T) {
 		_, errs := testParseDeclarations("static #foo")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 0, Line: 1, Column: 0},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+							EndPos:   ast.Position{Offset: 5, Line: 1, Column: 5},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -7046,11 +7075,15 @@ func TestParsePragmaNoArguments(t *testing.T) {
 		_, errs := testParseDeclarations("native #foo")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 0, Line: 1, Column: 0},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 0, Line: 1, Column: 0},
+							EndPos:   ast.Position{Offset: 5, Line: 1, Column: 5},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -8372,11 +8405,15 @@ func TestParseInvalidImportWithModifier(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 13, Line: 2, Column: 12},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 13, Line: 2, Column: 12},
+							EndPos:   ast.Position{Offset: 18, Line: 2, Column: 17},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -8417,11 +8454,15 @@ func TestParseInvalidImportWithModifier(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 13, Line: 2, Column: 12},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 13, Line: 2, Column: 12},
+							EndPos:   ast.Position{Offset: 18, Line: 2, Column: 17},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -8467,11 +8508,15 @@ func TestParseInvalidEventWithModifier(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 13, Line: 2, Column: 12},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 13, Line: 2, Column: 12},
+							EndPos:   ast.Position{Offset: 18, Line: 2, Column: 17},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -8512,11 +8557,15 @@ func TestParseInvalidEventWithModifier(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 13, Line: 2, Column: 12},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 13, Line: 2, Column: 12},
+							EndPos:   ast.Position{Offset: 18, Line: 2, Column: 17},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -8563,11 +8612,15 @@ func TestParseCompositeWithModifier(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 13, Line: 2, Column: 12},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 13, Line: 2, Column: 12},
+							EndPos:   ast.Position{Offset: 18, Line: 2, Column: 17},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -8608,11 +8661,15 @@ func TestParseCompositeWithModifier(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 13, Line: 2, Column: 12},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 13, Line: 2, Column: 12},
+							EndPos:   ast.Position{Offset: 18, Line: 2, Column: 17},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -8658,11 +8715,15 @@ func TestParseTransactionWithModifier(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 13, Line: 2, Column: 12},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 13, Line: 2, Column: 12},
+							EndPos:   ast.Position{Offset: 18, Line: 2, Column: 17},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -8703,11 +8764,15 @@ func TestParseTransactionWithModifier(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 13, Line: 2, Column: 12},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 13, Line: 2, Column: 12},
+							EndPos:   ast.Position{Offset: 18, Line: 2, Column: 17},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -9602,11 +9667,15 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 		_, errs := testParseDeclarations(" access(all) mapping M {} ")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 13, Line: 1, Column: 13},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 13, Line: 1, Column: 13},
+							EndPos:   ast.Position{Offset: 19, Line: 1, Column: 19},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -9620,11 +9689,15 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 		_, errs := testParseDeclarations(" access(all) entitlement M {} ")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: '{'",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 27, Line: 1, Column: 27},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 27, Line: 1, Column: 27},
+							EndPos:   ast.Position{Offset: 27, Line: 1, Column: 27},
+						},
+						Type: lexer.TokenBraceOpen,
+					},
 				},
 			},
 			errs,

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -3457,7 +3457,7 @@ func TestParseCompositeDeclaration(t *testing.T) {
 																Column: 23,
 															},
 														},
-														AccessPos: ast.Position{
+														AccessEndPos: ast.Position{
 															Offset: 118,
 															Line:   6,
 															Column: 22,
@@ -3572,7 +3572,7 @@ func TestParseCompositeDeclaration(t *testing.T) {
 															Column: 30,
 														},
 													},
-													AccessPos: ast.Position{
+													AccessEndPos: ast.Position{
 														Offset: 221,
 														Line:   10,
 														Column: 29,
@@ -6044,7 +6044,7 @@ func TestParseStructure(t *testing.T) {
 															Column: 21,
 														},
 													},
-													AccessPos: ast.Position{
+													AccessEndPos: ast.Position{
 														Offset: 110,
 														Line:   6,
 														Column: 20,
@@ -6158,7 +6158,7 @@ func TestParseStructure(t *testing.T) {
 														Column: 28,
 													},
 												},
-												AccessPos: ast.Position{
+												AccessEndPos: ast.Position{
 													Offset: 207,
 													Line:   10,
 													Column: 27,
@@ -8048,7 +8048,7 @@ func TestParseCompositeDeclarationWithSemicolonSeparatedMembers(t *testing.T) {
 															Pos:        ast.Position{Offset: 54, Line: 2, Column: 53},
 														},
 													},
-													AccessPos: ast.Position{Offset: 58, Line: 2, Column: 57},
+													AccessEndPos: ast.Position{Offset: 58, Line: 2, Column: 57},
 													Identifier: ast.Identifier{
 														Identifier: "id",
 														Pos:        ast.Position{Offset: 59, Line: 2, Column: 58},

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -913,6 +913,40 @@ func (*AccessKeywordEntitlementNameError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/access-control#entitlements"
 }
 
+// InvalidEntitlementSeparatorError is reported when an invalid token is used as an entitlement separator.
+type InvalidEntitlementSeparatorError struct {
+	Token lexer.Token
+}
+
+var _ ParseError = &InvalidEntitlementSeparatorError{}
+var _ errors.UserError = &InvalidEntitlementSeparatorError{}
+var _ errors.SecondaryError = &InvalidEntitlementSeparatorError{}
+var _ errors.HasDocumentationLink = &InvalidEntitlementSeparatorError{}
+
+func (*InvalidEntitlementSeparatorError) isParseError() {}
+
+func (*InvalidEntitlementSeparatorError) IsUserError() {}
+
+func (e *InvalidEntitlementSeparatorError) StartPosition() ast.Position {
+	return e.Token.StartPos
+}
+
+func (e *InvalidEntitlementSeparatorError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Token.EndPos
+}
+
+func (e *InvalidEntitlementSeparatorError) Error() string {
+	return fmt.Sprintf("unexpected entitlement separator %s", e.Token.Type.String())
+}
+
+func (*InvalidEntitlementSeparatorError) SecondaryError() string {
+	return "use a comma (,) for conjunctive entitlements or a vertical bar (|) for disjunctive entitlements"
+}
+
+func (*InvalidEntitlementSeparatorError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/access-control#entitlements"
+}
+
 // UnexpectedTokenAtEndError is reported when there is an unexpected token at the end of the program
 type UnexpectedTokenAtEndError struct {
 	Token lexer.Token

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -816,6 +816,34 @@ func (*PubAccessError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/access-control"
 }
 
+// AccessKeywordEntitlementNameError is reported when an access keyword (e.g. `all`, `self`)
+// is used as an entitlement name.
+type AccessKeywordEntitlementNameError struct {
+	Keyword string
+	ast.Range
+}
+
+var _ ParseError = &AccessKeywordEntitlementNameError{}
+var _ errors.UserError = &AccessKeywordEntitlementNameError{}
+var _ errors.SecondaryError = &AccessKeywordEntitlementNameError{}
+var _ errors.HasDocumentationLink = &AccessKeywordEntitlementNameError{}
+
+func (*AccessKeywordEntitlementNameError) isParseError() {}
+
+func (*AccessKeywordEntitlementNameError) IsUserError() {}
+
+func (e *AccessKeywordEntitlementNameError) Error() string {
+	return fmt.Sprintf("unexpected non-nominal type: %s", e.Keyword)
+}
+
+func (*AccessKeywordEntitlementNameError) SecondaryError() string {
+	return "use an entitlement name instead of an access control keyword"
+}
+
+func (*AccessKeywordEntitlementNameError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/access-control#entitlements"
+}
+
 // UnexpectedTokenAtEndError is reported when there is an unexpected token at the end of the program
 type UnexpectedTokenAtEndError struct {
 	Token lexer.Token

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -947,6 +947,40 @@ func (*UnexpectedTokenAtEndError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/syntax"
 }
 
+// SpecialFunctionReturnTypeError is reported when a special function has a return type.
+type SpecialFunctionReturnTypeError struct {
+	DeclarationKind common.DeclarationKind
+	ast.Range
+}
+
+var _ ParseError = &SpecialFunctionReturnTypeError{}
+var _ errors.UserError = &SpecialFunctionReturnTypeError{}
+var _ errors.SecondaryError = &SpecialFunctionReturnTypeError{}
+var _ errors.HasDocumentationLink = &SpecialFunctionReturnTypeError{}
+
+func (*SpecialFunctionReturnTypeError) isParseError() {}
+
+func (*SpecialFunctionReturnTypeError) IsUserError() {}
+
+func (e *SpecialFunctionReturnTypeError) Error() string {
+	var kindDescription string
+	if e.DeclarationKind != common.DeclarationKindUnknown {
+		kindDescription = e.DeclarationKind.Name()
+	} else {
+		kindDescription = "special function"
+	}
+
+	return fmt.Sprintf("invalid return type for %s", kindDescription)
+}
+
+func (*SpecialFunctionReturnTypeError) SecondaryError() string {
+	return "special functions like `init` or `prepare` cannot have return types"
+}
+
+func (*SpecialFunctionReturnTypeError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/functions"
+}
+
 // InvalidStaticModifierError
 
 type InvalidStaticModifierError struct {

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -169,7 +169,7 @@ func (e *SyntaxErrorWithSuggestedReplacement) Error() string {
 func (e *SyntaxErrorWithSuggestedReplacement) SuggestFixes(_ string) []errors.SuggestedFix[ast.TextEdit] {
 	return []errors.SuggestedFix[ast.TextEdit]{
 		{
-			Message: fmt.Sprintf("replace with %s", e.Replacement),
+			Message: fmt.Sprintf("Replace with %s", e.Replacement),
 			TextEdits: []ast.TextEdit{
 				{
 					Replacement: e.Replacement,

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -584,6 +584,48 @@ func (*InvalidViewModifierError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/functions#view-functions"
 }
 
+// DuplicateViewModifierError
+
+type DuplicateViewModifierError struct {
+	ast.Range
+}
+
+var _ ParseError = &DuplicateViewModifierError{}
+var _ errors.UserError = &DuplicateViewModifierError{}
+var _ errors.SecondaryError = &DuplicateViewModifierError{}
+var _ errors.HasSuggestedFixes[ast.TextEdit] = &DuplicateViewModifierError{}
+var _ errors.HasDocumentationLink = &DuplicateViewModifierError{}
+
+func (*DuplicateViewModifierError) isParseError() {}
+
+func (*DuplicateViewModifierError) IsUserError() {}
+
+func (*DuplicateViewModifierError) Error() string {
+	return "invalid second `view` modifier"
+}
+
+func (*DuplicateViewModifierError) SecondaryError() string {
+	return "the `view` modifier can only be used once per function declaration"
+}
+
+func (e *DuplicateViewModifierError) SuggestFixes(_ string) []errors.SuggestedFix[ast.TextEdit] {
+	return []errors.SuggestedFix[ast.TextEdit]{
+		{
+			Message: "Remove duplicate `view` modifier",
+			TextEdits: []ast.TextEdit{
+				{
+					Replacement: "",
+					Range:       e.Range,
+				},
+			},
+		},
+	}
+}
+
+func (*DuplicateViewModifierError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/functions#view-functions"
+}
+
 // InvalidStaticModifierError
 
 type InvalidStaticModifierError struct {

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -363,6 +363,59 @@ func (UnexpectedEOFError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/syntax"
 }
 
+// StatementSeparationError is reported when two statements on the same line
+// are not separated by a semicolon.
+type StatementSeparationError struct {
+	Pos ast.Position
+}
+
+var _ ParseError = &StatementSeparationError{}
+var _ errors.UserError = &StatementSeparationError{}
+var _ errors.SecondaryError = &StatementSeparationError{}
+var _ errors.HasDocumentationLink = &StatementSeparationError{}
+var _ errors.HasSuggestedFixes[ast.TextEdit] = &StatementSeparationError{}
+
+func (*StatementSeparationError) isParseError() {}
+
+func (*StatementSeparationError) IsUserError() {}
+
+func (e *StatementSeparationError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *StatementSeparationError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Pos
+}
+
+func (*StatementSeparationError) Error() string {
+	return "statements on the same line must be separated with a semicolon"
+}
+
+func (*StatementSeparationError) SecondaryError() string {
+	return "add a semicolon (;) between statements or place each statement on a separate line"
+}
+
+func (e *StatementSeparationError) SuggestFixes(_ string) []errors.SuggestedFix[ast.TextEdit] {
+	return []errors.SuggestedFix[ast.TextEdit]{
+		{
+			Message: "Add semicolon to separate statements",
+			TextEdits: []ast.TextEdit{
+				{
+					Insertion: "; ",
+					Range: ast.Range{
+						StartPos: e.Pos,
+						EndPos:   e.Pos,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (*StatementSeparationError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/syntax#semicolons"
+}
+
 // MissingCommaInParameterListError
 
 type MissingCommaInParameterListError struct {

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/parser/lexer"
 	"github.com/onflow/cadence/pretty"
 )
 
@@ -813,6 +814,40 @@ func (*PubAccessError) MigrationNote() string {
 
 func (*PubAccessError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/access-control"
+}
+
+// UnexpectedTokenAtEndError is reported when there is an unexpected token at the end of the program
+type UnexpectedTokenAtEndError struct {
+	Token lexer.Token
+}
+
+var _ ParseError = &UnexpectedTokenAtEndError{}
+var _ errors.UserError = &UnexpectedTokenAtEndError{}
+var _ errors.SecondaryError = &UnexpectedTokenAtEndError{}
+var _ errors.HasDocumentationLink = &UnexpectedTokenAtEndError{}
+
+func (*UnexpectedTokenAtEndError) isParseError() {}
+
+func (*UnexpectedTokenAtEndError) IsUserError() {}
+
+func (e *UnexpectedTokenAtEndError) StartPosition() ast.Position {
+	return e.Token.StartPos
+}
+
+func (e *UnexpectedTokenAtEndError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Token.EndPos
+}
+
+func (e *UnexpectedTokenAtEndError) Error() string {
+	return fmt.Sprintf("unexpected token: %s", e.Token.Type)
+}
+
+func (*UnexpectedTokenAtEndError) SecondaryError() string {
+	return "check for extra characters, missing semicolons, or incomplete statements"
+}
+
+func (*UnexpectedTokenAtEndError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/syntax"
 }
 
 // InvalidStaticModifierError

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1053,6 +1053,56 @@ func (*MemberAccessMissingNameError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/syntax"
 }
 
+// WhitespaceAfterMemberAccessError is reported when there is whitespace after a member access operator.
+type WhitespaceAfterMemberAccessError struct {
+	OperatorTokenType lexer.TokenType
+	WhitespaceRange   ast.Range
+}
+
+var _ ParseError = &WhitespaceAfterMemberAccessError{}
+var _ errors.UserError = &WhitespaceAfterMemberAccessError{}
+var _ errors.SecondaryError = &WhitespaceAfterMemberAccessError{}
+var _ errors.HasDocumentationLink = &WhitespaceAfterMemberAccessError{}
+var _ errors.HasSuggestedFixes[ast.TextEdit] = &WhitespaceAfterMemberAccessError{}
+
+func (*WhitespaceAfterMemberAccessError) isParseError() {}
+
+func (*WhitespaceAfterMemberAccessError) IsUserError() {}
+
+func (e *WhitespaceAfterMemberAccessError) StartPosition() ast.Position {
+	return e.WhitespaceRange.StartPos
+}
+
+func (e *WhitespaceAfterMemberAccessError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.WhitespaceRange.EndPos
+}
+
+func (e *WhitespaceAfterMemberAccessError) Error() string {
+	return fmt.Sprintf("invalid whitespace after %s", e.OperatorTokenType)
+}
+
+func (e *WhitespaceAfterMemberAccessError) SecondaryError() string {
+	return fmt.Sprintf("remove the space between %s and the member name", e.OperatorTokenType)
+}
+
+func (e *WhitespaceAfterMemberAccessError) SuggestFixes(_ string) []errors.SuggestedFix[ast.TextEdit] {
+	return []errors.SuggestedFix[ast.TextEdit]{
+		{
+			Message: "Remove whitespace",
+			TextEdits: []ast.TextEdit{
+				{
+					Replacement: "",
+					Range:       e.WhitespaceRange,
+				},
+			},
+		},
+	}
+}
+
+func (*WhitespaceAfterMemberAccessError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/syntax"
+}
+
 // InvalidStaticModifierError
 
 type InvalidStaticModifierError struct {

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -329,6 +329,40 @@ func (e TypeDepthLimitReachedError) EndPosition(_ common.MemoryGauge) ast.Positi
 	return e.Pos
 }
 
+// UnexpectedEOFError is reported when the end of the program is reached unexpectedly
+type UnexpectedEOFError struct {
+	Pos ast.Position
+}
+
+var _ ParseError = UnexpectedEOFError{}
+var _ errors.UserError = UnexpectedEOFError{}
+var _ errors.SecondaryError = UnexpectedEOFError{}
+var _ errors.HasDocumentationLink = UnexpectedEOFError{}
+
+func (UnexpectedEOFError) isParseError() {}
+
+func (UnexpectedEOFError) IsUserError() {}
+
+func (e UnexpectedEOFError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e UnexpectedEOFError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Pos
+}
+
+func (UnexpectedEOFError) Error() string {
+	return "unexpected end of program"
+}
+
+func (UnexpectedEOFError) SecondaryError() string {
+	return "check for incomplete expressions, missing tokens, or unterminated strings/comments"
+}
+
+func (UnexpectedEOFError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/syntax"
+}
+
 // MissingCommaInParameterListError
 
 type MissingCommaInParameterListError struct {

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1015,6 +1015,44 @@ func (*SpecialFunctionReturnTypeError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/functions"
 }
 
+// MemberAccessMissingNameError is reported when a member access is missing a name.
+type MemberAccessMissingNameError struct {
+	GotToken lexer.Token
+}
+
+var _ ParseError = &MemberAccessMissingNameError{}
+var _ errors.UserError = &MemberAccessMissingNameError{}
+var _ errors.SecondaryError = &MemberAccessMissingNameError{}
+var _ errors.HasDocumentationLink = &MemberAccessMissingNameError{}
+
+func (*MemberAccessMissingNameError) isParseError() {}
+
+func (*MemberAccessMissingNameError) IsUserError() {}
+
+func (e *MemberAccessMissingNameError) StartPosition() ast.Position {
+	return e.GotToken.StartPos
+}
+
+func (e *MemberAccessMissingNameError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.GotToken.EndPos
+}
+
+func (e *MemberAccessMissingNameError) Error() string {
+	tokenType := e.GotToken.Type
+	if tokenType == lexer.TokenEOF {
+		return "expected member name"
+	}
+	return fmt.Sprintf("expected member name, got %s", tokenType)
+}
+
+func (*MemberAccessMissingNameError) SecondaryError() string {
+	return "after a dot (.), you must provide a valid identifier for the member name"
+}
+
+func (*MemberAccessMissingNameError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/syntax"
+}
+
 // InvalidStaticModifierError
 
 type InvalidStaticModifierError struct {

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -626,6 +626,48 @@ func (*DuplicateViewModifierError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/functions#view-functions"
 }
 
+// DuplicateAccessModifierError
+
+type DuplicateAccessModifierError struct {
+	ast.Range
+}
+
+var _ ParseError = &DuplicateAccessModifierError{}
+var _ errors.UserError = &DuplicateAccessModifierError{}
+var _ errors.SecondaryError = &DuplicateAccessModifierError{}
+var _ errors.HasSuggestedFixes[ast.TextEdit] = &DuplicateAccessModifierError{}
+var _ errors.HasDocumentationLink = &DuplicateAccessModifierError{}
+
+func (*DuplicateAccessModifierError) isParseError() {}
+
+func (*DuplicateAccessModifierError) IsUserError() {}
+
+func (*DuplicateAccessModifierError) Error() string {
+	return "invalid second access modifier"
+}
+
+func (*DuplicateAccessModifierError) SecondaryError() string {
+	return "only one access modifier can be used per declaration"
+}
+
+func (e *DuplicateAccessModifierError) SuggestFixes(_ string) []errors.SuggestedFix[ast.TextEdit] {
+	return []errors.SuggestedFix[ast.TextEdit]{
+		{
+			Message: "Remove duplicate access modifier",
+			TextEdits: []ast.TextEdit{
+				{
+					Replacement: "",
+					Range:       e.Range,
+				},
+			},
+		},
+	}
+}
+
+func (*DuplicateAccessModifierError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/access-control"
+}
+
 // InvalidStaticModifierError
 
 type InvalidStaticModifierError struct {

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -816,6 +816,40 @@ func (*PubAccessError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/access-control"
 }
 
+// MissingEnumCaseNameError is reported when an enum case is missing a name.
+type MissingEnumCaseNameError struct {
+	GotToken lexer.Token
+}
+
+var _ ParseError = &MissingEnumCaseNameError{}
+var _ errors.UserError = &MissingEnumCaseNameError{}
+var _ errors.SecondaryError = &MissingEnumCaseNameError{}
+var _ errors.HasDocumentationLink = &MissingEnumCaseNameError{}
+
+func (*MissingEnumCaseNameError) isParseError() {}
+
+func (*MissingEnumCaseNameError) IsUserError() {}
+
+func (e *MissingEnumCaseNameError) StartPosition() ast.Position {
+	return e.GotToken.StartPos
+}
+
+func (e *MissingEnumCaseNameError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.GotToken.EndPos
+}
+
+func (e *MissingEnumCaseNameError) Error() string {
+	return fmt.Sprintf("expected identifier after start of enum case declaration, got %s", e.GotToken.Type)
+}
+
+func (*MissingEnumCaseNameError) SecondaryError() string {
+	return "provide a name for the enum case after the `case` keyword"
+}
+
+func (*MissingEnumCaseNameError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/enumerations"
+}
+
 // MissingConformanceError is reported when a colon for conformances is present,
 // but no conformances follow.
 type MissingConformanceError struct {

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -721,6 +721,100 @@ func (*DuplicateAccessModifierError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/access-control"
 }
 
+// PrivAccessError
+
+type PrivAccessError struct {
+	ast.Range
+}
+
+var _ ParseError = &PrivAccessError{}
+var _ errors.UserError = &PrivAccessError{}
+var _ errors.SecondaryError = &PrivAccessError{}
+var _ errors.HasSuggestedFixes[ast.TextEdit] = &PrivAccessError{}
+var _ errors.HasMigrationNote = &PrivAccessError{}
+var _ errors.HasDocumentationLink = &PrivAccessError{}
+
+func (*PrivAccessError) isParseError() {}
+
+func (*PrivAccessError) IsUserError() {}
+
+func (*PrivAccessError) Error() string {
+	return "`priv` is no longer a valid access modifier"
+}
+
+func (*PrivAccessError) SecondaryError() string {
+	return "use `access(self)` instead"
+}
+
+func (e *PrivAccessError) SuggestFixes(_ string) []errors.SuggestedFix[ast.TextEdit] {
+	return []errors.SuggestedFix[ast.TextEdit]{
+		{
+			Message: "Replace with `access(self)`",
+			TextEdits: []ast.TextEdit{
+				{
+					Replacement: "access(self)",
+					Range:       e.Range,
+				},
+			},
+		},
+	}
+}
+
+func (*PrivAccessError) MigrationNote() string {
+	return "This is pre-Cadence 1.0 syntax. The `priv` modifier was replaced with `access(self)`"
+}
+
+func (*PrivAccessError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/access-control"
+}
+
+// PubAccessError
+
+type PubAccessError struct {
+	ast.Range
+}
+
+var _ ParseError = &PubAccessError{}
+var _ errors.UserError = &PubAccessError{}
+var _ errors.SecondaryError = &PubAccessError{}
+var _ errors.HasSuggestedFixes[ast.TextEdit] = &PubAccessError{}
+var _ errors.HasMigrationNote = &PubAccessError{}
+var _ errors.HasDocumentationLink = &PubAccessError{}
+
+func (*PubAccessError) isParseError() {}
+
+func (*PubAccessError) IsUserError() {}
+
+func (*PubAccessError) Error() string {
+	return "`pub` is no longer a valid access modifier"
+}
+
+func (*PubAccessError) SecondaryError() string {
+	return "use `access(all)` instead"
+}
+
+func (e *PubAccessError) SuggestFixes(_ string) []errors.SuggestedFix[ast.TextEdit] {
+	return []errors.SuggestedFix[ast.TextEdit]{
+		{
+			Message: "Replace with `access(all)`",
+			TextEdits: []ast.TextEdit{
+				{
+					Replacement: "access(all)",
+					Range:       e.Range,
+				},
+			},
+		},
+	}
+}
+
+func (*PubAccessError) MigrationNote() string {
+	return "This is pre-Cadence 1.0 syntax. The `pub` modifier was replaced with `access(all)`"
+}
+
+func (*PubAccessError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/access-control"
+}
+
 // InvalidStaticModifierError
 
 type InvalidStaticModifierError struct {

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -816,6 +816,41 @@ func (*PubAccessError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/access-control"
 }
 
+// MissingConformanceError is reported when a colon for conformances is present,
+// but no conformances follow.
+type MissingConformanceError struct {
+	Pos ast.Position
+}
+
+var _ ParseError = &MissingConformanceError{}
+var _ errors.UserError = &MissingConformanceError{}
+var _ errors.SecondaryError = &MissingConformanceError{}
+var _ errors.HasDocumentationLink = &MissingConformanceError{}
+
+func (*MissingConformanceError) isParseError() {}
+
+func (*MissingConformanceError) IsUserError() {}
+
+func (e *MissingConformanceError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *MissingConformanceError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Pos
+}
+
+func (*MissingConformanceError) Error() string {
+	return "expected at least one conformance after :"
+}
+
+func (*MissingConformanceError) SecondaryError() string {
+	return "provide at least one interface or type to conform to, or remove the colon if no conformances are needed"
+}
+
+func (*MissingConformanceError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/interfaces"
+}
+
 // AccessKeywordEntitlementNameError is reported when an access keyword (e.g. `all`, `self`)
 // is used as an entitlement name.
 type AccessKeywordEntitlementNameError struct {

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -507,9 +507,9 @@ func init() {
 	defineIdentifierExpression()
 
 	setExprNullDenotation(lexer.TokenEOF, func(parser *parser, token lexer.Token) (ast.Expression, error) {
-		return nil, NewSyntaxError(token.StartPos, "unexpected end of program").
-			WithSecondary("check for incomplete expressions, missing tokens, or unterminated strings/comments").
-			WithDocumentation("https://cadence-lang.org/docs/language/syntax")
+		return nil, UnexpectedEOFError{
+			Pos: token.StartPos,
+		}
 	})
 }
 

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -1491,16 +1491,13 @@ func parseMemberAccess(p *parser, token lexer.Token, left ast.Expression, option
 	// Whitespace after '.' (dot token) and '?.' (question mark dot token) is not allowed.
 	// We parse it anyway and report an error
 
-	// TODO: Add suggested fix for this error
 	if p.current.Is(lexer.TokenSpace) {
-		errorPos := p.current.StartPos
+		whitespaceToken := p.current
 		p.skipSpaceAndComments()
-		p.report(NewSyntaxError(
-			errorPos,
-			"invalid whitespace after %s",
-			lexer.TokenDot,
-		).WithSecondary("remove the space between the dot (.) and the member name").
-			WithDocumentation("https://cadence-lang.org/docs/language/syntax"))
+		p.report(&WhitespaceAfterMemberAccessError{
+			OperatorTokenType: token.Type,
+			WhitespaceRange:   whitespaceToken.Range,
+		})
 	}
 
 	// If there is an identifier, use it.

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -1511,11 +1511,9 @@ func parseMemberAccess(p *parser, token lexer.Token, left ast.Expression, option
 		identifier = p.tokenToIdentifier(p.current)
 		p.next()
 	} else {
-		p.report(
-			p.newSyntaxError("expected member name, got %s", p.current.Type).
-				WithSecondary("after a dot (.), you must provide a valid identifier for the member name").
-				WithDocumentation("https://cadence-lang.org/docs/language/syntax"),
-		)
+		p.report(&MemberAccessMissingNameError{
+			GotToken: p.current,
+		})
 	}
 
 	return ast.NewMemberExpression(

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -1936,11 +1936,14 @@ func TestParseMemberExpression(t *testing.T) {
 		result, errs := testParseExpression("f.")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "expected member name, got EOF",
-					Secondary:     "after a dot (.), you must provide a valid identifier for the member name",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 2, Line: 1, Column: 2},
+				&MemberAccessMissingNameError{
+					GotToken: lexer.Token{
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 2, Line: 1, Column: 2},
+							EndPos:   ast.Position{Offset: 2, Line: 1, Column: 2},
+						},
+						Type: lexer.TokenEOF,
+					},
 				},
 			},
 			errs,
@@ -1957,6 +1960,30 @@ func TestParseMemberExpression(t *testing.T) {
 				AccessPos: ast.Position{Offset: 1, Line: 1, Column: 1},
 			},
 			result,
+		)
+	})
+
+	t.Run("not a name", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseExpression("f.-")
+		AssertEqualWithDiff(t,
+			[]error{
+				&MemberAccessMissingNameError{
+					GotToken: lexer.Token{
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 2, Line: 1, Column: 2},
+							EndPos:   ast.Position{Offset: 2, Line: 1, Column: 2},
+						},
+						Type: lexer.TokenMinus,
+					},
+				},
+				UnexpectedEOFError{
+					Pos: ast.Position{Offset: 3, Line: 1, Column: 3},
+				},
+			},
+			errs,
 		)
 	})
 

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -2970,11 +2970,15 @@ func TestParseAttach(t *testing.T) {
 		_, errs := testParseExpression("attach E() to r with (X)")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 16, Line: 1, Column: 16},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 16, Line: 1, Column: 16},
+							EndPos:   ast.Position{Offset: 19, Line: 1, Column: 19},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,
@@ -3210,11 +3214,15 @@ func TestParseFunctionExpression(t *testing.T) {
 		_, errs := testParseExpression("view for (): X { }")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected token: identifier",
-					Secondary:     "check for extra characters, missing semicolons, or incomplete statements",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 5, Line: 1, Column: 5},
+				&UnexpectedTokenAtEndError{
+					Token: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 5, Line: 1, Column: 5},
+							EndPos:   ast.Position{Offset: 7, Line: 1, Column: 7},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -6465,15 +6465,8 @@ func TestParseStringTemplate(t *testing.T) {
 						Column: 24,
 					},
 				},
-				&SyntaxError{
-					Message:       "statements on the same line must be separated with a semicolon",
-					Secondary:     "add a semicolon (;) between statements or place each statement on a separate line",
-					Documentation: "https://cadence-lang.org/docs/language/syntax#semicolons",
-					Pos: ast.Position{
-						Offset: 24,
-						Line:   2,
-						Column: 23,
-					},
+				&StatementSeparationError{
+					Pos: ast.Position{Offset: 24, Line: 2, Column: 23},
 				},
 			},
 			errs,
@@ -6499,15 +6492,8 @@ func TestParseStringTemplate(t *testing.T) {
 						Column: 38,
 					},
 				},
-				&SyntaxError{
-					Message:       "statements on the same line must be separated with a semicolon",
-					Secondary:     "add a semicolon (;) between statements or place each statement on a separate line",
-					Documentation: "https://cadence-lang.org/docs/language/syntax#semicolons",
-					Pos: ast.Position{
-						Offset: 33,
-						Line:   2,
-						Column: 32,
-					},
+				&StatementSeparationError{
+					Pos: ast.Position{Offset: 33, Line: 2, Column: 32},
 				},
 			},
 			errs,

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -2216,15 +2216,8 @@ func TestParseBlockComment(t *testing.T) {
 						Column: 33,
 					},
 				},
-				&SyntaxError{
-					Message:       "unexpected end of program",
-					Secondary:     "check for incomplete expressions, missing tokens, or unterminated strings/comments",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos: ast.Position{
-						Offset: 33,
-						Line:   1,
-						Column: 33,
-					},
+				UnexpectedEOFError{
+					Pos: ast.Position{Offset: 33, Line: 1, Column: 33},
 				},
 			},
 			errs,
@@ -2436,15 +2429,8 @@ func TestParseReference(t *testing.T) {
 		_, errs := testParseExpression(code)
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected end of program",
-					Secondary:     "check for incomplete expressions, missing tokens, or unterminated strings/comments",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos: ast.Position{
-						Offset: 13,
-						Line:   1,
-						Column: 13,
-					},
+				UnexpectedEOFError{
+					Pos: ast.Position{Offset: 13, Line: 1, Column: 13},
 				},
 			},
 			errs,
@@ -3062,11 +3048,8 @@ func TestParseAttach(t *testing.T) {
 		_, errs := testParseExpression("attach E() to")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected end of program",
-					Secondary:     "check for incomplete expressions, missing tokens, or unterminated strings/comments",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 13, Line: 1, Column: 13},
+				UnexpectedEOFError{
+					Pos: ast.Position{Offset: 13, Line: 1, Column: 13},
 				},
 			},
 			errs,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -195,11 +195,9 @@ func ParseTokenStream[T any](
 	p.skipSpaceAndComments()
 
 	if !p.current.Is(lexer.TokenEOF) {
-		p.report(
-			p.newSyntaxError("unexpected token: %s", p.current.Type).
-				WithSecondary("check for extra characters, missing semicolons, or incomplete statements").
-				WithDocumentation("https://cadence-lang.org/docs/language/syntax"),
-		)
+		p.report(&UnexpectedTokenAtEndError{
+			Token: p.current,
+		})
 	}
 
 	return result, p.errors

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -55,7 +55,6 @@ func parseStatements(p *parser, isEndToken func(token lexer.Token) bool) (statem
 
 			// Check that the previous statement (if any) followed a semicolon
 
-			// TODO: Add suggested fix for this error
 			if !sawSemicolon {
 				statementCount := len(statements)
 				if statementCount > 1 {
@@ -63,11 +62,9 @@ func parseStatements(p *parser, isEndToken func(token lexer.Token) bool) (statem
 					previousLine := previousStatement.EndPosition(p.memoryGauge).Line
 					currentStartPos := statement.StartPosition()
 					if previousLine == currentStartPos.Line {
-						p.report(NewSyntaxError(
-							currentStartPos,
-							"statements on the same line must be separated with a semicolon",
-						).WithSecondary("add a semicolon (;) between statements or place each statement on a separate line").
-							WithDocumentation("https://cadence-lang.org/docs/language/syntax#semicolons"))
+						p.report(&StatementSeparationError{
+							Pos: currentStartPos,
+						})
 					}
 				}
 			}

--- a/parser/statement_test.go
+++ b/parser/statement_test.go
@@ -1125,11 +1125,8 @@ func TestParseViewNonFunction(t *testing.T) {
 	_, errs := testParseStatements("view return 3")
 	AssertEqualWithDiff(t,
 		[]error{
-			&SyntaxError{
-				Message:       "statements on the same line must be separated with a semicolon",
-				Secondary:     "add a semicolon (;) between statements or place each statement on a separate line",
-				Documentation: "https://cadence-lang.org/docs/language/syntax#semicolons",
-				Pos:           ast.Position{Offset: 5, Line: 1, Column: 5},
+			&StatementSeparationError{
+				Pos: ast.Position{Offset: 5, Line: 1, Column: 5},
 			},
 		},
 		errs,
@@ -1195,11 +1192,8 @@ func TestParseStatements(t *testing.T) {
 		result, errs := testParseStatements(`assert true`)
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "statements on the same line must be separated with a semicolon",
-					Secondary:     "add a semicolon (;) between statements or place each statement on a separate line",
-					Documentation: "https://cadence-lang.org/docs/language/syntax#semicolons",
-					Pos:           ast.Position{Offset: 7, Line: 1, Column: 7},
+				&StatementSeparationError{
+					Pos: ast.Position{Offset: 7, Line: 1, Column: 7},
 				},
 			},
 			errs,

--- a/parser/statement_test.go
+++ b/parser/statement_test.go
@@ -1310,11 +1310,8 @@ func TestParseRemoveAttachmentStatement(t *testing.T) {
 					Message: "expected from keyword, got EOF",
 					Pos:     ast.Position{Offset: 8, Line: 1, Column: 8},
 				},
-				&SyntaxError{
-					Message:       "unexpected end of program",
-					Secondary:     "check for incomplete expressions, missing tokens, or unterminated strings/comments",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 8, Line: 1, Column: 8},
+				UnexpectedEOFError{
+					Pos: ast.Position{Offset: 8, Line: 1, Column: 8},
 				},
 			},
 			errs,
@@ -1329,11 +1326,8 @@ func TestParseRemoveAttachmentStatement(t *testing.T) {
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message:       "unexpected end of program",
-					Secondary:     "check for incomplete expressions, missing tokens, or unterminated strings/comments",
-					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos:           ast.Position{Offset: 13, Line: 1, Column: 13},
+				UnexpectedEOFError{
+					Pos: ast.Position{Offset: 13, Line: 1, Column: 13},
 				},
 			},
 			errs,

--- a/parser/statement_test.go
+++ b/parser/statement_test.go
@@ -2080,13 +2080,13 @@ func TestParseAccessAssignment(t *testing.T) {
 															Pos:        ast.Position{Offset: 31, Line: 3, Column: 12},
 														},
 													},
-													AccessPos: ast.Position{Offset: 32, Line: 3, Column: 13},
+													AccessEndPos: ast.Position{Offset: 32, Line: 3, Column: 13},
 													Identifier: ast.Identifier{
 														Identifier: "foo",
 														Pos:        ast.Position{Offset: 33, Line: 3, Column: 14},
 													},
 												},
-												AccessPos: ast.Position{Offset: 36, Line: 3, Column: 17},
+												AccessEndPos: ast.Position{Offset: 36, Line: 3, Column: 17},
 												Identifier: ast.Identifier{
 													Identifier: "bar",
 													Pos:        ast.Position{Offset: 37, Line: 3, Column: 18},
@@ -2120,7 +2120,7 @@ func TestParseAccessAssignment(t *testing.T) {
 											EndPos:   ast.Position{Offset: 45, Line: 3, Column: 26},
 										},
 									},
-									AccessPos: ast.Position{Offset: 46, Line: 3, Column: 27},
+									AccessEndPos: ast.Position{Offset: 46, Line: 3, Column: 27},
 									Identifier: ast.Identifier{
 										Identifier: "baz",
 										Pos:        ast.Position{Offset: 47, Line: 3, Column: 28},
@@ -2193,13 +2193,13 @@ func TestParseExpressionStatementWithAccess(t *testing.T) {
 															Pos:        ast.Position{Offset: 19, Line: 2, Column: 18},
 														},
 													},
-													AccessPos: ast.Position{Offset: 20, Line: 2, Column: 19},
+													AccessEndPos: ast.Position{Offset: 20, Line: 2, Column: 19},
 													Identifier: ast.Identifier{
 														Identifier: "foo",
 														Pos:        ast.Position{Offset: 21, Line: 2, Column: 20},
 													},
 												},
-												AccessPos: ast.Position{Offset: 24, Line: 2, Column: 23},
+												AccessEndPos: ast.Position{Offset: 24, Line: 2, Column: 23},
 												Identifier: ast.Identifier{
 													Identifier: "bar",
 													Pos:        ast.Position{Offset: 25, Line: 2, Column: 24},
@@ -2233,7 +2233,7 @@ func TestParseExpressionStatementWithAccess(t *testing.T) {
 											EndPos:   ast.Position{Offset: 33, Line: 2, Column: 32},
 										},
 									},
-									AccessPos: ast.Position{Offset: 34, Line: 2, Column: 33},
+									AccessEndPos: ast.Position{Offset: 34, Line: 2, Column: 33},
 									Identifier: ast.Identifier{
 										Identifier: "baz",
 										Pos:        ast.Position{Offset: 35, Line: 2, Column: 34},
@@ -2538,7 +2538,7 @@ func TestParseSwapStatementInFunctionDeclaration(t *testing.T) {
 											Pos:        ast.Position{Offset: 41, Line: 3, Column: 21},
 										},
 									},
-									AccessPos: ast.Position{Offset: 44, Line: 3, Column: 24},
+									AccessEndPos: ast.Position{Offset: 44, Line: 3, Column: 24},
 									Identifier: ast.Identifier{
 										Identifier: "baz",
 										Pos:        ast.Position{Offset: 45, Line: 3, Column: 25},

--- a/sema/composite_test.go
+++ b/sema/composite_test.go
@@ -2194,7 +2194,7 @@ func TestCheckInvalidMissingMember(t *testing.T) {
 		require.Equal(t,
 			[]errors.SuggestedFix[ast.TextEdit]{
 				{
-					Message: "use optional chaining",
+					Message: "Use optional chaining",
 					TextEdits: []ast.TextEdit{
 						{
 							Insertion: "?",

--- a/sema/declaration_test.go
+++ b/sema/declaration_test.go
@@ -744,7 +744,7 @@ func TestCheckIncorrectArgumentLabelError(t *testing.T) {
 	require.Equal(t,
 		[]errors.SuggestedFix[ast.TextEdit]{
 			{
-				Message: "replace argument label",
+				Message: "Replace argument label",
 				TextEdits: []ast.TextEdit{
 					{
 						Replacement: "x:",

--- a/sema/errors.go
+++ b/sema/errors.go
@@ -1357,7 +1357,7 @@ func (e *NotDeclaredMemberError) SuggestFixes(_ string) []errors.SuggestedFix[as
 		return nil
 	}
 
-	accessPos := e.Expression.AccessPos
+	accessPos := e.Expression.AccessEndPos
 
 	return []errors.SuggestedFix[ast.TextEdit]{
 		{

--- a/sema/errors.go
+++ b/sema/errors.go
@@ -585,7 +585,7 @@ func (*MissingArgumentLabelError) DocumentationLink() string {
 func (e *MissingArgumentLabelError) SuggestFixes(_ string) []errors.SuggestedFix[ast.TextEdit] {
 	return []errors.SuggestedFix[ast.TextEdit]{
 		{
-			Message: "insert argument label",
+			Message: "Insert argument label",
 			TextEdits: []ast.TextEdit{
 				{
 					Insertion: fmt.Sprintf("%s: ", e.ExpectedArgumentLabel),
@@ -638,7 +638,7 @@ func (e *IncorrectArgumentLabelError) SuggestFixes(code string) []errors.Suggest
 	if len(e.ExpectedArgumentLabel) > 0 {
 		return []errors.SuggestedFix[ast.TextEdit]{
 			{
-				Message: "replace argument label",
+				Message: "Replace argument label",
 				TextEdits: []ast.TextEdit{
 					{
 						Replacement: e.ExpectedArgumentLabel + ":",
@@ -663,7 +663,7 @@ func (e *IncorrectArgumentLabelError) SuggestFixes(code string) []errors.Suggest
 
 		return []errors.SuggestedFix[ast.TextEdit]{
 			{
-				Message: "remove argument label",
+				Message: "Remove argument label",
 				TextEdits: []ast.TextEdit{
 					{
 						Replacement: "",
@@ -1361,7 +1361,7 @@ func (e *NotDeclaredMemberError) SuggestFixes(_ string) []errors.SuggestedFix[as
 
 	return []errors.SuggestedFix[ast.TextEdit]{
 		{
-			Message: "use optional chaining",
+			Message: "Use optional chaining",
 			TextEdits: []ast.TextEdit{
 				{
 					Insertion: "?",
@@ -1957,7 +1957,7 @@ func (e *ConformanceError) ErrorNotes() (notes []errors.ErrorNote) {
 
 	if e.InitializerMismatch != nil && len(e.CompositeDeclaration.DeclarationMembers().Initializers()) > 0 {
 		compositeMemberIdentifierRange :=
-		//	right now we only support a single initializer
+			//	right now we only support a single initializer
 			ast.NewUnmeteredRangeFromPositioned(e.CompositeDeclaration.DeclarationMembers().Initializers()[0].FunctionDeclaration.Identifier)
 
 		notes = append(notes, &MemberMismatchNote{
@@ -3353,7 +3353,7 @@ func (*EmitDefaultDestroyEventError) SecondaryError() string {
 func (e *EmitDefaultDestroyEventError) SuggestFixes(_ string) []errors.SuggestedFix[ast.TextEdit] {
 	return []errors.SuggestedFix[ast.TextEdit]{
 		{
-			Message: "remove explicit emit statement",
+			Message: "Remove explicit emit statement",
 			TextEdits: []ast.TextEdit{
 				{
 					Replacement: "",

--- a/sema/events_test.go
+++ b/sema/events_test.go
@@ -691,7 +691,7 @@ func TestCheckDefaultEventDeclaration(t *testing.T) {
 		require.Equal(t,
 			[]errors.SuggestedFix[ast.TextEdit]{
 				{
-					Message: "remove explicit emit statement",
+					Message: "Remove explicit emit statement",
 					TextEdits: []ast.TextEdit{
 						{
 							Range: ast.Range{

--- a/sema/invocation_test.go
+++ b/sema/invocation_test.go
@@ -109,7 +109,7 @@ func TestCheckInvalidFunctionCallWithNotRequiredArgumentLabel(t *testing.T) {
 	require.Equal(t,
 		[]errors.SuggestedFix[ast.TextEdit]{
 			{
-				Message: "remove argument label",
+				Message: "Remove argument label",
 				TextEdits: []ast.TextEdit{
 					{
 						Range: ast.Range{
@@ -181,7 +181,7 @@ func TestCheckFunctionCallMissingArgumentLabel(t *testing.T) {
 	require.Equal(t,
 		[]errors.SuggestedFix[ast.TextEdit]{
 			{
-				Message: "insert argument label",
+				Message: "Insert argument label",
 				TextEdits: []ast.TextEdit{
 					{
 						Insertion: "x: ",
@@ -235,7 +235,7 @@ func TestCheckFunctionCallIncorrectArgumentLabel(t *testing.T) {
 	require.Equal(t,
 		[]errors.SuggestedFix[ast.TextEdit]{
 			{
-				Message: "replace argument label",
+				Message: "Replace argument label",
 				TextEdits: []ast.TextEdit{
 					{
 						Replacement: "x:",

--- a/sema/positioninfo.go
+++ b/sema/positioninfo.go
@@ -201,7 +201,7 @@ func (i *PositionInfo) recordMemberAccess(
 	memberAccessType Type,
 ) {
 	i.MemberAccesses.Put(
-		expression.AccessPos,
+		expression.AccessEndPos,
 		expression.EndPosition(memoryGauge),
 		memberAccessType,
 	)


### PR DESCRIPTION
Work towards #4062 

## Description

Follow up to #4126: Replace the ad-hoc syntax errors with dedicated error types. This is more efficient and allows us to validate the documentation links (see #4132).

Maybe best reviewed commit-by-commit.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
