### PR TITLE
[Compiler] Avoid creating an array for resource default-destroy events

### DIFF
--- a/bbq/commons/constants.go
+++ b/bbq/commons/constants.go
@@ -34,6 +34,7 @@ const (
 
 	GeneratedNameQualifier              = "$"
 	ResourceDestroyedEventsFunctionName = GeneratedNameQualifier + ast.ResourceDestructionDefaultEventName
+	CollectEventsParamName              = "collectEvents"
 
 	// Names used by generated constructs
 

--- a/bbq/commons/types.go
+++ b/bbq/commons/types.go
@@ -105,3 +105,16 @@ func LocationQualifier(typ sema.Type) string {
 		return string(typ.ID())
 	}
 }
+
+var CollectEventsFunctionType = &sema.FunctionType{
+	Purity:               sema.FunctionPurityImpure,
+	ReturnTypeAnnotation: sema.VoidTypeAnnotation,
+	Arity:                &sema.Arity{Min: 0, Max: -1},
+	Parameters: []sema.Parameter{
+		{
+			TypeAnnotation: sema.AnyStructTypeAnnotation,
+			Label:          sema.ArgumentLabelNotRequired,
+			Identifier:     CollectEventsParamName,
+		},
+	},
+}

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -9609,6 +9609,8 @@ func TestCompileInheritedDefaultDestroyEvent(t *testing.T) {
             resource ABC: Bar.XYZ {
                 var x: Int
 
+                event ResourceDestroyed(x: Int = self.x)
+
                 init() {
                     self.x = 6
                 }
@@ -9625,33 +9627,46 @@ func TestCompileInheritedDefaultDestroyEvent(t *testing.T) {
 	fooProgram := ParseCheckAndCompile(t, fooContract, fooLocation, programs)
 
 	functions = fooProgram.Functions
-	require.Len(t, functions, 8)
+	require.Len(t, functions, 11)
 
 	defaultDestroyEventEmittingFunction := functions[7]
 	require.Equal(t, "Foo.ABC.$ResourceDestroyed", defaultDestroyEventEmittingFunction.Name)
 
 	const inheritedEventConstructorIndex = 9
+	const selfDefinedABCEventConstructorIndex = 12
 
 	assert.Equal(t,
 		[]opcode.Instruction{
 			opcode.InstructionStatement{},
 
+			// Get the `collectEvents` parameter for invocation.
+			opcode.InstructionGetLocal{Local: 1},
+
 			// Construct the inherited event
 			// Bar.XYZ.ResourceDestroyed(self.x)
 			opcode.InstructionGetGlobal{Global: inheritedEventConstructorIndex},
 			opcode.InstructionGetLocal{Local: 0},
-			opcode.InstructionGetField{FieldName: 2, AccessedType: 8},
+			opcode.InstructionGetField{FieldName: 2, AccessedType: 5},
 			opcode.InstructionTransferAndConvert{Type: 6},
 			opcode.InstructionInvoke{ArgCount: 1},
+			opcode.InstructionTransferAndConvert{Type: 8},
 
-			// Create the array with the above event.
-			// `[Bar.XYZ.ResourceDestroyed(self.x)]`
-			opcode.InstructionTransferAndConvert{Type: 9},
-			opcode.InstructionNewArray{Type: 7, Size: 1, IsResource: false},
-			opcode.InstructionTransferAndConvert{Type: 7},
+			// Construct the self defined event
+			// Foo.ABC.ResourceDestroyed(self.x)
+			opcode.InstructionGetGlobal{Global: selfDefinedABCEventConstructorIndex},
+			opcode.InstructionGetLocal{Local: 0},
+			opcode.InstructionGetField{FieldName: 2, AccessedType: 9},
+			opcode.InstructionTransferAndConvert{Type: 6},
+			opcode.InstructionInvoke{ArgCount: 1},
+			opcode.InstructionTransferAndConvert{Type: 10},
 
-			// return the array
-			opcode.InstructionReturnValue{},
+			// Invoke `collectEvents` with the above event.
+			// `collectEvents(...)`
+			opcode.InstructionInvoke{ArgCount: 2},
+			opcode.InstructionDrop{},
+
+			// Return
+			opcode.InstructionReturn{},
 		},
 		defaultDestroyEventEmittingFunction.Code,
 	)

--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -2200,16 +2200,16 @@ func (d *Desugar) generateResourceDestroyedEventsGetterFunction(
 
 	// Generate a function:
 	// ```
-	//   func $ResourceDestroyed(): [AnyStruct] {
-	//      return [
-	//          R.$ResourceDestroyed(args...),
-	//          I.$ResourceDestroyed(args...),
+	//   func $ResourceDestroyed(collectEvents: fun(events...)) {
+	//      collectEvents(
+	//          R.ResourceDestroyed(args...),
+	//          I.ResourceDestroyed(args...),
 	//          ...,
-	//      ]
+	//      )
 	//   }
 	// ```
 
-	eventConstructorInvocations := make([]ast.Expression, 0)
+	eventConstructorInvocations := make(ast.Arguments, 0)
 	eventTypes := make([]sema.Type, 0)
 
 	addEventConstructorInvocation := func(
@@ -2301,7 +2301,16 @@ func (d *Desugar) generateResourceDestroyedEventsGetterFunction(
 
 		d.elaboration.SetInvocationExpressionTypes(eventConstructorInvocation, invocationTypes)
 
-		eventConstructorInvocations = append(eventConstructorInvocations, eventConstructorInvocation)
+		eventConstructorInvocations = append(
+			eventConstructorInvocations,
+			ast.NewArgument(
+				d.memoryGauge,
+				"",
+				&startPos,
+				&startPos,
+				eventConstructorInvocation,
+			),
+		)
 		eventTypes = append(eventTypes, eventType)
 	}
 
@@ -2340,38 +2349,65 @@ func (d *Desugar) generateResourceDestroyedEventsGetterFunction(
 	astRange := compositeDeclaration.Range
 	startPos := compositeDeclaration.StartPos
 
-	// Put all the events in an array.
-	arrayExpression := ast.NewArrayExpression(
+	// Invoke the 'collectEvents' parameter
+
+	invocation := ast.NewInvocationExpression(
 		d.memoryGauge,
+		ast.NewIdentifierExpression(
+			d.memoryGauge,
+			ast.NewIdentifier(
+				d.memoryGauge,
+				commons.CollectEventsParamName,
+				startPos,
+			),
+		),
+		nil,
 		eventConstructorInvocations,
-		astRange,
+		startPos,
+		startPos,
 	)
 
-	d.elaboration.SetArrayExpressionTypes(
-		arrayExpression,
-		sema.ArrayExpressionTypes{
-			ArrayType:     semaAnyStructArrayType,
-			ArgumentTypes: eventTypes,
+	d.elaboration.SetInvocationExpressionTypes(
+		invocation,
+		sema.InvocationExpressionTypes{
+			ReturnType:     sema.VoidType,
+			ArgumentTypes:  eventTypes,
+			ParameterTypes: eventTypes,
 		},
 	)
 
-	// Return the array.
-	returnStatement := ast.NewReturnStatement(
-		d.memoryGauge,
-		arrayExpression,
-		astRange,
-	)
-	d.elaboration.SetReturnStatementTypes(
-		returnStatement,
-		sema.ReturnStatementTypes{
-			ValueType:  semaAnyStructArrayType,
-			ReturnType: semaAnyStructArrayType,
-		},
-	)
+	expressionStmt := ast.NewExpressionStatement(d.memoryGauge, invocation)
 
 	functionName := commons.ResourceDestroyedEventsFunctionName
 
 	// Generate the function declaration.
+
+	parameter := ast.NewParameter(
+		d.memoryGauge,
+		sema.ArgumentLabelNotRequired,
+		ast.NewIdentifier(
+			d.memoryGauge,
+			commons.CollectEventsParamName,
+			startPos,
+		),
+		ast.NewTypeAnnotation(
+			d.memoryGauge,
+			false,
+			ast.NewFunctionType(
+				d.memoryGauge,
+				ast.FunctionPurityUnspecified,
+				[]*ast.TypeAnnotation{
+					anyStructTypeAnnotation,
+				},
+				nil,
+				astRange,
+			),
+			ast.EmptyPosition,
+		),
+		nil,
+		ast.EmptyPosition,
+	)
+
 	eventEmittingFunction := ast.NewFunctionDeclaration(
 		d.memoryGauge,
 		ast.AccessNotSpecified,
@@ -2384,18 +2420,17 @@ func (d *Desugar) generateResourceDestroyedEventsGetterFunction(
 			startPos,
 		),
 		nil,
-		nil,
-		ast.NewTypeAnnotation(
+		ast.NewParameterList(
 			d.memoryGauge,
-			false,
-			astAnyStructArrayType,
-			startPos,
+			[]*ast.Parameter{parameter},
+			astRange,
 		),
+		nil,
 		ast.NewFunctionBlock(
 			d.memoryGauge,
 			ast.NewBlock(
 				d.memoryGauge,
-				[]ast.Statement{returnStatement},
+				[]ast.Statement{expressionStmt},
 				astRange,
 			),
 			nil,
@@ -2549,17 +2584,21 @@ var executeFuncType = sema.NewSimpleFunctionType(
 	sema.VoidTypeAnnotation,
 )
 
-var eventEmittingFunctionType = sema.NewSimpleFunctionType(
-	sema.FunctionPurityImpure,
-	nil,
-	sema.VoidTypeAnnotation,
-)
-
-var semaAnyStructArrayType = &sema.VariableSizedType{
-	Type: sema.AnyStructType,
+var eventEmittingFunctionType = &sema.FunctionType{
+	Purity:               sema.FunctionPurityImpure,
+	ReturnTypeAnnotation: sema.VoidTypeAnnotation,
+	Parameters: []sema.Parameter{
+		{
+			TypeAnnotation: sema.TypeAnnotation{
+				Type: commons.CollectEventsFunctionType,
+			},
+			Label:      sema.ArgumentLabelNotRequired,
+			Identifier: commons.CollectEventsParamName,
+		},
+	},
 }
 
-var astAnyStructArrayType = &ast.VariableSizedType{
+var anyStructTypeAnnotation = &ast.TypeAnnotation{
 	Type: &ast.NominalType{
 		Identifier: ast.Identifier{
 			Identifier: sema.AnyStructType.Name,


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/4059

## Description

To be in parity with the register writes of interpreter, avoid creating a Cadence array when collecting the default-destroyed events.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
