### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/pretty/print.go
+++ b/pretty/print.go
@@ -347,10 +347,7 @@ func (p ErrorPrettyPrinter) writeCodeExcerpts(
 			// indicator line
 			p.writeString(emptyLineNumbers)
 
-			indicatorLength := excerpt.startPos.Column
-			if indicatorLength > maxLineLength {
-				indicatorLength = maxLineLength
-			}
+			indicatorLength := min(excerpt.startPos.Column, maxLineLength)
 			if indicatorLength > len(line) {
 				indicatorLength = len(line)
 			}

--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -50,7 +50,6 @@ func (c *LocationCoverage) AddLineHit(line int) {
 // statements percentage. It is defined as the ratio of covered
 // lines over the total statements for a given location.
 func (c *LocationCoverage) Percentage() string {
-	coveredLines := c.CoveredLines()
 	// The ground truth of which statements are interpreted/executed
 	// is the `InterpreterEnvironment.newOnStatementHandler()` function.
 	// This means that every call of `CoverageReport.AddLineHit()` from
@@ -59,12 +58,10 @@ func (c *LocationCoverage) Percentage() string {
 	// This is a good insight to solidify its implementation and debug
 	// the inspection failure. Ideally, this condition will never be true,
 	// except for tests. We just leave it here, as a fail-safe mechanism.
-	if coveredLines > c.Statements {
-		// We saturate the percentage at 100%, when the inspector
-		// fails to correctly count all statements for a given
-		// location.
-		coveredLines = c.Statements
-	}
+	// We saturate the percentage at 100%, when the inspector
+	// fails to correctly count all statements for a given
+	// location.
+	coveredLines := min(c.CoveredLines(), c.Statements)
 
 	percentage := 100 * float64(coveredLines) / float64(c.Statements)
 	return fmt.Sprintf("%0.1f%%", percentage)

--- a/sema/check_invocation_expression.go
+++ b/sema/check_invocation_expression.go
@@ -453,10 +453,7 @@ func (checker *Checker) checkInvocation(
 		invocationExpression,
 	)
 
-	minCount := argumentCount
-	if parameterCount < argumentCount {
-		minCount = parameterCount
-	}
+	minCount := min(parameterCount, argumentCount)
 
 	var parameterTypes []Type
 


### PR DESCRIPTION
Closes #???

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.


______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
