### PR TITLE
Refactor memory metering

### DIFF
--- a/common/metering.go
+++ b/common/metering.go
@@ -35,6 +35,14 @@ type MemoryGauge interface {
 	MeterMemory(usage MemoryUsage) error
 }
 
+type FunctionMemoryGauge func(usage MemoryUsage) error
+
+var _ MemoryGauge = FunctionMemoryGauge(nil)
+
+func (f FunctionMemoryGauge) MeterMemory(usage MemoryUsage) error {
+	return f(usage)
+}
+
 type ComputationUsage struct {
 	Kind      ComputationKind
 	Intensity uint64

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -75,8 +75,8 @@ type ExternalNonError struct {
 	Recovered any
 }
 
-func NewExternalNonError(recovered error) ExternalError {
-	return ExternalError{
+func NewExternalNonError(recovered any) ExternalNonError {
+	return ExternalNonError{
 		Recovered: recovered,
 	}
 }

--- a/errors/wrappanic.go
+++ b/errors/wrappanic.go
@@ -30,13 +30,9 @@ func WrapPanic(f func()) {
 			case goRuntime.Error, InternalError:
 				panic(r)
 			case error:
-				panic(ExternalError{
-					Recovered: r,
-				})
+				panic(NewExternalError(r))
 			default:
-				panic(ExternalNonError{
-					Recovered: r,
-				})
+				panic(NewExternalNonError(r))
 			}
 		}
 	}()

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -420,11 +420,11 @@ type NoOpReferenceCreationContext struct{}
 
 var _ interpreter.ReferenceCreationContext = NoOpReferenceCreationContext{}
 
-func (n NoOpReferenceCreationContext) ClearReferencedResourceKindedValues(valueID atree.ValueID) {
+func (n NoOpReferenceCreationContext) ClearReferencedResourceKindedValues(_ atree.ValueID) {
 	// NO-OP
 }
 
-func (n NoOpReferenceCreationContext) ReferencedResourceKindedValues(valueID atree.ValueID) map[*interpreter.EphemeralReferenceValue]struct{} {
+func (n NoOpReferenceCreationContext) ReferencedResourceKindedValues(_ atree.ValueID) map[*interpreter.EphemeralReferenceValue]struct{} {
 	// NO-OP
 	return nil
 }
@@ -433,51 +433,51 @@ func (n NoOpReferenceCreationContext) CheckInvalidatedResourceOrResourceReferenc
 	// NO-OP
 }
 
-func (n NoOpReferenceCreationContext) MaybeTrackReferencedResourceKindedValue(ref *interpreter.EphemeralReferenceValue) {
+func (n NoOpReferenceCreationContext) MaybeTrackReferencedResourceKindedValue(_ *interpreter.EphemeralReferenceValue) {
 	// NO-OP
 }
 
-func (n NoOpReferenceCreationContext) MeterMemory(usage common.MemoryUsage) error {
-	// NO-OP
-	return nil
-}
-
-func (n NoOpReferenceCreationContext) MeterComputation(usage common.ComputationUsage) error {
+func (n NoOpReferenceCreationContext) MeterMemory(_ common.MemoryUsage) error {
 	// NO-OP
 	return nil
 }
 
-func (n NoOpReferenceCreationContext) ReadStored(storageAddress common.Address, domain common.StorageDomain, identifier interpreter.StorageMapKey) interpreter.Value {
+func (n NoOpReferenceCreationContext) MeterComputation(_ common.ComputationUsage) error {
 	// NO-OP
 	return nil
 }
 
-func (n NoOpReferenceCreationContext) GetEntitlementType(typeID interpreter.TypeID) (*sema.EntitlementType, error) {
+func (n NoOpReferenceCreationContext) ReadStored(_ common.Address, _ common.StorageDomain, _ interpreter.StorageMapKey) interpreter.Value {
+	// NO-OP
+	return nil
+}
+
+func (n NoOpReferenceCreationContext) GetEntitlementType(_ interpreter.TypeID) (*sema.EntitlementType, error) {
 	// NO-OP
 	return nil, nil
 }
 
-func (n NoOpReferenceCreationContext) GetEntitlementMapType(typeID interpreter.TypeID) (*sema.EntitlementMapType, error) {
+func (n NoOpReferenceCreationContext) GetEntitlementMapType(_ interpreter.TypeID) (*sema.EntitlementMapType, error) {
 	// NO-OP
 	return nil, nil
 }
 
-func (n NoOpReferenceCreationContext) GetInterfaceType(location common.Location, qualifiedIdentifier string, typeID interpreter.TypeID) (*sema.InterfaceType, error) {
+func (n NoOpReferenceCreationContext) GetInterfaceType(_ common.Location, _ string, _ interpreter.TypeID) (*sema.InterfaceType, error) {
 	// NO-OP
 	return nil, nil
 }
 
-func (n NoOpReferenceCreationContext) GetCompositeType(location common.Location, qualifiedIdentifier string, typeID interpreter.TypeID) (*sema.CompositeType, error) {
+func (n NoOpReferenceCreationContext) GetCompositeType(_ common.Location, _ string, _ interpreter.TypeID) (*sema.CompositeType, error) {
 	// NO-OP
 	return nil, nil
 }
 
-func (n NoOpReferenceCreationContext) IsTypeInfoRecovered(location common.Location) bool {
+func (n NoOpReferenceCreationContext) IsTypeInfoRecovered(_ common.Location) bool {
 	// NO-OP
 	return false
 }
 
-func (n NoOpReferenceCreationContext) SemaTypeFromStaticType(staticType interpreter.StaticType) sema.Type {
+func (n NoOpReferenceCreationContext) SemaTypeFromStaticType(_ interpreter.StaticType) sema.Type {
 	// NO-OP
 	return nil
 }
@@ -489,7 +489,7 @@ type NoOpFunctionCreationContext struct {
 
 var _ interpreter.FunctionCreationContext = NoOpFunctionCreationContext{}
 
-func (n NoOpFunctionCreationContext) ClearReferencedResourceKindedValues(valueID atree.ValueID) {
+func (n NoOpFunctionCreationContext) ClearReferencedResourceKindedValues(_ atree.ValueID) {
 	// NO-OP
 }
 
@@ -511,7 +511,7 @@ func (n NoOpFunctionCreationContext) MaybeTrackReferencedResourceKindedValue(_ *
 	// NO-OP
 }
 
-func (n NoOpFunctionCreationContext) MeterMemory(usage common.MemoryUsage) error {
+func (n NoOpFunctionCreationContext) MeterMemory(_ common.MemoryUsage) error {
 	// NO-OP
 	return nil
 }

--- a/parser/expression_test.go
+++ b/parser/expression_test.go
@@ -322,7 +322,6 @@ func TestParseAdvancedExpression(t *testing.T) {
 		t.Parallel()
 
 		gauge := makeLimitingMemoryGauge()
-		gauge.debug = true
 		gauge.Limit(common.MemoryKindPosition, 11)
 
 		_, errs := ParseExpression(gauge, []byte("1 < 2"), Config{})

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -20,6 +20,7 @@ package runtime
 
 import (
 	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/common"
 )
 
 type Context struct {
@@ -27,6 +28,7 @@ type Context struct {
 	Location       Location
 	Environment    Environment
 	CoverageReport *CoverageReport
+	MemoryGauge    common.MemoryGauge
 
 	// UseVM configures if the VM should be used
 	UseVM bool

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -111,7 +111,10 @@ func (executor *contractFunctionExecutor) preprocess() (err error) {
 
 	storage := NewStorage(
 		runtimeInterface,
-		runtimeInterface,
+		common.NewCombinedGauge(
+			context.MemoryGauge,
+			runtimeInterface,
+		),
 		StorageConfig{},
 	)
 	executor.storage = storage
@@ -129,6 +132,7 @@ func (executor *contractFunctionExecutor) preprocess() (err error) {
 		runtimeInterface,
 		codesAndPrograms,
 		storage,
+		context.MemoryGauge,
 		context.CoverageReport,
 	)
 	executor.environment = environment

--- a/runtime/empty.go
+++ b/runtime/empty.go
@@ -37,11 +37,6 @@ type EmptyRuntimeInterface struct{}
 
 var _ Interface = EmptyRuntimeInterface{}
 
-func (EmptyRuntimeInterface) MeterMemory(_ common.MemoryUsage) error {
-	// NO-OP
-	return nil
-}
-
 func (EmptyRuntimeInterface) ResolveLocation(_ []Identifier, _ Location) ([]ResolvedLocation, error) {
 	panic("unexpected call to ResolveLocation")
 }
@@ -61,14 +56,6 @@ func (EmptyRuntimeInterface) MeterComputation(_ common.ComputationUsage) error {
 
 func (EmptyRuntimeInterface) ComputationUsed() (uint64, error) {
 	panic("unexpected call to ComputationUsed")
-}
-
-func (EmptyRuntimeInterface) MemoryUsed() (uint64, error) {
-	panic("unexpected call to MemoryUsed")
-}
-
-func (EmptyRuntimeInterface) InteractionUsed() (uint64, error) {
-	panic("unexpected call to InteractionUsed")
 }
 
 func (EmptyRuntimeInterface) GetCode(_ Location) ([]byte, error) {

--- a/runtime/entitlements_test.go
+++ b/runtime/entitlements_test.go
@@ -1531,7 +1531,10 @@ func TestRuntimeEntitlementMapIncludeDeduped(t *testing.T) {
 			code = accountCodes[location]
 			return code, nil
 		},
-		OnMeterMemory: func(usage common.MemoryUsage) error {
+	}
+
+	memoryGauge := common.FunctionMemoryGauge(
+		func(usage common.MemoryUsage) error {
 			if usage.Kind == common.MemoryKindEntitlementRelationSemaType {
 				totalRelations++
 			}
@@ -1540,16 +1543,17 @@ func TestRuntimeEntitlementMapIncludeDeduped(t *testing.T) {
 			}
 			return nil
 		},
-	}
+	)
 
 	_, err := rt.ExecuteScript(
 		Script{
 			Source: script,
 		},
 		Context{
-			Interface: runtimeInterface1,
-			Location:  nextScriptLocation(),
-			UseVM:     *compile,
+			Interface:   runtimeInterface1,
+			Location:    nextScriptLocation(),
+			MemoryGauge: memoryGauge,
+			UseVM:       *compile,
 		},
 	)
 

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -48,6 +48,7 @@ type Environment interface {
 		runtimeInterface Interface,
 		codesAndPrograms CodesAndPrograms,
 		storage *Storage,
+		memoryGauge common.MemoryGauge,
 		coverageReport *CoverageReport,
 	)
 	ParseAndCheckProgram(
@@ -111,7 +112,6 @@ var _ stdlib.BLSPublicKeyAggregator = &InterpreterEnvironment{}
 var _ stdlib.BLSSignatureAggregator = &InterpreterEnvironment{}
 var _ stdlib.Hasher = &InterpreterEnvironment{}
 var _ ArgumentDecoder = &InterpreterEnvironment{}
-var _ common.MemoryGauge = &InterpreterEnvironment{}
 var _ common.ComputationGauge = &InterpreterEnvironment{}
 
 func NewInterpreterEnvironment(config Config) *InterpreterEnvironment {
@@ -132,7 +132,6 @@ func NewInterpreterEnvironment(config Config) *InterpreterEnvironment {
 
 func (e *InterpreterEnvironment) NewInterpreterConfig() *interpreter.Config {
 	return &interpreter.Config{
-		MemoryGauge:                    e,
 		ComputationGauge:               e,
 		BaseActivationHandler:          e.getBaseActivation,
 		OnEventEmitted:                 newOnEventEmittedHandler(&e.Interface),
@@ -189,17 +188,20 @@ func (e *InterpreterEnvironment) Configure(
 	runtimeInterface Interface,
 	codesAndPrograms CodesAndPrograms,
 	storage *Storage,
+	memoryGauge common.MemoryGauge,
 	coverageReport *CoverageReport,
 ) {
 	e.Interface = runtimeInterface
 	e.storage = storage
 	e.InterpreterConfig.Storage = storage
+	e.InterpreterConfig.MemoryGauge = memoryGauge
 	e.coverageReport = coverageReport
 	e.stackDepthLimiter.depth = 0
 
 	e.CheckingEnvironment.configure(
 		runtimeInterface,
 		codesAndPrograms,
+		memoryGauge,
 	)
 
 	configureVersionedFeatures(runtimeInterface)

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -296,3 +296,16 @@ func (e *ParsingCheckingError) Unwrap() error {
 func (e *ParsingCheckingError) ImportLocation() Location {
 	return e.Location
 }
+
+type MemoryLimitExceededError struct {
+	Limit uint64
+	Usage uint64
+}
+
+var _ errors.UserError = MemoryLimitExceededError{}
+
+func (MemoryLimitExceededError) IsUserError() {}
+
+func (e MemoryLimitExceededError) Error() string {
+	return fmt.Sprintf("memory limit exceeded: %d > %d", e.Usage, e.Limit)
+}

--- a/runtime/external.go
+++ b/runtime/external.go
@@ -41,16 +41,6 @@ type ExternalInterface struct {
 var _ Interface = ExternalInterface{}
 var _ Metrics = ExternalInterface{}
 
-func (e ExternalInterface) MeterMemory(usage common.MemoryUsage) (err error) {
-	errors.WrapPanic(func() {
-		err = e.Interface.MeterMemory(usage)
-	})
-	if err != nil {
-		err = interpreter.WrappedExternalError(err)
-	}
-	return
-}
-
 func (e ExternalInterface) MeterComputation(usage common.ComputationUsage) (err error) {
 	errors.WrapPanic(func() {
 		err = e.Interface.MeterComputation(usage)
@@ -64,26 +54,6 @@ func (e ExternalInterface) MeterComputation(usage common.ComputationUsage) (err 
 func (e ExternalInterface) ComputationUsed() (usage uint64, err error) {
 	errors.WrapPanic(func() {
 		usage, err = e.Interface.ComputationUsed()
-	})
-	if err != nil {
-		err = interpreter.WrappedExternalError(err)
-	}
-	return
-}
-
-func (e ExternalInterface) MemoryUsed() (usage uint64, err error) {
-	errors.WrapPanic(func() {
-		usage, err = e.Interface.MemoryUsed()
-	})
-	if err != nil {
-		err = interpreter.WrappedExternalError(err)
-	}
-	return
-}
-
-func (e ExternalInterface) InteractionUsed() (usage uint64, err error) {
-	errors.WrapPanic(func() {
-		usage, err = e.Interface.InteractionUsed()
 	})
 	if err != nil {
 		err = interpreter.WrappedExternalError(err)

--- a/runtime/interface.go
+++ b/runtime/interface.go
@@ -161,17 +161,11 @@ type Interface interface {
 }
 
 type MeterInterface interface {
-	// MeterMemory gets called when new memory is allocated or used by the interpreter
-	MeterMemory(usage common.MemoryUsage) error
 	// MeterComputation is a callback method for metering computation, it returns error
 	// when computation passes the limit (set by the environment)
 	MeterComputation(usage common.ComputationUsage) error
 	// ComputationUsed returns the total computation used in the current runtime.
 	ComputationUsed() (uint64, error)
-	// MemoryUsed returns the total memory (estimate) used in the current runtime.
-	MemoryUsed() (uint64, error)
-	// InteractionUsed returns the total storage interaction used in the current runtime.
-	InteractionUsed() (uint64, error)
 }
 
 type Metrics interface {

--- a/runtime/memory.go
+++ b/runtime/memory.go
@@ -1,0 +1,58 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"math"
+
+	"github.com/onflow/cadence/common"
+)
+
+type LimitingMemoryGauge struct {
+	Weights map[common.MemoryKind]uint64
+	Usage   uint64
+	Limit   uint64
+}
+
+func NewLimitingMemoryGauge(
+	weights map[common.MemoryKind]uint64,
+	limit uint64,
+) *LimitingMemoryGauge {
+	if limit == 0 {
+		limit = math.MaxUint64
+	}
+	return &LimitingMemoryGauge{
+		Weights: weights,
+		Limit:   limit,
+		Usage:   0,
+	}
+}
+
+func (g *LimitingMemoryGauge) MeterMemory(usage common.MemoryUsage) error {
+	g.Usage += g.Weights[usage.Kind] * usage.Amount
+
+	if g.Usage > g.Limit {
+		return MemoryLimitExceededError{
+			Limit: g.Limit,
+			Usage: g.Usage,
+		}
+	}
+
+	return nil
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -328,6 +328,7 @@ func (r *runtime) ParseAndCheckProgram(
 		context.Interface,
 		codesAndPrograms,
 		nil,
+		context.MemoryGauge,
 		context.CoverageReport,
 	)
 
@@ -357,7 +358,10 @@ func (r *runtime) Storage(context Context) (*Storage, *interpreter.Interpreter, 
 
 	storage := NewStorage(
 		runtimeInterface,
-		runtimeInterface,
+		common.NewCombinedGauge(
+			context.MemoryGauge,
+			runtimeInterface,
+		),
 		StorageConfig{},
 	)
 
@@ -370,6 +374,7 @@ func (r *runtime) Storage(context Context) (*Storage, *interpreter.Interpreter, 
 		runtimeInterface,
 		codesAndPrograms,
 		storage,
+		context.MemoryGauge,
 		context.CoverageReport,
 	)
 

--- a/runtime/runtime_memory_metering_test.go
+++ b/runtime/runtime_memory_metering_test.go
@@ -68,14 +68,15 @@ func TestRuntimeInterpreterAddressLocationMetering(t *testing.T) {
 			let s = CompositeType("A.0000000000000001.S")
 		}
         `
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
+
 		var accountCode []byte
 		runtimeInterface := &TestRuntimeInterface{
 			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			Storage:       NewTestLedger(nil, nil),
-			OnMeterMemory: meter.MeterMemory,
+			Storage: NewTestLedger(nil, nil),
 			OnGetAccountContractCode: func(_ common.AddressLocation) (code []byte, err error) {
 				return accountCode, nil
 			},
@@ -88,17 +89,18 @@ func TestRuntimeInterpreterAddressLocationMetering(t *testing.T) {
 				Source: []byte(script),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindAddressLocation))
-		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindElaboration))
-		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindRawString))
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindCadenceVoidValue))
+		assert.Equal(t, uint64(1), memoryGauge.getMemory(common.MemoryKindAddressLocation))
+		assert.Equal(t, uint64(2), memoryGauge.getMemory(common.MemoryKindElaboration))
+		assert.Equal(t, uint64(0), memoryGauge.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, uint64(1), memoryGauge.getMemory(common.MemoryKindCadenceVoidValue))
 	})
 }
 
@@ -132,7 +134,7 @@ func TestRuntimeInterpreterElaborationImportMetering(t *testing.T) {
 
 			runtime := NewTestRuntime()
 
-			meter := newTestMemoryGauge()
+			memoryGauge := newTestMemoryGauge()
 
 			accountCodes := map[common.Location][]byte{}
 
@@ -153,9 +155,6 @@ func TestRuntimeInterpreterElaborationImportMetering(t *testing.T) {
 					code = accountCodes[location]
 					return code, nil
 				},
-				OnMeterMemory: func(usage common.MemoryUsage) error {
-					return meter.MeterMemory(usage)
-				},
 				OnEmitEvent: func(_ cadence.Event) error {
 					return nil
 				},
@@ -169,16 +168,17 @@ func TestRuntimeInterpreterElaborationImportMetering(t *testing.T) {
 						Source: DeploymentTransaction(fmt.Sprintf("C%d", j), contracts[j]),
 					},
 					Context{
-						Interface: runtimeInterface,
-						Location:  nextTransactionLocation(),
-						UseVM:     *compile,
+						Interface:   runtimeInterface,
+						Location:    nextTransactionLocation(),
+						MemoryGauge: memoryGauge,
+						UseVM:       *compile,
 					},
 				)
 				require.NoError(t, err)
 				// one for each deployment transaction and one for each contract
-				assert.Equal(t, uint64(2*j+2), meter.getMemory(common.MemoryKindElaboration))
+				assert.Equal(t, uint64(2*j+2), memoryGauge.getMemory(common.MemoryKindElaboration))
 
-				assert.Equal(t, uint64(1+j), meter.getMemory(common.MemoryKindCadenceAddressValue))
+				assert.Equal(t, uint64(1+j), memoryGauge.getMemory(common.MemoryKindCadenceAddressValue))
 			}
 
 			_, err := runtime.ExecuteScript(
@@ -186,16 +186,17 @@ func TestRuntimeInterpreterElaborationImportMetering(t *testing.T) {
 					Source: []byte(script),
 				},
 				Context{
-					Interface: runtimeInterface,
-					Location:  common.ScriptLocation{},
-					UseVM:     *compile,
+					Interface:   runtimeInterface,
+					Location:    common.ScriptLocation{},
+					MemoryGauge: memoryGauge,
+					UseVM:       *compile,
 				},
 			)
 			require.NoError(t, err)
 
 			// in addition to the elaborations metered above, we also meter
 			// one more for the script and one more for each contract imported
-			assert.Equal(t, uint64(3*imports+4), meter.getMemory(common.MemoryKindElaboration))
+			assert.Equal(t, uint64(3*imports+4), memoryGauge.getMemory(common.MemoryKindElaboration))
 		})
 	}
 
@@ -215,9 +216,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             access(all) fun main(a: Int) {
             }
         `
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
+
 		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
@@ -233,14 +235,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				}),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindCadenceVoidValue))
+		assert.Equal(t, uint64(1), memoryGauge.getMemory(common.MemoryKindCadenceVoidValue))
 	})
 
 	t.Run("import type Int large value", func(t *testing.T) {
@@ -250,9 +253,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             access(all) fun main(a: Int) {
             }
         `
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
+
 		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
@@ -273,14 +277,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				}),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindCadenceVoidValue))
+		assert.Equal(t, uint64(1), memoryGauge.getMemory(common.MemoryKindCadenceVoidValue))
 	})
 
 	t.Run("import type Int8", func(t *testing.T) {
@@ -290,9 +295,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             access(all) fun main(a: Int8) {
             }
         `
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
+
 		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
@@ -308,14 +314,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				}),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindCadenceVoidValue))
+		assert.Equal(t, uint64(1), memoryGauge.getMemory(common.MemoryKindCadenceVoidValue))
 	})
 
 	t.Run("import type Int16", func(t *testing.T) {
@@ -325,9 +332,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             access(all) fun main(a: Int16) {
             }
         `
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
+
 		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
@@ -343,14 +351,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				}),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindCadenceVoidValue))
+		assert.Equal(t, uint64(1), memoryGauge.getMemory(common.MemoryKindCadenceVoidValue))
 	})
 
 	t.Run("import type Int32", func(t *testing.T) {
@@ -360,9 +369,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             access(all) fun main(a: Int32) {
             }
         `
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
+
 		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
@@ -378,14 +388,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				}),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindCadenceVoidValue))
+		assert.Equal(t, uint64(1), memoryGauge.getMemory(common.MemoryKindCadenceVoidValue))
 	})
 
 	t.Run("import type Int64", func(t *testing.T) {
@@ -395,9 +406,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             access(all) fun main(a: Int64) {
             }
         `
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
+
 		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
@@ -413,14 +425,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				}),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindCadenceVoidValue))
+		assert.Equal(t, uint64(1), memoryGauge.getMemory(common.MemoryKindCadenceVoidValue))
 	})
 
 	t.Run("import type Int128", func(t *testing.T) {
@@ -430,9 +443,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             access(all) fun main(a: Int128) {
             }
         `
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
+
 		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
@@ -448,14 +462,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				}),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindCadenceVoidValue))
+		assert.Equal(t, uint64(1), memoryGauge.getMemory(common.MemoryKindCadenceVoidValue))
 	})
 
 	t.Run("import type Int256", func(t *testing.T) {
@@ -465,9 +480,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
             access(all) fun main(a: Int256) {
             }
         `
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
+
 		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
@@ -483,14 +499,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				}),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindCadenceVoidValue))
+		assert.Equal(t, uint64(1), memoryGauge.getMemory(common.MemoryKindCadenceVoidValue))
 	})
 
 	t.Run("return value Int small value", func(t *testing.T) {
@@ -502,9 +519,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				return a
             }
         `
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
+
 		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
@@ -517,14 +535,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				Source: []byte(script),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindCadenceIntValue))
+		assert.Equal(t, uint64(8), memoryGauge.getMemory(common.MemoryKindCadenceIntValue))
 	})
 
 	t.Run("return value Int large value", func(t *testing.T) {
@@ -537,9 +556,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				return b
             }
         `
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
+
 		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
@@ -552,14 +572,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				Source: []byte(script),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindCadenceIntValue))
+		assert.Equal(t, uint64(16), memoryGauge.getMemory(common.MemoryKindCadenceIntValue))
 	})
 
 	t.Run("return value Int8", func(t *testing.T) {
@@ -570,10 +591,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
                 return 12
             }
         `
-		meter := newTestMemoryGauge()
-		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
-		}
+
+		memoryGauge := newTestMemoryGauge()
+
+		runtimeInterface := &TestRuntimeInterface{}
 
 		runtime := NewTestRuntime()
 
@@ -582,14 +603,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				Source: []byte(script),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindCadenceNumberValue))
+		assert.Equal(t, uint64(1), memoryGauge.getMemory(common.MemoryKindCadenceNumberValue))
 	})
 
 	t.Run("return value Int16", func(t *testing.T) {
@@ -600,10 +622,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
                 return 12
             }
         `
-		meter := newTestMemoryGauge()
-		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
-		}
+
+		memoryGauge := newTestMemoryGauge()
+
+		runtimeInterface := &TestRuntimeInterface{}
 
 		runtime := NewTestRuntime()
 
@@ -612,14 +634,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				Source: []byte(script),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindCadenceNumberValue))
+		assert.Equal(t, uint64(2), memoryGauge.getMemory(common.MemoryKindCadenceNumberValue))
 	})
 
 	t.Run("return value Int32", func(t *testing.T) {
@@ -630,10 +653,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
                 return 12
             }
         `
-		meter := newTestMemoryGauge()
-		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
-		}
+
+		memoryGauge := newTestMemoryGauge()
+
+		runtimeInterface := &TestRuntimeInterface{}
 
 		runtime := NewTestRuntime()
 
@@ -642,14 +665,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				Source: []byte(script),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindCadenceNumberValue))
+		assert.Equal(t, uint64(4), memoryGauge.getMemory(common.MemoryKindCadenceNumberValue))
 	})
 
 	t.Run("return value Int64", func(t *testing.T) {
@@ -660,10 +684,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
                 return 12
             }
         `
-		meter := newTestMemoryGauge()
-		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
-		}
+
+		memoryGauge := newTestMemoryGauge()
+
+		runtimeInterface := &TestRuntimeInterface{}
 
 		runtime := NewTestRuntime()
 
@@ -672,14 +696,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				Source: []byte(script),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(8), meter.getMemory(common.MemoryKindCadenceNumberValue))
+		assert.Equal(t, uint64(8), memoryGauge.getMemory(common.MemoryKindCadenceNumberValue))
 	})
 
 	t.Run("return value Int128", func(t *testing.T) {
@@ -690,10 +715,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
                 return 12
             }
         `
-		meter := newTestMemoryGauge()
-		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
-		}
+
+		memoryGauge := newTestMemoryGauge()
+
+		runtimeInterface := &TestRuntimeInterface{}
 
 		runtime := NewTestRuntime()
 
@@ -702,14 +727,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				Source: []byte(script),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(16), meter.getMemory(common.MemoryKindCadenceNumberValue))
+		assert.Equal(t, uint64(16), memoryGauge.getMemory(common.MemoryKindCadenceNumberValue))
 	})
 
 	t.Run("return value Int256", func(t *testing.T) {
@@ -720,10 +746,10 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
                 return 12
             }
         `
-		meter := newTestMemoryGauge()
-		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: meter.MeterMemory,
-		}
+
+		memoryGauge := newTestMemoryGauge()
+
+		runtimeInterface := &TestRuntimeInterface{}
 
 		runtime := NewTestRuntime()
 
@@ -732,14 +758,15 @@ func TestRuntimeCadenceValueAndTypeMetering(t *testing.T) {
 				Source: []byte(script),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(32), meter.getMemory(common.MemoryKindCadenceNumberValue))
+		assert.Equal(t, uint64(32), memoryGauge.getMemory(common.MemoryKindCadenceNumberValue))
 	})
 }
 
@@ -762,14 +789,13 @@ func TestRuntimeLogFunctionStringConversionMetering(t *testing.T) {
 		var loggedString string
 		var accountCode []byte
 
-		meter := newTestMemoryGauge()
+		memoryGauge := newTestMemoryGauge()
 
 		runtimeInterface := &TestRuntimeInterface{
 			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			Storage:       NewTestLedger(nil, nil),
-			OnMeterMemory: meter.MeterMemory,
+			Storage: NewTestLedger(nil, nil),
 			OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
 				return accountCode, nil
 			},
@@ -785,14 +811,15 @@ func TestRuntimeLogFunctionStringConversionMetering(t *testing.T) {
 				Source: []byte(script),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
-		return meter.getMemory(common.MemoryKindRawString), uint64(len(loggedString))
+		return memoryGauge.getMemory(common.MemoryKindRawString), uint64(len(loggedString))
 	}
 
 	emptyStrMeteredAmount, emptyStrActualLen := testMetering("")
@@ -820,7 +847,7 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
             }
         `)
 
-		meter := newTestMemoryGauge()
+		memoryGauge := newTestMemoryGauge()
 
 		storageUsedInvoked := false
 
@@ -829,11 +856,10 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			OnMeterMemory: meter.MeterMemory,
 			OnGetStorageUsed: func(_ Address) (uint64, error) {
 				// Before the storageUsed function is invoked, the deltas must have been committed.
 				// So the encoded slabs must have been metered at this point.
-				assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindAtreeEncodedSlab))
+				assert.Equal(t, uint64(0), memoryGauge.getMemory(common.MemoryKindAtreeEncodedSlab))
 
 				storageUsedInvoked = true
 
@@ -848,15 +874,16 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 				Source: code,
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.TransactionLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.TransactionLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 
 		require.NoError(t, err)
 		assert.True(t, storageUsedInvoked)
-		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindAtreeEncodedSlab))
+		assert.Equal(t, uint64(0), memoryGauge.getMemory(common.MemoryKindAtreeEncodedSlab))
 	})
 
 	t.Run("account.storage.save", func(t *testing.T) {
@@ -870,14 +897,13 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
             }
         `)
 
-		meter := newTestMemoryGauge()
+		memoryGauge := newTestMemoryGauge()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: NewTestLedger(nil, nil),
 			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			OnMeterMemory: meter.MeterMemory,
 		}
 
 		runtime := NewTestRuntime()
@@ -887,16 +913,17 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 				Source: code,
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.TransactionLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.TransactionLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
 		assert.Equal(t,
 			uint64(5),
-			meter.getMemory(common.MemoryKindAtreeEncodedSlab),
+			memoryGauge.getMemory(common.MemoryKindAtreeEncodedSlab),
 		)
 	})
 
@@ -912,7 +939,8 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
             }
         `)
 
-		meter := newTestMemoryGauge()
+		memoryGauge := newTestMemoryGauge()
+
 		storageUsedInvoked := false
 
 		runtimeInterface := &TestRuntimeInterface{
@@ -920,13 +948,12 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{{42}}, nil
 			},
-			OnMeterMemory: meter.MeterMemory,
 			OnGetStorageUsed: func(_ Address) (uint64, error) {
 				// Before the storageUsed function is invoked, the deltas must have been committed.
 				// So the encoded slabs must have been metered at this point.
 				assert.Equal(t,
 					uint64(5),
-					meter.getMemory(common.MemoryKindAtreeEncodedSlab),
+					memoryGauge.getMemory(common.MemoryKindAtreeEncodedSlab),
 				)
 
 				storageUsedInvoked = true
@@ -942,9 +969,10 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 				Source: code,
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.TransactionLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.TransactionLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -952,9 +980,19 @@ func TestRuntimeStorageCommitsMetering(t *testing.T) {
 
 		assert.Equal(t,
 			uint64(5),
-			meter.getMemory(common.MemoryKindAtreeEncodedSlab),
+			memoryGauge.getMemory(common.MemoryKindAtreeEncodedSlab),
 		)
 	})
+}
+
+type testMemoryError struct{}
+
+var _ errors.UserError = testMemoryError{}
+
+func (testMemoryError) IsUserError() {}
+
+func (testMemoryError) Error() string {
+	return "memory limit exceeded"
 }
 
 func TestRuntimeMemoryMeteringErrors(t *testing.T) {
@@ -967,15 +1005,6 @@ func TestRuntimeMemoryMeteringErrors(t *testing.T) {
 
 	runtimeInterface := func(memoryMeter) *TestRuntimeInterface {
 		return &TestRuntimeInterface{
-			OnMeterMemory: func(usage common.MemoryUsage) error {
-				if usage.Kind == common.MemoryKindStringValue ||
-					usage.Kind == common.MemoryKindArrayValueBase ||
-					usage.Kind == common.MemoryKindErrorToken {
-
-					return testMemoryError{}
-				}
-				return nil
-			},
 			OnDecodeArgument: func(b []byte, t cadence.Type) (value cadence.Value, err error) {
 				return json.Decode(nil, b)
 			},
@@ -984,6 +1013,18 @@ func TestRuntimeMemoryMeteringErrors(t *testing.T) {
 
 	nextScriptLocation := NewScriptLocationGenerator()
 
+	memoryGauge := common.FunctionMemoryGauge(
+		func(usage common.MemoryUsage) error {
+			if usage.Kind == common.MemoryKindStringValue ||
+				usage.Kind == common.MemoryKindArrayValueBase ||
+				usage.Kind == common.MemoryKindErrorToken {
+
+				return testMemoryError{}
+			}
+			return nil
+		},
+	)
+
 	executeScript := func(script []byte, meter memoryMeter, args ...cadence.Value) error {
 		_, err := runtime.ExecuteScript(
 			Script{
@@ -991,9 +1032,10 @@ func TestRuntimeMemoryMeteringErrors(t *testing.T) {
 				Arguments: encodeArgs(args),
 			},
 			Context{
-				Interface: runtimeInterface(meter),
-				Location:  nextScriptLocation(),
-				UseVM:     *compile,
+				Interface:   runtimeInterface(meter),
+				Location:    nextScriptLocation(),
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 
@@ -1078,14 +1120,14 @@ func TestRuntimeMeterEncoding(t *testing.T) {
 
 		address := common.MustBytesToAddress([]byte{0x1})
 		storage := NewTestLedger(nil, nil)
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: storage,
 			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{address}, nil
 			},
-			OnMeterMemory: meter.MeterMemory,
 		}
 
 		text := "A quick brown fox jumps over the lazy dog"
@@ -1105,16 +1147,17 @@ func TestRuntimeMeterEncoding(t *testing.T) {
 				)),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.TransactionLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.TransactionLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
 		assert.Equal(t,
 			uint64(107),
-			meter.getMemory(common.MemoryKindBytes),
+			memoryGauge.getMemory(common.MemoryKindBytes),
 		)
 	})
 
@@ -1128,14 +1171,14 @@ func TestRuntimeMeterEncoding(t *testing.T) {
 
 		address := common.MustBytesToAddress([]byte{0x1})
 		storage := NewTestLedger(nil, nil)
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: storage,
 			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{address}, nil
 			},
-			OnMeterMemory: meter.MeterMemory,
 		}
 
 		text := "A quick brown fox jumps over the lazy dog"
@@ -1160,16 +1203,17 @@ func TestRuntimeMeterEncoding(t *testing.T) {
 				)),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.TransactionLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.TransactionLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
 
 		assert.Equal(t,
 			uint64(61494),
-			meter.getMemory(common.MemoryKindBytes),
+			memoryGauge.getMemory(common.MemoryKindBytes),
 		)
 	})
 
@@ -1183,14 +1227,14 @@ func TestRuntimeMeterEncoding(t *testing.T) {
 
 		address := common.MustBytesToAddress([]byte{0x1})
 		storage := NewTestLedger(nil, nil)
-		meter := newTestMemoryGauge()
+
+		memoryGauge := newTestMemoryGauge()
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: storage,
 			OnGetSigningAccounts: func() ([]Address, error) {
 				return []Address{address}, nil
 			},
-			OnMeterMemory: meter.MeterMemory,
 		}
 
 		_, err := rt.ExecuteScript(
@@ -1216,9 +1260,10 @@ func TestRuntimeMeterEncoding(t *testing.T) {
                 `),
 			},
 			Context{
-				Interface: runtimeInterface,
-				Location:  common.ScriptLocation{},
-				UseVM:     *compile,
+				Interface:   runtimeInterface,
+				Location:    common.ScriptLocation{},
+				MemoryGauge: memoryGauge,
+				UseVM:       *compile,
 			},
 		)
 		require.NoError(t, err)
@@ -1226,7 +1271,7 @@ func TestRuntimeMeterEncoding(t *testing.T) {
 		// Scripts should not perform any encoding
 		assert.Equal(t,
 			uint64(0),
-			meter.getMemory(common.MemoryKindBytes),
+			memoryGauge.getMemory(common.MemoryKindBytes),
 		)
 	})
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -7922,7 +7922,7 @@ func TestRuntimeInternalErrors(t *testing.T) {
 		runtime := NewTestRuntime()
 
 		runtimeInterface := &TestRuntimeInterface{
-			OnMeterMemory: func(usage common.MemoryUsage) error {
+			OnGetOrLoadProgram: func(_ Location, _ func() (*Program, error)) (*Program, error) {
 				// panic with a non-error type
 				panic("crasher")
 			},
@@ -13504,7 +13504,6 @@ func TestRuntimeMetering(t *testing.T) {
 	memoryGauge := newTestMemoryGauge()
 	computationGauge := newTestComputationGauge()
 
-	runtimeInterface.OnMeterMemory = memoryGauge.MeterMemory
 	runtimeInterface.OnMeterComputation = computationGauge.MeterComputation
 
 	_, err = runtime.InvokeContractFunction(
@@ -13516,9 +13515,10 @@ func TestRuntimeMetering(t *testing.T) {
 		nil,
 		nil,
 		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-			UseVM:     *compile,
+			Interface:   runtimeInterface,
+			Location:    nextTransactionLocation(),
+			MemoryGauge: memoryGauge,
+			UseVM:       *compile,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/bbq/vm"
+	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
@@ -112,7 +113,10 @@ func (executor *scriptExecutor) preprocess() (err error) {
 
 	storage := NewStorage(
 		runtimeInterface,
-		runtimeInterface,
+		common.NewCombinedGauge(
+			context.MemoryGauge,
+			runtimeInterface,
+		),
 		StorageConfig{},
 	)
 	executor.storage = storage
@@ -130,6 +134,7 @@ func (executor *scriptExecutor) preprocess() (err error) {
 		runtimeInterface,
 		codesAndPrograms,
 		storage,
+		context.MemoryGauge,
 		context.CoverageReport,
 	)
 	executor.environment = environment

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/bbq/vm"
+	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
@@ -111,7 +112,10 @@ func (executor *transactionExecutor) preprocess() (err error) {
 
 	storage := NewStorage(
 		runtimeInterface,
-		runtimeInterface,
+		common.NewCombinedGauge(
+			context.MemoryGauge,
+			runtimeInterface,
+		),
 		StorageConfig{},
 	)
 	executor.storage = storage
@@ -129,6 +133,7 @@ func (executor *transactionExecutor) preprocess() (err error) {
 		runtimeInterface,
 		codesAndPrograms,
 		storage,
+		context.MemoryGauge,
 		context.CoverageReport,
 	)
 	executor.environment = environment

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -82,7 +82,6 @@ var _ stdlib.BLSPublicKeyAggregator = &vmEnvironment{}
 var _ stdlib.BLSSignatureAggregator = &vmEnvironment{}
 var _ stdlib.Hasher = &vmEnvironment{}
 var _ ArgumentDecoder = &vmEnvironment{}
-var _ common.MemoryGauge = &vmEnvironment{}
 
 func newVMEnvironment(config Config) *vmEnvironment {
 	env := &vmEnvironment{
@@ -136,7 +135,6 @@ func NewScriptVMEnvironment(config Config) Environment {
 
 func (e *vmEnvironment) newVMConfig() *vm.Config {
 	conf := vm.NewConfig(nil)
-	conf.MemoryGauge = e
 	conf.ComputationGauge = e
 	conf.TypeLoader = e.loadType
 	conf.BuiltinGlobalsProvider = e.vmBuiltinGlobals
@@ -193,7 +191,6 @@ func (e *vmEnvironment) loadContractValue(
 
 func (e *vmEnvironment) newCompilerConfig() *compiler.Config {
 	return &compiler.Config{
-		MemoryGauge:            e,
 		BuiltinGlobalsProvider: e.compilerBuiltinGlobals,
 		LocationHandler:        e.ResolveLocation,
 		ImportHandler:          e.importProgram,
@@ -205,15 +202,19 @@ func (e *vmEnvironment) Configure(
 	runtimeInterface Interface,
 	codesAndPrograms CodesAndPrograms,
 	storage *Storage,
+	memoryGauge common.MemoryGauge,
 	coverageReport *CoverageReport,
 ) {
 	e.Interface = runtimeInterface
 	e.storage = storage
 	e.VMConfig.SetStorage(storage)
+	e.VMConfig.MemoryGauge = memoryGauge
+	e.compilerConfig.MemoryGauge = memoryGauge
 
 	e.checkingEnvironment.configure(
 		runtimeInterface,
 		codesAndPrograms,
+		memoryGauge,
 	)
 
 	// TODO: add support for coverage report

--- a/test_utils/runtime_utils/testinterface.go
+++ b/test_utils/runtime_utils/testinterface.go
@@ -107,10 +107,7 @@ type TestRuntimeInterface struct {
 		duration time.Duration,
 		attrs []attribute.KeyValue,
 	)
-	OnMeterMemory                    func(usage common.MemoryUsage) error
 	OnComputationUsed                func() (uint64, error)
-	OnMemoryUsed                     func() (uint64, error)
-	OnInteractionUsed                func() (uint64, error)
 	OnGenerateAccountID              func(address common.Address) (uint64, error)
 	OnRecoverProgram                 func(program *ast.Program, location common.Location) ([]byte, error)
 	OnValidateAccountCapabilitiesGet func(
@@ -548,36 +545,12 @@ func (i *TestRuntimeInterface) RecordTrace(
 	i.OnRecordTrace(operation, duration, attrs)
 }
 
-func (i *TestRuntimeInterface) MeterMemory(usage common.MemoryUsage) error {
-	if i.OnMeterMemory == nil {
-		return nil
-	}
-
-	return i.OnMeterMemory(usage)
-}
-
 func (i *TestRuntimeInterface) ComputationUsed() (uint64, error) {
 	if i.OnComputationUsed == nil {
 		return 0, nil
 	}
 
 	return i.OnComputationUsed()
-}
-
-func (i *TestRuntimeInterface) MemoryUsed() (uint64, error) {
-	if i.OnMemoryUsed == nil {
-		return 0, nil
-	}
-
-	return i.OnMemoryUsed()
-}
-
-func (i *TestRuntimeInterface) InteractionUsed() (uint64, error) {
-	if i.OnInteractionUsed == nil {
-		return 0, nil
-	}
-
-	return i.OnInteractionUsed()
 }
 
 func (i *TestRuntimeInterface) onTransactionExecutionStart() {


### PR DESCRIPTION
Work towards #4058

Moved from https://github.com/onflow/cadence-internal/pull/344

## Description

Refactor the metering of memory: Instead of calling into the embedder (e.g. FVM) via the runtime interface, have it optionally pass a memory gauge in the context. This should hopefully reduce the overhead for memory metering a bit.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
