### PR TITLE
[Compiler] Split VM Typeloader into separate dedicated methods.

### DIFF
--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -697,42 +697,77 @@ func ContractValueHandler(contractName string, arguments ...vm.Value) vm.Contrac
 	}
 }
 
-func CompiledProgramsTypeLoader(
+func CompiledProgramsCompositeTypeLoader(
 	programs CompiledPrograms,
-) func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
-	return func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+) func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+	return func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 		program, ok := programs[location]
 		if !ok {
-			return nil, interpreter.TypeLoadingError{
-				TypeID: typeID,
-			}
+			return nil
 		}
 
 		elaboration := program.DesugaredElaboration
 
 		compositeType := elaboration.CompositeType(typeID)
-		if compositeType != nil {
-			return compositeType, nil
+
+		return compositeType
+	}
+}
+
+func CompiledProgramsInterfaceTypeLoader(
+	programs CompiledPrograms,
+) func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+	return func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+		program, ok := programs[location]
+		if !ok {
+			return nil
 		}
 
+		elaboration := program.DesugaredElaboration
+
 		interfaceType := elaboration.InterfaceType(typeID)
-		if interfaceType != nil {
-			return interfaceType, nil
+
+		return interfaceType
+	}
+}
+
+func CompiledProgramsEntitlementTypeLoader(
+	programs CompiledPrograms,
+) func(location common.Location, typeID interpreter.TypeID) *sema.EntitlementType {
+	return func(location common.Location, typeID interpreter.TypeID) *sema.EntitlementType {
+		program, ok := programs[location]
+		if !ok {
+			return nil
 		}
+
+		elaboration := program.DesugaredElaboration
 
 		entitlementType := elaboration.EntitlementType(typeID)
 		if entitlementType != nil {
-			return entitlementType, nil
+			return entitlementType
 		}
+
+		return nil
+	}
+}
+
+func CompiledProgramsEntitlementMapTypeLoader(
+	programs CompiledPrograms,
+) func(location common.Location, typeID interpreter.TypeID) *sema.EntitlementMapType {
+	return func(location common.Location, typeID interpreter.TypeID) *sema.EntitlementMapType {
+		program, ok := programs[location]
+		if !ok {
+			return nil
+		}
+
+		elaboration := program.DesugaredElaboration
 
 		entitlementMapType := elaboration.EntitlementMapType(typeID)
 		if entitlementMapType != nil {
-			return entitlementMapType, nil
+			return entitlementMapType
 		}
 
-		return nil, interpreter.TypeLoadingError{
-			TypeID: typeID,
-		}
+		return nil
 	}
 }
 
@@ -795,8 +830,20 @@ func PrepareVMConfig(
 		}
 	}
 
-	if config.TypeLoader == nil {
-		config.TypeLoader = CompiledProgramsTypeLoader(programs)
+	if config.CompositeTypeHandler == nil {
+		config.CompositeTypeHandler = CompiledProgramsCompositeTypeLoader(programs)
+	}
+
+	if config.InterfaceTypeHandler == nil {
+		config.InterfaceTypeHandler = CompiledProgramsInterfaceTypeLoader(programs)
+	}
+
+	if config.EntitlementTypeHandler == nil {
+		config.EntitlementTypeHandler = CompiledProgramsEntitlementTypeLoader(programs)
+	}
+
+	if config.EntitlementMapTypeHandler == nil {
+		config.EntitlementMapTypeHandler = CompiledProgramsEntitlementMapTypeLoader(programs)
 	}
 
 	if config.ImportHandler == nil {

--- a/bbq/vm/test/vm_bench_test.go
+++ b/bbq/vm/test/vm_bench_test.go
@@ -478,14 +478,15 @@ func BenchmarkMethodCall(b *testing.B) {
 		vmConfig.ContractValueHandler = func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
 			return importedContractValue
 		}
-		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 			elaboration := importedChecker.Elaboration
 			compositeType := elaboration.CompositeType(typeID)
-			if compositeType != nil {
-				return compositeType, nil
-			}
-
-			return elaboration.InterfaceType(typeID), nil
+			return compositeType
+		}
+		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			elaboration := importedChecker.Elaboration
+			interfaceType := elaboration.InterfaceType(typeID)
+			return interfaceType
 		}
 
 		scriptLocation := runtime_utils.NewScriptLocationGenerator()

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -548,14 +548,15 @@ func TestImport(t *testing.T) {
 	vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 		return importedProgram
 	}
-	vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 		elaboration := importedChecker.Elaboration
 		compositeType := elaboration.CompositeType(typeID)
-		if compositeType != nil {
-			return compositeType, nil
-		}
-
-		return elaboration.InterfaceType(typeID), nil
+		return compositeType
+	}
+	vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+		elaboration := importedChecker.Elaboration
+		interfaceType := elaboration.InterfaceType(typeID)
+		return interfaceType
 	}
 
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
@@ -673,14 +674,15 @@ func TestImportError(t *testing.T) {
 	vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 		return importedContractValue
 	}
-	vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 		elaboration := importedChecker.Elaboration
 		compositeType := elaboration.CompositeType(typeID)
-		if compositeType != nil {
-			return compositeType, nil
-		}
-
-		return elaboration.InterfaceType(typeID), nil
+		return compositeType
+	}
+	vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+		elaboration := importedChecker.Elaboration
+		interfaceType := elaboration.InterfaceType(typeID)
+		return interfaceType
 	}
 	vmConfig.BuiltinGlobalsProvider = VMBuiltinGlobalsProviderWithDefaultsAndPanic
 
@@ -789,14 +791,15 @@ func TestContractImport(t *testing.T) {
 		vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
 			return importedContractValue
 		}
-		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 			elaboration := importedChecker.Elaboration
 			compositeType := elaboration.CompositeType(typeID)
-			if compositeType != nil {
-				return compositeType, nil
-			}
-
-			return elaboration.InterfaceType(typeID), nil
+			return compositeType
+		}
+		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			elaboration := importedChecker.Elaboration
+			interfaceType := elaboration.InterfaceType(typeID)
+			return interfaceType
 		}
 
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
@@ -850,14 +853,15 @@ func TestContractImport(t *testing.T) {
 		vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
 			return importedContractValue
 		}
-		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 			elaboration := importedChecker.Elaboration
 			compositeType := elaboration.CompositeType(typeID)
-			if compositeType != nil {
-				return compositeType, nil
-			}
-
-			return elaboration.InterfaceType(typeID), nil
+			return compositeType
+		}
+		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			elaboration := importedChecker.Elaboration
+			interfaceType := elaboration.InterfaceType(typeID)
+			return interfaceType
 		}
 
 		_, importedContractValue = initializeContract(
@@ -953,16 +957,19 @@ func TestContractImport(t *testing.T) {
 			require.Equal(t, fooLocation, location)
 			return fooContractValue
 		}
-		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 			require.Equal(t, fooLocation, location)
 
 			elaboration := fooChecker.Elaboration
 			compositeType := elaboration.CompositeType(typeID)
-			if compositeType != nil {
-				return compositeType, nil
-			}
+			return compositeType
+		}
+		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			require.Equal(t, fooLocation, location)
 
-			return elaboration.InterfaceType(typeID), nil
+			elaboration := fooChecker.Elaboration
+			interfaceType := elaboration.InterfaceType(typeID)
+			return interfaceType
 		}
 
 		_, fooContractValue = initializeContract(
@@ -1102,8 +1109,7 @@ func TestContractImport(t *testing.T) {
 				return nil
 			}
 		}
-		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
-
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 			var elaboration *sema.Elaboration
 
 			switch location {
@@ -1116,11 +1122,23 @@ func TestContractImport(t *testing.T) {
 			}
 
 			compositeType := elaboration.CompositeType(typeID)
-			if compositeType != nil {
-				return compositeType, nil
+			return compositeType
+		}
+
+		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			var elaboration *sema.Elaboration
+
+			switch location {
+			case fooLocation:
+				elaboration = fooChecker.Elaboration
+			case barLocation:
+				elaboration = barChecker.Elaboration
+			default:
+				assert.FailNow(t, fmt.Sprintf("invalid location %s", location))
 			}
 
-			return elaboration.InterfaceType(typeID), nil
+			interfaceType := elaboration.InterfaceType(typeID)
+			return interfaceType
 		}
 
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
@@ -1312,8 +1330,7 @@ func TestContractImport(t *testing.T) {
 				return nil
 			}
 		}
-		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
-
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 			var elaboration *sema.Elaboration
 
 			switch location {
@@ -1324,11 +1341,20 @@ func TestContractImport(t *testing.T) {
 			}
 
 			compositeType := elaboration.CompositeType(typeID)
-			if compositeType != nil {
-				return compositeType, nil
+			return compositeType
+		}
+		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			var elaboration *sema.Elaboration
+
+			switch location {
+			case barLocation:
+				elaboration = barChecker.Elaboration
+			default:
+				assert.FailNow(t, fmt.Sprintf("invalid location %s", location))
 			}
 
-			return elaboration.InterfaceType(typeID), nil
+			interfaceType := elaboration.InterfaceType(typeID)
+			return interfaceType
 		}
 		vmConfig.BuiltinGlobalsProvider = VMBuiltinGlobalsProviderWithDefaultsAndPanic
 
@@ -1398,14 +1424,15 @@ func TestContractImport(t *testing.T) {
 		vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
 			return importedContractValue
 		}
-		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 			elaboration := importedChecker.Elaboration
 			compositeType := elaboration.CompositeType(typeID)
-			if compositeType != nil {
-				return compositeType, nil
-			}
-
-			return elaboration.InterfaceType(typeID), nil
+			return compositeType
+		}
+		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			elaboration := importedChecker.Elaboration
+			interfaceType := elaboration.InterfaceType(typeID)
+			return interfaceType
 		}
 		vmConfig.BuiltinGlobalsProvider = NewVMBuiltinGlobalsProviderWithDefaultsPanicAndConditionLog(&logs)
 
@@ -1746,14 +1773,15 @@ func TestContractField(t *testing.T) {
 		vmConfig.ContractValueHandler = func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
 			return importedContractValue
 		}
-		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 			elaboration := importedChecker.Elaboration
 			compositeType := elaboration.CompositeType(typeID)
-			if compositeType != nil {
-				return compositeType, nil
-			}
-
-			return elaboration.InterfaceType(typeID), nil
+			return compositeType
+		}
+		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			elaboration := importedChecker.Elaboration
+			interfaceType := elaboration.InterfaceType(typeID)
+			return interfaceType
 		}
 
 		_, importedContractValue = initializeContract(
@@ -1839,14 +1867,15 @@ func TestContractField(t *testing.T) {
 		vmConfig.ContractValueHandler = func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
 			return importedContractValue
 		}
-		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 			elaboration := importedChecker.Elaboration
 			compositeType := elaboration.CompositeType(typeID)
-			if compositeType != nil {
-				return compositeType, nil
-			}
-
-			return elaboration.InterfaceType(typeID), nil
+			return compositeType
+		}
+		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			elaboration := importedChecker.Elaboration
+			interfaceType := elaboration.InterfaceType(typeID)
+			return interfaceType
 		}
 
 		_, importedContractValue = initializeContract(
@@ -2599,14 +2628,15 @@ func TestInterfaceMethodCall(t *testing.T) {
 		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 			return importedContractValue
 		}
-		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 			elaboration := importedChecker.Elaboration
 			compositeType := elaboration.CompositeType(typeID)
-			if compositeType != nil {
-				return compositeType, nil
-			}
-
-			return elaboration.InterfaceType(typeID), nil
+			return compositeType
+		}
+		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			elaboration := importedChecker.Elaboration
+			interfaceType := elaboration.InterfaceType(typeID)
+			return interfaceType
 		}
 
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
@@ -2782,8 +2812,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 				return nil
 			}
 		}
-		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
-
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 			var elaboration *sema.Elaboration
 
 			switch location {
@@ -2796,11 +2825,22 @@ func TestInterfaceMethodCall(t *testing.T) {
 			}
 
 			compositeType := elaboration.CompositeType(typeID)
-			if compositeType != nil {
-				return compositeType, nil
+			return compositeType
+		}
+		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			var elaboration *sema.Elaboration
+
+			switch location {
+			case fooLocation:
+				elaboration = fooChecker.Elaboration
+			case barLocation:
+				elaboration = barChecker.Elaboration
+			default:
+				assert.FailNow(t, fmt.Sprintf("invalid location %s", location))
 			}
 
-			return elaboration.InterfaceType(typeID), nil
+			interfaceType := elaboration.InterfaceType(typeID)
+			return interfaceType
 		}
 
 		_, bazContractValue := initializeContract(
@@ -2874,7 +2914,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 				return nil
 			}
 		}
-		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 			var elaboration *sema.Elaboration
 
 			switch location {
@@ -2887,11 +2927,22 @@ func TestInterfaceMethodCall(t *testing.T) {
 			}
 
 			compositeType := elaboration.CompositeType(typeID)
-			if compositeType != nil {
-				return compositeType, nil
+			return compositeType
+		}
+		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			var elaboration *sema.Elaboration
+
+			switch location {
+			case barLocation:
+				elaboration = barChecker.Elaboration
+			case bazLocation:
+				elaboration = bazChecker.Elaboration
+			default:
+				assert.FailNow(t, fmt.Sprintf("invalid location %s", location))
 			}
 
-			return elaboration.InterfaceType(typeID), nil
+			interfaceType := elaboration.InterfaceType(typeID)
+			return interfaceType
 		}
 
 		scriptVM := vm.NewVM(scriptLocation(), program, vmConfig)
@@ -2982,8 +3033,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 				return nil
 			}
 		}
-		vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
-
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 			var elaboration *sema.Elaboration
 
 			switch location {
@@ -2998,11 +3048,24 @@ func TestInterfaceMethodCall(t *testing.T) {
 			}
 
 			compositeType := elaboration.CompositeType(typeID)
-			if compositeType != nil {
-				return compositeType, nil
+			return compositeType
+		}
+		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			var elaboration *sema.Elaboration
+
+			switch location {
+			case fooLocation:
+				elaboration = fooChecker.Elaboration
+			case barLocation:
+				elaboration = barChecker.Elaboration
+			case bazLocation:
+				elaboration = bazChecker.Elaboration
+			default:
+				assert.FailNow(t, fmt.Sprintf("invalid location %s", location))
 			}
 
-			return elaboration.InterfaceType(typeID), nil
+			interfaceType := elaboration.InterfaceType(typeID)
+			return interfaceType
 		}
 
 		scriptVM = vm.NewVM(scriptLocation(), program, vmConfig)
@@ -3413,7 +3476,10 @@ func TestDefaultFunctions(t *testing.T) {
 			}
 			return contractValue
 		}
-		vmConfig.TypeLoader = CompiledProgramsTypeLoader(programs)
+		vmConfig.CompositeTypeHandler = CompiledProgramsCompositeTypeLoader(programs)
+		vmConfig.InterfaceTypeHandler = CompiledProgramsInterfaceTypeLoader(programs)
+		vmConfig.EntitlementTypeHandler = CompiledProgramsEntitlementTypeLoader(programs)
+		vmConfig.EntitlementMapTypeHandler = CompiledProgramsEntitlementMapTypeLoader(programs)
 
 		var uuid uint64 = 42
 		vmConfig.UUIDHandler = func() (uint64, error) {
@@ -3536,7 +3602,10 @@ func TestDefaultFunctions(t *testing.T) {
 			}
 			return contractValue
 		}
-		vmConfig.TypeLoader = CompiledProgramsTypeLoader(programs)
+		vmConfig.CompositeTypeHandler = CompiledProgramsCompositeTypeLoader(programs)
+		vmConfig.InterfaceTypeHandler = CompiledProgramsInterfaceTypeLoader(programs)
+		vmConfig.EntitlementTypeHandler = CompiledProgramsEntitlementTypeLoader(programs)
+		vmConfig.EntitlementMapTypeHandler = CompiledProgramsEntitlementMapTypeLoader(programs)
 
 		var uuid uint64 = 42
 		vmConfig.UUIDHandler = func() (uint64, error) {
@@ -3651,7 +3720,10 @@ func TestDefaultFunctions(t *testing.T) {
 			}
 			return contractValue
 		}
-		vmConfig.TypeLoader = CompiledProgramsTypeLoader(programs)
+		vmConfig.CompositeTypeHandler = CompiledProgramsCompositeTypeLoader(programs)
+		vmConfig.InterfaceTypeHandler = CompiledProgramsInterfaceTypeLoader(programs)
+		vmConfig.EntitlementTypeHandler = CompiledProgramsEntitlementTypeLoader(programs)
+		vmConfig.EntitlementMapTypeHandler = CompiledProgramsEntitlementMapTypeLoader(programs)
 
 		var uuid uint64 = 42
 		vmConfig.UUIDHandler = func() (uint64, error) {
@@ -4038,7 +4110,10 @@ func TestFunctionPreConditions(t *testing.T) {
 			}
 			return contractValue
 		}
-		vmConfig.TypeLoader = CompiledProgramsTypeLoader(programs)
+		vmConfig.CompositeTypeHandler = CompiledProgramsCompositeTypeLoader(programs)
+		vmConfig.InterfaceTypeHandler = CompiledProgramsInterfaceTypeLoader(programs)
+		vmConfig.EntitlementTypeHandler = CompiledProgramsEntitlementTypeLoader(programs)
+		vmConfig.EntitlementMapTypeHandler = CompiledProgramsEntitlementMapTypeLoader(programs)
 
 		vmConfig.BuiltinGlobalsProvider = NewVMBuiltinGlobalsProviderWithDefaultsPanicAndConditionLog(&logs)
 
@@ -6271,14 +6346,15 @@ func TestContractAccount(t *testing.T) {
 	vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
 		return importedContractValue
 	}
-	vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 		elaboration := importedChecker.Elaboration
 		compositeType := elaboration.CompositeType(typeID)
-		if compositeType != nil {
-			return compositeType, nil
-		}
-
-		return elaboration.InterfaceType(typeID), nil
+		return compositeType
+	}
+	vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+		elaboration := importedChecker.Elaboration
+		interfaceType := elaboration.InterfaceType(typeID)
+		return interfaceType
 	}
 
 	vmConfig.InjectedCompositeFieldsHandler = func(
@@ -6395,14 +6471,15 @@ func TestResourceOwner(t *testing.T) {
 	vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
 		return importedContractValue
 	}
-	vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 		elaboration := importedChecker.Elaboration
 		compositeType := elaboration.CompositeType(typeID)
-		if compositeType != nil {
-			return compositeType, nil
-		}
-
-		return elaboration.InterfaceType(typeID), nil
+		return compositeType
+	}
+	vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+		elaboration := importedChecker.Elaboration
+		interfaceType := elaboration.InterfaceType(typeID)
+		return interfaceType
 	}
 
 	vmConfig.UUIDHandler = func() (uint64, error) {
@@ -6527,14 +6604,15 @@ func TestResourceUUID(t *testing.T) {
 	vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
 		return importedContractValue
 	}
-	vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 		elaboration := importedChecker.Elaboration
 		compositeType := elaboration.CompositeType(typeID)
-		if compositeType != nil {
-			return compositeType, nil
-		}
-
-		return elaboration.InterfaceType(typeID), nil
+		return compositeType
+	}
+	vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+		elaboration := importedChecker.Elaboration
+		interfaceType := elaboration.InterfaceType(typeID)
+		return interfaceType
 	}
 
 	vmConfig.UUIDHandler = func() (uint64, error) {
@@ -6929,14 +7007,15 @@ func TestContractClosure(t *testing.T) {
 	vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
 		return importedContractValue
 	}
-	vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 		elaboration := importedChecker.Elaboration
 		compositeType := elaboration.CompositeType(typeID)
-		if compositeType != nil {
-			return compositeType, nil
-		}
-
-		return elaboration.InterfaceType(typeID), nil
+		return compositeType
+	}
+	vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+		elaboration := importedChecker.Elaboration
+		interfaceType := elaboration.InterfaceType(typeID)
+		return interfaceType
 	}
 	vmConfig.BuiltinGlobalsProvider = VMBuiltinGlobalsProviderWithDefaultsAndPanic
 
@@ -7168,7 +7247,10 @@ func TestEmitInContract(t *testing.T) {
 			}
 			return contractValue
 		}
-		vmConfig.TypeLoader = CompiledProgramsTypeLoader(programs)
+		vmConfig.CompositeTypeHandler = CompiledProgramsCompositeTypeLoader(programs)
+		vmConfig.InterfaceTypeHandler = CompiledProgramsInterfaceTypeLoader(programs)
+		vmConfig.EntitlementTypeHandler = CompiledProgramsEntitlementTypeLoader(programs)
+		vmConfig.EntitlementMapTypeHandler = CompiledProgramsEntitlementMapTypeLoader(programs)
 
 		var uuid uint64 = 42
 		vmConfig.UUIDHandler = func() (uint64, error) {
@@ -7301,7 +7383,10 @@ func TestInheritedConditions(t *testing.T) {
 			}
 			return contractValue
 		}
-		vmConfig.TypeLoader = CompiledProgramsTypeLoader(programs)
+		vmConfig.CompositeTypeHandler = CompiledProgramsCompositeTypeLoader(programs)
+		vmConfig.InterfaceTypeHandler = CompiledProgramsInterfaceTypeLoader(programs)
+		vmConfig.EntitlementTypeHandler = CompiledProgramsEntitlementTypeLoader(programs)
+		vmConfig.EntitlementMapTypeHandler = CompiledProgramsEntitlementMapTypeLoader(programs)
 
 		var uuid uint64 = 42
 		vmConfig.UUIDHandler = func() (uint64, error) {
@@ -7452,7 +7537,10 @@ func TestInheritedConditions(t *testing.T) {
 			}
 			return contractValue
 		}
-		vmConfig.TypeLoader = CompiledProgramsTypeLoader(programs)
+		vmConfig.CompositeTypeHandler = CompiledProgramsCompositeTypeLoader(programs)
+		vmConfig.InterfaceTypeHandler = CompiledProgramsInterfaceTypeLoader(programs)
+		vmConfig.EntitlementTypeHandler = CompiledProgramsEntitlementTypeLoader(programs)
+		vmConfig.EntitlementMapTypeHandler = CompiledProgramsEntitlementMapTypeLoader(programs)
 
 		var uuid uint64 = 42
 		vmConfig.UUIDHandler = func() (uint64, error) {
@@ -9286,14 +9374,17 @@ func TestInjectedContract(t *testing.T) {
 
 	programs := map[common.Location]*CompiledProgram{}
 
-	compiledProgramsTypeLoader := CompiledProgramsTypeLoader(programs)
+	compositeTypeLoader := CompiledProgramsCompositeTypeLoader(programs)
+	vmConfig.InterfaceTypeHandler = CompiledProgramsInterfaceTypeLoader(programs)
+	vmConfig.EntitlementTypeHandler = CompiledProgramsEntitlementTypeLoader(programs)
+	vmConfig.EntitlementMapTypeHandler = CompiledProgramsEntitlementMapTypeLoader(programs)
 
-	vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 		if location == nil && typeID == "B" {
-			return bType, nil
+			return bType
 		}
 
-		return compiledProgramsTypeLoader(location, typeID)
+		return compositeTypeLoader(location, typeID)
 	}
 
 	result, err := CompileAndInvokeWithOptions(
@@ -9398,7 +9489,10 @@ func TestInheritedDefaultDestroyEvent(t *testing.T) {
 		}
 		return contractValue
 	}
-	vmConfig.TypeLoader = CompiledProgramsTypeLoader(programs)
+	vmConfig.CompositeTypeHandler = CompiledProgramsCompositeTypeLoader(programs)
+	vmConfig.InterfaceTypeHandler = CompiledProgramsInterfaceTypeLoader(programs)
+	vmConfig.EntitlementTypeHandler = CompiledProgramsEntitlementTypeLoader(programs)
+	vmConfig.EntitlementMapTypeHandler = CompiledProgramsEntitlementMapTypeLoader(programs)
 
 	vmConfig.BuiltinGlobalsProvider = NewVMBuiltinGlobalsProviderWithDefaultsPanicAndConditionLog(&logs)
 

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -452,6 +452,11 @@ func (e *vmEnvironment) loadDesugaredElaboration(location common.Location) (*com
 }
 
 func (e *vmEnvironment) loadCompositeType(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+	ty := e.allDeclaredTypes[typeID]
+	if ty != nil {
+		return ty.(*sema.CompositeType)
+	}
+
 	if _, ok := location.(stdlib.FlowLocation); ok {
 		return stdlib.FlowEventTypes[typeID]
 	}
@@ -470,6 +475,11 @@ func (e *vmEnvironment) loadCompositeType(location common.Location, typeID inter
 }
 
 func (e *vmEnvironment) loadInterfaceType(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+	ty := e.allDeclaredTypes[typeID]
+	if ty != nil {
+		return ty.(*sema.InterfaceType)
+	}
+
 	elaboration, err := e.loadDesugaredElaboration(location)
 	if err != nil {
 		return nil
@@ -484,6 +494,11 @@ func (e *vmEnvironment) loadInterfaceType(location common.Location, typeID inter
 }
 
 func (e *vmEnvironment) loadEntitlementType(location common.Location, typeID interpreter.TypeID) *sema.EntitlementType {
+	ty := e.allDeclaredTypes[typeID]
+	if ty != nil {
+		return ty.(*sema.EntitlementType)
+	}
+
 	elaboration, err := e.loadDesugaredElaboration(location)
 	if err != nil {
 		return nil
@@ -498,6 +513,11 @@ func (e *vmEnvironment) loadEntitlementType(location common.Location, typeID int
 }
 
 func (e *vmEnvironment) loadEntitlementMapType(location common.Location, typeID interpreter.TypeID) *sema.EntitlementMapType {
+	ty := e.allDeclaredTypes[typeID]
+	if ty != nil {
+		return ty.(*sema.EntitlementMapType)
+	}
+
 	elaboration, err := e.loadDesugaredElaboration(location)
 	if err != nil {
 		return nil

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -250,20 +250,53 @@ func ParseCheckAndPrepareWithOptions(
 	vmConfig := vm.NewConfig(storage).
 		WithDebugEnabled()
 
-	typeLoader := compilerUtils.CompiledProgramsTypeLoader(programs)
+	compositeTypeLoader := compilerUtils.CompiledProgramsCompositeTypeLoader(programs)
+	interfaceTypeLoader := compilerUtils.CompiledProgramsInterfaceTypeLoader(programs)
+	entitlementTypeLoader := compilerUtils.CompiledProgramsEntitlementTypeLoader(programs)
+	entitlementMapTypeLoader := compilerUtils.CompiledProgramsEntitlementMapTypeLoader(programs)
 
 	if options.ParseAndCheckOptions != nil && options.ParseAndCheckOptions.CheckerConfig != nil {
 		typeActivationHandler := options.ParseAndCheckOptions.CheckerConfig.BaseTypeActivationHandler
 		if typeActivationHandler != nil {
-			vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+			vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 				activation := typeActivationHandler(location)
 				typeName := location.QualifiedIdentifier(typeID)
 				variable := activation.Find(typeName)
 				if variable != nil {
-					return variable.Type, nil
+					return variable.Type.(*sema.CompositeType)
 				}
 
-				return typeLoader(location, typeID)
+				return compositeTypeLoader(location, typeID)
+			}
+			vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+				activation := typeActivationHandler(location)
+				typeName := location.QualifiedIdentifier(typeID)
+				variable := activation.Find(typeName)
+				if variable != nil {
+					return variable.Type.(*sema.InterfaceType)
+				}
+
+				return interfaceTypeLoader(location, typeID)
+			}
+			vmConfig.EntitlementTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.EntitlementType {
+				activation := typeActivationHandler(location)
+				typeName := location.QualifiedIdentifier(typeID)
+				variable := activation.Find(typeName)
+				if variable != nil {
+					return variable.Type.(*sema.EntitlementType)
+				}
+
+				return entitlementTypeLoader(location, typeID)
+			}
+			vmConfig.EntitlementMapTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.EntitlementMapType {
+				activation := typeActivationHandler(location)
+				typeName := location.QualifiedIdentifier(typeID)
+				variable := activation.Find(typeName)
+				if variable != nil {
+					return variable.Type.(*sema.EntitlementMapType)
+				}
+
+				return entitlementMapTypeLoader(location, typeID)
 			}
 		}
 	}
@@ -373,23 +406,21 @@ func ParseCheckAndPrepareWithOptions(
 		}
 
 		if interpreterConfig.ImportLocationHandler != nil {
-			originalTypeLoader := vmConfig.TypeLoader
-			vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+			originalCompositeTypeHandler := vmConfig.CompositeTypeHandler
+			vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 				impt := interpreterConfig.ImportLocationHandler(nil, location)
 				switch impt := impt.(type) {
 				case interpreter.VirtualImport:
-					return impt.Elaboration.CompositeType(typeID), nil
+					return impt.Elaboration.CompositeType(typeID)
 				case interpreter.InterpreterImport:
-					return impt.Interpreter.Program.Elaboration.CompositeType(typeID), nil
+					return impt.Interpreter.Program.Elaboration.CompositeType(typeID)
 				}
 
-				if originalTypeLoader != nil {
-					return originalTypeLoader(location, typeID)
+				if originalCompositeTypeHandler != nil {
+					return originalCompositeTypeHandler(location, typeID)
 				}
 
-				return nil, interpreter.TypeLoadingError{
-					TypeID: typeID,
-				}
+				return nil
 			}
 
 			vmConfig.ElaborationResolver = func(location common.Location) (*sema.Elaboration, error) {
@@ -411,26 +442,33 @@ func ParseCheckAndPrepareWithOptions(
 		}
 
 		if interpreterConfig.CompositeTypeHandler != nil {
-			originalTypeLoader := vmConfig.TypeLoader
-			vmConfig.TypeLoader = func(location common.Location, typeID interpreter.TypeID) (sema.Type, error) {
+			originalCompositeTypeHandler := vmConfig.CompositeTypeHandler
+			vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
 				ty := interpreterConfig.CompositeTypeHandler(location, typeID)
 				if ty != nil {
-					return ty, nil
+					return ty
 				}
 
-				if originalTypeLoader != nil {
-					return originalTypeLoader(location, typeID)
+				if originalCompositeTypeHandler != nil {
+					return originalCompositeTypeHandler(location, typeID)
 				}
 
-				return nil, interpreter.TypeLoadingError{
-					TypeID: typeID,
-				}
+				return nil
 			}
 		}
 	}
 
-	if vmConfig.TypeLoader == nil {
-		vmConfig.TypeLoader = typeLoader
+	if vmConfig.CompositeTypeHandler == nil {
+		vmConfig.CompositeTypeHandler = compositeTypeLoader
+	}
+	if vmConfig.InterfaceTypeHandler == nil {
+		vmConfig.InterfaceTypeHandler = interfaceTypeLoader
+	}
+	if vmConfig.EntitlementTypeHandler == nil {
+		vmConfig.EntitlementTypeHandler = entitlementTypeLoader
+	}
+	if vmConfig.EntitlementMapTypeHandler == nil {
+		vmConfig.EntitlementMapTypeHandler = entitlementMapTypeLoader
 	}
 
 	if vmConfig.BuiltinGlobalsProvider == nil {


### PR DESCRIPTION
Closes #4186 

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Splits `TypeLoader` into dedicated methods `__TypeHandler` like in the interpreter. Updates tests to use new methods.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
