### PR TITLE
[Compiler] Fix result variable transfer

### DIFF
--- a/ast/transferoperation.go
+++ b/ast/transferoperation.go
@@ -33,6 +33,7 @@ const (
 	TransferOperationCopy
 	TransferOperationMove
 	TransferOperationMoveForced
+	TransferOperationInternalNoTransfer // internal use only
 )
 
 func TransferOperationCount() int {
@@ -47,6 +48,8 @@ func (k TransferOperation) Operator() string {
 		return "<-"
 	case TransferOperationMoveForced:
 		return "<-!"
+	case TransferOperationInternalNoTransfer:
+		return "$noTransfer"
 	}
 
 	panic(errors.NewUnreachableError())

--- a/ast/transferoperation_string.go
+++ b/ast/transferoperation_string.go
@@ -12,11 +12,12 @@ func _() {
 	_ = x[TransferOperationCopy-1]
 	_ = x[TransferOperationMove-2]
 	_ = x[TransferOperationMoveForced-3]
+	_ = x[TransferOperationInternalNoTransfer-4]
 }
 
-const _TransferOperation_name = "TransferOperationUnknownTransferOperationCopyTransferOperationMoveTransferOperationMoveForced"
+const _TransferOperation_name = "TransferOperationUnknownTransferOperationCopyTransferOperationMoveTransferOperationMoveForcedTransferOperationInternalNoTransfer"
 
-var _TransferOperation_index = [...]uint8{0, 24, 45, 66, 93}
+var _TransferOperation_index = [...]uint8{0, 24, 45, 66, 93, 128}
 
 func (i TransferOperation) String() string {
 	if i >= TransferOperation(len(_TransferOperation_index)-1) {

--- a/bbq/compiler/desugar.go
+++ b/bbq/compiler/desugar.go
@@ -325,11 +325,7 @@ func (d *Desugar) tempResultVariable(
 		// We just need the variable to be defined. Value is assigned later.
 		nil,
 
-		ast.NewTransfer(
-			d.memoryGauge,
-			ast.TransferOperationCopy, // TODO: determine based on return value (if resource, this should be a move)
-			pos,
-		),
+		nil,
 		pos,
 		nil,
 		nil,
@@ -357,8 +353,8 @@ func (d *Desugar) declareResultVariable(
 	pos := funcBlock.EndPosition(d.memoryGauge)
 	resultVarType, exist := d.elaboration.ResultVariableType(funcBlock)
 
-	// Declare 'result' variable as needed, and assign the temp-result to it.
-	// i.e: `let result = $_result`
+	// Declare 'result' variable and assign the temp-result to it, if needed.
+	// i.e: `let result $noTransfer $_result`
 	if !exist || resultVarType == sema.VoidType {
 		return modifiedStatements
 	}
@@ -389,9 +385,8 @@ func (d *Desugar) declareResultVariable(
 		returnValueExpr,
 		ast.NewTransfer(
 			d.memoryGauge,
-			// This is always a copy.
-			// Because result becomes a reference, if the return type is resource.
-			ast.TransferOperationCopy,
+			// NOTE: Use the internal "no transfer" operator, so no additional transfer occurs.
+			ast.TransferOperationInternalNoTransfer,
 			pos,
 		),
 		pos,

--- a/interpreter/function_test.go
+++ b/interpreter/function_test.go
@@ -404,7 +404,48 @@ func TestInterpretGenericFunctionSubtyping(t *testing.T) {
 		require.ErrorAs(t, err, &typeErr)
 	})
 
-	t.Run("no transfer", func(t *testing.T) {
+	t.Run("no transfer, result is used", func(t *testing.T) {
+		t.Parallel()
+
+		storage := newUnmeteredInMemoryStorage()
+
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+              struct S {}
+
+              fun test(): S {
+                  post { result != nil }
+                  return S()
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				InterpreterConfig: &interpreter.Config{
+					Storage: storage,
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.NoError(t, err)
+
+		slabID, err := storage.BasicSlabStorage.GenerateSlabID(atree.AddressUndefined)
+		require.NoError(t, err)
+
+		var expectedSlabIndex atree.SlabIndex
+		binary.BigEndian.PutUint64(expectedSlabIndex[:], 3)
+
+		require.Equal(
+			t,
+			atree.NewSlabID(
+				atree.AddressUndefined,
+				expectedSlabIndex,
+			),
+			slabID,
+		)
+	})
+
+	t.Run("no transfer, result is not used", func(t *testing.T) {
 		t.Parallel()
 
 		storage := newUnmeteredInMemoryStorage()

--- a/interpreter/function_test.go
+++ b/interpreter/function_test.go
@@ -19,8 +19,10 @@
 package interpreter_test
 
 import (
+	"encoding/binary"
 	"testing"
 
+	"github.com/onflow/atree"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -400,6 +402,47 @@ func TestInterpretGenericFunctionSubtyping(t *testing.T) {
 
 		var typeErr *interpreter.ForceCastTypeMismatchError
 		require.ErrorAs(t, err, &typeErr)
+	})
+
+	t.Run("no transfer", func(t *testing.T) {
+		t.Parallel()
+
+		storage := newUnmeteredInMemoryStorage()
+
+		inter, err := parseCheckAndPrepareWithOptions(t,
+			`
+              struct S {}
+
+              fun test(): S {
+                  post { true }
+                  return S()
+              }
+            `,
+			ParseCheckAndInterpretOptions{
+				InterpreterConfig: &interpreter.Config{
+					Storage: storage,
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.NoError(t, err)
+
+		slabID, err := storage.BasicSlabStorage.GenerateSlabID(atree.AddressUndefined)
+		require.NoError(t, err)
+
+		var expectedSlabIndex atree.SlabIndex
+		binary.BigEndian.PutUint64(expectedSlabIndex[:], 3)
+
+		require.Equal(
+			t,
+			atree.NewSlabID(
+				atree.AddressUndefined,
+				expectedSlabIndex,
+			),
+			slabID,
+		)
 	})
 }
 


### PR DESCRIPTION
Work towards #4059 

## Description

The `result` variable should not have additional transfers beyond the return from the function.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
