### PR TITLE
[Compiler] Improve error position/location info

### DIFF
--- a/interpreter/errors.go
+++ b/interpreter/errors.go
@@ -105,6 +105,8 @@ type StackTraceError struct {
 	LocationRange
 }
 
+var _ HasLocationRange = &StackTraceError{}
+
 func (e *StackTraceError) Error() string {
 	return ""
 }

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -558,7 +558,7 @@ func (interpreter *Interpreter) InvokeTransaction(arguments []Value, signers ...
 
 func (interpreter *Interpreter) RecoverErrors(onError func(error)) {
 	if r := recover(); r != nil {
-		// Recover all errors, because interpreter can be directly invoked by FVM.
+		// Recover all errors, because FVM can directly invoke interpreter.
 		err := AsCadenceError(r)
 
 		// if the error is not yet an interpreter error, wrap it
@@ -568,11 +568,11 @@ func (interpreter *Interpreter) RecoverErrors(onError func(error)) {
 
 			_, ok := err.(ast.HasPosition)
 			if !ok && interpreter.statement != nil {
-				r := ast.NewUnmeteredRangeFromPositioned(interpreter.statement)
+				errRange := ast.NewUnmeteredRangeFromPositioned(interpreter.statement)
 
 				err = PositionedError{
 					Err:   err,
-					Range: r,
+					Range: errRange,
 				}
 			}
 
@@ -615,7 +615,7 @@ func AsCadenceError(r any) error {
 }
 
 func (interpreter *Interpreter) CallStack() []Invocation {
-	return interpreter.SharedState.callStack.Invocations[:]
+	return interpreter.SharedState.callStack.Invocations
 }
 
 func (interpreter *Interpreter) CallStackLocations() []LocationRange {

--- a/runtime/capabilitycontrollers_test.go
+++ b/runtime/capabilitycontrollers_test.go
@@ -1941,7 +1941,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 			)
 			RequireError(t, err)
 
-			var mutationErr stdlib.CapabilityControllersMutatedDuringIterationError
+			var mutationErr *stdlib.CapabilityControllersMutatedDuringIterationError
 			require.ErrorAs(t, err, &mutationErr)
 
 			require.Equal(t,
@@ -2028,7 +2028,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 			)
 			RequireError(t, err)
 
-			var mutationErr stdlib.CapabilityControllersMutatedDuringIterationError
+			var mutationErr *stdlib.CapabilityControllersMutatedDuringIterationError
 			require.ErrorAs(t, err, &mutationErr)
 
 			require.Equal(t,
@@ -2527,7 +2527,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 			)
 			RequireError(t, err)
 
-			var mutationErr stdlib.CapabilityControllersMutatedDuringIterationError
+			var mutationErr *stdlib.CapabilityControllersMutatedDuringIterationError
 			require.ErrorAs(t, err, &mutationErr)
 
 			require.Equal(t,
@@ -2604,7 +2604,7 @@ func TestRuntimeCapabilityControllers(t *testing.T) {
 			)
 			RequireError(t, err)
 
-			var mutationErr stdlib.CapabilityControllersMutatedDuringIterationError
+			var mutationErr *stdlib.CapabilityControllersMutatedDuringIterationError
 			require.ErrorAs(t, err, &mutationErr)
 
 			require.Equal(t,

--- a/runtime/deployment_test.go
+++ b/runtime/deployment_test.go
@@ -215,16 +215,11 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 	t.Run("with incorrect argument", func(t *testing.T) {
 
 		expectedErrorMessage := "Execution failed:\n" +
-			"error: invalid argument at index 0: expected type `Int`, got `Bool`\n"
-
-		// TODO: additional info when using compiler/VM
-		if !*compile {
-			expectedErrorMessage +=
-				" --> 0000000000000000000000000000000000000000000000000000000000000000:5:22\n" +
-					"  |\n" +
-					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202061636365737328616c6c2920636f6e74726163742054657374207b0a202020202020202020202020202020202020696e6974285f20783a20496e7429207b7d0a20202020202020202020202020207d0a202020202020202020202020\".decodeHex(), true)\n" +
-					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
-		}
+			"error: invalid argument at index 0: expected type `Int`, got `Bool`\n" +
+			" --> 0000000000000000000000000000000000000000000000000000000000000000:5:22\n" +
+			"  |\n" +
+			"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202061636365737328616c6c2920636f6e74726163742054657374207b0a202020202020202020202020202020202020696e6974285f20783a20496e7429207b7d0a20202020202020202020202020207d0a202020202020202020202020\".decodeHex(), true)\n" +
+			"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
 
 		test(t, testCase{
 			contract: `
@@ -245,16 +240,12 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 	t.Run("additional argument", func(t *testing.T) {
 
 		expectedErrorMessage := "Execution failed:\n" +
-			"error: invalid argument count, too many arguments: expected 0, got 1\n"
+			"error: invalid argument count, too many arguments: expected 0, got 1\n" +
+			" --> 0000000000000000000000000000000000000000000000000000000000000000:5:22\n" +
+			"  |\n" +
+			"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202061636365737328616c6c2920636f6e74726163742054657374207b7d0a202020202020202020202020\".decodeHex(), 1)\n" +
+			"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
 
-		// TODO: additional info when using compiler/VM
-		if !*compile {
-			expectedErrorMessage +=
-				" --> 0000000000000000000000000000000000000000000000000000000000000000:5:22\n" +
-					"  |\n" +
-					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202061636365737328616c6c2920636f6e74726163742054657374207b7d0a202020202020202020202020\".decodeHex(), 1)\n" +
-					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
-		}
 		test(t, testCase{
 			contract: `
               access(all) contract Test {}
@@ -272,31 +263,26 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 	t.Run("additional code which is invalid at top-level", func(t *testing.T) {
 
 		expectedErrorMessage := "Execution failed:\n" +
-			"error: cannot deploy invalid contract\n"
-
-		// TODO: additional info when using compiler/VM
-		if !*compile {
-			expectedErrorMessage +=
-				" --> 0000000000000000000000000000000000000000000000000000000000000000:5:22\n" +
-					"  |\n" +
-					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202061636365737328616c6c2920636f6e74726163742054657374207b7d0a0a202020202020202020202020202066756e2074657374436173652829207b7d0a202020202020202020202020\".decodeHex())\n" +
-					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-					"\n" +
-					"error: function declarations are not valid at the top-level\n" +
-					" --> 2a00000000000000.Test:4:18\n" +
-					"  |\n" +
-					"4 |               fun testCase() {}\n" +
-					"  |                   ^^^^^^^^ move this declaration into a contract\n" +
-					"\n" +
-					"error: missing access modifier for function\n" +
-					" --> 2a00000000000000.Test:4:14\n" +
-					"  |\n" +
-					"4 |               fun testCase() {}\n" +
-					"  |               ^ an access modifier is required for this declaration; add an access modifier, like e.g. `access(all)` or `access(self)`\n" +
-					"\n" +
-					"  See documentation at: https://cadence-lang.org/docs/language/access-control\n" +
-					"\n"
-		}
+			"error: cannot deploy invalid contract\n" +
+			" --> 0000000000000000000000000000000000000000000000000000000000000000:5:22\n" +
+			"  |\n" +
+			"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202061636365737328616c6c2920636f6e74726163742054657374207b7d0a0a202020202020202020202020202066756e2074657374436173652829207b7d0a202020202020202020202020\".decodeHex())\n" +
+			"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"\n" +
+			"error: function declarations are not valid at the top-level\n" +
+			" --> 2a00000000000000.Test:4:18\n" +
+			"  |\n" +
+			"4 |               fun testCase() {}\n" +
+			"  |                   ^^^^^^^^ move this declaration into a contract\n" +
+			"\n" +
+			"error: missing access modifier for function\n" +
+			" --> 2a00000000000000.Test:4:14\n" +
+			"  |\n" +
+			"4 |               fun testCase() {}\n" +
+			"  |               ^ an access modifier is required for this declaration; add an access modifier, like e.g. `access(all)` or `access(self)`\n" +
+			"\n" +
+			"  See documentation at: https://cadence-lang.org/docs/language/access-control\n" +
+			"\n"
 
 		test(t, testCase{
 			contract: `
@@ -315,22 +301,17 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 	t.Run("invalid contract, parsing error", func(t *testing.T) {
 
 		expectedErrorMessage := "Execution failed:\n" +
-			"error: cannot deploy invalid contract\n"
-
-		// TODO: additional info when using compiler/VM
-		if !*compile {
-			expectedErrorMessage +=
-				" --> 0000000000000000000000000000000000000000000000000000000000000000:5:22\n" +
-					"  |\n" +
-					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a2020202020202020202020202020580a202020202020202020202020\".decodeHex())\n" +
-					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-					"\n" +
-					"error: unexpected token: identifier\n" +
-					" --> 2a00000000000000.Test:2:14\n" +
-					"  |\n" +
-					"2 |               X\n" +
-					"  |               ^ check for extra characters, missing semicolons, or incomplete statements\n"
-		}
+			"error: cannot deploy invalid contract\n" +
+			" --> 0000000000000000000000000000000000000000000000000000000000000000:5:22\n" +
+			"  |\n" +
+			"5 |                       signer.contracts.add(name: \"Test\", code: \"0a2020202020202020202020202020580a202020202020202020202020\".decodeHex())\n" +
+			"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"\n" +
+			"error: unexpected token: identifier\n" +
+			" --> 2a00000000000000.Test:2:14\n" +
+			"  |\n" +
+			"2 |               X\n" +
+			"  |               ^ check for extra characters, missing semicolons, or incomplete statements\n"
 
 		test(t, testCase{
 			contract: `
@@ -346,22 +327,17 @@ func TestRuntimeTransactionWithContractDeployment(t *testing.T) {
 
 	t.Run("invalid contract, checking error", func(t *testing.T) {
 		expectedErrorMessage := "Execution failed:\n" +
-			"error: cannot deploy invalid contract\n"
-
-		// TODO: additional info when using compiler/VM
-		if !*compile {
-			expectedErrorMessage +=
-				" --> 0000000000000000000000000000000000000000000000000000000000000000:5:22\n" +
-					"  |\n" +
-					"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202061636365737328616c6c2920636f6e74726163742054657374207b0a20202020202020202020202020202020202061636365737328616c6c292066756e20746573742829207b2058207d0a20202020202020202020202020207d0a202020202020202020202020\".decodeHex())\n" +
-					"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-					"\n" +
-					"error: cannot find variable in this scope: `X`\n" +
-					" --> 2a00000000000000.Test:3:43\n" +
-					"  |\n" +
-					"3 |                   access(all) fun test() { X }\n" +
-					"  |                                            ^ not found in this scope; check for typos or declare it\n"
-		}
+			"error: cannot deploy invalid contract\n" +
+			" --> 0000000000000000000000000000000000000000000000000000000000000000:5:22\n" +
+			"  |\n" +
+			"5 |                       signer.contracts.add(name: \"Test\", code: \"0a202020202020202020202020202061636365737328616c6c2920636f6e74726163742054657374207b0a20202020202020202020202020202020202061636365737328616c6c292066756e20746573742829207b2058207d0a20202020202020202020202020207d0a202020202020202020202020\".decodeHex())\n" +
+			"  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"\n" +
+			"error: cannot find variable in this scope: `X`\n" +
+			" --> 2a00000000000000.Test:3:43\n" +
+			"  |\n" +
+			"3 |                   access(all) fun test() { X }\n" +
+			"  |                                            ^ not found in this scope; check for typos or declare it\n"
 
 		test(t, testCase{
 			contract: `

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -2458,6 +2458,7 @@ type InvalidContractDeploymentError struct {
 
 var _ errors.UserError = &InvalidContractDeploymentError{}
 var _ errors.ParentError = &InvalidContractDeploymentError{}
+var _ interpreter.HasLocationRange = &InvalidContractDeploymentError{}
 
 func (*InvalidContractDeploymentError) IsUserError() {}
 
@@ -2478,17 +2479,26 @@ func (e *InvalidContractDeploymentError) Unwrap() error {
 	return e.Err
 }
 
+func (e *InvalidContractDeploymentError) SetLocationRange(locationRange interpreter.LocationRange) {
+	e.LocationRange = locationRange
+}
+
 // InvalidContractDeploymentOriginError
 type InvalidContractDeploymentOriginError struct {
 	interpreter.LocationRange
 }
 
 var _ errors.UserError = &InvalidContractDeploymentOriginError{}
+var _ interpreter.HasLocationRange = &InvalidContractDeploymentOriginError{}
 
 func (*InvalidContractDeploymentOriginError) IsUserError() {}
 
 func (*InvalidContractDeploymentOriginError) Error() string {
 	return "cannot deploy invalid contract"
+}
+
+func (e *InvalidContractDeploymentOriginError) SetLocationRange(locationRange interpreter.LocationRange) {
+	e.LocationRange = locationRange
 }
 
 // ignoreUpdatedProgramParserError determines if the parsing error
@@ -2850,11 +2860,16 @@ type ContractRemovalError struct {
 }
 
 var _ errors.UserError = &ContractRemovalError{}
+var _ interpreter.HasLocationRange = &ContractRemovalError{}
 
 func (*ContractRemovalError) IsUserError() {}
 
 func (e *ContractRemovalError) Error() string {
 	return fmt.Sprintf("cannot remove contract `%s`", e.Name)
+}
+
+func (e *ContractRemovalError) SetLocationRange(locationRange interpreter.LocationRange) {
+	e.LocationRange = locationRange
 }
 
 const getAccountFunctionDocString = `
@@ -3434,7 +3449,7 @@ func AccountStorageCapabilitiesForeachController(
 		// In order to be safe, we perform this check here to effectively enforce
 		// that users return `false` from their callback in all cases where storage is mutated.
 		if invocationContext.MutationDuringCapabilityControllerIteration() {
-			panic(CapabilityControllersMutatedDuringIterationError{
+			panic(&CapabilityControllersMutatedDuringIterationError{
 				LocationRange: locationRange,
 			})
 		}
@@ -5577,12 +5592,17 @@ type CapabilityControllersMutatedDuringIterationError struct {
 	interpreter.LocationRange
 }
 
-var _ errors.UserError = CapabilityControllersMutatedDuringIterationError{}
+var _ errors.UserError = &CapabilityControllersMutatedDuringIterationError{}
+var _ interpreter.HasLocationRange = &CapabilityControllersMutatedDuringIterationError{}
 
-func (CapabilityControllersMutatedDuringIterationError) IsUserError() {}
+func (*CapabilityControllersMutatedDuringIterationError) IsUserError() {}
 
-func (CapabilityControllersMutatedDuringIterationError) Error() string {
+func (*CapabilityControllersMutatedDuringIterationError) Error() string {
 	return "capability controller iteration continued after changes to controllers"
+}
+
+func (e *CapabilityControllersMutatedDuringIterationError) SetLocationRange(locationRange interpreter.LocationRange) {
+	e.LocationRange = locationRange
 }
 
 func newInterpreterAccountAccountCapabilitiesForEachControllerFunction(
@@ -5733,7 +5753,7 @@ func AccountCapabilitiesForEachController(
 		// In order to be safe, we perform this check here to effectively enforce
 		// that users return `false` from their callback in all cases where storage is mutated.
 		if invocationContext.MutationDuringCapabilityControllerIteration() {
-			panic(CapabilityControllersMutatedDuringIterationError{
+			panic(&CapabilityControllersMutatedDuringIterationError{
 				LocationRange: locationRange,
 			})
 		}

--- a/stdlib/assert.go
+++ b/stdlib/assert.go
@@ -113,7 +113,7 @@ var VMAssertFunction = NewVMStandardLibraryStaticFunction(
 
 func Assert(result interpreter.BoolValue, message string, locationRange interpreter.LocationRange) interpreter.Value {
 	if !result {
-		panic(AssertionError{
+		panic(&AssertionError{
 			Message:       message,
 			LocationRange: locationRange,
 		})
@@ -128,14 +128,19 @@ type AssertionError struct {
 	Message string
 }
 
-var _ errors.UserError = AssertionError{}
+var _ errors.UserError = &AssertionError{}
+var _ interpreter.HasLocationRange = &AssertionError{}
 
-func (AssertionError) IsUserError() {}
+func (*AssertionError) IsUserError() {}
 
-func (e AssertionError) Error() string {
+func (e *AssertionError) Error() string {
 	const message = "assertion failed"
 	if e.Message == "" {
 		return message
 	}
 	return fmt.Sprintf("%s: %s", message, e.Message)
+}
+
+func (e *AssertionError) SetLocationRange(locationRange interpreter.LocationRange) {
+	e.LocationRange = locationRange
 }

--- a/stdlib/builtin_test.go
+++ b/stdlib/builtin_test.go
@@ -180,7 +180,7 @@ func TestInterpretAssert(t *testing.T) {
 	)
 	assert.Equal(t,
 		interpreter.Error{
-			Err: AssertionError{
+			Err: &AssertionError{
 				Message: "oops",
 			},
 			Location: TestLocation,
@@ -191,7 +191,7 @@ func TestInterpretAssert(t *testing.T) {
 	_, err = inter.Invoke("test", interpreter.FalseValue)
 	assert.Equal(t,
 		interpreter.Error{
-			Err: AssertionError{
+			Err: &AssertionError{
 				Message: "",
 			},
 			Location: TestLocation,

--- a/stdlib/rlp.go
+++ b/stdlib/rlp.go
@@ -36,12 +36,17 @@ type RLPDecodeStringError struct {
 	Msg string
 }
 
-var _ errors.UserError = RLPDecodeStringError{}
+var _ errors.UserError = &RLPDecodeStringError{}
+var _ interpreter.HasLocationRange = &RLPDecodeStringError{}
 
-func (RLPDecodeStringError) IsUserError() {}
+func (*RLPDecodeStringError) IsUserError() {}
 
-func (e RLPDecodeStringError) Error() string {
+func (e *RLPDecodeStringError) Error() string {
 	return fmt.Sprintf("failed to RLP-decode string: %s", e.Msg)
+}
+
+func (e *RLPDecodeStringError) SetLocationRange(locationRange interpreter.LocationRange) {
+	e.LocationRange = locationRange
 }
 
 const rlpErrMsgInputContainsExtraBytes = "input data is expected to be RLP-encoded of a single string or a single list but it seems it contains extra trailing bytes."
@@ -94,7 +99,7 @@ func RLPDecodeString(
 ) interpreter.Value {
 	convertedInput, err := interpreter.ByteArrayValueToByteSlice(context, input, locationRange)
 	if err != nil {
-		panic(RLPDecodeStringError{
+		panic(&RLPDecodeStringError{
 			Msg:           err.Error(),
 			LocationRange: locationRange,
 		})
@@ -110,14 +115,14 @@ func RLPDecodeString(
 
 	output, bytesRead, err := rlp.DecodeString(convertedInput, 0)
 	if err != nil {
-		panic(RLPDecodeStringError{
+		panic(&RLPDecodeStringError{
 			Msg:           err.Error(),
 			LocationRange: locationRange,
 		})
 	}
 
 	if bytesRead != len(convertedInput) {
-		panic(RLPDecodeStringError{
+		panic(&RLPDecodeStringError{
 			Msg:           rlpErrMsgInputContainsExtraBytes,
 			LocationRange: locationRange,
 		})
@@ -131,12 +136,17 @@ type RLPDecodeListError struct {
 	Msg string
 }
 
-var _ errors.UserError = RLPDecodeListError{}
+var _ errors.UserError = &RLPDecodeListError{}
+var _ interpreter.HasLocationRange = &RLPDecodeListError{}
 
-func (RLPDecodeListError) IsUserError() {}
+func (*RLPDecodeListError) IsUserError() {}
 
-func (e RLPDecodeListError) Error() string {
+func (e *RLPDecodeListError) Error() string {
 	return fmt.Sprintf("failed to RLP-decode list: %s", e.Msg)
+}
+
+func (e *RLPDecodeListError) SetLocationRange(locationRange interpreter.LocationRange) {
+	e.LocationRange = locationRange
 }
 
 // interpreterRLPDecodeListFunction is a static function
@@ -187,7 +197,7 @@ func RLPDecodeList(
 ) interpreter.Value {
 	convertedInput, err := interpreter.ByteArrayValueToByteSlice(context, input, locationRange)
 	if err != nil {
-		panic(RLPDecodeListError{
+		panic(&RLPDecodeListError{
 			Msg:           err.Error(),
 			LocationRange: locationRange,
 		})
@@ -204,14 +214,14 @@ func RLPDecodeList(
 	output, bytesRead, err := rlp.DecodeList(convertedInput, 0)
 
 	if err != nil {
-		panic(RLPDecodeListError{
+		panic(&RLPDecodeListError{
 			Msg:           err.Error(),
 			LocationRange: locationRange,
 		})
 	}
 
 	if bytesRead != len(convertedInput) {
-		panic(RLPDecodeListError{
+		panic(&RLPDecodeListError{
 			Msg:           rlpErrMsgInputContainsExtraBytes,
 			LocationRange: locationRange,
 		})

--- a/stdlib/test_contract.go
+++ b/stdlib/test_contract.go
@@ -102,7 +102,7 @@ func testTypeAssertFunction(
 			}
 
 			if !condition {
-				panic(AssertionError{
+				panic(&AssertionError{
 					Message:       message,
 					LocationRange: invocation.LocationRange,
 				})
@@ -173,7 +173,7 @@ func testTypeAssertEqualFunction(
 					expectedType,
 					actualType,
 				)
-				panic(AssertionError{
+				panic(&AssertionError{
 					Message:       message,
 					LocationRange: invocation.LocationRange,
 				})
@@ -191,7 +191,7 @@ func testTypeAssertEqualFunction(
 					expected,
 					actual,
 				)
-				panic(AssertionError{
+				panic(&AssertionError{
 					Message:       message,
 					LocationRange: invocation.LocationRange,
 				})
@@ -241,7 +241,7 @@ func testTypeFailFunction(
 				message = messageValue.Str
 			}
 
-			panic(AssertionError{
+			panic(&AssertionError{
 				Message:       message,
 				LocationRange: invocation.LocationRange,
 			})
@@ -317,7 +317,7 @@ func newTestTypeExpectFunction(functionType *sema.FunctionType) testContractBoun
 						"given value is: %s",
 						value,
 					)
-					panic(AssertionError{
+					panic(&AssertionError{
 						Message:       message,
 						LocationRange: locationRange,
 					})

--- a/stdlib/test_test.go
+++ b/stdlib/test_test.go
@@ -755,7 +755,10 @@ func TestAssertEqual(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
-		assert.ErrorAs(t, err, &AssertionError{})
+
+		var assertionErr *AssertionError
+		assert.ErrorAs(t, err, &assertionErr)
+
 		assert.ErrorContains(
 			t,
 			err,
@@ -782,7 +785,10 @@ func TestAssertEqual(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
-		assert.ErrorAs(t, err, &AssertionError{})
+
+		var assertionErr *AssertionError
+		assert.ErrorAs(t, err, &assertionErr)
+
 		assert.ErrorContains(
 			t,
 			err,
@@ -807,7 +813,10 @@ func TestAssertEqual(t *testing.T) {
 
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
-		assert.ErrorAs(t, err, &AssertionError{})
+
+		var assertionErr *AssertionError
+		assert.ErrorAs(t, err, &assertionErr)
+
 		assert.ErrorContains(
 			t,
 			err,
@@ -844,7 +853,10 @@ func TestAssertEqual(t *testing.T) {
 
 		_, err = inter.Invoke("testNotEqual")
 		require.Error(t, err)
-		assert.ErrorAs(t, err, &AssertionError{})
+
+		var assertionErr *AssertionError
+		assert.ErrorAs(t, err, &assertionErr)
+
 		assert.ErrorContains(
 			t,
 			err,
@@ -892,7 +904,10 @@ func TestAssertEqual(t *testing.T) {
 
 		_, err = inter.Invoke("testNotEqual")
 		require.Error(t, err)
-		assert.ErrorAs(t, err, &AssertionError{})
+
+		var assertionErr *AssertionError
+		assert.ErrorAs(t, err, &assertionErr)
+
 		assert.ErrorContains(
 			t,
 			err,
@@ -929,7 +944,10 @@ func TestAssertEqual(t *testing.T) {
 
 		_, err = inter.Invoke("testNotEqual")
 		require.Error(t, err)
-		assert.ErrorAs(t, err, &AssertionError{})
+
+		var assertionErr *AssertionError
+		assert.ErrorAs(t, err, &assertionErr)
+
 		assert.ErrorContains(
 			t,
 			err,
@@ -966,7 +984,10 @@ func TestAssertEqual(t *testing.T) {
 
 		_, err = inter.Invoke("testNotEqual")
 		require.Error(t, err)
-		assert.ErrorAs(t, err, &AssertionError{})
+
+		var assertionErr *AssertionError
+		assert.ErrorAs(t, err, &assertionErr)
+
 		assert.ErrorContains(
 			t,
 			err,
@@ -1874,8 +1895,8 @@ func TestTestExpect(t *testing.T) {
 		_, err = inter.Invoke("test")
 		require.Error(t, err)
 
-		assertionErr := &AssertionError{}
-		assert.ErrorAs(t, err, assertionErr)
+		var assertionErr *AssertionError
+		require.ErrorAs(t, err, &assertionErr)
 		assert.Equal(t, "given value is: \"this string\"", assertionErr.Message)
 		assert.Equal(t, "test", assertionErr.LocationRange.Location.String())
 		assert.Equal(t, 6, assertionErr.LocationRange.StartPosition().Line)


### PR DESCRIPTION
Work towards #4059 

## Description

- Implement `SetLocationRange` for remaining stdlib errors (`PanicError` already did)
- Just like the interpreter, wrap the error in a `PositionError` if the error does not have position info itself 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
