### PR TITLE
[Compiler] Simplify imported globals linking

### DIFF
--- a/bbq/compiler/builtin_globals.go
+++ b/bbq/compiler/builtin_globals.go
@@ -106,11 +106,8 @@ func registerBoundFunctions(typ sema.Type) {
 func registerGlobalImport(name string, activation *activations.Activation[GlobalImport]) {
 	activation.Set(
 		name,
-		GlobalImport{
-			// This is a native function, so the location is nil.
-			Location: nil,
-			Name:     name,
-		},
+		// This is a native function, so the location is nil.
+		NewGlobalImport(name),
 	)
 }
 

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -3968,9 +3968,7 @@ func TestCompileFunctionConditions(t *testing.T) {
 						activation := activations.NewActivation(nil, compiler.DefaultBuiltinGlobals())
 						activation.Set(
 							stdlib.LogFunctionName,
-							compiler.GlobalImport{
-								Name: stdlib.LogFunctionName,
-							},
+							compiler.NewGlobalImport(stdlib.LogFunctionName),
 						)
 						return activation
 					},
@@ -7837,9 +7835,7 @@ func TestCompileOptionalArgument(t *testing.T) {
 				activation := activations.NewActivation(nil, compiler.DefaultBuiltinGlobals())
 				activation.Set(
 					stdlib.AssertFunctionName,
-					compiler.GlobalImport{
-						Name: stdlib.AssertFunctionName,
-					},
+					compiler.NewGlobalImport(stdlib.AssertFunctionName),
 				)
 				return activation
 			},
@@ -9382,15 +9378,11 @@ func TestCompileInjectedContract(t *testing.T) {
 			activation := activations.NewActivation(nil, compiler.DefaultBuiltinGlobals())
 			activation.Set(
 				"B",
-				compiler.GlobalImport{
-					Name: "B",
-				},
+				compiler.NewGlobalImport("B"),
 			)
 			activation.Set(
 				"B.c",
-				compiler.GlobalImport{
-					Name: "B.c",
-				},
+				compiler.NewGlobalImport("B.c"),
 			)
 			return activation
 		},
@@ -9743,19 +9735,22 @@ func TestCompileImportAlias(t *testing.T) {
 			t,
 			map[string]bbq.GlobalInfo{
 				"test": {
-					Location: nil,
-					Name:     "test",
-					Index:    0,
+					Location:      nil,
+					Name:          "test",
+					QualifiedName: "test",
+					Index:         0,
 				},
 				"A.0000000000000001.Foo": {
-					Location: importLocation,
-					Name:     "A.0000000000000001.Foo",
-					Index:    1,
+					Location:      importLocation,
+					Name:          "Foo",
+					QualifiedName: "A.0000000000000001.Foo",
+					Index:         1,
 				},
 				"A.0000000000000001.Foo.hello": {
-					Location: importLocation,
-					Name:     "A.0000000000000001.Foo.hello",
-					Index:    2,
+					Location:      importLocation,
+					Name:          "Foo.hello",
+					QualifiedName: "A.0000000000000001.Foo.hello",
+					Index:         2,
 				},
 			},
 			comp.Globals,
@@ -9845,34 +9840,40 @@ func TestCompileImportAlias(t *testing.T) {
 			t,
 			map[string]bbq.GlobalInfo{
 				"Bar": {
-					Location: nil,
-					Name:     "Bar",
-					Index:    0,
+					Location:      nil,
+					Name:          "Bar",
+					QualifiedName: "Bar",
+					Index:         0,
 				},
 				"Bar.getType": {
-					Location: nil,
-					Name:     "Bar.getType",
-					Index:    1,
+					Location:      nil,
+					Name:          "Bar.getType",
+					QualifiedName: "Bar.getType",
+					Index:         1,
 				},
 				"Bar.hello": {
-					Location: nil,
-					Name:     "Bar.hello",
-					Index:    3,
+					Location:      nil,
+					Name:          "Bar.hello",
+					QualifiedName: "Bar.hello",
+					Index:         3,
 				},
 				"Bar.isInstance": {
-					Location: nil,
-					Name:     "Bar.isInstance",
-					Index:    2,
+					Location:      nil,
+					Name:          "Bar.isInstance",
+					QualifiedName: "Bar.isInstance",
+					Index:         2,
 				},
 				"Bar.defaultHello": {
-					Location: nil,
-					Name:     "Bar.defaultHello",
-					Index:    4,
+					Location:      nil,
+					Name:          "Bar.defaultHello",
+					QualifiedName: "Bar.defaultHello",
+					Index:         4,
 				},
 				"A.0000000000000001.FooInterface.defaultHello": {
-					Location: importLocation,
-					Name:     "A.0000000000000001.FooInterface.defaultHello",
-					Index:    5,
+					Location:      importLocation,
+					Name:          "FooInterface.defaultHello",
+					QualifiedName: "A.0000000000000001.FooInterface.defaultHello",
+					Index:         5,
 				},
 			},
 			comp.Globals,

--- a/bbq/global.go
+++ b/bbq/global.go
@@ -32,9 +32,14 @@ const (
 )
 
 type GlobalInfo struct {
-	Name     string
-	Location common.Location
-	Index    uint16
+	Name string
+	// Need to maintain both "qualified" and "unqualified" names for a global,
+	// because when type-aliasing is used, imported global name becomes qualified.
+	// However, the same imported-global must use the unqualified name when linking.
+	// TODO: We can simplify this by always using qualified names for all imports.
+	QualifiedName string
+	Location      common.Location
+	Index         uint16
 }
 
 type Global interface {
@@ -69,9 +74,11 @@ func NewFunctionGlobal[E any](
 	common.UseMemory(memoryGauge, common.CompilerGlobalMemoryUsage)
 	return &FunctionGlobal[E]{
 		GlobalInfo: GlobalInfo{
-			Name:     name,
-			Location: location,
-			Index:    index,
+			Name: name,
+			// For non-imported global, qualified-name is same the name
+			QualifiedName: name,
+			Location:      location,
+			Index:         index,
 		},
 	}
 }
@@ -101,9 +108,11 @@ func NewVariableGlobal[E any](
 	common.UseMemory(memoryGauge, common.CompilerGlobalMemoryUsage)
 	return &VariableGlobal[E]{
 		GlobalInfo: GlobalInfo{
-			Name:     name,
-			Location: location,
-			Index:    index,
+			Name: name,
+			// For non-imported global, qualified-name is same the name
+			QualifiedName: name,
+			Location:      location,
+			Index:         index,
 		},
 	}
 }
@@ -117,9 +126,11 @@ func NewContractGlobal(
 	common.UseMemory(memoryGauge, common.CompilerGlobalMemoryUsage)
 	return &ContractGlobal{
 		GlobalInfo: GlobalInfo{
-			Name:     name,
-			Location: location,
-			Index:    index,
+			Name: name,
+			// For non-imported global, qualified-name is same the name
+			QualifiedName: name,
+			Location:      location,
+			Index:         index,
 		},
 	}
 }
@@ -127,15 +138,17 @@ func NewContractGlobal(
 func NewImportedGlobal(
 	memoryGauge common.MemoryGauge,
 	name string,
+	qualifiedName string,
 	location common.Location,
 	index uint16,
 ) *ImportedGlobal {
 	common.UseMemory(memoryGauge, common.CompilerGlobalMemoryUsage)
 	return &ImportedGlobal{
 		GlobalInfo: GlobalInfo{
-			Name:     name,
-			Location: location,
-			Index:    index,
+			Name:          name,
+			QualifiedName: qualifiedName,
+			Location:      location,
+			Index:         index,
 		},
 	}
 }

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -30,9 +30,6 @@ import (
 )
 
 type LinkedGlobals struct {
-	// context shared by the globals in the program.
-	executable *ExecutableProgram
-
 	// globals defined in the program, indexed by name.
 	indexedGlobals *activations.Activation[Variable]
 }
@@ -189,7 +186,6 @@ func LinkGlobals(
 	// Return only the globals defined in the current program.
 	// Because the importer/caller doesn't need to know globals of nested imports.
 	return LinkedGlobals{
-		executable:     executable,
 		indexedGlobals: indexedGlobals,
 	}
 }

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -111,6 +111,8 @@ func LinkGlobals(
 
 			// Don't need to add to the `indexedGlobals`, since, like the below comment says,
 			// importer/caller doesn't need to know globals of nested imports
+		default:
+			panic(errors.NewUnexpectedError("unsupported global type: %T", global))
 		}
 	}
 

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -102,23 +102,17 @@ func compiledFTTransfer(tb testing.TB) {
 
 			activation.Set(
 				stdlib.AssertFunctionName,
-				compiler.GlobalImport{
-					Name: stdlib.AssertFunctionName,
-				},
+				compiler.NewGlobalImport(stdlib.AssertFunctionName),
 			)
 
 			activation.Set(
 				stdlib.GetAccountFunctionName,
-				compiler.GlobalImport{
-					Name: stdlib.GetAccountFunctionName,
-				},
+				compiler.NewGlobalImport(stdlib.GetAccountFunctionName),
 			)
 
 			activation.Set(
 				stdlib.PanicFunctionName,
-				compiler.GlobalImport{
-					Name: stdlib.PanicFunctionName,
-				},
+				compiler.NewGlobalImport(stdlib.PanicFunctionName),
 			)
 
 			return activation

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -389,9 +389,7 @@ func CompilerDefaultBuiltinGlobalsWithDefaultsAndLog(_ common.Location) *activat
 
 	activation.Set(
 		stdlib.LogFunctionName,
-		compiler.GlobalImport{
-			Name: stdlib.LogFunctionName,
-		},
+		compiler.NewGlobalImport(stdlib.LogFunctionName),
 	)
 
 	return activation
@@ -402,9 +400,7 @@ func CompilerDefaultBuiltinGlobalsWithDefaultsAndPanic(_ common.Location) *activ
 
 	activation.Set(
 		stdlib.PanicFunctionName,
-		compiler.GlobalImport{
-			Name: stdlib.PanicFunctionName,
-		},
+		compiler.NewGlobalImport(stdlib.PanicFunctionName),
 	)
 
 	return activation
@@ -415,9 +411,7 @@ func CompilerDefaultBuiltinGlobalsWithDefaultsAndConditionLog(_ common.Location)
 
 	activation.Set(
 		conditionLogFunctionName,
-		compiler.GlobalImport{
-			Name: conditionLogFunctionName,
-		},
+		compiler.NewGlobalImport(conditionLogFunctionName),
 	)
 
 	return activation

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -2035,9 +2035,7 @@ func TestNativeFunctions(t *testing.T) {
 				activation := activations.NewActivation(nil, compiler.DefaultBuiltinGlobals())
 				activation.Set(
 					stdlib.AssertFunctionName,
-					compiler.GlobalImport{
-						Name: stdlib.AssertFunctionName,
-					},
+					compiler.NewGlobalImport(stdlib.AssertFunctionName),
 				)
 				return activation
 			},
@@ -8752,9 +8750,7 @@ func TestFunctionInvocationWithOptionalArgs(t *testing.T) {
 			activation := activations.NewActivation[compiler.GlobalImport](nil, compiler.DefaultBuiltinGlobals())
 			activation.Set(
 				functionName,
-				compiler.GlobalImport{
-					Name: functionName,
-				},
+				compiler.NewGlobalImport(functionName),
 			)
 			return activation
 		},
@@ -9099,9 +9095,7 @@ func TestGetAuthAccount(t *testing.T) {
 				activation := activations.NewActivation(nil, compiler.DefaultBuiltinGlobals())
 				activation.Set(
 					stdlib.GetAuthAccountFunctionName,
-					compiler.GlobalImport{
-						Name: stdlib.GetAuthAccountFunctionName,
-					},
+					compiler.NewGlobalImport(stdlib.GetAuthAccountFunctionName),
 				)
 				return activation
 			},
@@ -9336,15 +9330,11 @@ func TestInjectedContract(t *testing.T) {
 			activation := activations.NewActivation(nil, compiler.DefaultBuiltinGlobals())
 			activation.Set(
 				"B",
-				compiler.GlobalImport{
-					Name: "B",
-				},
+				compiler.NewGlobalImport("B"),
 			)
 			activation.Set(
 				"B.c",
-				compiler.GlobalImport{
-					Name: "B.c",
-				},
+				compiler.NewGlobalImport("B.c"),
 			)
 			return activation
 		},
@@ -9677,9 +9667,7 @@ func TestFunctionInclusiveRangeConstruction(t *testing.T) {
 			activation := activations.NewActivation[compiler.GlobalImport](nil, compiler.DefaultBuiltinGlobals())
 			activation.Set(
 				stdlib.VMInclusiveRangeConstructor.Name,
-				compiler.GlobalImport{
-					Name: stdlib.VMInclusiveRangeConstructor.Name,
-				},
+				compiler.NewGlobalImport(stdlib.VMInclusiveRangeConstructor.Name),
 			)
 			return activation
 		},

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -651,9 +651,7 @@ func testAccountWithErrorHandlerWithCompiler(
 								}
 								activation.Set(
 									name,
-									compiler.GlobalImport{
-										Name: name,
-									},
+									compiler.NewGlobalImport(name),
 								)
 							}
 							return activation

--- a/runtime/rlp_test.go
+++ b/runtime/rlp_test.go
@@ -366,7 +366,7 @@ func TestRuntimeRLPGetTypeAndIsInstance(t *testing.T) {
 		Context{
 			Interface: runtimeInterface,
 			Location:  common.ScriptLocation{},
-			UseVM:     *compile,
+			UseVM:     true,
 		},
 	)
 	require.NoError(t, err)

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -165,9 +165,7 @@ func (e *vmEnvironment) defineValue(name string, value vm.Value) {
 	if e.defaultCompilerBuiltinGlobals.Find(name) == (compiler.GlobalImport{}) {
 		e.defaultCompilerBuiltinGlobals.Set(
 			name,
-			compiler.GlobalImport{
-				Name: name,
-			},
+			compiler.NewGlobalImport(name),
 		)
 	}
 
@@ -242,9 +240,7 @@ func (e *vmEnvironment) declareCompilerValue(valueDeclaration stdlib.StandardLib
 
 	compilerBuiltinGlobals.Set(
 		name,
-		compiler.GlobalImport{
-			Name: name,
-		},
+		compiler.NewGlobalImport(name),
 	)
 
 	for _, function := range compiler.CommonBuiltinTypeBoundFunctions {
@@ -254,9 +250,7 @@ func (e *vmEnvironment) declareCompilerValue(valueDeclaration stdlib.StandardLib
 		)
 		compilerBuiltinGlobals.Set(
 			qualifiedFunctionName,
-			compiler.GlobalImport{
-				Name: qualifiedFunctionName,
-			},
+			compiler.NewGlobalImport(qualifiedFunctionName),
 		)
 	}
 }

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -395,9 +395,7 @@ func ParseCheckAndPrepareWithOptions(
 						}
 						activation.Set(
 							name,
-							compiler.GlobalImport{
-								Name: name,
-							},
+							compiler.NewGlobalImport(name),
 						)
 					}
 					return activation


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/4059

## Description

Previously, linker used to link imported globals based on the `Imports` section of the `bbq.Program`. This is because `bbq.Program.Globals` didn't have enough information needed for linking. However, with https://github.com/onflow/cadence/pull/4211,  `Globals` now has more information that is sufficient to link the globals.

- Therefore, switch to linking the imported globals also using `bbq.Program.Globals` instead of `bbq.Program.Imports`.
- This further eliminates the implicit dependency of order of imports between compiler and the VM.
- Also eliminates the need for recursive linking, as the `bbq.Program.Globals` already includes all symbols/values needed to execute the program, including transitive dependencies.
- After this, `bbq.Program.Imports` are only used by the compiler.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
