### PR TITLE
Improve tracing and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           cache: true
 
       - name: Test
-        run: make test-with-tracing
+        run: make ci-with-tracing
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,18 +20,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test
+  commands-and-tools:
+    name: Commands and tools
     runs-on: ubuntu-latest
     steps:
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install wabt
-
       - name: Clone
         uses: actions/checkout@v3
-        with:
-          # fetch all tags. required to update the embedded version
-          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v3
@@ -40,7 +34,42 @@ jobs:
           cache: true
 
       - name: Build
-        run: make -j8 build
+        run: make -j build
+
+      - name: Test
+        run: make -j test-tools
+
+  linter:
+    name: Build linter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Build linter
+        run: make -j build-linter
+
+      - name: Test linter
+        run: make -j test-linter
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Test
         run: make ci
@@ -51,11 +80,8 @@ jobs:
           file: ./coverage.txt
           flags: unittests
 
-      - name: Check tidy
-        run: make check-tidy
-
-  lint:
-    name: Lint
+  test-with-tracing:
+    name: Test with tracing
     runs-on: ubuntu-latest
     steps:
       - name: Clone
@@ -67,8 +93,31 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
+      - name: Test
+        run: make test-with-tracing
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+        with:
+          # fetch all tags.
+          # required to update the embedded version during code generation
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
       - name: Lint
         run: make lint
+
+      - name: Check tidy
+        run: make check-tidy
 
       - name: Check license headers
         run: make check-headers

--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,18 @@ GOPATH ?= $(HOME)/go
 # Ensure go bin path is in path (Especially for CI)
 PATH := $(PATH):$(GOPATH)/bin
 
-COVERPKGS := $(shell go list ./... | grep -v /cmd | grep -v /test | tr "\n" "," | sed 's/,*$$//')
-
-
 LINTERS :=
 ifneq ($(linters),)
 	LINTERS = -E $(linters)
 endif
 
 .PHONY: build
-build: build-tools ./cmd/parse/parse ./cmd/parse/parse.wasm ./cmd/check/check ./cmd/main/main
+build: build-commands build-tools
+
+# Commands
+
+.PHONY: build-commands
+build-commands: ./cmd/parse/parse ./cmd/parse/parse.wasm ./cmd/check/check ./cmd/main/main
 
 ./cmd/parse/parse:
 	go build -o $@ ./cmd/parse
@@ -44,54 +46,71 @@ build: build-tools ./cmd/parse/parse ./cmd/parse/parse.wasm ./cmd/check/check ./
 ./cmd/main/main:
 	go build -o $@ ./cmd/main
 
+# Tools
+
 .PHONY: build-tools
 build-tools: build-analysis build-get-contracts build-compatibility-check
+
+.PHONY: test-tools
+test-tools: test-analysis test-compatibility-check
+
+## Analysis tool
 
 .PHONY: build-analysis
 build-analysis:
 	(cd ./tools/analysis && go build .)
 
+.PHONY: test-analysis
+test-analysis:
+	(cd ./tools/analysis && go test .)
+
+## Get contracts tool
+
 .PHONY: build-get-contracts
 build-get-contracts:
 	(cd ./tools/get-contracts && go build .)
+
+## Compatibility check tool
 
 .PHONY: build-compatibility-check
 build-compatibility-check:
 	(cd ./tools/compatibility-check && go build .)
 
-.PHONY: ci
-ci: test-with-compiler test-with-tracing test-tools
-	# test all packages
-	go test -coverprofile=coverage.txt -covermode=atomic -parallel 8 -race -coverpkg $(COVERPKGS) ./...
-	# run interpreter smoke tests. results from run above are reused, so no tests runs are duplicated
-	go test -count=5 ./interpreter/... -runSmokeTests=true -validateAtree=false
-	# remove coverage of empty functions from report
-	sed -i -e 's/^.* 0 0$$//' coverage.txt
+.PHONY: test-compatibility-check
+test-compatibility-check:
+	(cd ./tools/compatibility-check && go test .)
+
+# Testing
+
+TESTPKGS := $(shell go list ./... | grep -Ev '/cmd|/analysis|/tools')
+COVERPKGS := $(shell echo $(TESTPKGS) | tr ' ' ',')
 
 .PHONY: test
-test: test-all-packages test-tools test-with-compiler
-
-.PHONY: test-all-packages
-test-all-packages:
-	(go test -parallel 8 ./...)
-
-.PHONY: test-tools
-test-tools:
-	(cd ./tools/analysis && go test -parallel 8 ./)
-	(cd ./tools/compatibility-check && go test -parallel 8 ./)
-	(cd ./tools/constructorcheck && go test -parallel 8 ./)
-	(cd ./tools/maprange && go test -parallel 8 ./)
-
-
-.PHONY: test-with-compiler
-test-with-compiler:
-	(go test -parallel 8 ./interpreter/... -compile=true)
-	(go test -parallel 8 ./runtime/... -compile=true)
+test: test-with-compiler test-with-tracing
+	go test $(TESTPKGS)
 
 .PHONY: test-with-tracing
 test-with-tracing:
-	(go test -parallel 8 ./runtime/... -run TestInterpreterTracing -tags cadence_tracing)
-	(go test -parallel 8 ./runtime/... -run TestRuntimeTracing -tags cadence_tracing)
+	go test -tags cadence_tracing $(TESTPKGS)
+
+.PHONY: ci
+ci: test-with-coverage smoke-test test-with-compiler
+
+.PHONY: test-with-coverage
+test-with-coverage:
+	go test -coverprofile=coverage.txt -covermode=atomic -race -coverpkg $(COVERPKGS) $(TESTPKGS)
+	# remove coverage of empty functions from report
+	sed -i -e 's/^.* 0 0$$//' coverage.txt
+
+.PHONY: smoke-test
+smoke-test:
+	go test -count=5 ./interpreter/... -runSmokeTests=true -validateAtree=false
+
+.PHONY: test-with-compiler
+test-with-compiler:
+	go test ./interpreter/... ./runtime/... -compile=true
+
+# Linting
 
 .PHONY: lint
 lint: build-linter
@@ -104,43 +123,78 @@ fix-lint: build-linter
 .PHONY: build-linter
 build-linter: tools/golangci-lint/golangci-lint tools/maprange/maprange.so tools/unkeyed/unkeyed.so tools/constructorcheck/constructorcheck.so
 
+.PHONY: test-linter
+test-linter: test-maprange test-unkeyed test-constructorcheck
+
+.PHONY: clean-linter
+clean-linter: clean-maprange clean-unkeyed clean-constructorcheck
+	rm -f tools/golangci-lint/golangci-lint
+
+## Maprange linter
+
 tools/maprange/maprange.so:
 	(cd tools/maprange && $(MAKE))
+
+.PHONY: clean-maprange
+clean-maprange:
+	rm -f tools/maprange/maprange.so
+
+.PHONY: test-maprange
+test-maprange:
+	(cd ./tools/maprange && go test .)
+
+## Unkeyed linter
 
 tools/unkeyed/unkeyed.so:
 	(cd tools/unkeyed && $(MAKE))
 
+.PHONY: clean-unkeyed
+clean-unkeyed:
+	rm -f tools/unkeyed/unkeyed.so
+
+.PHONY: test-unkeyed
+test-unkeyed:
+	(cd ./tools/unkeyed && go test .)
+
+## Constructorcheck linter
+
 tools/constructorcheck/constructorcheck.so:
 	(cd tools/constructorcheck && $(MAKE))
+
+.PHONY: test-constructorcheck
+test-constructorcheck:
+	(cd ./tools/constructorcheck && go test .)
 
 tools/golangci-lint/golangci-lint:
 	(cd tools/golangci-lint && $(MAKE))
 
-.PHONY: clean-linter
-clean-linter:
-	rm -f tools/golangci-lint/golangci-lint \
-		tools/maprange/maprange.so \
-		tools/unkeyed/unkeyed.so \
-		tools/constructorcheck/constructorcheck.so
+.PHONY: clean-constructorcheck
+clean-constructorcheck:
+	rm -f tools/constructorcheck/constructorcheck.so
 
-.PHONY: check-headers
-check-headers:
-	@./check-headers.sh
+# Code generation
 
 .PHONY: generate
 generate:
 	go install golang.org/x/tools/cmd/stringer@v0.32.0
 	go generate -v ./...
 
+# Other checks and validation
+
+.PHONY: check-headers
+check-headers:
+	@./check-headers.sh
+
 .PHONY: check-tidy
 check-tidy: generate
 	go mod tidy
-	git diff --exit-code
 	git diff --exit-code
 
 .PHONY: validate-error-doc-links
 validate-error-doc-links:
 	go run ./cmd/errors validate-doc-links
+
+# Release (version bumping)
 
 .PHONY: release
 release:

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,10 @@ test-with-tracing:
 	go test -tags cadence_tracing $(TESTPKGS)
 
 .PHONY: ci
-ci: test-with-coverage smoke-test test-with-compiler
+ci: test-with-coverage test-with-compiler smoke-test
+
+.PHONY: ci-with-tracing
+ci-with-tracing: test-with-tracing test-with-compiler-and-tracing
 
 .PHONY: test-with-coverage
 test-with-coverage:
@@ -109,6 +112,10 @@ smoke-test:
 .PHONY: test-with-compiler
 test-with-compiler:
 	go test ./interpreter/... ./runtime/... -compile=true
+
+.PHONY: test-with-compiler-and-tracing
+test-with-compiler-and-tracing:
+	go test -tags cadence_tracing ./interpreter/... ./runtime/... -compile=true
 
 # Linting
 

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -77,9 +77,14 @@ type Config struct {
 }
 
 func NewConfig(storage interpreter.Storage) *Config {
+	var tracer interpreter.Tracer
+	if interpreter.TracingEnabled {
+		tracer = interpreter.CallbackTracer(nil)
+	}
 	return &Config{
 		storage:         storage,
 		StackDepthLimit: math.MaxInt,
+		Tracer:          tracer,
 	}
 }
 

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -79,7 +79,7 @@ type Config struct {
 func NewConfig(storage interpreter.Storage) *Config {
 	var tracer interpreter.Tracer
 	if interpreter.TracingEnabled {
-		tracer = interpreter.CallbackTracer(nil)
+		tracer = interpreter.NoOpTracer{}
 	}
 	return &Config{
 		storage:         storage,

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -445,8 +445,6 @@ func compiledFTTransfer(tb testing.TB) {
 		b.StopTimer()
 	}
 
-	vmConfig.Tracer = nil
-
 	// Run validation scripts
 
 	for _, address := range []common.Address{

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -5531,7 +5531,7 @@ func TestForLoop(t *testing.T) {
 	})
 }
 
-func TestCompileIf(t *testing.T) {
+func TestIf(t *testing.T) {
 
 	t.Parallel()
 
@@ -5570,7 +5570,7 @@ func TestCompileIf(t *testing.T) {
 	})
 }
 
-func TestCompileConditional(t *testing.T) {
+func TestConditional(t *testing.T) {
 
 	t.Parallel()
 
@@ -5603,7 +5603,7 @@ func TestCompileConditional(t *testing.T) {
 	})
 }
 
-func TestCompileOr(t *testing.T) {
+func TestOr(t *testing.T) {
 
 	t.Parallel()
 
@@ -5681,7 +5681,7 @@ func TestCompileOr(t *testing.T) {
 	})
 }
 
-func TestCompileAnd(t *testing.T) {
+func TestAnd(t *testing.T) {
 
 	t.Parallel()
 
@@ -5759,7 +5759,7 @@ func TestCompileAnd(t *testing.T) {
 	})
 }
 
-func TestCompileUnaryNot(t *testing.T) {
+func TestUnaryNot(t *testing.T) {
 
 	t.Parallel()
 
@@ -5794,7 +5794,7 @@ func TestCompileUnaryNot(t *testing.T) {
 	})
 }
 
-func TestCompileUnaryNegate(t *testing.T) {
+func TestUnaryNegate(t *testing.T) {
 
 	t.Parallel()
 
@@ -5812,7 +5812,7 @@ func TestCompileUnaryNegate(t *testing.T) {
 	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(-42), actual)
 }
 
-func TestCompileUnaryDeref(t *testing.T) {
+func TestUnaryDeref(t *testing.T) {
 
 	t.Parallel()
 
@@ -5831,7 +5831,7 @@ func TestCompileUnaryDeref(t *testing.T) {
 	assert.Equal(t, interpreter.NewUnmeteredIntValueFromInt64(42), actual)
 }
 
-func TestCompileUnaryDerefSome(t *testing.T) {
+func TestUnaryDerefSome(t *testing.T) {
 
 	t.Parallel()
 
@@ -5854,7 +5854,7 @@ func TestCompileUnaryDerefSome(t *testing.T) {
 	)
 }
 
-func TestCompileUnaryDerefNil(t *testing.T) {
+func TestUnaryDerefNil(t *testing.T) {
 
 	t.Parallel()
 
@@ -5925,7 +5925,7 @@ func TestBinary(t *testing.T) {
 	}
 }
 
-func TestCompileForce(t *testing.T) {
+func TestForce(t *testing.T) {
 
 	t.Parallel()
 

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -285,7 +285,12 @@ func NewInterpreterWithSharedState(
 
 	var tracer Tracer
 	if TracingEnabled {
-		tracer = CallbackTracer(sharedState.Config.OnRecordTrace)
+		onRecordTrace := sharedState.Config.OnRecordTrace
+		if onRecordTrace == nil {
+			tracer = NoOpTracer{}
+		} else {
+			tracer = CallbackTracer(onRecordTrace)
+		}
 	}
 
 	interpreter := &Interpreter{

--- a/interpreter/interpreter_tracing.go
+++ b/interpreter/interpreter_tracing.go
@@ -22,8 +22,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
-
-	"github.com/onflow/cadence/errors"
 )
 
 const (
@@ -492,106 +490,62 @@ type NoOpTracer struct{}
 
 var _ Tracer = NoOpTracer{}
 
-func (NoOpTracer) ReportInvokeTrace(_ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportInvokeTrace(_ string, _ string, _ time.Duration) {}
 
-func (NoOpTracer) ReportImportTrace(_ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportImportTrace(_ string, _ time.Duration) {}
 
-func (NoOpTracer) ReportEmitEventTrace(_ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportEmitEventTrace(_ string, _ time.Duration) {}
 
-func (NoOpTracer) ReportArrayValueDeepRemoveTrace(_ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportArrayValueDeepRemoveTrace(_ string, _ string, _ time.Duration) {}
 
-func (NoOpTracer) ReportArrayValueTransferTrace(_ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportArrayValueTransferTrace(_ string, _ string, _ time.Duration) {}
 
-func (NoOpTracer) ReportArrayValueDestroyTrace(_ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportArrayValueDestroyTrace(_ string, _ string, _ time.Duration) {}
 
-func (NoOpTracer) ReportArrayValueConstructTrace(_ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportArrayValueConstructTrace(_ string, _ string, _ time.Duration) {}
 
-func (NoOpTracer) ReportDictionaryValueTransferTrace(_ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportDictionaryValueTransferTrace(_ string, _ string, _ time.Duration) {}
 
-func (NoOpTracer) ReportArrayValueConformsToStaticTypeTrace(_ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportArrayValueConformsToStaticTypeTrace(_ string, _ string, _ time.Duration) {}
 
-func (NoOpTracer) ReportDictionaryValueDestroyTrace(_ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportDictionaryValueDestroyTrace(_ string, _ string, _ time.Duration) {}
 
-func (NoOpTracer) ReportDictionaryValueDeepRemoveTrace(_ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportDictionaryValueDeepRemoveTrace(_ string, _ string, _ time.Duration) {}
 
 func (NoOpTracer) ReportCompositeValueDeepRemoveTrace(_ string, _ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
 }
 
 func (NoOpTracer) ReportDictionaryValueGetMemberTrace(_ string, _ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
 }
 
-func (NoOpTracer) ReportDictionaryValueConstructTrace(_ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportDictionaryValueConstructTrace(_ string, _ string, _ time.Duration) {}
 
 func (NoOpTracer) ReportDictionaryValueConformsToStaticTypeTrace(_ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
 }
 
-func (NoOpTracer) ReportCompositeValueTransferTrace(_ string, _ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportCompositeValueTransferTrace(_ string, _ string, _ string, _ time.Duration) {}
 
 func (NoOpTracer) ReportCompositeValueSetMemberTrace(_ string, _ string, _ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
 }
 
-func (NoOpTracer) ReportCompositeValueDestroyTrace(_ string, _ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportCompositeValueDestroyTrace(_ string, _ string, _ string, _ time.Duration) {}
 
 func (NoOpTracer) ReportCompositeValueGetMemberTrace(_ string, _ string, _ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
 }
 
-func (NoOpTracer) ReportCompositeValueConstructTrace(_ string, _ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportCompositeValueConstructTrace(_ string, _ string, _ string, _ time.Duration) {}
 
 func (NoOpTracer) ReportCompositeValueConformsToStaticTypeTrace(_ string, _ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
 }
 
 func (NoOpTracer) ReportCompositeValueRemoveMemberTrace(_ string, _ string, _ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
 }
 
-func (NoOpTracer) ReportDomainStorageMapDeepRemoveTrace(_ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportDomainStorageMapDeepRemoveTrace(_ string, _ string, _ time.Duration) {}
 
-func (NoOpTracer) ReportAtreeNewArrayFromBatchDataTrace(_ string, _ string, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportAtreeNewArrayFromBatchDataTrace(_ string, _ string, _ time.Duration) {}
 
-func (NoOpTracer) ReportAtreeNewMapTrace(_ string, _ string, _ uint64, _ time.Duration) {
-	panic(errors.NewUnreachableError())
-}
+func (NoOpTracer) ReportAtreeNewMapTrace(_ string, _ string, _ uint64, _ time.Duration) {}
 
 func (NoOpTracer) ReportAtreeNewMapFromBatchDataTrace(_ string, _ string, _ uint64, _ time.Duration) {
-	panic(errors.NewUnreachableError())
 }

--- a/interpreter/interpreter_tracing_test.go
+++ b/interpreter/interpreter_tracing_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -88,6 +89,8 @@ func TestInterpreterTracing(t *testing.T) {
 	t.Parallel()
 
 	t.Run("array tracing", func(t *testing.T) {
+		t.Parallel()
+
 		var traceOps []string
 		inter := prepareWithTracingCallBack(t, func(opName string) {
 			traceOps = append(traceOps, opName)
@@ -102,21 +105,25 @@ func TestInterpreterTracing(t *testing.T) {
 			owner,
 		)
 		require.NotNil(t, array)
-		require.Equal(t, len(traceOps), 1)
-		require.Equal(t, traceOps[0], "array.construct")
+		require.Len(t, traceOps, 2)
+		assert.Equal(t, "atreeArray.newFromBatchData", traceOps[0])
+		assert.Equal(t, "array.construct", traceOps[1])
 
 		cloned := array.Clone(inter)
 		require.NotNil(t, cloned)
+
 		cloned.DeepRemove(inter, true)
-		require.Equal(t, len(traceOps), 2)
-		require.Equal(t, traceOps[1], "array.deepRemove")
+		require.Len(t, traceOps, 3)
+		assert.Equal(t, "array.deepRemove", traceOps[2])
 
 		array.Destroy(inter, interpreter.EmptyLocationRange)
-		require.Equal(t, len(traceOps), 3)
-		require.Equal(t, traceOps[2], "array.destroy")
+		require.Len(t, traceOps, 4)
+		assert.Equal(t, "array.destroy", traceOps[3])
 	})
 
 	t.Run("dictionary tracing", func(t *testing.T) {
+		t.Parallel()
+
 		var traceOps []string
 		inter := prepareWithTracingCallBack(t, func(opName string) {
 			traceOps = append(traceOps, opName)
@@ -131,21 +138,25 @@ func TestInterpreterTracing(t *testing.T) {
 			interpreter.NewUnmeteredStringValue("test"), interpreter.NewUnmeteredIntValueFromInt64(42),
 		)
 		require.NotNil(t, dict)
-		require.Equal(t, len(traceOps), 1)
-		require.Equal(t, traceOps[0], "dictionary.construct")
+		require.Len(t, traceOps, 2)
+		assert.Equal(t, "atreeMap.new", traceOps[0])
+		assert.Equal(t, "dictionary.construct", traceOps[1])
 
 		cloned := dict.Clone(inter)
 		require.NotNil(t, cloned)
+
 		cloned.DeepRemove(inter, true)
-		require.Equal(t, len(traceOps), 2)
-		require.Equal(t, traceOps[1], "dictionary.deepRemove")
+		require.Len(t, traceOps, 3)
+		assert.Equal(t, "dictionary.deepRemove", traceOps[2])
 
 		dict.Destroy(inter, interpreter.EmptyLocationRange)
-		require.Equal(t, len(traceOps), 3)
-		require.Equal(t, traceOps[2], "dictionary.destroy")
+		require.Len(t, traceOps, 4)
+		assert.Equal(t, "dictionary.destroy", traceOps[3])
 	})
 
 	t.Run("composite tracing", func(t *testing.T) {
+		t.Parallel()
+
 		var traceOps []string
 		inter := prepareWithTracingCallBack(t, func(opName string) {
 			traceOps = append(traceOps, opName)
@@ -154,30 +165,32 @@ func TestInterpreterTracing(t *testing.T) {
 
 		value := newTestCompositeValue(inter, owner)
 
-		require.Equal(t, len(traceOps), 1)
-		require.Equal(t, traceOps[0], "composite.construct")
+		require.Len(t, traceOps, 2)
+		assert.Equal(t, "atreeMap.new", traceOps[0])
+		assert.Equal(t, "composite.construct", traceOps[1])
 
 		cloned := value.Clone(inter)
 		require.NotNil(t, cloned)
+
 		cloned.DeepRemove(inter, true)
-		require.Equal(t, len(traceOps), 2)
-		require.Equal(t, traceOps[1], "composite.deepRemove")
+		require.Len(t, traceOps, 3)
+		assert.Equal(t, "composite.deepRemove", traceOps[2])
 
 		value.SetMember(inter, interpreter.EmptyLocationRange, "abc", interpreter.Nil)
-		require.Equal(t, len(traceOps), 3)
-		require.Equal(t, traceOps[2], "composite.setMember.abc")
+		require.Len(t, traceOps, 4)
+		assert.Equal(t, "composite.setMember", traceOps[3])
 
 		value.GetMember(inter, interpreter.EmptyLocationRange, "abc")
-		require.Equal(t, len(traceOps), 4)
-		require.Equal(t, traceOps[3], "composite.getMember.abc")
+		require.Len(t, traceOps, 5)
+		assert.Equal(t, "composite.getMember", traceOps[4])
 
 		value.RemoveMember(inter, interpreter.EmptyLocationRange, "abc")
-		require.Equal(t, len(traceOps), 5)
-		require.Equal(t, traceOps[4], "composite.removeMember.abc")
+		require.Len(t, traceOps, 6)
+		assert.Equal(t, "composite.removeMember", traceOps[5])
 
 		value.Destroy(inter, interpreter.EmptyLocationRange)
-		require.Equal(t, len(traceOps), 6)
-		require.Equal(t, traceOps[5], "composite.destroy")
+		require.Len(t, traceOps, 7)
+		assert.Equal(t, "composite.destroy", traceOps[6])
 
 		array := interpreter.NewArrayValue(
 			inter,
@@ -189,8 +202,10 @@ func TestInterpreterTracing(t *testing.T) {
 			cloned,
 		)
 		require.NotNil(t, array)
-		require.Equal(t, len(traceOps), 8)
-		require.Equal(t, traceOps[6], "composite.transfer")
-		require.Equal(t, traceOps[7], "array.construct")
+		require.Len(t, traceOps, 11)
+		assert.Equal(t, "atreeMap.newFromBatchData", traceOps[7])
+		assert.Equal(t, "composite.transfer", traceOps[8])
+		assert.Equal(t, "atreeArray.newFromBatchData", traceOps[9])
+		assert.Equal(t, "array.construct", traceOps[10])
 	})
 }

--- a/interpreter/memory_metering_test.go
+++ b/interpreter/memory_metering_test.go
@@ -62,6 +62,13 @@ func (g *testMemoryGauge) getMemory(kind common.MemoryKind) uint64 {
 	return g.meter[kind]
 }
 
+func ifTracing[T any](tracingValue, nonTracingValue T) T {
+	if interpreter.TracingEnabled {
+		return tracingValue
+	}
+	return nonTracingValue
+}
+
 func parseCheckAndPrepareWithMemoryMetering(
 	t *testing.T,
 	code string,
@@ -709,7 +716,7 @@ func TestInterpretCompositeMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindStringValue))
-		assert.Equal(t, uint64(9), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, ifTracing[uint64](27, 9), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindCompositeValueBase))
 		assert.Equal(t, uint64(3), meter.getMemory(common.MemoryKindAtreeMapDataSlab))
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindAtreeMapMetaDataSlab))
@@ -817,7 +824,7 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, ifTracing[uint64](9, 0), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindCompositeValueBase))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindAtreeMapDataSlab))
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindAtreeMapMetaDataSlab))
@@ -848,7 +855,7 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, ifTracing[uint64](11, 2), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindCompositeValueBase))
 		assert.Equal(t, uint64(1), meter.getMemory(common.MemoryKindAtreeMapElementOverhead))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindAtreeMapDataSlab))
@@ -882,7 +889,7 @@ func TestInterpretCompositeFieldMetering(t *testing.T) {
 		_, err = inter.Invoke("main")
 		require.NoError(t, err)
 
-		assert.Equal(t, uint64(4), meter.getMemory(common.MemoryKindRawString))
+		assert.Equal(t, ifTracing[uint64](13, 2), meter.getMemory(common.MemoryKindRawString))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindAtreeMapDataSlab))
 		assert.Equal(t, uint64(2), meter.getMemory(common.MemoryKindAtreeMapElementOverhead))
 		assert.Equal(t, uint64(0), meter.getMemory(common.MemoryKindAtreeMapMetaDataSlab))

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -109,7 +109,10 @@ func NewArrayValueWithIterator(
 			}
 
 			valueID := v.ValueID().String()
-			typeID := string(v.Type.ID())
+			var typeID string
+			if v.Type != nil {
+				typeID = string(v.Type.ID())
+			}
 
 			context.ReportArrayValueConstructTrace(
 				valueID,
@@ -125,8 +128,17 @@ func NewArrayValueWithIterator(
 			startTime := time.Now()
 
 			defer func() {
+				// NOTE: in defer, as array is only initialized at the end of the function,
+				// if there was no error during construction
+				if array == nil {
+					return
+				}
+
 				valueID := array.ValueID().String()
-				typeID := string(arrayType.ID())
+				var typeID string
+				if arrayType != nil {
+					typeID = string(arrayType.ID())
+				}
 
 				context.ReportAtreeNewArrayFromBatchDataTrace(
 					valueID,

--- a/runtime/imported_values_memory_metering_test.go
+++ b/runtime/imported_values_memory_metering_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/encoding/json"
+	"github.com/onflow/cadence/interpreter"
 	. "github.com/onflow/cadence/runtime"
 	. "github.com/onflow/cadence/test_utils/common_utils"
 	. "github.com/onflow/cadence/test_utils/runtime_utils"
@@ -38,6 +39,13 @@ func testUseMemory(meter map[common.MemoryKind]uint64) common.FunctionMemoryGaug
 		meter[usage.Kind] += usage.Amount
 		return nil
 	}
+}
+
+func ifTracing[T any](tracingValue, nonTracingValue T) T {
+	if interpreter.TracingEnabled {
+		return tracingValue
+	}
+	return nonTracingValue
 }
 
 func TestRuntimeImportedValueMemoryMetering(t *testing.T) {
@@ -444,7 +452,7 @@ func TestRuntimeImportedValueMemoryMetering(t *testing.T) {
 
 		executeScript(t, script, meter, structValue)
 		assert.Equal(t, uint64(1), meter[common.MemoryKindCompositeValueBase])
-		assert.Equal(t, uint64(71), meter[common.MemoryKindRawString])
+		assert.Equal(t, ifTracing[uint64](142, 71), meter[common.MemoryKindRawString])
 	})
 
 	t.Run("InclusiveRange", func(t *testing.T) {


### PR DESCRIPTION
Work towards #3804 

## Description

- Improve the Makefile, 
- Split testing with tracing into a separate CI job
- Fix tests when run with tracing enabled
- Improve parallelism by combining `go test` commands (Go tests packages in parallel)
- Move tidy checking to linting job
- Build and test commands and tools, and linter, separate from main code
- 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
