### PR TITLE
Test least-significant decimal point truncation

### DIFF
--- a/interpreter/value_fix128.go
+++ b/interpreter/value_fix128.go
@@ -609,12 +609,17 @@ func (v Fix128Value) ToBigInt() *big.Int {
 }
 
 func handleFixedpointError(err error, _ LocationRange) {
-	if err == nil {
+	switch err {
+	// `fix.ErrUnderflow` happens when the value is within the range but is too small
+	// to be represented using the current bit-length.
+	// These should be treated as non-errors, and should return the truncated value
+	// (assumes that the value returned is already the truncated value).
+	case nil, fix.ErrUnderflow:
 		return
+	default:
+		// TODO: wrap external error with a cadence overflow/underflow error.
+		panic(err)
 	}
-
-	// TODO: handle/wrap external error with a cadence overflow/underflow error.
-	panic(err)
 }
 
 func performFix128SaturationArithmatic(


### PR DESCRIPTION
Working towards https://github.com/onflow/cadence/issues/484

Depends on https://github.com/onflow/cadence/pull/4151

## Description

As discussed, this test currently fails for 128-bit fixed-points, due to the difference in the behaviour. Should only merge once the of the fixed-point library is updated to match the existing behaviour of [u]fix64 types.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
