### PR TITLE
[Compiler] Add control flow basic block visualization to program printer.

### DIFF
--- a/bbq/opcode/print.go
+++ b/bbq/opcode/print.go
@@ -478,6 +478,11 @@ func (r *BlockRenderer) renderBlock(
 	}
 	builder.WriteString("┐\n")
 
+	opcodePadding := maxOpcodeLen
+	if r.colorize {
+		opcodePadding += len(aurora.White("").String())
+	}
+
 	// Block instructions
 	for instrIndex := block.Start; instrIndex <= block.End; instrIndex++ {
 		instruction := r.instructions[instrIndex]
@@ -511,8 +516,10 @@ func (r *BlockRenderer) renderBlock(
 
 		// Format instruction line
 		builder.WriteString("│ ")
-		fmt.Fprintf(builder, "%4s | %-22s | %s",
+
+		fmt.Fprintf(builder, "%4s | %-*s | %s",
 			formattedOffset,
+			opcodePadding,
 			formattedOpcode,
 			operandsBuilder.String(),
 		)
@@ -523,6 +530,17 @@ func (r *BlockRenderer) renderBlock(
 	builder.WriteString("└")
 	builder.WriteString(strings.Repeat("─", maxWidth-1))
 	builder.WriteString("┘\n")
+}
+
+var maxOpcodeLen int
+
+func init() {
+	for opcode := range OpcodeMax {
+		l := len(opcode.String())
+		if l > maxOpcodeLen {
+			maxOpcodeLen = l
+		}
+	}
 }
 
 // renderBlockConnections shows connections from a block to other blocks

--- a/bbq/opcode/print.go
+++ b/bbq/opcode/print.go
@@ -51,6 +51,29 @@ func PrintBytecode(
 	)
 }
 
+// PrintBytecodeWithFlowMode prints bytecode in block format with flow visualization
+func PrintBytecodeWithFlow(
+	builder *strings.Builder,
+	code []byte,
+	resolve bool,
+	constants []constant.Constant,
+	types [][]byte,
+	functionNames []string,
+	colorize bool,
+) error {
+	instructions := DecodeInstructions(code)
+	staticTypes := DecodeStaticTypes(types)
+	return PrintInstructionsWithFlow(
+		builder,
+		instructions,
+		resolve,
+		constants,
+		staticTypes,
+		functionNames,
+		colorize,
+	)
+}
+
 func DecodeStaticTypes(types [][]byte) []interpreter.StaticType {
 	var staticTypes []interpreter.StaticType
 	if len(types) > 0 {
@@ -122,8 +145,33 @@ func PrintInstructions(
 	return nil
 }
 
+// PrintInstructionsWithFlowMode prints instructions with specified flow visualization mode
+func PrintInstructionsWithFlow(
+	builder *strings.Builder,
+	instructions []Instruction,
+	resolve bool,
+	constants []constant.Constant,
+	types []interpreter.StaticType,
+	functionNames []string,
+	colorize bool,
+) error {
+
+	flowAnalysis := analyzeControlFlow(instructions)
+
+	// Render as basic blocks
+	blockRenderer := &BlockRenderer{
+		analysis:     flowAnalysis,
+		colorize:     colorize,
+		instructions: instructions,
+	}
+	blockOutput := blockRenderer.renderBasicBlocks(constants, types, functionNames, resolve)
+	builder.WriteString(blockOutput)
+
+	return nil
+}
+
 func ColorizeOffset(offset int) string {
-	return aurora.Gray(12, offset).String()
+	return aurora.Gray(12, fmt.Sprintf("%3d", offset)).String()
 }
 
 func ColorizeOpcode(opcode Opcode) string {
@@ -132,4 +180,433 @@ func ColorizeOpcode(opcode Opcode) string {
 	}
 
 	return aurora.Blue(opcode).String()
+}
+
+// Flow visualization types and constants
+
+// JumpType categorizes different kinds of control flow
+type JumpType int
+
+const (
+	JumpUnconditional JumpType = iota
+	JumpConditional
+	JumpCall
+	JumpReturn
+)
+
+// FlowAnalysis contains control flow information for a sequence of instructions
+type FlowAnalysis struct {
+	JumpSources map[int][]JumpInfo // instruction index -> list of jumps from this instruction
+	JumpTargets map[int][]int      // instruction index -> list of instructions that jump here
+	BasicBlocks []BasicBlock       // identified basic blocks
+}
+
+// JumpInfo describes a jump from one instruction to another
+type JumpInfo struct {
+	Target    int      // target instruction index
+	JumpType  JumpType // conditional, unconditional, call, return
+	Condition string   // condition description (e.g., "if false", "if nil")
+}
+
+// BasicBlock represents a sequence of instructions with single entry/exit
+type BasicBlock struct {
+	Start        int   // first instruction index
+	End          int   // last instruction index
+	Successors   []int // indices of blocks that can follow this one
+	Predecessors []int // indices of blocks that can precede this one
+}
+
+// analyzeControlFlow performs control flow analysis on a sequence of instructions
+func analyzeControlFlow(instructions []Instruction) *FlowAnalysis {
+	analysis := &FlowAnalysis{
+		JumpSources: make(map[int][]JumpInfo),
+		JumpTargets: make(map[int][]int),
+	}
+
+	// First pass: identify all jumps
+	for i, instr := range instructions {
+		switch instr.Opcode() {
+		case Jump:
+			if jumpInstr, ok := instr.(InstructionJump); ok {
+				target := int(jumpInstr.Target)
+				jumpInfo := JumpInfo{
+					Target:   target,
+					JumpType: JumpUnconditional,
+				}
+				analysis.JumpSources[i] = append(analysis.JumpSources[i], jumpInfo)
+				analysis.JumpTargets[target] = append(analysis.JumpTargets[target], i)
+			}
+		case JumpIfFalse:
+			if jumpInstr, ok := instr.(InstructionJumpIfFalse); ok {
+				target := int(jumpInstr.Target)
+				jumpInfo := JumpInfo{
+					Target:    target,
+					JumpType:  JumpConditional,
+					Condition: "if false",
+				}
+				analysis.JumpSources[i] = append(analysis.JumpSources[i], jumpInfo)
+				analysis.JumpTargets[target] = append(analysis.JumpTargets[target], i)
+			}
+		case JumpIfTrue:
+			if jumpInstr, ok := instr.(InstructionJumpIfTrue); ok {
+				target := int(jumpInstr.Target)
+				jumpInfo := JumpInfo{
+					Target:    target,
+					JumpType:  JumpConditional,
+					Condition: "if true",
+				}
+				analysis.JumpSources[i] = append(analysis.JumpSources[i], jumpInfo)
+				analysis.JumpTargets[target] = append(analysis.JumpTargets[target], i)
+			}
+		case JumpIfNil:
+			if jumpInstr, ok := instr.(InstructionJumpIfNil); ok {
+				target := int(jumpInstr.Target)
+				jumpInfo := JumpInfo{
+					Target:    target,
+					JumpType:  JumpConditional,
+					Condition: "if nil",
+				}
+				analysis.JumpSources[i] = append(analysis.JumpSources[i], jumpInfo)
+				analysis.JumpTargets[target] = append(analysis.JumpTargets[target], i)
+			}
+		case Invoke, InvokeDynamic:
+			// Function calls
+			jumpInfo := JumpInfo{
+				Target:   -1, // unknown target by default
+				JumpType: JumpCall,
+			}
+
+			// could analyze for call targets here, complicated
+
+			analysis.JumpSources[i] = append(analysis.JumpSources[i], jumpInfo)
+		case Return, ReturnValue:
+			jumpInfo := JumpInfo{
+				Target:   -1, // function exit
+				JumpType: JumpReturn,
+			}
+			analysis.JumpSources[i] = append(analysis.JumpSources[i], jumpInfo)
+		}
+	}
+
+	// Second pass: identify basic blocks
+	analysis.BasicBlocks = identifyBasicBlocks(instructions, analysis)
+
+	return analysis
+}
+
+// identifyBasicBlocks finds basic blocks in the instruction sequence
+func identifyBasicBlocks(instructions []Instruction, analysis *FlowAnalysis) []BasicBlock {
+	leaders := make(map[int]bool)
+
+	// First instruction is always a leader
+	leaders[0] = true
+
+	// Instructions that are jump targets are leaders
+	for target := range analysis.JumpTargets {
+		if target >= 0 && target < len(instructions) {
+			leaders[target] = true
+		}
+	}
+
+	// Instructions immediately after jumps are leaders
+	for source := range analysis.JumpSources {
+		if source+1 < len(instructions) {
+			leaders[source+1] = true
+		}
+	}
+
+	// Build basic blocks
+	var blocks []BasicBlock
+	var leaderIndices []int
+	for i := range leaders {
+		leaderIndices = append(leaderIndices, i)
+	}
+
+	// Sort leader indices
+	for i := 0; i < len(leaderIndices); i++ {
+		for j := i + 1; j < len(leaderIndices); j++ {
+			if leaderIndices[i] > leaderIndices[j] {
+				leaderIndices[i], leaderIndices[j] = leaderIndices[j], leaderIndices[i]
+			}
+		}
+	}
+
+	// Create blocks
+	for i, start := range leaderIndices {
+		end := len(instructions) - 1
+		if i+1 < len(leaderIndices) {
+			end = leaderIndices[i+1] - 1
+		}
+
+		block := BasicBlock{
+			Start: start,
+			End:   end,
+		}
+		blocks = append(blocks, block)
+	}
+
+	return blocks
+}
+
+// BlockRenderer handles basic block visualization
+type BlockRenderer struct {
+	analysis      *FlowAnalysis
+	colorize      bool
+	instructions  []Instruction
+	functionNames []string
+}
+
+// renderBasicBlocks creates a basic block visualization
+func (r *BlockRenderer) renderBasicBlocks(
+	constants []constant.Constant,
+	types []interpreter.StaticType,
+	functionNames []string,
+	resolve bool,
+) string {
+	var builder strings.Builder
+
+	// Build block connections map
+	blockConnections := r.buildBlockConnections()
+
+	// Render each basic block
+	for i, block := range r.analysis.BasicBlocks {
+		r.renderBlock(&builder, i, block, constants, types, functionNames, resolve)
+
+		// Show connections to other blocks
+		if connections, hasConnections := blockConnections[i]; hasConnections {
+			r.renderBlockConnections(&builder, i, connections)
+		}
+
+		builder.WriteString("\n")
+	}
+
+	return builder.String()
+}
+
+// buildBlockConnections maps block indices to their successor blocks
+func (r *BlockRenderer) buildBlockConnections() map[int][]BlockConnection {
+	connections := make(map[int][]BlockConnection)
+
+	for blockIndex, block := range r.analysis.BasicBlocks {
+		var blockConnections []BlockConnection
+
+		// Check jumps from the last instruction of this block
+		lastInstrIndex := block.End
+		if jumps, hasJumps := r.analysis.JumpSources[lastInstrIndex]; hasJumps {
+			for _, jump := range jumps {
+				if jump.JumpType == JumpCall {
+					// Function calls are considered external jumps
+					conn := BlockConnection{
+						TargetBlock: -1,
+						JumpType:    jump.JumpType,
+						Condition:   jump.Condition,
+						IsJump:      true,
+					}
+					blockConnections = append(blockConnections, conn)
+				} else if jump.Target >= 0 {
+					// Regular jumps within the function
+					targetBlock := r.findBlockContaining(jump.Target)
+					if targetBlock >= 0 && targetBlock != blockIndex {
+						conn := BlockConnection{
+							TargetBlock: targetBlock,
+							JumpType:    jump.JumpType,
+							Condition:   jump.Condition,
+							IsJump:      true,
+						}
+						blockConnections = append(blockConnections, conn)
+					}
+				}
+			}
+		}
+
+		// Check for fall-through to next block
+		if blockIndex+1 < len(r.analysis.BasicBlocks) {
+			// If last instruction doesn't unconditionally jump or return or call, add fall-through
+			if !r.hasUnconditionalExit(lastInstrIndex) {
+				conn := BlockConnection{
+					TargetBlock: blockIndex + 1,
+					JumpType:    JumpUnconditional,
+					Condition:   "fall through",
+					IsJump:      false,
+				}
+				blockConnections = append(blockConnections, conn)
+			}
+		}
+
+		if len(blockConnections) > 0 {
+			connections[blockIndex] = blockConnections
+		}
+	}
+
+	return connections
+}
+
+// BlockConnection represents a connection between basic blocks
+type BlockConnection struct {
+	TargetBlock int
+	JumpType    JumpType
+	Condition   string
+	IsJump      bool
+}
+
+// findBlockContaining finds which basic block contains the given instruction index
+func (r *BlockRenderer) findBlockContaining(instrIndex int) int {
+	for i, block := range r.analysis.BasicBlocks {
+		if instrIndex >= block.Start && instrIndex <= block.End {
+			return i
+		}
+	}
+	return -1
+}
+
+// hasUnconditionalExit checks if an instruction unconditionally exits (jump/return)
+func (r *BlockRenderer) hasUnconditionalExit(instrIndex int) bool {
+	if jumps, hasJumps := r.analysis.JumpSources[instrIndex]; hasJumps {
+		for _, jump := range jumps {
+			if jump.JumpType == JumpUnconditional || jump.JumpType == JumpReturn || jump.JumpType == JumpCall {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// renderBlock renders a single basic block
+func (r *BlockRenderer) renderBlock(
+	builder *strings.Builder,
+	blockIndex int,
+	block BasicBlock,
+	constants []constant.Constant,
+	types []interpreter.StaticType,
+	functionNames []string,
+	resolve bool,
+) {
+	// Block header
+	header := fmt.Sprintf("Block %d (%d-%d)", blockIndex, block.Start, block.End)
+	if r.colorize {
+		header = aurora.Bold(aurora.Cyan(header)).String()
+	}
+
+	builder.WriteString("┌─ ")
+	builder.WriteString(header)
+	builder.WriteString(" ")
+
+	// Calculate padding for box drawing
+	maxWidth := 70
+	headerLen := len(fmt.Sprintf("Block %d (%d-%d)", blockIndex, block.Start, block.End))
+	padding := maxWidth - headerLen - 4
+	if padding > 0 {
+		builder.WriteString(strings.Repeat("─", padding))
+	}
+	builder.WriteString("┐\n")
+
+	// Block instructions
+	for instrIndex := block.Start; instrIndex <= block.End; instrIndex++ {
+		instruction := r.instructions[instrIndex]
+
+		var operandsBuilder strings.Builder
+		if resolve {
+			instruction.ResolvedOperandsString(
+				&operandsBuilder,
+				constants,
+				types,
+				functionNames,
+				r.colorize,
+			)
+		} else {
+			instruction.OperandsString(&operandsBuilder, r.colorize)
+		}
+
+		var formattedOffset string
+		if r.colorize {
+			formattedOffset = ColorizeOffset(instrIndex)
+		} else {
+			formattedOffset = fmt.Sprintf("%3d", instrIndex)
+		}
+
+		var formattedOpcode string
+		if r.colorize {
+			formattedOpcode = ColorizeOpcode(instruction.Opcode())
+		} else {
+			formattedOpcode = fmt.Sprint(instruction.Opcode())
+		}
+
+		// Format instruction line
+		builder.WriteString("│ ")
+		builder.WriteString(fmt.Sprintf("%4s | %-20s | %s",
+			formattedOffset,
+			formattedOpcode,
+			operandsBuilder.String(),
+		))
+		builder.WriteString("\n")
+	}
+
+	// Block footer
+	builder.WriteString("└")
+	builder.WriteString(strings.Repeat("─", maxWidth-1))
+	builder.WriteString("┘\n")
+}
+
+// renderBlockConnections shows connections from a block to other blocks
+func (r *BlockRenderer) renderBlockConnections(
+	builder *strings.Builder,
+	fromBlock int,
+	connections []BlockConnection,
+) {
+	if len(connections) == 0 {
+		return
+	}
+
+	for i, conn := range connections {
+		var arrow, description string
+
+		switch conn.JumpType {
+		case JumpUnconditional:
+			if conn.IsJump {
+				arrow = "──→"
+				description = "jump"
+			} else {
+				arrow = "──→"
+				description = "fall through"
+			}
+		case JumpConditional:
+			arrow = "─?→"
+			description = fmt.Sprintf("jump %s", conn.Condition)
+		case JumpReturn:
+			arrow = "──↩"
+			description = "return"
+		case JumpCall:
+			arrow = "──→"
+			description = "function_call"
+		}
+
+		connectionText := fmt.Sprintf("    %s Block %d", arrow, conn.TargetBlock)
+		if conn.TargetBlock == -1 {
+			connectionText = fmt.Sprintf("    %s Unknown target", arrow)
+		}
+		if description != "" && description != "jump" {
+			connectionText += fmt.Sprintf(" (%s)", description)
+		}
+
+		if r.colorize {
+			switch conn.JumpType {
+			case JumpUnconditional:
+				connectionText = aurora.Green(connectionText).String()
+			case JumpConditional:
+				connectionText = aurora.Yellow(connectionText).String()
+			case JumpReturn:
+				connectionText = aurora.Red(connectionText).String()
+			case JumpCall:
+				connectionText = aurora.Blue(connectionText).String()
+			}
+		}
+
+		builder.WriteString(connectionText)
+		builder.WriteString("\n")
+
+		// Add spacing between multiple connections
+		if i < len(connections)-1 {
+			builder.WriteString("\n")
+		}
+	}
 }

--- a/bbq/opcode/print.go
+++ b/bbq/opcode/print.go
@@ -52,7 +52,6 @@ func PrintBytecode(
 	)
 }
 
-// PrintBytecodeWithFlowMode prints bytecode in block format with flow visualization
 func PrintBytecodeWithFlow(
 	builder *strings.Builder,
 	code []byte,
@@ -146,7 +145,7 @@ func PrintInstructions(
 	return nil
 }
 
-// PrintInstructionsWithFlowMode prints instructions with specified flow visualization mode
+// PrintInstructionsWithFlowMode prints instructions in block format with flow visualization
 func PrintInstructionsWithFlow(
 	builder *strings.Builder,
 	instructions []Instruction,
@@ -295,7 +294,7 @@ func analyzeControlFlow(instructions []Instruction) *FlowAnalysis {
 				JumpType: JumpReturn,
 			}
 			analysis.JumpInfoMap[i] = jumpInfo
-			// instructions immediately after jumps are leaders
+			// instructions immediately after jumps are leaders, potentially end of program as well
 			if i+1 < len(instructions) {
 				analysis.BlockLeaders = append(analysis.BlockLeaders, i+1)
 			}
@@ -357,7 +356,7 @@ func (r *BlockRenderer) renderBasicBlocks(
 
 		// Show connections to other blocks
 		if connections, hasConnections := blockConnections[i]; hasConnections {
-			r.renderBlockConnections(&builder, i, connections)
+			r.renderBlockConnections(&builder, connections)
 		}
 
 		builder.WriteString("\n")
@@ -529,7 +528,6 @@ func (r *BlockRenderer) renderBlock(
 // renderBlockConnections shows connections from a block to other blocks
 func (r *BlockRenderer) renderBlockConnections(
 	builder *strings.Builder,
-	fromBlock int,
 	connections []BlockConnection,
 ) {
 	if len(connections) == 0 {

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -284,3 +284,139 @@ func TestPrintInstruction(t *testing.T) {
 		})
 	}
 }
+
+func TestPrintRecursionFibWithFlow(t *testing.T) {
+	t.Parallel()
+
+	code := []byte{
+		// if n < 2
+		byte(GetLocal), 0, 0,
+		byte(GetConstant), 0, 0,
+		byte(Less),
+		byte(JumpIfFalse), 0, 14,
+		// then return n
+		byte(GetLocal), 0, 0,
+		byte(ReturnValue),
+		// fib(n - 1)
+		byte(GetLocal), 0, 0,
+		byte(GetConstant), 0, 1,
+		byte(Subtract),
+		byte(TransferAndConvert), 0, 0,
+		byte(GetGlobal), 0, 0,
+		byte(Invoke), 0, 0, 0, 0,
+		// fib(n - 2)
+		byte(GetLocal), 0, 0,
+		byte(GetConstant), 0, 0,
+		byte(Subtract),
+		byte(TransferAndConvert), 0, 0,
+		byte(GetGlobal), 0, 0,
+		byte(Invoke), 0, 0, 0, 0,
+		// return sum
+		byte(Add),
+		byte(ReturnValue),
+	}
+
+	const expected = `┌─ Block 0 (0-3) ─────────────────────────────────────────────────────┐
+│    0 | GetLocal               |  local:0
+│    1 | GetConstant            |  constant:0
+│    2 | Less                   | 
+│    3 | JumpIfFalse            |  target:14
+└─────────────────────────────────────────────────────────────────────┘
+    ─?→ Block 4 (jump if false)
+
+    ──→ Block 1 (fall through)
+
+┌─ Block 1 (4-5) ─────────────────────────────────────────────────────┐
+│    4 | GetLocal               |  local:0
+│    5 | ReturnValue            | 
+└─────────────────────────────────────────────────────────────────────┘
+
+┌─ Block 2 (6-11) ────────────────────────────────────────────────────┐
+│    6 | GetLocal               |  local:0
+│    7 | GetConstant            |  constant:1
+│    8 | Subtract               | 
+│    9 | TransferAndConvert     |  type:0
+│   10 | GetGlobal              |  global:0
+│   11 | Invoke                 |  typeArgs:[] argCount:0
+└─────────────────────────────────────────────────────────────────────┘
+    ──→ Unknown target (function_call)
+
+┌─ Block 3 (12-13) ───────────────────────────────────────────────────┐
+│   12 | GetLocal               |  local:0
+│   13 | GetConstant            |  constant:0
+└─────────────────────────────────────────────────────────────────────┘
+    ──→ Block 4 (fall through)
+
+┌─ Block 4 (14-17) ───────────────────────────────────────────────────┐
+│   14 | Subtract               | 
+│   15 | TransferAndConvert     |  type:0
+│   16 | GetGlobal              |  global:0
+│   17 | Invoke                 |  typeArgs:[] argCount:0
+└─────────────────────────────────────────────────────────────────────┘
+    ──→ Unknown target (function_call)
+
+┌─ Block 5 (18-19) ───────────────────────────────────────────────────┐
+│   18 | Add                    | 
+│   19 | ReturnValue            | 
+└─────────────────────────────────────────────────────────────────────┘
+
+`
+
+	var builder strings.Builder
+	const resolve = false
+	const colorize = false
+	const showFlow = true
+	err := PrintBytecodeWithFlow(&builder, code, resolve, nil, nil, nil, colorize)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, builder.String())
+}
+
+func TestFlowAnalysis(t *testing.T) {
+	t.Parallel()
+
+	instructions := []Instruction{
+		InstructionGetLocal{Local: 0},
+		InstructionGetConstant{Constant: 0},
+		InstructionLess{},
+		InstructionJumpIfFalse{Target: 6},
+		InstructionGetLocal{Local: 0},
+		InstructionReturnValue{},
+		InstructionGetLocal{Local: 0},
+		InstructionReturnValue{},
+	}
+
+	analysis := analyzeControlFlow(instructions)
+
+	// Should identify the conditional jump
+	require.Contains(t, analysis.JumpSources, 3)
+	jumpInfo := analysis.JumpSources[3][0]
+	assert.Equal(t, 6, jumpInfo.Target)
+	assert.Equal(t, JumpConditional, jumpInfo.JumpType)
+	assert.Equal(t, "if false", jumpInfo.Condition)
+
+	// Should identify jump target
+	require.Contains(t, analysis.JumpTargets, 6)
+	assert.Contains(t, analysis.JumpTargets[6], 3)
+
+	// Should identify returns
+	require.Contains(t, analysis.JumpSources, 5) // first return
+	require.Contains(t, analysis.JumpSources, 7) // second return
+	assert.Equal(t, JumpReturn, analysis.JumpSources[5][0].JumpType)
+	assert.Equal(t, JumpReturn, analysis.JumpSources[7][0].JumpType)
+
+	// Should identify basic blocks
+	assert.Len(t, analysis.BasicBlocks, 3)
+
+	// Block 0: instructions 0-3
+	assert.Equal(t, 0, analysis.BasicBlocks[0].Start)
+	assert.Equal(t, 3, analysis.BasicBlocks[0].End)
+
+	// Block 1: instructions 4-5
+	assert.Equal(t, 4, analysis.BasicBlocks[1].Start)
+	assert.Equal(t, 5, analysis.BasicBlocks[1].End)
+
+	// Block 2: instructions 6-7
+	assert.Equal(t, 6, analysis.BasicBlocks[2].Start)
+	assert.Equal(t, 7, analysis.BasicBlocks[2].End)
+}

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -391,14 +391,14 @@ func TestFlowAnalysis(t *testing.T) {
 	require.Contains(t, analysis.JumpInfoMap, 3)
 	jumpInfo := analysis.JumpInfoMap[3]
 	assert.Equal(t, 6, jumpInfo.Target)
-	assert.Equal(t, JumpConditional, jumpInfo.JumpType)
+	assert.Equal(t, JumpTypeConditional, jumpInfo.JumpType)
 	assert.Equal(t, "if false", jumpInfo.Condition)
 
 	// Should identify returns
 	require.Contains(t, analysis.JumpInfoMap, 5) // first return
 	require.Contains(t, analysis.JumpInfoMap, 7) // second return
-	assert.Equal(t, JumpReturn, analysis.JumpInfoMap[5].JumpType)
-	assert.Equal(t, JumpReturn, analysis.JumpInfoMap[7].JumpType)
+	assert.Equal(t, JumpTypeReturn, analysis.JumpInfoMap[5].JumpType)
+	assert.Equal(t, JumpTypeReturn, analysis.JumpInfoMap[7].JumpType)
 
 	// Should identify basic blocks
 	assert.Len(t, analysis.BasicBlocks, 3)

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -317,47 +317,47 @@ func TestPrintRecursionFibWithFlow(t *testing.T) {
 	}
 
 	const expected = `┌─ Block 0 (0-3) ─────────────────────────────────────────────────────┐
-│    0 | GetLocal               |  local:0
-│    1 | GetConstant            |  constant:0
-│    2 | Less                   | 
-│    3 | JumpIfFalse            |  target:14
+│    0 | GetLocal           |  local:0
+│    1 | GetConstant        |  constant:0
+│    2 | Less               | 
+│    3 | JumpIfFalse        |  target:14
 └─────────────────────────────────────────────────────────────────────┘
     ─?→ Block 4 (jump if false)
 
     ──→ Block 1 (fall through)
 
 ┌─ Block 1 (4-5) ─────────────────────────────────────────────────────┐
-│    4 | GetLocal               |  local:0
-│    5 | ReturnValue            | 
+│    4 | GetLocal           |  local:0
+│    5 | ReturnValue        | 
 └─────────────────────────────────────────────────────────────────────┘
 
 ┌─ Block 2 (6-11) ────────────────────────────────────────────────────┐
-│    6 | GetLocal               |  local:0
-│    7 | GetConstant            |  constant:1
-│    8 | Subtract               | 
-│    9 | TransferAndConvert     |  type:0
-│   10 | GetGlobal              |  global:0
-│   11 | Invoke                 |  typeArgs:[] argCount:0
+│    6 | GetLocal           |  local:0
+│    7 | GetConstant        |  constant:1
+│    8 | Subtract           | 
+│    9 | TransferAndConvert |  type:0
+│   10 | GetGlobal          |  global:0
+│   11 | Invoke             |  typeArgs:[] argCount:0
 └─────────────────────────────────────────────────────────────────────┘
     ──→ Unknown target (function_call)
 
 ┌─ Block 3 (12-13) ───────────────────────────────────────────────────┐
-│   12 | GetLocal               |  local:0
-│   13 | GetConstant            |  constant:0
+│   12 | GetLocal           |  local:0
+│   13 | GetConstant        |  constant:0
 └─────────────────────────────────────────────────────────────────────┘
     ──→ Block 4 (fall through)
 
 ┌─ Block 4 (14-17) ───────────────────────────────────────────────────┐
-│   14 | Subtract               | 
-│   15 | TransferAndConvert     |  type:0
-│   16 | GetGlobal              |  global:0
-│   17 | Invoke                 |  typeArgs:[] argCount:0
+│   14 | Subtract           | 
+│   15 | TransferAndConvert |  type:0
+│   16 | GetGlobal          |  global:0
+│   17 | Invoke             |  typeArgs:[] argCount:0
 └─────────────────────────────────────────────────────────────────────┘
     ──→ Unknown target (function_call)
 
 ┌─ Block 5 (18-19) ───────────────────────────────────────────────────┐
-│   18 | Add                    | 
-│   19 | ReturnValue            | 
+│   18 | Add                | 
+│   19 | ReturnValue        | 
 └─────────────────────────────────────────────────────────────────────┘
 
 `

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -365,7 +365,6 @@ func TestPrintRecursionFibWithFlow(t *testing.T) {
 	var builder strings.Builder
 	const resolve = false
 	const colorize = false
-	const showFlow = true
 	err := PrintBytecodeWithFlow(&builder, code, resolve, nil, nil, nil, colorize)
 	require.NoError(t, err)
 

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -388,21 +388,17 @@ func TestFlowAnalysis(t *testing.T) {
 	analysis := analyzeControlFlow(instructions)
 
 	// Should identify the conditional jump
-	require.Contains(t, analysis.JumpSources, 3)
-	jumpInfo := analysis.JumpSources[3][0]
+	require.Contains(t, analysis.JumpInfoMap, 3)
+	jumpInfo := analysis.JumpInfoMap[3]
 	assert.Equal(t, 6, jumpInfo.Target)
 	assert.Equal(t, JumpConditional, jumpInfo.JumpType)
 	assert.Equal(t, "if false", jumpInfo.Condition)
 
-	// Should identify jump target
-	require.Contains(t, analysis.JumpTargets, 6)
-	assert.Contains(t, analysis.JumpTargets[6], 3)
-
 	// Should identify returns
-	require.Contains(t, analysis.JumpSources, 5) // first return
-	require.Contains(t, analysis.JumpSources, 7) // second return
-	assert.Equal(t, JumpReturn, analysis.JumpSources[5][0].JumpType)
-	assert.Equal(t, JumpReturn, analysis.JumpSources[7][0].JumpType)
+	require.Contains(t, analysis.JumpInfoMap, 5) // first return
+	require.Contains(t, analysis.JumpInfoMap, 7) // second return
+	assert.Equal(t, JumpReturn, analysis.JumpInfoMap[5].JumpType)
+	assert.Equal(t, JumpReturn, analysis.JumpInfoMap[7].JumpType)
 
 	// Should identify basic blocks
 	assert.Len(t, analysis.BasicBlocks, 3)

--- a/bbq/program_printer.go
+++ b/bbq/program_printer.go
@@ -50,18 +50,26 @@ type ProgramPrinter[E, T any] struct {
 	colorize      bool
 }
 
-func NewBytecodeProgramPrinter(resolve bool, colorize bool) *ProgramPrinter[byte, []byte] {
+func NewBytecodeProgramPrinter(resolve bool, colorize bool, showFlow bool) *ProgramPrinter[byte, []byte] {
+	printerFunc := opcode.PrintBytecode
+	if showFlow {
+		printerFunc = opcode.PrintBytecodeWithFlow
+	}
 	return &ProgramPrinter[byte, []byte]{
-		codePrinter: opcode.PrintBytecode,
+		codePrinter: printerFunc,
 		typeDecoder: interpreter.StaticTypeFromBytes,
 		resolve:     resolve,
 		colorize:    colorize,
 	}
 }
 
-func NewInstructionsProgramPrinter(resolve bool, colorize bool) *ProgramPrinter[opcode.Instruction, StaticType] {
+func NewInstructionsProgramPrinter(resolve bool, colorize bool, showFlow bool) *ProgramPrinter[opcode.Instruction, StaticType] {
+	printerFunc := opcode.PrintInstructions
+	if showFlow {
+		printerFunc = opcode.PrintInstructionsWithFlow
+	}
 	return &ProgramPrinter[opcode.Instruction, StaticType]{
-		codePrinter: opcode.PrintInstructions,
+		codePrinter: printerFunc,
 		typeDecoder: func(typ StaticType) (StaticType, error) {
 			return typ, nil
 		},
@@ -127,6 +135,7 @@ func (p *ProgramPrinter[E, T]) printFunction(
 		functionNames,
 		p.colorize,
 	)
+
 	if err != nil {
 		// TODO: propagate error
 		panic(err)

--- a/bbq/test_utils/utils.go
+++ b/bbq/test_utils/utils.go
@@ -56,7 +56,7 @@ func SingleIdentifierLocationResolver(t testing.TB) sema.LocationHandlerFunc {
 func PrintProgram(name string, program *bbq.InstructionProgram) { //nolint:unused
 	const resolve = true
 	const colorize = true
-	printer := bbq.NewInstructionsProgramPrinter(resolve, colorize)
+	printer := bbq.NewInstructionsProgramPrinter(resolve, colorize, true)
 	fmt.Println("===================", name, "===================")
 	fmt.Println(printer.PrintProgram(program))
 }
@@ -126,7 +126,7 @@ func ParseCheckAndCompileCodeWithOptions(
 	// Ensure the program can be printed
 	const resolve = false
 	const colorize = false
-	printer := bbq.NewInstructionsProgramPrinter(resolve, colorize)
+	printer := bbq.NewInstructionsProgramPrinter(resolve, colorize, false)
 
 	_ = printer.PrintProgram(program)
 


### PR DESCRIPTION
Closes #4195 

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Adds a control flow visualization option to `PrintProgram()`.

Sample imperative fib control flow:
<img width="1036" height="1820" alt="image" src="https://github.com/user-attachments/assets/29cd143e-6c6f-4bc5-9b12-c347ebc3e483" />


______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
