### PR TITLE
Add Rosetta to the config of the update tool

### DIFF
--- a/tools/update/config.yaml
+++ b/tools/update/config.yaml
@@ -41,6 +41,15 @@ repos:
         - onflow/flow-go-sdk
         - onflow/flow-go
 
+- repo: onflow/rosetta
+  needsRelease: true
+  mods:
+    - path: ""
+      deps:
+        - onflow/cadence
+        - onflow/flow-go-sdk
+        - onflow/flow-go
+
 - repo: onflow/cadence-tools
   needsRelease: true
   prefixPRTitle: true


### PR DESCRIPTION
## Description

Also automatically update the https://github.com/onflow/rosetta repo. See https://www.notion.so/flowfoundation/Forte-Spork-Go-No-Go-Review-2011aee1232480d69547caf341b985d5?source=copy_link#2501aee1232480cabf64f628f14427bd

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
