### PR TITLE
Improve parsing errors

### DIFF
--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -1380,30 +1380,22 @@ func parseAttachmentDeclaration(
 		// Skip the `for` keyword
 		p.nextSemanticToken()
 	} else {
-		p.reportSyntaxError(
-			"expected 'for', got %s",
-			p.current.Type,
-		)
-	}
-
-	if !p.current.Is(lexer.TokenIdentifier) {
-		return nil, p.newSyntaxError(
-			"expected %s, got %s",
-			lexer.TokenIdentifier,
-			p.current.Type,
-		)
+		p.report(&MissingForKeywordInAttachmentDeclarationError{
+			GotToken: p.current,
+		})
 	}
 
 	baseType, err := parseType(p, lowestBindingPower)
+	if err != nil {
+		return nil, err
+	}
+
 	baseNominalType, ok := baseType.(*ast.NominalType)
 	if !ok {
 		p.reportSyntaxError(
 			"expected nominal type, got %s",
 			baseType,
 		)
-	}
-	if err != nil {
-		return nil, err
 	}
 
 	p.skipSpaceAndComments()

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -1177,6 +1177,7 @@ func parseEntitlementOrMappingDeclaration(
 		if err != nil {
 			return nil, err
 		}
+
 		declarationRange := ast.NewRange(
 			p.memoryGauge,
 			startPos,
@@ -1688,7 +1689,7 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 				).
 					WithSecondary("remove the identifier before the pragma declaration")
 			}
-			rejectAllModifiers(p, access, accessPos, staticPos, nativePos, nil, common.DeclarationKindPragma)
+			rejectAllModifiers(p, access, accessPos, staticPos, nativePos, purityPos, common.DeclarationKindPragma)
 			return parsePragmaDeclaration(p)
 
 		case lexer.TokenColon:

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -1392,10 +1392,9 @@ func parseAttachmentDeclaration(
 
 	baseNominalType, ok := baseType.(*ast.NominalType)
 	if !ok {
-		p.reportSyntaxError(
-			"expected nominal type, got %s",
-			baseType,
-		)
+		p.report(&InvalidAttachmentBaseTypeError{
+			Range: ast.NewRangeFromPositioned(p.memoryGauge, baseType),
+		})
 	}
 
 	p.skipSpaceAndComments()

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -1378,15 +1378,15 @@ func parseAttachmentDeclaration(
 
 	p.skipSpaceAndComments()
 
-	if !p.isToken(p.current, lexer.TokenIdentifier, KeywordFor) {
-		return nil, p.newSyntaxError(
+	if p.isToken(p.current, lexer.TokenIdentifier, KeywordFor) {
+		// Skip the `for` keyword
+		p.nextSemanticToken()
+	} else {
+		p.reportSyntaxError(
 			"expected 'for', got %s",
 			p.current.Type,
 		)
 	}
-
-	// skip the `for` keyword
-	p.nextSemanticToken()
 
 	if !p.current.Is(lexer.TokenIdentifier) {
 		return nil, p.newSyntaxError(

--- a/parser/declaration.go
+++ b/parser/declaration.go
@@ -219,7 +219,7 @@ func parseDeclaration(p *parser, docString string) (ast.Declaration, error) {
 				}
 
 				if nativePos != nil {
-					p.reportSyntaxError("invalid second native modifier")
+					p.reportSyntaxError("invalid second `native` modifier")
 				}
 				pos := p.current.StartPos
 				nativePos = &pos
@@ -1148,6 +1148,7 @@ func parseEntitlementOrMappingDeclaration(
 		// we are parsing an entitlement mapping
 		// Skip the `mapping` keyword
 		p.nextSemanticToken()
+
 		isMapping = true
 		expectString = "following entitlement mapping declaration"
 	}
@@ -1657,7 +1658,7 @@ func parseMemberOrNestedDeclaration(p *parser, docString string) (ast.Declaratio
 				}
 
 				if nativePos != nil {
-					p.reportSyntaxError("invalid second native modifier")
+					p.reportSyntaxError("invalid second `native` modifier")
 				}
 				pos := p.current.StartPos
 				nativePos = &pos

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -4447,13 +4447,28 @@ func TestParseAttachmentDeclaration(t *testing.T) {
 		_, errs := testParseDeclarations("attachment E {} ")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "expected 'for', got '{'",
-					Pos:     ast.Position{Offset: 13, Line: 1, Column: 13},
+				&MissingForKeywordInAttachmentDeclarationError{
+					GotToken: lexer.Token{
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 13, Line: 1, Column: 13},
+							EndPos:   ast.Position{Offset: 13, Line: 1, Column: 13},
+						},
+						Type: lexer.TokenBraceOpen,
+					},
 				},
 				&SyntaxError{
-					Message: "expected identifier, got '{'",
-					Pos:     ast.Position{Offset: 13, Line: 1, Column: 13},
+					Message: "expected nominal type, got {}",
+					Pos:     ast.Position{Offset: 15, Line: 1, Column: 15},
+				},
+				&SyntaxError{
+					Message:       "expected token '{'",
+					Secondary:     "check for missing punctuation, operators, or syntax elements",
+					Documentation: "https://cadence-lang.org/docs/language/syntax",
+					Pos: ast.Position{
+						Offset: 16,
+						Line:   1,
+						Column: 16,
+					},
 				},
 			},
 			errs,

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -4316,28 +4316,6 @@ func TestParseInvalidCompositeFunctionWithSelfParameter(t *testing.T) {
 	}
 }
 
-func TestParseInvalidPubSetModifier(t *testing.T) {
-
-	t.Parallel()
-
-	_, errs := testParseDeclarations("pub(foo) fun x() {}")
-
-	AssertEqualWithDiff(t,
-		[]error{
-			&InvalidPubSetModifierError{
-				GotToken: lexer.Token{
-					Type: lexer.TokenIdentifier,
-					Range: ast.Range{
-						StartPos: ast.Position{Offset: 4, Line: 1, Column: 4},
-						EndPos:   ast.Position{Offset: 6, Line: 1, Column: 6},
-					},
-				},
-			},
-		},
-		errs,
-	)
-}
-
 func TestParseInvalidParameterWithoutLabel(t *testing.T) {
 	t.Parallel()
 
@@ -4471,6 +4449,10 @@ func TestParseAttachmentDeclaration(t *testing.T) {
 			[]error{
 				&SyntaxError{
 					Message: "expected 'for', got '{'",
+					Pos:     ast.Position{Offset: 13, Line: 1, Column: 13},
+				},
+				&SyntaxError{
+					Message: "expected identifier, got '{'",
 					Pos:     ast.Position{Offset: 13, Line: 1, Column: 13},
 				},
 			},
@@ -10818,6 +10800,27 @@ func TestParseDeprecatedAccessModifiers(t *testing.T) {
 					Range: ast.Range{
 						StartPos: ast.Position{Offset: 1, Line: 1, Column: 1},
 						EndPos:   ast.Position{Offset: 8, Line: 1, Column: 8},
+					},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("pub(foo)", func(t *testing.T) {
+		t.Parallel()
+
+		_, errs := testParseDeclarations("pub(foo) fun x() {}")
+
+		AssertEqualWithDiff(t,
+			[]error{
+				&InvalidPubModifierError{
+					GotToken: lexer.Token{
+						Type: lexer.TokenIdentifier,
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 4, Line: 1, Column: 4},
+							EndPos:   ast.Position{Offset: 6, Line: 1, Column: 6},
+						},
 					},
 				},
 			},

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -4456,19 +4456,17 @@ func TestParseAttachmentDeclaration(t *testing.T) {
 						Type: lexer.TokenBraceOpen,
 					},
 				},
-				&SyntaxError{
-					Message: "expected nominal type, got {}",
-					Pos:     ast.Position{Offset: 15, Line: 1, Column: 15},
+				&InvalidAttachmentBaseTypeError{
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 13, Line: 1, Column: 13},
+						EndPos:   ast.Position{Offset: 14, Line: 1, Column: 14},
+					},
 				},
 				&SyntaxError{
 					Message:       "expected token '{'",
 					Secondary:     "check for missing punctuation, operators, or syntax elements",
 					Documentation: "https://cadence-lang.org/docs/language/syntax",
-					Pos: ast.Position{
-						Offset: 16,
-						Line:   1,
-						Column: 16,
-					},
+					Pos:           ast.Position{Offset: 16, Line: 1, Column: 16},
 				},
 			},
 			errs,

--- a/parser/declaration_test.go
+++ b/parser/declaration_test.go
@@ -10456,15 +10456,19 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := testParseDeclarations(` access(all) entitlement mapping M { 
-			&A -> B
-		} `)
+		_, errs := testParseDeclarations(`
+          access(all) entitlement mapping M {
+              &A -> B
+          }
+        `)
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "expected nominal type, got &A",
-					Pos:     ast.Position{Offset: 43, Line: 2, Column: 5},
+				&InvalidEntitlementMappingTypeError{
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 61, Line: 3, Column: 14},
+						EndPos:   ast.Position{Offset: 62, Line: 3, Column: 15},
+					},
 				},
 			},
 			errs,
@@ -10475,15 +10479,19 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := testParseDeclarations(` access(all) entitlement mapping M { 
-			A -> [B]
-		} `)
+		_, errs := testParseDeclarations(`
+          access(all) entitlement mapping M {
+              A -> [B]
+          }
+        `)
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "expected nominal type, got [B]",
-					Pos:     ast.Position{Offset: 49, Line: 2, Column: 11},
+				&InvalidEntitlementMappingTypeError{
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 66, Line: 3, Column: 19},
+						EndPos:   ast.Position{Offset: 68, Line: 3, Column: 21},
+					},
 				},
 			},
 			errs,
@@ -10536,15 +10544,19 @@ func TestParseEntitlementMappingDeclaration(t *testing.T) {
 
 		t.Parallel()
 
-		_, errs := testParseDeclarations(` access(all) entitlement mapping M { 
-			include &A
-		} `)
+		_, errs := testParseDeclarations(`
+          access(all) entitlement mapping M {
+              include &A
+          }
+        `)
 
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "expected nominal type, got &A",
-					Pos:     ast.Position{Offset: 51, Line: 2, Column: 13},
+				&InvalidEntitlementMappingIncludeTypeError{
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 69, Line: 3, Column: 22},
+						EndPos:   ast.Position{Offset: 70, Line: 3, Column: 23},
+					},
 				},
 			},
 			errs,

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -2477,40 +2477,40 @@ func (*PubSetAccessError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/cadence-migration-guide/improvements#-motivation-11"
 }
 
-// InvalidPubSetModifierError is reported when the modifier for `pub` is not `set`.
-type InvalidPubSetModifierError struct {
+// InvalidPubModifierError is reported when the modifier for `pub` is not `set`.
+type InvalidPubModifierError struct {
 	GotToken lexer.Token
 }
 
-var _ ParseError = &InvalidPubSetModifierError{}
-var _ errors.UserError = &InvalidPubSetModifierError{}
-var _ errors.SecondaryError = &InvalidPubSetModifierError{}
-var _ errors.HasDocumentationLink = &InvalidPubSetModifierError{}
+var _ ParseError = &InvalidPubModifierError{}
+var _ errors.UserError = &InvalidPubModifierError{}
+var _ errors.SecondaryError = &InvalidPubModifierError{}
+var _ errors.HasDocumentationLink = &InvalidPubModifierError{}
 
-func (*InvalidPubSetModifierError) isParseError() {}
+func (*InvalidPubModifierError) isParseError() {}
 
-func (*InvalidPubSetModifierError) IsUserError() {}
+func (*InvalidPubModifierError) IsUserError() {}
 
-func (e *InvalidPubSetModifierError) StartPosition() ast.Position {
+func (e *InvalidPubModifierError) StartPosition() ast.Position {
 	return e.GotToken.StartPos
 }
 
-func (e *InvalidPubSetModifierError) EndPosition(_ common.MemoryGauge) ast.Position {
+func (e *InvalidPubModifierError) EndPosition(_ common.MemoryGauge) ast.Position {
 	return e.GotToken.EndPos
 }
 
-func (e *InvalidPubSetModifierError) Error() string {
+func (e *InvalidPubModifierError) Error() string {
 	return expectedButGotToken(
 		`expected keyword "set"`,
 		e.GotToken.Type,
 	)
 }
 
-func (*InvalidPubSetModifierError) SecondaryError() string {
+func (*InvalidPubModifierError) SecondaryError() string {
 	return "the 'set' keyword is used in access control modifiers to specify settable access"
 }
 
-func (*InvalidPubSetModifierError) DocumentationLink() string {
+func (*InvalidPubModifierError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/access-control"
 }
 

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1277,6 +1277,43 @@ func (*MissingFromKeywordInRemoveStatementError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/attachments#removing-attachments"
 }
 
+// MissingToKeywordInAttachExpressionError is reported when the 'to' keyword is missing in an attach expression.
+type MissingToKeywordInAttachExpressionError struct {
+	GotToken lexer.Token
+}
+
+var _ ParseError = &MissingToKeywordInAttachExpressionError{}
+var _ errors.UserError = &MissingToKeywordInAttachExpressionError{}
+var _ errors.SecondaryError = &MissingToKeywordInAttachExpressionError{}
+var _ errors.HasDocumentationLink = &MissingToKeywordInAttachExpressionError{}
+
+func (*MissingToKeywordInAttachExpressionError) isParseError() {}
+
+func (*MissingToKeywordInAttachExpressionError) IsUserError() {}
+
+func (e *MissingToKeywordInAttachExpressionError) StartPosition() ast.Position {
+	return e.GotToken.StartPos
+}
+
+func (e *MissingToKeywordInAttachExpressionError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.GotToken.EndPos
+}
+
+func (e *MissingToKeywordInAttachExpressionError) Error() string {
+	return expectedButGotToken(
+		"expected 'to' keyword",
+		e.GotToken.Type,
+	)
+}
+
+func (*MissingToKeywordInAttachExpressionError) SecondaryError() string {
+	return "the 'attach' expression requires the 'to' keyword to specify the value to attach to"
+}
+
+func (*MissingToKeywordInAttachExpressionError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/attachments#creating-attachments"
+}
+
 // InvalidAttachmentRemovalTypeError is reported when a removed attachment type is not nominal.
 type InvalidAttachmentRemovalTypeError struct {
 	ast.Range

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -3628,3 +3628,29 @@ func (*MissingForKeywordInAttachmentDeclarationError) SecondaryError() string {
 func (*MissingForKeywordInAttachmentDeclarationError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/attachments#declaring-attachments"
 }
+
+// InvalidAttachmentBaseTypeError is reported when an attachment declaration has an invalid base type.
+type InvalidAttachmentBaseTypeError struct {
+	ast.Range
+}
+
+var _ ParseError = &InvalidAttachmentBaseTypeError{}
+var _ errors.UserError = &InvalidAttachmentBaseTypeError{}
+var _ errors.SecondaryError = &InvalidAttachmentBaseTypeError{}
+var _ errors.HasDocumentationLink = &InvalidAttachmentBaseTypeError{}
+
+func (*InvalidAttachmentBaseTypeError) isParseError() {}
+
+func (*InvalidAttachmentBaseTypeError) IsUserError() {}
+
+func (e *InvalidAttachmentBaseTypeError) Error() string {
+	return "expected nominal type"
+}
+
+func (*InvalidAttachmentBaseTypeError) SecondaryError() string {
+	return "attachments can only be declared for nominal types"
+}
+
+func (*InvalidAttachmentBaseTypeError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/attachments#declaring-attachments"
+}

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1277,7 +1277,7 @@ func (*MissingFromKeywordInRemoveStatementError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/attachments#removing-attachments"
 }
 
-// InvalidAttachmentTypeError is reported when a removed attachment type is not nominal.
+// InvalidAttachmentRemovalTypeError is reported when a removed attachment type is not nominal.
 type InvalidAttachmentRemovalTypeError struct {
 	ast.Range
 }
@@ -3435,7 +3435,7 @@ func (e *InvalidStaticModifierError) StartPosition() ast.Position {
 }
 
 func (e *InvalidStaticModifierError) EndPosition(memoryGauge common.MemoryGauge) ast.Position {
-	return e.Pos.Shifted(memoryGauge, len(KeywordNative)-1)
+	return e.Pos.Shifted(memoryGauge, len(KeywordStatic)-1)
 }
 
 func (e *InvalidStaticModifierError) Error() string {

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1642,9 +1642,7 @@ func (*InvalidNonNominalTypeInIntersectionError) isParseError() {}
 func (*InvalidNonNominalTypeInIntersectionError) IsUserError() {}
 
 func (e *InvalidNonNominalTypeInIntersectionError) Error() string {
-	return fmt.Sprintf(
-		"non-nominal type in intersection type",
-	)
+	return "non-nominal type in intersection type"
 }
 
 func (*InvalidNonNominalTypeInIntersectionError) SecondaryError() string {
@@ -3592,4 +3590,41 @@ func (*NestedTypeMissingNameError) SecondaryError() string {
 
 func (*NestedTypeMissingNameError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/syntax"
+}
+
+// MissingForKeywordInAttachmentDeclarationError is reported when the 'for' keyword is missing in an attachment declaration.
+type MissingForKeywordInAttachmentDeclarationError struct {
+	GotToken lexer.Token
+}
+
+var _ ParseError = &MissingForKeywordInAttachmentDeclarationError{}
+var _ errors.UserError = &MissingForKeywordInAttachmentDeclarationError{}
+var _ errors.SecondaryError = &MissingForKeywordInAttachmentDeclarationError{}
+var _ errors.HasDocumentationLink = &MissingForKeywordInAttachmentDeclarationError{}
+
+func (*MissingForKeywordInAttachmentDeclarationError) isParseError() {}
+
+func (*MissingForKeywordInAttachmentDeclarationError) IsUserError() {}
+
+func (e *MissingForKeywordInAttachmentDeclarationError) StartPosition() ast.Position {
+	return e.GotToken.StartPos
+}
+
+func (e *MissingForKeywordInAttachmentDeclarationError) EndPosition(_ common.MemoryGauge) ast.Position {
+	return e.GotToken.EndPos
+}
+
+func (e *MissingForKeywordInAttachmentDeclarationError) Error() string {
+	return expectedButGotToken(
+		"expected 'for' keyword",
+		e.GotToken.Type,
+	)
+}
+
+func (*MissingForKeywordInAttachmentDeclarationError) SecondaryError() string {
+	return "the 'attachment' declaration requires the 'for' keyword to specify the target"
+}
+
+func (*MissingForKeywordInAttachmentDeclarationError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/attachments#declaring-attachments"
 }

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1575,6 +1575,58 @@ func (*UnexpectedColonInIntersectionTypeError) DocumentationLink() string {
 	return "https://cadence-lang.org/docs/language/types-and-type-system/intersection-types"
 }
 
+// InvalidEntitlementMappingTypeError is reported when an entitlement mapping type is not nominal.
+type InvalidEntitlementMappingTypeError struct {
+	ast.Range
+}
+
+var _ ParseError = &InvalidEntitlementMappingTypeError{}
+var _ errors.UserError = &InvalidEntitlementMappingTypeError{}
+var _ errors.SecondaryError = &InvalidEntitlementMappingTypeError{}
+var _ errors.HasDocumentationLink = &InvalidEntitlementMappingTypeError{}
+
+func (*InvalidEntitlementMappingTypeError) isParseError() {}
+
+func (*InvalidEntitlementMappingTypeError) IsUserError() {}
+
+func (e *InvalidEntitlementMappingTypeError) Error() string {
+	return "expected entitlement type"
+}
+
+func (*InvalidEntitlementMappingTypeError) SecondaryError() string {
+	return "only entitlement types can be used in entitlement mappings"
+}
+
+func (*InvalidEntitlementMappingTypeError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/access-control#entitlement-mappings"
+}
+
+// InvalidEntitlementMappingIncludeTypeError is reported when an included entitlement mapping type is not nominal.
+type InvalidEntitlementMappingIncludeTypeError struct {
+	ast.Range
+}
+
+var _ ParseError = &InvalidEntitlementMappingIncludeTypeError{}
+var _ errors.UserError = &InvalidEntitlementMappingIncludeTypeError{}
+var _ errors.SecondaryError = &InvalidEntitlementMappingIncludeTypeError{}
+var _ errors.HasDocumentationLink = &InvalidEntitlementMappingIncludeTypeError{}
+
+func (*InvalidEntitlementMappingIncludeTypeError) isParseError() {}
+
+func (*InvalidEntitlementMappingIncludeTypeError) IsUserError() {}
+
+func (e *InvalidEntitlementMappingIncludeTypeError) Error() string {
+	return "expected entitlement mapping type"
+}
+
+func (*InvalidEntitlementMappingIncludeTypeError) SecondaryError() string {
+	return "only entitlement mapping types can be included in entitlement mappings"
+}
+
+func (*InvalidEntitlementMappingIncludeTypeError) DocumentationLink() string {
+	return "https://cadence-lang.org/docs/language/access-control#mapping-composition"
+}
+
 // InvalidNonNominalTypeInIntersectionError is reported when a non-nominal type is found in an intersection type.
 type InvalidNonNominalTypeInIntersectionError struct {
 	ast.Range

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -825,8 +825,9 @@ func defineIdentifierExpression() {
 				p.skipSpaceAndComments()
 
 				if p.isToken(p.current, lexer.TokenIdentifier, KeywordFun) {
-					// skip the `fun` keyword
+					// Skip the `fun` keyword
 					p.nextSemanticToken()
+
 					return parseFunctionExpression(p, token, ast.FunctionPurityView)
 				}
 
@@ -957,15 +958,15 @@ func parseAttachExpressionRemainder(p *parser, token lexer.Token) (*ast.AttachEx
 
 	p.skipSpaceAndComments()
 
-	if !p.isToken(p.current, lexer.TokenIdentifier, KeywordTo) {
-		return nil, p.newSyntaxError(
+	if p.isToken(p.current, lexer.TokenIdentifier, KeywordTo) {
+		// Skip the `to` keyword
+		p.nextSemanticToken()
+	} else {
+		p.reportSyntaxError(
 			"expected 'to', got %s",
 			p.current.Type,
 		)
 	}
-
-	// consume the `to` token
-	p.nextSemanticToken()
 
 	base, err := parseExpression(p, lowestBindingPower)
 	if err != nil {

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -962,10 +962,9 @@ func parseAttachExpressionRemainder(p *parser, token lexer.Token) (*ast.AttachEx
 		// Skip the `to` keyword
 		p.nextSemanticToken()
 	} else {
-		p.reportSyntaxError(
-			"expected 'to', got %s",
-			p.current.Type,
-		)
+		p.report(&MissingToKeywordInAttachExpressionError{
+			GotToken: p.current,
+		})
 	}
 
 	base, err := parseExpression(p, lowestBindingPower)

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -3048,6 +3048,9 @@ func TestParseAttach(t *testing.T) {
 					Message: "expected 'to', got EOF",
 					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
 				},
+				UnexpectedEOFError{
+					Pos: ast.Position{Offset: 10, Line: 1, Column: 10},
+				},
 			},
 			errs,
 		)

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -3044,9 +3044,14 @@ func TestParseAttach(t *testing.T) {
 		_, errs := testParseExpression("attach A()")
 		AssertEqualWithDiff(t,
 			[]error{
-				&SyntaxError{
-					Message: "expected 'to', got EOF",
-					Pos:     ast.Position{Offset: 10, Line: 1, Column: 10},
+				&MissingToKeywordInAttachExpressionError{
+					GotToken: lexer.Token{
+						Range: ast.Range{
+							StartPos: ast.Position{Offset: 10, Line: 1, Column: 10},
+							EndPos:   ast.Position{Offset: 10, Line: 1, Column: 10},
+						},
+						Type: lexer.TokenEOF,
+					},
 				},
 				UnexpectedEOFError{
 					Pos: ast.Position{Offset: 10, Line: 1, Column: 10},

--- a/parser/function.go
+++ b/parser/function.go
@@ -26,9 +26,12 @@ import (
 func parsePurityAnnotation(p *parser) ast.FunctionPurity {
 	// get the purity annotation (if one exists) and skip it
 	if p.isToken(p.current, lexer.TokenIdentifier, KeywordView) {
+		// Skip the `view` keyword
 		p.nextSemanticToken()
+
 		return ast.FunctionPurityView
 	}
+
 	return ast.FunctionPurityUnspecified
 }
 

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -348,7 +348,9 @@ func parseIfStatement(p *parser) (*ast.IfStatement, error) {
 
 		p.skipSpaceAndComments()
 		if p.isToken(p.current, lexer.TokenIdentifier, KeywordElse) {
+			// Skip the `else` keyword
 			p.nextSemanticToken()
+
 			if p.isToken(p.current, lexer.TokenIdentifier, KeywordIf) {
 				parseNested = true
 			} else {
@@ -458,7 +460,8 @@ func parseForStatement(p *parser) (*ast.ForStatement, error) {
 	}
 
 	if p.isToken(p.current, lexer.TokenIdentifier, KeywordIn) {
-		p.next()
+		// Skip the `in` keyword
+		p.nextSemanticToken()
 	} else {
 		p.report(&MissingInKeywordInForStatementError{
 			GotToken: p.current,
@@ -527,8 +530,10 @@ func parseFunctionBlock(p *parser) (*ast.FunctionBlock, error) {
 	var preConditions *ast.Conditions
 	if p.isToken(p.current, lexer.TokenIdentifier, KeywordPre) {
 		prePos := p.current.StartPos
+
 		// Skip the `pre` keyword
-		p.next()
+		p.nextSemanticToken()
+
 		preConditions, err = parseConditions(p, prePos)
 		if err != nil {
 			return nil, err
@@ -540,8 +545,10 @@ func parseFunctionBlock(p *parser) (*ast.FunctionBlock, error) {
 	var postConditions *ast.Conditions
 	if p.isToken(p.current, lexer.TokenIdentifier, KeywordPost) {
 		startPos := p.current.StartPos
+
 		// Skip the `post` keyword
-		p.next()
+		p.nextSemanticToken()
+
 		postConditions, err = parseConditions(p, startPos)
 		if err != nil {
 			return nil, err
@@ -867,13 +874,14 @@ func parseRemoveStatement(
 
 	p.skipSpaceAndComments()
 
-	// check and skip `from` keyword
-	if !p.isToken(p.current, lexer.TokenIdentifier, KeywordFrom) {
+	if p.isToken(p.current, lexer.TokenIdentifier, KeywordFrom) {
+		// Skip the `from` keyword
+		p.nextSemanticToken()
+	} else {
 		p.report(&MissingFromKeywordInRemoveStatementError{
 			GotToken: p.current,
 		})
 	}
-	p.nextSemanticToken()
 
 	attached, err := parseExpression(p, lowestBindingPower)
 	if err != nil {

--- a/parser/transaction.go
+++ b/parser/transaction.go
@@ -123,10 +123,13 @@ func parseTransactionDeclaration(p *parser, docString string) (*ast.TransactionD
 
 	if execute == nil {
 		p.skipSpaceAndComments()
+
 		if p.isToken(p.current, lexer.TokenIdentifier, KeywordPre) {
 			preStartPos := p.current.StartPos
+
 			// Skip the `pre` keyword
-			p.next()
+			p.nextSemanticToken()
+
 			preConditions, err = parseConditions(p, preStartPos)
 			if err != nil {
 				return nil, err

--- a/parser/type.go
+++ b/parser/type.go
@@ -966,16 +966,17 @@ func defineIdentifierTypes() {
 				current := p.current
 				cursor := p.tokens.Cursor()
 
-				// look ahead for the `fun` keyword, if it exists
+				// Look ahead for the `fun` keyword, if it exists
 				p.skipSpaceAndComments()
 
 				if p.isToken(p.current, lexer.TokenIdentifier, KeywordFun) {
-					// skip the `fun` keyword
+					// Skip the `fun` keyword
 					p.nextSemanticToken()
+
 					return parseFunctionType(p, current.StartPos, ast.FunctionPurityView)
 				}
 
-				// backtrack otherwise - view is a nominal type here
+				// Backtrack otherwise - view is a nominal type here
 				p.current = current
 				p.tokens.Revert(cursor)
 			}


### PR DESCRIPTION
Work towards #4062 

## Description

Continue improving errors, mainly focusing on "remaining" parsing errors. While at it, also improve parsing a bit to be more resilient (#529).

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
