### PR TITLE
Return non-pointer error types as non-pointer values

### DIFF
--- a/interpreter/encode.go
+++ b/interpreter/encode.go
@@ -1399,7 +1399,7 @@ func (t *CapabilityStaticType) Encode(e *cbor.StreamEncoder) error {
 }
 
 func (t FunctionStaticType) Encode(_ *cbor.StreamEncoder) error {
-	return &NonStorableStaticTypeError{
+	return NonStorableStaticTypeError{
 		Type: t.Type,
 	}
 }

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5236,7 +5236,7 @@ func (interpreter *Interpreter) GetInterfaceType(
 		if interfaceType != nil {
 			return interfaceType, nil
 		}
-		return nil, &InterfaceMissingLocationError{
+		return nil, InterfaceMissingLocationError{
 			QualifiedIdentifier: qualifiedIdentifier,
 		}
 	}


### PR DESCRIPTION

## Description

Small fix: Some error values are non-pointer types so should be returned as such.

Found these by trying out https://github.com/fillmore-labs/errortype.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
