### PR TITLE
Fix tracing of function invocations

### DIFF
--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -986,7 +986,6 @@ func invokeFunction(
 		if interpreter.TracingEnabled {
 			startTime := time.Now()
 			defer func() {
-
 				context.ReportInvokeTrace(
 					// Use the original function value, to get the correct type.
 					// The native function value might have been wrapped in a bound function.

--- a/interpreter/interpreter_expression.go
+++ b/interpreter/interpreter_expression.go
@@ -1195,11 +1195,16 @@ func (interpreter *Interpreter) visitInvocationExpressionWithImplicitArgument(in
 		startTime := time.Now()
 
 		defer func() {
-			interpreter.ReportInvokeTrace(
-				function.FunctionType(interpreter).String(),
-				"?",
-				time.Since(startTime),
-			)
+			// `function` might be nil for:
+			// - optional chaining invocations where the target is nil (no function invoked)
+			// - for invalid programs (panic, e.g. invoking a non-function value)
+			if function != nil {
+				interpreter.ReportInvokeTrace(
+					function.FunctionType(interpreter).String(),
+					"?",
+					time.Since(startTime),
+				)
+			}
 		}()
 	}
 


### PR DESCRIPTION

## Description

Only report an invocation trace (and get the function type) if there is a function value. 
The function might be `nil` for:
- Optional chaining invocations where the target is `nil` (no function invoked)
- Invalid programs (panic, e.g. invoking a non-function value)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
