### PR TITLE
Handle partial AST nodes when pretty printing

### DIFF
--- a/ast/access.go
+++ b/ast/access.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/turbolent/prettier"
+
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 )
@@ -34,6 +36,7 @@ type Access interface {
 	Description() string
 	String() string
 	MarshalJSON() ([]byte, error)
+	Doc() prettier.Doc
 }
 
 type Separator uint8
@@ -143,6 +146,10 @@ func (e EntitlementAccess) Keyword() string {
 	return sb.String()
 }
 
+func (e EntitlementAccess) Doc() prettier.Doc {
+	return prettier.Text(e.Keyword())
+}
+
 func (e EntitlementAccess) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.String())
 }
@@ -192,6 +199,10 @@ func (a *MappedAccess) Keyword() string {
 	str.WriteString(a.String())
 	str.WriteString(")")
 	return str.String()
+}
+
+func (a *MappedAccess) Doc() prettier.Doc {
+	return prettier.Text(a.Keyword())
 }
 
 func (a *MappedAccess) MarshalJSON() ([]byte, error) {
@@ -287,4 +298,8 @@ func (a PrimitiveAccess) Description() string {
 
 func (a PrimitiveAccess) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a.String())
+}
+
+func (a PrimitiveAccess) Doc() prettier.Doc {
+	return prettier.Text(a.Keyword())
 }

--- a/ast/argument.go
+++ b/ast/argument.go
@@ -84,7 +84,13 @@ func (a *Argument) MarshalJSON() ([]byte, error) {
 }
 
 func (a *Argument) Doc() prettier.Doc {
-	argumentDoc := a.Expression.Doc()
+	var argumentDoc prettier.Doc
+	if a.Expression == nil {
+		argumentDoc = prettier.Text("")
+	} else {
+		argumentDoc = a.Expression.Doc()
+	}
+
 	if a.Label == "" {
 		return argumentDoc
 	}

--- a/ast/argument.go
+++ b/ast/argument.go
@@ -84,12 +84,7 @@ func (a *Argument) MarshalJSON() ([]byte, error) {
 }
 
 func (a *Argument) Doc() prettier.Doc {
-	var argumentDoc prettier.Doc
-	if a.Expression == nil {
-		argumentDoc = prettier.Text("")
-	} else {
-		argumentDoc = a.Expression.Doc()
-	}
+	argumentDoc := docOrEmpty(a.Expression)
 
 	if a.Label == "" {
 		return argumentDoc

--- a/ast/argument_test.go
+++ b/ast/argument_test.go
@@ -153,6 +153,37 @@ func TestArgument_Doc(t *testing.T) {
 			argument.Doc(),
 		)
 	})
+
+	t.Run("without expression, without label", func(t *testing.T) {
+
+		t.Parallel()
+
+		argument := &Argument{}
+
+		require.Equal(
+			t,
+			prettier.Text(""),
+			argument.Doc(),
+		)
+	})
+
+	t.Run("without expression, with label", func(t *testing.T) {
+
+		t.Parallel()
+
+		argument := &Argument{
+			Label: "ok",
+		}
+
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("ok: "),
+				prettier.Text(""),
+			},
+			argument.Doc(),
+		)
+	})
 }
 
 func TestArgument_String(t *testing.T) {
@@ -190,6 +221,34 @@ func TestArgument_String(t *testing.T) {
 		require.Equal(
 			t,
 			"ok: false",
+			argument.String(),
+		)
+	})
+
+	t.Run("without expression, without label", func(t *testing.T) {
+
+		t.Parallel()
+
+		argument := &Argument{}
+
+		require.Equal(
+			t,
+			"",
+			argument.String(),
+		)
+	})
+
+	t.Run("without expression, with label", func(t *testing.T) {
+
+		t.Parallel()
+
+		argument := &Argument{
+			Label: "ok",
+		}
+
+		require.Equal(
+			t,
+			"ok: ",
 			argument.String(),
 		)
 	})

--- a/ast/attachment.go
+++ b/ast/attachment.go
@@ -123,16 +123,9 @@ func (d *AttachmentDeclaration) Doc() prettier.Doc {
 	var doc prettier.Concat
 
 	if d.Access != AccessNotSpecified {
-		var accessDoc prettier.Doc
-		if d.Access == nil {
-			accessDoc = prettier.Text("")
-		} else {
-			accessDoc = d.Access.Doc()
-		}
-
 		doc = append(
 			doc,
-			accessDoc,
+			docOrEmpty(d.Access),
 			prettier.HardLine{},
 		)
 	}

--- a/ast/attachment.go
+++ b/ast/attachment.go
@@ -123,9 +123,16 @@ func (d *AttachmentDeclaration) Doc() prettier.Doc {
 	var doc prettier.Concat
 
 	if d.Access != AccessNotSpecified {
+		var accessDoc prettier.Doc
+		if d.Access == nil {
+			accessDoc = prettier.Text("")
+		} else {
+			accessDoc = d.Access.Doc()
+		}
+
 		doc = append(
 			doc,
-			prettier.Text(d.Access.Keyword()),
+			accessDoc,
 			prettier.HardLine{},
 		)
 	}

--- a/ast/block.go
+++ b/ast/block.go
@@ -77,18 +77,10 @@ func StatementsDoc(statements []Statement) prettier.Doc {
 	var doc prettier.Concat
 
 	for _, statement := range statements {
-
-		var statementDoc prettier.Doc
-		if statement == nil {
-			statementDoc = prettier.Text("")
-		} else {
-			statementDoc = statement.Doc()
-		}
-
 		doc = append(
 			doc,
 			prettier.HardLine{},
-			statementDoc,
+			docOrEmpty(statement),
 		)
 	}
 
@@ -297,14 +289,7 @@ func (c TestCondition) MarshalJSON() ([]byte, error) {
 }
 
 func (c TestCondition) Doc() prettier.Doc {
-	var testDoc prettier.Doc
-	if c.Test == nil {
-		testDoc = prettier.Text("")
-	} else {
-		testDoc = c.Test.Doc()
-	}
-
-	doc := testDoc
+	doc := docOrEmpty(c.Test)
 
 	if c.Message != nil {
 		messageDoc := c.Message.Doc()
@@ -390,18 +375,10 @@ func (c *Conditions) Doc(keywordDoc prettier.Doc) prettier.Doc {
 	var doc prettier.Concat
 
 	for _, condition := range c.Conditions {
-
-		var conditionDoc prettier.Doc
-		if condition == nil {
-			conditionDoc = prettier.Text("")
-		} else {
-			conditionDoc = condition.Doc()
-		}
-
 		doc = append(
 			doc,
 			prettier.HardLine{},
-			conditionDoc,
+			docOrEmpty(condition),
 		)
 	}
 

--- a/ast/block.go
+++ b/ast/block.go
@@ -77,10 +77,18 @@ func StatementsDoc(statements []Statement) prettier.Doc {
 	var doc prettier.Concat
 
 	for _, statement := range statements {
+
+		var statementDoc prettier.Doc
+		if statement == nil {
+			statementDoc = prettier.Text("")
+		} else {
+			statementDoc = statement.Doc()
+		}
+
 		doc = append(
 			doc,
 			prettier.HardLine{},
-			statement.Doc(),
+			statementDoc,
 		)
 	}
 
@@ -289,15 +297,25 @@ func (c TestCondition) MarshalJSON() ([]byte, error) {
 }
 
 func (c TestCondition) Doc() prettier.Doc {
-	doc := c.Test.Doc()
+	var testDoc prettier.Doc
+	if c.Test == nil {
+		testDoc = prettier.Text("")
+	} else {
+		testDoc = c.Test.Doc()
+	}
+
+	doc := testDoc
+
 	if c.Message != nil {
+		messageDoc := c.Message.Doc()
+
 		doc = prettier.Concat{
 			doc,
 			prettier.Text(":"),
 			prettier.Indent{
 				Doc: prettier.Concat{
 					prettier.HardLine{},
-					c.Message.Doc(),
+					messageDoc,
 				},
 			},
 		}
@@ -372,10 +390,18 @@ func (c *Conditions) Doc(keywordDoc prettier.Doc) prettier.Doc {
 	var doc prettier.Concat
 
 	for _, condition := range c.Conditions {
+
+		var conditionDoc prettier.Doc
+		if condition == nil {
+			conditionDoc = prettier.Text("")
+		} else {
+			conditionDoc = condition.Doc()
+		}
+
 		doc = append(
 			doc,
 			prettier.HardLine{},
-			condition.Doc(),
+			conditionDoc,
 		)
 	}
 

--- a/ast/block_test.go
+++ b/ast/block_test.go
@@ -803,17 +803,9 @@ func TestTestCondition_Doc(t *testing.T) {
 		condition := TestCondition{
 			Test: &BoolExpression{
 				Value: true,
-				Range: Range{
-					StartPos: Position{Offset: 1, Line: 2, Column: 3},
-					EndPos:   Position{Offset: 4, Line: 5, Column: 6},
-				},
 			},
 			Message: &StringExpression{
 				Value: "Test condition",
-				Range: Range{
-					StartPos: Position{Offset: 7, Line: 8, Column: 9},
-					EndPos:   Position{Offset: 10, Line: 11, Column: 12},
-				},
 			},
 		}
 

--- a/ast/block_test.go
+++ b/ast/block_test.go
@@ -82,38 +82,80 @@ func TestBlock_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	block := &Block{
-		Statements: []Statement{
-			&ExpressionStatement{
-				Expression: &BoolExpression{
-					Value: false,
-				},
-			},
-			&ExpressionStatement{
-				Expression: &StringExpression{
-					Value: "test",
-				},
-			},
-		},
-	}
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
 
-	require.Equal(
-		t,
-		prettier.Concat{
-			prettier.Text("{"),
-			prettier.Indent{
-				Doc: prettier.Concat{
-					prettier.HardLine{},
-					prettier.Text("false"),
-					prettier.HardLine{},
-					prettier.Text("\"test\""),
+		block := &Block{}
+
+		require.Equal(
+			t,
+			prettier.Text("{}"),
+			block.Doc(),
+		)
+	})
+
+	t.Run("with statements", func(t *testing.T) {
+		t.Parallel()
+
+		block := &Block{
+			Statements: []Statement{
+				&ExpressionStatement{
+					Expression: &BoolExpression{
+						Value: false,
+					},
+				},
+				&ExpressionStatement{
+					Expression: &StringExpression{
+						Value: "test",
+					},
 				},
 			},
-			prettier.HardLine{},
-			prettier.Text("}"),
-		},
-		block.Doc(),
-	)
+		}
+
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.HardLine{},
+						prettier.Text("false"),
+						prettier.HardLine{},
+						prettier.Text("\"test\""),
+					},
+				},
+				prettier.HardLine{},
+				prettier.Text("}"),
+			},
+			block.Doc(),
+		)
+	})
+
+	t.Run("with nil statement", func(t *testing.T) {
+		t.Parallel()
+
+		block := &Block{
+			Statements: []Statement{
+				nil,
+			},
+		}
+
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.HardLine{},
+						prettier.Text(""),
+					},
+				},
+				prettier.HardLine{},
+				prettier.Text("}"),
+			},
+			block.Doc(),
+		)
+	})
 }
 
 func TestBlock_String(t *testing.T) {
@@ -368,6 +410,20 @@ func TestFunctionBlock_Doc(t *testing.T) {
 
 	t.Parallel()
 
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		block := &FunctionBlock{
+			Block: &Block{},
+		}
+
+		require.Equal(
+			t,
+			prettier.Text("{}"),
+			block.Doc(),
+		)
+	})
+
 	t.Run("with statements", func(t *testing.T) {
 
 		t.Parallel()
@@ -399,7 +455,8 @@ func TestFunctionBlock_Doc(t *testing.T) {
 						prettier.Text("false"),
 						prettier.HardLine{},
 						prettier.Text("\"test\""),
-					}},
+					},
+				},
 				prettier.HardLine{},
 				prettier.Text("}"),
 			},
@@ -497,7 +554,8 @@ func TestFunctionBlock_Doc(t *testing.T) {
 								},
 								prettier.HardLine{},
 								prettier.Text("}"),
-							}},
+							},
+						},
 						prettier.HardLine{},
 						prettier.Group{
 							Doc: prettier.Concat{
@@ -514,20 +572,91 @@ func TestFunctionBlock_Doc(t *testing.T) {
 								},
 								prettier.HardLine{},
 								prettier.Text("}"),
-							}},
+							},
+						},
 						prettier.Concat{
 							prettier.HardLine{},
 							prettier.Text("false"),
 							prettier.HardLine{},
 							prettier.Text("\"test\""),
 						},
-					}},
+					},
+				},
 				prettier.HardLine{},
 				prettier.Text("}"),
 			},
 			block.Doc(),
 		)
 	})
+
+	t.Run("with nil precondition and postcondition", func(t *testing.T) {
+
+		t.Parallel()
+
+		block := &FunctionBlock{
+			Block: &Block{
+				Statements: []Statement{},
+			},
+			PreConditions: &Conditions{
+				Conditions: []Condition{
+					nil,
+				},
+			},
+			PostConditions: &Conditions{
+				Conditions: []Condition{
+					nil,
+				},
+			},
+		}
+
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.HardLine{},
+						prettier.Group{
+							Doc: prettier.Concat{
+								prettier.Text("pre"),
+								prettier.Text(" "),
+								prettier.Text("{"),
+								prettier.Indent{
+									Doc: prettier.Concat{
+										prettier.HardLine{},
+										prettier.Text(""),
+									},
+								},
+								prettier.HardLine{},
+								prettier.Text("}"),
+							},
+						},
+						prettier.HardLine{},
+						prettier.Group{
+							Doc: prettier.Concat{
+								prettier.Text("post"),
+								prettier.Text(" "),
+								prettier.Text("{"),
+								prettier.Indent{
+									Doc: prettier.Concat{
+										prettier.HardLine{},
+										prettier.Text(""),
+									},
+								},
+								prettier.HardLine{},
+								prettier.Text("}"),
+							},
+						},
+						prettier.Concat(nil),
+					},
+				},
+				prettier.HardLine{},
+				prettier.Text("}"),
+			},
+			block.Doc(),
+		)
+	})
+
 }
 
 func TestFunctionBlock_String(t *testing.T) {
@@ -625,6 +754,151 @@ func TestFunctionBlock_String(t *testing.T) {
 				"    \"test\"\n"+
 				"}",
 			block.String(),
+		)
+	})
+
+	t.Run("with nil precondition and postcondition", func(t *testing.T) {
+
+		t.Parallel()
+
+		block := &FunctionBlock{
+			Block: &Block{
+				Statements: []Statement{},
+			},
+			PreConditions: &Conditions{
+				Conditions: []Condition{
+					nil,
+				},
+			},
+			PostConditions: &Conditions{
+				Conditions: []Condition{
+					nil,
+				},
+			},
+		}
+
+		require.Equal(
+			t,
+			"{\n"+
+				"    pre {\n"+
+				"        \n"+
+				"    }\n"+
+				"    post {\n"+
+				"        \n"+
+				"    }\n"+
+				"}",
+			block.String(),
+		)
+	})
+
+}
+
+func TestTestCondition_Doc(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with test and message", func(t *testing.T) {
+
+		t.Parallel()
+
+		condition := TestCondition{
+			Test: &BoolExpression{
+				Value: true,
+				Range: Range{
+					StartPos: Position{Offset: 1, Line: 2, Column: 3},
+					EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+				},
+			},
+			Message: &StringExpression{
+				Value: "Test condition",
+				Range: Range{
+					StartPos: Position{Offset: 7, Line: 8, Column: 9},
+					EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+				},
+			},
+		}
+
+		require.Equal(
+			t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("true"),
+					prettier.Text(":"),
+					prettier.Indent{
+						Doc: prettier.Concat{
+							prettier.HardLine{},
+							prettier.Text(`"Test condition"`),
+						},
+					},
+				},
+			},
+			condition.Doc(),
+		)
+	})
+
+	t.Run("with test, without message", func(t *testing.T) {
+
+		t.Parallel()
+
+		condition := TestCondition{
+			Test: &BoolExpression{
+				Value: true,
+				Range: Range{
+					StartPos: Position{Offset: 1, Line: 2, Column: 3},
+					EndPos:   Position{Offset: 4, Line: 5, Column: 6},
+				},
+			},
+		}
+
+		require.Equal(t,
+			prettier.Group{
+				Doc: prettier.Text("true"),
+			},
+			condition.Doc(),
+		)
+	})
+
+	t.Run("without test, with message", func(t *testing.T) {
+
+		t.Parallel()
+
+		condition := TestCondition{
+			Message: &StringExpression{
+				Value: "Test condition",
+				Range: Range{
+					StartPos: Position{Offset: 7, Line: 8, Column: 9},
+					EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+				},
+			},
+		}
+
+		require.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text(""),
+					prettier.Text(":"),
+					prettier.Indent{
+						Doc: prettier.Concat{
+							prettier.HardLine{},
+							prettier.Text(`"Test condition"`),
+						},
+					},
+				},
+			},
+			condition.Doc(),
+		)
+	})
+
+	t.Run("without test, without message", func(t *testing.T) {
+
+		t.Parallel()
+
+		condition := TestCondition{}
+
+		require.Equal(t,
+			prettier.Group{
+				Doc: prettier.Text(""),
+			},
+			condition.Doc(),
 		)
 	})
 }

--- a/ast/composite.go
+++ b/ast/composite.go
@@ -154,9 +154,16 @@ func (d *CompositeDeclaration) EventDoc() prettier.Doc {
 	var doc prettier.Concat
 
 	if d.Access != AccessNotSpecified {
+		var accessDoc prettier.Doc
+		if d.Access == nil {
+			accessDoc = prettier.Text("")
+		} else {
+			accessDoc = d.Access.Doc()
+		}
+
 		doc = append(
 			doc,
-			prettier.Text(d.Access.Keyword()),
+			accessDoc,
 			prettier.HardLine{},
 		)
 	}
@@ -202,9 +209,16 @@ func CompositeDocument(
 	var doc prettier.Concat
 
 	if access != AccessNotSpecified {
+		var accessDoc prettier.Doc
+		if access == nil {
+			accessDoc = prettier.Text("")
+		} else {
+			accessDoc = access.Doc()
+		}
+
 		doc = append(
 			doc,
-			prettier.Text(access.Keyword()),
+			accessDoc,
 			prettier.HardLine{},
 		)
 	}
@@ -465,8 +479,15 @@ func (d *FieldDeclaration) Doc() prettier.Doc {
 	}
 
 	if d.Access != AccessNotSpecified {
+		var accessDoc prettier.Doc
+		if d.Access == nil {
+			accessDoc = prettier.Text("")
+		} else {
+			accessDoc = d.Access.Doc()
+		}
+
 		doc = prettier.Concat{
-			prettier.Text(d.Access.Keyword()),
+			accessDoc,
 			prettier.HardLine{},
 			doc,
 		}
@@ -575,9 +596,16 @@ func (d *EnumCaseDeclaration) Doc() prettier.Doc {
 	var doc prettier.Concat
 
 	if d.Access != AccessNotSpecified {
+		var accessDoc prettier.Doc
+		if d.Access == nil {
+			accessDoc = prettier.Text("")
+		} else {
+			accessDoc = d.Access.Doc()
+		}
+
 		doc = append(
 			doc,
-			prettier.Text(d.Access.Keyword()),
+			accessDoc,
 			prettier.HardLine{},
 		)
 	}

--- a/ast/composite.go
+++ b/ast/composite.go
@@ -154,16 +154,9 @@ func (d *CompositeDeclaration) EventDoc() prettier.Doc {
 	var doc prettier.Concat
 
 	if d.Access != AccessNotSpecified {
-		var accessDoc prettier.Doc
-		if d.Access == nil {
-			accessDoc = prettier.Text("")
-		} else {
-			accessDoc = d.Access.Doc()
-		}
-
 		doc = append(
 			doc,
-			accessDoc,
+			docOrEmpty(d.Access),
 			prettier.HardLine{},
 		)
 	}
@@ -209,16 +202,9 @@ func CompositeDocument(
 	var doc prettier.Concat
 
 	if access != AccessNotSpecified {
-		var accessDoc prettier.Doc
-		if access == nil {
-			accessDoc = prettier.Text("")
-		} else {
-			accessDoc = access.Doc()
-		}
-
 		doc = append(
 			doc,
-			accessDoc,
+			docOrEmpty(access),
 			prettier.HardLine{},
 		)
 	}
@@ -479,15 +465,8 @@ func (d *FieldDeclaration) Doc() prettier.Doc {
 	}
 
 	if d.Access != AccessNotSpecified {
-		var accessDoc prettier.Doc
-		if d.Access == nil {
-			accessDoc = prettier.Text("")
-		} else {
-			accessDoc = d.Access.Doc()
-		}
-
 		doc = prettier.Concat{
-			accessDoc,
+			docOrEmpty(d.Access),
 			prettier.HardLine{},
 			doc,
 		}
@@ -596,16 +575,9 @@ func (d *EnumCaseDeclaration) Doc() prettier.Doc {
 	var doc prettier.Concat
 
 	if d.Access != AccessNotSpecified {
-		var accessDoc prettier.Doc
-		if d.Access == nil {
-			accessDoc = prettier.Text("")
-		} else {
-			accessDoc = d.Access.Doc()
-		}
-
 		doc = append(
 			doc,
-			accessDoc,
+			docOrEmpty(d.Access),
 			prettier.HardLine{},
 		)
 	}

--- a/ast/entitlement_declaration.go
+++ b/ast/entitlement_declaration.go
@@ -105,16 +105,9 @@ func (d *EntitlementDeclaration) Doc() prettier.Doc {
 	var doc prettier.Concat
 
 	if d.Access != AccessNotSpecified {
-		var accessDoc prettier.Doc
-		if d.Access == nil {
-			accessDoc = prettier.Text("")
-		} else {
-			accessDoc = d.Access.Doc()
-		}
-
 		doc = append(
 			doc,
-			accessDoc,
+			docOrEmpty(d.Access),
 			prettier.HardLine{},
 		)
 	}
@@ -274,16 +267,9 @@ func (d *EntitlementMappingDeclaration) Doc() prettier.Doc {
 	var doc prettier.Concat
 
 	if d.Access != AccessNotSpecified {
-		var accessDoc prettier.Doc
-		if d.Access == nil {
-			accessDoc = prettier.Text("")
-		} else {
-			accessDoc = d.Access.Doc()
-		}
-
 		doc = append(
 			doc,
-			accessDoc,
+			docOrEmpty(d.Access),
 			prettier.HardLine{},
 		)
 	}

--- a/ast/entitlement_declaration.go
+++ b/ast/entitlement_declaration.go
@@ -105,9 +105,16 @@ func (d *EntitlementDeclaration) Doc() prettier.Doc {
 	var doc prettier.Concat
 
 	if d.Access != AccessNotSpecified {
+		var accessDoc prettier.Doc
+		if d.Access == nil {
+			accessDoc = prettier.Text("")
+		} else {
+			accessDoc = d.Access.Doc()
+		}
+
 		doc = append(
 			doc,
-			prettier.Text(d.Access.Keyword()),
+			accessDoc,
 			prettier.HardLine{},
 		)
 	}
@@ -267,9 +274,16 @@ func (d *EntitlementMappingDeclaration) Doc() prettier.Doc {
 	var doc prettier.Concat
 
 	if d.Access != AccessNotSpecified {
+		var accessDoc prettier.Doc
+		if d.Access == nil {
+			accessDoc = prettier.Text("")
+		} else {
+			accessDoc = d.Access.Doc()
+		}
+
 		doc = append(
 			doc,
-			prettier.Text(d.Access.Keyword()),
+			accessDoc,
 			prettier.HardLine{},
 		)
 	}

--- a/ast/expression.go
+++ b/ast/expression.go
@@ -1241,7 +1241,7 @@ func parenthesizedExpressionDoc(e Expression, parentPrecedence precedence) prett
 
 func (e *UnaryExpression) Doc() prettier.Doc {
 	return prettier.Concat{
-		prettier.Text(e.Operation.Symbol()),
+		e.Operation.Doc(),
 		parenthesizedExpressionDoc(
 			e.Expression,
 			e.precedence(),
@@ -1347,7 +1347,7 @@ func (e *BinaryExpression) Doc() prettier.Doc {
 				Doc: leftDoc,
 			},
 			prettier.Line{},
-			prettier.Text(e.Operation.Symbol()),
+			e.Operation.Doc(),
 			prettier.Space,
 			prettier.Group{
 				Doc: rightDoc,
@@ -1678,7 +1678,7 @@ func (e *CastingExpression) Doc() prettier.Doc {
 				Doc: doc,
 			},
 			prettier.Line{},
-			prettier.Text(e.Operation.Symbol()),
+			e.Operation.Doc(),
 			prettier.Line{},
 			e.TypeAnnotation.Doc(),
 		},

--- a/ast/expression.go
+++ b/ast/expression.go
@@ -1513,9 +1513,16 @@ func FunctionDocument(
 	var doc prettier.Concat
 
 	if access != AccessNotSpecified {
+		var accessDoc prettier.Doc
+		if access == nil {
+			accessDoc = prettier.Text("")
+		} else {
+			accessDoc = access.Doc()
+		}
+
 		doc = append(
 			doc,
-			prettier.Text(access.Keyword()),
+			accessDoc,
 			prettier.HardLine{},
 		)
 	}

--- a/ast/expression.go
+++ b/ast/expression.go
@@ -1513,16 +1513,9 @@ func FunctionDocument(
 	var doc prettier.Concat
 
 	if access != AccessNotSpecified {
-		var accessDoc prettier.Doc
-		if access == nil {
-			accessDoc = prettier.Text("")
-		} else {
-			accessDoc = access.Doc()
-		}
-
 		doc = append(
 			doc,
-			accessDoc,
+			docOrEmpty(access),
 			prettier.HardLine{},
 		)
 	}

--- a/ast/operation.go
+++ b/ast/operation.go
@@ -21,6 +21,8 @@ package ast
 import (
 	"encoding/json"
 
+	"github.com/turbolent/prettier"
+
 	"github.com/onflow/cadence/errors"
 )
 
@@ -110,6 +112,8 @@ func (s Operation) Symbol() string {
 		return "<<"
 	case OperationBitwiseRightShift:
 		return ">>"
+	case OperationUnknown:
+		return ""
 	}
 
 	panic(errors.NewUnreachableError())
@@ -161,4 +165,8 @@ func (s Operation) Category() string {
 
 func (s Operation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.String())
+}
+
+func (s Operation) Doc() prettier.Doc {
+	return prettier.Text(s.Symbol())
 }

--- a/ast/parameter.go
+++ b/ast/parameter.go
@@ -104,15 +104,23 @@ func (p *Parameter) Doc() prettier.Doc {
 		)
 	}
 
+	var typeAnnotationDoc prettier.Doc
+	if p.TypeAnnotation == nil {
+		typeAnnotationDoc = prettier.Text("")
+	} else {
+		typeAnnotationDoc = p.TypeAnnotation.Doc()
+	}
+
 	parameterDoc = append(
 		parameterDoc,
 		prettier.Text(p.Identifier.Identifier),
 		typeSeparatorSpaceDoc,
-		p.TypeAnnotation.Doc(),
+		typeAnnotationDoc,
 	)
 
 	if p.DefaultArgument != nil {
-		parameterDoc = append(parameterDoc,
+		parameterDoc = append(
+			parameterDoc,
 			prettier.Space,
 			prettier.Text(parameterDefaultArgumentSeparator),
 			prettier.Space,
@@ -121,4 +129,8 @@ func (p *Parameter) Doc() prettier.Doc {
 	}
 
 	return parameterDoc
+}
+
+func (p *Parameter) String() string {
+	return Prettier(p)
 }

--- a/ast/parameter.go
+++ b/ast/parameter.go
@@ -104,18 +104,11 @@ func (p *Parameter) Doc() prettier.Doc {
 		)
 	}
 
-	var typeAnnotationDoc prettier.Doc
-	if p.TypeAnnotation == nil {
-		typeAnnotationDoc = prettier.Text("")
-	} else {
-		typeAnnotationDoc = p.TypeAnnotation.Doc()
-	}
-
 	parameterDoc = append(
 		parameterDoc,
 		prettier.Text(p.Identifier.Identifier),
 		typeSeparatorSpaceDoc,
-		typeAnnotationDoc,
+		docOrEmpty(p.TypeAnnotation),
 	)
 
 	if p.DefaultArgument != nil {

--- a/ast/parameter_test.go
+++ b/ast/parameter_test.go
@@ -1,0 +1,232 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/turbolent/prettier"
+)
+
+func TestParameter_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("without label", func(t *testing.T) {
+		t.Parallel()
+
+		parameter := &Parameter{
+			Identifier: Identifier{Identifier: "e"},
+			TypeAnnotation: &TypeAnnotation{
+				Type: &NominalType{
+					Identifier: Identifier{Identifier: "E"},
+				},
+			},
+		}
+
+		require.Equal(t,
+			prettier.Concat{
+				prettier.Text("e"),
+				prettier.Text(": "),
+				prettier.Text("E"),
+			},
+			parameter.Doc(),
+		)
+
+	})
+
+	t.Run("with label", func(t *testing.T) {
+		t.Parallel()
+
+		parameter := &Parameter{
+			Label:      "c",
+			Identifier: Identifier{Identifier: "d"},
+			TypeAnnotation: &TypeAnnotation{
+				Type: &NominalType{
+					Identifier: Identifier{Identifier: "D"},
+				},
+			},
+		}
+
+		require.Equal(t,
+			prettier.Concat{
+				prettier.Text("c"),
+				prettier.Text(" "),
+				prettier.Text("d"),
+				prettier.Text(": "),
+				prettier.Text("D"),
+			},
+			parameter.Doc(),
+		)
+	})
+
+	t.Run("with label, without type annotation", func(t *testing.T) {
+		t.Parallel()
+
+		parameter := &Parameter{
+			Label:      "a",
+			Identifier: Identifier{Identifier: "b"},
+		}
+
+		require.Equal(t,
+			prettier.Concat{
+				prettier.Text("a"),
+				prettier.Text(" "),
+				prettier.Text("b"),
+				prettier.Text(": "),
+				prettier.Text(""),
+			},
+			parameter.Doc(),
+		)
+	})
+
+	t.Run("without label, without type annotation", func(t *testing.T) {
+		t.Parallel()
+
+		parameter := &Parameter{
+			Identifier: Identifier{Identifier: "b"},
+		}
+
+		require.Equal(t,
+			prettier.Concat{
+				prettier.Text("b"),
+				prettier.Text(": "),
+				prettier.Text(""),
+			},
+			parameter.Doc(),
+		)
+	})
+
+	t.Run("with default argument", func(t *testing.T) {
+		t.Parallel()
+
+		parameter := &Parameter{
+			Identifier: Identifier{Identifier: "bool"},
+			TypeAnnotation: &TypeAnnotation{
+				Type: &NominalType{
+					Identifier: Identifier{Identifier: "Bool"},
+				},
+			},
+			DefaultArgument: &BoolExpression{Value: true},
+		}
+
+		require.Equal(t,
+			prettier.Concat{
+				prettier.Text("bool"),
+				prettier.Text(": "),
+				prettier.Text("Bool"),
+				prettier.Text(" "),
+				prettier.Text("="),
+				prettier.Text(" "),
+				prettier.Text("true"),
+			},
+			parameter.Doc(),
+		)
+	})
+}
+
+func TestParameter_String(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("without label", func(t *testing.T) {
+		t.Parallel()
+
+		parameter := &Parameter{
+			Identifier: Identifier{Identifier: "e"},
+			TypeAnnotation: &TypeAnnotation{
+				Type: &NominalType{
+					Identifier: Identifier{Identifier: "E"},
+				},
+			},
+		}
+
+		require.Equal(t,
+			"e: E",
+			parameter.String(),
+		)
+
+	})
+
+	t.Run("with label", func(t *testing.T) {
+		t.Parallel()
+
+		parameter := &Parameter{
+			Label:      "c",
+			Identifier: Identifier{Identifier: "d"},
+			TypeAnnotation: &TypeAnnotation{
+				Type: &NominalType{
+					Identifier: Identifier{Identifier: "D"},
+				},
+			},
+		}
+
+		require.Equal(t,
+			"c d: D",
+			parameter.String(),
+		)
+	})
+
+	t.Run("with label, without type annotation", func(t *testing.T) {
+		t.Parallel()
+
+		parameter := &Parameter{
+			Label:      "a",
+			Identifier: Identifier{Identifier: "b"},
+		}
+
+		require.Equal(t,
+			"a b: ",
+			parameter.String(),
+		)
+	})
+
+	t.Run("without label, without type annotation", func(t *testing.T) {
+		t.Parallel()
+
+		parameter := &Parameter{
+			Identifier: Identifier{Identifier: "b"},
+		}
+
+		require.Equal(t,
+			"b: ",
+			parameter.String(),
+		)
+	})
+
+	t.Run("with default argument", func(t *testing.T) {
+		t.Parallel()
+
+		parameter := &Parameter{
+			Identifier: Identifier{Identifier: "bool"},
+			TypeAnnotation: &TypeAnnotation{
+				Type: &NominalType{
+					Identifier: Identifier{Identifier: "Bool"},
+				},
+			},
+			DefaultArgument: &BoolExpression{Value: true},
+		}
+
+		require.Equal(t,
+			"bool: Bool = true",
+			parameter.String(),
+		)
+	})
+}

--- a/ast/parameterlist.go
+++ b/ast/parameterlist.go
@@ -92,13 +92,10 @@ func (l *ParameterList) Doc() prettier.Doc {
 	parameterDocs := make([]prettier.Doc, 0, len(l.Parameters))
 
 	for _, parameter := range l.Parameters {
-		var parameterDoc prettier.Doc
-		if parameter == nil {
-			parameterDoc = prettier.Text("")
-		} else {
-			parameterDoc = parameter.Doc()
-		}
-		parameterDocs = append(parameterDocs, parameterDoc)
+		parameterDocs = append(
+			parameterDocs,
+			docOrEmpty(parameter),
+		)
 	}
 
 	return prettier.WrapParentheses(

--- a/ast/parameterlist.go
+++ b/ast/parameterlist.go
@@ -92,7 +92,13 @@ func (l *ParameterList) Doc() prettier.Doc {
 	parameterDocs := make([]prettier.Doc, 0, len(l.Parameters))
 
 	for _, parameter := range l.Parameters {
-		parameterDocs = append(parameterDocs, parameter.Doc())
+		var parameterDoc prettier.Doc
+		if parameter == nil {
+			parameterDoc = prettier.Text("")
+		} else {
+			parameterDoc = parameter.Doc()
+		}
+		parameterDocs = append(parameterDocs, parameterDoc)
 	}
 
 	return prettier.WrapParentheses(

--- a/ast/parameterlist_test.go
+++ b/ast/parameterlist_test.go
@@ -91,120 +91,188 @@ func TestParameterList_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	params := &ParameterList{
-		Parameters: []*Parameter{
-			{
-				Identifier: Identifier{Identifier: "e"},
-				TypeAnnotation: &TypeAnnotation{
-					Type: &NominalType{
-						Identifier: Identifier{Identifier: "E"},
-					},
-				},
-			},
-			{
-				Label:      "c",
-				Identifier: Identifier{Identifier: "d"},
-				TypeAnnotation: &TypeAnnotation{
-					Type: &NominalType{
-						Identifier: Identifier{Identifier: "D"},
-					},
-				},
-			},
-			{
-				Label:      "a",
-				Identifier: Identifier{Identifier: "b"},
-				TypeAnnotation: &TypeAnnotation{
-					Type: &NominalType{
-						Identifier: Identifier{Identifier: "B"},
-					},
-				},
-			},
-		},
-	}
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
 
-	require.Equal(t,
-		prettier.Group{
-			Doc: prettier.Concat{
-				prettier.Text("("),
-				prettier.Indent{
-					Doc: prettier.Concat{
-						prettier.SoftLine{},
-						prettier.Concat{
-							prettier.Concat{
-								prettier.Text("e"),
-								prettier.Text(": "),
-								prettier.Text("E"),
-							},
-							prettier.Concat{
-								prettier.Text(","),
-								prettier.Line{},
-							},
-							prettier.Concat{
-								prettier.Text("c"),
-								prettier.Text(" "),
-								prettier.Text("d"),
-								prettier.Text(": "),
-								prettier.Text("D"),
-							},
-							prettier.Concat{
-								prettier.Text(","),
-								prettier.Line{},
-							},
-							prettier.Concat{
-								prettier.Text("a"),
-								prettier.Text(" "),
-								prettier.Text("b"),
-								prettier.Text(": "),
-								prettier.Text("B"),
-							},
+		params := &ParameterList{}
+		require.Equal(t,
+			prettier.Text("()"),
+			params.Doc(),
+		)
+	})
+
+	t.Run("with nil parameter", func(t *testing.T) {
+		t.Parallel()
+
+		params := &ParameterList{
+			Parameters: []*Parameter{
+				nil,
+			},
+		}
+		require.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("("),
+					prettier.Indent{
+						Doc: prettier.Concat{
+							prettier.SoftLine{},
+							prettier.Text(""),
+						},
+					},
+					prettier.SoftLine{},
+					prettier.Text(")"),
+				},
+			},
+			params.Doc(),
+		)
+	})
+
+	t.Run("with parameters", func(t *testing.T) {
+		t.Parallel()
+
+		params := &ParameterList{
+			Parameters: []*Parameter{
+				{
+					Identifier: Identifier{Identifier: "e"},
+					TypeAnnotation: &TypeAnnotation{
+						Type: &NominalType{
+							Identifier: Identifier{Identifier: "E"},
 						},
 					},
 				},
-				prettier.SoftLine{},
-				prettier.Text(")"),
+				{
+					Label:      "c",
+					Identifier: Identifier{Identifier: "d"},
+					TypeAnnotation: &TypeAnnotation{
+						Type: &NominalType{
+							Identifier: Identifier{Identifier: "D"},
+						},
+					},
+				},
+				{
+					Label:      "a",
+					Identifier: Identifier{Identifier: "b"},
+					TypeAnnotation: &TypeAnnotation{
+						Type: &NominalType{
+							Identifier: Identifier{Identifier: "B"},
+						},
+					},
+				},
 			},
-		},
-		params.Doc(),
-	)
+		}
+
+		require.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("("),
+					prettier.Indent{
+						Doc: prettier.Concat{
+							prettier.SoftLine{},
+							prettier.Concat{
+								prettier.Concat{
+									prettier.Text("e"),
+									prettier.Text(": "),
+									prettier.Text("E"),
+								},
+								prettier.Concat{
+									prettier.Text(","),
+									prettier.Line{},
+								},
+								prettier.Concat{
+									prettier.Text("c"),
+									prettier.Text(" "),
+									prettier.Text("d"),
+									prettier.Text(": "),
+									prettier.Text("D"),
+								},
+								prettier.Concat{
+									prettier.Text(","),
+									prettier.Line{},
+								},
+								prettier.Concat{
+									prettier.Text("a"),
+									prettier.Text(" "),
+									prettier.Text("b"),
+									prettier.Text(": "),
+									prettier.Text("B"),
+								},
+							},
+						},
+					},
+					prettier.SoftLine{},
+					prettier.Text(")"),
+				},
+			},
+			params.Doc(),
+		)
+	})
 }
 
 func TestParameterList_String(t *testing.T) {
 
 	t.Parallel()
 
-	params := &ParameterList{
-		Parameters: []*Parameter{
-			{
-				Identifier: Identifier{Identifier: "e"},
-				TypeAnnotation: &TypeAnnotation{
-					Type: &NominalType{
-						Identifier: Identifier{Identifier: "E"},
-					},
-				},
-			},
-			{
-				Label:      "c",
-				Identifier: Identifier{Identifier: "d"},
-				TypeAnnotation: &TypeAnnotation{
-					Type: &NominalType{
-						Identifier: Identifier{Identifier: "D"},
-					},
-				},
-			},
-			{
-				Label:      "a",
-				Identifier: Identifier{Identifier: "b"},
-				TypeAnnotation: &TypeAnnotation{
-					Type: &NominalType{
-						Identifier: Identifier{Identifier: "B"},
-					},
-				},
-			},
-		},
-	}
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
 
-	require.Equal(t,
-		"(e: E, c d: D, a b: B)",
-		params.String(),
-	)
+		params := &ParameterList{}
+		require.Equal(t,
+			"()",
+			params.String(),
+		)
+	})
+
+	t.Run("with nil parameter", func(t *testing.T) {
+		t.Parallel()
+
+		params := &ParameterList{
+			Parameters: []*Parameter{
+				nil,
+			},
+		}
+		require.Equal(t,
+			"()",
+			params.String(),
+		)
+	})
+
+	t.Run("with parameters", func(t *testing.T) {
+		t.Parallel()
+
+		params := &ParameterList{
+			Parameters: []*Parameter{
+				{
+					Identifier: Identifier{Identifier: "e"},
+					TypeAnnotation: &TypeAnnotation{
+						Type: &NominalType{
+							Identifier: Identifier{Identifier: "E"},
+						},
+					},
+				},
+				{
+					Label:      "c",
+					Identifier: Identifier{Identifier: "d"},
+					TypeAnnotation: &TypeAnnotation{
+						Type: &NominalType{
+							Identifier: Identifier{Identifier: "D"},
+						},
+					},
+				},
+				{
+					Label:      "a",
+					Identifier: Identifier{Identifier: "b"},
+					TypeAnnotation: &TypeAnnotation{
+						Type: &NominalType{
+							Identifier: Identifier{Identifier: "B"},
+						},
+					},
+				},
+			},
+		}
+
+		require.Equal(t,
+			"(e: E, c d: D, a b: B)",
+			params.String(),
+		)
+	})
 }

--- a/ast/pragma.go
+++ b/ast/pragma.go
@@ -88,9 +88,17 @@ func (d *PragmaDeclaration) MarshalJSON() ([]byte, error) {
 	})
 }
 
+var pragmaStartDoc prettier.Doc = prettier.Text("#")
+
 func (d *PragmaDeclaration) Doc() prettier.Doc {
+	doc := pragmaStartDoc
+
+	if d.Expression == nil {
+		return doc
+	}
+
 	return prettier.Concat{
-		prettier.Text("#"),
+		doc,
 		d.Expression.Doc(),
 	}
 }

--- a/ast/pragma_test.go
+++ b/ast/pragma_test.go
@@ -71,35 +71,62 @@ func TestPragmaDeclaration_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	decl := &PragmaDeclaration{
-		Expression: &BoolExpression{
-			Value: false,
-		},
-	}
+	t.Run("nil expression", func(t *testing.T) {
+		decl := &PragmaDeclaration{}
 
-	require.Equal(
-		t,
-		prettier.Concat{
+		require.Equal(
+			t,
 			prettier.Text("#"),
-			prettier.Text("false"),
-		},
-		decl.Doc(),
-	)
+			decl.Doc(),
+		)
+	})
+
+	t.Run("with expression", func(t *testing.T) {
+
+		decl := &PragmaDeclaration{
+			Expression: &BoolExpression{
+				Value: false,
+			},
+		}
+
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("#"),
+				prettier.Text("false"),
+			},
+			decl.Doc(),
+		)
+	})
 }
 
 func TestPragmaDeclaration_String(t *testing.T) {
 
 	t.Parallel()
 
-	decl := &PragmaDeclaration{
-		Expression: &BoolExpression{
-			Value: false,
-		},
-	}
+	t.Run("nil expression", func(t *testing.T) {
+		decl := &PragmaDeclaration{}
 
-	require.Equal(
-		t,
-		"#false",
-		decl.String(),
-	)
+		require.Equal(
+			t,
+			"#",
+			decl.String(),
+		)
+	})
+
+	t.Run("with expression", func(t *testing.T) {
+		t.Parallel()
+
+		decl := &PragmaDeclaration{
+			Expression: &BoolExpression{
+				Value: false,
+			},
+		}
+
+		require.Equal(
+			t,
+			"#false",
+			decl.String(),
+		)
+	})
 }

--- a/ast/prettier.go
+++ b/ast/prettier.go
@@ -24,9 +24,30 @@ import (
 	"github.com/turbolent/prettier"
 )
 
-func Prettier(element interface{ Doc() prettier.Doc }) string {
+type Pretty interface {
+	Doc() prettier.Doc
+}
+
+func Prettier(element Pretty) string {
 	var builder strings.Builder
 	doc := element.Doc().Flatten()
 	prettier.Prettier(&builder, doc, 80, "    ")
 	return builder.String()
+}
+
+// docOrEmpty returns the document of the given element,
+// or an empty text document if the element is the zero value.
+//
+// NOTE: The function is generic because the version which takes an interface
+// will not properly allow for a nil check: When passing a pointer typed value as an interface,
+// a typed nil is created, which is not equal to nil.
+func docOrEmpty[T interface {
+	Pretty
+	comparable
+}](element T) prettier.Doc {
+	var empty T
+	if element == empty {
+		return prettier.Text("")
+	}
+	return element.Doc()
 }

--- a/ast/program.go
+++ b/ast/program.go
@@ -214,3 +214,7 @@ func (p *Program) Doc() prettier.Doc {
 
 	return prettier.Join(programSeparatorDoc, docs...)
 }
+
+func (p *Program) String() string {
+	return Prettier(p)
+}

--- a/ast/program.go
+++ b/ast/program.go
@@ -196,10 +196,20 @@ var programSeparatorDoc = prettier.Concat{
 func (p *Program) Doc() prettier.Doc {
 	declarations := p.Declarations()
 
+	if len(declarations) == 0 {
+		return prettier.Text("")
+	}
+
 	docs := make([]prettier.Doc, 0, len(declarations))
 
 	for _, declaration := range declarations {
-		docs = append(docs, declaration.Doc())
+		var declarationDoc prettier.Doc
+		if declaration == nil {
+			declarationDoc = prettier.Text("")
+		} else {
+			declarationDoc = declaration.Doc()
+		}
+		docs = append(docs, declarationDoc)
 	}
 
 	return prettier.Join(programSeparatorDoc, docs...)

--- a/ast/program.go
+++ b/ast/program.go
@@ -203,13 +203,7 @@ func (p *Program) Doc() prettier.Doc {
 	docs := make([]prettier.Doc, 0, len(declarations))
 
 	for _, declaration := range declarations {
-		var declarationDoc prettier.Doc
-		if declaration == nil {
-			declarationDoc = prettier.Text("")
-		} else {
-			declarationDoc = declaration.Doc()
-		}
-		docs = append(docs, declarationDoc)
+		docs = append(docs, docOrEmpty(declaration))
 	}
 
 	return prettier.Join(programSeparatorDoc, docs...)

--- a/ast/program_test.go
+++ b/ast/program_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/turbolent/prettier"
 )
 
 func TestProgram_MarshalJSON(t *testing.T) {
@@ -45,4 +46,65 @@ func TestProgram_MarshalJSON(t *testing.T) {
         `,
 		string(actual),
 	)
+}
+
+func TestProgram_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		program := NewProgram(nil, []Declaration{})
+
+		assert.Equal(t,
+			prettier.Text(""),
+			program.Doc(),
+		)
+	})
+
+	t.Run("with nil declaration", func(t *testing.T) {
+		t.Parallel()
+
+		program := NewProgram(nil, []Declaration{
+			nil,
+		})
+
+		assert.Equal(t,
+			prettier.Text(""),
+			program.Doc(),
+		)
+	})
+
+	t.Run("with declarations", func(t *testing.T) {
+		t.Parallel()
+
+		program := NewProgram(nil, []Declaration{
+			&PragmaDeclaration{
+				Expression: &BoolExpression{Value: true},
+			},
+			&PragmaDeclaration{
+				Expression: &BoolExpression{Value: false},
+			},
+		})
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Concat{
+					prettier.Text("#"),
+					prettier.Text("true"),
+				},
+				prettier.Concat{
+					prettier.HardLine{},
+					prettier.HardLine{},
+				},
+				prettier.Concat{
+					prettier.Text("#"),
+					prettier.Text("false"),
+				},
+			},
+			program.Doc(),
+		)
+	})
+
 }

--- a/ast/program_test.go
+++ b/ast/program_test.go
@@ -106,5 +106,54 @@ func TestProgram_Doc(t *testing.T) {
 			program.Doc(),
 		)
 	})
+}
+
+func TestProgram_String(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		program := NewProgram(nil, []Declaration{})
+
+		assert.Equal(t,
+			"",
+			program.String(),
+		)
+	})
+
+	t.Run("with nil declaration", func(t *testing.T) {
+		t.Parallel()
+
+		program := NewProgram(nil, []Declaration{
+			nil,
+		})
+
+		assert.Equal(t,
+			"",
+			program.String(),
+		)
+	})
+
+	t.Run("with declarations", func(t *testing.T) {
+		t.Parallel()
+
+		program := NewProgram(nil, []Declaration{
+			&PragmaDeclaration{
+				Expression: &BoolExpression{Value: true},
+			},
+			&PragmaDeclaration{
+				Expression: &BoolExpression{Value: false},
+			},
+		})
+
+		assert.Equal(t,
+			"#true\n"+
+				"\n"+
+				"#false",
+			program.String(),
+		)
+	})
 
 }

--- a/ast/transfer.go
+++ b/ast/transfer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/turbolent/prettier"
 
 	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/errors"
 )
 
 // Transfer represents the operation in variable declarations
@@ -69,11 +70,19 @@ var forceMoveTransferDoc prettier.Doc = prettier.Text("<-!")
 
 func (f Transfer) Doc() prettier.Doc {
 	switch f.Operation {
+	case TransferOperationCopy:
+		return copyTransferDoc
 	case TransferOperationMove:
 		return moveTransferDoc
 	case TransferOperationMoveForced:
 		return forceMoveTransferDoc
-	default:
-		return copyTransferDoc
+	case TransferOperationUnknown:
+		return prettier.Text("")
 	}
+
+	panic(errors.NewUnreachableError())
+}
+
+func (f Transfer) String() string {
+	return Prettier(f)
 }

--- a/ast/transfer_test.go
+++ b/ast/transfer_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/turbolent/prettier"
 )
 
 func TestTransfer_MarshalJSON(t *testing.T) {
@@ -50,4 +51,118 @@ func TestTransfer_MarshalJSON(t *testing.T) {
         `,
 		string(actual),
 	)
+}
+
+func TestTransfer_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("unknown operation", func(t *testing.T) {
+		t.Parallel()
+
+		transfer := Transfer{
+			Operation: TransferOperationUnknown,
+		}
+
+		assert.Equal(t,
+			prettier.Text(""),
+			transfer.Doc(),
+		)
+	})
+
+	t.Run("copy operation", func(t *testing.T) {
+		t.Parallel()
+
+		transfer := Transfer{
+			Operation: TransferOperationCopy,
+		}
+
+		assert.Equal(t,
+			prettier.Text("="),
+			transfer.Doc(),
+		)
+	})
+
+	t.Run("move operation", func(t *testing.T) {
+		t.Parallel()
+
+		transfer := Transfer{
+			Operation: TransferOperationMove,
+		}
+
+		assert.Equal(t,
+			prettier.Text("<-"),
+			transfer.Doc(),
+		)
+	})
+
+	t.Run("forced move operation", func(t *testing.T) {
+		t.Parallel()
+
+		transfer := Transfer{
+			Operation: TransferOperationMoveForced,
+		}
+
+		assert.Equal(t,
+			prettier.Text("<-!"),
+			transfer.Doc(),
+		)
+	})
+}
+
+func TestTransfer_String(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("unknown operation", func(t *testing.T) {
+		t.Parallel()
+
+		transfer := Transfer{
+			Operation: TransferOperationUnknown,
+		}
+
+		assert.Equal(t,
+			"",
+			transfer.String(),
+		)
+	})
+
+	t.Run("copy operation", func(t *testing.T) {
+		t.Parallel()
+
+		transfer := Transfer{
+			Operation: TransferOperationCopy,
+		}
+
+		assert.Equal(t,
+			"=",
+			transfer.String(),
+		)
+	})
+
+	t.Run("move operation", func(t *testing.T) {
+		t.Parallel()
+
+		transfer := Transfer{
+			Operation: TransferOperationMove,
+		}
+
+		assert.Equal(t,
+			"<-",
+			transfer.String(),
+		)
+	})
+
+	t.Run("forced move operation", func(t *testing.T) {
+		t.Parallel()
+
+		transfer := Transfer{
+			Operation: TransferOperationMoveForced,
+		}
+
+		assert.Equal(t,
+			"<-!",
+			transfer.String(),
+		)
+	})
 }

--- a/ast/type.go
+++ b/ast/type.go
@@ -808,6 +808,7 @@ const instantiationTypeEndDoc = prettier.Text(">")
 const instantiationTypeSeparatorDoc = prettier.Text(",")
 
 func (t *InstantiationType) Doc() prettier.Doc {
+
 	typeArgumentsDoc := prettier.Concat{
 		prettier.SoftLine{},
 	}
@@ -820,14 +821,29 @@ func (t *InstantiationType) Doc() prettier.Doc {
 				prettier.Line{},
 			)
 		}
+
+		var typeArgumentDoc prettier.Doc
+		if typeArgument == nil {
+			typeArgumentDoc = prettier.Text("")
+		} else {
+			typeArgumentDoc = typeArgument.Doc()
+		}
+
 		typeArgumentsDoc = append(
 			typeArgumentsDoc,
-			typeArgument.Doc(),
+			typeArgumentDoc,
 		)
 	}
 
+	var typeDoc prettier.Doc
+	if t.Type == nil {
+		typeDoc = prettier.Text("")
+	} else {
+		typeDoc = t.Type.Doc()
+	}
+
 	return prettier.Concat{
-		t.Type.Doc(),
+		typeDoc,
 		prettier.Group{
 			Doc: prettier.Concat{
 				instantiationTypeStartDoc,

--- a/ast/type.go
+++ b/ast/type.go
@@ -230,8 +230,14 @@ func (t *OptionalType) EndPosition(memoryGauge common.MemoryGauge) Position {
 const optionalTypeSymbolDoc = prettier.Text("?")
 
 func (t *OptionalType) Doc() prettier.Doc {
+	var typeDoc prettier.Doc
+	if t.Type == nil {
+		typeDoc = prettier.Text("")
+	} else {
+		typeDoc = t.Type.Doc()
+	}
 	return prettier.Concat{
-		t.Type.Doc(),
+		typeDoc,
 		optionalTypeSymbolDoc,
 	}
 }

--- a/ast/type.go
+++ b/ast/type.go
@@ -712,6 +712,7 @@ const intersectionTypeEndDoc = prettier.Text("}")
 const intersectionTypeSeparatorDoc = prettier.Text(",")
 
 func (t *IntersectionType) Doc() prettier.Doc {
+
 	intersectionDoc := prettier.Concat{
 		prettier.SoftLine{},
 	}
@@ -724,27 +725,28 @@ func (t *IntersectionType) Doc() prettier.Doc {
 				prettier.Line{},
 			)
 		}
+
+		var typDoc prettier.Doc
+		if typ == nil {
+			typDoc = prettier.Text("")
+		} else {
+			typDoc = typ.Doc()
+		}
+
 		intersectionDoc = append(
 			intersectionDoc,
-			typ.Doc(),
+			typDoc,
 		)
 	}
 
-	var doc prettier.Concat
-
-	return append(doc,
-		prettier.Group{
-			Doc: prettier.Concat{
-				intersectionTypeStartDoc,
-				prettier.Indent{
-					Doc: intersectionDoc,
-				},
-				prettier.SoftLine{},
-				intersectionTypeEndDoc,
-			},
+	return prettier.Concat{
+		intersectionTypeStartDoc,
+		prettier.Indent{
+			Doc: intersectionDoc,
 		},
-	)
-
+		prettier.SoftLine{},
+		intersectionTypeEndDoc,
+	}
 }
 
 func (t *IntersectionType) MarshalJSON() ([]byte, error) {

--- a/ast/type.go
+++ b/ast/type.go
@@ -290,12 +290,18 @@ const arrayTypeStartDoc = prettier.Text("[")
 const arrayTypeEndDoc = prettier.Text("]")
 
 func (t *VariableSizedType) Doc() prettier.Doc {
+	var typeDoc prettier.Doc
+	if t.Type == nil {
+		typeDoc = prettier.Text("")
+	} else {
+		typeDoc = t.Type.Doc()
+	}
 	return prettier.Concat{
 		arrayTypeStartDoc,
 		prettier.Indent{
 			Doc: prettier.Concat{
 				prettier.SoftLine{},
-				t.Type.Doc(),
+				typeDoc,
 			},
 		},
 		prettier.SoftLine{},

--- a/ast/type.go
+++ b/ast/type.go
@@ -68,12 +68,7 @@ func (t *TypeAnnotation) EndPosition(memoryGauge common.MemoryGauge) Position {
 const typeAnnotationResourceSymbolDoc = prettier.Text("@")
 
 func (t *TypeAnnotation) Doc() prettier.Doc {
-	var typeDoc prettier.Doc
-	if t.Type == nil {
-		typeDoc = prettier.Text("")
-	} else {
-		typeDoc = t.Type.Doc()
-	}
+	typeDoc := docOrEmpty(t.Type)
 
 	if !t.IsResource {
 		return typeDoc
@@ -230,12 +225,7 @@ func (t *OptionalType) EndPosition(memoryGauge common.MemoryGauge) Position {
 const optionalTypeSymbolDoc = prettier.Text("?")
 
 func (t *OptionalType) Doc() prettier.Doc {
-	var typeDoc prettier.Doc
-	if t.Type == nil {
-		typeDoc = prettier.Text("")
-	} else {
-		typeDoc = t.Type.Doc()
-	}
+	typeDoc := docOrEmpty(t.Type)
 	return prettier.Concat{
 		typeDoc,
 		optionalTypeSymbolDoc,
@@ -290,18 +280,12 @@ const arrayTypeStartDoc = prettier.Text("[")
 const arrayTypeEndDoc = prettier.Text("]")
 
 func (t *VariableSizedType) Doc() prettier.Doc {
-	var typeDoc prettier.Doc
-	if t.Type == nil {
-		typeDoc = prettier.Text("")
-	} else {
-		typeDoc = t.Type.Doc()
-	}
 	return prettier.Concat{
 		arrayTypeStartDoc,
 		prettier.Indent{
 			Doc: prettier.Concat{
 				prettier.SoftLine{},
-				typeDoc,
+				docOrEmpty(t.Type),
 			},
 		},
 		prettier.SoftLine{},
@@ -357,28 +341,14 @@ func (t *ConstantSizedType) String() string {
 const constantSizedTypeSeparatorSpaceDoc = prettier.Text("; ")
 
 func (t *ConstantSizedType) Doc() prettier.Doc {
-	var typeDoc prettier.Doc
-	if t.Type == nil {
-		typeDoc = prettier.Text("")
-	} else {
-		typeDoc = t.Type.Doc()
-	}
-
-	var sizeDoc prettier.Doc
-	if t.Size == nil {
-		sizeDoc = prettier.Text("")
-	} else {
-		sizeDoc = t.Size.Doc()
-	}
-
 	return prettier.Concat{
 		arrayTypeStartDoc,
 		prettier.Indent{
 			Doc: prettier.Concat{
 				prettier.SoftLine{},
-				typeDoc,
+				docOrEmpty(t.Type),
 				constantSizedTypeSeparatorSpaceDoc,
-				sizeDoc,
+				docOrEmpty(t.Size),
 			},
 		},
 		prettier.SoftLine{},
@@ -435,28 +405,14 @@ const dictionaryTypeStartDoc = prettier.Text("{")
 const dictionaryTypeEndDoc = prettier.Text("}")
 
 func (t *DictionaryType) Doc() prettier.Doc {
-	var keyTypeDoc prettier.Doc
-	if t.KeyType == nil {
-		keyTypeDoc = prettier.Text("")
-	} else {
-		keyTypeDoc = t.KeyType.Doc()
-	}
-
-	var valueTypeDoc prettier.Doc
-	if t.ValueType == nil {
-		valueTypeDoc = prettier.Text("")
-	} else {
-		valueTypeDoc = t.ValueType.Doc()
-	}
-
 	return prettier.Concat{
 		dictionaryTypeStartDoc,
 		prettier.Indent{
 			Doc: prettier.Concat{
 				prettier.SoftLine{},
-				keyTypeDoc,
+				docOrEmpty(t.KeyType),
 				typeSeparatorSpaceDoc,
-				valueTypeDoc,
+				docOrEmpty(t.ValueType),
 			},
 		},
 		prettier.SoftLine{},
@@ -547,24 +503,10 @@ func (t *FunctionType) Doc() prettier.Doc {
 			)
 		}
 
-		var parameterTypeAnnotationDoc prettier.Doc
-		if parameterTypeAnnotation == nil {
-			parameterTypeAnnotationDoc = prettier.Text("")
-		} else {
-			parameterTypeAnnotationDoc = parameterTypeAnnotation.Doc()
-		}
-
 		parametersDoc = append(
 			parametersDoc,
-			parameterTypeAnnotationDoc,
+			docOrEmpty(parameterTypeAnnotation),
 		)
-	}
-
-	var returnTypeAnnotationDoc prettier.Doc
-	if t.ReturnTypeAnnotation == nil {
-		returnTypeAnnotationDoc = prettier.Text("")
-	} else {
-		returnTypeAnnotationDoc = t.ReturnTypeAnnotation.Doc()
 	}
 
 	result = append(
@@ -580,7 +522,7 @@ func (t *FunctionType) Doc() prettier.Doc {
 			},
 		},
 		typeSeparatorSpaceDoc,
-		returnTypeAnnotationDoc,
+		docOrEmpty(t.ReturnTypeAnnotation),
 	)
 
 	return result
@@ -662,35 +604,21 @@ func (t *ReferenceType) Doc() prettier.Doc {
 				separatorDoc := prettier.Text(authorization.Separator().String())
 
 				for i, entitlement := range entitlements {
-					var entitlementDoc prettier.Doc
-					if entitlement == nil {
-						entitlementDoc = prettier.Text("")
-					} else {
-						entitlementDoc = entitlement.Doc()
-					}
-
-					doc = append(doc, entitlementDoc)
-					if i < len(entitlements)-1 {
+					if i > 0 {
 						doc = append(
 							doc,
 							separatorDoc,
 							prettier.Line{},
 						)
 					}
+					doc = append(doc, docOrEmpty(entitlement))
 				}
 			}
 
 		case *MappedAccess:
-			var entitlementMapDoc prettier.Doc
-			if authorization.EntitlementMap == nil {
-				entitlementMapDoc = prettier.Text("")
-			} else {
-				entitlementMapDoc = authorization.EntitlementMap.Doc()
-			}
-
 			doc = append(doc,
 				referenceTypeMappingKeywordDoc,
-				entitlementMapDoc,
+				docOrEmpty(authorization.EntitlementMap),
 			)
 
 		default:
@@ -704,17 +632,10 @@ func (t *ReferenceType) Doc() prettier.Doc {
 		)
 	}
 
-	var typeDoc prettier.Doc
-	if t.Type == nil {
-		typeDoc = prettier.Text("")
-	} else {
-		typeDoc = t.Type.Doc()
-	}
-
 	return append(
 		doc,
 		referenceTypeSymbolDoc,
-		typeDoc,
+		docOrEmpty(t.Type),
 	)
 }
 
@@ -782,16 +703,9 @@ func (t *IntersectionType) Doc() prettier.Doc {
 			)
 		}
 
-		var typDoc prettier.Doc
-		if typ == nil {
-			typDoc = prettier.Text("")
-		} else {
-			typDoc = typ.Doc()
-		}
-
 		intersectionDoc = append(
 			intersectionDoc,
-			typDoc,
+			docOrEmpty(typ),
 		)
 	}
 
@@ -880,28 +794,14 @@ func (t *InstantiationType) Doc() prettier.Doc {
 			)
 		}
 
-		var typeArgumentDoc prettier.Doc
-		if typeArgument == nil {
-			typeArgumentDoc = prettier.Text("")
-		} else {
-			typeArgumentDoc = typeArgument.Doc()
-		}
-
 		typeArgumentsDoc = append(
 			typeArgumentsDoc,
-			typeArgumentDoc,
+			docOrEmpty(typeArgument),
 		)
 	}
 
-	var typeDoc prettier.Doc
-	if t.Type == nil {
-		typeDoc = prettier.Text("")
-	} else {
-		typeDoc = t.Type.Doc()
-	}
-
 	return prettier.Concat{
-		typeDoc,
+		docOrEmpty(t.Type),
 		prettier.Group{
 			Doc: prettier.Concat{
 				instantiationTypeStartDoc,

--- a/ast/type.go
+++ b/ast/type.go
@@ -528,11 +528,15 @@ func (t *FunctionType) Doc() prettier.Doc {
 		result = append(
 			result,
 			prettier.Text(t.PurityAnnotation.Keyword()),
-			prettier.Space,
+			prettier.Line{},
 		)
 	}
 
-	result = append(result, functionTypeKeywordDoc, prettier.Space)
+	result = append(
+		result,
+		functionTypeKeywordDoc,
+		prettier.Line{},
+	)
 
 	for i, parameterTypeAnnotation := range t.ParameterTypeAnnotations {
 		if i > 0 {
@@ -542,10 +546,25 @@ func (t *FunctionType) Doc() prettier.Doc {
 				prettier.Line{},
 			)
 		}
+
+		var parameterTypeAnnotationDoc prettier.Doc
+		if parameterTypeAnnotation == nil {
+			parameterTypeAnnotationDoc = prettier.Text("")
+		} else {
+			parameterTypeAnnotationDoc = parameterTypeAnnotation.Doc()
+		}
+
 		parametersDoc = append(
 			parametersDoc,
-			parameterTypeAnnotation.Doc(),
+			parameterTypeAnnotationDoc,
 		)
+	}
+
+	var returnTypeAnnotationDoc prettier.Doc
+	if t.ReturnTypeAnnotation == nil {
+		returnTypeAnnotationDoc = prettier.Text("")
+	} else {
+		returnTypeAnnotationDoc = t.ReturnTypeAnnotation.Doc()
 	}
 
 	result = append(
@@ -561,7 +580,7 @@ func (t *FunctionType) Doc() prettier.Doc {
 			},
 		},
 		typeSeparatorSpaceDoc,
-		t.ReturnTypeAnnotation.Doc(),
+		returnTypeAnnotationDoc,
 	)
 
 	return result

--- a/ast/type.go
+++ b/ast/type.go
@@ -357,14 +357,28 @@ func (t *ConstantSizedType) String() string {
 const constantSizedTypeSeparatorSpaceDoc = prettier.Text("; ")
 
 func (t *ConstantSizedType) Doc() prettier.Doc {
+	var typeDoc prettier.Doc
+	if t.Type == nil {
+		typeDoc = prettier.Text("")
+	} else {
+		typeDoc = t.Type.Doc()
+	}
+
+	var sizeDoc prettier.Doc
+	if t.Size == nil {
+		sizeDoc = prettier.Text("")
+	} else {
+		sizeDoc = t.Size.Doc()
+	}
+
 	return prettier.Concat{
 		arrayTypeStartDoc,
 		prettier.Indent{
 			Doc: prettier.Concat{
 				prettier.SoftLine{},
-				t.Type.Doc(),
+				typeDoc,
 				constantSizedTypeSeparatorSpaceDoc,
-				t.Size.Doc(),
+				sizeDoc,
 			},
 		},
 		prettier.SoftLine{},

--- a/ast/type.go
+++ b/ast/type.go
@@ -435,14 +435,28 @@ const dictionaryTypeStartDoc = prettier.Text("{")
 const dictionaryTypeEndDoc = prettier.Text("}")
 
 func (t *DictionaryType) Doc() prettier.Doc {
+	var keyTypeDoc prettier.Doc
+	if t.KeyType == nil {
+		keyTypeDoc = prettier.Text("")
+	} else {
+		keyTypeDoc = t.KeyType.Doc()
+	}
+
+	var valueTypeDoc prettier.Doc
+	if t.ValueType == nil {
+		valueTypeDoc = prettier.Text("")
+	} else {
+		valueTypeDoc = t.ValueType.Doc()
+	}
+
 	return prettier.Concat{
 		dictionaryTypeStartDoc,
 		prettier.Indent{
 			Doc: prettier.Concat{
 				prettier.SoftLine{},
-				t.KeyType.Doc(),
+				keyTypeDoc,
 				typeSeparatorSpaceDoc,
-				t.ValueType.Doc(),
+				valueTypeDoc,
 			},
 		},
 		prettier.SoftLine{},

--- a/ast/type.go
+++ b/ast/type.go
@@ -68,13 +68,20 @@ func (t *TypeAnnotation) EndPosition(memoryGauge common.MemoryGauge) Position {
 const typeAnnotationResourceSymbolDoc = prettier.Text("@")
 
 func (t *TypeAnnotation) Doc() prettier.Doc {
+	var typeDoc prettier.Doc
+	if t.Type == nil {
+		typeDoc = prettier.Text("")
+	} else {
+		typeDoc = t.Type.Doc()
+	}
+
 	if !t.IsResource {
-		return t.Type.Doc()
+		return typeDoc
 	}
 
 	return prettier.Concat{
 		typeAnnotationResourceSymbolDoc,
-		t.Type.Doc(),
+		typeDoc,
 	}
 }
 

--- a/ast/type_test.go
+++ b/ast/type_test.go
@@ -354,39 +354,72 @@ func TestOptionalType_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &OptionalType{
-		Type: &NominalType{
-			Identifier: Identifier{
-				Identifier: "R",
-			},
-		},
-	}
+	t.Run("with type", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		prettier.Concat{
-			prettier.Text("R"),
-			prettier.Text("?"),
-		},
-		ty.Doc(),
-	)
+		ty := &OptionalType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "R",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("R"),
+				prettier.Text("?"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("nil type", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &OptionalType{}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text(""),
+				prettier.Text("?"),
+			},
+			ty.Doc(),
+		)
+	})
 }
 
 func TestOptionalType_String(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &OptionalType{
-		Type: &NominalType{
-			Identifier: Identifier{
-				Identifier: "R",
-			},
-		},
-	}
+	t.Run("with type", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		"R?",
-		ty.String(),
-	)
+		ty := &OptionalType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "R",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"R?",
+			ty.String(),
+		)
+	})
+
+	t.Run("nil type", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &OptionalType{}
+
+		assert.Equal(t,
+			"?",
+			ty.String(),
+		)
+	})
 }
 
 func TestOptionalType_MarshalJSON(t *testing.T) {

--- a/ast/type_test.go
+++ b/ast/type_test.go
@@ -847,58 +847,194 @@ func TestDictionaryType_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &DictionaryType{
-		KeyType: &NominalType{
-			Identifier: Identifier{
-				Identifier: "AB",
-			},
-		},
-		ValueType: &NominalType{
-			Identifier: Identifier{
-				Identifier: "CD",
-			},
-		},
-	}
+	t.Run("with key, with value", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		prettier.Concat{
-			prettier.Text("{"),
-			prettier.Indent{
-				Doc: prettier.Concat{
-					prettier.SoftLine{},
-					prettier.Text("AB"),
-					prettier.Text(": "),
-					prettier.Text("CD"),
+		ty := &DictionaryType{
+			KeyType: &NominalType{
+				Identifier: Identifier{
+					Identifier: "AB",
 				},
 			},
-			prettier.SoftLine{},
-			prettier.Text("}"),
-		},
-		ty.Doc(),
-	)
+			ValueType: &NominalType{
+				Identifier: Identifier{
+					Identifier: "CD",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.SoftLine{},
+						prettier.Text("AB"),
+						prettier.Text(": "),
+						prettier.Text("CD"),
+					},
+				},
+				prettier.SoftLine{},
+				prettier.Text("}"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("without key, with value", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &DictionaryType{
+			ValueType: &NominalType{
+				Identifier: Identifier{
+					Identifier: "CD",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.SoftLine{},
+						prettier.Text(""),
+						prettier.Text(": "),
+						prettier.Text("CD"),
+					},
+				},
+				prettier.SoftLine{},
+				prettier.Text("}"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("with key, without value", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &DictionaryType{
+			KeyType: &NominalType{
+				Identifier: Identifier{
+					Identifier: "AB",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.SoftLine{},
+						prettier.Text("AB"),
+						prettier.Text(": "),
+						prettier.Text(""),
+					},
+				},
+				prettier.SoftLine{},
+				prettier.Text("}"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("without key, without value", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &DictionaryType{}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.SoftLine{},
+						prettier.Text(""),
+						prettier.Text(": "),
+						prettier.Text(""),
+					},
+				},
+				prettier.SoftLine{},
+				prettier.Text("}"),
+			},
+			ty.Doc(),
+		)
+	})
+
 }
 
 func TestDictionaryType_String(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &DictionaryType{
-		KeyType: &NominalType{
-			Identifier: Identifier{
-				Identifier: "AB",
-			},
-		},
-		ValueType: &NominalType{
-			Identifier: Identifier{
-				Identifier: "CD",
-			},
-		},
-	}
+	t.Run("with key, with value", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		"{AB: CD}",
-		ty.String(),
-	)
+		ty := &DictionaryType{
+			KeyType: &NominalType{
+				Identifier: Identifier{
+					Identifier: "AB",
+				},
+			},
+			ValueType: &NominalType{
+				Identifier: Identifier{
+					Identifier: "CD",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"{AB: CD}",
+			ty.String(),
+		)
+	})
+
+	t.Run("without key, with value", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &DictionaryType{
+			ValueType: &NominalType{
+				Identifier: Identifier{
+					Identifier: "CD",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"{: CD}",
+			ty.String(),
+		)
+	})
+
+	t.Run("with key, without value", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &DictionaryType{
+			KeyType: &NominalType{
+				Identifier: Identifier{
+					Identifier: "AB",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"{AB: }",
+			ty.String(),
+		)
+	})
+
+	t.Run("without key, without value", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &DictionaryType{}
+
+		assert.Equal(t,
+			"{: }",
+			ty.String(),
+		)
+	})
+
 }
 
 func TestDictionaryType_MarshalJSON(t *testing.T) {

--- a/ast/type_test.go
+++ b/ast/type_test.go
@@ -1688,67 +1688,147 @@ func TestIntersectionType_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &IntersectionType{
-		Types: []*NominalType{
-			{
-				Identifier: Identifier{
-					Identifier: "CD",
-				},
-			},
-			{
-				Identifier: Identifier{
-					Identifier: "EF",
-				},
-			},
-		},
-	}
+	t.Run("no types", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		prettier.Concat{
-			prettier.Group{
-				Doc: prettier.Concat{
-					prettier.Text("{"),
-					prettier.Indent{
-						Doc: prettier.Concat{
-							prettier.SoftLine{},
-							prettier.Text("CD"),
-							prettier.Text(","),
-							prettier.Line{},
-							prettier.Text("EF"),
-						},
+		ty := &IntersectionType{}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.SoftLine{},
 					},
-					prettier.SoftLine{},
-					prettier.Text("}"),
+				},
+				prettier.SoftLine{},
+				prettier.Text("}"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("nil type", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &IntersectionType{
+			Types: []*NominalType{
+				nil,
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.SoftLine{},
+						prettier.Text(""),
+					},
+				},
+				prettier.SoftLine{},
+				prettier.Text("}"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("with types", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &IntersectionType{
+			Types: []*NominalType{
+				{
+					Identifier: Identifier{
+						Identifier: "CD",
+					},
+				},
+				{
+					Identifier: Identifier{
+						Identifier: "EF",
+					},
 				},
 			},
-		},
-		ty.Doc(),
-	)
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.SoftLine{},
+						prettier.Text("CD"),
+						prettier.Text(","),
+						prettier.Line{},
+						prettier.Text("EF"),
+					},
+				},
+				prettier.SoftLine{},
+				prettier.Text("}"),
+			},
+			ty.Doc(),
+		)
+	})
 }
 
 func TestIntersectionType_String(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &IntersectionType{
-		Types: []*NominalType{
-			{
-				Identifier: Identifier{
-					Identifier: "CD",
-				},
-			},
-			{
-				Identifier: Identifier{
-					Identifier: "EF",
-				},
-			},
-		},
-	}
+	t.Run("no types", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		"{CD, EF}",
-		ty.String(),
-	)
+		ty := &IntersectionType{}
+
+		assert.Equal(t,
+			"{}",
+			ty.String(),
+		)
+	})
+
+	t.Run("nil type", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &IntersectionType{
+			Types: []*NominalType{
+				{
+					Identifier: Identifier{
+						Identifier: "T",
+					},
+				},
+				nil,
+			},
+		}
+
+		assert.Equal(t,
+			"{T, }",
+			ty.String(),
+		)
+	})
+
+	t.Run("with types", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &IntersectionType{
+			Types: []*NominalType{
+				{
+					Identifier: Identifier{
+						Identifier: "CD",
+					},
+				},
+				{
+					Identifier: Identifier{
+						Identifier: "EF",
+					},
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"{CD, EF}",
+			ty.String(),
+		)
+	})
 }
 
 func TestIntersectionType_MarshalJSON(t *testing.T) {

--- a/ast/type_test.go
+++ b/ast/type_test.go
@@ -1315,7 +1315,38 @@ func TestReferenceType_Doc(t *testing.T) {
 				prettier.Text("("),
 				prettier.Text("X"),
 				prettier.Text(")"),
-				prettier.Space,
+				prettier.Line{},
+				prettier.Text("&"),
+				prettier.Text("T"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("auth with nil entitlement", func(t *testing.T) {
+
+		t.Parallel()
+
+		ty := &ReferenceType{
+			Authorization: &ConjunctiveEntitlementSet{
+				Elements: []*NominalType{
+					nil,
+				},
+			},
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("auth"),
+				prettier.Text("("),
+				prettier.Text(""),
+				prettier.Text(")"),
+				prettier.Line{},
 				prettier.Text("&"),
 				prettier.Text("T"),
 			},
@@ -1349,7 +1380,37 @@ func TestReferenceType_Doc(t *testing.T) {
 				prettier.Text("mapping "),
 				prettier.Text("X"),
 				prettier.Text(")"),
-				prettier.Space,
+				prettier.Line{},
+				prettier.Text("&"),
+				prettier.Text("T"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("auth with nil mapping", func(t *testing.T) {
+
+		t.Parallel()
+
+		ty := &ReferenceType{
+			Authorization: &MappedAccess{
+				EntitlementMap: nil,
+			},
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("auth"),
+				prettier.Text("("),
+				prettier.Text("mapping "),
+				prettier.Text(""),
+				prettier.Text(")"),
+				prettier.Line{},
 				prettier.Text("&"),
 				prettier.Text("T"),
 			},
@@ -1389,10 +1450,10 @@ func TestReferenceType_Doc(t *testing.T) {
 				prettier.Text("("),
 				prettier.Text("X"),
 				prettier.Text(","),
-				prettier.Space,
+				prettier.Line{},
 				prettier.Text("Y"),
 				prettier.Text(")"),
-				prettier.Space,
+				prettier.Line{},
 				prettier.Text("&"),
 				prettier.Text("T"),
 			},
@@ -1432,10 +1493,10 @@ func TestReferenceType_Doc(t *testing.T) {
 				prettier.Text("("),
 				prettier.Text("X"),
 				prettier.Text(" |"),
-				prettier.Space,
+				prettier.Line{},
 				prettier.Text("Y"),
 				prettier.Text(")"),
-				prettier.Space,
+				prettier.Line{},
 				prettier.Text("&"),
 				prettier.Text("T"),
 			},
@@ -1459,6 +1520,21 @@ func TestReferenceType_Doc(t *testing.T) {
 			prettier.Concat{
 				prettier.Text("&"),
 				prettier.Text("T"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("un-auth, nil type", func(t *testing.T) {
+
+		t.Parallel()
+
+		ty := &ReferenceType{}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("&"),
+				prettier.Text(""),
 			},
 			ty.Doc(),
 		)
@@ -1496,6 +1572,29 @@ func TestReferenceType_String(t *testing.T) {
 		)
 	})
 
+	t.Run("auth with nil entitlement", func(t *testing.T) {
+
+		t.Parallel()
+
+		ty := &ReferenceType{
+			Authorization: &ConjunctiveEntitlementSet{
+				Elements: []*NominalType{
+					nil,
+				},
+			},
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"auth() &T",
+			ty.String(),
+		)
+	})
+
 	t.Run("auth with mapping", func(t *testing.T) {
 
 		t.Parallel()
@@ -1517,6 +1616,27 @@ func TestReferenceType_String(t *testing.T) {
 
 		assert.Equal(t,
 			"auth(mapping X) &T",
+			ty.String(),
+		)
+	})
+
+	t.Run("auth with nil mapping", func(t *testing.T) {
+
+		t.Parallel()
+
+		ty := &ReferenceType{
+			Authorization: &MappedAccess{
+				EntitlementMap: nil,
+			},
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"auth(mapping ) &T",
 			ty.String(),
 		)
 	})
@@ -1603,6 +1723,17 @@ func TestReferenceType_String(t *testing.T) {
 		)
 	})
 
+	t.Run("un-auth, nil type", func(t *testing.T) {
+
+		t.Parallel()
+
+		ty := &ReferenceType{}
+
+		assert.Equal(t,
+			"&",
+			ty.String(),
+		)
+	})
 }
 
 func TestReferenceType_MarshalJSON(t *testing.T) {

--- a/ast/type_test.go
+++ b/ast/type_test.go
@@ -32,41 +32,134 @@ func TestTypeAnnotation_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &TypeAnnotation{
-		IsResource: true,
-		Type: &NominalType{
-			Identifier: Identifier{
-				Identifier: "R",
-			},
-		},
-	}
+	t.Run("non-resource, no type", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		prettier.Concat{
-			prettier.Text("@"),
-			prettier.Text("R"),
-		},
-		ty.Doc(),
-	)
+		ty := &TypeAnnotation{}
+
+		assert.Equal(t,
+			prettier.Text(""),
+			ty.Doc(),
+		)
+	})
+
+	t.Run("non-resource, with type", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &TypeAnnotation{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Text("T"),
+			ty.Doc(),
+		)
+	})
+
+	t.Run("resource, no type", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &TypeAnnotation{
+			IsResource: true,
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("@"),
+				prettier.Text(""),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("resource, with type", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &TypeAnnotation{
+			IsResource: true,
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "R",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("@"),
+				prettier.Text("R"),
+			},
+			ty.Doc(),
+		)
+	})
 }
 
 func TestTypeAnnotation_String(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &TypeAnnotation{
-		IsResource: true,
-		Type: &NominalType{
-			Identifier: Identifier{
-				Identifier: "R",
-			},
-		},
-	}
+	t.Run("non-resource, no type", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		"@R",
-		ty.String(),
-	)
+		ty := &TypeAnnotation{}
+
+		assert.Equal(t,
+			"",
+			ty.String(),
+		)
+	})
+
+	t.Run("non-resource, with type", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &TypeAnnotation{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"T",
+			ty.String(),
+		)
+	})
+
+	t.Run("resource, no type", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &TypeAnnotation{
+			IsResource: true,
+		}
+
+		assert.Equal(t,
+			"@",
+			ty.String(),
+		)
+	})
+
+	t.Run("resource, with type", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &TypeAnnotation{
+			IsResource: true,
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "R",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"@R",
+			ty.String(),
+		)
+	})
 }
 
 func TestTypeAnnotation_MarshalJSON(t *testing.T) {

--- a/ast/type_test.go
+++ b/ast/type_test.go
@@ -1819,93 +1819,240 @@ func TestInstantiationType_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &InstantiationType{
-		Type: &NominalType{
-			Identifier: Identifier{
-				Identifier: "AB",
-			},
-		},
-		TypeArguments: []*TypeAnnotation{
-			{
-				IsResource: true,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "CD",
-					},
-				},
-			},
-			{
-				IsResource: false,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "EF",
-					},
-				},
-			},
-		},
-	}
+	t.Run("with type, no type arguments", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		prettier.Concat{
-			prettier.Text("AB"),
-			prettier.Group{
-				Doc: prettier.Concat{
-					prettier.Text("<"),
-					prettier.Indent{
-						Doc: prettier.Concat{
-							prettier.SoftLine{},
-							prettier.Concat{
-								prettier.Text("@"),
-								prettier.Text("CD"),
+		ty := &InstantiationType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "AB",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("AB"),
+				prettier.Group{
+					Doc: prettier.Concat{
+						prettier.Text("<"),
+						prettier.Indent{
+							Doc: prettier.Concat{
+								prettier.SoftLine{},
 							},
-							prettier.Text(","),
-							prettier.Line{},
-							prettier.Text("EF"),
+						},
+						prettier.SoftLine{},
+						prettier.Text(">"),
+					},
+				},
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("nil type, no type arguments", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &InstantiationType{}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text(""),
+				prettier.Group{
+					Doc: prettier.Concat{
+						prettier.Text("<"),
+						prettier.Indent{
+							Doc: prettier.Concat{
+								prettier.SoftLine{},
+							},
+						},
+						prettier.SoftLine{},
+						prettier.Text(">"),
+					},
+				},
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("with type, type arguments", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &InstantiationType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "AB",
+				},
+			},
+			TypeArguments: []*TypeAnnotation{
+				{
+					IsResource: true,
+					Type: &NominalType{
+						Identifier: Identifier{
+							Identifier: "CD",
 						},
 					},
-					prettier.SoftLine{},
-					prettier.Text(">"),
+				},
+				{
+					IsResource: false,
+					Type: &NominalType{
+						Identifier: Identifier{
+							Identifier: "EF",
+						},
+					},
 				},
 			},
-		},
-		ty.Doc(),
-	)
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("AB"),
+				prettier.Group{
+					Doc: prettier.Concat{
+						prettier.Text("<"),
+						prettier.Indent{
+							Doc: prettier.Concat{
+								prettier.SoftLine{},
+								prettier.Concat{
+									prettier.Text("@"),
+									prettier.Text("CD"),
+								},
+								prettier.Text(","),
+								prettier.Line{},
+								prettier.Text("EF"),
+							},
+						},
+						prettier.SoftLine{},
+						prettier.Text(">"),
+					},
+				},
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("with type, nil type argument", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &InstantiationType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "AB",
+				},
+			},
+			TypeArguments: []*TypeAnnotation{
+				nil,
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("AB"),
+				prettier.Group{
+					Doc: prettier.Concat{
+						prettier.Text("<"),
+						prettier.Indent{
+							Doc: prettier.Concat{
+								prettier.SoftLine{},
+								prettier.Text(""),
+							},
+						},
+						prettier.SoftLine{},
+						prettier.Text(">"),
+					},
+				},
+			},
+			ty.Doc(),
+		)
+	})
 }
 
 func TestInstantiationType_String(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &InstantiationType{
-		Type: &NominalType{
-			Identifier: Identifier{
-				Identifier: "AB",
-			},
-		},
-		TypeArguments: []*TypeAnnotation{
-			{
-				IsResource: true,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "CD",
-					},
-				},
-			},
-			{
-				IsResource: false,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "EF",
-					},
-				},
-			},
-		},
-	}
+	t.Run("with type, no type arguments", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		"AB<@CD, EF>",
-		ty.String(),
-	)
+		ty := &InstantiationType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "AB",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"AB<>",
+			ty.String(),
+		)
+	})
+
+	t.Run("nil type, no type arguments", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &InstantiationType{}
+
+		assert.Equal(t,
+			"<>",
+			ty.String(),
+		)
+	})
+
+	t.Run("with type, type arguments", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &InstantiationType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "AB",
+				},
+			},
+			TypeArguments: []*TypeAnnotation{
+				{
+					IsResource: true,
+					Type: &NominalType{
+						Identifier: Identifier{
+							Identifier: "CD",
+						},
+					},
+				},
+				{
+					IsResource: false,
+					Type: &NominalType{
+						Identifier: Identifier{
+							Identifier: "EF",
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"AB<@CD, EF>",
+			ty.String(),
+		)
+	})
+
+	t.Run("with type, nil type argument", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &InstantiationType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "AB",
+				},
+			},
+			TypeArguments: []*TypeAnnotation{
+				nil,
+			},
+		}
+
+		assert.Equal(t,
+			"AB<>",
+			ty.String(),
+		)
+	})
 }
 
 func TestInstantiationType_MarshalJSON(t *testing.T) {

--- a/ast/type_test.go
+++ b/ast/type_test.go
@@ -595,58 +595,192 @@ func TestConstantSizedType_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &ConstantSizedType{
-		Type: &NominalType{
-			Identifier: Identifier{
-				Identifier: "T",
-			},
-		},
-		Size: &IntegerExpression{
-			PositiveLiteral: []byte("42"),
-			Value:           big.NewInt(42),
-			Base:            10,
-		},
-	}
+	t.Run("with type, with size", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		prettier.Concat{
-			prettier.Text("["),
-			prettier.Indent{
-				Doc: prettier.Concat{
-					prettier.SoftLine{},
-					prettier.Text("T"),
-					prettier.Text("; "),
-					prettier.Text("42"),
+		ty := &ConstantSizedType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
 				},
 			},
-			prettier.SoftLine{},
-			prettier.Text("]"),
-		},
-		ty.Doc(),
-	)
+			Size: &IntegerExpression{
+				PositiveLiteral: []byte("42"),
+				Value:           big.NewInt(42),
+				Base:            10,
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("["),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.SoftLine{},
+						prettier.Text("T"),
+						prettier.Text("; "),
+						prettier.Text("42"),
+					},
+				},
+				prettier.SoftLine{},
+				prettier.Text("]"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("nil type, with size", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &ConstantSizedType{
+			Size: &IntegerExpression{
+				PositiveLiteral: []byte("42"),
+				Value:           big.NewInt(42),
+				Base:            10,
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("["),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.SoftLine{},
+						prettier.Text(""),
+						prettier.Text("; "),
+						prettier.Text("42"),
+					},
+				},
+				prettier.SoftLine{},
+				prettier.Text("]"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("with type, nil size", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &ConstantSizedType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("["),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.SoftLine{},
+						prettier.Text("T"),
+						prettier.Text("; "),
+						prettier.Text(""),
+					},
+				},
+				prettier.SoftLine{},
+				prettier.Text("]"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("nil type, nil size", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &ConstantSizedType{}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("["),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.SoftLine{},
+						prettier.Text(""),
+						prettier.Text("; "),
+						prettier.Text(""),
+					},
+				},
+				prettier.SoftLine{},
+				prettier.Text("]"),
+			},
+			ty.Doc(),
+		)
+	})
 }
 
 func TestConstantSizedType_String(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &ConstantSizedType{
-		Type: &NominalType{
-			Identifier: Identifier{
-				Identifier: "T",
-			},
-		},
-		Size: &IntegerExpression{
-			PositiveLiteral: []byte("42"),
-			Value:           big.NewInt(42),
-			Base:            10,
-		},
-	}
+	t.Run("with type, with size", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		"[T; 42]",
-		ty.String(),
-	)
+		ty := &ConstantSizedType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
+				},
+			},
+			Size: &IntegerExpression{
+				PositiveLiteral: []byte("42"),
+				Value:           big.NewInt(42),
+				Base:            10,
+			},
+		}
+
+		assert.Equal(t,
+			"[T; 42]",
+			ty.String(),
+		)
+	})
+
+	t.Run("nil type, with size", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &ConstantSizedType{
+			Size: &IntegerExpression{
+				PositiveLiteral: []byte("42"),
+				Value:           big.NewInt(42),
+				Base:            10,
+			},
+		}
+
+		assert.Equal(t,
+			"[; 42]",
+			ty.String(),
+		)
+	})
+
+	t.Run("with type, nil size", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &ConstantSizedType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"[T; ]",
+			ty.String(),
+		)
+	})
+
+	t.Run("nil type, nil size", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &ConstantSizedType{}
+
+		assert.Equal(t,
+			"[; ]",
+			ty.String(),
+		)
+	})
 }
 
 func TestConstantSizedType_MarshalJSON(t *testing.T) {

--- a/ast/type_test.go
+++ b/ast/type_test.go
@@ -1100,106 +1100,169 @@ func TestFunctionType_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &FunctionType{
-		PurityAnnotation: FunctionPurityView,
-		ParameterTypeAnnotations: []*TypeAnnotation{
-			{
-				IsResource: true,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "AB",
-					},
-				},
-			},
-			{
-				IsResource: true,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "CD",
-					},
-				},
-			},
-		},
-		ReturnTypeAnnotation: &TypeAnnotation{
-			Type: &NominalType{
-				Identifier: Identifier{
-					Identifier: "EF",
-				},
-			},
-		},
-	}
+	t.Run("with parameter types, with return type", func(t *testing.T) {
 
-	assert.Equal(t,
-		prettier.Concat{
-			prettier.Text("view"),
-			prettier.Space,
-			prettier.Text("fun"),
-			prettier.Space,
-			prettier.Group{
-				Doc: prettier.Concat{
-					prettier.Text("("),
-					prettier.Indent{
-						Doc: prettier.Concat{
-							prettier.SoftLine{},
-							prettier.Concat{
-								prettier.Text("@"),
-								prettier.Text("AB"),
-							},
-							prettier.Text(","),
-							prettier.Line{},
-							prettier.Concat{
-								prettier.Text("@"),
-								prettier.Text("CD"),
-							},
+		t.Parallel()
+
+		ty := &FunctionType{
+			PurityAnnotation: FunctionPurityView,
+			ParameterTypeAnnotations: []*TypeAnnotation{
+				{
+					IsResource: true,
+					Type: &NominalType{
+						Identifier: Identifier{
+							Identifier: "AB",
 						},
 					},
-					prettier.SoftLine{},
-					prettier.Text(")"),
+				},
+				{
+					IsResource: true,
+					Type: &NominalType{
+						Identifier: Identifier{
+							Identifier: "CD",
+						},
+					},
 				},
 			},
-			prettier.Text(": "),
-			prettier.Text("EF"),
-		},
-		ty.Doc(),
-	)
+			ReturnTypeAnnotation: &TypeAnnotation{
+				Type: &NominalType{
+					Identifier: Identifier{
+						Identifier: "EF",
+					},
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("view"),
+				prettier.Line{},
+				prettier.Text("fun"),
+				prettier.Line{},
+				prettier.Group{
+					Doc: prettier.Concat{
+						prettier.Text("("),
+						prettier.Indent{
+							Doc: prettier.Concat{
+								prettier.SoftLine{},
+								prettier.Concat{
+									prettier.Text("@"),
+									prettier.Text("AB"),
+								},
+								prettier.Text(","),
+								prettier.Line{},
+								prettier.Concat{
+									prettier.Text("@"),
+									prettier.Text("CD"),
+								},
+							},
+						},
+						prettier.SoftLine{},
+						prettier.Text(")"),
+					},
+				},
+				prettier.Text(": "),
+				prettier.Text("EF"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("nil parameter type, nil return type", func(t *testing.T) {
+
+		t.Parallel()
+
+		ty := &FunctionType{
+			ParameterTypeAnnotations: []*TypeAnnotation{
+				nil,
+			},
+			ReturnTypeAnnotation: nil,
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("fun"),
+				prettier.Line{},
+				prettier.Group{
+					Doc: prettier.Concat{
+						prettier.Text("("),
+						prettier.Indent{
+							Doc: prettier.Concat{
+								prettier.SoftLine{},
+								prettier.Text(""),
+							},
+						},
+						prettier.SoftLine{},
+						prettier.Text(")"),
+					},
+				},
+				prettier.Text(": "),
+				prettier.Text(""),
+			},
+			ty.Doc(),
+		)
+	})
+
 }
 
 func TestFunctionType_String(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &FunctionType{
-		ParameterTypeAnnotations: []*TypeAnnotation{
-			{
-				IsResource: true,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "AB",
-					},
-				},
-			},
-			{
-				IsResource: true,
-				Type: &NominalType{
-					Identifier: Identifier{
-						Identifier: "CD",
-					},
-				},
-			},
-		},
-		ReturnTypeAnnotation: &TypeAnnotation{
-			Type: &NominalType{
-				Identifier: Identifier{
-					Identifier: "EF",
-				},
-			},
-		},
-	}
+	t.Run("with parameter types, with return type", func(t *testing.T) {
 
-	assert.Equal(t,
-		"fun (@AB, @CD): EF",
-		ty.String(),
-	)
+		t.Parallel()
+
+		ty := &FunctionType{
+			ParameterTypeAnnotations: []*TypeAnnotation{
+				{
+					IsResource: true,
+					Type: &NominalType{
+						Identifier: Identifier{
+							Identifier: "AB",
+						},
+					},
+				},
+				{
+					IsResource: true,
+					Type: &NominalType{
+						Identifier: Identifier{
+							Identifier: "CD",
+						},
+					},
+				},
+			},
+			ReturnTypeAnnotation: &TypeAnnotation{
+				Type: &NominalType{
+					Identifier: Identifier{
+						Identifier: "EF",
+					},
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"fun (@AB, @CD): EF",
+			ty.String(),
+		)
+	})
+
+	t.Run("nil parameter type, nil return type", func(t *testing.T) {
+
+		t.Parallel()
+
+		ty := &FunctionType{
+			ParameterTypeAnnotations: []*TypeAnnotation{
+				nil,
+			},
+			ReturnTypeAnnotation: nil,
+		}
+
+		assert.Equal(t,
+			"fun (): ",
+			ty.String(),
+		)
+	})
 }
 
 func TestFunctionType_MarshalJSON(t *testing.T) {

--- a/ast/type_test.go
+++ b/ast/type_test.go
@@ -466,46 +466,86 @@ func TestVariableSizedType_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &VariableSizedType{
-		Type: &NominalType{
-			Identifier: Identifier{
-				Identifier: "T",
-			},
-		},
-	}
+	t.Run("with type", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		prettier.Concat{
-			prettier.Text("["),
-			prettier.Indent{
-				Doc: prettier.Concat{
-					prettier.SoftLine{},
-					prettier.Text("T"),
+		ty := &VariableSizedType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
 				},
 			},
-			prettier.SoftLine{},
-			prettier.Text("]"),
-		},
-		ty.Doc(),
-	)
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("["),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.SoftLine{},
+						prettier.Text("T"),
+					},
+				},
+				prettier.SoftLine{},
+				prettier.Text("]"),
+			},
+			ty.Doc(),
+		)
+	})
+
+	t.Run("nil type", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &VariableSizedType{}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Text("["),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.SoftLine{},
+						prettier.Text(""),
+					},
+				},
+				prettier.SoftLine{},
+				prettier.Text("]"),
+			},
+			ty.Doc(),
+		)
+	})
 }
 
 func TestVariableSizedType_String(t *testing.T) {
 
 	t.Parallel()
 
-	ty := &VariableSizedType{
-		Type: &NominalType{
-			Identifier: Identifier{
-				Identifier: "T",
-			},
-		},
-	}
+	t.Run("with type", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		"[T]",
-		ty.String(),
-	)
+		ty := &VariableSizedType{
+			Type: &NominalType{
+				Identifier: Identifier{
+					Identifier: "T",
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"[T]",
+			ty.String(),
+		)
+	})
+
+	t.Run("nil type", func(t *testing.T) {
+		t.Parallel()
+
+		ty := &VariableSizedType{}
+
+		assert.Equal(t,
+			"[]",
+			ty.String(),
+		)
+	})
 }
 
 func TestVariableSizedType_MarshalJSON(t *testing.T) {

--- a/ast/typeparameter.go
+++ b/ast/typeparameter.go
@@ -58,16 +58,10 @@ func (t *TypeParameter) Doc() prettier.Doc {
 	var doc prettier.Doc = prettier.Text(t.Identifier.Identifier)
 
 	if t.TypeBound != nil {
-		var typeBoundDoc prettier.Doc
-		if t.TypeBound == nil {
-			typeBoundDoc = prettier.Text("")
-		} else {
-			typeBoundDoc = t.TypeBound.Doc()
-		}
 		doc = prettier.Concat{
 			doc,
 			typeSeparatorSpaceDoc,
-			typeBoundDoc,
+			t.TypeBound.Doc(),
 		}
 	}
 

--- a/ast/typeparameter.go
+++ b/ast/typeparameter.go
@@ -18,7 +18,11 @@
 
 package ast
 
-import "github.com/onflow/cadence/common"
+import (
+	"github.com/turbolent/prettier"
+
+	"github.com/onflow/cadence/common"
+)
 
 type TypeParameter struct {
 	Identifier Identifier
@@ -48,4 +52,28 @@ func (t *TypeParameter) EndPosition(memoryGauge common.MemoryGauge) Position {
 		return t.TypeBound.EndPosition(memoryGauge)
 	}
 	return t.Identifier.EndPosition(memoryGauge)
+}
+
+func (t *TypeParameter) Doc() prettier.Doc {
+	var doc prettier.Doc = prettier.Text(t.Identifier.Identifier)
+
+	if t.TypeBound != nil {
+		var typeBoundDoc prettier.Doc
+		if t.TypeBound == nil {
+			typeBoundDoc = prettier.Text("")
+		} else {
+			typeBoundDoc = t.TypeBound.Doc()
+		}
+		doc = prettier.Concat{
+			doc,
+			typeSeparatorSpaceDoc,
+			typeBoundDoc,
+		}
+	}
+
+	return doc
+}
+
+func (t *TypeParameter) String() string {
+	return Prettier(t)
 }

--- a/ast/typeparameter_test.go
+++ b/ast/typeparameter_test.go
@@ -1,0 +1,67 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/turbolent/prettier"
+)
+
+func TestTypeParameter_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("without bound", func(t *testing.T) {
+		t.Parallel()
+
+		parameter := &TypeParameter{
+			Identifier: Identifier{Identifier: "T"},
+		}
+
+		require.Equal(t,
+			prettier.Text("T"),
+			parameter.Doc(),
+		)
+
+	})
+
+	t.Run("with bound", func(t *testing.T) {
+		t.Parallel()
+
+		parameter := &TypeParameter{
+			Identifier: Identifier{Identifier: "T"},
+			TypeBound: &TypeAnnotation{
+				Type: &NominalType{
+					Identifier: Identifier{Identifier: "U"},
+				},
+			},
+		}
+
+		require.Equal(t,
+			prettier.Concat{
+				prettier.Text("T"),
+				prettier.Text(": "),
+				prettier.Text("U"),
+			},
+			parameter.Doc(),
+		)
+	})
+}

--- a/ast/typeparameterlist.go
+++ b/ast/typeparameterlist.go
@@ -71,15 +71,9 @@ func (l *TypeParameterList) Doc() prettier.Doc {
 	typeParameterDocs := make([]prettier.Doc, 0, len(l.TypeParameters))
 
 	for _, typeParameter := range l.TypeParameters {
-		var typeParameterDoc prettier.Doc
-		if typeParameter == nil {
-			typeParameterDoc = prettier.Text("")
-		} else {
-			typeParameterDoc = typeParameter.Doc()
-		}
 		typeParameterDocs = append(
 			typeParameterDocs,
-			typeParameterDoc,
+			docOrEmpty(typeParameter),
 		)
 	}
 

--- a/ast/typeparameterlist.go
+++ b/ast/typeparameterlist.go
@@ -65,28 +65,22 @@ func (l *TypeParameterList) IsEmpty() bool {
 func (l *TypeParameterList) Doc() prettier.Doc {
 
 	if len(l.TypeParameters) == 0 {
-		return nil
+		return prettier.Text("")
 	}
 
 	typeParameterDocs := make([]prettier.Doc, 0, len(l.TypeParameters))
 
 	for _, typeParameter := range l.TypeParameters {
-		var parameterDoc prettier.Concat
-
-		parameterDoc = append(
-			parameterDoc,
-			prettier.Text(typeParameter.Identifier.Identifier),
-		)
-
-		if typeParameter.TypeBound != nil {
-			parameterDoc = append(
-				parameterDoc,
-				typeSeparatorSpaceDoc,
-				typeParameter.TypeBound.Doc(),
-			)
+		var typeParameterDoc prettier.Doc
+		if typeParameter == nil {
+			typeParameterDoc = prettier.Text("")
+		} else {
+			typeParameterDoc = typeParameter.Doc()
 		}
-
-		typeParameterDocs = append(typeParameterDocs, parameterDoc)
+		typeParameterDocs = append(
+			typeParameterDocs,
+			typeParameterDoc,
+		)
 	}
 
 	return prettier.Wrap(

--- a/ast/typeparameterlist_test.go
+++ b/ast/typeparameterlist_test.go
@@ -1,0 +1,165 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/turbolent/prettier"
+)
+
+func TestTypeParameterList_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		params := &TypeParameterList{}
+		require.Equal(t,
+			prettier.Text(""),
+			params.Doc(),
+		)
+	})
+
+	t.Run("with nil type parameter", func(t *testing.T) {
+		t.Parallel()
+
+		params := &TypeParameterList{
+			TypeParameters: []*TypeParameter{nil},
+		}
+		require.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("<"),
+					prettier.Indent{
+						Doc: prettier.Concat{
+							prettier.SoftLine{},
+							prettier.Text(""),
+						},
+					},
+					prettier.SoftLine{},
+					prettier.Text(">"),
+				},
+			},
+			params.Doc(),
+		)
+	})
+
+	t.Run("with type parameters", func(t *testing.T) {
+		t.Parallel()
+
+		params := &TypeParameterList{
+			TypeParameters: []*TypeParameter{
+				{
+					Identifier: Identifier{Identifier: "T"},
+					TypeBound: &TypeAnnotation{
+						Type: &NominalType{
+							Identifier: Identifier{Identifier: "U"},
+						},
+					},
+				},
+				{
+					Identifier: Identifier{Identifier: "V"},
+				},
+			},
+		}
+
+		require.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("<"),
+					prettier.Indent{
+						Doc: prettier.Concat{
+							prettier.SoftLine{},
+							prettier.Concat{
+								prettier.Concat{
+									prettier.Text("T"),
+									prettier.Text(": "),
+									prettier.Text("U"),
+								},
+								prettier.Concat{
+									prettier.Text(","),
+									prettier.Line{},
+								},
+								prettier.Text("V"),
+							},
+						},
+					},
+					prettier.SoftLine{},
+					prettier.Text(">"),
+				},
+			},
+			params.Doc(),
+		)
+	})
+}
+
+func TestTypeParameterList_String(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		params := &TypeParameterList{}
+		require.Equal(t,
+			"",
+			params.String(),
+		)
+	})
+
+	t.Run("with nil type parameter", func(t *testing.T) {
+		t.Parallel()
+
+		params := &TypeParameterList{
+			TypeParameters: []*TypeParameter{nil},
+		}
+		require.Equal(t,
+			"<>",
+			params.String(),
+		)
+	})
+
+	t.Run("with type parameters", func(t *testing.T) {
+		t.Parallel()
+
+		params := &TypeParameterList{
+			TypeParameters: []*TypeParameter{
+				{
+					Identifier: Identifier{Identifier: "T"},
+					TypeBound: &TypeAnnotation{
+						Type: &NominalType{
+							Identifier: Identifier{Identifier: "U"},
+						},
+					},
+				},
+				{
+					Identifier: Identifier{Identifier: "V"},
+				},
+			},
+		}
+
+		require.Equal(t,
+			"<T: U, V>",
+			params.String(),
+		)
+	})
+}

--- a/ast/variable_declaration.go
+++ b/ast/variable_declaration.go
@@ -219,16 +219,9 @@ func (d *VariableDeclaration) Doc() prettier.Doc {
 	var doc prettier.Concat
 
 	if d.Access != AccessNotSpecified {
-		var accessDoc prettier.Doc
-		if d.Access == nil {
-			accessDoc = prettier.Text("")
-		} else {
-			accessDoc = d.Access.Doc()
-		}
-
 		doc = append(
 			doc,
-			accessDoc,
+			docOrEmpty(d.Access),
 			prettier.HardLine{},
 		)
 	}

--- a/ast/variable_declaration.go
+++ b/ast/variable_declaration.go
@@ -219,9 +219,16 @@ func (d *VariableDeclaration) Doc() prettier.Doc {
 	var doc prettier.Concat
 
 	if d.Access != AccessNotSpecified {
+		var accessDoc prettier.Doc
+		if d.Access == nil {
+			accessDoc = prettier.Text("")
+		} else {
+			accessDoc = d.Access.Doc()
+		}
+
 		doc = append(
 			doc,
-			prettier.Text(d.Access.Keyword()),
+			accessDoc,
 			prettier.HardLine{},
 		)
 	}


### PR DESCRIPTION
Work towards #4171 

## Description

The parser may produce partial AST nodes, i.e. parts may be `nil`, increasingly so as we make the parser more resilient (#529). 

Partial AST nodes are for example printed in tooling like the linter.

Start handling `nil` in all type AST nodes and some others. Produce an empty document in such cases.
While at it, also add missing tests.

Best viewed [with whitespace changes disabled](https://github.com/onflow/cadence/pull/4173/files?w=1)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
