### PR TITLE
[Compiler] Create unified interface for native/host functions

### DIFF
--- a/bbq/vm/builtin_globals.go
+++ b/bbq/vm/builtin_globals.go
@@ -431,13 +431,14 @@ func registerBuiltinSaturatingArithmeticFunctions() {
 }
 
 func registerBuiltinTypeSaturatingArithmeticFunctions(t sema.SaturatingArithmeticType) {
+	functionType := sema.SaturatingArithmeticTypeFunctionTypes[t]
 
 	if t.SupportsSaturatingAdd() {
 		registerBuiltinTypeBoundFunction(
 			commons.TypeQualifier(t),
 			NewUnifiedNativeFunctionValue(
 				sema.NumericTypeSaturatingAddFunctionName,
-				sema.SaturatingArithmeticTypeFunctionTypes[t],
+				functionType,
 				interpreter.UnifiedNumberSaturatingAddFunction,
 			),
 		)
@@ -448,7 +449,7 @@ func registerBuiltinTypeSaturatingArithmeticFunctions(t sema.SaturatingArithmeti
 			commons.TypeQualifier(t),
 			NewUnifiedNativeFunctionValue(
 				sema.NumericTypeSaturatingSubtractFunctionName,
-				sema.SaturatingArithmeticTypeFunctionTypes[t],
+				functionType,
 				interpreter.UnifiedNumberSaturatingSubtractFunction,
 			),
 		)
@@ -459,7 +460,7 @@ func registerBuiltinTypeSaturatingArithmeticFunctions(t sema.SaturatingArithmeti
 			commons.TypeQualifier(t),
 			NewUnifiedNativeFunctionValue(
 				sema.NumericTypeSaturatingMultiplyFunctionName,
-				sema.SaturatingArithmeticTypeFunctionTypes[t],
+				functionType,
 				interpreter.UnifiedNumberSaturatingMultiplyFunction,
 			),
 		)
@@ -470,7 +471,7 @@ func registerBuiltinTypeSaturatingArithmeticFunctions(t sema.SaturatingArithmeti
 			commons.TypeQualifier(t),
 			NewUnifiedNativeFunctionValue(
 				sema.NumericTypeSaturatingDivideFunctionName,
-				sema.SaturatingArithmeticTypeFunctionTypes[t],
+				functionType,
 				interpreter.UnifiedNumberSaturatingDivideFunction,
 			),
 		)

--- a/bbq/vm/builtin_globals.go
+++ b/bbq/vm/builtin_globals.go
@@ -432,78 +432,47 @@ func registerBuiltinSaturatingArithmeticFunctions() {
 
 func registerBuiltinTypeSaturatingArithmeticFunctions(t sema.SaturatingArithmeticType) {
 
-	register := func(
-		functionName string,
-		op func(context *Context, v, other interpreter.NumberValue) interpreter.NumberValue,
-	) {
+	if t.SupportsSaturatingAdd() {
 		registerBuiltinTypeBoundFunction(
 			commons.TypeQualifier(t),
-			NewNativeFunctionValue(
-				functionName,
+			NewUnifiedNativeFunctionValue(
+				sema.NumericTypeSaturatingAddFunctionName,
 				sema.SaturatingArithmeticTypeFunctionTypes[t],
-				func(context *Context, _ []bbq.StaticType, receiver Value, args ...Value) Value {
-					this := receiver.(interpreter.NumberValue)
-
-					other, ok := args[0].(interpreter.NumberValue)
-					if !ok {
-						panic(errors.NewUnreachableError())
-					}
-
-					return op(context, this, other)
-				},
+				interpreter.UnifiedNumberSaturatingAddFunction,
 			),
 		)
 	}
 
-	if t.SupportsSaturatingAdd() {
-		register(
-			sema.NumericTypeSaturatingAddFunctionName,
-			func(context *Context, v, other interpreter.NumberValue) interpreter.NumberValue {
-				return v.SaturatingPlus(
-					context,
-					other,
-					EmptyLocationRange,
-				)
-			},
-		)
-	}
-
 	if t.SupportsSaturatingSubtract() {
-		register(
-			sema.NumericTypeSaturatingSubtractFunctionName,
-			func(context *Context, v, other interpreter.NumberValue) interpreter.NumberValue {
-				return v.SaturatingMinus(
-					context,
-					other,
-					EmptyLocationRange,
-				)
-			},
+		registerBuiltinTypeBoundFunction(
+			commons.TypeQualifier(t),
+			NewUnifiedNativeFunctionValue(
+				sema.NumericTypeSaturatingSubtractFunctionName,
+				sema.SaturatingArithmeticTypeFunctionTypes[t],
+				interpreter.UnifiedNumberSaturatingSubtractFunction,
+			),
 		)
 	}
 
 	if t.SupportsSaturatingMultiply() {
-		register(
-			sema.NumericTypeSaturatingMultiplyFunctionName,
-			func(context *Context, v, other interpreter.NumberValue) interpreter.NumberValue {
-				return v.SaturatingMul(
-					context,
-					other,
-					EmptyLocationRange,
-				)
-			},
+		registerBuiltinTypeBoundFunction(
+			commons.TypeQualifier(t),
+			NewUnifiedNativeFunctionValue(
+				sema.NumericTypeSaturatingMultiplyFunctionName,
+				sema.SaturatingArithmeticTypeFunctionTypes[t],
+				interpreter.UnifiedNumberSaturatingMultiplyFunction,
+			),
 		)
 	}
 
 	if t.SupportsSaturatingDivide() {
-		register(
-			sema.NumericTypeSaturatingDivideFunctionName,
-			func(context *Context, v, other interpreter.NumberValue) interpreter.NumberValue {
-				return v.SaturatingDiv(
-					context,
-					other,
-					EmptyLocationRange,
-				)
-			},
+		registerBuiltinTypeBoundFunction(
+			commons.TypeQualifier(t),
+			NewUnifiedNativeFunctionValue(
+				sema.NumericTypeSaturatingDivideFunctionName,
+				sema.SaturatingArithmeticTypeFunctionTypes[t],
+				interpreter.UnifiedNumberSaturatingDivideFunction,
+			),
 		)
 	}
 }

--- a/bbq/vm/unified_adapter.go
+++ b/bbq/vm/unified_adapter.go
@@ -1,0 +1,75 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vm
+
+import (
+	"github.com/onflow/cadence/bbq"
+	"github.com/onflow/cadence/interpreter"
+	"github.com/onflow/cadence/sema"
+)
+
+// AdaptUnifiedFunctionForVM converts a UnifiedNativeFunction to work with the VM
+func AdaptUnifiedFunctionForVM(fn interpreter.UnifiedNativeFunction) NativeFunction {
+	return func(context *Context, typeArguments []bbq.StaticType, receiver Value, arguments ...Value) Value {
+		// Create a minimal adapter that implements UnifiedFunctionContext
+		args := interpreter.NewInterpreterArgumentExtractor(arguments)
+
+		// Convert bbq.StaticType to interpreter.StaticType
+		commonTypeArgs := make([]interpreter.StaticType, len(typeArguments))
+		for i, typeArg := range typeArguments {
+			commonTypeArgs[i] = typeArg
+		}
+
+		result, err := fn(context, args, receiver, commonTypeArgs, interpreter.EmptyLocationRange)
+		if err != nil {
+			// In the VM system, errors are typically panicked
+			panic(err)
+		}
+		return result
+	}
+}
+
+// NewUnifiedNativeFunctionValue creates a native function value using the unified approach
+func NewUnifiedNativeFunctionValue(
+	name string,
+	funcType *sema.FunctionType,
+	fn interpreter.UnifiedNativeFunction,
+) *NativeFunctionValue {
+	return NewNativeFunctionValue(
+		name,
+		funcType,
+		AdaptUnifiedFunctionForVM(fn),
+	)
+}
+
+// For bound functions in the VM, we can just use the same AdaptUnifiedFunctionForVM
+// since the VM already passes the receiver as a parameter to NativeFunction
+
+// NewUnifiedNativeFunctionValueWithDerivedType creates a native function value with derived type using the unified approach
+func NewUnifiedNativeFunctionValueWithDerivedType(
+	name string,
+	typeGetter func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType,
+	fn interpreter.UnifiedNativeFunction,
+) *NativeFunctionValue {
+	return NewNativeFunctionValueWithDerivedType(
+		name,
+		typeGetter,
+		AdaptUnifiedFunctionForVM(fn),
+	)
+}

--- a/bbq/vm/unified_adapter.go
+++ b/bbq/vm/unified_adapter.go
@@ -27,9 +27,8 @@ import (
 // Like in the interpreter's unified_function, these are all the functions that need to exist to work with the VM
 func AdaptUnifiedFunctionForVM(fn interpreter.UnifiedNativeFunction) NativeFunction {
 	return func(context *Context, typeArguments []bbq.StaticType, receiver Value, arguments ...Value) Value {
-		args := interpreter.NewArgumentExtractor(arguments)
 
-		result := fn(context, args, receiver, typeArguments, interpreter.EmptyLocationRange)
+		result := fn(context, interpreter.EmptyLocationRange, typeArguments, receiver, arguments...)
 
 		return result
 	}

--- a/bbq/vm/unified_adapter.go
+++ b/bbq/vm/unified_adapter.go
@@ -55,9 +55,7 @@ func AdaptUnifiedFunctionForVM(fn interpreter.UnifiedNativeFunction) NativeFunct
 	return func(context *Context, typeArguments []bbq.StaticType, receiver Value, arguments ...Value) Value {
 		typeParameterGetter := NewVMTypeParameterGetter(context, typeArguments)
 
-		result := fn(context, interpreter.EmptyLocationRange, typeParameterGetter, receiver, arguments...)
-
-		return result
+		return fn(context, interpreter.EmptyLocationRange, typeParameterGetter, receiver, arguments...)
 	}
 }
 

--- a/bbq/vm/unified_adapter.go
+++ b/bbq/vm/unified_adapter.go
@@ -25,12 +25,14 @@ import (
 )
 
 type VMTypeParameterGetter struct {
+	index              int
 	context            *Context
 	typeParameterTypes []bbq.StaticType
 }
 
 func NewVMTypeParameterGetter(context *Context, typeParameterTypes []bbq.StaticType) *VMTypeParameterGetter {
 	return &VMTypeParameterGetter{
+		index:              0,
 		context:            context,
 		typeParameterTypes: typeParameterTypes,
 	}
@@ -39,11 +41,15 @@ func NewVMTypeParameterGetter(context *Context, typeParameterTypes []bbq.StaticT
 var _ interpreter.TypeParameterGetter = &VMTypeParameterGetter{}
 
 func (g *VMTypeParameterGetter) NextStatic() interpreter.StaticType {
-	return g.typeParameterTypes[0]
+	current := g.index
+	g.index++
+	return g.typeParameterTypes[current]
 }
 
 func (g *VMTypeParameterGetter) NextSema() sema.Type {
-	return g.context.SemaTypeFromStaticType(g.typeParameterTypes[0])
+	current := g.index
+	g.index++
+	return g.context.SemaTypeFromStaticType(g.typeParameterTypes[current])
 }
 
 // Like in the interpreter's unified_function, these are all the functions that need to exist to work with the VM

--- a/bbq/vm/unified_adapter.go
+++ b/bbq/vm/unified_adapter.go
@@ -47,9 +47,7 @@ func (g *VMTypeParameterGetter) NextStatic() interpreter.StaticType {
 }
 
 func (g *VMTypeParameterGetter) NextSema() sema.Type {
-	current := g.index
-	g.index++
-	return g.context.SemaTypeFromStaticType(g.typeParameterTypes[current])
+	return g.context.SemaTypeFromStaticType(g.NextStatic())
 }
 
 // Like in the interpreter's unified_function, these are all the functions that need to exist to work with the VM

--- a/bbq/vm/value_array.go
+++ b/bbq/vm/value_array.go
@@ -119,18 +119,13 @@ func init() {
 
 	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
-		NewNativeFunctionValueWithDerivedType(
+		NewUnifiedNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeAppendFunctionName,
 			func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArrayAppendFunctionType(elementType)
 			},
-			func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-				array := receiver.(*interpreter.ArrayValue)
-				element := arguments[0]
-				array.Append(context, EmptyLocationRange, element)
-				return interpreter.Void
-			},
+			interpreter.UnifiedArrayAppendFunction,
 		),
 	)
 

--- a/bbq/vm/value_array.go
+++ b/bbq/vm/value_array.go
@@ -19,7 +19,6 @@
 package vm
 
 import (
-	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/bbq/commons"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
@@ -37,80 +36,61 @@ func init() {
 	} {
 		registerBuiltinTypeBoundFunction(
 			typeQualifier,
-			NewNativeFunctionValueWithDerivedType(
+			NewUnifiedNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeFirstIndexFunctionName,
 				func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 					elementType := arrayElementTypeFromValue(receiver, context)
 					return sema.ArrayFirstIndexFunctionType(elementType)
 				},
-				func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-					array := receiver.(*interpreter.ArrayValue)
-					element := arguments[0]
-					return array.FirstIndex(context, EmptyLocationRange, element)
-				},
+				interpreter.UnifiedArrayFirstIndexFunction,
 			),
 		)
 
 		registerBuiltinTypeBoundFunction(
 			typeQualifier,
-			NewNativeFunctionValueWithDerivedType(
+			NewUnifiedNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeContainsFunctionName,
 				func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 					elementType := arrayElementTypeFromValue(receiver, context)
 					return sema.ArrayContainsFunctionType(elementType)
 				},
-				func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-					array := receiver.(*interpreter.ArrayValue)
-					element := arguments[0]
-					return array.Contains(context, EmptyLocationRange, element)
-				},
+				interpreter.UnifiedArrayContainsFunction,
 			),
 		)
 
 		registerBuiltinTypeBoundFunction(
 			typeQualifier,
-			NewNativeFunctionValueWithDerivedType(
+			NewUnifiedNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeReverseFunctionName,
 				func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 					arrayType := arrayTypeFromValue(receiver, context)
 					return sema.ArrayReverseFunctionType(arrayType)
 				},
-				func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-					array := receiver.(*interpreter.ArrayValue)
-					return array.Reverse(context, EmptyLocationRange)
-				},
+				interpreter.UnifiedArrayReverseFunction,
 			),
 		)
 
 		registerBuiltinTypeBoundFunction(
 			typeQualifier,
-			NewNativeFunctionValueWithDerivedType(
+			NewUnifiedNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeFilterFunctionName,
 				func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 					elementType := arrayElementTypeFromValue(receiver, context)
 					return sema.ArrayFilterFunctionType(context, elementType)
 				},
-				func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-					array := receiver.(*interpreter.ArrayValue)
-					funcArgument := arguments[0].(FunctionValue)
-					return array.Filter(context, EmptyLocationRange, funcArgument)
-				},
+				interpreter.UnifiedArrayFilterFunction,
 			),
 		)
 
 		registerBuiltinTypeBoundFunction(
 			typeQualifier,
-			NewNativeFunctionValueWithDerivedType(
+			NewUnifiedNativeFunctionValueWithDerivedType(
 				sema.ArrayTypeMapFunctionName,
 				func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 					arrayType := arrayTypeFromValue(receiver, context)
 					return sema.ArrayMapFunctionType(context, arrayType)
 				},
-				func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-					array := receiver.(*interpreter.ArrayValue)
-					funcArgument := arguments[0].(FunctionValue)
-					return array.Map(context, EmptyLocationRange, funcArgument)
-				},
+				interpreter.UnifiedArrayMapFunction,
 			),
 		)
 	}
@@ -131,163 +111,97 @@ func init() {
 
 	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
-		NewNativeFunctionValueWithDerivedType(
+		NewUnifiedNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeAppendAllFunctionName,
 			func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 				arrayType := arrayTypeFromValue(receiver, context)
 				return sema.ArrayAppendAllFunctionType(arrayType)
 			},
-			func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-				array := receiver.(*interpreter.ArrayValue)
-				otherArray := arguments[0].(*interpreter.ArrayValue)
-
-				array.AppendAll(
-					context,
-					EmptyLocationRange,
-					otherArray,
-				)
-				return interpreter.Void
-			},
+			interpreter.UnifiedArrayAppendAllFunction,
 		),
 	)
 
 	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
-		NewNativeFunctionValueWithDerivedType(
+		NewUnifiedNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeConcatFunctionName,
 			func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 				arrayType := arrayTypeFromValue(receiver, context)
 				return sema.ArrayConcatFunctionType(arrayType)
 			},
-			func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-				array := receiver.(*interpreter.ArrayValue)
-				otherArray := arguments[0].(*interpreter.ArrayValue)
-				return array.Concat(context, EmptyLocationRange, otherArray)
-			},
+			interpreter.UnifiedArrayConcatFunction,
 		),
 	)
 
 	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
-		NewNativeFunctionValueWithDerivedType(
+		NewUnifiedNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeInsertFunctionName,
 			func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArrayInsertFunctionType(elementType)
 			},
-			func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-				array := receiver.(*interpreter.ArrayValue)
-				indexValue := arguments[0].(interpreter.NumberValue)
-				element := arguments[1]
-
-				locationRange := EmptyLocationRange
-				index := indexValue.ToInt(locationRange)
-
-				array.Insert(
-					context,
-					locationRange,
-					index,
-					element,
-				)
-
-				return interpreter.Void
-			},
+			interpreter.UnifiedArrayInsertFunction,
 		),
 	)
 
 	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
-		NewNativeFunctionValueWithDerivedType(
+		NewUnifiedNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeRemoveFunctionName,
 			func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArrayRemoveFunctionType(elementType)
 			},
-			func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-				array := receiver.(*interpreter.ArrayValue)
-				indexValue := arguments[0].(interpreter.NumberValue)
-
-				locationRange := EmptyLocationRange
-				index := indexValue.ToInt(locationRange)
-
-				return array.Remove(
-					context,
-					locationRange,
-					index,
-				)
-			},
+			interpreter.UnifiedArrayRemoveFunction,
 		),
 	)
 
 	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
-		NewNativeFunctionValueWithDerivedType(
+		NewUnifiedNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeRemoveFirstFunctionName,
 			func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArrayRemoveFirstFunctionType(elementType)
 			},
-			func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-				array := receiver.(*interpreter.ArrayValue)
-				return array.RemoveFirst(context, EmptyLocationRange)
-			},
+			interpreter.UnifiedArrayRemoveFirstFunction,
 		),
 	)
 
 	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
-		NewNativeFunctionValueWithDerivedType(
+		NewUnifiedNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeRemoveLastFunctionName,
 			func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArrayRemoveLastFunctionType(elementType)
 			},
-			func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-				array := receiver.(*interpreter.ArrayValue)
-				return array.RemoveLast(context, EmptyLocationRange)
-			},
+			interpreter.UnifiedArrayRemoveLastFunction,
 		),
 	)
 
 	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
-		NewNativeFunctionValueWithDerivedType(
+		NewUnifiedNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeSliceFunctionName,
 			func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArraySliceFunctionType(elementType)
 			},
-			func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-				array := receiver.(*interpreter.ArrayValue)
-				from := arguments[0].(interpreter.IntValue)
-				to := arguments[1].(interpreter.IntValue)
-				return array.Slice(
-					context,
-					from,
-					to,
-					EmptyLocationRange,
-				)
-			},
+			interpreter.UnifiedArraySliceFunction,
 		),
 	)
 
 	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayVariableSized,
-		NewNativeFunctionValueWithDerivedType(
+		NewUnifiedNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeToConstantSizedFunctionName,
 			func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArrayToConstantSizedFunctionType(elementType)
 			},
-			func(context *Context, typeArguments []bbq.StaticType, receiver Value, arguments ...Value) Value {
-				array := receiver.(*interpreter.ArrayValue)
-				constantSizedArrayType := typeArguments[0].(*interpreter.ConstantSizedStaticType)
-				return array.ToConstantSized(
-					context,
-					EmptyLocationRange,
-					constantSizedArrayType.Size,
-				)
-			},
+			interpreter.UnifiedArrayToConstantSizedFunction,
 		),
 	)
 
@@ -295,16 +209,13 @@ func init() {
 
 	registerBuiltinTypeBoundFunction(
 		commons.TypeQualifierArrayConstantSized,
-		NewNativeFunctionValueWithDerivedType(
+		NewUnifiedNativeFunctionValueWithDerivedType(
 			sema.ArrayTypeToVariableSizedFunctionName,
 			func(receiver Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 				elementType := arrayElementTypeFromValue(receiver, context)
 				return sema.ArrayToVariableSizedFunctionType(elementType)
 			},
-			func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-				array := receiver.(*interpreter.ArrayValue)
-				return array.ToVariableSized(context, EmptyLocationRange)
-			},
+			interpreter.UnifiedArrayToVariableSizedFunction,
 		),
 	)
 }

--- a/bbq/vm/value_number.go
+++ b/bbq/vm/value_number.go
@@ -19,7 +19,6 @@
 package vm
 
 import (
-	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/bbq/commons"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
@@ -28,36 +27,24 @@ import (
 // members
 
 func init() {
-	for _, pathType := range sema.AllNumberTypes {
-		typeName := commons.TypeQualifier(pathType)
+	for _, numType := range sema.AllNumberTypes {
+		typeName := commons.TypeQualifier(numType)
 
 		registerBuiltinTypeBoundFunction(
 			typeName,
-			NewNativeFunctionValue(
+			NewUnifiedNativeFunctionValue(
 				sema.ToStringFunctionName,
 				sema.ToStringFunctionType,
-				func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-					number := receiver.(interpreter.NumberValue)
-					return interpreter.NumberValueToString(
-						context,
-						number,
-					)
-				},
+				interpreter.UnifiedNumberToStringFunction,
 			),
 		)
 
 		registerBuiltinTypeBoundFunction(
 			typeName,
-			NewNativeFunctionValue(
+			NewUnifiedNativeFunctionValue(
 				sema.ToBigEndianBytesFunctionName,
 				sema.ToBigEndianBytesFunctionType,
-				func(context *Context, _ []bbq.StaticType, receiver Value, arguments ...Value) Value {
-					number := receiver.(interpreter.NumberValue)
-					return interpreter.ByteSliceToByteArrayValue(
-						context,
-						number.ToBigEndianBytes(),
-					)
-				},
+				interpreter.UnifiedNumberToBigEndianBytesFunction,
 			),
 		)
 	}

--- a/interpreter/unified_function.go
+++ b/interpreter/unified_function.go
@@ -33,77 +33,16 @@ type UnifiedFunctionContext interface {
 
 type UnifiedNativeFunction func(
 	context UnifiedFunctionContext,
-	args *ArgumentExtractor,
-	receiver Value,
-	typeArguments []StaticType,
 	locationRange LocationRange,
+	typeArguments []StaticType,
+	receiver Value,
+	args ...Value,
 ) Value
-
-type ArgumentExtractor struct {
-	arguments []Value
-}
-
-func NewArgumentExtractor(arguments []Value) *ArgumentExtractor {
-	return &ArgumentExtractor{
-		arguments: arguments,
-	}
-}
-
-func (e *ArgumentExtractor) Count() int {
-	return len(e.arguments)
-}
-
-func (e *ArgumentExtractor) Get(index int) Value {
-	if index < 0 || index >= len(e.arguments) {
-		panic(errors.NewUnreachableError())
-	}
-	return e.arguments[index]
-}
-
-func (e *ArgumentExtractor) GetNumber(index int) NumberValue {
-	value := e.Get(index)
-	numberValue, ok := value.(NumberValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-	return numberValue
-}
-
-func (e *ArgumentExtractor) GetInt(index int) IntValue {
-	value := e.Get(index)
-
-	intValue, ok := value.(IntValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-	return intValue
-}
-
-func (e *ArgumentExtractor) GetArray(index int) *ArrayValue {
-	value := e.Get(index)
-
-	arrayValue, ok := value.(*ArrayValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-	return arrayValue
-}
-
-func (e *ArgumentExtractor) GetFunction(index int) FunctionValue {
-	value := e.Get(index)
-
-	functionValue, ok := value.(FunctionValue)
-	if !ok {
-		panic(errors.NewUnreachableError())
-	}
-	return functionValue
-}
 
 // These are all the functions that need to exist to work with the interpreter
 func AdaptUnifiedFunctionForInterpreter(fn UnifiedNativeFunction) HostFunction {
 	return func(invocation Invocation) Value {
 		context := invocation.InvocationContext
-		args := NewArgumentExtractor(invocation.Arguments)
 
 		var receiver Value
 		if invocation.Self != nil {
@@ -120,7 +59,7 @@ func AdaptUnifiedFunctionForInterpreter(fn UnifiedNativeFunction) HostFunction {
 			})
 		}
 
-		result := fn(context, args, receiver, typeArguments, invocation.LocationRange)
+		result := fn(context, invocation.LocationRange, typeArguments, receiver, invocation.Arguments...)
 
 		return result
 	}
@@ -157,4 +96,14 @@ func NewUnifiedBoundHostFunctionValue(
 		&self,
 		nil,
 	)
+}
+
+// generic helper function to assert that the provided value is of a specific type
+// useful for asserting receiver and argument types in unified functions
+func assertValueOfType[T Value](val Value) T {
+	value, ok := val.(T)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+	return value
 }

--- a/interpreter/unified_function.go
+++ b/interpreter/unified_function.go
@@ -52,9 +52,7 @@ func NewInterpreterTypeParameterGetter(memoryGauge common.MemoryGauge, typeParam
 }
 
 func (i *InterpreterTypeParameterGetter) NextStatic() StaticType {
-	current := i.typeParameterTypes.Oldest()
-	i.typeParameterTypes.Delete(current.Key)
-	return ConvertSemaToStaticType(i.memoryGauge, current.Value)
+	return ConvertSemaToStaticType(i.memoryGauge, i.NextSema())
 }
 
 func (i *InterpreterTypeParameterGetter) NextSema() sema.Type {
@@ -83,9 +81,7 @@ func AdaptUnifiedFunctionForInterpreter(fn UnifiedNativeFunction) HostFunction {
 
 		typeParameterGetter := NewInterpreterTypeParameterGetter(context, invocation.TypeParameterTypes)
 
-		result := fn(context, invocation.LocationRange, typeParameterGetter, receiver, invocation.Arguments...)
-
-		return result
+		return fn(context, invocation.LocationRange, typeParameterGetter, receiver, invocation.Arguments...)
 	}
 }
 

--- a/interpreter/unified_function.go
+++ b/interpreter/unified_function.go
@@ -52,11 +52,15 @@ func NewInterpreterTypeParameterGetter(memoryGauge common.MemoryGauge, typeParam
 }
 
 func (i *InterpreterTypeParameterGetter) NextStatic() StaticType {
-	return ConvertSemaToStaticType(i.memoryGauge, i.typeParameterTypes.Oldest().Value)
+	current := i.typeParameterTypes.Oldest()
+	i.typeParameterTypes.Delete(current.Key)
+	return ConvertSemaToStaticType(i.memoryGauge, current.Value)
 }
 
 func (i *InterpreterTypeParameterGetter) NextSema() sema.Type {
-	return i.typeParameterTypes.Oldest().Value
+	current := i.typeParameterTypes.Oldest()
+	i.typeParameterTypes.Delete(current.Key)
+	return current.Value
 }
 
 type UnifiedNativeFunction func(

--- a/interpreter/unified_function.go
+++ b/interpreter/unified_function.go
@@ -64,6 +64,15 @@ func (e *ArgumentExtractor) Get(index int) Value {
 	return e.arguments[index]
 }
 
+func (e *ArgumentExtractor) GetNumber(index int) NumberValue {
+	value := e.Get(index)
+	numberValue, ok := value.(NumberValue)
+	if !ok {
+		panic(errors.NewUnreachableError())
+	}
+	return numberValue
+}
+
 func (e *ArgumentExtractor) GetString(index int) *StringValue {
 	value := e.Get(index)
 

--- a/interpreter/unified_function.go
+++ b/interpreter/unified_function.go
@@ -1,0 +1,303 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"reflect"
+
+	"github.com/onflow/cadence/errors"
+	"github.com/onflow/cadence/sema"
+)
+
+// minimal interfaces needed by all native/host functions
+type UnifiedFunctionContext interface {
+	ReferenceTracker
+	ValueStaticTypeContext
+	ValueTransferContext
+	StorageContext
+	StaticTypeConversionHandler
+	ValueComparisonContext
+	InvocationContext
+}
+
+// ArgumentExtractor provides a unified interface for extracting and validating arguments
+type ArgumentExtractor interface {
+	Count() int
+	Get(index int) (Value, error)
+	GetString(index int) (*StringValue, error)
+	GetInt(index int) (IntValue, error)
+	GetArray(index int) (*ArrayValue, error)
+	GetType(index int) (TypeValue, error)
+	GetOptional(index int) (OptionalValue, error)
+	GetBool(index int) (BoolValue, error)
+	GetAddress(index int) (AddressValue, error)
+}
+
+// UnifiedNativeFunction uses our minimal UnifiedFunctionContext
+// This provides just what most functions need without the complexity of InvocationContext
+type UnifiedNativeFunction func(
+	context UnifiedFunctionContext,
+	args ArgumentExtractor,
+	receiver Value,
+	typeArguments []StaticType,
+	locationRange LocationRange,
+) (Value, error)
+
+// ArgumentIndexError is returned when trying to access an argument at an invalid index
+type ArgumentIndexError struct {
+	Index int
+	Count int
+}
+
+var _ errors.UserError = ArgumentIndexError{}
+
+func (e ArgumentIndexError) IsUserError() {}
+
+func (e ArgumentIndexError) Error() string {
+	return "argument index out of bounds"
+}
+
+// ArgumentTypeError is returned when an argument has an unexpected type
+type ArgumentTypeError struct {
+	Index    int
+	Expected string
+	Actual   string
+}
+
+var _ errors.UserError = ArgumentTypeError{}
+
+func (e ArgumentTypeError) IsUserError() {}
+
+func (e ArgumentTypeError) Error() string {
+	return "invalid argument type"
+}
+
+// UnifiedArgumentCountError is returned when the number of arguments doesn't match expectations
+type UnifiedArgumentCountError struct {
+	Expected int
+	Actual   int
+}
+
+var _ errors.UserError = UnifiedArgumentCountError{}
+
+func (e UnifiedArgumentCountError) IsUserError() {}
+
+func (e UnifiedArgumentCountError) Error() string {
+	return "invalid argument count"
+}
+
+// InterpreterArgumentExtractor adapts interpreter arguments to ArgumentExtractor
+type InterpreterArgumentExtractor struct {
+	arguments []Value
+}
+
+func NewInterpreterArgumentExtractor(arguments []Value) *InterpreterArgumentExtractor {
+	return &InterpreterArgumentExtractor{
+		arguments: arguments,
+	}
+}
+
+func (e *InterpreterArgumentExtractor) Count() int {
+	return len(e.arguments)
+}
+
+func (e *InterpreterArgumentExtractor) Get(index int) (Value, error) {
+	if index < 0 || index >= len(e.arguments) {
+		return nil, ArgumentIndexError{
+			Index: index,
+			Count: len(e.arguments),
+		}
+	}
+	return e.arguments[index], nil
+}
+
+func (e *InterpreterArgumentExtractor) GetString(index int) (*StringValue, error) {
+	value, err := e.Get(index)
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := value.(*StringValue)
+	if !ok {
+		return nil, ArgumentTypeError{
+			Index:    index,
+			Expected: "String",
+			Actual:   reflect.TypeOf(value).String(),
+		}
+	}
+	return stringValue, nil
+}
+
+func (e *InterpreterArgumentExtractor) GetInt(index int) (IntValue, error) {
+	value, err := e.Get(index)
+	if err != nil {
+		return NewUnmeteredIntValueFromInt64(0), err
+	}
+
+	intValue, ok := value.(IntValue)
+	if !ok {
+		return NewUnmeteredIntValueFromInt64(0), ArgumentTypeError{
+			Index:    index,
+			Expected: "Int",
+			Actual:   reflect.TypeOf(value).String(),
+		}
+	}
+	return intValue, nil
+}
+
+func (e *InterpreterArgumentExtractor) GetArray(index int) (*ArrayValue, error) {
+	value, err := e.Get(index)
+	if err != nil {
+		return nil, err
+	}
+
+	arrayValue, ok := value.(*ArrayValue)
+	if !ok {
+		return nil, ArgumentTypeError{
+			Index:    index,
+			Expected: "Array",
+			Actual:   reflect.TypeOf(value).String(),
+		}
+	}
+	return arrayValue, nil
+}
+
+func (e *InterpreterArgumentExtractor) GetType(index int) (TypeValue, error) {
+	value, err := e.Get(index)
+	if err != nil {
+		return NewTypeValue(nil, PrimitiveStaticTypeAny), err
+	}
+
+	typeValue, ok := value.(TypeValue)
+	if !ok {
+		return NewTypeValue(nil, PrimitiveStaticTypeAny), ArgumentTypeError{
+			Index:    index,
+			Expected: "Type",
+			Actual:   reflect.TypeOf(value).String(),
+		}
+	}
+	return typeValue, nil
+}
+
+func (e *InterpreterArgumentExtractor) GetOptional(index int) (OptionalValue, error) {
+	value, err := e.Get(index)
+	if err != nil {
+		return nil, err
+	}
+
+	optionalValue, ok := value.(OptionalValue)
+	if !ok {
+		return nil, ArgumentTypeError{
+			Index:    index,
+			Expected: "Optional",
+			Actual:   reflect.TypeOf(value).String(),
+		}
+	}
+	return optionalValue, nil
+}
+
+func (e *InterpreterArgumentExtractor) GetBool(index int) (BoolValue, error) {
+	value, err := e.Get(index)
+	if err != nil {
+		return FalseValue, err
+	}
+
+	boolValue, ok := value.(BoolValue)
+	if !ok {
+		return FalseValue, ArgumentTypeError{
+			Index:    index,
+			Expected: "Bool",
+			Actual:   reflect.TypeOf(value).String(),
+		}
+	}
+	return boolValue, nil
+}
+
+func (e *InterpreterArgumentExtractor) GetAddress(index int) (AddressValue, error) {
+	value, err := e.Get(index)
+	if err != nil {
+		return NewUnmeteredAddressValueFromBytes([]byte{}), err
+	}
+
+	addressValue, ok := value.(AddressValue)
+	if !ok {
+		return NewUnmeteredAddressValueFromBytes([]byte{}), ArgumentTypeError{
+			Index:    index,
+			Expected: "Address",
+			Actual:   reflect.TypeOf(value).String(),
+		}
+	}
+	return addressValue, nil
+}
+
+// AdaptUnifiedFunction converts a UnifiedNativeFunction to work with the interpreter
+func AdaptUnifiedFunction(fn UnifiedNativeFunction) HostFunction {
+	return func(invocation Invocation) Value {
+		context := invocation.InvocationContext
+		args := NewInterpreterArgumentExtractor(invocation.Arguments)
+
+		var receiver Value
+		if invocation.Self != nil {
+			receiver = *invocation.Self
+		}
+
+		// Type arguments are not available in interpreter invocations
+		result, err := fn(context, args, receiver, nil, invocation.LocationRange)
+		if err != nil {
+			// In the interpreter system, errors are typically panicked
+			panic(err)
+		}
+		return result
+	}
+}
+
+// NewUnifiedHostFunctionValue creates a host function value using the unified approach
+func NewUnifiedStaticHostFunctionValue(
+	context InvocationContext,
+	functionType *sema.FunctionType,
+	fn UnifiedNativeFunction,
+) *HostFunctionValue {
+	return NewStaticHostFunctionValue(
+		context,
+		functionType,
+		AdaptUnifiedFunction(fn),
+	)
+}
+
+// NewBoundUnifiedHostFunctionValue creates a bound function value using the unified approach
+// This uses the same UnifiedNativeFunction signature but handles type casting internally
+func NewUnifiedBoundHostFunctionValue(
+	context FunctionCreationContext,
+	self Value,
+	funcType *sema.FunctionType,
+	function UnifiedNativeFunction,
+) BoundFunctionValue {
+
+	// Wrap the unified function to work with the standard HostFunction signature
+	wrappedFunction := AdaptUnifiedFunction(function)
+
+	hostFunc := NewStaticHostFunctionValue(context, funcType, wrappedFunction)
+
+	return NewBoundFunctionValue(
+		context,
+		hostFunc,
+		&self,
+		nil,
+	)
+}

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -1964,7 +1964,7 @@ var UnifiedArrayAppendFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
@@ -1980,7 +1980,7 @@ var UnifiedArrayAppendAllFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
@@ -1996,7 +1996,7 @@ var UnifiedArrayConcatFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
@@ -2011,7 +2011,7 @@ var UnifiedArrayInsertFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
@@ -2028,7 +2028,7 @@ var UnifiedArrayRemoveFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
@@ -2043,7 +2043,7 @@ var UnifiedArrayContainsFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
@@ -2058,7 +2058,7 @@ var UnifiedArraySliceFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
@@ -2074,7 +2074,7 @@ var UnifiedArrayReverseFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
@@ -2088,7 +2088,7 @@ var UnifiedArrayFilterFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
@@ -2103,7 +2103,7 @@ var UnifiedArrayMapFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
@@ -2118,7 +2118,7 @@ var UnifiedArrayToVariableSizedFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
@@ -2132,12 +2132,12 @@ var UnifiedArrayToConstantSizedFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
 		thisArray := assertValueOfType[*ArrayValue](receiver)
-		constantSizedArrayType, ok := typeArguments[0].(*ConstantSizedStaticType)
+		constantSizedArrayType, ok := typeParameterGetter.NextStatic().(*ConstantSizedStaticType)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
@@ -2150,7 +2150,7 @@ var UnifiedArrayFirstIndexFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
@@ -2165,7 +2165,7 @@ var UnifiedArrayRemoveFirstFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {
@@ -2179,7 +2179,7 @@ var UnifiedArrayRemoveLastFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
 		locationRange LocationRange,
-		typeArguments []StaticType,
+		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
 	) Value {

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -1963,17 +1963,13 @@ func (i *ArrayIterator) ValueID() (atree.ValueID, bool) {
 var UnifiedArrayAppendFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
-		element := args.Get(0)
+		thisArray := assertValueOfType[*ArrayValue](receiver)
+		element := args[0]
 
 		thisArray.Append(context, locationRange, element)
 		return Void
@@ -1983,17 +1979,13 @@ var UnifiedArrayAppendFunction = UnifiedNativeFunction(
 var UnifiedArrayAppendAllFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
-		otherArray := args.GetArray(0)
+		thisArray := assertValueOfType[*ArrayValue](receiver)
+		otherArray := assertValueOfType[*ArrayValue](args[0])
 
 		thisArray.AppendAll(context, locationRange, otherArray)
 		return Void
@@ -2003,17 +1995,13 @@ var UnifiedArrayAppendAllFunction = UnifiedNativeFunction(
 var UnifiedArrayConcatFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
-		otherArray := args.GetArray(0)
+		thisArray := assertValueOfType[*ArrayValue](receiver)
+		otherArray := assertValueOfType[*ArrayValue](args[0])
 
 		return thisArray.Concat(context, locationRange, otherArray)
 	},
@@ -2022,18 +2010,14 @@ var UnifiedArrayConcatFunction = UnifiedNativeFunction(
 var UnifiedArrayInsertFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
-		index := args.GetNumber(0)
-		element := args.Get(1)
+		thisArray := assertValueOfType[*ArrayValue](receiver)
+		index := assertValueOfType[NumberValue](args[0])
+		element := args[1]
 
 		thisArray.Insert(context, locationRange, index.ToInt(locationRange), element)
 		return Void
@@ -2043,18 +2027,13 @@ var UnifiedArrayInsertFunction = UnifiedNativeFunction(
 var UnifiedArrayRemoveFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		// Validate receiver
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
-		index := args.GetNumber(0)
+		thisArray := assertValueOfType[*ArrayValue](receiver)
+		index := assertValueOfType[NumberValue](args[0])
 
 		return thisArray.Remove(context, locationRange, index.ToInt(locationRange))
 	},
@@ -2063,19 +2042,13 @@ var UnifiedArrayRemoveFunction = UnifiedNativeFunction(
 var UnifiedArrayContainsFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		// Validate receiver
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
-		// Extract argument
-		element := args.Get(0)
+		thisArray := assertValueOfType[*ArrayValue](receiver)
+		element := args[0]
 
 		return thisArray.Contains(context, locationRange, element)
 	},
@@ -2084,18 +2057,14 @@ var UnifiedArrayContainsFunction = UnifiedNativeFunction(
 var UnifiedArraySliceFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
-		fromValue := args.GetInt(0)
-		toValue := args.GetInt(1)
+		thisArray := assertValueOfType[*ArrayValue](receiver)
+		fromValue := assertValueOfType[IntValue](args[0])
+		toValue := assertValueOfType[IntValue](args[1])
 
 		return thisArray.Slice(context, fromValue, toValue, locationRange)
 	},
@@ -2104,15 +2073,12 @@ var UnifiedArraySliceFunction = UnifiedNativeFunction(
 var UnifiedArrayReverseFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
+		thisArray := assertValueOfType[*ArrayValue](receiver)
 
 		return thisArray.Reverse(context, locationRange)
 	},
@@ -2121,17 +2087,13 @@ var UnifiedArrayReverseFunction = UnifiedNativeFunction(
 var UnifiedArrayFilterFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
-		funcValue := args.GetFunction(0)
+		thisArray := assertValueOfType[*ArrayValue](receiver)
+		funcValue := assertValueOfType[FunctionValue](args[0])
 
 		return thisArray.Filter(context, locationRange, funcValue)
 	},
@@ -2140,17 +2102,13 @@ var UnifiedArrayFilterFunction = UnifiedNativeFunction(
 var UnifiedArrayMapFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
-		funcValue := args.GetFunction(0)
+		thisArray := assertValueOfType[*ArrayValue](receiver)
+		funcValue := assertValueOfType[FunctionValue](args[0])
 
 		return thisArray.Map(context, locationRange, funcValue)
 	},
@@ -2159,15 +2117,12 @@ var UnifiedArrayMapFunction = UnifiedNativeFunction(
 var UnifiedArrayToVariableSizedFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
+		thisArray := assertValueOfType[*ArrayValue](receiver)
 
 		return thisArray.ToVariableSized(context, locationRange)
 	},
@@ -2176,16 +2131,12 @@ var UnifiedArrayToVariableSizedFunction = UnifiedNativeFunction(
 var UnifiedArrayToConstantSizedFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
+		thisArray := assertValueOfType[*ArrayValue](receiver)
 		constantSizedArrayType, ok := typeArguments[0].(*ConstantSizedStaticType)
 		if !ok {
 			panic(errors.NewUnreachableError())
@@ -2198,17 +2149,13 @@ var UnifiedArrayToConstantSizedFunction = UnifiedNativeFunction(
 var UnifiedArrayFirstIndexFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
-		element := args.Get(0)
+		thisArray := assertValueOfType[*ArrayValue](receiver)
+		element := args[0]
 
 		return thisArray.FirstIndex(context, locationRange, element)
 	},
@@ -2217,15 +2164,13 @@ var UnifiedArrayFirstIndexFunction = UnifiedNativeFunction(
 var UnifiedArrayRemoveFirstFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
+		thisArray := assertValueOfType[*ArrayValue](receiver)
+
 		return thisArray.RemoveFirst(context, locationRange)
 	},
 )
@@ -2233,15 +2178,13 @@ var UnifiedArrayRemoveFirstFunction = UnifiedNativeFunction(
 var UnifiedArrayRemoveLastFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args *ArgumentExtractor,
-		receiver Value,
-		typeArguments []StaticType,
 		locationRange LocationRange,
+		typeArguments []StaticType,
+		receiver Value,
+		args ...Value,
 	) Value {
-		thisArray, ok := receiver.(*ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
+		thisArray := assertValueOfType[*ArrayValue](receiver)
+
 		return thisArray.RemoveLast(context, locationRange)
 	},
 )

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -1968,13 +1968,11 @@ var UnifiedArrayAppendFunction = UnifiedNativeFunction(
 		typeArguments []StaticType,
 		locationRange LocationRange,
 	) Value {
-		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
 
-		// Extract the argument
 		element := args.Get(0)
 
 		thisArray.Append(context, locationRange, element)
@@ -1990,13 +1988,11 @@ var UnifiedArrayAppendAllFunction = UnifiedNativeFunction(
 		typeArguments []StaticType,
 		locationRange LocationRange,
 	) Value {
-		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
 
-		// Extract the argument
 		otherArray := args.GetArray(0)
 
 		thisArray.AppendAll(context, locationRange, otherArray)
@@ -2012,13 +2008,11 @@ var UnifiedArrayConcatFunction = UnifiedNativeFunction(
 		typeArguments []StaticType,
 		locationRange LocationRange,
 	) Value {
-		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
 
-		// Extract the argument
 		otherArray := args.GetArray(0)
 
 		return thisArray.Concat(context, locationRange, otherArray)
@@ -2033,19 +2027,12 @@ var UnifiedArrayInsertFunction = UnifiedNativeFunction(
 		typeArguments []StaticType,
 		locationRange LocationRange,
 	) Value {
-		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
 
-		// Extract arguments
-		indexValue := args.Get(0)
-		index, ok := indexValue.(NumberValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
+		index := args.GetNumber(0)
 		element := args.Get(1)
 
 		thisArray.Insert(context, locationRange, index.ToInt(locationRange), element)
@@ -2067,17 +2054,7 @@ var UnifiedArrayRemoveFunction = UnifiedNativeFunction(
 			panic(errors.NewUnreachableError())
 		}
 
-		// Validate argument count
-		if args.Count() != 1 {
-			panic(errors.NewUnreachableError())
-		}
-
-		// Extract argument
-		indexValue := args.Get(0)
-		index, ok := indexValue.(NumberValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
+		index := args.GetNumber(0)
 
 		return thisArray.Remove(context, locationRange, index.ToInt(locationRange))
 	},
@@ -2112,13 +2089,11 @@ var UnifiedArraySliceFunction = UnifiedNativeFunction(
 		typeArguments []StaticType,
 		locationRange LocationRange,
 	) Value {
-		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
 
-		// Extract arguments
 		fromValue := args.GetInt(0)
 		toValue := args.GetInt(1)
 
@@ -2134,7 +2109,6 @@ var UnifiedArrayReverseFunction = UnifiedNativeFunction(
 		typeArguments []StaticType,
 		locationRange LocationRange,
 	) Value {
-		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
@@ -2152,13 +2126,11 @@ var UnifiedArrayFilterFunction = UnifiedNativeFunction(
 		typeArguments []StaticType,
 		locationRange LocationRange,
 	) Value {
-		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
 
-		// Extract argument
 		funcValue := args.GetFunction(0)
 
 		return thisArray.Filter(context, locationRange, funcValue)
@@ -2173,13 +2145,11 @@ var UnifiedArrayMapFunction = UnifiedNativeFunction(
 		typeArguments []StaticType,
 		locationRange LocationRange,
 	) Value {
-		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
 
-		// Extract argument
 		funcValue := args.GetFunction(0)
 
 		return thisArray.Map(context, locationRange, funcValue)
@@ -2194,7 +2164,6 @@ var UnifiedArrayToVariableSizedFunction = UnifiedNativeFunction(
 		typeArguments []StaticType,
 		locationRange LocationRange,
 	) Value {
-		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
@@ -2212,7 +2181,6 @@ var UnifiedArrayToConstantSizedFunction = UnifiedNativeFunction(
 		typeArguments []StaticType,
 		locationRange LocationRange,
 	) Value {
-		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
@@ -2235,13 +2203,11 @@ var UnifiedArrayFirstIndexFunction = UnifiedNativeFunction(
 		typeArguments []StaticType,
 		locationRange LocationRange,
 	) Value {
-		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
 
-		// Extract argument
 		element := args.Get(0)
 
 		return thisArray.FirstIndex(context, locationRange, element)
@@ -2256,7 +2222,6 @@ var UnifiedArrayRemoveFirstFunction = UnifiedNativeFunction(
 		typeArguments []StaticType,
 		locationRange LocationRange,
 	) Value {
-		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
 			panic(errors.NewUnreachableError())
@@ -2273,7 +2238,6 @@ var UnifiedArrayRemoveLastFunction = UnifiedNativeFunction(
 		typeArguments []StaticType,
 		locationRange LocationRange,
 	) Value {
-		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
 			panic(errors.NewUnreachableError())

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -891,297 +891,145 @@ func (v *ArrayValue) GetMethod(
 		)
 
 	case sema.ArrayTypeAppendAllFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArrayAppendAllFunctionType(
 				v.SemaType(context),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				otherArray, ok := invocation.Arguments[0].(*ArrayValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-				v.AppendAll(
-					invocation.InvocationContext,
-					invocation.LocationRange,
-					otherArray,
-				)
-				return Void
-			},
+			UnifiedArrayAppendAllFunction,
 		)
 
 	case sema.ArrayTypeConcatFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArrayConcatFunctionType(
 				v.SemaType(context),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				otherArray, ok := invocation.Arguments[0].(*ArrayValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-				return v.Concat(
-					invocation.InvocationContext,
-					invocation.LocationRange,
-					otherArray,
-				)
-			},
+			UnifiedArrayConcatFunction,
 		)
 
 	case sema.ArrayTypeInsertFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArrayInsertFunctionType(
 				v.SemaType(context).ElementType(false),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				inter := invocation.InvocationContext
-				locationRange := invocation.LocationRange
-
-				indexValue, ok := invocation.Arguments[0].(NumberValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-				index := indexValue.ToInt(locationRange)
-
-				element := invocation.Arguments[1]
-
-				v.Insert(
-					inter,
-					locationRange,
-					index,
-					element,
-				)
-				return Void
-			},
+			UnifiedArrayInsertFunction,
 		)
 
 	case sema.ArrayTypeRemoveFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArrayRemoveFunctionType(
 				v.SemaType(context).ElementType(false),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				inter := invocation.InvocationContext
-				locationRange := invocation.LocationRange
-
-				indexValue, ok := invocation.Arguments[0].(NumberValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-				index := indexValue.ToInt(locationRange)
-
-				return v.Remove(
-					inter,
-					locationRange,
-					index,
-				)
-			},
+			UnifiedArrayRemoveFunction,
 		)
 
 	case sema.ArrayTypeRemoveFirstFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArrayRemoveFirstFunctionType(
 				v.SemaType(context).ElementType(false),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				return v.RemoveFirst(
-					invocation.InvocationContext,
-					invocation.LocationRange,
-				)
-			},
+			UnifiedArrayRemoveFirstFunction,
 		)
 
 	case sema.ArrayTypeRemoveLastFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArrayRemoveLastFunctionType(
 				v.SemaType(context).ElementType(false),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				return v.RemoveLast(
-					invocation.InvocationContext,
-					invocation.LocationRange,
-				)
-			},
+			UnifiedArrayRemoveLastFunction,
 		)
 
 	case sema.ArrayTypeFirstIndexFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArrayFirstIndexFunctionType(
 				v.SemaType(context).ElementType(false),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				return v.FirstIndex(
-					invocation.InvocationContext,
-					invocation.LocationRange,
-					invocation.Arguments[0],
-				)
-			},
+			UnifiedArrayFirstIndexFunction,
 		)
 
 	case sema.ArrayTypeContainsFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArrayContainsFunctionType(
 				v.SemaType(context).ElementType(false),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				return v.Contains(
-					invocation.InvocationContext,
-					invocation.LocationRange,
-					invocation.Arguments[0],
-				)
-			},
+			UnifiedArrayContainsFunction,
 		)
 
 	case sema.ArrayTypeSliceFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArraySliceFunctionType(
 				v.SemaType(context).ElementType(false),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				from, ok := invocation.Arguments[0].(IntValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-
-				to, ok := invocation.Arguments[1].(IntValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-
-				return v.Slice(
-					invocation.InvocationContext,
-					from,
-					to,
-					invocation.LocationRange,
-				)
-			},
+			UnifiedArraySliceFunction,
 		)
 
 	case sema.ArrayTypeReverseFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArrayReverseFunctionType(
 				v.SemaType(context),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				return v.Reverse(
-					invocation.InvocationContext,
-					invocation.LocationRange,
-				)
-			},
+			UnifiedArrayReverseFunction,
 		)
 
 	case sema.ArrayTypeFilterFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArrayFilterFunctionType(
 				context,
 				v.SemaType(context).ElementType(false),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				interpreter := invocation.InvocationContext
-
-				funcArgument, ok := invocation.Arguments[0].(FunctionValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-
-				return v.Filter(
-					interpreter,
-					invocation.LocationRange,
-					funcArgument,
-				)
-			},
+			UnifiedArrayFilterFunction,
 		)
 
 	case sema.ArrayTypeMapFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArrayMapFunctionType(
 				context,
 				v.SemaType(context),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				interpreter := invocation.InvocationContext
-
-				funcArgument, ok := invocation.Arguments[0].(FunctionValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-
-				return v.Map(
-					interpreter,
-					invocation.LocationRange,
-					funcArgument,
-				)
-			},
+			UnifiedArrayMapFunction,
 		)
 
 	case sema.ArrayTypeToVariableSizedFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArrayToVariableSizedFunctionType(
 				v.SemaType(context).ElementType(false),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				interpreter := invocation.InvocationContext
-
-				return v.ToVariableSized(
-					interpreter,
-					invocation.LocationRange,
-				)
-			},
+			UnifiedArrayToVariableSizedFunction,
 		)
 
 	case sema.ArrayTypeToConstantSizedFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ArrayToConstantSizedFunctionType(
 				v.SemaType(context).ElementType(false),
 			),
-			func(v *ArrayValue, invocation Invocation) Value {
-				interpreter := invocation.InvocationContext
-
-				typeParameterPair := invocation.TypeParameterTypes.Oldest()
-				if typeParameterPair == nil {
-					panic(errors.NewUnreachableError())
-				}
-
-				ty := typeParameterPair.Value
-
-				constantSizedArrayType, ok := ty.(*sema.ConstantSizedType)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-
-				return v.ToConstantSized(
-					interpreter,
-					invocation.LocationRange,
-					constantSizedArrayType.Size,
-				)
-			},
+			UnifiedArrayToConstantSizedFunction,
 		)
 	}
 
@@ -2111,40 +1959,325 @@ func (i *ArrayIterator) ValueID() (atree.ValueID, bool) {
 	return i.valueID, true
 }
 
-// UnifiedArrayAppendFunction is a unified implementation of array append
+// define all native functions for array type
 var UnifiedArrayAppendFunction = UnifiedNativeFunction(
 	func(
 		context UnifiedFunctionContext,
-		args ArgumentExtractor,
+		args *ArgumentExtractor,
 		receiver Value,
 		typeArguments []StaticType,
 		locationRange LocationRange,
-	) (Value, error) {
+	) Value {
 		// Validate receiver
 		thisArray, ok := receiver.(*ArrayValue)
 		if !ok {
-			return nil, ArgumentTypeError{
-				Index:    -1,
-				Expected: "Array",
-				Actual:   "unknown",
-			}
+			panic(errors.NewUnreachableError())
+		}
+
+		// Extract the argument
+		element := args.Get(0)
+
+		thisArray.Append(context, locationRange, element)
+		return Void
+	},
+)
+
+var UnifiedArrayAppendAllFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		// Extract the argument
+		otherArray := args.GetArray(0)
+
+		thisArray.AppendAll(context, locationRange, otherArray)
+		return Void
+	},
+)
+
+var UnifiedArrayConcatFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		// Extract the argument
+		otherArray := args.GetArray(0)
+
+		return thisArray.Concat(context, locationRange, otherArray)
+	},
+)
+
+var UnifiedArrayInsertFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		// Extract arguments
+		indexValue := args.Get(0)
+		index, ok := indexValue.(NumberValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		element := args.Get(1)
+
+		thisArray.Insert(context, locationRange, index.ToInt(locationRange), element)
+		return Void
+	},
+)
+
+var UnifiedArrayRemoveFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
 		}
 
 		// Validate argument count
 		if args.Count() != 1 {
-			return nil, UnifiedArgumentCountError{
-				Expected: 1,
-				Actual:   args.Count(),
-			}
+			panic(errors.NewUnreachableError())
 		}
 
-		// Extract the argument
-		element, err := args.Get(0)
-		if err != nil {
-			return nil, err
+		// Extract argument
+		indexValue := args.Get(0)
+		index, ok := indexValue.(NumberValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
 		}
 
-		thisArray.Append(context, locationRange, element)
-		return Void, nil
+		return thisArray.Remove(context, locationRange, index.ToInt(locationRange))
+	},
+)
+
+var UnifiedArrayContainsFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		// Extract argument
+		element := args.Get(0)
+
+		return thisArray.Contains(context, locationRange, element)
+	},
+)
+
+var UnifiedArraySliceFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		// Extract arguments
+		fromValue := args.GetInt(0)
+		toValue := args.GetInt(1)
+
+		return thisArray.Slice(context, fromValue, toValue, locationRange)
+	},
+)
+
+var UnifiedArrayReverseFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		return thisArray.Reverse(context, locationRange)
+	},
+)
+
+var UnifiedArrayFilterFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		// Extract argument
+		funcValue := args.GetFunction(0)
+
+		return thisArray.Filter(context, locationRange, funcValue)
+	},
+)
+
+var UnifiedArrayMapFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		// Extract argument
+		funcValue := args.GetFunction(0)
+
+		return thisArray.Map(context, locationRange, funcValue)
+	},
+)
+
+var UnifiedArrayToVariableSizedFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		return thisArray.ToVariableSized(context, locationRange)
+	},
+)
+
+var UnifiedArrayToConstantSizedFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		constantSizedArrayType, ok := typeArguments[0].(*ConstantSizedStaticType)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		return thisArray.ToConstantSized(context, locationRange, constantSizedArrayType.Size)
+	},
+)
+
+var UnifiedArrayFirstIndexFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+
+		// Extract argument
+		element := args.Get(0)
+
+		return thisArray.FirstIndex(context, locationRange, element)
+	},
+)
+
+var UnifiedArrayRemoveFirstFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+		return thisArray.RemoveFirst(context, locationRange)
+	},
+)
+
+var UnifiedArrayRemoveLastFunction = UnifiedNativeFunction(
+	func(
+		context UnifiedFunctionContext,
+		args *ArgumentExtractor,
+		receiver Value,
+		typeArguments []StaticType,
+		locationRange LocationRange,
+	) Value {
+		// Validate receiver
+		thisArray, ok := receiver.(*ArrayValue)
+		if !ok {
+			panic(errors.NewUnreachableError())
+		}
+		return thisArray.RemoveLast(context, locationRange)
 	},
 )

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -139,17 +139,15 @@ type BigNumberValue interface {
 	ToBigInt(memoryGauge common.MemoryGauge) *big.Int
 }
 
-// Unified number functions
+// all native number functions
 var UnifiedNumberToStringFunction = UnifiedNativeFunction(
 	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
-		// No arguments needed for toString
 		return NumberValueToString(context, receiver.(NumberValue))
 	},
 )
 
 var UnifiedNumberToBigEndianBytesFunction = UnifiedNativeFunction(
 	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
-		// No arguments needed for toBigEndianBytes
 		return ByteSliceToByteArrayValue(context, receiver.(NumberValue).ToBigEndianBytes())
 	},
 )

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -141,40 +141,40 @@ type BigNumberValue interface {
 
 // all native number functions
 var UnifiedNumberToStringFunction = UnifiedNativeFunction(
-	func(context UnifiedFunctionContext, locationRange LocationRange, typeArguments []StaticType, receiver Value, args ...Value) Value {
+	func(context UnifiedFunctionContext, locationRange LocationRange, typeParameterGetter TypeParameterGetter, receiver Value, args ...Value) Value {
 		return NumberValueToString(context, receiver.(NumberValue))
 	},
 )
 
 var UnifiedNumberToBigEndianBytesFunction = UnifiedNativeFunction(
-	func(context UnifiedFunctionContext, locationRange LocationRange, typeArguments []StaticType, receiver Value, args ...Value) Value {
+	func(context UnifiedFunctionContext, locationRange LocationRange, typeParameterGetter TypeParameterGetter, receiver Value, args ...Value) Value {
 		return ByteSliceToByteArrayValue(context, receiver.(NumberValue).ToBigEndianBytes())
 	},
 )
 
 var UnifiedNumberSaturatingAddFunction = UnifiedNativeFunction(
-	func(context UnifiedFunctionContext, locationRange LocationRange, typeArguments []StaticType, receiver Value, args ...Value) Value {
+	func(context UnifiedFunctionContext, locationRange LocationRange, typeParameterGetter TypeParameterGetter, receiver Value, args ...Value) Value {
 		other := assertValueOfType[NumberValue](args[0])
 		return receiver.(NumberValue).SaturatingPlus(context, other, locationRange)
 	},
 )
 
 var UnifiedNumberSaturatingSubtractFunction = UnifiedNativeFunction(
-	func(context UnifiedFunctionContext, locationRange LocationRange, typeArguments []StaticType, receiver Value, args ...Value) Value {
+	func(context UnifiedFunctionContext, locationRange LocationRange, typeParameterGetter TypeParameterGetter, receiver Value, args ...Value) Value {
 		other := assertValueOfType[NumberValue](args[0])
 		return receiver.(NumberValue).SaturatingMinus(context, other, locationRange)
 	},
 )
 
 var UnifiedNumberSaturatingMultiplyFunction = UnifiedNativeFunction(
-	func(context UnifiedFunctionContext, locationRange LocationRange, typeArguments []StaticType, receiver Value, args ...Value) Value {
+	func(context UnifiedFunctionContext, locationRange LocationRange, typeParameterGetter TypeParameterGetter, receiver Value, args ...Value) Value {
 		other := assertValueOfType[NumberValue](args[0])
 		return receiver.(NumberValue).SaturatingMul(context, other, locationRange)
 	},
 )
 
 var UnifiedNumberSaturatingDivideFunction = UnifiedNativeFunction(
-	func(context UnifiedFunctionContext, locationRange LocationRange, typeArguments []StaticType, receiver Value, args ...Value) Value {
+	func(context UnifiedFunctionContext, locationRange LocationRange, typeParameterGetter TypeParameterGetter, receiver Value, args ...Value) Value {
 		other := assertValueOfType[NumberValue](args[0])
 		return receiver.(NumberValue).SaturatingDiv(context, other, locationRange)
 	},

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -141,41 +141,41 @@ type BigNumberValue interface {
 
 // all native number functions
 var UnifiedNumberToStringFunction = UnifiedNativeFunction(
-	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
+	func(context UnifiedFunctionContext, locationRange LocationRange, typeArguments []StaticType, receiver Value, args ...Value) Value {
 		return NumberValueToString(context, receiver.(NumberValue))
 	},
 )
 
 var UnifiedNumberToBigEndianBytesFunction = UnifiedNativeFunction(
-	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
+	func(context UnifiedFunctionContext, locationRange LocationRange, typeArguments []StaticType, receiver Value, args ...Value) Value {
 		return ByteSliceToByteArrayValue(context, receiver.(NumberValue).ToBigEndianBytes())
 	},
 )
 
 var UnifiedNumberSaturatingAddFunction = UnifiedNativeFunction(
-	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
-		other := args.GetNumber(0)
+	func(context UnifiedFunctionContext, locationRange LocationRange, typeArguments []StaticType, receiver Value, args ...Value) Value {
+		other := assertValueOfType[NumberValue](args[0])
 		return receiver.(NumberValue).SaturatingPlus(context, other, locationRange)
 	},
 )
 
 var UnifiedNumberSaturatingSubtractFunction = UnifiedNativeFunction(
-	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
-		other := args.GetNumber(0)
+	func(context UnifiedFunctionContext, locationRange LocationRange, typeArguments []StaticType, receiver Value, args ...Value) Value {
+		other := assertValueOfType[NumberValue](args[0])
 		return receiver.(NumberValue).SaturatingMinus(context, other, locationRange)
 	},
 )
 
 var UnifiedNumberSaturatingMultiplyFunction = UnifiedNativeFunction(
-	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
-		other := args.GetNumber(0)
+	func(context UnifiedFunctionContext, locationRange LocationRange, typeArguments []StaticType, receiver Value, args ...Value) Value {
+		other := assertValueOfType[NumberValue](args[0])
 		return receiver.(NumberValue).SaturatingMul(context, other, locationRange)
 	},
 )
 
 var UnifiedNumberSaturatingDivideFunction = UnifiedNativeFunction(
-	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
-		other := args.GetNumber(0)
+	func(context UnifiedFunctionContext, locationRange LocationRange, typeArguments []StaticType, receiver Value, args ...Value) Value {
+		other := assertValueOfType[NumberValue](args[0])
 		return receiver.(NumberValue).SaturatingDiv(context, other, locationRange)
 	},
 )

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -22,7 +22,6 @@ import (
 	"math/big"
 
 	"github.com/onflow/cadence/common"
-	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/sema"
 )
 
@@ -59,103 +58,51 @@ func getNumberValueFunctionMember(
 	switch name {
 
 	case sema.ToStringFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ToStringFunctionType,
-			func(v NumberValue, invocation Invocation) Value {
-				invocationContext := invocation.InvocationContext
-				return NumberValueToString(invocationContext, v)
-			},
+			UnifiedNumberToStringFunction,
 		)
 
 	case sema.ToBigEndianBytesFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.ToBigEndianBytesFunctionType,
-			func(v NumberValue, invocation Invocation) Value {
-				return ByteSliceToByteArrayValue(
-					invocation.InvocationContext,
-					v.ToBigEndianBytes(),
-				)
-			},
+			UnifiedNumberToBigEndianBytesFunction,
 		)
 
 	case sema.NumericTypeSaturatingAddFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.SaturatingArithmeticTypeFunctionTypes[typ],
-			func(v NumberValue, invocation Invocation) Value {
-				other, ok := invocation.Arguments[0].(NumberValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-
-				return v.SaturatingPlus(
-					invocation.InvocationContext,
-					other,
-					locationRange,
-				)
-			},
+			UnifiedNumberSaturatingAddFunction,
 		)
 
 	case sema.NumericTypeSaturatingSubtractFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.SaturatingArithmeticTypeFunctionTypes[typ],
-			func(v NumberValue, invocation Invocation) Value {
-				other, ok := invocation.Arguments[0].(NumberValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-
-				return v.SaturatingMinus(
-					invocation.InvocationContext,
-					other,
-					locationRange,
-				)
-			},
+			UnifiedNumberSaturatingSubtractFunction,
 		)
 
 	case sema.NumericTypeSaturatingMultiplyFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.SaturatingArithmeticTypeFunctionTypes[typ],
-			func(v NumberValue, invocation Invocation) Value {
-				other, ok := invocation.Arguments[0].(NumberValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-
-				return v.SaturatingMul(
-					invocation.InvocationContext,
-					other,
-					locationRange,
-				)
-			},
+			UnifiedNumberSaturatingMultiplyFunction,
 		)
 
 	case sema.NumericTypeSaturatingDivideFunctionName:
-		return NewBoundHostFunctionValue(
+		return NewUnifiedBoundHostFunctionValue(
 			context,
 			v,
 			sema.SaturatingArithmeticTypeFunctionTypes[typ],
-			func(v NumberValue, invocation Invocation) Value {
-				other, ok := invocation.Arguments[0].(NumberValue)
-				if !ok {
-					panic(errors.NewUnreachableError())
-				}
-
-				return v.SaturatingDiv(
-					invocation.InvocationContext,
-					other,
-					locationRange,
-				)
-			},
+			UnifiedNumberSaturatingDivideFunction,
 		)
 	}
 
@@ -191,3 +138,46 @@ type BigNumberValue interface {
 	ByteLength() int
 	ToBigInt(memoryGauge common.MemoryGauge) *big.Int
 }
+
+// Unified number functions
+var UnifiedNumberToStringFunction = UnifiedNativeFunction(
+	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
+		// No arguments needed for toString
+		return NumberValueToString(context, receiver.(NumberValue))
+	},
+)
+
+var UnifiedNumberToBigEndianBytesFunction = UnifiedNativeFunction(
+	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
+		// No arguments needed for toBigEndianBytes
+		return ByteSliceToByteArrayValue(context, receiver.(NumberValue).ToBigEndianBytes())
+	},
+)
+
+var UnifiedNumberSaturatingAddFunction = UnifiedNativeFunction(
+	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
+		other := args.GetNumber(0)
+		return receiver.(NumberValue).SaturatingPlus(context, other, locationRange)
+	},
+)
+
+var UnifiedNumberSaturatingSubtractFunction = UnifiedNativeFunction(
+	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
+		other := args.GetNumber(0)
+		return receiver.(NumberValue).SaturatingMinus(context, other, locationRange)
+	},
+)
+
+var UnifiedNumberSaturatingMultiplyFunction = UnifiedNativeFunction(
+	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
+		other := args.GetNumber(0)
+		return receiver.(NumberValue).SaturatingMul(context, other, locationRange)
+	},
+)
+
+var UnifiedNumberSaturatingDivideFunction = UnifiedNativeFunction(
+	func(context UnifiedFunctionContext, args *ArgumentExtractor, receiver Value, typeArguments []StaticType, locationRange LocationRange) Value {
+		other := args.GetNumber(0)
+		return receiver.(NumberValue).SaturatingDiv(context, other, locationRange)
+	},
+)


### PR DESCRIPTION
Working towards #4216

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Adds a unified interface so that a single definition for a native/host function in the interpreter can be reused in the vm, with some adaptor functions.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
