### PR TITLE
Handle partial AST nodes when pretty printing – Part 4

### DIFF
--- a/ast/attachment.go
+++ b/ast/attachment.go
@@ -257,12 +257,12 @@ const attachExpressionToDoc = prettier.Text("to")
 func (e *AttachExpression) Doc() prettier.Doc {
 	return prettier.Concat{
 		attachExpressionDoc,
-		prettier.Space,
-		e.Attachment.Doc(),
-		prettier.Space,
+		prettier.Line{},
+		docOrEmpty(e.Attachment),
+		prettier.Line{},
 		attachExpressionToDoc,
-		prettier.Space,
-		e.Base.Doc(),
+		prettier.Line{},
+		docOrEmpty(e.Base),
 	}
 }
 

--- a/ast/attachment.go
+++ b/ast/attachment.go
@@ -340,12 +340,12 @@ const removeStatementFromKeywordDoc = prettier.Text("from")
 func (s *RemoveStatement) Doc() prettier.Doc {
 	return prettier.Concat{
 		removeStatementRemoveKeywordDoc,
-		prettier.Space,
-		s.Attachment.Doc(),
-		prettier.Space,
+		prettier.Line{},
+		docOrEmpty(s.Attachment),
+		prettier.Line{},
 		removeStatementFromKeywordDoc,
-		prettier.Space,
-		s.Value.Doc(),
+		prettier.Line{},
+		docOrEmpty(s.Value),
 	}
 }
 

--- a/ast/attachment.go
+++ b/ast/attachment.go
@@ -112,12 +112,6 @@ func (d *AttachmentDeclaration) ConformanceList() []*NominalType {
 
 const attachmentStatementDoc = prettier.Text("attachment")
 const attachmentStatementForDoc = prettier.Text("for")
-const attachmentConformancesSeparatorDoc = prettier.Text(":")
-
-var attachmentConformanceSeparatorDoc prettier.Doc = prettier.Concat{
-	prettier.Text(","),
-	prettier.Line{},
-}
 
 func (d *AttachmentDeclaration) Doc() prettier.Doc {
 	var doc prettier.Concat
@@ -133,18 +127,18 @@ func (d *AttachmentDeclaration) Doc() prettier.Doc {
 	doc = append(
 		doc,
 		attachmentStatementDoc,
-		prettier.Space,
+		prettier.Line{},
 		prettier.Text(d.Identifier.Identifier),
-		prettier.Space,
+		prettier.Line{},
 		attachmentStatementForDoc,
-		prettier.Space,
-		d.BaseType.Doc(),
+		prettier.Line{},
+		docOrEmpty(d.BaseType),
 	)
-	var membersDoc prettier.Concat
 
-	membersDoc = append(membersDoc, prettier.Line{}, d.Members.Doc())
+	membersDoc := d.Members.Doc()
 
 	if len(d.Conformances) > 0 {
+
 		conformancesDoc := prettier.Concat{
 			prettier.Line{},
 		}
@@ -153,13 +147,13 @@ func (d *AttachmentDeclaration) Doc() prettier.Doc {
 			if i > 0 {
 				conformancesDoc = append(
 					conformancesDoc,
-					attachmentConformanceSeparatorDoc,
+					compositeConformanceSeparatorDoc,
 				)
 			}
 
 			conformancesDoc = append(
 				conformancesDoc,
-				conformance.Doc(),
+				docOrEmpty(conformance),
 			)
 		}
 
@@ -175,7 +169,7 @@ func (d *AttachmentDeclaration) Doc() prettier.Doc {
 
 		doc = append(
 			doc,
-			attachmentConformancesSeparatorDoc,
+			compositeConformancesSeparatorDoc,
 			prettier.Group{
 				Doc: prettier.Indent{
 					Doc: conformancesDoc,

--- a/ast/attachment_test.go
+++ b/ast/attachment_test.go
@@ -116,61 +116,50 @@ func TestAttachmentDeclaration_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	decl := &AttachmentDeclaration{
-		Access: AccessAll,
-		Identifier: NewIdentifier(
-			nil,
-			"Foo",
-			Position{Offset: 1, Line: 2, Column: 3},
-		),
-		BaseType: NewNominalType(
-			nil,
-			NewIdentifier(
-				nil,
-				"Bar",
-				Position{Offset: 1, Line: 2, Column: 3},
-			),
-			[]Identifier{},
-		),
-		Conformances: []*NominalType{
-			{
-				Identifier: NewIdentifier(
-					nil,
-					"Baz",
-					Position{Offset: 1, Line: 2, Column: 3},
-				),
-			},
-		},
-		Members:   NewMembers(nil, []Declaration{}),
-		DocString: "test",
-		Range: Range{
-			StartPos: Position{Offset: 1, Line: 2, Column: 3},
-			EndPos:   Position{Offset: 4, Line: 5, Column: 6},
-		},
-	}
+	t.Run("with elements", func(t *testing.T) {
 
-	require.Equal(
-		t,
-		prettier.Concat{
-			prettier.Text("access(all)"),
-			prettier.HardLine{},
-			prettier.Text("attachment"),
-			prettier.Text(" "),
-			prettier.Text("Foo"),
-			prettier.Text(" "),
-			prettier.Text("for"),
-			prettier.Text(" "),
-			prettier.Text("Bar"),
-			prettier.Text(":"),
-			prettier.Group{
-				Doc: prettier.Indent{
-					Doc: prettier.Concat{
-						prettier.Line{},
-						prettier.Text("Baz"),
-						prettier.Dedent{
-							Doc: prettier.Concat{
-								prettier.Line{},
-								prettier.Concat{
+		t.Parallel()
+
+		decl := &AttachmentDeclaration{
+			Access: AccessAll,
+			Identifier: Identifier{
+				Identifier: "Foo",
+			},
+			BaseType: &NominalType{
+				Identifier: Identifier{
+					Identifier: "Bar",
+				},
+			},
+			Conformances: []*NominalType{
+				{
+					Identifier: Identifier{
+						Identifier: "Baz",
+					},
+				},
+			},
+			Members: NewMembers(nil, []Declaration{}),
+		}
+
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("access(all)"),
+				prettier.HardLine{},
+				prettier.Text("attachment"),
+				prettier.Line{},
+				prettier.Text("Foo"),
+				prettier.Line{},
+				prettier.Text("for"),
+				prettier.Line{},
+				prettier.Text("Bar"),
+				prettier.Text(":"),
+				prettier.Group{
+					Doc: prettier.Indent{
+						Doc: prettier.Concat{
+							prettier.Line{},
+							prettier.Text("Baz"),
+							prettier.Dedent{
+								Doc: prettier.Concat{
 									prettier.Line{},
 									prettier.Text("{}"),
 								},
@@ -179,15 +168,84 @@ func TestAttachmentDeclaration_Doc(t *testing.T) {
 					},
 				},
 			},
-		},
-		decl.Doc(),
-	)
+			decl.Doc(),
+		)
+	})
 
-	require.Equal(t,
-		`access(all)
-attachment Foo for Bar: Baz  {}`,
-		decl.String(),
-	)
+	t.Run("without elements", func(t *testing.T) {
+
+		t.Parallel()
+
+		decl := &AttachmentDeclaration{}
+
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text(""),
+				prettier.HardLine{},
+				prettier.Text("attachment"),
+				prettier.Line{},
+				prettier.Text(""),
+				prettier.Line{},
+				prettier.Text("for"),
+				prettier.Line{},
+				prettier.Text(""),
+				prettier.Text(" "),
+				prettier.Text("{}"),
+			},
+			decl.Doc(),
+		)
+	})
+}
+
+func TestAttachmentDeclaration_String(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("with elements", func(t *testing.T) {
+
+		t.Parallel()
+
+		decl := &AttachmentDeclaration{
+			Access: AccessAll,
+			Identifier: Identifier{
+				Identifier: "Foo",
+			},
+			BaseType: &NominalType{
+				Identifier: Identifier{
+					Identifier: "Bar",
+				},
+			},
+			Conformances: []*NominalType{
+				{
+					Identifier: Identifier{
+						Identifier: "Baz",
+					},
+				},
+			},
+			Members: NewMembers(nil, []Declaration{}),
+		}
+
+		require.Equal(t,
+			`access(all)
+attachment Foo for Bar: Baz {}`,
+			decl.String(),
+		)
+	})
+
+	t.Run("without elements", func(t *testing.T) {
+
+		t.Parallel()
+
+		decl := &AttachmentDeclaration{}
+
+		require.Equal(
+			t,
+			`
+attachment  for  {}`,
+			decl.String(),
+		)
+	})
 }
 
 func TestAttachExpressionMarshallJSON(t *testing.T) {

--- a/ast/attachment_test.go
+++ b/ast/attachment_test.go
@@ -381,40 +381,101 @@ func TestRemoveStatement_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	decl := &RemoveStatement{
-		Attachment: NewNominalType(
-			nil,
-			NewIdentifier(
-				nil,
-				"E",
-				Position{Offset: 1, Line: 2, Column: 3},
-			),
-			[]Identifier{},
-		),
-		Value: NewIdentifierExpression(
-			nil,
-			NewIdentifier(
-				nil,
-				"baz",
-				Position{Offset: 1, Line: 2, Column: 3},
-			),
-		),
-		StartPos: Position{Offset: 1, Line: 2, Column: 3},
-	}
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
 
-	require.Equal(
-		t,
-		prettier.Concat{
-			prettier.Text("remove"),
-			prettier.Text(" "),
-			prettier.Text("E"),
-			prettier.Text(" "),
-			prettier.Text("from"),
-			prettier.Text(" "),
-			prettier.Text("baz"),
-		},
-		decl.Doc(),
-	)
+		decl := &RemoveStatement{
+			Attachment: &NominalType{
+				Identifier: Identifier{
+					Identifier: "E",
+				},
+			},
+			Value: NewIdentifierExpression(
+				nil,
+				Identifier{
+					Identifier: "baz",
+				},
+			),
+		}
 
-	require.Equal(t, "remove E from baz", decl.String())
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("remove"),
+				prettier.Line{},
+				prettier.Text("E"),
+				prettier.Line{},
+				prettier.Text("from"),
+				prettier.Line{},
+				prettier.Text("baz"),
+			},
+			decl.Doc(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		decl := &RemoveStatement{
+			Attachment: nil,
+			Value:      nil,
+		}
+
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("remove"),
+				prettier.Line{},
+				prettier.Text(""),
+				prettier.Line{},
+				prettier.Text("from"),
+				prettier.Line{},
+				prettier.Text(""),
+			},
+			decl.Doc(),
+		)
+	})
+}
+
+func TestRemoveStatement_String(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
+
+		decl := &RemoveStatement{
+			Attachment: &NominalType{
+				Identifier: Identifier{
+					Identifier: "E",
+				},
+			},
+			Value: NewIdentifierExpression(
+				nil,
+				Identifier{
+					Identifier: "baz",
+				},
+			),
+		}
+
+		require.Equal(t,
+			"remove E from baz",
+			decl.String(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		decl := &RemoveStatement{
+			Attachment: nil,
+			Value:      nil,
+		}
+
+		require.Equal(
+			t,
+			"remove  from ",
+			decl.String(),
+		)
+	})
 }

--- a/ast/attachment_test.go
+++ b/ast/attachment_test.go
@@ -269,51 +269,101 @@ func TestAttachExpression_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	decl := &AttachExpression{
-		Base: NewIdentifierExpression(
-			nil,
-			NewIdentifier(
-				nil,
-				"foo",
-				Position{Offset: 1, Line: 2, Column: 3},
-			),
-		),
-		Attachment: NewInvocationExpression(
-			nil,
-			NewIdentifierExpression(
-				nil,
-				NewIdentifier(
-					nil,
-					"bar",
-					Position{Offset: 1, Line: 2, Column: 3},
-				),
-			),
-			[]*TypeAnnotation{},
-			Arguments{},
-			Position{Offset: 1, Line: 2, Column: 3},
-			Position{Offset: 1, Line: 2, Column: 3},
-		),
-		StartPos: Position{Offset: 1, Line: 2, Column: 3},
-	}
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
 
-	require.Equal(
-		t,
-		prettier.Concat{
-			prettier.Text("attach"),
-			prettier.Text(" "),
-			prettier.Concat{
-				prettier.Text("bar"),
-				prettier.Text("()"),
+		decl := &AttachExpression{
+			Base: &IdentifierExpression{
+				Identifier: Identifier{
+					Identifier: "foo",
+				},
 			},
-			prettier.Text(" "),
-			prettier.Text("to"),
-			prettier.Text(" "),
-			prettier.Text("foo"),
-		},
-		decl.Doc(),
-	)
+			Attachment: &InvocationExpression{
+				InvokedExpression: &IdentifierExpression{
+					Identifier: Identifier{
+						Identifier: "bar",
+					},
+				},
+			},
+		}
 
-	require.Equal(t, "attach bar() to foo", decl.String())
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("attach"),
+				prettier.Line{},
+				prettier.Concat{
+					prettier.Text("bar"),
+					prettier.Text("()"),
+				},
+				prettier.Line{},
+				prettier.Text("to"),
+				prettier.Line{},
+				prettier.Text("foo"),
+			},
+			decl.Doc(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		decl := &AttachExpression{}
+
+		require.Equal(
+			t,
+			prettier.Concat{
+				prettier.Text("attach"),
+				prettier.Line{},
+				prettier.Text(""),
+				prettier.Line{},
+				prettier.Text("to"),
+				prettier.Line{},
+				prettier.Text(""),
+			},
+			decl.Doc(),
+		)
+	})
+}
+
+func TestAttachExpression_String(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
+
+		decl := &AttachExpression{
+			Base: &IdentifierExpression{
+				Identifier: Identifier{
+					Identifier: "foo",
+				},
+			},
+			Attachment: &InvocationExpression{
+				InvokedExpression: &IdentifierExpression{
+					Identifier: Identifier{
+						Identifier: "bar",
+					},
+				},
+			},
+		}
+
+		require.Equal(t,
+			"attach bar() to foo",
+			decl.String(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		decl := &AttachExpression{}
+
+		require.Equal(t,
+			"attach  to ",
+			decl.String(),
+		)
+	})
 }
 
 func TestRemoveStatement_MarshallJSON(t *testing.T) {

--- a/ast/block.go
+++ b/ast/block.go
@@ -59,7 +59,7 @@ var blockEndDoc prettier.Doc = prettier.Text("}")
 var blockEmptyDoc prettier.Doc = prettier.Text("{}")
 
 func (b *Block) Doc() prettier.Doc {
-	if b.IsEmpty() {
+	if b == nil || b.IsEmpty() {
 		return blockEmptyDoc
 	}
 

--- a/ast/composite.go
+++ b/ast/composite.go
@@ -227,12 +227,7 @@ func CompositeDocument(
 		prettier.Text(identifier),
 	)
 
-	var membersDoc prettier.Doc
-	if members == nil {
-		membersDoc = membersEmptyDoc
-	} else {
-		membersDoc = members.Doc()
-	}
+	membersDoc := members.Doc()
 
 	if len(conformances) > 0 {
 

--- a/ast/members.go
+++ b/ast/members.go
@@ -148,7 +148,7 @@ var membersEndDoc prettier.Doc = prettier.Text("}")
 var membersEmptyDoc prettier.Doc = prettier.Text("{}")
 
 func (m *Members) Doc() prettier.Doc {
-	if len(m.declarations) == 0 {
+	if m == nil || len(m.declarations) == 0 {
 		return membersEmptyDoc
 	}
 

--- a/ast/statement.go
+++ b/ast/statement.go
@@ -588,13 +588,13 @@ func (s *AssignmentStatement) Walk(walkChild func(Element)) {
 func (s *AssignmentStatement) Doc() prettier.Doc {
 	return prettier.Group{
 		Doc: prettier.Concat{
-			s.Target.Doc(),
+			docOrEmpty(s.Target),
 			prettier.Space,
-			s.Transfer.Doc(),
+			docOrEmpty(s.Transfer),
 			prettier.Space,
 			prettier.Group{
 				Doc: prettier.Indent{
-					Doc: s.Value.Doc(),
+					Doc: docOrEmpty(s.Value),
 				},
 			},
 		},

--- a/ast/statement.go
+++ b/ast/statement.go
@@ -253,18 +253,11 @@ const ifStatementSpaceElseKeywordSpaceDoc = prettier.Text(" else ")
 
 func (s *IfStatement) Doc() prettier.Doc {
 
-	var thenDoc prettier.Doc
-	if s.Then == nil {
-		thenDoc = blockEmptyDoc
-	} else {
-		thenDoc = s.Then.Doc()
-	}
-
 	doc := prettier.Concat{
 		ifStatementIfKeywordSpaceDoc,
 		docOrEmpty(s.Test),
 		prettier.Space,
-		thenDoc,
+		s.Then.Doc(),
 	}
 
 	if s.Else != nil && len(s.Else.Statements) > 0 {

--- a/ast/statement.go
+++ b/ast/statement.go
@@ -252,13 +252,19 @@ const ifStatementIfKeywordSpaceDoc = prettier.Text("if ")
 const ifStatementSpaceElseKeywordSpaceDoc = prettier.Text(" else ")
 
 func (s *IfStatement) Doc() prettier.Doc {
-	testDoc := s.Test.Doc()
+
+	var thenDoc prettier.Doc
+	if s.Then == nil {
+		thenDoc = blockEmptyDoc
+	} else {
+		thenDoc = s.Then.Doc()
+	}
 
 	doc := prettier.Concat{
 		ifStatementIfKeywordSpaceDoc,
-		testDoc,
+		docOrEmpty(s.Test),
 		prettier.Space,
-		s.Then.Doc(),
+		thenDoc,
 	}
 
 	if s.Else != nil && len(s.Else.Statements) > 0 {

--- a/ast/statement.go
+++ b/ast/statement.go
@@ -447,7 +447,7 @@ func (s *ForStatement) Doc() prettier.Doc {
 		doc,
 		prettier.Text(s.Identifier.Identifier),
 		forStatementSpaceInKeywordSpaceDoc,
-		s.Value.Doc(),
+		docOrEmpty(s.Value),
 		prettier.Space,
 		s.Block.Doc(),
 	)

--- a/ast/statement.go
+++ b/ast/statement.go
@@ -660,9 +660,9 @@ const swapStatementSpaceSymbolSpaceDoc = prettier.Text(" <-> ")
 func (s *SwapStatement) Doc() prettier.Doc {
 	return prettier.Group{
 		Doc: prettier.Concat{
-			s.Left.Doc(),
+			docOrEmpty(s.Left),
 			swapStatementSpaceSymbolSpaceDoc,
-			s.Right.Doc(),
+			docOrEmpty(s.Right),
 		},
 	}
 }

--- a/ast/statement.go
+++ b/ast/statement.go
@@ -359,7 +359,7 @@ func (s *WhileStatement) Doc() prettier.Doc {
 	return prettier.Group{
 		Doc: prettier.Concat{
 			whileStatementKeywordSpaceDoc,
-			s.Test.Doc(),
+			docOrEmpty(s.Test),
 			prettier.Space,
 			s.Block.Doc(),
 		},

--- a/ast/statement.go
+++ b/ast/statement.go
@@ -788,11 +788,13 @@ func (s *SwitchStatement) Doc() prettier.Doc {
 
 	bodyDoc := make(prettier.Concat, 0, len(s.Cases))
 
-	for _, switchCase := range s.Cases {
+	for i, switchCase := range s.Cases {
+		isLast := i == len(s.Cases)-1
+
 		bodyDoc = append(
 			bodyDoc,
 			prettier.HardLine{},
-			switchCase.Doc(),
+			switchCase.Doc(isLast),
 		)
 	}
 
@@ -803,7 +805,7 @@ func (s *SwitchStatement) Doc() prettier.Doc {
 				prettier.Indent{
 					Doc: prettier.Concat{
 						prettier.SoftLine{},
-						s.Expression.Doc(),
+						docOrEmpty(s.Expression),
 					},
 				},
 				prettier.Line{},
@@ -870,12 +872,12 @@ const switchCaseKeywordSpaceDoc = prettier.Text("case ")
 const switchCaseColonSymbolDoc = prettier.Text(":")
 const switchCaseDefaultKeywordSpaceDoc = prettier.Text("default:")
 
-func (s *SwitchCase) Doc() prettier.Doc {
+func (s *SwitchCase) Doc(isLast bool) prettier.Doc {
 	statementsDoc := prettier.Indent{
 		Doc: StatementsDoc(s.Statements),
 	}
 
-	if s.Expression == nil {
+	if isLast && s.Expression == nil {
 		return prettier.Concat{
 			switchCaseDefaultKeywordSpaceDoc,
 			statementsDoc,
@@ -884,7 +886,7 @@ func (s *SwitchCase) Doc() prettier.Doc {
 
 	return prettier.Concat{
 		switchCaseKeywordSpaceDoc,
-		s.Expression.Doc(),
+		docOrEmpty(s.Expression),
 		switchCaseColonSymbolDoc,
 		statementsDoc,
 	}

--- a/ast/statement.go
+++ b/ast/statement.go
@@ -519,7 +519,7 @@ const emitStatementKeywordSpaceDoc = prettier.Text("emit ")
 func (s *EmitStatement) Doc() prettier.Doc {
 	return prettier.Concat{
 		emitStatementKeywordSpaceDoc,
-		s.InvocationExpression.Doc(),
+		docOrEmpty(s.InvocationExpression),
 	}
 }
 

--- a/ast/statement.go
+++ b/ast/statement.go
@@ -720,7 +720,7 @@ func (s *ExpressionStatement) Walk(walkChild func(Element)) {
 }
 
 func (s *ExpressionStatement) Doc() prettier.Doc {
-	return s.Expression.Doc()
+	return docOrEmpty(s.Expression)
 }
 
 func (s *ExpressionStatement) MarshalJSON() ([]byte, error) {

--- a/ast/statement_test.go
+++ b/ast/statement_test.go
@@ -477,6 +477,25 @@ func TestIfStatement_Doc(t *testing.T) {
 			stmt.Doc(),
 		)
 	})
+
+	t.Run("nil", func(t *testing.T) {
+
+		t.Parallel()
+
+		stmt := &IfStatement{}
+
+		assert.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("if "),
+					prettier.Text(""),
+					prettier.Text(" "),
+					prettier.Text("{}"),
+				},
+			},
+			stmt.Doc(),
+		)
+	})
 }
 
 func TestIfStatement_String(t *testing.T) {
@@ -532,6 +551,18 @@ func TestIfStatement_String(t *testing.T) {
 
 		assert.Equal(t,
 			"if false {} else if true {}",
+			stmt.String(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+
+		t.Parallel()
+
+		stmt := &IfStatement{}
+
+		assert.Equal(t,
+			"if  {}",
 			stmt.String(),
 		)
 	})

--- a/ast/statement_test.go
+++ b/ast/statement_test.go
@@ -1327,46 +1327,79 @@ func TestEmitStatement_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &EmitStatement{
-		InvocationExpression: &InvocationExpression{
-			InvokedExpression: &IdentifierExpression{
-				Identifier: Identifier{
-					Identifier: "foobar",
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &EmitStatement{
+			InvocationExpression: &InvocationExpression{
+				InvokedExpression: &IdentifierExpression{
+					Identifier: Identifier{
+						Identifier: "foobar",
+					},
 				},
 			},
-		},
-	}
+		}
 
-	require.Equal(t,
-		prettier.Concat{
-			prettier.Text("emit "),
+		require.Equal(t,
 			prettier.Concat{
-				prettier.Text("foobar"),
-				prettier.Text("()"),
+				prettier.Text("emit "),
+				prettier.Concat{
+					prettier.Text("foobar"),
+					prettier.Text("()"),
+				},
 			},
-		},
-		stmt.Doc(),
-	)
+			stmt.Doc(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &EmitStatement{}
+
+		require.Equal(t,
+			prettier.Concat{
+				prettier.Text("emit "),
+				prettier.Text(""),
+			},
+			stmt.Doc(),
+		)
+	})
+
 }
 
 func TestEmitStatement_String(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &EmitStatement{
-		InvocationExpression: &InvocationExpression{
-			InvokedExpression: &IdentifierExpression{
-				Identifier: Identifier{
-					Identifier: "foobar",
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
+		stmt := &EmitStatement{
+			InvocationExpression: &InvocationExpression{
+				InvokedExpression: &IdentifierExpression{
+					Identifier: Identifier{
+						Identifier: "foobar",
+					},
 				},
 			},
-		},
-	}
+		}
 
-	require.Equal(t,
-		"emit foobar()",
-		stmt.String(),
-	)
+		require.Equal(t,
+			"emit foobar()",
+			stmt.String(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &EmitStatement{}
+
+		require.Equal(t,
+			"emit ",
+			stmt.String(),
+		)
+	})
 }
 
 func TestSwitchStatement_MarshalJSON(t *testing.T) {

--- a/ast/statement_test.go
+++ b/ast/statement_test.go
@@ -1211,48 +1211,84 @@ func TestSwapStatement_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &SwapStatement{
-		Left: &IdentifierExpression{
-			Identifier: Identifier{
-				Identifier: "foobar",
-			},
-		},
-		Right: &BoolExpression{
-			Value: false,
-		},
-	}
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		prettier.Group{
-			Doc: prettier.Concat{
-				prettier.Text("foobar"),
-				swapStatementSpaceSymbolSpaceDoc,
-				prettier.Text("false"),
+		stmt := &SwapStatement{
+			Left: &IdentifierExpression{
+				Identifier: Identifier{
+					Identifier: "foobar",
+				},
 			},
-		},
-		stmt.Doc(),
-	)
+			Right: &BoolExpression{
+				Value: false,
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("foobar"),
+					prettier.Text(" <-> "),
+					prettier.Text("false"),
+				},
+			},
+			stmt.Doc(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &SwapStatement{}
+
+		assert.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text(""),
+					prettier.Text(" <-> "),
+					prettier.Text(""),
+				},
+			},
+			stmt.Doc(),
+		)
+	})
 }
 
 func TestSwapStatement_String(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &SwapStatement{
-		Left: &IdentifierExpression{
-			Identifier: Identifier{
-				Identifier: "foobar",
-			},
-		},
-		Right: &BoolExpression{
-			Value: false,
-		},
-	}
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		"foobar <-> false",
-		stmt.String(),
-	)
+		stmt := &SwapStatement{
+			Left: &IdentifierExpression{
+				Identifier: Identifier{
+					Identifier: "foobar",
+				},
+			},
+			Right: &BoolExpression{
+				Value: false,
+			},
+		}
+
+		assert.Equal(t,
+			"foobar <-> false",
+			stmt.String(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &SwapStatement{}
+
+		assert.Equal(t,
+			" <-> ",
+			stmt.String(),
+		)
+	})
 }
 
 func TestEmitStatement_MarshalJSON(t *testing.T) {

--- a/ast/statement_test.go
+++ b/ast/statement_test.go
@@ -67,32 +67,67 @@ func TestExpressionStatement_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &ExpressionStatement{
-		Expression: &BoolExpression{
-			Value: false,
-		},
-	}
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		prettier.Text("false"),
-		stmt.Doc(),
-	)
+		stmt := &ExpressionStatement{
+			Expression: &BoolExpression{
+				Value: false,
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Text("false"),
+			stmt.Doc(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &ExpressionStatement{
+			Expression: nil,
+		}
+
+		assert.Equal(t,
+			prettier.Text(""),
+			stmt.Doc(),
+		)
+	})
 }
 
 func TestExpressionStatement_String(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &ExpressionStatement{
-		Expression: &BoolExpression{
-			Value: false,
-		},
-	}
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		"false",
-		stmt.String(),
-	)
+		stmt := &ExpressionStatement{
+			Expression: &BoolExpression{
+				Value: false,
+			},
+		}
+
+		assert.Equal(t,
+			"false",
+			stmt.String(),
+		)
+
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &ExpressionStatement{
+			Expression: nil,
+		}
+
+		assert.Equal(t,
+			"",
+			stmt.String(),
+		)
+	})
 }
 
 func TestReturnStatement_MarshalJSON(t *testing.T) {

--- a/ast/statement_test.go
+++ b/ast/statement_test.go
@@ -904,6 +904,27 @@ func TestForStatement_Doc(t *testing.T) {
 			stmt.Doc(),
 		)
 	})
+
+	t.Run("nil", func(t *testing.T) {
+
+		t.Parallel()
+
+		stmt := &ForStatement{}
+
+		assert.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("for "),
+					prettier.Text(""),
+					prettier.Text(" in "),
+					prettier.Text(""),
+					prettier.Text(" "),
+					prettier.Text("{}"),
+				},
+			},
+			stmt.Doc(),
+		)
+	})
 }
 
 func TestForStatement_String(t *testing.T) {
@@ -953,6 +974,18 @@ func TestForStatement_String(t *testing.T) {
 
 		assert.Equal(t,
 			"for i, foobar in false {}",
+			stmt.String(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+
+		t.Parallel()
+
+		stmt := &ForStatement{}
+
+		assert.Equal(t,
+			"for  in  {}",
 			stmt.String(),
 		)
 	})

--- a/ast/statement_test.go
+++ b/ast/statement_test.go
@@ -1057,60 +1057,102 @@ func TestAssignmentStatement_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &AssignmentStatement{
-		Target: &IdentifierExpression{
-			Identifier: Identifier{
-				Identifier: "foobar",
-			},
-		},
-		Transfer: &Transfer{
-			Operation: TransferOperationCopy,
-		},
-		Value: &BoolExpression{
-			Value: false,
-		},
-	}
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
 
-	require.Equal(t,
-		prettier.Group{
-			Doc: prettier.Concat{
-				prettier.Text("foobar"),
-				prettier.Text(" "),
-				prettier.Text("="),
-				prettier.Text(" "),
-				prettier.Group{
-					Doc: prettier.Indent{
-						Doc: prettier.Text("false"),
+		stmt := &AssignmentStatement{
+			Target: &IdentifierExpression{
+				Identifier: Identifier{
+					Identifier: "foobar",
+				},
+			},
+			Transfer: &Transfer{
+				Operation: TransferOperationCopy,
+			},
+			Value: &BoolExpression{
+				Value: false,
+			},
+		}
+
+		require.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("foobar"),
+					prettier.Text(" "),
+					prettier.Text("="),
+					prettier.Text(" "),
+					prettier.Group{
+						Doc: prettier.Indent{
+							Doc: prettier.Text("false"),
+						},
 					},
 				},
 			},
-		},
-		stmt.Doc(),
-	)
+			stmt.Doc(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &AssignmentStatement{}
+
+		require.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text(""),
+					prettier.Text(" "),
+					prettier.Text(""),
+					prettier.Text(" "),
+					prettier.Group{
+						Doc: prettier.Indent{
+							Doc: prettier.Text(""),
+						},
+					},
+				},
+			},
+			stmt.Doc(),
+		)
+	})
 }
 
 func TestAssignmentStatement_String(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &AssignmentStatement{
-		Target: &IdentifierExpression{
-			Identifier: Identifier{
-				Identifier: "foobar",
-			},
-		},
-		Transfer: &Transfer{
-			Operation: TransferOperationCopy,
-		},
-		Value: &BoolExpression{
-			Value: false,
-		},
-	}
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
 
-	require.Equal(t,
-		"foobar = false",
-		stmt.String(),
-	)
+		stmt := &AssignmentStatement{
+			Target: &IdentifierExpression{
+				Identifier: Identifier{
+					Identifier: "foobar",
+				},
+			},
+			Transfer: &Transfer{
+				Operation: TransferOperationCopy,
+			},
+			Value: &BoolExpression{
+				Value: false,
+			},
+		}
+
+		require.Equal(t,
+			"foobar = false",
+			stmt.String(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &AssignmentStatement{}
+
+		require.Equal(t,
+			"  ",
+			stmt.String(),
+		)
+	})
 }
 
 func TestSwapStatement_MarshalJSON(t *testing.T) {

--- a/ast/statement_test.go
+++ b/ast/statement_test.go
@@ -1617,139 +1617,228 @@ func TestSwitchStatement_MarshalJSON(t *testing.T) {
 	)
 }
 
-func TestSwitchStatement_String(t *testing.T) {
-
-	t.Parallel()
-
-	stmt := &SwitchStatement{
-		Expression: &IdentifierExpression{
-			Identifier: Identifier{
-				Identifier: "foo",
-			},
-		},
-		Cases: []*SwitchCase{
-			{
-				Expression: &BoolExpression{
-					Value: false,
-				},
-				Statements: []Statement{
-					&ExpressionStatement{
-						Expression: &IdentifierExpression{
-							Identifier: Identifier{
-								Identifier: "bar",
-							},
-						},
-					},
-				},
-			},
-			{
-				Statements: []Statement{
-					&ExpressionStatement{
-						Expression: &IdentifierExpression{
-							Identifier: Identifier{
-								Identifier: "baz",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	assert.Equal(t,
-		prettier.Concat{
-			prettier.Group{
-				Doc: prettier.Concat{
-					switchStatementKeywordSpaceDoc,
-					prettier.Indent{
-						Doc: prettier.Concat{
-							prettier.SoftLine{},
-							prettier.Text("foo"),
-						},
-					},
-					prettier.Line{},
-				},
-			},
-			prettier.Text("{"),
-			prettier.Indent{
-				Doc: prettier.Concat{
-					prettier.HardLine{},
-					prettier.Concat{
-						switchCaseKeywordSpaceDoc,
-						prettier.Text("false"),
-						switchCaseColonSymbolDoc,
-						prettier.Indent{
-							Doc: prettier.Concat{
-								prettier.HardLine{},
-								prettier.Text("bar"),
-							},
-						},
-					},
-					prettier.HardLine{},
-					prettier.Concat{
-						switchCaseDefaultKeywordSpaceDoc,
-						prettier.Indent{
-							Doc: prettier.Concat{
-								prettier.HardLine{},
-								prettier.Text("baz"),
-							},
-						},
-					},
-				},
-			},
-			prettier.HardLine{},
-			prettier.Text("}"),
-		},
-		stmt.Doc(),
-	)
-}
-
 func TestSwitchStatement_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &SwitchStatement{
-		Expression: &IdentifierExpression{
-			Identifier: Identifier{
-				Identifier: "foo",
-			},
-		},
-		Cases: []*SwitchCase{
-			{
-				Expression: &BoolExpression{
-					Value: false,
-				},
-				Statements: []Statement{
-					&ExpressionStatement{
-						Expression: &IdentifierExpression{
-							Identifier: Identifier{
-								Identifier: "bar",
-							},
-						},
-					},
-				},
-			},
-			{
-				Statements: []Statement{
-					&ExpressionStatement{
-						Expression: &IdentifierExpression{
-							Identifier: Identifier{
-								Identifier: "baz",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		"switch foo {\n"+
-			"    case false:\n"+
-			"        bar\n"+
-			"    default:\n"+
-			"        baz\n"+
-			"}",
-		stmt.String(),
-	)
+		stmt := &SwitchStatement{
+			Expression: &IdentifierExpression{
+				Identifier: Identifier{
+					Identifier: "foo",
+				},
+			},
+			Cases: []*SwitchCase{
+				{
+					Expression: &BoolExpression{
+						Value: false,
+					},
+					Statements: []Statement{
+						&ExpressionStatement{
+							Expression: &IdentifierExpression{
+								Identifier: Identifier{
+									Identifier: "bar",
+								},
+							},
+						},
+					},
+				},
+				{
+					Statements: []Statement{
+						&ExpressionStatement{
+							Expression: &IdentifierExpression{
+								Identifier: Identifier{
+									Identifier: "baz",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Group{
+					Doc: prettier.Concat{
+						switchStatementKeywordSpaceDoc,
+						prettier.Indent{
+							Doc: prettier.Concat{
+								prettier.SoftLine{},
+								prettier.Text("foo"),
+							},
+						},
+						prettier.Line{},
+					},
+				},
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.HardLine{},
+						prettier.Concat{
+							switchCaseKeywordSpaceDoc,
+							prettier.Text("false"),
+							switchCaseColonSymbolDoc,
+							prettier.Indent{
+								Doc: prettier.Concat{
+									prettier.HardLine{},
+									prettier.Text("bar"),
+								},
+							},
+						},
+						prettier.HardLine{},
+						prettier.Concat{
+							switchCaseDefaultKeywordSpaceDoc,
+							prettier.Indent{
+								Doc: prettier.Concat{
+									prettier.HardLine{},
+									prettier.Text("baz"),
+								},
+							},
+						},
+					},
+				},
+				prettier.HardLine{},
+				prettier.Text("}"),
+			},
+			stmt.Doc(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &SwitchStatement{
+			Expression: nil,
+			Cases: []*SwitchCase{
+				{
+					Expression: nil,
+				},
+				{
+					Expression: nil,
+				},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Concat{
+				prettier.Group{
+					Doc: prettier.Concat{
+						prettier.Text("switch "),
+						prettier.Indent{
+							Doc: prettier.Concat{
+								prettier.SoftLine{},
+								prettier.Text(""),
+							},
+						},
+						prettier.Line{},
+					},
+				},
+				prettier.Text("{"),
+				prettier.Indent{
+					Doc: prettier.Concat{
+						prettier.HardLine{},
+						prettier.Concat{
+							prettier.Text("case "),
+							prettier.Text(""),
+							prettier.Text(":"),
+							prettier.Indent{
+								Doc: prettier.Concat(nil),
+							},
+						},
+						prettier.HardLine{},
+						prettier.Concat{
+							prettier.Text("default:"),
+							prettier.Indent{
+								Doc: prettier.Concat(nil),
+							},
+						},
+					},
+				},
+				prettier.HardLine{},
+				prettier.Text("}"),
+			},
+			stmt.Doc(),
+		)
+	})
+}
+
+func TestSwitchStatement_String(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &SwitchStatement{
+			Expression: &IdentifierExpression{
+				Identifier: Identifier{
+					Identifier: "foo",
+				},
+			},
+			Cases: []*SwitchCase{
+				{
+					Expression: &BoolExpression{
+						Value: false,
+					},
+					Statements: []Statement{
+						&ExpressionStatement{
+							Expression: &IdentifierExpression{
+								Identifier: Identifier{
+									Identifier: "bar",
+								},
+							},
+						},
+					},
+				},
+				{
+					Statements: []Statement{
+						&ExpressionStatement{
+							Expression: &IdentifierExpression{
+								Identifier: Identifier{
+									Identifier: "baz",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t,
+			"switch foo {\n"+
+				"    case false:\n"+
+				"        bar\n"+
+				"    default:\n"+
+				"        baz\n"+
+				"}",
+			stmt.String(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &SwitchStatement{
+			Expression: nil,
+			Cases: []*SwitchCase{
+				{
+					Expression: nil,
+				},
+				{
+					Expression: nil,
+				},
+			},
+		}
+
+		assert.Equal(t,
+			`switch  {
+    case :
+    default:
+}`,
+			stmt.String(),
+		)
+	})
 }

--- a/ast/statement_test.go
+++ b/ast/statement_test.go
@@ -622,45 +622,82 @@ func TestWhileStatement_Doc(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &WhileStatement{
-		Test: &BoolExpression{
-			Value: false,
-		},
-		Block: &Block{
-			Statements: []Statement{},
-		},
-	}
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		prettier.Group{
-			Doc: prettier.Concat{
-				prettier.Text("while "),
-				prettier.Text("false"),
-				prettier.Text(" "),
-				prettier.Text("{}"),
+		stmt := &WhileStatement{
+			Test: &BoolExpression{
+				Value: false,
 			},
-		},
-		stmt.Doc(),
-	)
+			Block: &Block{
+				Statements: []Statement{},
+			},
+		}
+
+		assert.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("while "),
+					prettier.Text("false"),
+					prettier.Text(" "),
+					prettier.Text("{}"),
+				},
+			},
+			stmt.Doc(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &WhileStatement{}
+
+		assert.Equal(t,
+			prettier.Group{
+				Doc: prettier.Concat{
+					prettier.Text("while "),
+					prettier.Text(""),
+					prettier.Text(" "),
+					prettier.Text("{}"),
+				},
+			},
+			stmt.Doc(),
+		)
+	})
 }
 
 func TestWhileStatement_String(t *testing.T) {
 
 	t.Parallel()
 
-	stmt := &WhileStatement{
-		Test: &BoolExpression{
-			Value: false,
-		},
-		Block: &Block{
-			Statements: []Statement{},
-		},
-	}
+	t.Run("simple", func(t *testing.T) {
+		t.Parallel()
 
-	assert.Equal(t,
-		"while false {}",
-		stmt.String(),
-	)
+		stmt := &WhileStatement{
+			Test: &BoolExpression{
+				Value: false,
+			},
+			Block: &Block{
+				Statements: []Statement{},
+			},
+		}
+
+		assert.Equal(t,
+			"while false {}",
+			stmt.String(),
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		stmt := &WhileStatement{}
+
+		assert.Equal(t,
+			"while  {}",
+			stmt.String(),
+		)
+	})
 }
 
 func TestForStatement_MarshalJSON(t *testing.T) {

--- a/pretty/print.go
+++ b/pretty/print.go
@@ -347,10 +347,7 @@ func (p ErrorPrettyPrinter) writeCodeExcerpts(
 			// indicator line
 			p.writeString(emptyLineNumbers)
 
-			indicatorLength := excerpt.startPos.Column
-			if indicatorLength > maxLineLength {
-				indicatorLength = maxLineLength
-			}
+			indicatorLength := min(excerpt.startPos.Column, maxLineLength)
 			if indicatorLength > len(line) {
 				indicatorLength = len(line)
 			}

--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -50,7 +50,6 @@ func (c *LocationCoverage) AddLineHit(line int) {
 // statements percentage. It is defined as the ratio of covered
 // lines over the total statements for a given location.
 func (c *LocationCoverage) Percentage() string {
-	coveredLines := c.CoveredLines()
 	// The ground truth of which statements are interpreted/executed
 	// is the `InterpreterEnvironment.newOnStatementHandler()` function.
 	// This means that every call of `CoverageReport.AddLineHit()` from
@@ -59,12 +58,10 @@ func (c *LocationCoverage) Percentage() string {
 	// This is a good insight to solidify its implementation and debug
 	// the inspection failure. Ideally, this condition will never be true,
 	// except for tests. We just leave it here, as a fail-safe mechanism.
-	if coveredLines > c.Statements {
-		// We saturate the percentage at 100%, when the inspector
-		// fails to correctly count all statements for a given
-		// location.
-		coveredLines = c.Statements
-	}
+	// We saturate the percentage at 100%, when the inspector
+	// fails to correctly count all statements for a given
+	// location.
+	coveredLines := min(c.CoveredLines(), c.Statements)
 
 	percentage := 100 * float64(coveredLines) / float64(c.Statements)
 	return fmt.Sprintf("%0.1f%%", percentage)

--- a/sema/check_invocation_expression.go
+++ b/sema/check_invocation_expression.go
@@ -453,10 +453,7 @@ func (checker *Checker) checkInvocation(
 		invocationExpression,
 	)
 
-	minCount := argumentCount
-	if parameterCount < argumentCount {
-		minCount = parameterCount
-	}
+	minCount := min(parameterCount, argumentCount)
 
 	var parameterTypes []Type
 


### PR DESCRIPTION
Depends on #4178
Closes #4171

## Description

Improve the `Doc()` methods of AST statement and attachment elements to handle `nil` and add tests where missing.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
