### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/cmd/decode-state-values/main.go
+++ b/cmd/decode-state-values/main.go
@@ -31,6 +31,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
@@ -564,14 +565,7 @@ payloadLoop:
 
 		if filter {
 			owner := common.MustBytesToAddress([]byte(storageKey[0]))
-			var found bool
-			for _, address := range addresses {
-				if owner == address {
-					found = true
-					break
-				}
-			}
-			if !found {
+			if !slices.Contains(addresses, owner) {
 				continue payloadLoop
 			}
 		}

--- a/sema/type.go
+++ b/sema/type.go
@@ -6782,15 +6782,12 @@ func (t *InclusiveRangeType) Instantiate(
 	}
 
 	// memberType must only be a leaf integer type.
-	for _, ty := range AllNonLeafIntegerTypes {
-		if memberType == ty {
-			report(&InvalidTypeArgumentError{
-				TypeArgumentName: inclusiveRangeTypeParameter.Name,
-				Range:            getRange(),
-				Details:          fmt.Sprintf("Creation of InclusiveRange<%s> is disallowed", memberType),
-			})
-			break
-		}
+	if slices.Contains(AllNonLeafIntegerTypes, memberType) {
+		report(&InvalidTypeArgumentError{
+			TypeArgumentName: inclusiveRangeTypeParameter.Name,
+			Range:            getRange(),
+			Details:          fmt.Sprintf("Creation of InclusiveRange<%s> is disallowed", memberType),
+		})
 	}
 
 	return &InclusiveRangeType{


### PR DESCRIPTION
Closes #???

## Description

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
