### PR TITLE
Handle partial AST nodes when pretty printing – Part 2

### DIFF
--- a/ast/composite.go
+++ b/ast/composite.go
@@ -241,6 +241,13 @@ func CompositeDocument(
 		prettier.Text(identifier),
 	)
 
+	var membersDoc prettier.Doc
+	if members == nil {
+		membersDoc = membersEmptyDoc
+	} else {
+		membersDoc = members.Doc()
+	}
+
 	if len(conformances) > 0 {
 
 		conformancesDoc := prettier.Concat{
@@ -255,9 +262,16 @@ func CompositeDocument(
 				)
 			}
 
+			var conformanceDoc prettier.Doc
+			if conformance == nil {
+				conformanceDoc = prettier.Text("")
+			} else {
+				conformanceDoc = conformance.Doc()
+			}
+
 			conformancesDoc = append(
 				conformancesDoc,
-				conformance.Doc(),
+				conformanceDoc,
 			)
 		}
 
@@ -266,7 +280,7 @@ func CompositeDocument(
 			prettier.Dedent{
 				Doc: prettier.Concat{
 					prettier.Line{},
-					members.Doc(),
+					membersDoc,
 				},
 			},
 		)
@@ -285,7 +299,7 @@ func CompositeDocument(
 		doc = append(
 			doc,
 			prettier.Space,
-			members.Doc(),
+			membersDoc,
 		)
 	}
 

--- a/ast/composite.go
+++ b/ast/composite.go
@@ -248,16 +248,9 @@ func CompositeDocument(
 				)
 			}
 
-			var conformanceDoc prettier.Doc
-			if conformance == nil {
-				conformanceDoc = prettier.Text("")
-			} else {
-				conformanceDoc = conformance.Doc()
-			}
-
 			conformancesDoc = append(
 				conformancesDoc,
-				conformanceDoc,
+				docOrEmpty(conformance),
 			)
 		}
 

--- a/ast/composite_test.go
+++ b/ast/composite_test.go
@@ -270,6 +270,28 @@ func TestFieldDeclaration_Doc(t *testing.T) {
 		)
 	})
 
+	t.Run("without access, without kind, no type", func(t *testing.T) {
+
+		t.Parallel()
+
+		decl := &FieldDeclaration{
+			Access: AccessNotSpecified,
+			Identifier: Identifier{
+				Identifier: "xyz",
+			},
+		}
+
+		require.Equal(
+			t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("xyz"),
+				},
+			},
+			decl.Doc(),
+		)
+	})
+
 }
 
 func TestFieldDeclaration_String(t *testing.T) {
@@ -385,6 +407,23 @@ xyz: @CD`,
 		)
 	})
 
+	t.Run("without access, without kind, no type", func(t *testing.T) {
+
+		t.Parallel()
+
+		decl := &FieldDeclaration{
+			Access: AccessNotSpecified,
+			Identifier: Identifier{
+				Identifier: "xyz",
+			},
+		}
+
+		require.Equal(
+			t,
+			"xyz",
+			decl.String(),
+		)
+	})
 }
 
 func TestCompositeDeclaration_MarshalJSON(t *testing.T) {
@@ -501,6 +540,49 @@ func TestCompositeDeclaration_Doc(t *testing.T) {
 								prettier.Line{},
 							},
 							prettier.Text("EF"),
+							prettier.Dedent{
+								Doc: prettier.Concat{
+									prettier.Line{},
+									prettier.Text("{}"),
+								},
+							},
+						},
+					},
+				},
+			},
+			decl.Doc(),
+		)
+	})
+
+	t.Run("nil members, nil conformance", func(t *testing.T) {
+
+		t.Parallel()
+
+		decl := &CompositeDeclaration{
+			Access:        AccessAll,
+			CompositeKind: common.CompositeKindResource,
+			Identifier: Identifier{
+				Identifier: "AB",
+			},
+			Conformances: []*NominalType{
+				nil,
+			},
+		}
+
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("access(all)"),
+				prettier.HardLine{},
+				prettier.Text("resource"),
+				prettier.Text(" "),
+				prettier.Text("AB"),
+				prettier.Text(":"),
+				prettier.Group{
+					Doc: prettier.Indent{
+						Doc: prettier.Concat{
+							prettier.Line{},
+							prettier.Text(""),
 							prettier.Dedent{
 								Doc: prettier.Concat{
 									prettier.Line{},
@@ -767,6 +849,29 @@ func TestCompositeDeclaration_String(t *testing.T) {
 			t,
 			`access(all)
 resource AB: CD, EF {}`,
+			decl.String(),
+		)
+	})
+
+	t.Run("nil members, nil conformance", func(t *testing.T) {
+
+		t.Parallel()
+
+		decl := &CompositeDeclaration{
+			Access:        AccessAll,
+			CompositeKind: common.CompositeKindResource,
+			Identifier: Identifier{
+				Identifier: "AB",
+			},
+			Conformances: []*NominalType{
+				nil,
+			},
+		}
+
+		require.Equal(
+			t,
+			`access(all)
+resource AB:  {}`,
 			decl.String(),
 		)
 	})

--- a/ast/entitlement_declaration.go
+++ b/ast/entitlement_declaration.go
@@ -155,24 +155,10 @@ var arrowKeywordSpaceDoc = prettier.Text(" -> ")
 func (*EntitlementMapRelation) isEntitlementMapElement() {}
 
 func (d *EntitlementMapRelation) Doc() prettier.Doc {
-	var inputDoc prettier.Doc
-	if d.Input == nil {
-		inputDoc = prettier.Text("")
-	} else {
-		inputDoc = d.Input.Doc()
-	}
-
-	var outputDoc prettier.Doc
-	if d.Output == nil {
-		outputDoc = prettier.Text("")
-	} else {
-		outputDoc = d.Output.Doc()
-	}
-
 	return prettier.Concat{
-		inputDoc,
+		docOrEmpty(d.Input),
 		arrowKeywordSpaceDoc,
-		outputDoc,
+		docOrEmpty(d.Output),
 	}
 }
 

--- a/ast/entitlement_declaration.go
+++ b/ast/entitlement_declaration.go
@@ -162,14 +162,25 @@ var arrowKeywordSpaceDoc = prettier.Text(" -> ")
 func (*EntitlementMapRelation) isEntitlementMapElement() {}
 
 func (d *EntitlementMapRelation) Doc() prettier.Doc {
-	var doc prettier.Concat
+	var inputDoc prettier.Doc
+	if d.Input == nil {
+		inputDoc = prettier.Text("")
+	} else {
+		inputDoc = d.Input.Doc()
+	}
 
-	return append(
-		doc,
-		d.Input.Doc(),
+	var outputDoc prettier.Doc
+	if d.Output == nil {
+		outputDoc = prettier.Text("")
+	} else {
+		outputDoc = d.Output.Doc()
+	}
+
+	return prettier.Concat{
+		inputDoc,
 		arrowKeywordSpaceDoc,
-		d.Output.Doc(),
-	)
+		outputDoc,
+	}
 }
 
 // EntitlementMappingDeclaration
@@ -288,19 +299,25 @@ func (d *EntitlementMappingDeclaration) Doc() prettier.Doc {
 		)
 	}
 
-	var mappingElementsDoc prettier.Concat
+	var elementsDocs prettier.Concat
 
 	for _, element := range d.Elements {
-		var elementDoc prettier.Concat
+
+		var elementDoc prettier.Doc
 
 		if _, isNominalType := element.(*NominalType); isNominalType {
-			elementDoc = append(elementDoc, includeKeywordSpaceDoc)
+			elementDoc = prettier.Concat{
+				includeKeywordSpaceDoc,
+				element.Doc(),
+			}
+		} else if element == nil {
+			elementDoc = prettier.Text("")
+		} else {
+			elementDoc = element.Doc()
 		}
 
-		elementDoc = append(elementDoc, element.Doc())
-
-		mappingElementsDoc = append(
-			mappingElementsDoc,
+		elementsDocs = append(
+			elementsDocs,
 			elementDoc,
 		)
 	}
@@ -316,7 +333,7 @@ func (d *EntitlementMappingDeclaration) Doc() prettier.Doc {
 		prettier.Indent{
 			Doc: prettier.Join(
 				prettier.HardLine{},
-				mappingElementsDoc...,
+				elementsDocs...,
 			),
 		},
 		prettier.HardLine{},

--- a/ast/entitlement_declaration_test.go
+++ b/ast/entitlement_declaration_test.go
@@ -221,59 +221,108 @@ func TestEntitlementMappingDeclaration_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	decl := &EntitlementMappingDeclaration{
-		Access: AccessAll,
-		Identifier: Identifier{
-			Identifier: "AB",
-			Pos:        Position{Offset: 1, Line: 2, Column: 3},
-		},
-		DocString: "test",
-		Range: Range{
-			StartPos: Position{Offset: 7, Line: 8, Column: 9},
-			EndPos:   Position{Offset: 10, Line: 11, Column: 12},
-		},
-		Elements: []EntitlementMapElement{
-			&NominalType{
-				Identifier: Identifier{Identifier: "X",
-					Pos: Position{Offset: 1, Line: 2, Column: 3},
-				},
-			},
-			&EntitlementMapRelation{
-				Input: &NominalType{
-					Identifier: Identifier{
-						Identifier: "X",
-						Pos:        Position{Offset: 1, Line: 2, Column: 3},
-					},
-				},
-				Output: &NominalType{
-					Identifier: Identifier{
-						Identifier: "Y",
-						Pos:        Position{Offset: 1, Line: 2, Column: 3},
-					},
-				},
-			},
-		},
-	}
+	t.Run("no input, no output", func(t *testing.T) {
+		t.Parallel()
 
-	require.Equal(
-		t,
-		prettier.Concat{
-			prettier.Text("access(all)"),
-			prettier.HardLine{},
-			prettier.Text("entitlement "),
-			prettier.Text("mapping "),
-			prettier.Text("AB"),
-			prettier.Space,
-			prettier.Text("{"),
-			prettier.HardLine{},
-			prettier.Indent{
-				Doc: prettier.Concat{
-					prettier.Concat{
-						prettier.Text("include "),
-						prettier.Text("X"),
+		decl := &EntitlementMappingDeclaration{
+			Access: AccessAll,
+			Identifier: Identifier{
+				Identifier: "AB",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+			DocString: "test",
+			Range: Range{
+				StartPos: Position{Offset: 7, Line: 8, Column: 9},
+				EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+			},
+			Elements: []EntitlementMapElement{
+				&EntitlementMapRelation{
+					Input:  nil,
+					Output: nil,
+				},
+			},
+		}
+
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("access(all)"),
+				prettier.HardLine{},
+				prettier.Text("entitlement "),
+				prettier.Text("mapping "),
+				prettier.Text("AB"),
+				prettier.Space,
+				prettier.Text("{"),
+				prettier.HardLine{},
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.Text(""),
+						prettier.Text(" -> "),
+						prettier.Text(""),
 					},
-					prettier.HardLine{},
-					prettier.Concat{
+				},
+				prettier.HardLine{},
+				prettier.Text("}"),
+			},
+			decl.Doc(),
+		)
+	})
+
+	t.Run("elements", func(t *testing.T) {
+		t.Parallel()
+
+		decl := &EntitlementMappingDeclaration{
+			Access: AccessAll,
+			Identifier: Identifier{
+				Identifier: "AB",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+			DocString: "test",
+			Range: Range{
+				StartPos: Position{Offset: 7, Line: 8, Column: 9},
+				EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+			},
+			Elements: []EntitlementMapElement{
+				&NominalType{
+					Identifier: Identifier{Identifier: "X",
+						Pos: Position{Offset: 1, Line: 2, Column: 3},
+					},
+				},
+				&EntitlementMapRelation{
+					Input: &NominalType{
+						Identifier: Identifier{
+							Identifier: "X",
+							Pos:        Position{Offset: 1, Line: 2, Column: 3},
+						},
+					},
+					Output: &NominalType{
+						Identifier: Identifier{
+							Identifier: "Y",
+							Pos:        Position{Offset: 1, Line: 2, Column: 3},
+						},
+					},
+				},
+			},
+		}
+
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("access(all)"),
+				prettier.HardLine{},
+				prettier.Text("entitlement "),
+				prettier.Text("mapping "),
+				prettier.Text("AB"),
+				prettier.Space,
+				prettier.Text("{"),
+				prettier.HardLine{},
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.Concat{
+							prettier.Text("include "),
+							prettier.Text("X"),
+						},
+						prettier.HardLine{},
 						prettier.Concat{
 							prettier.Text("X"),
 							prettier.Text(" -> "),
@@ -281,61 +330,95 @@ func TestEntitlementMappingDeclaration_Doc(t *testing.T) {
 						},
 					},
 				},
+				prettier.HardLine{},
+				prettier.Text("}"),
 			},
-			prettier.HardLine{},
-			prettier.Text("}"),
-		},
-		decl.Doc(),
-	)
-
+			decl.Doc(),
+		)
+	})
 }
 
 func TestEntitlementMappingDeclaration_String(t *testing.T) {
 
 	t.Parallel()
 
-	decl := &EntitlementMappingDeclaration{
-		Access: AccessAll,
-		Identifier: Identifier{
-			Identifier: "AB",
-			Pos:        Position{Offset: 1, Line: 2, Column: 3},
-		},
-		DocString: "test",
-		Range: Range{
-			StartPos: Position{Offset: 7, Line: 8, Column: 9},
-			EndPos:   Position{Offset: 10, Line: 11, Column: 12},
-		},
-		Elements: []EntitlementMapElement{
-			&NominalType{
-				Identifier: Identifier{Identifier: "X",
-					Pos: Position{Offset: 1, Line: 2, Column: 3},
-				},
-			},
-			&EntitlementMapRelation{
-				Input: &NominalType{
-					Identifier: Identifier{
-						Identifier: "X",
-						Pos:        Position{Offset: 1, Line: 2, Column: 3},
-					},
-				},
-				Output: &NominalType{
-					Identifier: Identifier{
-						Identifier: "Y",
-						Pos:        Position{Offset: 1, Line: 2, Column: 3},
-					},
-				},
-			},
-		},
-	}
+	t.Run("no input, no output", func(t *testing.T) {
+		t.Parallel()
 
-	require.Equal(
-		t,
-		`access(all)
+		decl := &EntitlementMappingDeclaration{
+			Access: AccessAll,
+			Identifier: Identifier{
+				Identifier: "AB",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+			DocString: "test",
+			Range: Range{
+				StartPos: Position{Offset: 7, Line: 8, Column: 9},
+				EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+			},
+			Elements: []EntitlementMapElement{
+				&EntitlementMapRelation{
+					Input:  nil,
+					Output: nil,
+				},
+			},
+		}
+
+		require.Equal(
+			t,
+			`access(all)
+entitlement mapping AB {
+ -> 
+}`,
+			decl.String(),
+		)
+	})
+
+	t.Run("elements", func(t *testing.T) {
+		t.Parallel()
+
+		decl := &EntitlementMappingDeclaration{
+			Access: AccessAll,
+			Identifier: Identifier{
+				Identifier: "AB",
+				Pos:        Position{Offset: 1, Line: 2, Column: 3},
+			},
+			DocString: "test",
+			Range: Range{
+				StartPos: Position{Offset: 7, Line: 8, Column: 9},
+				EndPos:   Position{Offset: 10, Line: 11, Column: 12},
+			},
+			Elements: []EntitlementMapElement{
+				&NominalType{
+					Identifier: Identifier{Identifier: "X",
+						Pos: Position{Offset: 1, Line: 2, Column: 3},
+					},
+				},
+				&EntitlementMapRelation{
+					Input: &NominalType{
+						Identifier: Identifier{
+							Identifier: "X",
+							Pos:        Position{Offset: 1, Line: 2, Column: 3},
+						},
+					},
+					Output: &NominalType{
+						Identifier: Identifier{
+							Identifier: "Y",
+							Pos:        Position{Offset: 1, Line: 2, Column: 3},
+						},
+					},
+				},
+			},
+		}
+
+		require.Equal(
+			t,
+			`access(all)
 entitlement mapping AB {
 include X
     X -> Y
 }`,
-		decl.String(),
-	)
-
+			decl.String(),
+		)
+	})
 }

--- a/ast/members.go
+++ b/ast/members.go
@@ -147,7 +147,11 @@ var membersStartDoc prettier.Doc = prettier.Text("{")
 var membersEndDoc prettier.Doc = prettier.Text("}")
 var membersEmptyDoc prettier.Doc = prettier.Text("{}")
 
-func (m *Members) docWithNoBraces() prettier.Concat {
+func (m *Members) Doc() prettier.Doc {
+	if len(m.declarations) == 0 {
+		return membersEmptyDoc
+	}
+
 	var docs []prettier.Doc
 
 	for _, decl := range m.declarations {
@@ -161,6 +165,7 @@ func (m *Members) docWithNoBraces() prettier.Concat {
 	}
 
 	return prettier.Concat{
+		membersStartDoc,
 		prettier.Indent{
 			Doc: prettier.Join(
 				prettier.HardLine{},
@@ -168,16 +173,10 @@ func (m *Members) docWithNoBraces() prettier.Concat {
 			),
 		},
 		prettier.HardLine{},
+		membersEndDoc,
 	}
 }
 
-func (m *Members) Doc() prettier.Doc {
-	if len(m.declarations) == 0 {
-		return membersEmptyDoc
-	}
-
-	membersDoc := m.docWithNoBraces()
-	membersDoc = append(prettier.Concat{membersStartDoc}, membersDoc...)
-	membersDoc = append(membersDoc, membersEndDoc)
-	return membersDoc
+func (m *Members) String() string {
+	return Prettier(m)
 }

--- a/ast/members_test.go
+++ b/ast/members_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/turbolent/prettier"
 )
 
 func TestMembers_MarshalJSON(t *testing.T) {
@@ -44,4 +45,181 @@ func TestMembers_MarshalJSON(t *testing.T) {
         `,
 		string(actual),
 	)
+}
+
+func TestMembers_Doc(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		members := NewUnmeteredMembers([]Declaration{})
+
+		require.Equal(t,
+			prettier.Text("{}"),
+			members.Doc(),
+		)
+	})
+
+	t.Run("with members", func(t *testing.T) {
+		t.Parallel()
+
+		members := NewUnmeteredMembers([]Declaration{
+			&VariableDeclaration{
+				Access: AccessNotSpecified,
+				Identifier: Identifier{
+					Identifier: "x",
+				},
+				Transfer: &Transfer{
+					Operation: TransferOperationCopy,
+				},
+				Value: &BoolExpression{
+					Value: true,
+				},
+			},
+			&VariableDeclaration{
+				Access: AccessNotSpecified,
+				Identifier: Identifier{
+					Identifier: "y",
+				},
+				Transfer: &Transfer{
+					Operation: TransferOperationCopy,
+				},
+				Value: &BoolExpression{
+					Value: false,
+				},
+			},
+		})
+
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.Concat{
+							prettier.HardLine{},
+							prettier.Group{
+								Doc: prettier.Concat{
+									prettier.Text("var"),
+									prettier.Text(" "),
+									prettier.Group{
+										Doc: prettier.Concat{
+											prettier.Group{
+												Doc: prettier.Concat{
+													prettier.Text("x"),
+												},
+											},
+											prettier.Text(" "),
+											prettier.Text("="),
+											prettier.Group{
+												Doc: prettier.Indent{
+													Doc: prettier.Concat{
+														prettier.Line{},
+														prettier.Text("true"),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						prettier.HardLine{},
+						prettier.Concat{
+							prettier.HardLine{},
+							prettier.Group{
+								Doc: prettier.Concat{
+									prettier.Text("var"),
+									prettier.Text(" "),
+									prettier.Group{
+										Doc: prettier.Concat{
+											prettier.Group{
+												Doc: prettier.Concat{
+													prettier.Text("y"),
+												},
+											},
+											prettier.Text(" "),
+											prettier.Text("="),
+											prettier.Group{
+												Doc: prettier.Indent{
+													Doc: prettier.Concat{
+														prettier.Line{},
+														prettier.Text("false"),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				prettier.HardLine{},
+				prettier.Text("}"),
+			},
+			members.Doc(),
+		)
+	})
+
+}
+
+func TestMembers_String(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		members := NewUnmeteredMembers([]Declaration{})
+
+		require.Equal(t,
+			prettier.Text("{}"),
+			members.Doc(),
+		)
+	})
+
+	t.Run("with members", func(t *testing.T) {
+		t.Parallel()
+
+		members := NewUnmeteredMembers([]Declaration{
+			&VariableDeclaration{
+				Access: AccessNotSpecified,
+				Identifier: Identifier{
+					Identifier: "x",
+				},
+				Transfer: &Transfer{
+					Operation: TransferOperationCopy,
+				},
+				Value: &BoolExpression{
+					Value: true,
+				},
+			},
+			&VariableDeclaration{
+				Access: AccessNotSpecified,
+				Identifier: Identifier{
+					Identifier: "y",
+				},
+				Transfer: &Transfer{
+					Operation: TransferOperationCopy,
+				},
+				Value: &BoolExpression{
+					Value: false,
+				},
+			},
+		})
+
+		require.Equal(
+			t,
+			`{
+    var x = true
+    
+    var y = false
+}`,
+			members.String(),
+		)
+	})
+
 }

--- a/ast/variable_declaration.go
+++ b/ast/variable_declaration.go
@@ -158,15 +158,21 @@ func (d *VariableDeclaration) Doc() prettier.Doc {
 		)
 	}
 
-	// Desugared `result` variable is uninitialized at first,
-	// hence would not have a value or transfer.
-	var valueDoc, transferDoc prettier.Doc
-	if d.Value != nil {
-		valueDoc = d.Value.Doc()
-		transferDoc = d.Transfer.Doc()
+	// Transfer and value might be nil.
+	// For example, a desugared `result` variable is uninitialized at first.
+
+	var transferDoc prettier.Doc
+	if d.Transfer == nil {
+		transferDoc = prettier.Text("")
 	} else {
-		valueDoc = prettier.Line{}
-		transferDoc = prettier.Line{}
+		transferDoc = d.Transfer.Doc()
+	}
+
+	var valueDoc prettier.Doc
+	if d.Value == nil {
+		valueDoc = prettier.Text("")
+	} else {
+		valueDoc = d.Value.Doc()
 	}
 
 	var valuesDoc prettier.Doc
@@ -192,6 +198,13 @@ func (d *VariableDeclaration) Doc() prettier.Doc {
 	} else {
 		secondValueDoc := d.SecondValue.Doc()
 
+		var secondTransferDoc prettier.Doc
+		if d.SecondTransfer == nil {
+			secondTransferDoc = prettier.Text("")
+		} else {
+			secondTransferDoc = d.SecondTransfer.Doc()
+		}
+
 		// Put transfers at start of value lines,
 		// and break both values at once
 
@@ -203,11 +216,11 @@ func (d *VariableDeclaration) Doc() prettier.Doc {
 				Doc: prettier.Indent{
 					Doc: prettier.Concat{
 						prettier.Line{},
-						d.Transfer.Doc(),
+						transferDoc,
 						prettier.Space,
 						valueDoc,
 						prettier.Line{},
-						d.SecondTransfer.Doc(),
+						secondTransferDoc,
 						prettier.Space,
 						secondValueDoc,
 					},

--- a/ast/variable_declaration.go
+++ b/ast/variable_declaration.go
@@ -161,19 +161,8 @@ func (d *VariableDeclaration) Doc() prettier.Doc {
 	// Transfer and value might be nil.
 	// For example, a desugared `result` variable is uninitialized at first.
 
-	var transferDoc prettier.Doc
-	if d.Transfer == nil {
-		transferDoc = prettier.Text("")
-	} else {
-		transferDoc = d.Transfer.Doc()
-	}
-
-	var valueDoc prettier.Doc
-	if d.Value == nil {
-		valueDoc = prettier.Text("")
-	} else {
-		valueDoc = d.Value.Doc()
-	}
+	transferDoc := docOrEmpty(d.Transfer)
+	valueDoc := docOrEmpty(d.Value)
 
 	var valuesDoc prettier.Doc
 
@@ -196,14 +185,8 @@ func (d *VariableDeclaration) Doc() prettier.Doc {
 			},
 		}
 	} else {
+		secondTransferDoc := docOrEmpty(d.SecondTransfer)
 		secondValueDoc := d.SecondValue.Doc()
-
-		var secondTransferDoc prettier.Doc
-		if d.SecondTransfer == nil {
-			secondTransferDoc = prettier.Text("")
-		} else {
-			secondTransferDoc = d.SecondTransfer.Doc()
-		}
 
 		// Put transfers at start of value lines,
 		// and break both values at once

--- a/ast/variable_declaration_test.go
+++ b/ast/variable_declaration_test.go
@@ -276,6 +276,48 @@ func TestVariableDeclaration_Doc(t *testing.T) {
 			decl.Doc(),
 		)
 	})
+
+	t.Run("without value and transfer", func(t *testing.T) {
+
+		t.Parallel()
+
+		decl := &VariableDeclaration{
+			Access:     AccessNotSpecified,
+			IsConstant: true,
+			Identifier: Identifier{
+				Identifier: "foo",
+			},
+		}
+
+		require.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("let"),
+					prettier.Text(" "),
+					prettier.Group{
+						Doc: prettier.Concat{
+							prettier.Group{
+								Doc: prettier.Concat{
+									prettier.Text("foo"),
+								},
+							},
+							prettier.Text(" "),
+							prettier.Text(""),
+							prettier.Group{
+								Doc: prettier.Indent{
+									Doc: prettier.Concat{
+										prettier.Line{},
+										prettier.Text(""),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			decl.Doc(),
+		)
+	})
 }
 
 func TestVariableDeclaration_String(t *testing.T) {
@@ -350,6 +392,24 @@ let foo: @AB <- true`,
 		require.Equal(t,
 			`access(all)
 let foo: @AB <- true <- false`,
+			decl.String(),
+		)
+	})
+
+	t.Run("without value and transfer", func(t *testing.T) {
+
+		t.Parallel()
+
+		decl := &VariableDeclaration{
+			Access:     AccessNotSpecified,
+			IsConstant: true,
+			Identifier: Identifier{
+				Identifier: "foo",
+			},
+		}
+
+		require.Equal(t,
+			"let foo  ",
 			decl.String(),
 		)
 	})


### PR DESCRIPTION
Work towards #4171

## Description

Continue improving the `Doc()` methods of AST elements to handle `nil` and add tests where missing.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
