### PR TITLE
Remove per-context coverage report, use runtime config's

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -27,7 +27,6 @@ type Context struct {
 	Interface        Interface
 	Location         Location
 	Environment      Environment
-	CoverageReport   *CoverageReport
 	MemoryGauge      common.MemoryGauge
 	ComputationGauge common.ComputationGauge
 

--- a/runtime/contract_function_executor.go
+++ b/runtime/contract_function_executor.go
@@ -131,7 +131,6 @@ func (executor *contractFunctionExecutor) preprocess() (err error) {
 		storage,
 		context.MemoryGauge,
 		context.ComputationGauge,
-		context.CoverageReport,
 	)
 	executor.environment = environment
 

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -1416,9 +1416,8 @@ func TestRuntimeCoverage(t *testing.T) {
 			Source: script,
 		},
 		Context{
-			Interface:      runtimeInterface,
-			Location:       common.ScriptLocation{},
-			CoverageReport: coverageReport,
+			Interface: runtimeInterface,
+			Location:  common.ScriptLocation{},
 		},
 	)
 	require.NoError(t, err)
@@ -1574,9 +1573,8 @@ func TestRuntimeCoverageWithExcludedLocation(t *testing.T) {
 			Source: script,
 		},
 		Context{
-			Interface:      runtimeInterface,
-			Location:       scriptlocation,
-			CoverageReport: coverageReport,
+			Interface: runtimeInterface,
+			Location:  scriptlocation,
 		},
 	)
 	require.NoError(t, err)
@@ -1715,9 +1713,8 @@ func TestRuntimeCoverageWithLocationFilter(t *testing.T) {
 			Source: script,
 		},
 		Context{
-			Interface:      runtimeInterface,
-			Location:       scriptlocation,
-			CoverageReport: coverageReport,
+			Interface: runtimeInterface,
+			Location:  scriptlocation,
 		},
 	)
 	require.NoError(t, err)
@@ -1821,9 +1818,8 @@ func TestRuntimeCoverageWithNoStatements(t *testing.T) {
 			Source: deploy,
 		},
 		Context{
-			Interface:      runtimeInterface,
-			Location:       txLocation,
-			CoverageReport: coverageReport,
+			Interface: runtimeInterface,
+			Location:  txLocation,
 		},
 	)
 	require.NoError(t, err)
@@ -1834,9 +1830,8 @@ func TestRuntimeCoverageWithNoStatements(t *testing.T) {
 			Source: script,
 		},
 		Context{
-			Interface:      runtimeInterface,
-			Location:       scriptLocation,
-			CoverageReport: coverageReport,
+			Interface: runtimeInterface,
+			Location:  scriptLocation,
 		},
 	)
 	require.NoError(t, err)
@@ -1958,9 +1953,8 @@ func TestRuntimeCoverageReportLCOVFormat(t *testing.T) {
 				Source: script,
 			},
 			Context{
-				Interface:      runtimeInterface,
-				Location:       scriptlocation,
-				CoverageReport: coverageReport,
+				Interface: runtimeInterface,
+				Location:  scriptlocation,
 			},
 		)
 		require.NoError(t, err)
@@ -2029,9 +2023,8 @@ end_of_record
 				Source: script,
 			},
 			Context{
-				Interface:      runtimeInterface,
-				Location:       scriptlocation,
-				CoverageReport: coverageReport,
+				Interface: runtimeInterface,
+				Location:  scriptlocation,
 			},
 		)
 		require.NoError(t, err)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -330,7 +330,6 @@ func (r *runtime) ParseAndCheckProgram(
 		nil,
 		context.MemoryGauge,
 		context.ComputationGauge,
-		context.CoverageReport,
 	)
 
 	program, err = environment.ParseAndCheckProgram(
@@ -374,7 +373,6 @@ func (r *runtime) Storage(context Context) (*Storage, *interpreter.Interpreter, 
 		storage,
 		context.MemoryGauge,
 		context.ComputationGauge,
-		context.CoverageReport,
 	)
 
 	interpreterEnv, ok := environment.(*InterpreterEnvironment)

--- a/runtime/script_executor.go
+++ b/runtime/script_executor.go
@@ -132,7 +132,6 @@ func (executor *scriptExecutor) preprocess() (err error) {
 		storage,
 		context.MemoryGauge,
 		context.ComputationGauge,
-		context.CoverageReport,
 	)
 	executor.environment = environment
 

--- a/runtime/transaction_executor.go
+++ b/runtime/transaction_executor.go
@@ -131,7 +131,6 @@ func (executor *transactionExecutor) preprocess() (err error) {
 		storage,
 		context.MemoryGauge,
 		context.ComputationGauge,
-		context.CoverageReport,
 	)
 	executor.environment = environment
 

--- a/runtime/vm_environment.go
+++ b/runtime/vm_environment.go
@@ -84,6 +84,7 @@ var _ stdlib.Hasher = &vmEnvironment{}
 var _ ArgumentDecoder = &vmEnvironment{}
 
 func newVMEnvironment(config Config) *vmEnvironment {
+	// TODO: add support for coverage report
 	env := &vmEnvironment{
 		config:                        config,
 		SimpleContractAdditionTracker: stdlib.NewSimpleContractAdditionTracker(),
@@ -204,7 +205,6 @@ func (e *vmEnvironment) Configure(
 	storage *Storage,
 	memoryGauge common.MemoryGauge,
 	computationGauge common.ComputationGauge,
-	coverageReport *CoverageReport,
 ) {
 	e.Interface = runtimeInterface
 	e.storage = storage
@@ -218,9 +218,6 @@ func (e *vmEnvironment) Configure(
 		codesAndPrograms,
 		memoryGauge,
 	)
-
-	// TODO: add support for coverage report
-	_ = coverageReport
 
 	configureVersionedFeatures(runtimeInterface)
 }


### PR DESCRIPTION
## Description

Support for a coverage report was not properly supported on a per-context basis. Instead of fixing it, just remove support, keeping per-runtime support.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
