### PR TITLE
[Compiler] Use global's index instead of array index during linking

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -889,6 +889,11 @@ func (c *Compiler[E, _]) exportGlobals() []bbq.Global {
 
 	for _, global := range c.Globals { //nolint:maprange
 		index := int(global.GetGlobalInfo().Index)
+
+		if globals[index] != nil {
+			panic(errors.NewUnexpectedError("duplicate global index %d", index))
+		}
+
 		globals[index] = global
 	}
 

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -19,10 +19,8 @@
 package compiler
 
 import (
-	"maps"
 	"math"
 	"math/big"
-	"slices"
 	"strings"
 
 	"github.com/onflow/cadence/activations"
@@ -887,14 +885,14 @@ func (c *Compiler[_, T]) exportTypes() []T {
 }
 
 func (c *Compiler[E, _]) exportGlobals() []bbq.Global {
-	// create a sorted global slice by index for linker efficiency
-	// tradeoff: compiler does more work to sort the globals, but linker does less work to link the globals
-	// ignore linting, order doesn't matter since its sorted after
-	globalsSlice := slices.Collect(maps.Values(c.Globals)) //nolint:forbidigo
-	slices.SortFunc(globalsSlice, func(a, b bbq.Global) int {
-		return int(a.GetGlobalInfo().Index) - int(b.GetGlobalInfo().Index)
-	})
-	return globalsSlice
+	globals := make([]bbq.Global, len(c.Globals))
+
+	for _, global := range c.Globals { //nolint:maprange
+		index := int(global.GetGlobalInfo().Index)
+		globals[index] = global
+	}
+
+	return globals
 }
 
 // removeAlias removes the address qualifier from the name if it exists

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -52,13 +52,7 @@ func LinkGlobals(
 	// NOTE: ensure both the context and the mapping are updated
 
 	for _, global := range program.Globals {
-
 		index := int(global.GetGlobalInfo().Index)
-
-		// Sanity check to avoid global index clashing.
-		if globals[index] != nil {
-			panic(errors.NewUnexpectedError("duplicate global index %d", index))
-		}
 
 		switch typedGlobal := global.(type) {
 		case *bbq.FunctionGlobal[opcode.Instruction]:


### PR DESCRIPTION
Closes https://github.com/onflow/cadence/issues/4059

## Description

Could also get rid of the sorting at compile time, by placing the globals in the slice using the index.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
