### PR TITLE
Handle external overflow/underflow errors from library

### DIFF
--- a/interpreter/arithmetic_test.go
+++ b/interpreter/arithmetic_test.go
@@ -26,10 +26,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/fixedpoint"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
+	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
 )
 
@@ -218,581 +220,638 @@ func TestInterpretModOperator(t *testing.T) {
 	}
 }
 
+type testCall struct {
+	left, right interpreter.Value
+	expected    interpreter.EquatableValue
+}
+
+type testCalls struct {
+	underflow, overflow testCall
+}
+
+type testCase struct {
+	add, subtract, multiply, divide testCalls
+}
+
+var testCases = map[sema.Type]testCase{
+	sema.Int8Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt8Value(math.MaxInt8),
+				interpreter.NewUnmeteredInt8Value(2),
+				interpreter.NewUnmeteredInt8Value(math.MaxInt8),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt8Value(math.MinInt8),
+				interpreter.NewUnmeteredInt8Value(-2),
+				interpreter.NewUnmeteredInt8Value(math.MinInt8),
+			},
+		},
+		subtract: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt8Value(math.MaxInt8),
+				interpreter.NewUnmeteredInt8Value(-2),
+				interpreter.NewUnmeteredInt8Value(math.MaxInt8),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt8Value(math.MinInt8),
+				interpreter.NewUnmeteredInt8Value(2),
+				interpreter.NewUnmeteredInt8Value(math.MinInt8),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt8Value(math.MaxInt8),
+				interpreter.NewUnmeteredInt8Value(2),
+				interpreter.NewUnmeteredInt8Value(math.MaxInt8),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt8Value(math.MinInt8),
+				interpreter.NewUnmeteredInt8Value(2),
+				interpreter.NewUnmeteredInt8Value(math.MinInt8),
+			},
+		},
+		divide: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt8Value(math.MinInt8),
+				interpreter.NewUnmeteredInt8Value(-1),
+				interpreter.NewUnmeteredInt8Value(math.MaxInt8),
+			},
+		},
+	},
+	sema.Int16Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt16Value(math.MaxInt16),
+				interpreter.NewUnmeteredInt16Value(2),
+				interpreter.NewUnmeteredInt16Value(math.MaxInt16),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt16Value(math.MinInt16),
+				interpreter.NewUnmeteredInt16Value(-2),
+				interpreter.NewUnmeteredInt16Value(math.MinInt16),
+			},
+		},
+		subtract: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt16Value(math.MaxInt16),
+				interpreter.NewUnmeteredInt16Value(-2),
+				interpreter.NewUnmeteredInt16Value(math.MaxInt16),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt16Value(math.MinInt16),
+				interpreter.NewUnmeteredInt16Value(2),
+				interpreter.NewUnmeteredInt16Value(math.MinInt16),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt16Value(math.MaxInt16),
+				interpreter.NewUnmeteredInt16Value(2),
+				interpreter.NewUnmeteredInt16Value(math.MaxInt16),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt16Value(math.MinInt16),
+				interpreter.NewUnmeteredInt16Value(2),
+				interpreter.NewUnmeteredInt16Value(math.MinInt16),
+			},
+		},
+		divide: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt16Value(math.MinInt16),
+				interpreter.NewUnmeteredInt16Value(-1),
+				interpreter.NewUnmeteredInt16Value(math.MaxInt16),
+			},
+		},
+	},
+	sema.Int32Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt32Value(math.MaxInt32),
+				interpreter.NewUnmeteredInt32Value(2),
+				interpreter.NewUnmeteredInt32Value(math.MaxInt32),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt32Value(math.MinInt32),
+				interpreter.NewUnmeteredInt32Value(-2),
+				interpreter.NewUnmeteredInt32Value(math.MinInt32),
+			},
+		},
+		subtract: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt32Value(math.MaxInt32),
+				interpreter.NewUnmeteredInt32Value(-2),
+				interpreter.NewUnmeteredInt32Value(math.MaxInt32),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt32Value(math.MinInt32),
+				interpreter.NewUnmeteredInt32Value(2),
+				interpreter.NewUnmeteredInt32Value(math.MinInt32),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt32Value(math.MaxInt32),
+				interpreter.NewUnmeteredInt32Value(2),
+				interpreter.NewUnmeteredInt32Value(math.MaxInt32),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt32Value(math.MinInt32),
+				interpreter.NewUnmeteredInt32Value(2),
+				interpreter.NewUnmeteredInt32Value(math.MinInt32),
+			},
+		},
+		divide: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt32Value(math.MinInt32),
+				interpreter.NewUnmeteredInt32Value(-1),
+				interpreter.NewUnmeteredInt32Value(math.MaxInt32),
+			},
+		},
+	},
+	sema.Int64Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt64Value(math.MaxInt64),
+				interpreter.NewUnmeteredInt64Value(2),
+				interpreter.NewUnmeteredInt64Value(math.MaxInt64),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt64Value(math.MinInt64),
+				interpreter.NewUnmeteredInt64Value(-2),
+				interpreter.NewUnmeteredInt64Value(math.MinInt64),
+			},
+		},
+		subtract: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt64Value(math.MaxInt64),
+				interpreter.NewUnmeteredInt64Value(-2),
+				interpreter.NewUnmeteredInt64Value(math.MaxInt64),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt64Value(math.MinInt64),
+				interpreter.NewUnmeteredInt64Value(2),
+				interpreter.NewUnmeteredInt64Value(math.MinInt64),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt64Value(math.MaxInt64),
+				interpreter.NewUnmeteredInt64Value(2),
+				interpreter.NewUnmeteredInt64Value(math.MaxInt64),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt64Value(math.MinInt64),
+				interpreter.NewUnmeteredInt64Value(2),
+				interpreter.NewUnmeteredInt64Value(math.MinInt64),
+			},
+		},
+		divide: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt64Value(math.MinInt64),
+				interpreter.NewUnmeteredInt64Value(-1),
+				interpreter.NewUnmeteredInt64Value(math.MaxInt64),
+			},
+		},
+	},
+	sema.Int128Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+				interpreter.NewUnmeteredInt128ValueFromInt64(2),
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+				interpreter.NewUnmeteredInt128ValueFromInt64(-2),
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+			},
+		},
+		subtract: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+				interpreter.NewUnmeteredInt128ValueFromInt64(-2),
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+				interpreter.NewUnmeteredInt128ValueFromInt64(2),
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+				interpreter.NewUnmeteredInt128ValueFromInt64(2),
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+				interpreter.NewUnmeteredInt128ValueFromInt64(2),
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+			},
+		},
+		divide: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
+				interpreter.NewUnmeteredInt128ValueFromInt64(-1),
+				interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
+			},
+		},
+	},
+	sema.Int256Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+				interpreter.NewUnmeteredInt256ValueFromInt64(2),
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+				interpreter.NewUnmeteredInt256ValueFromInt64(-2),
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+			},
+		},
+		subtract: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+				interpreter.NewUnmeteredInt256ValueFromInt64(-2),
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+				interpreter.NewUnmeteredInt256ValueFromInt64(2),
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+				interpreter.NewUnmeteredInt256ValueFromInt64(2),
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+				interpreter.NewUnmeteredInt256ValueFromInt64(2),
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+			},
+		},
+		divide: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
+				interpreter.NewUnmeteredInt256ValueFromInt64(-1),
+				interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
+			},
+		},
+	},
+
+	sema.Fix64Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredFix64Value(math.MaxInt64),
+				interpreter.NewUnmeteredFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix64Value(math.MaxInt64),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredFix64Value(math.MinInt64),
+				interpreter.NewUnmeteredFix64ValueWithInteger(-2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix64Value(math.MinInt64),
+			},
+		},
+		subtract: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredFix64Value(math.MaxInt64),
+				interpreter.NewUnmeteredFix64ValueWithInteger(-2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix64Value(math.MaxInt64),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredFix64Value(math.MinInt64),
+				interpreter.NewUnmeteredFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix64Value(math.MinInt64),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredFix64Value(math.MaxInt64),
+				interpreter.NewUnmeteredFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix64Value(math.MaxInt64),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredFix64Value(math.MinInt64),
+				interpreter.NewUnmeteredFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix64Value(math.MinInt64),
+			},
+		},
+		divide: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredFix64Value(math.MinInt64),
+				interpreter.NewUnmeteredFix64ValueWithInteger(-1, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix64Value(math.MaxInt64),
+			},
+		},
+	},
+	sema.Fix128Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
+				interpreter.NewUnmeteredFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
+				interpreter.NewUnmeteredFix128ValueWithInteger(-2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
+			},
+		},
+		subtract: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
+				interpreter.NewUnmeteredFix128ValueWithInteger(-2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
+				interpreter.NewUnmeteredFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
+				interpreter.NewUnmeteredFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
+			},
+			underflow: testCall{
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
+				interpreter.NewUnmeteredFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
+			},
+		},
+		divide: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
+				interpreter.NewUnmeteredFix128ValueWithInteger(-1, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
+			},
+		},
+	},
+
+	sema.UIntType: {
+		subtract: testCalls{
+			underflow: testCall{
+				interpreter.NewUnmeteredUIntValueFromBigInt(sema.UIntTypeMin),
+				interpreter.NewUnmeteredUIntValueFromUint64(2),
+				interpreter.NewUnmeteredUIntValueFromBigInt(sema.UIntTypeMin),
+			},
+		},
+	},
+	sema.UInt8Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUInt8Value(math.MaxUint8),
+				interpreter.NewUnmeteredUInt8Value(2),
+				interpreter.NewUnmeteredUInt8Value(math.MaxUint8),
+			},
+		},
+		subtract: testCalls{
+			underflow: testCall{
+				interpreter.NewUnmeteredUInt8Value(0),
+				interpreter.NewUnmeteredUInt8Value(2),
+				interpreter.NewUnmeteredUInt8Value(0),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUInt8Value(math.MaxUint8),
+				interpreter.NewUnmeteredUInt8Value(2),
+				interpreter.NewUnmeteredUInt8Value(math.MaxUint8),
+			},
+		},
+	},
+	sema.UInt16Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUInt16Value(math.MaxUint16),
+				interpreter.NewUnmeteredUInt16Value(2),
+				interpreter.NewUnmeteredUInt16Value(math.MaxUint16),
+			},
+		},
+		subtract: testCalls{
+			underflow: testCall{
+				interpreter.NewUnmeteredUInt16Value(0),
+				interpreter.NewUnmeteredUInt16Value(2),
+				interpreter.NewUnmeteredUInt16Value(0),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUInt16Value(math.MaxUint16),
+				interpreter.NewUnmeteredUInt16Value(2),
+				interpreter.NewUnmeteredUInt16Value(math.MaxUint16),
+			},
+		},
+	},
+	sema.UInt32Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUInt32Value(math.MaxUint32),
+				interpreter.NewUnmeteredUInt32Value(2),
+				interpreter.NewUnmeteredUInt32Value(math.MaxUint32),
+			},
+		},
+		subtract: testCalls{
+			underflow: testCall{
+				interpreter.NewUnmeteredUInt32Value(0),
+				interpreter.NewUnmeteredUInt32Value(2),
+				interpreter.NewUnmeteredUInt32Value(0),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUInt32Value(math.MaxUint32),
+				interpreter.NewUnmeteredUInt32Value(2),
+				interpreter.NewUnmeteredUInt32Value(math.MaxUint32),
+			},
+		},
+	},
+	sema.UInt64Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUInt64Value(math.MaxUint64),
+				interpreter.NewUnmeteredUInt64Value(2),
+				interpreter.NewUnmeteredUInt64Value(math.MaxUint64),
+			},
+		},
+		subtract: testCalls{
+			underflow: testCall{
+				interpreter.NewUnmeteredUInt64Value(0),
+				interpreter.NewUnmeteredUInt64Value(2),
+				interpreter.NewUnmeteredUInt64Value(0),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUInt64Value(math.MaxUint64),
+				interpreter.NewUnmeteredUInt64Value(2),
+				interpreter.NewUnmeteredUInt64Value(math.MaxUint64),
+			},
+		},
+	},
+	sema.UInt128Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
+				interpreter.NewUnmeteredUInt128ValueFromUint64(2),
+				interpreter.NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
+			},
+		},
+		subtract: testCalls{
+			underflow: testCall{
+				interpreter.NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMinIntBig),
+				interpreter.NewUnmeteredUInt128ValueFromUint64(2),
+				interpreter.NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMinIntBig),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
+				interpreter.NewUnmeteredUInt128ValueFromUint64(2),
+				interpreter.NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
+			},
+		},
+	},
+	sema.UInt256Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
+				interpreter.NewUnmeteredUInt256ValueFromUint64(2),
+				interpreter.NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
+			},
+		},
+		subtract: testCalls{
+			underflow: testCall{
+				interpreter.NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMinIntBig),
+				interpreter.NewUnmeteredUInt256ValueFromUint64(2),
+				interpreter.NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMinIntBig),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
+				interpreter.NewUnmeteredUInt256ValueFromUint64(2),
+				interpreter.NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
+			},
+		},
+	},
+	sema.UFix64Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUFix64Value(math.MaxUint64),
+				interpreter.NewUnmeteredUFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredUFix64Value(math.MaxUint64),
+			},
+		},
+		subtract: testCalls{
+			underflow: testCall{
+				interpreter.NewUnmeteredUFix64Value(0),
+				interpreter.NewUnmeteredUFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredUFix64Value(0),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUFix64Value(math.MaxUint64),
+				interpreter.NewUnmeteredUFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredUFix64Value(math.MaxUint64),
+			},
+		},
+	},
+	sema.UFix128Type: {
+		add: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUFix128Value(fixedpoint.UFix128TypeMax),
+				interpreter.NewUnmeteredUFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredUFix128Value(fixedpoint.UFix128TypeMax),
+			},
+		},
+		subtract: testCalls{
+			underflow: testCall{
+				interpreter.NewUnmeteredUFix128Value(fixedpoint.UFix128TypeMin),
+				interpreter.NewUnmeteredUFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredUFix128Value(fixedpoint.UFix128TypeMin),
+			},
+		},
+		multiply: testCalls{
+			overflow: testCall{
+				interpreter.NewUnmeteredUFix128Value(fixedpoint.UFix128TypeMax),
+				interpreter.NewUnmeteredUFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
+				interpreter.NewUnmeteredUFix128Value(fixedpoint.UFix128TypeMax),
+			},
+		},
+	},
+}
+
 func TestInterpretSaturatedArithmeticFunctions(t *testing.T) {
 
 	t.Parallel()
 
-	type testCall struct {
-		left, right interpreter.Value
-		expected    interpreter.EquatableValue
+	verifyArithmeticTests(t)
+
+	test := func(ty sema.Type, method string, calls testCalls) {
+
+		method = fmt.Sprintf("saturating%s", method)
+
+		for kind, call := range map[string]testCall{
+			"overflow":  calls.overflow,
+			"underflow": calls.underflow,
+		} {
+
+			if call.expected == nil {
+				continue
+			}
+
+			kind := kind
+			call := call
+
+			t.Run(fmt.Sprintf("%s %s %s", ty, method, kind), func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndPrepare(t,
+					fmt.Sprintf(
+						`
+                          fun test(a: %[1]s, b: %[1]s): %[1]s {
+                              return a.%[2]s(b)
+                          }
+                        `,
+						ty,
+						method,
+					),
+				)
+
+				result, err := inter.Invoke("test", call.left, call.right)
+				require.NoError(t, err)
+
+				require.True(t,
+					call.expected.Equal(inter, interpreter.EmptyLocationRange, result),
+					fmt.Sprintf(
+						"%s(%s, %s) = %s != %s",
+						method, call.left, call.right, result, call.expected,
+					),
+				)
+			})
+		}
 	}
 
-	type testCalls struct {
-		underflow, overflow testCall
+	for ty, testCase := range testCases {
+		test(ty, "Add", testCase.add)
+		test(ty, "Subtract", testCase.subtract)
+		test(ty, "Multiply", testCase.multiply)
+		test(ty, "Divide", testCase.divide)
 	}
+}
 
-	type testCase struct {
-		add, subtract, multiply, divide testCalls
-	}
-
-	testCases := map[sema.Type]testCase{
-		sema.Int8Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt8Value(math.MaxInt8),
-					interpreter.NewUnmeteredInt8Value(2),
-					interpreter.NewUnmeteredInt8Value(math.MaxInt8),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt8Value(math.MinInt8),
-					interpreter.NewUnmeteredInt8Value(-2),
-					interpreter.NewUnmeteredInt8Value(math.MinInt8),
-				},
-			},
-			subtract: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt8Value(math.MaxInt8),
-					interpreter.NewUnmeteredInt8Value(-2),
-					interpreter.NewUnmeteredInt8Value(math.MaxInt8),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt8Value(math.MinInt8),
-					interpreter.NewUnmeteredInt8Value(2),
-					interpreter.NewUnmeteredInt8Value(math.MinInt8),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt8Value(math.MaxInt8),
-					interpreter.NewUnmeteredInt8Value(2),
-					interpreter.NewUnmeteredInt8Value(math.MaxInt8),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt8Value(math.MinInt8),
-					interpreter.NewUnmeteredInt8Value(2),
-					interpreter.NewUnmeteredInt8Value(math.MinInt8),
-				},
-			},
-			divide: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt8Value(math.MinInt8),
-					interpreter.NewUnmeteredInt8Value(-1),
-					interpreter.NewUnmeteredInt8Value(math.MaxInt8),
-				},
-			},
-		},
-		sema.Int16Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt16Value(math.MaxInt16),
-					interpreter.NewUnmeteredInt16Value(2),
-					interpreter.NewUnmeteredInt16Value(math.MaxInt16),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt16Value(math.MinInt16),
-					interpreter.NewUnmeteredInt16Value(-2),
-					interpreter.NewUnmeteredInt16Value(math.MinInt16),
-				},
-			},
-			subtract: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt16Value(math.MaxInt16),
-					interpreter.NewUnmeteredInt16Value(-2),
-					interpreter.NewUnmeteredInt16Value(math.MaxInt16),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt16Value(math.MinInt16),
-					interpreter.NewUnmeteredInt16Value(2),
-					interpreter.NewUnmeteredInt16Value(math.MinInt16),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt16Value(math.MaxInt16),
-					interpreter.NewUnmeteredInt16Value(2),
-					interpreter.NewUnmeteredInt16Value(math.MaxInt16),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt16Value(math.MinInt16),
-					interpreter.NewUnmeteredInt16Value(2),
-					interpreter.NewUnmeteredInt16Value(math.MinInt16),
-				},
-			},
-			divide: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt16Value(math.MinInt16),
-					interpreter.NewUnmeteredInt16Value(-1),
-					interpreter.NewUnmeteredInt16Value(math.MaxInt16),
-				},
-			},
-		},
-		sema.Int32Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt32Value(math.MaxInt32),
-					interpreter.NewUnmeteredInt32Value(2),
-					interpreter.NewUnmeteredInt32Value(math.MaxInt32),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt32Value(math.MinInt32),
-					interpreter.NewUnmeteredInt32Value(-2),
-					interpreter.NewUnmeteredInt32Value(math.MinInt32),
-				},
-			},
-			subtract: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt32Value(math.MaxInt32),
-					interpreter.NewUnmeteredInt32Value(-2),
-					interpreter.NewUnmeteredInt32Value(math.MaxInt32),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt32Value(math.MinInt32),
-					interpreter.NewUnmeteredInt32Value(2),
-					interpreter.NewUnmeteredInt32Value(math.MinInt32),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt32Value(math.MaxInt32),
-					interpreter.NewUnmeteredInt32Value(2),
-					interpreter.NewUnmeteredInt32Value(math.MaxInt32),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt32Value(math.MinInt32),
-					interpreter.NewUnmeteredInt32Value(2),
-					interpreter.NewUnmeteredInt32Value(math.MinInt32),
-				},
-			},
-			divide: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt32Value(math.MinInt32),
-					interpreter.NewUnmeteredInt32Value(-1),
-					interpreter.NewUnmeteredInt32Value(math.MaxInt32),
-				},
-			},
-		},
-		sema.Int64Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt64Value(math.MaxInt64),
-					interpreter.NewUnmeteredInt64Value(2),
-					interpreter.NewUnmeteredInt64Value(math.MaxInt64),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt64Value(math.MinInt64),
-					interpreter.NewUnmeteredInt64Value(-2),
-					interpreter.NewUnmeteredInt64Value(math.MinInt64),
-				},
-			},
-			subtract: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt64Value(math.MaxInt64),
-					interpreter.NewUnmeteredInt64Value(-2),
-					interpreter.NewUnmeteredInt64Value(math.MaxInt64),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt64Value(math.MinInt64),
-					interpreter.NewUnmeteredInt64Value(2),
-					interpreter.NewUnmeteredInt64Value(math.MinInt64),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt64Value(math.MaxInt64),
-					interpreter.NewUnmeteredInt64Value(2),
-					interpreter.NewUnmeteredInt64Value(math.MaxInt64),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt64Value(math.MinInt64),
-					interpreter.NewUnmeteredInt64Value(2),
-					interpreter.NewUnmeteredInt64Value(math.MinInt64),
-				},
-			},
-			divide: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt64Value(math.MinInt64),
-					interpreter.NewUnmeteredInt64Value(-1),
-					interpreter.NewUnmeteredInt64Value(math.MaxInt64),
-				},
-			},
-		},
-		sema.Int128Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
-					interpreter.NewUnmeteredInt128ValueFromInt64(2),
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
-					interpreter.NewUnmeteredInt128ValueFromInt64(-2),
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
-				},
-			},
-			subtract: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
-					interpreter.NewUnmeteredInt128ValueFromInt64(-2),
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
-					interpreter.NewUnmeteredInt128ValueFromInt64(2),
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
-					interpreter.NewUnmeteredInt128ValueFromInt64(2),
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
-					interpreter.NewUnmeteredInt128ValueFromInt64(2),
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
-				},
-			},
-			divide: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMinIntBig),
-					interpreter.NewUnmeteredInt128ValueFromInt64(-1),
-					interpreter.NewUnmeteredInt128ValueFromBigInt(sema.Int128TypeMaxIntBig),
-				},
-			},
-		},
-		sema.Int256Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
-					interpreter.NewUnmeteredInt256ValueFromInt64(2),
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
-					interpreter.NewUnmeteredInt256ValueFromInt64(-2),
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
-				},
-			},
-			subtract: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
-					interpreter.NewUnmeteredInt256ValueFromInt64(-2),
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
-					interpreter.NewUnmeteredInt256ValueFromInt64(2),
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
-					interpreter.NewUnmeteredInt256ValueFromInt64(2),
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
-					interpreter.NewUnmeteredInt256ValueFromInt64(2),
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
-				},
-			},
-			divide: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMinIntBig),
-					interpreter.NewUnmeteredInt256ValueFromInt64(-1),
-					interpreter.NewUnmeteredInt256ValueFromBigInt(sema.Int256TypeMaxIntBig),
-				},
-			},
-		},
-
-		sema.Fix64Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredFix64Value(math.MaxInt64),
-					interpreter.NewUnmeteredFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix64Value(math.MaxInt64),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredFix64Value(math.MinInt64),
-					interpreter.NewUnmeteredFix64ValueWithInteger(-2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix64Value(math.MinInt64),
-				},
-			},
-			subtract: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredFix64Value(math.MaxInt64),
-					interpreter.NewUnmeteredFix64ValueWithInteger(-2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix64Value(math.MaxInt64),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredFix64Value(math.MinInt64),
-					interpreter.NewUnmeteredFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix64Value(math.MinInt64),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredFix64Value(math.MaxInt64),
-					interpreter.NewUnmeteredFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix64Value(math.MaxInt64),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredFix64Value(math.MinInt64),
-					interpreter.NewUnmeteredFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix64Value(math.MinInt64),
-				},
-			},
-			divide: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredFix64Value(math.MinInt64),
-					interpreter.NewUnmeteredFix64ValueWithInteger(-1, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix64Value(math.MaxInt64),
-				},
-			},
-		},
-		sema.Fix128Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
-					interpreter.NewUnmeteredFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
-					interpreter.NewUnmeteredFix128ValueWithInteger(-2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
-				},
-			},
-			subtract: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
-					interpreter.NewUnmeteredFix128ValueWithInteger(-2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
-					interpreter.NewUnmeteredFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
-					interpreter.NewUnmeteredFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
-				},
-				underflow: testCall{
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
-					interpreter.NewUnmeteredFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
-				},
-			},
-			divide: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMin),
-					interpreter.NewUnmeteredFix128ValueWithInteger(-1, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredFix128Value(fixedpoint.Fix128TypeMax),
-				},
-			},
-		},
-
-		sema.UIntType: {
-			subtract: testCalls{
-				underflow: testCall{
-					interpreter.NewUnmeteredUIntValueFromBigInt(sema.UIntTypeMin),
-					interpreter.NewUnmeteredUIntValueFromUint64(2),
-					interpreter.NewUnmeteredUIntValueFromBigInt(sema.UIntTypeMin),
-				},
-			},
-		},
-		sema.UInt8Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUInt8Value(math.MaxUint8),
-					interpreter.NewUnmeteredUInt8Value(2),
-					interpreter.NewUnmeteredUInt8Value(math.MaxUint8),
-				},
-			},
-			subtract: testCalls{
-				underflow: testCall{
-					interpreter.NewUnmeteredUInt8Value(0),
-					interpreter.NewUnmeteredUInt8Value(2),
-					interpreter.NewUnmeteredUInt8Value(0),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUInt8Value(math.MaxUint8),
-					interpreter.NewUnmeteredUInt8Value(2),
-					interpreter.NewUnmeteredUInt8Value(math.MaxUint8),
-				},
-			},
-		},
-		sema.UInt16Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUInt16Value(math.MaxUint16),
-					interpreter.NewUnmeteredUInt16Value(2),
-					interpreter.NewUnmeteredUInt16Value(math.MaxUint16),
-				},
-			},
-			subtract: testCalls{
-				underflow: testCall{
-					interpreter.NewUnmeteredUInt16Value(0),
-					interpreter.NewUnmeteredUInt16Value(2),
-					interpreter.NewUnmeteredUInt16Value(0),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUInt16Value(math.MaxUint16),
-					interpreter.NewUnmeteredUInt16Value(2),
-					interpreter.NewUnmeteredUInt16Value(math.MaxUint16),
-				},
-			},
-		},
-		sema.UInt32Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUInt32Value(math.MaxUint32),
-					interpreter.NewUnmeteredUInt32Value(2),
-					interpreter.NewUnmeteredUInt32Value(math.MaxUint32),
-				},
-			},
-			subtract: testCalls{
-				underflow: testCall{
-					interpreter.NewUnmeteredUInt32Value(0),
-					interpreter.NewUnmeteredUInt32Value(2),
-					interpreter.NewUnmeteredUInt32Value(0),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUInt32Value(math.MaxUint32),
-					interpreter.NewUnmeteredUInt32Value(2),
-					interpreter.NewUnmeteredUInt32Value(math.MaxUint32),
-				},
-			},
-		},
-		sema.UInt64Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUInt64Value(math.MaxUint64),
-					interpreter.NewUnmeteredUInt64Value(2),
-					interpreter.NewUnmeteredUInt64Value(math.MaxUint64),
-				},
-			},
-			subtract: testCalls{
-				underflow: testCall{
-					interpreter.NewUnmeteredUInt64Value(0),
-					interpreter.NewUnmeteredUInt64Value(2),
-					interpreter.NewUnmeteredUInt64Value(0),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUInt64Value(math.MaxUint64),
-					interpreter.NewUnmeteredUInt64Value(2),
-					interpreter.NewUnmeteredUInt64Value(math.MaxUint64),
-				},
-			},
-		},
-		sema.UInt128Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
-					interpreter.NewUnmeteredUInt128ValueFromUint64(2),
-					interpreter.NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
-				},
-			},
-			subtract: testCalls{
-				underflow: testCall{
-					interpreter.NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMinIntBig),
-					interpreter.NewUnmeteredUInt128ValueFromUint64(2),
-					interpreter.NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMinIntBig),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
-					interpreter.NewUnmeteredUInt128ValueFromUint64(2),
-					interpreter.NewUnmeteredUInt128ValueFromBigInt(sema.UInt128TypeMaxIntBig),
-				},
-			},
-		},
-		sema.UInt256Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
-					interpreter.NewUnmeteredUInt256ValueFromUint64(2),
-					interpreter.NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
-				},
-			},
-			subtract: testCalls{
-				underflow: testCall{
-					interpreter.NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMinIntBig),
-					interpreter.NewUnmeteredUInt256ValueFromUint64(2),
-					interpreter.NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMinIntBig),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
-					interpreter.NewUnmeteredUInt256ValueFromUint64(2),
-					interpreter.NewUnmeteredUInt256ValueFromBigInt(sema.UInt256TypeMaxIntBig),
-				},
-			},
-		},
-		sema.UFix64Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUFix64Value(math.MaxUint64),
-					interpreter.NewUnmeteredUFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredUFix64Value(math.MaxUint64),
-				},
-			},
-			subtract: testCalls{
-				underflow: testCall{
-					interpreter.NewUnmeteredUFix64Value(0),
-					interpreter.NewUnmeteredUFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredUFix64Value(0),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUFix64Value(math.MaxUint64),
-					interpreter.NewUnmeteredUFix64ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredUFix64Value(math.MaxUint64),
-				},
-			},
-		},
-		sema.UFix128Type: {
-			add: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUFix128Value(fixedpoint.UFix128TypeMax),
-					interpreter.NewUnmeteredUFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredUFix128Value(fixedpoint.UFix128TypeMax),
-				},
-			},
-			subtract: testCalls{
-				underflow: testCall{
-					interpreter.NewUnmeteredUFix128Value(fixedpoint.UFix128TypeMin),
-					interpreter.NewUnmeteredUFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredUFix128Value(fixedpoint.UFix128TypeMin),
-				},
-			},
-			multiply: testCalls{
-				overflow: testCall{
-					interpreter.NewUnmeteredUFix128Value(fixedpoint.UFix128TypeMax),
-					interpreter.NewUnmeteredUFix128ValueWithInteger(2, interpreter.EmptyLocationRange),
-					interpreter.NewUnmeteredUFix128Value(fixedpoint.UFix128TypeMax),
-				},
-			},
-		},
-	}
-
+func verifyArithmeticTests(t *testing.T) {
 	// Verify all test cases exist
 
 	for _, ty := range common.Concat(
@@ -858,52 +917,70 @@ func TestInterpretSaturatedArithmeticFunctions(t *testing.T) {
 			require.Nil(t, testCase.divide.underflow.expected)
 		}
 	}
+}
 
-	test := func(ty sema.Type, method string, calls testCalls) {
+func TestInterpretArithmeticOperatorsOverflowAndUnderflow(t *testing.T) {
 
-		method = fmt.Sprintf("saturating%s", method)
+	t.Parallel()
+
+	verifyArithmeticTests(t)
+
+	const (
+		errorKindOverflow  = "overflow"
+		errorKindUnderflow = "underflow"
+	)
+
+	test := func(ty sema.Type, operation ast.Operation, calls testCalls) {
 
 		for kind, call := range map[string]testCall{
-			"overflow":  calls.overflow,
-			"underflow": calls.underflow,
+			errorKindOverflow:  calls.overflow,
+			errorKindUnderflow: calls.underflow,
 		} {
 
 			if call.expected == nil {
 				continue
 			}
 
-			t.Run(fmt.Sprintf("%s %s %s", ty, method, kind), func(t *testing.T) {
+			kind := kind
+			call := call
+
+			t.Run(fmt.Sprintf("%s %s %s", ty, operation.Symbol(), kind), func(t *testing.T) {
+
+				t.Parallel()
 
 				inter := parseCheckAndPrepare(t,
 					fmt.Sprintf(
 						`
                           fun test(a: %[1]s, b: %[1]s): %[1]s {
-                              return a.%[2]s(b)
+                              return a %[2]s b
                           }
                         `,
 						ty,
-						method,
+						operation.Symbol(),
 					),
 				)
 
-				result, err := inter.Invoke("test", call.left, call.right)
-				require.NoError(t, err)
+				_, err := inter.Invoke("test", call.left, call.right)
+				RequireError(t, err)
 
-				require.True(t,
-					call.expected.Equal(inter, interpreter.EmptyLocationRange, result),
-					fmt.Sprintf(
-						"%s(%s, %s) = %s != %s",
-						method, call.left, call.right, result, call.expected,
-					),
-				)
+				switch kind {
+				case errorKindOverflow:
+					expectedError := &interpreter.OverflowError{}
+					require.ErrorAs(t, err, &expectedError)
+				case errorKindUnderflow:
+					expectedError := &interpreter.UnderflowError{}
+					require.ErrorAs(t, err, &expectedError)
+				default:
+					t.Fail()
+				}
 			})
 		}
 	}
 
 	for ty, testCase := range testCases {
-		test(ty, "Add", testCase.add)
-		test(ty, "Subtract", testCase.subtract)
-		test(ty, "Multiply", testCase.multiply)
-		test(ty, "Divide", testCase.divide)
+		test(ty, ast.OperationPlus, testCase.add)
+		test(ty, ast.OperationMinus, testCase.subtract)
+		test(ty, ast.OperationMul, testCase.multiply)
+		test(ty, ast.OperationDiv, testCase.divide)
 	}
 }

--- a/interpreter/div_mod_test.go
+++ b/interpreter/div_mod_test.go
@@ -27,7 +27,6 @@ import (
 
 	. "github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
-	"github.com/onflow/cadence/values"
 )
 
 func TestDivModUInt8(t *testing.T) {
@@ -3292,7 +3291,7 @@ func TestDivModUFix64(t *testing.T) {
 		{0, ufix64ZeroDotOne, nil},
 		{1, ufix64ZeroDotOne, nil},
 		{2, ufix64ZeroDotOne, nil},
-		{ufix64MaxIntDividend, ufix64ZeroDotOne, values.OverflowError{}},
+		{ufix64MaxIntDividend, ufix64ZeroDotOne, &OverflowError{}},
 		{ufix64MaxIntDividend + 1, ufix64ZeroDotOne, &OverflowError{}},
 
 		// 1.0

--- a/interpreter/fixedpoint_test.go
+++ b/interpreter/fixedpoint_test.go
@@ -547,7 +547,6 @@ func TestInterpretFixedPointToFixedPointConversions(t *testing.T) {
 
 		if expectedError != nil {
 			RequireError(t, err)
-
 			require.ErrorAs(t, err, &expectedError)
 		} else {
 			require.NoError(t, err)

--- a/interpreter/value_fix128.go
+++ b/interpreter/value_fix128.go
@@ -608,7 +608,7 @@ func (v Fix128Value) ToBigInt() *big.Int {
 	return fixedpoint.Fix128ToBigInt(fix.Fix128(v))
 }
 
-func handleFixedpointError(err error, _ LocationRange) {
+func handleFixedpointError(err error, locationRange LocationRange) {
 	switch err {
 	// `fix.ErrUnderflow` happens when the value is within the range but is too small
 	// to be represented using the current bit-length.
@@ -616,8 +616,15 @@ func handleFixedpointError(err error, _ LocationRange) {
 	// (assumes that the value returned is already the truncated value).
 	case nil, fix.ErrUnderflow:
 		return
+	case fix.ErrOverflow:
+		panic(&OverflowError{
+			LocationRange: locationRange,
+		})
+	case fix.ErrNegOverflow:
+		panic(&UnderflowError{
+			LocationRange: locationRange,
+		})
 	default:
-		// TODO: wrap external error with a cadence overflow/underflow error.
 		panic(err)
 	}
 }

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -208,11 +208,11 @@ func (v Fix64Value) Minus(context NumberValueArithmeticContext, other NumberValu
 	valueGetter := func() int64 {
 		// INT32-C
 		if (o > 0) && (v < (math.MinInt64 + o)) {
-			panic(&OverflowError{
+			panic(&UnderflowError{
 				LocationRange: locationRange,
 			})
 		} else if (o < 0) && (v > (math.MaxInt64 + o)) {
-			panic(&UnderflowError{
+			panic(&OverflowError{
 				LocationRange: locationRange,
 			})
 		}

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -192,11 +192,11 @@ func (v Int16Value) Minus(context NumberValueArithmeticContext, other NumberValu
 
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt16 + o)) {
-		panic(&OverflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v > (math.MaxInt16 + o)) {
-		panic(&UnderflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -192,11 +192,11 @@ func (v Int32Value) Minus(context NumberValueArithmeticContext, other NumberValu
 
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt32 + o)) {
-		panic(&OverflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v > (math.MaxInt32 + o)) {
-		panic(&UnderflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -195,11 +195,11 @@ func (v Int64Value) Minus(context NumberValueArithmeticContext, other NumberValu
 
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt64 + o)) {
-		panic(&OverflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v > (math.MaxInt64 + o)) {
-		panic(&UnderflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -189,11 +189,11 @@ func (v Int8Value) Minus(context NumberValueArithmeticContext, other NumberValue
 
 	// INT32-C
 	if (o > 0) && (v < (math.MinInt8 + o)) {
-		panic(&OverflowError{
+		panic(&UnderflowError{
 			LocationRange: locationRange,
 		})
 	} else if (o < 0) && (v > (math.MaxInt8 + o)) {
-		panic(&UnderflowError{
+		panic(&OverflowError{
 			LocationRange: locationRange,
 		})
 	}

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -245,9 +245,8 @@ func (v UFix64Value) Plus(context NumberValueArithmeticContext, other NumberValu
 		})
 	}
 	result, err := v.UFix64Value.Plus(context, o.UFix64Value)
-	if err != nil {
-		panic(err)
-	}
+	handleFix64Error(err, locationRange)
+
 	return UFix64Value{UFix64Value: result}
 }
 
@@ -263,9 +262,8 @@ func (v UFix64Value) SaturatingPlus(context NumberValueArithmeticContext, other 
 	}
 
 	result, err := v.UFix64Value.SaturatingPlus(context, o.UFix64Value)
-	if err != nil {
-		panic(err)
-	}
+	handleFix64Error(err, locationRange)
+
 	return UFix64Value{UFix64Value: result}
 }
 
@@ -281,9 +279,8 @@ func (v UFix64Value) Minus(context NumberValueArithmeticContext, other NumberVal
 	}
 
 	result, err := v.UFix64Value.Minus(context, o.UFix64Value)
-	if err != nil {
-		panic(err)
-	}
+	handleFix64Error(err, locationRange)
+
 	return UFix64Value{UFix64Value: result}
 }
 
@@ -299,9 +296,8 @@ func (v UFix64Value) SaturatingMinus(context NumberValueArithmeticContext, other
 	}
 
 	result, err := v.UFix64Value.SaturatingMinus(context, o.UFix64Value)
-	if err != nil {
-		panic(err)
-	}
+	handleFix64Error(err, locationRange)
+
 	return UFix64Value{UFix64Value: result}
 }
 
@@ -317,9 +313,8 @@ func (v UFix64Value) Mul(context NumberValueArithmeticContext, other NumberValue
 	}
 
 	result, err := v.UFix64Value.Mul(context, o.UFix64Value)
-	if err != nil {
-		panic(err)
-	}
+	handleFix64Error(err, locationRange)
+
 	return UFix64Value{UFix64Value: result}
 }
 
@@ -335,9 +330,8 @@ func (v UFix64Value) SaturatingMul(context NumberValueArithmeticContext, other N
 	}
 
 	result, err := v.UFix64Value.SaturatingMul(context, o.UFix64Value)
-	if err != nil {
-		panic(err)
-	}
+	handleFix64Error(err, locationRange)
+
 	return UFix64Value{UFix64Value: result}
 }
 
@@ -353,9 +347,8 @@ func (v UFix64Value) Div(context NumberValueArithmeticContext, other NumberValue
 	}
 
 	result, err := v.UFix64Value.Div(context, o.UFix64Value)
-	if err != nil {
-		panic(err)
-	}
+	handleFix64Error(err, locationRange)
+
 	return UFix64Value{UFix64Value: result}
 }
 
@@ -376,9 +369,8 @@ func (v UFix64Value) Mod(context NumberValueArithmeticContext, other NumberValue
 	}
 
 	result, err := v.UFix64Value.Mod(context, o.UFix64Value)
-	if err != nil {
-		panic(err)
-	}
+	handleFix64Error(err, locationRange)
+
 	return UFix64Value{UFix64Value: result}
 }
 
@@ -547,4 +539,21 @@ func fix128BigIntToUFix64(
 			return bigInt.Uint64()
 		},
 	)
+}
+
+func handleFix64Error(err error, locationRange LocationRange) {
+	switch err.(type) {
+	case nil:
+		return
+	case values.OverflowError:
+		panic(&OverflowError{
+			LocationRange: locationRange,
+		})
+	case values.UnderflowError:
+		panic(&UnderflowError{
+			LocationRange: locationRange,
+		})
+	default:
+		panic(err)
+	}
 }


### PR DESCRIPTION
Working towards https://github.com/onflow/cadence/issues/484

## Description

Handle the external overflow/underflow errors thrown from the fixed-point library and re-throw the corresponding interpreter error, so that they are treated as user errors.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
