### PR TITLE
Improve type conversion error

### DIFF
--- a/sema/checker.go
+++ b/sema/checker.go
@@ -884,6 +884,9 @@ func (checker *Checker) ConvertType(t ast.Type) Type {
 	case *ast.InstantiationType:
 		return checker.convertInstantiationType(t)
 
+	case nil:
+		return InvalidType
+
 	default:
 		checker.report(&UnconvertibleTypeError{
 			Range: ast.NewRangeFromPositioned(checker.memoryGauge, t),

--- a/sema/errors.go
+++ b/sema/errors.go
@@ -6847,7 +6847,6 @@ type UnconvertibleTypeError struct {
 var _ SemanticError = &UnconvertibleTypeError{}
 var _ errors.UserError = &UnconvertibleTypeError{}
 var _ errors.SecondaryError = &UnconvertibleTypeError{}
-var _ errors.HasDocumentationLink = &UnconvertibleTypeError{}
 
 func (e *UnconvertibleTypeError) isSemanticError() {}
 
@@ -6858,11 +6857,7 @@ func (e *UnconvertibleTypeError) Error() string {
 }
 
 func (*UnconvertibleTypeError) SecondaryError() string {
-	return "use explicit type conversion or check if the type supports conversion"
-}
-
-func (*UnconvertibleTypeError) DocumentationLink() string {
-	return "https://cadence-lang.org/docs/language/values-and-types"
+	return "report this to the Cadence team at https://github.com/onflow/cadence/issues/new"
 }
 
 // InvalidMappingAuthorizationError


### PR DESCRIPTION
Work towards #4062 

## Description

While testing #4171 I noticed `UnconvertibleTypeError` being reported. The error message is currently misleading, the error is actually an implementation error: somehow Cadence should, but is unable to convert the AST type to a sema type. The error also has no position information, so it is reported at the end of the file.

<img width="945" height="198" alt="Screenshot 2025-08-26 at 4 15 12 PM" src="https://github.com/user-attachments/assets/0be2346b-8c08-418a-b38c-bb643e02f7ca" />


Instead of changing the error from a user error to an implementation error, urge the user to report this case to us.

Also, handle the case that caused the conversion failure: The type (`ast.Type`) might be `nil` when the parser is used in tooling, e.g. the linter, as the parser is becoming more resilient (#529).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
