### PR TITLE
[Compiler] Reuse elaboration for imports when possible.

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -3337,21 +3337,25 @@ func (c *Compiler[_, _]) VisitImportDeclaration(declaration *ast.ImportDeclarati
 
 	// Resolve and add globals from transitive imports.
 
-	// TODO: Is it possible to reuse the resolved locations from the elaboration?
-	// resolvedLocations := c.DesugaredElaboration.elaboration.ImportDeclarationResolvedLocations(declaration)
+	resolvedLocations := c.DesugaredElaboration.elaboration.ImportDeclarationResolvedLocations(declaration)
 
-	var identifiers []ast.Identifier
-	for _, imp := range declaration.Imports {
-		identifiers = append(identifiers, imp.Identifier)
-	}
+	// some import declarations are added during desugaring and do not have resolved locations from the elaboration
+	if len(resolvedLocations) == 0 {
+		var identifiers []ast.Identifier
+		for _, imp := range declaration.Imports {
+			identifiers = append(identifiers, imp.Identifier)
+		}
 
-	resolvedLocations, err := commons.ResolveLocation(
-		c.Config.LocationHandler,
-		identifiers,
-		declaration.Location,
-	)
-	if err != nil {
-		panic(err)
+		var err error
+		resolvedLocations, err = commons.ResolveLocation(
+			c.Config.LocationHandler,
+			identifiers,
+			declaration.Location,
+		)
+		if err != nil {
+			panic(err)
+		}
+
 	}
 
 	aliases := c.DesugaredElaboration.elaboration.ImportDeclarationAliases(declaration)

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -3340,7 +3340,7 @@ func (c *Compiler[_, _]) VisitImportDeclaration(declaration *ast.ImportDeclarati
 	resolvedLocations := c.DesugaredElaboration.elaboration.ImportDeclarationResolvedLocations(declaration)
 
 	// some import declarations are added during desugaring and do not have resolved locations from the elaboration
-	if len(resolvedLocations) == 0 {
+	if resolvedLocations == nil {
 		var identifiers []ast.Identifier
 		for _, imp := range declaration.Imports {
 			identifiers = append(identifiers, imp.Identifier)


### PR DESCRIPTION
Closes #4213 

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Desugaring adds import declarations which do not have elaboration. Manually resolve locations in that scenario. 

- Also tried to update the elaboration in desugaring when the new imports are added, but ran into a lot of issues matching the correct elaboration (not as simple as just using the one at the time of creation) and some weird race conditions

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
