### PR TITLE
Improve release note generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -13,6 +13,8 @@ changelog:
     - title: 🛠 Improvements
       labels:
         - Improvement
+        - Performance
+        - Technical Debt
     - title: 🐞 Bug Fixes
       labels:
         - Bugfix


### PR DESCRIPTION

## Description

Consider PRs labeled "Technical Debt" and "Performance" as improvements

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
