### PR TITLE
Add additional authentication options for Cadence update tool

### DIFF
--- a/tools/update/README.md
+++ b/tools/update/README.md
@@ -12,17 +12,39 @@ The tool automatically detects versions and supports multiple modules per repo.
 npm i -g typescript ts-node
 ```
 
+### Authentication
+
+The tool requires a GitHub token to access the GitHub API. It will automatically try to find a token from several sources (in order):
+
+1. **Environment variables**: `GH_TOKEN` or `GITHUB_TOKEN`
+2. **Git config**: `git config --get github.token`  
+3. **GitHub CLI**: `gh auth token` (if `gh` is installed and authenticated)
+4. **macOS Keychain**: github.com password (macOS only)
+
+#### Setup Options
+
+**Option 1: Environment variable**
+```sh
+export GH_TOKEN=<your_github_token>
+ts-node main.ts update --version <version>
+```
+
+**Option 2: Git config (recommended for development)**
+```sh
+git config --global github.token <your_github_token>
+ts-node main.ts update --version <version>
+```
+
+**Option 3: GitHub CLI**
+```sh
+gh auth login  # one-time setup
+ts-node main.ts update --version <version>
+```
+
 ### Run
 
 ```sh
-GH_TOKEN=<github_token> ts-node main.ts update --version <version>
-```
-
-If the github CLI (`gh`) is installed and configured, the auth token can also be retrieved from the github CLI,
-instead of manually providing.
-
-```sh
-GH_TOKEN=`gh auth token` ts-node main.ts update --version <version>
+ts-node main.ts update --version <version>
 ```
 
 The `update` command use HTTPS to connect to github by default. To use SSH instead, use `--useSSH true` as arguments in
@@ -42,7 +64,7 @@ Then, updating the remaining of downstream dependencies can be done by providing
 to the update command. The `--versions` flag would take a comma separated set of repos.
 
 ```sh
-GH_TOKEN=<github_token> ts-node main.ts update --version v0.30.0 --versions onflow/flow-go-sdk@v0.31.0,onflow/flow-go@v0.26.0
+ts-node main.ts update --version v0.30.0 --versions onflow/flow-go-sdk@v0.31.0,onflow/flow-go@v0.26.0
 ```
 
 Above will update the rest of the dependencies to:

--- a/tools/update/README.md
+++ b/tools/update/README.md
@@ -17,25 +17,17 @@ npm i -g typescript ts-node
 The tool requires a GitHub token to access the GitHub API. It will automatically try to find a token from several sources (in order):
 
 1. **Environment variables**: `GH_TOKEN` or `GITHUB_TOKEN`
-2. **Git config**: `git config --get github.token`  
-3. **GitHub CLI**: `gh auth token` (if `gh` is installed and authenticated)
-4. **macOS Keychain**: github.com password (macOS only)
+2. **GitHub CLI**: `gh auth token` (if `gh` is installed and authenticated)
+3. **macOS Keychain**: github.com password (macOS only)
 
 #### Setup Options
 
 **Option 1: Environment variable**
 ```sh
-export GH_TOKEN=<your_github_token>
-ts-node main.ts update --version <version>
+GH_TOKEN=<your_github_token> ts-node main.ts update --version <version>
 ```
 
-**Option 2: Git config (recommended for development)**
-```sh
-git config --global github.token <your_github_token>
-ts-node main.ts update --version <version>
-```
-
-**Option 3: GitHub CLI**
+**Option 2: GitHub CLI**
 ```sh
 gh auth login  # one-time setup
 ts-node main.ts update --version <version>
@@ -77,7 +69,7 @@ Instead of the version, it is also possible to provide a commit,
 in Go's expected format, i.e. the first 12 characters of the commit hash.
 
 ```sh
-GH_TOKEN=`gh auth token` ts-node main.ts update --version v0.30.0 --versions onflow/flow-go@<commit>
+ts-node main.ts update --version v0.30.0 --versions onflow/flow-go@<commit>
 ```
 
 #### Configuring dependencies
@@ -107,7 +99,7 @@ Start the process of updating all downstream dependencies by invoking the `updat
 The Cadence version needs to be provided using the `--version` flag.
 
 ```shell
-$ GH_TOKEN=`gh auth token` ts-node main.ts update \
+ts-node main.ts update \
     --version v1.0.0-M8
 ```
 
@@ -187,7 +179,7 @@ In this example, the next version is `v1.0.0-M5`.
 Use the `release` subcommand to create a new tag:
 
 ```shell
-$ GH_TOKEN=`gh auth token` ts-node main.ts release --repo onflow/flow-go-sdk --version v1.0.0-M5
+ts-node main.ts release --repo onflow/flow-go-sdk --version v1.0.0-M5
 ```
 
 <details>
@@ -221,7 +213,7 @@ Once the GitHub release has been published, re-run the `update` subcommand. The 
 Versions are specified using the `--versions` flag, comma-separated.
 
 ```shell
-GH_TOKEN=`gh auth token` ts-node main.ts update \
+ts-node main.ts update \
     --version v1.0.0-M8
 ```
 
@@ -289,7 +281,7 @@ Checking repo onflow/cadence-tools ...
   For example, to `flow-emulator` depends on `flow-go`, and it can be updated using:
 
   ```shell
-  $ GH_TOKEN=`gh auth token` ts-node main.ts update \
+  ts-node main.ts update \
       --version v1.0.0-M8 \
       --versions onflow/flow-go@3677206d445c
   ```
@@ -301,7 +293,7 @@ Checking repo onflow/cadence-tools ...
   For example, to release module `lint` in repo `cadence-tools`:
 
   ```shell
-  $ GH_TOKEN=`gh auth token` ts-node main.ts release \
+  ts-node main.ts release \
       -r onflow/cadence-tools \
       --mod lint \
       --version v1.0.0-M5

--- a/tools/update/main.ts
+++ b/tools/update/main.ts
@@ -488,18 +488,7 @@ async function getGitHubToken(): Promise<string | undefined> {
         return process.env.GITHUB_TOKEN
     }
 
-    // 2. Try git config
-    try {
-        const result = await exec.quiet('git config --get github.token')
-        if (result.stdout?.trim()) {
-            console.log("🔑 Using GitHub token from git config")
-            return result.stdout.trim()
-        }
-    } catch (error) {
-        // Git config doesn't have github.token, continue
-    }
-
-    // 3. Try GitHub CLI auth token
+    // 2. Try GitHub CLI auth token
     try {
         const result = await exec.quiet('gh auth token')
         if (result.stdout?.trim()) {
@@ -510,7 +499,7 @@ async function getGitHubToken(): Promise<string | undefined> {
         // GitHub CLI not available or not authenticated, continue
     }
 
-    // 4. Try macOS keychain (if on macOS)
+    // 3. Try macOS keychain (if on macOS)
     if (process.platform === 'darwin') {
         try {
             // Try to get github.com token from keychain
@@ -534,9 +523,8 @@ async function authenticate(): Promise<Octokit> {
         console.error("❌ No GitHub token found!")
         console.error("Please set up authentication using one of these methods:")
         console.error("  1. Set GH_TOKEN or GITHUB_TOKEN environment variable")
-        console.error("  2. Run: git config --global github.token YOUR_TOKEN")
-        console.error("  3. Install and authenticate with GitHub CLI: gh auth login")
-        console.error("  4. Add token to macOS Keychain for github.com")
+        console.error("  2. Install and authenticate with GitHub CLI: gh auth login")
+        console.error("  3. Add token to macOS Keychain for github.com")
         process.exit(1)
     }
 

--- a/tools/update/main.ts
+++ b/tools/update/main.ts
@@ -476,15 +476,82 @@ ${updateList}
     }
 }
 
+async function getGitHubToken(): Promise<string | undefined> {
+    // 1. Try environment variable first
+    if (process.env.GH_TOKEN) {
+        console.log("🔑 Using GitHub token from GH_TOKEN environment variable")
+        return process.env.GH_TOKEN
+    }
+
+    if (process.env.GITHUB_TOKEN) {
+        console.log("🔑 Using GitHub token from GITHUB_TOKEN environment variable")
+        return process.env.GITHUB_TOKEN
+    }
+
+    // 2. Try git config
+    try {
+        const result = await exec.quiet('git config --get github.token')
+        if (result.stdout?.trim()) {
+            console.log("🔑 Using GitHub token from git config")
+            return result.stdout.trim()
+        }
+    } catch (error) {
+        // Git config doesn't have github.token, continue
+    }
+
+    // 3. Try GitHub CLI auth token
+    try {
+        const result = await exec.quiet('gh auth token')
+        if (result.stdout?.trim()) {
+            console.log("🔑 Using GitHub token from GitHub CLI")
+            return result.stdout.trim()
+        }
+    } catch (error) {
+        // GitHub CLI not available or not authenticated, continue
+    }
+
+    // 4. Try macOS keychain (if on macOS)
+    if (process.platform === 'darwin') {
+        try {
+            // Try to get github.com token from keychain
+            const result = await exec.quiet('security find-internet-password -s github.com -w')
+            if (result.stdout?.trim()) {
+                console.log("🔑 Using GitHub token from macOS Keychain")
+                return result.stdout.trim()
+            }
+        } catch (error) {
+            // Keychain doesn't have github.com password, continue
+        }
+    }
+
+    return undefined
+}
+
 async function authenticate(): Promise<Octokit> {
+    const token = await getGitHubToken()
+    
+    if (!token) {
+        console.error("❌ No GitHub token found!")
+        console.error("Please set up authentication using one of these methods:")
+        console.error("  1. Set GH_TOKEN or GITHUB_TOKEN environment variable")
+        console.error("  2. Run: git config --global github.token YOUR_TOKEN")
+        console.error("  3. Install and authenticate with GitHub CLI: gh auth login")
+        console.error("  4. Add token to macOS Keychain for github.com")
+        process.exit(1)
+    }
+
     const octokit = new Octokit({
-        auth: process.env.GH_TOKEN
+        auth: token
     })
 
-    const {data: {login}} = await octokit.rest.users.getAuthenticated()
-    console.log("👋 Hello, %s", login)
-
-    return octokit
+    try {
+        const {data: {login}} = await octokit.rest.users.getAuthenticated()
+        console.log("👋 Hello, %s", login)
+        return octokit
+    } catch (error) {
+        console.error("❌ Failed to authenticate with GitHub. Please check your token.")
+        throw error
+    }
 }
 
 function getTagName(modPath: string, version: string) {


### PR DESCRIPTION
## Description

The tool now automatically tries to find GitHub tokens from multiple sources in this priority order:

1.  **Environment variables** - `GH_TOKEN` or `GITHUB_TOKEN`
2.  **GitHub CLI** - `gh auth token` (if installed and authenticated)
3.  **macOS Keychain** - github.com password (macOS only)

This helps improve user experience by falling back to credentials that may already be stored on the machine instead of requiring the user to manually configure a token.

_I've personally found myself constantly re-generating new PATs for one-off use with the update tool._
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
