### PR TITLE
Improve type parsing errors

### DIFF
--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -3662,6 +3662,22 @@ func TestParseCompositeDeclaration(t *testing.T) {
 		)
 	})
 
+	t.Run("struct, one conformance, missing body", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations("access(all) struct S: RI")
+		AssertEqualWithDiff(t,
+			[]error{
+				&UnexpectedEOFExpectedTokenError{
+					ExpectedToken: lexer.TokenBraceOpen,
+					Pos:           ast.Position{Offset: 24, Line: 1, Column: 24},
+				},
+			},
+			errs,
+		)
+	})
+
 	t.Run("struct, with fields, functions, and special functions", func(t *testing.T) {
 
 		t.Parallel()

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -2159,9 +2159,17 @@ func TestParseAccess(t *testing.T) {
 		result, errs := parse("access ( foo | bar , baz )")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "unexpected token: got ',', expected '|' or ')'",
-					Pos:     ast.Position{Offset: 19, Line: 1, Column: 19},
+				&UnexpectedTokenInsteadOfSeparatorError{
+					GotToken: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 19, Line: 1, Column: 19},
+							EndPos:   ast.Position{Offset: 19, Line: 1, Column: 19},
+						},
+						Type: lexer.TokenComma,
+					},
+					ExpectedSeparator: lexer.TokenVerticalBar,
+					ExpectedEndToken:  lexer.TokenParenClose,
 				},
 			},
 			errs,
@@ -2180,9 +2188,17 @@ func TestParseAccess(t *testing.T) {
 		result, errs := parse("access ( foo , bar | baz )")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "unexpected token: got '|', expected ',' or ')'",
-					Pos:     ast.Position{Offset: 19, Line: 1, Column: 19},
+				&UnexpectedTokenInsteadOfSeparatorError{
+					GotToken: lexer.Token{
+						SpaceOrError: nil,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 19, Line: 1, Column: 19},
+							EndPos:   ast.Position{Offset: 19, Line: 1, Column: 19},
+						},
+						Type: lexer.TokenVerticalBar,
+					},
+					ExpectedSeparator: lexer.TokenComma,
+					ExpectedEndToken:  lexer.TokenParenClose,
 				},
 			},
 			errs,
@@ -2329,6 +2345,34 @@ func TestParseAccess(t *testing.T) {
 				&ExpectedTypeInsteadSeparatorError{
 					Pos:       ast.Position{Offset: 15, Line: 1, Column: 15},
 					Separator: lexer.TokenComma,
+				},
+			},
+			errs,
+		)
+
+		AssertEqualWithDiff(t,
+			ast.AccessNotSpecified,
+			result,
+		)
+	})
+
+	t.Run("access, conjunctive entitlements list with missing separator", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := parse("access ( foo, bar baz )")
+		AssertEqualWithDiff(t,
+			[]error{
+				&UnexpectedTokenInsteadOfSeparatorError{
+					GotToken: lexer.Token{
+						Type: lexer.TokenIdentifier,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 18, Line: 1, Column: 18},
+							EndPos:   ast.Position{Offset: 20, Line: 1, Column: 20},
+						},
+					},
+					ExpectedSeparator: lexer.TokenComma,
+					ExpectedEndToken:  lexer.TokenParenClose,
 				},
 			},
 			errs,

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -2319,6 +2319,27 @@ func TestParseAccess(t *testing.T) {
 		)
 	})
 
+	t.Run("access, conjunctive entitlements list with leading comma", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := parse("access ( , foo )")
+		AssertEqualWithDiff(t,
+			[]error{
+				&ExpectedTypeInsteadSeparatorError{
+					Pos:       ast.Position{Offset: 9, Line: 1, Column: 9},
+					Separator: lexer.TokenComma,
+				},
+			},
+			errs,
+		)
+
+		AssertEqualWithDiff(t,
+			ast.AccessNotSpecified,
+			result,
+		)
+	})
+
 	t.Run("access, disjunctive entitlements list ending with keyword", func(t *testing.T) {
 
 		t.Parallel()
@@ -3208,6 +3229,21 @@ func TestParseEvent(t *testing.T) {
 				&SyntaxError{
 					Pos:     ast.Position{Line: 1, Column: 6, Offset: 6},
 					Message: "expected identifier after start of event declaration, got keyword continue",
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("leading separator in conformances", func(t *testing.T) {
+		t.Parallel()
+
+		_, errs := testParseDeclarations("struct Test: , I {}")
+		AssertEqualWithDiff(t,
+			[]error{
+				&ExpectedTypeInsteadSeparatorError{
+					Pos:       ast.Position{Offset: 13, Line: 1, Column: 13},
+					Separator: lexer.TokenComma,
 				},
 			},
 			errs,

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -2323,11 +2323,11 @@ func TestParseAccess(t *testing.T) {
 
 		t.Parallel()
 
-		result, errs := parse("access ( , foo )")
+		result, errs := parse("access ( foo , , )")
 		AssertEqualWithDiff(t,
 			[]error{
 				&ExpectedTypeInsteadSeparatorError{
-					Pos:       ast.Position{Offset: 9, Line: 1, Column: 9},
+					Pos:       ast.Position{Offset: 15, Line: 1, Column: 15},
 					Separator: lexer.TokenComma,
 				},
 			},

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -3678,6 +3678,21 @@ func TestParseCompositeDeclaration(t *testing.T) {
 		)
 	})
 
+	t.Run("struct, one conformance, missing type after comma", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseDeclarations("access(all) struct S: RI, ")
+		AssertEqualWithDiff(t,
+			[]error{
+				&UnexpectedEOFExpectedTypeError{
+					Pos:           ast.Position{Offset: 26, Line: 1, Column: 26},
+				},
+			},
+			errs,
+		)
+	})
+
 	t.Run("struct, with fields, functions, and special functions", func(t *testing.T) {
 
 		t.Parallel()

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1485,6 +1485,42 @@ func (*MissingSeparatorInIntersectionOrDictionaryTypeError) DocumentationLink() 
 	return "https://cadence-lang.org/docs/language/types-and-type-system/intersection-types"
 }
 
+// ExpectedTypeInsteadSeparatorError is reported when a separator is found at an unexpected position,
+// where a type was expected.
+type ExpectedTypeInsteadSeparatorError struct {
+	Pos       ast.Position
+	Separator lexer.TokenType
+}
+
+var _ ParseError = &ExpectedTypeInsteadSeparatorError{}
+var _ errors.UserError = &ExpectedTypeInsteadSeparatorError{}
+var _ errors.SecondaryError = &ExpectedTypeInsteadSeparatorError{}
+var _ errors.HasDocumentationLink = &ExpectedTypeInsteadSeparatorError{}
+
+func (*ExpectedTypeInsteadSeparatorError) isParseError() {}
+
+func (*ExpectedTypeInsteadSeparatorError) IsUserError() {}
+
+func (e *ExpectedTypeInsteadSeparatorError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *ExpectedTypeInsteadSeparatorError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Pos
+}
+
+func (e *ExpectedTypeInsteadSeparatorError) Error() string {
+	return fmt.Sprintf("expected type, got separator '%s'", e.Separator)
+}
+
+func (e *ExpectedTypeInsteadSeparatorError) SecondaryError() string {
+	return "a type was expected, but a separator was found instead"
+}
+
+func (*ExpectedTypeInsteadSeparatorError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/syntax"
+}
+
 // MissingClosingParenInArgumentListError is reported when an argument list is missing a closing parenthesis.
 type MissingClosingParenInArgumentListError struct {
 	Pos ast.Position

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1521,42 +1521,6 @@ func (*ExpectedTypeInsteadSeparatorError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/syntax"
 }
 
-// ExpectedTypeAnnotationInsteadSeparatorError is reported when a separator is found at an unexpected position,
-// where a type was expected.
-type ExpectedTypeAnnotationInsteadSeparatorError struct {
-	Pos       ast.Position
-	Separator lexer.TokenType
-}
-
-var _ ParseError = &ExpectedTypeAnnotationInsteadSeparatorError{}
-var _ errors.UserError = &ExpectedTypeAnnotationInsteadSeparatorError{}
-var _ errors.SecondaryError = &ExpectedTypeAnnotationInsteadSeparatorError{}
-var _ errors.HasDocumentationLink = &ExpectedTypeAnnotationInsteadSeparatorError{}
-
-func (*ExpectedTypeAnnotationInsteadSeparatorError) isParseError() {}
-
-func (*ExpectedTypeAnnotationInsteadSeparatorError) IsUserError() {}
-
-func (e *ExpectedTypeAnnotationInsteadSeparatorError) StartPosition() ast.Position {
-	return e.Pos
-}
-
-func (e *ExpectedTypeAnnotationInsteadSeparatorError) EndPosition(_ common.MemoryGauge) ast.Position {
-	return e.Pos
-}
-
-func (e *ExpectedTypeAnnotationInsteadSeparatorError) Error() string {
-	return fmt.Sprintf("expected type annotation, got separator '%s'", e.Separator)
-}
-
-func (e *ExpectedTypeAnnotationInsteadSeparatorError) SecondaryError() string {
-	return "a type annotation was expected, but a separator was found instead"
-}
-
-func (*ExpectedTypeAnnotationInsteadSeparatorError) DocumentationLink() string {
-	return "https://cadence-lang.org/docs/language/syntax"
-}
-
 // MissingClosingParenInArgumentListError is reported when an argument list is missing a closing parenthesis.
 type MissingClosingParenInArgumentListError struct {
 	Pos ast.Position

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -2849,3 +2849,41 @@ func (*NonNominalTypeError) SecondaryError() string {
 func (*NonNominalTypeError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/types-and-type-system/"
 }
+
+// NestedTypeMissingNameError is reported when a nested type is missing a name.
+type NestedTypeMissingNameError struct {
+	GotToken lexer.Token
+}
+
+var _ ParseError = &NestedTypeMissingNameError{}
+var _ errors.UserError = &NestedTypeMissingNameError{}
+var _ errors.SecondaryError = &NestedTypeMissingNameError{}
+var _ errors.HasDocumentationLink = &NestedTypeMissingNameError{}
+
+func (*NestedTypeMissingNameError) isParseError() {}
+
+func (*NestedTypeMissingNameError) IsUserError() {}
+
+func (e *NestedTypeMissingNameError) StartPosition() ast.Position {
+	return e.GotToken.StartPos
+}
+
+func (e *NestedTypeMissingNameError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.GotToken.EndPos
+}
+
+func (e *NestedTypeMissingNameError) Error() string {
+	tokenType := e.GotToken.Type
+	if tokenType == lexer.TokenEOF {
+		return "expected nested type name after dot (.)"
+	}
+	return fmt.Sprintf("expected nested type name after dot (.) got %s", tokenType)
+}
+
+func (*NestedTypeMissingNameError) SecondaryError() string {
+	return "after a dot (.), you must provide a valid identifier for the nested type name"
+}
+
+func (*NestedTypeMissingNameError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/syntax"
+}

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1446,6 +1446,45 @@ func (*MissingTypeAfterSeparatorError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/syntax"
 }
 
+// MissingSeparatorInIntersectionOrDictionaryTypeError is reported when a separator is missing
+// between types in an intersection or dictionary type.
+type MissingSeparatorInIntersectionOrDictionaryTypeError struct {
+	GotToken lexer.Token
+}
+
+var _ ParseError = &MissingSeparatorInIntersectionOrDictionaryTypeError{}
+var _ errors.UserError = &MissingSeparatorInIntersectionOrDictionaryTypeError{}
+var _ errors.SecondaryError = &MissingSeparatorInIntersectionOrDictionaryTypeError{}
+var _ errors.HasDocumentationLink = &MissingSeparatorInIntersectionOrDictionaryTypeError{}
+
+func (*MissingSeparatorInIntersectionOrDictionaryTypeError) isParseError() {}
+
+func (*MissingSeparatorInIntersectionOrDictionaryTypeError) IsUserError() {}
+
+func (e *MissingSeparatorInIntersectionOrDictionaryTypeError) StartPosition() ast.Position {
+	return e.GotToken.StartPos
+}
+
+func (e *MissingSeparatorInIntersectionOrDictionaryTypeError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.GotToken.EndPos
+}
+
+func (e *MissingSeparatorInIntersectionOrDictionaryTypeError) Error() string {
+	return fmt.Sprintf(
+		"missing separator in type list, got %s",
+		e.GotToken.Type,
+	)
+}
+
+func (*MissingSeparatorInIntersectionOrDictionaryTypeError) SecondaryError() string {
+	return "types in an intersection type must be separated by a comma (,) " +
+		"and types in a dictionary type must be separated by a colon (:)"
+}
+
+func (*MissingSeparatorInIntersectionOrDictionaryTypeError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/types-and-type-system/intersection-types"
+}
+
 // MissingClosingParenInArgumentListError is reported when an argument list is missing a closing parenthesis.
 type MissingClosingParenInArgumentListError struct {
 	Pos ast.Position

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -309,7 +309,7 @@ func (e *UnexpectedEOFExpectedTypeError) EndPosition(_ common.MemoryGauge) ast.P
 }
 
 func (*UnexpectedEOFExpectedTypeError) Error() string {
-	return "invalid end of input, expected type"
+	return "unexpected end of input, expected type"
 }
 
 func (*UnexpectedEOFExpectedTypeError) SecondaryError() string {
@@ -317,6 +317,45 @@ func (*UnexpectedEOFExpectedTypeError) SecondaryError() string {
 }
 
 func (*UnexpectedEOFExpectedTypeError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/syntax"
+}
+
+// UnexpectedEOFExpectedTokenError is reported when the end of the program is reached unexpectedly,
+// but a specific token was expected.
+type UnexpectedEOFExpectedTokenError struct {
+	ExpectedToken lexer.TokenType
+	Pos           ast.Position
+}
+
+var _ ParseError = &UnexpectedEOFExpectedTokenError{}
+var _ errors.UserError = &UnexpectedEOFExpectedTokenError{}
+var _ errors.SecondaryError = &UnexpectedEOFExpectedTokenError{}
+var _ errors.HasDocumentationLink = &UnexpectedEOFExpectedTokenError{}
+
+func (*UnexpectedEOFExpectedTokenError) isParseError() {}
+
+func (*UnexpectedEOFExpectedTokenError) IsUserError() {}
+
+func (e *UnexpectedEOFExpectedTokenError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *UnexpectedEOFExpectedTokenError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Pos
+}
+
+func (e *UnexpectedEOFExpectedTokenError) Error() string {
+	return fmt.Sprintf(
+		"unexpected end of input, expected %s",
+		e.ExpectedToken,
+	)
+}
+
+func (*UnexpectedEOFExpectedTokenError) SecondaryError() string {
+	return "check for incomplete expressions, missing tokens, or unterminated strings/comments"
+}
+
+func (*UnexpectedEOFExpectedTokenError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/syntax"
 }
 

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1137,7 +1137,7 @@ func (*MultipleColonInDictionaryTypeError) SecondaryError() string {
 }
 
 func (*MultipleColonInDictionaryTypeError) DocumentationLink() string {
-	return "https://cadence-lang.org/docs/language/values-and-types/dictionaries"
+	return "https://cadence-lang.org/docs/language/values-and-types/dictionaries#dictionary-types"
 }
 
 // UnexpectedCommaInTypeAnnotationListError is reported when a comma is found at an unexpected position in a type annotation list.

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1411,6 +1411,41 @@ func (*MissingTypeAfterCommaInIntersectionError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/types-and-type-system/intersection-types"
 }
 
+// MissingTypeAfterSeparatorError is reported when a type is missing after a separator.
+type MissingTypeAfterSeparatorError struct {
+	Pos       ast.Position
+	Separator lexer.TokenType
+}
+
+var _ ParseError = &MissingTypeAfterSeparatorError{}
+var _ errors.UserError = &MissingTypeAfterSeparatorError{}
+var _ errors.SecondaryError = &MissingTypeAfterSeparatorError{}
+var _ errors.HasDocumentationLink = &MissingTypeAfterSeparatorError{}
+
+func (*MissingTypeAfterSeparatorError) isParseError() {}
+
+func (*MissingTypeAfterSeparatorError) IsUserError() {}
+
+func (e *MissingTypeAfterSeparatorError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *MissingTypeAfterSeparatorError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Pos
+}
+
+func (e *MissingTypeAfterSeparatorError) Error() string {
+	return fmt.Sprintf("missing type after separator: %s", e.Separator)
+}
+
+func (e *MissingTypeAfterSeparatorError) SecondaryError() string {
+	return fmt.Sprintf("a type is expected after the %s separator", e.Separator)
+}
+
+func (*MissingTypeAfterSeparatorError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/syntax"
+}
+
 // MissingClosingParenInArgumentListError is reported when an argument list is missing a closing parenthesis.
 type MissingClosingParenInArgumentListError struct {
 	Pos ast.Position

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1521,6 +1521,42 @@ func (*ExpectedTypeInsteadSeparatorError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/syntax"
 }
 
+// ExpectedTypeAnnotationInsteadSeparatorError is reported when a separator is found at an unexpected position,
+// where a type was expected.
+type ExpectedTypeAnnotationInsteadSeparatorError struct {
+	Pos       ast.Position
+	Separator lexer.TokenType
+}
+
+var _ ParseError = &ExpectedTypeAnnotationInsteadSeparatorError{}
+var _ errors.UserError = &ExpectedTypeAnnotationInsteadSeparatorError{}
+var _ errors.SecondaryError = &ExpectedTypeAnnotationInsteadSeparatorError{}
+var _ errors.HasDocumentationLink = &ExpectedTypeAnnotationInsteadSeparatorError{}
+
+func (*ExpectedTypeAnnotationInsteadSeparatorError) isParseError() {}
+
+func (*ExpectedTypeAnnotationInsteadSeparatorError) IsUserError() {}
+
+func (e *ExpectedTypeAnnotationInsteadSeparatorError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *ExpectedTypeAnnotationInsteadSeparatorError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Pos
+}
+
+func (e *ExpectedTypeAnnotationInsteadSeparatorError) Error() string {
+	return fmt.Sprintf("expected type annotation, got separator '%s'", e.Separator)
+}
+
+func (e *ExpectedTypeAnnotationInsteadSeparatorError) SecondaryError() string {
+	return "a type annotation was expected, but a separator was found instead"
+}
+
+func (*ExpectedTypeAnnotationInsteadSeparatorError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/syntax"
+}
+
 // MissingClosingParenInArgumentListError is reported when an argument list is missing a closing parenthesis.
 type MissingClosingParenInArgumentListError struct {
 	Pos ast.Position

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1521,6 +1521,52 @@ func (*ExpectedTypeInsteadSeparatorError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/syntax"
 }
 
+// UnexpectedTokenInsteadOfSeparatorError is reported when an unexpected token is found,
+// where a separator or an end token was expected.
+type UnexpectedTokenInsteadOfSeparatorError struct {
+	GotToken          lexer.Token
+	ExpectedSeparator lexer.TokenType
+	ExpectedEndToken  lexer.TokenType
+}
+
+var _ ParseError = &UnexpectedTokenInsteadOfSeparatorError{}
+var _ errors.UserError = &UnexpectedTokenInsteadOfSeparatorError{}
+var _ errors.SecondaryError = &UnexpectedTokenInsteadOfSeparatorError{}
+var _ errors.HasDocumentationLink = &UnexpectedTokenInsteadOfSeparatorError{}
+
+func (*UnexpectedTokenInsteadOfSeparatorError) isParseError() {}
+
+func (*UnexpectedTokenInsteadOfSeparatorError) IsUserError() {}
+
+func (e *UnexpectedTokenInsteadOfSeparatorError) StartPosition() ast.Position {
+	return e.GotToken.StartPos
+}
+
+func (e *UnexpectedTokenInsteadOfSeparatorError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.GotToken.EndPos
+}
+
+func (e *UnexpectedTokenInsteadOfSeparatorError) Error() string {
+	return fmt.Sprintf(
+		"unexpected token: got %s, expected %s or separator %s",
+		e.GotToken.Type,
+		e.ExpectedEndToken,
+		e.ExpectedSeparator,
+	)
+}
+
+func (e *UnexpectedTokenInsteadOfSeparatorError) SecondaryError() string {
+	return fmt.Sprintf(
+		"did you miss a separator ('%s') or a closing token ('%s')?",
+		e.ExpectedSeparator,
+		e.ExpectedEndToken,
+	)
+}
+
+func (*UnexpectedTokenInsteadOfSeparatorError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/syntax"
+}
+
 // MissingClosingParenInArgumentListError is reported when an argument list is missing a closing parenthesis.
 type MissingClosingParenInArgumentListError struct {
 	Pos ast.Position

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1140,6 +1140,40 @@ func (*MultipleColonInDictionaryTypeError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/values-and-types/dictionaries#dictionary-types"
 }
 
+// MissingDictionaryValueTypeError is reported when a dictionary type is missing a value type.
+type MissingDictionaryValueTypeError struct {
+	Pos ast.Position
+}
+
+var _ ParseError = &MissingDictionaryValueTypeError{}
+var _ errors.UserError = &MissingDictionaryValueTypeError{}
+var _ errors.SecondaryError = &MissingDictionaryValueTypeError{}
+var _ errors.HasDocumentationLink = &MissingDictionaryValueTypeError{}
+
+func (*MissingDictionaryValueTypeError) isParseError() {}
+
+func (*MissingDictionaryValueTypeError) IsUserError() {}
+
+func (e *MissingDictionaryValueTypeError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *MissingDictionaryValueTypeError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Pos
+}
+
+func (*MissingDictionaryValueTypeError) Error() string {
+	return "missing dictionary value type"
+}
+
+func (*MissingDictionaryValueTypeError) SecondaryError() string {
+	return "a value type is expected after the colon (:)"
+}
+
+func (*MissingDictionaryValueTypeError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/values-and-types/dictionaries#dictionary-types"
+}
+
 // UnexpectedCommaInTypeAnnotationListError is reported when a comma is found at an unexpected position in a type annotation list.
 type UnexpectedCommaInTypeAnnotationListError struct {
 	Pos ast.Position

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -535,9 +535,8 @@ func (e *MissingStartOfParameterListError) EndPosition(_ common.MemoryGauge) ast
 }
 
 func (e *MissingStartOfParameterListError) Error() string {
-	return fmt.Sprintf(
-		"expected %s as start of parameter list, got %s",
-		lexer.TokenParenOpen,
+	return expectedButGotToken(
+		"expected open parenthesis '(' as start of parameter list",
 		e.GotToken.Type,
 	)
 }
@@ -613,8 +612,8 @@ func (e *UnexpectedTokenInParameterListError) EndPosition(_ common.MemoryGauge) 
 }
 
 func (e *UnexpectedTokenInParameterListError) Error() string {
-	return fmt.Sprintf(
-		"expected parameter or end of parameter list, got %s",
+	return expectedButGotToken(
+		"expected parameter or end of parameter list",
 		e.GotToken.Type,
 	)
 }
@@ -687,8 +686,8 @@ func (e *ExpectedCommaOrEndOfParameterListError) EndPosition(_ common.MemoryGaug
 }
 
 func (e *ExpectedCommaOrEndOfParameterListError) Error() string {
-	return fmt.Sprintf(
-		"expected comma or end of parameter list, got %s",
+	return expectedButGotToken(
+		"expected comma or end of parameter list",
 		e.GotToken.Type,
 	)
 }
@@ -724,9 +723,8 @@ func (e *MissingColonAfterParameterNameError) EndPosition(_ common.MemoryGauge) 
 }
 
 func (e *MissingColonAfterParameterNameError) Error() string {
-	return fmt.Sprintf(
-		"expected %s after parameter name, got %s",
-		lexer.TokenColon,
+	return expectedButGotToken(
+		"expected colon (:) after parameter name",
 		e.GotToken.Type,
 	)
 }
@@ -762,8 +760,8 @@ func (e *MissingDefaultArgumentError) EndPosition(_ common.MemoryGauge) ast.Posi
 }
 
 func (e *MissingDefaultArgumentError) Error() string {
-	return fmt.Sprintf(
-		"expected a default argument after type annotation, got %s",
+	return expectedButGotToken(
+		"expected a default argument after type annotation",
 		e.GotToken.Type,
 	)
 }
@@ -886,8 +884,8 @@ func (e *UnexpectedTokenInTypeParameterListError) EndPosition(_ common.MemoryGau
 }
 
 func (e *UnexpectedTokenInTypeParameterListError) Error() string {
-	return fmt.Sprintf(
-		"expected type parameter or end of type parameter list, got %s",
+	return expectedButGotToken(
+		"expected type parameter or end of type parameter list",
 		e.GotToken.Type,
 	)
 }
@@ -960,8 +958,8 @@ func (e *ExpectedCommaOrEndOfTypeParameterListError) EndPosition(_ common.Memory
 }
 
 func (e *ExpectedCommaOrEndOfTypeParameterListError) Error() string {
-	return fmt.Sprintf(
-		"expected comma or end of type parameter list, got %s",
+	return expectedButGotToken(
+		"expected comma (,) or end of type parameter list",
 		e.GotToken.Type,
 	)
 }
@@ -997,8 +995,8 @@ func (e *InvalidTypeParameterNameError) EndPosition(_ common.MemoryGauge) ast.Po
 }
 
 func (e *InvalidTypeParameterNameError) Error() string {
-	return fmt.Sprintf(
-		"expected type parameter name, got %s",
+	return expectedButGotToken(
+		"expected type parameter name",
 		e.GotToken.Type,
 	)
 }
@@ -1108,7 +1106,7 @@ func (e *ExpectedPrepareOrExecuteError) EndPosition(memoryGauge common.MemoryGau
 
 func (e *ExpectedPrepareOrExecuteError) Error() string {
 	return fmt.Sprintf(
-		"unexpected identifier, expected keyword %q or %q, got %q",
+		"unexpected identifier: expected keyword %q or %q, got %q",
 		KeywordPrepare,
 		KeywordExecute,
 		e.GotIdentifier,
@@ -1149,7 +1147,7 @@ func (e *ExpectedExecuteOrPostError) EndPosition(memoryGauge common.MemoryGauge)
 
 func (e *ExpectedExecuteOrPostError) Error() string {
 	return fmt.Sprintf(
-		"unexpected identifier, expected keyword %q or %q, got %q",
+		"unexpected identifier: expected keyword %q or %q, got %q",
 		KeywordExecute,
 		KeywordPost,
 		e.GotIdentifier,
@@ -1557,8 +1555,8 @@ func (e *MissingSeparatorInIntersectionOrDictionaryTypeError) EndPosition(_ comm
 }
 
 func (e *MissingSeparatorInIntersectionOrDictionaryTypeError) Error() string {
-	return fmt.Sprintf(
-		"missing separator in type list, got %s",
+	return expectedButGotToken(
+		"missing separator in type list",
 		e.GotToken.Type,
 	)
 }
@@ -1634,11 +1632,13 @@ func (e *UnexpectedTokenInsteadOfSeparatorError) EndPosition(_ common.MemoryGaug
 }
 
 func (e *UnexpectedTokenInsteadOfSeparatorError) Error() string {
-	return fmt.Sprintf(
-		"unexpected token: got %s, expected %s or separator %s",
+	return expectedButGotToken(
+		fmt.Sprintf(
+			"unexpected token: expected %s or separator %s",
+			e.ExpectedEndToken,
+			e.ExpectedSeparator,
+		),
 		e.GotToken.Type,
-		e.ExpectedEndToken,
-		e.ExpectedSeparator,
 	)
 }
 
@@ -1746,8 +1746,8 @@ func (e *MissingCommaInArgumentListError) EndPosition(_ common.MemoryGauge) ast.
 }
 
 func (e *MissingCommaInArgumentListError) Error() string {
-	return fmt.Sprintf(
-		"unexpected argument in argument list (expecting delimiter or end of argument list), got %s",
+	return expectedButGotToken(
+		"unexpected argument in argument list: expected delimiter or end of argument list",
 		e.GotToken.Type,
 	)
 }
@@ -2359,7 +2359,10 @@ func (e *InvalidPubSetModifierError) EndPosition(_ common.MemoryGauge) ast.Posit
 }
 
 func (e *InvalidPubSetModifierError) Error() string {
-	return fmt.Sprintf("expected keyword %q, got %s", "set", e.GotToken.Type)
+	return expectedButGotToken(
+		`expected keyword "set"`,
+		e.GotToken.Type,
+	)
 }
 
 func (*InvalidPubSetModifierError) SecondaryError() string {
@@ -2397,9 +2400,11 @@ func (e *MissingAccessKeywordError) Error() string {
 		[]string{`"all"`, `"account"`, `"contract"`, `"self"`},
 		"or",
 	)
-	return fmt.Sprintf(
-		"expected keyword %s, got %s",
-		keywords,
+	return expectedButGotToken(
+		fmt.Sprintf(
+			"expected keyword %s",
+			keywords,
+		),
 		e.GotToken.Type,
 	)
 }
@@ -2435,7 +2440,10 @@ func (e *MissingEnumCaseNameError) EndPosition(_ common.MemoryGauge) ast.Positio
 }
 
 func (e *MissingEnumCaseNameError) Error() string {
-	return fmt.Sprintf("expected identifier after start of enum case declaration, got %s", e.GotToken.Type)
+	return expectedButGotToken(
+		"expected identifier after start of enum case declaration",
+		e.GotToken.Type,
+	)
 }
 
 func (*MissingEnumCaseNameError) SecondaryError() string {
@@ -2469,7 +2477,10 @@ func (e *MissingFieldNameError) EndPosition(_ common.MemoryGauge) ast.Position {
 }
 
 func (e *MissingFieldNameError) Error() string {
-	return fmt.Sprintf("expected identifier after start of field declaration, got %s", e.GotToken.Type)
+	return expectedButGotToken(
+		"expected identifier after start of field declaration",
+		e.GotToken.Type,
+	)
 }
 
 func (*MissingFieldNameError) SecondaryError() string {
@@ -2538,8 +2549,8 @@ func (e *InvalidImportLocationError) EndPosition(_ common.MemoryGauge) ast.Posit
 }
 
 func (e *InvalidImportLocationError) Error() string {
-	return fmt.Sprintf(
-		"unexpected token in import declaration: got %s, expected address, string, or identifier",
+	return expectedButGotToken(
+		"unexpected token in import declaration: expected address, string, or identifier",
 		e.GotToken.Type,
 	)
 }
@@ -2576,16 +2587,19 @@ func (e *InvalidImportContinuationError) EndPosition(_ common.MemoryGauge) ast.P
 }
 
 func (e *InvalidImportContinuationError) Error() string {
-	return fmt.Sprintf(
-		"unexpected token in import declaration: got %s, expected keyword %q or %s",
+	return expectedButGotToken(
+		fmt.Sprintf(
+			"unexpected token in import declaration: expected keyword %q or %s",
+			KeywordFrom,
+			lexer.TokenComma,
+		),
 		e.GotToken.Type,
-		KeywordFrom,
-		lexer.TokenComma,
 	)
 }
 
 func (*InvalidImportContinuationError) SecondaryError() string {
-	return "after an imported identifier, expect either a comma to import more items or the 'from' keyword to specify the import location"
+	return "after an imported identifier, expect either a comma to import more items " +
+		"or the 'from' keyword to specify the import location"
 }
 
 func (*InvalidImportContinuationError) DocumentationLink() string {
@@ -2687,9 +2701,11 @@ func (e *InvalidTokenInImportListError) EndPosition(_ common.MemoryGauge) ast.Po
 }
 
 func (e *InvalidTokenInImportListError) Error() string {
-	return fmt.Sprintf(
-		"expected identifier or keyword %q, got %s",
-		KeywordFrom,
+	return expectedButGotToken(
+		fmt.Sprintf(
+			"expected identifier or keyword %q",
+			KeywordFrom,
+		),
 		e.GotToken.Type,
 	)
 }
@@ -2795,7 +2811,7 @@ func (e *InvalidInterfaceNameError) EndPosition(_ common.MemoryGauge) ast.Positi
 }
 
 func (e *InvalidInterfaceNameError) Error() string {
-	return fmt.Sprintf("expected interface name, got keyword %q", "interface")
+	return fmt.Sprintf("expected interface name, got keyword %q", KeywordInterface)
 }
 
 func (*InvalidInterfaceNameError) SecondaryError() string {
@@ -2994,11 +3010,10 @@ func (e *MemberAccessMissingNameError) EndPosition(_ common.MemoryGauge) ast.Pos
 }
 
 func (e *MemberAccessMissingNameError) Error() string {
-	tokenType := e.GotToken.Type
-	if tokenType == lexer.TokenEOF {
-		return "expected member name"
-	}
-	return fmt.Sprintf("expected member name, got %s", tokenType)
+	return expectedButGotToken(
+		"expected member name",
+		e.GotToken.Type,
+	)
 }
 
 func (*MemberAccessMissingNameError) SecondaryError() string {
@@ -3223,11 +3238,10 @@ func (e *NestedTypeMissingNameError) EndPosition(_ common.MemoryGauge) ast.Posit
 }
 
 func (e *NestedTypeMissingNameError) Error() string {
-	tokenType := e.GotToken.Type
-	if tokenType == lexer.TokenEOF {
-		return "expected nested type name after dot (.)"
-	}
-	return fmt.Sprintf("expected nested type name after dot (.) got %s", tokenType)
+	return expectedButGotToken(
+		"expected nested type name after dot (.)",
+		e.GotToken.Type,
+	)
 }
 
 func (*NestedTypeMissingNameError) SecondaryError() string {

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1338,6 +1338,40 @@ func (*InvalidNonNominalTypeInIntersectionError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/types-and-type-system/intersection-types"
 }
 
+// MissingTypeAfterCommaInIntersectionError is reported when a type is missing after a comma in an intersection type.
+type MissingTypeAfterCommaInIntersectionError struct {
+	Pos ast.Position
+}
+
+var _ ParseError = &MissingTypeAfterCommaInIntersectionError{}
+var _ errors.UserError = &MissingTypeAfterCommaInIntersectionError{}
+var _ errors.SecondaryError = &MissingTypeAfterCommaInIntersectionError{}
+var _ errors.HasDocumentationLink = &MissingTypeAfterCommaInIntersectionError{}
+
+func (*MissingTypeAfterCommaInIntersectionError) isParseError() {}
+
+func (*MissingTypeAfterCommaInIntersectionError) IsUserError() {}
+
+func (e *MissingTypeAfterCommaInIntersectionError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *MissingTypeAfterCommaInIntersectionError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Pos
+}
+
+func (*MissingTypeAfterCommaInIntersectionError) Error() string {
+	return "missing type after comma"
+}
+
+func (*MissingTypeAfterCommaInIntersectionError) SecondaryError() string {
+	return "a type is expected after the comma"
+}
+
+func (*MissingTypeAfterCommaInIntersectionError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/types-and-type-system/intersection-types"
+}
+
 // MissingClosingParenInArgumentListError is reported when an argument list is missing a closing parenthesis.
 type MissingClosingParenInArgumentListError struct {
 	Pos ast.Position

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -286,7 +286,8 @@ func (UnexpectedEOFError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/syntax"
 }
 
-// UnexpectedEOFExpectedTypeError is reported when the end of the program is reached unexpectedly, but a type was expected.
+// UnexpectedEOFExpectedTypeError is reported when the end of the program is reached unexpectedly,
+// but a type was expected.
 type UnexpectedEOFExpectedTypeError struct {
 	Pos ast.Position
 }
@@ -317,6 +318,41 @@ func (*UnexpectedEOFExpectedTypeError) SecondaryError() string {
 }
 
 func (*UnexpectedEOFExpectedTypeError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/syntax"
+}
+
+// UnexpectedEOFExpectedTypeAnnotationError is reported when the end of the program is reached unexpectedly,
+// but a type annotation was expected.
+type UnexpectedEOFExpectedTypeAnnotationError struct {
+	Pos ast.Position
+}
+
+var _ ParseError = &UnexpectedEOFExpectedTypeAnnotationError{}
+var _ errors.UserError = &UnexpectedEOFExpectedTypeAnnotationError{}
+var _ errors.SecondaryError = &UnexpectedEOFExpectedTypeAnnotationError{}
+var _ errors.HasDocumentationLink = &UnexpectedEOFExpectedTypeAnnotationError{}
+
+func (*UnexpectedEOFExpectedTypeAnnotationError) isParseError() {}
+
+func (*UnexpectedEOFExpectedTypeAnnotationError) IsUserError() {}
+
+func (e *UnexpectedEOFExpectedTypeAnnotationError) StartPosition() ast.Position {
+	return e.Pos
+}
+
+func (e *UnexpectedEOFExpectedTypeAnnotationError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.Pos
+}
+
+func (*UnexpectedEOFExpectedTypeAnnotationError) Error() string {
+	return "unexpected end of input, expected type annotation"
+}
+
+func (*UnexpectedEOFExpectedTypeAnnotationError) SecondaryError() string {
+	return "check for incomplete expressions, missing tokens, or unterminated strings/comments"
+}
+
+func (*UnexpectedEOFExpectedTypeAnnotationError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/syntax"
 }
 

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1584,6 +1584,33 @@ func (*UnexpectedTokenInTypeError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/syntax"
 }
 
+// InvalidConstantSizedTypeSizeError
+
+type InvalidConstantSizedTypeSizeError struct {
+	ast.Range
+}
+
+var _ ParseError = &InvalidConstantSizedTypeSizeError{}
+var _ errors.UserError = &InvalidConstantSizedTypeSizeError{}
+var _ errors.SecondaryError = &InvalidConstantSizedTypeSizeError{}
+var _ errors.HasDocumentationLink = &InvalidConstantSizedTypeSizeError{}
+
+func (*InvalidConstantSizedTypeSizeError) isParseError() {}
+
+func (*InvalidConstantSizedTypeSizeError) IsUserError() {}
+
+func (*InvalidConstantSizedTypeSizeError) Error() string {
+	return "expected positive integer size for constant sized type"
+}
+
+func (*InvalidConstantSizedTypeSizeError) SecondaryError() string {
+	return "the size of a constant-sized array must be a positive integer literal"
+}
+
+func (*InvalidConstantSizedTypeSizeError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/values-and-types/arrays#array-types"
+}
+
 // CustomDestructorError
 
 type CustomDestructorError struct {

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -3051,6 +3051,38 @@ func TestParseCreate(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("nested", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := testParseExpression("create Foo.Bar()")
+		require.Empty(t, errs)
+
+		AssertEqualWithDiff(t,
+			&ast.CreateExpression{
+				InvocationExpression: &ast.InvocationExpression{
+					InvokedExpression: &ast.MemberExpression{
+						Expression: &ast.IdentifierExpression{
+							Identifier: ast.Identifier{
+								Identifier: "Foo",
+								Pos:        ast.Position{Line: 1, Column: 7, Offset: 7},
+							},
+						},
+						AccessEndPos: ast.Position{Line: 1, Column: 11, Offset: 11},
+						Identifier: ast.Identifier{
+							Identifier: "Bar",
+							Pos:        ast.Position{Line: 1, Column: 11, Offset: 11},
+						},
+					},
+					ArgumentsStartPos: ast.Position{Line: 1, Column: 14, Offset: 14},
+					EndPos:            ast.Position{Line: 1, Column: 15, Offset: 15},
+				},
+				StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+			},
+			result,
+		)
+	})
 }
 
 func TestParseNil(t *testing.T) {

--- a/parser/type.go
+++ b/parser/type.go
@@ -27,7 +27,6 @@ import (
 const (
 	typeLeftBindingPowerOptional = 10 * (iota + 1)
 	typeLeftBindingPowerReference
-	typeLeftBindingPowerIntersection
 	typeLeftBindingPowerInstantiation
 )
 

--- a/parser/type.go
+++ b/parser/type.go
@@ -852,7 +852,7 @@ func parseCommaSeparatedTypeAnnotations(
 
 		case lexer.TokenEOF:
 			if expectTypeAnnotation {
-				return nil, &UnexpectedEOFExpectedTypeError{
+				return nil, &UnexpectedEOFExpectedTypeAnnotationError{
 					Pos: p.current.StartPos,
 				}
 			} else {

--- a/parser/type.go
+++ b/parser/type.go
@@ -435,7 +435,10 @@ func defineIntersectionOrDictionaryType() {
 							Pos: p.current.StartPos,
 						}
 					} else {
-						return nil, p.newSyntaxError("invalid end of input, expected %s", lexer.TokenBraceClose)
+						return nil, &UnexpectedEOFExpectedTokenError{
+							ExpectedToken: lexer.TokenBraceClose,
+							Pos:           p.current.StartPos,
+						}
 					}
 
 				default:
@@ -587,7 +590,10 @@ func parseNominalTypes(
 					Pos: p.current.StartPos,
 				}
 			} else {
-				return nil, ast.EmptyPosition, p.newSyntaxError("invalid end of input, expected %s", endTokenType)
+				return nil, ast.EmptyPosition, &UnexpectedEOFExpectedTokenError{
+					ExpectedToken: endTokenType,
+					Pos:           p.current.StartPos,
+				}
 			}
 
 		default:
@@ -648,10 +654,10 @@ func parseParameterTypeAnnotations(p *parser) (typeAnnotations []*ast.TypeAnnota
 			atEnd = true
 
 		case lexer.TokenEOF:
-			return nil, p.newSyntaxError(
-				"missing %q at end of list",
-				lexer.TokenParenClose,
-			)
+			return nil, &UnexpectedEOFExpectedTokenError{
+				ExpectedToken: lexer.TokenParenClose,
+				Pos:           p.current.StartPos,
+			}
 
 		default:
 			if !expectTypeAnnotation {
@@ -898,7 +904,10 @@ func parseCommaSeparatedTypeAnnotations(
 					Pos: p.current.StartPos,
 				}
 			} else {
-				return nil, p.newSyntaxError("invalid end of input, expected %s", endTokenType)
+				return nil, &UnexpectedEOFExpectedTokenError{
+					ExpectedToken: endTokenType,
+					Pos:           p.current.StartPos,
+				}
 			}
 
 		default:

--- a/parser/type.go
+++ b/parser/type.go
@@ -180,11 +180,9 @@ func parseNominalTypeRemainder(p *parser, token lexer.Token) (*ast.NominalType, 
 		nestedToken := p.current
 
 		if !nestedToken.Is(lexer.TokenIdentifier) {
-			return nil, p.newSyntaxError(
-				"expected identifier after %s, got %s",
-				lexer.TokenDot,
-				nestedToken.Type,
-			)
+			return nil, &NestedTypeMissingNameError{
+				GotToken: nestedToken,
+			}
 		}
 
 		nestedIdentifier := p.tokenToIdentifier(nestedToken)
@@ -196,7 +194,6 @@ func parseNominalTypeRemainder(p *parser, token lexer.Token) (*ast.NominalType, 
 			nestedIdentifiers,
 			nestedIdentifier,
 		)
-
 	}
 
 	return ast.NewNominalType(
@@ -543,8 +540,7 @@ func parseNominalType(
 	return nominalType, nil
 }
 
-// parseNominalTypes parses zero or more nominal types separated by a separator, either
-// a comma `,` or a vertical bar `|`.
+// parseNominalTypes parses zero or more nominal types separated by a separator.
 func parseNominalTypes(
 	p *parser,
 	endTokenType lexer.TokenType,

--- a/parser/type.go
+++ b/parser/type.go
@@ -934,7 +934,9 @@ func defineIdentifierTypes() {
 						return nil, err
 					}
 				} else {
-					p.reportSyntaxError("expected authorization (entitlement list)")
+					p.report(&MissingStartOfAuthorizationError{
+						GotToken: p.current,
+					})
 				}
 
 				p.skipSpaceAndComments()

--- a/parser/type.go
+++ b/parser/type.go
@@ -415,7 +415,9 @@ func defineIntersectionOrDictionaryType() {
 					if expectType {
 						switch {
 						case dictionaryType != nil:
-							p.reportSyntaxError("missing dictionary value type")
+							p.report(&MissingDictionaryValueTypeError{
+								Pos: p.current.StartPos,
+							})
 						case intersectionType != nil:
 							p.reportSyntaxError("missing type after comma")
 						}

--- a/parser/type.go
+++ b/parser/type.go
@@ -600,21 +600,21 @@ func parseNominalTypes(
 
 		default:
 			if !expectType {
-				return nil, ast.EmptyPosition, p.newSyntaxError(
-					"unexpected token: got %s, expected %s or %s",
-					p.current.Type,
-					separator,
-					endTokenType,
-				)
+				return nil, ast.EmptyPosition, &UnexpectedTokenInsteadOfSeparatorError{
+					GotToken:          p.current,
+					ExpectedSeparator: separator,
+					ExpectedEndToken:  endTokenType,
+				}
 			}
-
-			expectType = false
 
 			nominalType, err := parseNominalType(p)
 			if err != nil {
 				return nil, ast.EmptyPosition, err
 			}
+
 			nominalTypes = append(nominalTypes, nominalType)
+
+			expectType = false
 		}
 	}
 
@@ -864,12 +864,11 @@ func parseCommaSeparatedTypeAnnotations(
 
 		default:
 			if !expectTypeAnnotation {
-				return nil, p.newSyntaxError(
-					"unexpected token: got %s, expected %s or %s",
-					p.current.Type,
-					lexer.TokenComma,
-					endTokenType,
-				)
+				return nil, &UnexpectedTokenInsteadOfSeparatorError{
+					GotToken:          p.current,
+					ExpectedSeparator: lexer.TokenComma,
+					ExpectedEndToken:  endTokenType,
+				}
 			}
 
 			typeAnnotation, err := parseTypeAnnotation(p)

--- a/parser/type.go
+++ b/parser/type.go
@@ -367,6 +367,7 @@ func defineIntersectionOrDictionaryType() {
 							ast.NewRange(
 								p.memoryGauge,
 								startToken.StartPos,
+								// Unknown at the moment, set later
 								ast.EmptyPosition,
 							),
 						)
@@ -388,7 +389,7 @@ func defineIntersectionOrDictionaryType() {
 					}
 					if dictionaryType == nil {
 						if firstType == nil {
-							return nil, p.newSyntaxError("unexpected colon after missing dictionary key type")
+							panic(errors.NewUnreachableError())
 						}
 						dictionaryType = ast.NewDictionaryType(
 							p.memoryGauge,
@@ -397,6 +398,7 @@ func defineIntersectionOrDictionaryType() {
 							ast.NewRange(
 								p.memoryGauge,
 								startToken.StartPos,
+								// Unknown at the moment, set later
 								ast.EmptyPosition,
 							),
 						)

--- a/parser/type.go
+++ b/parser/type.go
@@ -641,10 +641,10 @@ func parseParameterTypeAnnotations(p *parser) (typeAnnotations []*ast.TypeAnnota
 		switch p.current.Type {
 		case lexer.TokenComma:
 			if expectTypeAnnotation {
-				return nil, p.newSyntaxError(
-					"expected type annotation or end of list, got %q",
-					p.current.Type,
-				)
+				return nil, &ExpectedTypeAnnotationInsteadSeparatorError{
+					Pos:       p.current.StartPos,
+					Separator: lexer.TokenComma,
+				}
 			}
 			// Skip the comma
 			p.next()

--- a/parser/type.go
+++ b/parser/type.go
@@ -437,7 +437,9 @@ func defineIntersectionOrDictionaryType() {
 
 				default:
 					if !expectType {
-						return nil, p.newSyntaxError("unexpected type")
+						return nil, &MissingSeparatorInIntersectionOrDictionaryTypeError{
+							GotToken: p.current,
+						}
 					}
 
 					ty, err := parseType(p, lowestBindingPower)

--- a/parser/type.go
+++ b/parser/type.go
@@ -224,24 +224,18 @@ func defineArrayType() {
 				// Skip the semicolon
 				p.nextSemanticToken()
 
-				if !p.current.Type.IsIntegerLiteral() {
-					p.reportSyntaxError("expected positive integer size for constant sized type")
+				sizeExpression, err := parseExpression(p, lowestBindingPower)
+				if err != nil {
+					return nil, err
+				}
 
-					// Skip the invalid non-integer literal token
-					p.next()
-
+				integerExpression, ok := sizeExpression.(*ast.IntegerExpression)
+				if !ok || integerExpression.Value.Sign() < 0 {
+					p.report(&InvalidConstantSizedTypeSizeError{
+						Range: ast.NewRangeFromPositioned(p.memoryGauge, sizeExpression),
+					})
 				} else {
-					numberExpression, err := parseExpression(p, lowestBindingPower)
-					if err != nil {
-						return nil, err
-					}
-
-					integerExpression, ok := numberExpression.(*ast.IntegerExpression)
-					if !ok || integerExpression.Value.Sign() < 0 {
-						p.reportSyntaxError("expected positive integer size for constant sized type")
-					} else {
-						size = integerExpression
-					}
+					size = integerExpression
 				}
 			}
 

--- a/parser/type.go
+++ b/parser/type.go
@@ -573,7 +573,10 @@ func parseNominalTypes(
 
 		case endTokenType:
 			if expectType && len(nominalTypes) > 0 {
-				p.reportSyntaxError("missing type after separator")
+				p.report(&MissingTypeAfterSeparatorError{
+					Pos:       p.current.StartPos,
+					Separator: separator,
+				})
 			}
 			endPos = p.current.EndPos
 			atEnd = true

--- a/parser/type.go
+++ b/parser/type.go
@@ -567,7 +567,10 @@ func parseNominalTypes(
 		switch p.current.Type {
 		case separator:
 			if expectType {
-				return nil, ast.EmptyPosition, p.newSyntaxError("unexpected separator")
+				return nil, ast.EmptyPosition, &ExpectedTypeInsteadSeparatorError{
+					Pos:       p.current.StartPos,
+					Separator: separator,
+				}
 			}
 			// Skip the separator
 			p.next()

--- a/parser/type.go
+++ b/parser/type.go
@@ -94,11 +94,6 @@ func setTypeMetaLeftDenotation(tokenType lexer.TokenType, metaLeftDenotation typ
 type prefixTypeFunc func(parser *parser, right ast.Type, tokenRange ast.Range) ast.Type
 type postfixTypeFunc func(parser *parser, left ast.Type, tokenRange ast.Range) ast.Type
 
-type literalType struct {
-	nullDenotation typeNullDenotationFunc
-	tokenType      lexer.TokenType
-}
-
 type prefixType struct {
 	nullDenotation prefixTypeFunc
 	bindingPower   int
@@ -126,6 +121,7 @@ func defineType(def any) {
 				return def.nullDenotation(parser, right, token.Range), nil
 			},
 		)
+
 	case postfixType:
 		tokenType := def.tokenType
 		setTypeLeftBindingPower(tokenType, def.bindingPower)
@@ -135,9 +131,7 @@ func defineType(def any) {
 				return def.leftDenotation(p, left, token.Range), nil
 			},
 		)
-	case literalType:
-		tokenType := def.tokenType
-		setTypeNullDenotation(tokenType, def.nullDenotation)
+
 	default:
 		panic(errors.NewUnreachableError())
 	}

--- a/parser/type.go
+++ b/parser/type.go
@@ -419,7 +419,9 @@ func defineIntersectionOrDictionaryType() {
 								Pos: p.current.StartPos,
 							})
 						case intersectionType != nil:
-							p.reportSyntaxError("missing type after comma")
+							p.report(&MissingTypeAfterCommaInIntersectionError{
+								Pos: p.current.StartPos,
+							})
 						}
 					}
 					endPos = p.current.EndPos

--- a/parser/type_test.go
+++ b/parser/type_test.go
@@ -1312,6 +1312,54 @@ func TestParseFunctionType(t *testing.T) {
 		)
 	})
 
+	t.Run("no parameters, no return type", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := testParseType("fun()")
+		require.Empty(t, errs)
+
+		AssertEqualWithDiff(t,
+			&ast.FunctionType{
+				PurityAnnotation: ast.FunctionPurityUnspecified,
+				ReturnTypeAnnotation: &ast.TypeAnnotation{
+					IsResource: false,
+					Type: &ast.NominalType{
+						Identifier: ast.Identifier{
+							Identifier: "",
+							Pos:        ast.Position{Line: 1, Column: 4, Offset: 4},
+						},
+					},
+					StartPos: ast.Position{Line: 1, Column: 4, Offset: 4},
+				},
+				Range: ast.Range{
+					StartPos: ast.Position{Line: 1, Column: 0, Offset: 0},
+					EndPos:   ast.Position{Line: 1, Column: 4, Offset: 4},
+				},
+			},
+			result,
+		)
+	})
+
+	t.Run("no parameter list", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseType("fun")
+		AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message:       "expected token '('",
+					Secondary:     "check for missing punctuation, operators, or syntax elements",
+					Migration:     "",
+					Documentation: "https://cadence-lang.org/docs/language/syntax",
+					Pos:           ast.Position{Offset: 3, Line: 1, Column: 3},
+				},
+			},
+			errs,
+		)
+	})
+
 	t.Run("view function type", func(t *testing.T) {
 
 		t.Parallel()

--- a/parser/type_test.go
+++ b/parser/type_test.go
@@ -97,6 +97,21 @@ func TestParseNominalType(t *testing.T) {
 			errs,
 		)
 	})
+
+	t.Run("incomplete parameter list", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseType("fun(T,")
+		AssertEqualWithDiff(t,
+			[]error{
+				&UnexpectedEOFExpectedTypeAnnotationError{
+					Pos: ast.Position{Offset: 6, Line: 1, Column: 6},
+				},
+			},
+			errs,
+		)
+	})
 }
 
 func TestParseInvalidType(t *testing.T) {

--- a/parser/type_test.go
+++ b/parser/type_test.go
@@ -568,9 +568,16 @@ func TestParseReferenceType(t *testing.T) {
 		_, errs := testParseType("auth(X, Y | Z) &Int")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "unexpected token: got '|', expected ',' or ')'",
-					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
+				&UnexpectedTokenInsteadOfSeparatorError{
+					GotToken: lexer.Token{
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 10, Line: 1, Column: 10},
+							EndPos:   ast.Position{Offset: 10, Line: 1, Column: 10},
+						},
+						Type: lexer.TokenVerticalBar,
+					},
+					ExpectedSeparator: lexer.TokenComma,
+					ExpectedEndToken:  lexer.TokenParenClose,
 				},
 			},
 			errs,
@@ -584,9 +591,16 @@ func TestParseReferenceType(t *testing.T) {
 		_, errs := testParseType("auth(X | Y, Z) &Int")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "unexpected token: got ',', expected '|' or ')'",
-					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
+				&UnexpectedTokenInsteadOfSeparatorError{
+					GotToken: lexer.Token{
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 10, Line: 1, Column: 10},
+							EndPos:   ast.Position{Offset: 10, Line: 1, Column: 10},
+						},
+						Type: lexer.TokenComma,
+					},
+					ExpectedSeparator: lexer.TokenVerticalBar,
+					ExpectedEndToken:  lexer.TokenParenClose,
 				},
 			},
 			errs,
@@ -1636,6 +1650,31 @@ func TestParseInstantiationType(t *testing.T) {
 			[]error{
 				&UnexpectedCommaInTypeAnnotationListError{
 					Pos: ast.Position{Offset: 2, Line: 1, Column: 2},
+				},
+			},
+			errs,
+		)
+
+		assert.Nil(t, result)
+	})
+
+	t.Run("invalid: missing separator", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := testParseType("T<U V>")
+		AssertEqualWithDiff(t,
+			[]error{
+				&UnexpectedTokenInsteadOfSeparatorError{
+					GotToken: lexer.Token{
+						Type: lexer.TokenIdentifier,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 4, Line: 1, Column: 4},
+							EndPos:   ast.Position{Offset: 4, Line: 1, Column: 4},
+						},
+					},
+					ExpectedSeparator: lexer.TokenComma,
+					ExpectedEndToken:  lexer.TokenGreater,
 				},
 			},
 			errs,

--- a/parser/type_test.go
+++ b/parser/type_test.go
@@ -1311,6 +1311,22 @@ func TestParseFunctionType(t *testing.T) {
 		)
 	})
 
+	t.Run("invalid, leading comma", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseType("fun(,) : Void")
+		AssertEqualWithDiff(t,
+			[]error{
+				&ExpectedTypeAnnotationInsteadSeparatorError{
+					Pos:       ast.Position{Offset: 4, Line: 1, Column: 4},
+					Separator: lexer.TokenComma,
+				},
+			},
+			errs,
+		)
+	})
+
 	t.Run("three parameters, Int return type", func(t *testing.T) {
 
 		t.Parallel()

--- a/parser/type_test.go
+++ b/parser/type_test.go
@@ -854,9 +854,14 @@ func TestParseIntersectionType(t *testing.T) {
 		result, errs := testParseType("{ T U }")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "unexpected type",
-					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
+				&MissingSeparatorInIntersectionOrDictionaryTypeError{
+					GotToken: lexer.Token{
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 4, Line: 1, Column: 4},
+							EndPos:   ast.Position{Offset: 4, Line: 1, Column: 4},
+						},
+						Type: lexer.TokenIdentifier,
+					},
 				},
 			},
 			errs,

--- a/parser/type_test.go
+++ b/parser/type_test.go
@@ -724,8 +724,7 @@ func TestParseIntersectionType(t *testing.T) {
 		result, errs := testParseType("{ T , }")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "missing type after comma",
+				&MissingTypeAfterCommaInIntersectionError{
 					Pos:     ast.Position{Offset: 6, Line: 1, Column: 6},
 				},
 			},

--- a/parser/type_test.go
+++ b/parser/type_test.go
@@ -533,6 +533,22 @@ func TestParseReferenceType(t *testing.T) {
 		)
 	})
 
+	t.Run("authorized, missing closing paren after entitlements", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseType("auth(X, Y")
+		AssertEqualWithDiff(t,
+			[]error{
+				&UnexpectedEOFExpectedTokenError{
+					ExpectedToken: lexer.TokenParenClose,
+					Pos:           ast.Position{Offset: 9, Line: 1, Column: 9},
+				},
+			},
+			errs,
+		)
+	})
+
 	t.Run("authorized, map", func(t *testing.T) {
 
 		t.Parallel()
@@ -871,8 +887,8 @@ func TestParseIntersectionType(t *testing.T) {
 		result, errs := testParseType("{U")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "invalid end of input, expected '}'",
+				&UnexpectedEOFExpectedTokenError{
+					ExpectedToken: lexer.TokenBraceClose,
 					Pos:     ast.Position{Offset: 2, Line: 1, Column: 2},
 				},
 			},
@@ -1096,8 +1112,8 @@ func TestParseDictionaryType(t *testing.T) {
 		result, errs := testParseType("{T:U")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "invalid end of input, expected '}'",
+				&UnexpectedEOFExpectedTokenError{
+					ExpectedToken: lexer.TokenBraceClose,
 					Pos:     ast.Position{Offset: 4, Line: 1, Column: 4},
 				},
 			},
@@ -1169,6 +1185,22 @@ func TestParseFunctionType(t *testing.T) {
 				},
 			},
 			result,
+		)
+	})
+
+	t.Run("missing closing paren", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseType("fun(Int")
+		AssertEqualWithDiff(t,
+			[]error{
+				&UnexpectedEOFExpectedTokenError{
+					ExpectedToken: lexer.TokenParenClose,
+					Pos:           ast.Position{Offset: 7, Line: 1, Column: 7},
+				},
+			},
+			errs,
 		)
 	})
 
@@ -1469,6 +1501,23 @@ func TestParseInstantiationType(t *testing.T) {
 			errs,
 		)
 
+		assert.Nil(t, result)
+	})
+
+	t.Run("invalid: missing closing greater", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := testParseType("T<U")
+		AssertEqualWithDiff(t,
+			[]error{
+				&UnexpectedEOFExpectedTokenError{
+					ExpectedToken: lexer.TokenGreater,
+					Pos:           ast.Position{Offset: 3, Line: 1, Column: 3},
+				},
+			},
+			errs,
+		)
 		assert.Nil(t, result)
 	})
 

--- a/parser/type_test.go
+++ b/parser/type_test.go
@@ -431,16 +431,21 @@ func TestParseReferenceType(t *testing.T) {
 		)
 	})
 
-	t.Run("authorized, no entitlements", func(t *testing.T) {
+	t.Run("authorized, missing parens", func(t *testing.T) {
 
 		t.Parallel()
 
 		_, errs := testParseType("auth &Int")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "expected authorization (entitlement list)",
-					Pos:     ast.Position{Offset: 5, Line: 1, Column: 5},
+				&MissingStartOfAuthorizationError{
+					GotToken: lexer.Token{
+						Type: lexer.TokenAmpersand,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 5, Line: 1, Column: 5},
+							EndPos:   ast.Position{Offset: 5, Line: 1, Column: 5},
+						},
+					},
 				},
 			},
 			errs,
@@ -3307,9 +3312,15 @@ func TestParseAuthorizedReferenceTypeWithNoEntitlements(t *testing.T) {
 
 	AssertEqualWithDiff(t,
 		[]error{
-			&SyntaxError{
-				Message: "expected authorization (entitlement list)",
-				Pos:     ast.Position{Offset: 20, Line: 2, Column: 19},
+			&MissingStartOfAuthorizationError{
+				GotToken: lexer.Token{
+					SpaceOrError: nil,
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 20, Line: 2, Column: 19},
+						EndPos:   ast.Position{Offset: 20, Line: 2, Column: 19},
+					},
+					Type: lexer.TokenAmpersand,
+				},
 			},
 		},
 		errs.(Error).Errors,

--- a/parser/type_test.go
+++ b/parser/type_test.go
@@ -1038,6 +1038,24 @@ func TestParseIntersectionType(t *testing.T) {
 
 		assert.Nil(t, result)
 	})
+
+	t.Run("invalid: leading comma", func(t *testing.T) {
+
+		t.Parallel()
+
+		result, errs := testParseType("{ , T }")
+		AssertEqualWithDiff(t,
+			[]error{
+				&UnexpectedCommaInIntersectionTypeError{
+					Pos: ast.Position{Offset: 2, Line: 1, Column: 2},
+				},
+			},
+			errs,
+		)
+
+		// TODO: return type
+		assert.Nil(t, result)
+	})
 }
 
 func TestParseDictionaryType(t *testing.T) {
@@ -1318,9 +1336,8 @@ func TestParseFunctionType(t *testing.T) {
 		_, errs := testParseType("fun(,) : Void")
 		AssertEqualWithDiff(t,
 			[]error{
-				&ExpectedTypeAnnotationInsteadSeparatorError{
-					Pos:       ast.Position{Offset: 4, Line: 1, Column: 4},
-					Separator: lexer.TokenComma,
+				&UnexpectedCommaInTypeAnnotationListError{
+					Pos: ast.Position{Offset: 4, Line: 1, Column: 4},
 				},
 			},
 			errs,

--- a/parser/type_test.go
+++ b/parser/type_test.go
@@ -76,6 +76,27 @@ func TestParseNominalType(t *testing.T) {
 			result,
 		)
 	})
+
+	t.Run("invalid nested", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseType("Foo.1")
+		AssertEqualWithDiff(t,
+			[]error{
+				&NestedTypeMissingNameError{
+					GotToken: lexer.Token{
+						Type: lexer.TokenDecimalIntegerLiteral,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 4, Line: 1, Column: 4},
+							EndPos:   ast.Position{Offset: 4, Line: 1, Column: 4},
+						},
+					},
+				},
+			},
+			errs,
+		)
+	})
 }
 
 func TestParseInvalidType(t *testing.T) {

--- a/parser/type_test.go
+++ b/parser/type_test.go
@@ -959,8 +959,7 @@ func TestParseDictionaryType(t *testing.T) {
 		result, errs := testParseType("{T:}")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "missing dictionary value type",
+				&MissingDictionaryValueTypeError{
 					Pos:     ast.Position{Offset: 3, Line: 1, Column: 3},
 				},
 			},


### PR DESCRIPTION
⚠️ Depends on #4128 
Work towards #4062 

## Description

Continue improving errors. Focus on type parsing errors, refactoring all generic syntax error cases to error types. Also, add tests for all cases, which improves coverage to ~95% for `type.go`. 

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
