### PR TITLE
Fix rounding behaviour for division of negative number values backed by big.Int

### DIFF
--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -328,7 +328,7 @@ func (v Fix64Value) Div(context NumberValueArithmeticContext, other NumberValue,
 
 	valueGetter := func() int64 {
 		result := new(big.Int).Mul(a, sema.Fix64FactorBig)
-		result.Div(result, b)
+		result.Quo(result, b)
 
 		if result.Cmp(minInt64Big) < 0 {
 			panic(&UnderflowError{
@@ -362,7 +362,7 @@ func (v Fix64Value) SaturatingDiv(context NumberValueArithmeticContext, other Nu
 
 	valueGetter := func() int64 {
 		result := new(big.Int).Mul(a, sema.Fix64FactorBig)
-		result.Div(result, b)
+		result.Quo(result, b)
 
 		if result.Cmp(minInt64Big) < 0 {
 			return math.MinInt64

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -459,7 +459,7 @@ func (v Int128Value) Div(context NumberValueArithmeticContext, other NumberValue
 				LocationRange: locationRange,
 			})
 		}
-		res.Div(v.BigInt, o.BigInt)
+		res.Quo(v.BigInt, o.BigInt)
 
 		return res
 	}
@@ -495,7 +495,7 @@ func (v Int128Value) SaturatingDiv(context NumberValueArithmeticContext, other N
 		if (v.BigInt.Cmp(sema.Int128TypeMinIntBig) == 0) && (o.BigInt.Cmp(res) == 0) {
 			return sema.Int128TypeMaxIntBig
 		}
-		res.Div(v.BigInt, o.BigInt)
+		res.Quo(v.BigInt, o.BigInt)
 
 		return res
 	}

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -428,7 +428,7 @@ func (v Int256Value) Div(context NumberValueArithmeticContext, other NumberValue
 				LocationRange: locationRange,
 			})
 		}
-		res.Div(v.BigInt, o.BigInt)
+		res.Quo(v.BigInt, o.BigInt)
 		return res
 	}
 
@@ -463,7 +463,7 @@ func (v Int256Value) SaturatingDiv(context NumberValueArithmeticContext, other N
 		if (v.BigInt.Cmp(sema.Int256TypeMinIntBig) == 0) && (o.BigInt.Cmp(res) == 0) {
 			return sema.Int256TypeMaxIntBig
 		}
-		res.Div(v.BigInt, o.BigInt)
+		res.Quo(v.BigInt, o.BigInt)
 		return res
 	}
 

--- a/values/value_int.go
+++ b/values/value_int.go
@@ -162,7 +162,7 @@ func (v IntValue) Div(gauge common.MemoryGauge, other IntValue) (IntValue, error
 		common.NewDivBigIntMemoryUsage(v.BigInt, other.BigInt),
 		func() *big.Int {
 			res := new(big.Int)
-			return res.Div(v.BigInt, other.BigInt)
+			return res.Quo(v.BigInt, other.BigInt)
 		},
 	), nil
 }


### PR DESCRIPTION
Closes #4172

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
