### PR TITLE
[Compiler] Fix and improve compiler/VM benchmarks and tests, fix CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,16 +47,18 @@ jobs:
         run: make -j8 build
 
       - name: Run benchmark on current branch
+        shell: bash
         run: |
-          ( for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./... -run=XXX -bench=. -benchmem -shuffle=on; done | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\/' ) | tee new.txt
+          ( for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./... -run=XXX -bench=. -benchmem -shuffle=on; done | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\//' ) | tee new.txt
       # the package replace line above is to make the results table more readable, since it is not fragmented by package
 
       - name: Checkout base branch
         run: git checkout ${{ github.event.pull_request.base.sha }}
 
       - name: Run benchmark on base branch
+        shell: bash
         run: |
-          ( for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./... -run=XXX -bench=. -benchmem -shuffle=on; done | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\/' ) | tee old.txt
+          ( for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./... -run=XXX -bench=. -benchmem -shuffle=on; done | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\//' ) | tee old.txt
 
       # see https://trstringer.com/github-actions-multiline-strings/ to see why this part is complex
       - name: Use benchstat for comparison

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -5204,6 +5204,8 @@ func TestCompileForce(t *testing.T) {
 
 	t.Run("optional", func(t *testing.T) {
 
+		t.Parallel()
+
 		checker, err := ParseAndCheck(t, `
             fun test(x: Int?): Int {
                 return x!
@@ -5237,6 +5239,7 @@ func TestCompileForce(t *testing.T) {
 	})
 
 	t.Run("non-optional", func(t *testing.T) {
+		t.Parallel()
 
 		checker, err := ParseAndCheck(t, `
             fun test(x: Int): Int {
@@ -9780,7 +9783,12 @@ func TestCompileImportAlias(t *testing.T) {
 
 	t.Run("simple alias", func(t *testing.T) {
 
-		importLocation := common.NewAddressLocation(nil, common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1}, "")
+		t.Parallel()
+
+		importLocation := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "Foo",
+		}
 
 		importedChecker, err := ParseAndCheckWithOptions(t,
 			`
@@ -9812,7 +9820,9 @@ func TestCompileImportAlias(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
-					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					LocationHandler: SingleIdentifierLocationResolver(t),
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.Equal(t, importedChecker.Location, location)
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -9827,6 +9837,7 @@ func TestCompileImportAlias(t *testing.T) {
 			checker.Location,
 		)
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importLocation, location)
 			return importedProgram
 		}
 
@@ -9877,7 +9888,12 @@ func TestCompileImportAlias(t *testing.T) {
 
 	t.Run("interface", func(t *testing.T) {
 
-		importLocation := common.NewAddressLocation(nil, common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1}, "")
+		t.Parallel()
+
+		importLocation := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "FooInterface",
+		}
 
 		importedChecker, err := ParseAndCheckWithOptions(t,
 			`
@@ -9913,7 +9929,9 @@ func TestCompileImportAlias(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
-					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					LocationHandler: SingleIdentifierLocationResolver(t),
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.Equal(t, importedChecker.Location, location)
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil

--- a/bbq/vm/test/vm_bench_test.go
+++ b/bbq/vm/test/vm_bench_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/bbq"
+	. "github.com/onflow/cadence/bbq/test_utils"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
@@ -178,7 +179,7 @@ func BenchmarkNewStruct(b *testing.B) {
               i = i + 1
           }
       }
-  `)
+    `)
 	require.NoError(b, err)
 
 	value := interpreter.NewUnmeteredIntValueFromInt64(10)
@@ -190,6 +191,15 @@ func BenchmarkNewStruct(b *testing.B) {
 	program := comp.Compile()
 
 	vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
+	vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		require.Equal(b, checker.Location, location)
+		return program
+	}
+	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+		require.Equal(b, checker.Location, location)
+		return checker.Elaboration.CompositeType(typeID)
+	}
+
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 
 	b.ReportAllocs()
@@ -239,6 +249,20 @@ func BenchmarkNewResource(b *testing.B) {
 		program := comp.Compile()
 
 		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
+		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(b, checker.Location, location)
+			return program
+		}
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+			require.Equal(b, checker.Location, location)
+			return checker.Elaboration.CompositeType(typeID)
+		}
+		var uuid uint64 = 1
+		vmConfig.UUIDHandler = func() (uint64, error) {
+			uuid++
+			return uuid, nil
+		}
+
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
 		_, err := vmInstance.InvokeExternally("test", value)
 		require.NoError(b, err)
@@ -283,37 +307,40 @@ func BenchmarkNewStructRaw(b *testing.B) {
 
 func BenchmarkContractImport(b *testing.B) {
 
-	location := common.NewAddressLocation(nil, common.Address{0x1}, "MyContract")
+	importedLocation := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{0x1}),
+		Name:    "MyContract",
+	}
 
 	importedChecker, err := ParseAndCheckWithOptions(b,
 		`
-      contract MyContract {
-          var s: String
+          contract MyContract {
+              var s: String
 
-          fun helloText(): String {
-              return self.s
-          }
-
-          init() {
-              self.s = "contract function of the imported program"
-          }
-
-          struct Foo {
-              var id : String
-
-              init(_ id: String) {
-                  self.id = id
+              fun helloText(): String {
+                  return self.s
               }
 
-              fun sayHello(_ id: Int): String {
-                  // return self.id
-                  return MyContract.helloText()
+              init() {
+                  self.s = "contract function of the imported program"
+              }
+
+              struct Foo {
+                  var id : String
+
+                  init(_ id: String) {
+                      self.id = id
+                  }
+
+                  fun sayHello(_ id: Int): String {
+                      // return self.id
+                      return MyContract.helloText()
+                  }
               }
           }
-      }
         `,
 		ParseAndCheckOptions{
-			Location: location,
+			Location: importedLocation,
 		},
 	)
 	require.NoError(b, err)
@@ -324,25 +351,35 @@ func BenchmarkContractImport(b *testing.B) {
 	)
 	importedProgram := importCompiler.Compile()
 
-	_, importedContractValue := initializeContract(
-		b,
-		location,
-		importedProgram,
-		nil,
-	)
+	var importedContractValue *interpreter.CompositeValue
 
 	vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 	vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		require.Equal(b, importedChecker.Location, location)
 		return importedProgram
 	}
-	vmConfig.ContractValueHandler = func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
+	vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+		require.Equal(b, importedChecker.Location, location)
 		return importedContractValue
 	}
+	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+		require.Equal(b, importedChecker.Location, location)
+		return importedChecker.Elaboration.CompositeType(typeID)
+	}
+
+	_, importedContractValue = initializeContract(
+		b,
+		importedLocation,
+		importedProgram,
+		vmConfig,
+	)
 
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	value := interpreter.NewUnmeteredIntValueFromInt64(7)
+
+	locationResolver := SingleIdentifierLocationResolver(b)
 
 	for i := 0; i < b.N; i++ {
 		checker, err := ParseAndCheckWithOptions(b,
@@ -362,7 +399,9 @@ func BenchmarkContractImport(b *testing.B) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
-					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					LocationHandler: locationResolver,
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.Equal(b, importedChecker.Location, location)
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -376,9 +415,12 @@ func BenchmarkContractImport(b *testing.B) {
 			interpreter.ProgramFromChecker(checker),
 			checker.Location,
 		)
+		comp.Config.LocationHandler = locationResolver
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(b, importedChecker.Location, location)
 			return importedProgram
 		}
+
 		program := comp.Compile()
 
 		scriptLocation := runtime_utils.NewScriptLocationGenerator()
@@ -392,7 +434,10 @@ func BenchmarkContractImport(b *testing.B) {
 func BenchmarkMethodCall(b *testing.B) {
 
 	b.Run("interface method call", func(b *testing.B) {
-		location := common.NewAddressLocation(nil, common.Address{0x1}, "MyContract")
+		importedLocation := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "MyContract",
+		}
 
 		importedChecker, err := ParseAndCheckWithOptions(b,
 			`
@@ -418,7 +463,7 @@ func BenchmarkMethodCall(b *testing.B) {
               }
             `,
 			ParseAndCheckOptions{
-				Location: location,
+				Location: importedLocation,
 			},
 		)
 		require.NoError(b, err)
@@ -431,7 +476,7 @@ func BenchmarkMethodCall(b *testing.B) {
 
 		_, importedContractValue := initializeContract(
 			b,
-			location,
+			importedLocation,
 			importedProgram,
 			nil,
 		)
@@ -451,7 +496,9 @@ func BenchmarkMethodCall(b *testing.B) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
-					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					LocationHandler: SingleIdentifierLocationResolver(b),
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.Equal(b, importedChecker.Location, location)
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -466,6 +513,7 @@ func BenchmarkMethodCall(b *testing.B) {
 			checker.Location,
 		)
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(b, importedChecker.Location, location)
 			return importedProgram
 		}
 
@@ -473,20 +521,22 @@ func BenchmarkMethodCall(b *testing.B) {
 
 		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(b, importedChecker.Location, location)
 			return importedProgram
 		}
-		vmConfig.ContractValueHandler = func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+			require.Equal(b, importedChecker.Location, location)
 			return importedContractValue
 		}
 		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+			require.Equal(b, importedChecker.Location, location)
 			elaboration := importedChecker.Elaboration
-			compositeType := elaboration.CompositeType(typeID)
-			return compositeType
+			return elaboration.CompositeType(typeID)
 		}
 		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			require.Equal(b, importedChecker.Location, location)
 			elaboration := importedChecker.Elaboration
-			interfaceType := elaboration.InterfaceType(typeID)
-			return interfaceType
+			return elaboration.InterfaceType(typeID)
 		}
 
 		scriptLocation := runtime_utils.NewScriptLocationGenerator()
@@ -504,7 +554,10 @@ func BenchmarkMethodCall(b *testing.B) {
 	})
 
 	b.Run("concrete type method call", func(b *testing.B) {
-		location := common.NewAddressLocation(nil, common.Address{0x1}, "MyContract")
+		importedLocation := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "MyContract",
+		}
 
 		importedChecker, err := ParseAndCheckWithOptions(b,
 			`
@@ -530,7 +583,7 @@ func BenchmarkMethodCall(b *testing.B) {
               }
             `,
 			ParseAndCheckOptions{
-				Location: location,
+				Location: importedLocation,
 			},
 		)
 		require.NoError(b, err)
@@ -543,26 +596,29 @@ func BenchmarkMethodCall(b *testing.B) {
 
 		_, importedContractValue := initializeContract(
 			b,
-			location,
+			importedLocation,
 			importedProgram,
 			nil,
 		)
 
-		checker, err := ParseAndCheckWithOptions(b, `
-        import MyContract from 0x01
+		checker, err := ParseAndCheckWithOptions(b,
+			`
+              import MyContract from 0x01
 
-        fun test(count: Int) {
-            var r: MyContract.Foo = MyContract.Foo("Hello from Foo!")
-            var i = 0
-            while i < count {
-                i = i + 1
-                r.sayHello(1)
-            }
-        }`,
-
+              fun test(count: Int) {
+                  var r: MyContract.Foo = MyContract.Foo("Hello from Foo!")
+                  var i = 0
+                  while i < count {
+                      i = i + 1
+                      r.sayHello(1)
+                  }
+              }
+            `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
-					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					LocationHandler: SingleIdentifierLocationResolver(b),
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.Equal(b, importedChecker.Location, location)
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -577,6 +633,7 @@ func BenchmarkMethodCall(b *testing.B) {
 			checker.Location,
 		)
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(b, importedChecker.Location, location)
 			return importedProgram
 		}
 
@@ -584,10 +641,16 @@ func BenchmarkMethodCall(b *testing.B) {
 
 		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(b, importedChecker.Location, location)
 			return importedProgram
 		}
-		vmConfig.ContractValueHandler = func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+			require.Equal(b, importedChecker.Location, location)
 			return importedContractValue
+		}
+		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+			require.Equal(b, importedChecker.Location, location)
+			return importedChecker.Elaboration.CompositeType(typeID)
 		}
 
 		scriptLocation := runtime_utils.NewScriptLocationGenerator()

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -482,6 +482,11 @@ func TestImport(t *testing.T) {
 
 	t.Parallel()
 
+	importedLocation := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{0x1}),
+		Name:    "Foo",
+	}
+
 	importedChecker, err := ParseAndCheckWithOptions(t,
 		`
           fun helloText(): String {
@@ -502,7 +507,7 @@ func TestImport(t *testing.T) {
           }
         `,
 		ParseAndCheckOptions{
-			Location: ImportedLocation,
+			Location: importedLocation,
 		},
 	)
 	require.NoError(t, err)
@@ -524,7 +529,9 @@ func TestImport(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			CheckerConfig: &sema.Config{
-				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+				LocationHandler: SingleIdentifierLocationResolver(t),
+				ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+					require.Equal(t, importedChecker.Location, location)
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
 					}, nil
@@ -539,6 +546,7 @@ func TestImport(t *testing.T) {
 		checker.Location,
 	)
 	importCompiler.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		require.Equal(t, importedChecker.Location, location)
 		return importedProgram
 	}
 
@@ -546,17 +554,18 @@ func TestImport(t *testing.T) {
 
 	vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 	vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		require.Equal(t, importedChecker.Location, location)
 		return importedProgram
 	}
 	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+		require.Equal(t, importedChecker.Location, location)
 		elaboration := importedChecker.Elaboration
-		compositeType := elaboration.CompositeType(typeID)
-		return compositeType
+		return elaboration.CompositeType(typeID)
 	}
 	vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+		require.Equal(t, importedChecker.Location, location)
 		elaboration := importedChecker.Elaboration
-		interfaceType := elaboration.InterfaceType(typeID)
-		return interfaceType
+		return elaboration.InterfaceType(typeID)
 	}
 
 	vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
@@ -572,7 +581,10 @@ func TestImportError(t *testing.T) {
 
 	t.Parallel()
 
-	importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "Test")
+	importLocation := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{0x1}),
+		Name:    "Test",
+	}
 
 	importedChecker, err := ParseAndCheckWithOptions(t,
 		`
@@ -639,7 +651,9 @@ func TestImportError(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			CheckerConfig: &sema.Config{
-				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+				LocationHandler: SingleIdentifierLocationResolver(t),
+				ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+					require.Equal(t, importedChecker.Location, location)
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
 					}, nil
@@ -653,7 +667,9 @@ func TestImportError(t *testing.T) {
 	require.NoError(t, err)
 
 	compConfig := &compiler.Config{
+		LocationHandler: SingleIdentifierLocationResolver(t),
 		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importLocation, location)
 			return importedProgram
 		},
 		BuiltinGlobalsProvider: CompilerDefaultBuiltinGlobalsWithDefaultsAndPanic,
@@ -669,20 +685,22 @@ func TestImportError(t *testing.T) {
 
 	vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 	vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		require.Equal(t, importLocation, location)
 		return importedProgram
 	}
 	vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+		require.Equal(t, importLocation, location)
 		return importedContractValue
 	}
 	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+		require.Equal(t, importLocation, location)
 		elaboration := importedChecker.Elaboration
-		compositeType := elaboration.CompositeType(typeID)
-		return compositeType
+		return elaboration.CompositeType(typeID)
 	}
 	vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+		require.Equal(t, importLocation, location)
 		elaboration := importedChecker.Elaboration
-		interfaceType := elaboration.InterfaceType(typeID)
-		return interfaceType
+		return elaboration.InterfaceType(typeID)
 	}
 	vmConfig.BuiltinGlobalsProvider = VMBuiltinGlobalsProviderWithDefaultsAndPanic
 
@@ -708,7 +726,10 @@ func TestContractImport(t *testing.T) {
 
 		t.Parallel()
 
-		importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "MyContract")
+		importLocation := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "MyContract",
+		}
 
 		importedChecker, err := ParseAndCheckWithOptions(t,
 			`
@@ -764,7 +785,9 @@ func TestContractImport(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
-					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					LocationHandler: SingleIdentifierLocationResolver(t),
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.Equal(t, importedChecker.Location, location)
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -779,6 +802,7 @@ func TestContractImport(t *testing.T) {
 			checker.Location,
 		)
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importedChecker.Location, location)
 			return importedProgram
 		}
 
@@ -786,20 +810,22 @@ func TestContractImport(t *testing.T) {
 
 		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importedChecker.Location, location)
 			return importedProgram
 		}
-		vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+			require.Equal(t, importedChecker.Location, location)
 			return importedContractValue
 		}
 		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+			require.Equal(t, importedChecker.Location, location)
 			elaboration := importedChecker.Elaboration
-			compositeType := elaboration.CompositeType(typeID)
-			return compositeType
+			return elaboration.CompositeType(typeID)
 		}
 		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			require.Equal(t, importedChecker.Location, location)
 			elaboration := importedChecker.Elaboration
-			interfaceType := elaboration.InterfaceType(typeID)
-			return interfaceType
+			return elaboration.InterfaceType(typeID)
 		}
 
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
@@ -815,8 +841,10 @@ func TestContractImport(t *testing.T) {
 
 		t.Parallel()
 
-		importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "MyContract")
-
+		importLocation := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "MyContract",
+		}
 		importedChecker, err := ParseAndCheckWithOptions(t,
 			`
               contract MyContract {
@@ -848,20 +876,22 @@ func TestContractImport(t *testing.T) {
 
 		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importedChecker.Location, location)
 			return importedProgram
 		}
-		vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+			require.Equal(t, importedChecker.Location, location)
 			return importedContractValue
 		}
 		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+			require.Equal(t, importedChecker.Location, location)
 			elaboration := importedChecker.Elaboration
-			compositeType := elaboration.CompositeType(typeID)
-			return compositeType
+			return elaboration.CompositeType(typeID)
 		}
 		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			require.Equal(t, importedChecker.Location, location)
 			elaboration := importedChecker.Elaboration
-			interfaceType := elaboration.InterfaceType(typeID)
-			return interfaceType
+			return elaboration.InterfaceType(typeID)
 		}
 
 		_, importedContractValue = initializeContract(
@@ -881,7 +911,9 @@ func TestContractImport(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
-					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					LocationHandler: SingleIdentifierLocationResolver(t),
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.Equal(t, importedChecker.Location, location)
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -896,6 +928,7 @@ func TestContractImport(t *testing.T) {
 			checker.Location,
 		)
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importedChecker.Location, location)
 			return importedProgram
 		}
 
@@ -918,7 +951,7 @@ func TestContractImport(t *testing.T) {
 
 		fooLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			common.MustBytesToAddress([]byte{0x1}),
 			"Foo",
 		)
 
@@ -961,15 +994,13 @@ func TestContractImport(t *testing.T) {
 			require.Equal(t, fooLocation, location)
 
 			elaboration := fooChecker.Elaboration
-			compositeType := elaboration.CompositeType(typeID)
-			return compositeType
+			return elaboration.CompositeType(typeID)
 		}
 		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
 			require.Equal(t, fooLocation, location)
 
 			elaboration := fooChecker.Elaboration
-			interfaceType := elaboration.InterfaceType(typeID)
-			return interfaceType
+			return elaboration.InterfaceType(typeID)
 		}
 
 		_, fooContractValue = initializeContract(
@@ -983,7 +1014,7 @@ func TestContractImport(t *testing.T) {
 
 		barLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+			common.MustBytesToAddress([]byte{0x2}),
 			"Bar",
 		)
 
@@ -1001,13 +1032,13 @@ func TestContractImport(t *testing.T) {
 			ParseAndCheckOptions{
 				Location: barLocation,
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.Equal(t, fooLocation, location)
 						return sema.ElaborationImport{
 							Elaboration: fooChecker.Elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -1044,6 +1075,7 @@ func TestContractImport(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.IsType(t, common.AddressLocation{}, location)
 						addressLocation := location.(common.AddressLocation)
@@ -1061,7 +1093,6 @@ func TestContractImport(t *testing.T) {
 							Elaboration: elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -1158,7 +1189,7 @@ func TestContractImport(t *testing.T) {
 
 		fooLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			common.MustBytesToAddress([]byte{0x1}),
 			"Foo",
 		)
 
@@ -1188,7 +1219,7 @@ func TestContractImport(t *testing.T) {
 
 		barLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+			common.MustBytesToAddress([]byte{0x2}),
 			"Bar",
 		)
 
@@ -1206,13 +1237,13 @@ func TestContractImport(t *testing.T) {
 			ParseAndCheckOptions{
 				Location: barLocation,
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.Equal(t, fooLocation, location)
 						return sema.ElaborationImport{
 							Elaboration: fooChecker.Elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -1267,6 +1298,7 @@ func TestContractImport(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.IsType(t, common.AddressLocation{}, location)
 						addressLocation := location.(common.AddressLocation)
@@ -1284,7 +1316,6 @@ func TestContractImport(t *testing.T) {
 							Elaboration: elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -1371,8 +1402,10 @@ func TestContractImport(t *testing.T) {
 
 		t.Parallel()
 
-		importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "MyContract")
-
+		importLocation := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "Foo",
+		}
 		compilerConfig := &compiler.Config{
 			BuiltinGlobalsProvider: CompilerDefaultBuiltinGlobalsWithDefaultsAndConditionLog,
 		}
@@ -1419,20 +1452,22 @@ func TestContractImport(t *testing.T) {
 
 		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importLocation, location)
 			return importedProgram
 		}
-		vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+			require.Equal(t, importLocation, location)
 			return importedContractValue
 		}
 		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+			require.Equal(t, importLocation, location)
 			elaboration := importedChecker.Elaboration
-			compositeType := elaboration.CompositeType(typeID)
-			return compositeType
+			return elaboration.CompositeType(typeID)
 		}
 		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			require.Equal(t, importLocation, location)
 			elaboration := importedChecker.Elaboration
-			interfaceType := elaboration.InterfaceType(typeID)
-			return interfaceType
+			return elaboration.InterfaceType(typeID)
 		}
 		vmConfig.BuiltinGlobalsProvider = NewVMBuiltinGlobalsProviderWithDefaultsPanicAndConditionLog(&logs)
 
@@ -1455,7 +1490,9 @@ func TestContractImport(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
-					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					LocationHandler: SingleIdentifierLocationResolver(t),
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.Equal(t, importedChecker.Location, location)
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -1474,6 +1511,7 @@ func TestContractImport(t *testing.T) {
 			compilerConfig,
 		)
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importedChecker.Location, location)
 			return importedProgram
 		}
 		program := comp.Compile()
@@ -1497,7 +1535,10 @@ func TestInitializeContract(t *testing.T) {
 
 	t.Parallel()
 
-	location := common.NewAddressLocation(nil, common.Address{0x1}, "MyContract")
+	location := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{0x1}),
+		Name:    "MyContract",
+	}
 	programs := map[common.Location]*CompiledProgram{}
 
 	program := ParseCheckAndCompileCodeWithOptions(t,
@@ -1534,7 +1575,10 @@ func TestContractAccessDuringInit(t *testing.T) {
 	t.Run("using contract name", func(t *testing.T) {
 		t.Parallel()
 
-		location := common.NewAddressLocation(nil, common.Address{0x1}, "MyContract")
+		location := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "MyContract",
+		}
 		programs := CompiledPrograms{}
 
 		program := ParseCheckAndCompile(t,
@@ -1571,8 +1615,10 @@ func TestContractAccessDuringInit(t *testing.T) {
 	t.Run("using self", func(t *testing.T) {
 		t.Parallel()
 
-		location := common.NewAddressLocation(nil, common.Address{0x1}, "MyContract")
-
+		location := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "MyContract",
+		}
 		programs := CompiledPrograms{}
 
 		program := ParseCheckAndCompile(t,
@@ -1673,6 +1719,10 @@ func TestFunctionOrder(t *testing.T) {
 	t.Run("nested", func(t *testing.T) {
 		t.Parallel()
 
+		location := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "MyContract",
+		}
 		code := `
           contract MyContract {
 
@@ -1709,7 +1759,7 @@ func TestFunctionOrder(t *testing.T) {
 			t,
 			code,
 			ParseAndCheckOptions{
-				Location: common.NewAddressLocation(nil, common.Address{0x1}, "MyContract"),
+				Location: location,
 			},
 		)
 		require.NoError(t, err)
@@ -1740,8 +1790,10 @@ func TestContractField(t *testing.T) {
 	t.Run("get", func(t *testing.T) {
 		t.Parallel()
 
-		importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "MyContract")
-
+		importLocation := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "MyContract",
+		}
 		importedChecker, err := ParseAndCheckWithOptions(t,
 			`
               contract MyContract {
@@ -1768,20 +1820,22 @@ func TestContractField(t *testing.T) {
 
 		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importLocation, location)
 			return importedProgram
 		}
-		vmConfig.ContractValueHandler = func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+			require.Equal(t, importLocation, location)
 			return importedContractValue
 		}
 		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+			require.Equal(t, importLocation, location)
 			elaboration := importedChecker.Elaboration
-			compositeType := elaboration.CompositeType(typeID)
-			return compositeType
+			return elaboration.CompositeType(typeID)
 		}
 		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			require.Equal(t, importLocation, location)
 			elaboration := importedChecker.Elaboration
-			interfaceType := elaboration.InterfaceType(typeID)
-			return interfaceType
+			return elaboration.InterfaceType(typeID)
 		}
 
 		_, importedContractValue = initializeContract(
@@ -1801,7 +1855,9 @@ func TestContractField(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
-					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					LocationHandler: SingleIdentifierLocationResolver(t),
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.Equal(t, importedChecker.Location, location)
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -1815,7 +1871,9 @@ func TestContractField(t *testing.T) {
 			interpreter.ProgramFromChecker(checker),
 			checker.Location,
 			&compiler.Config{
+				LocationHandler: SingleIdentifierLocationResolver(t),
 				ImportHandler: func(location common.Location) *bbq.InstructionProgram {
+					require.Equal(t, importedChecker.Location, location)
 					return importedProgram
 				},
 			},
@@ -1834,8 +1892,10 @@ func TestContractField(t *testing.T) {
 	t.Run("set", func(t *testing.T) {
 		t.Parallel()
 
-		importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "MyContract")
-
+		importLocation := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "MyContract",
+		}
 		importedChecker, err := ParseAndCheckWithOptions(t,
 			`
               contract MyContract {
@@ -1862,20 +1922,22 @@ func TestContractField(t *testing.T) {
 
 		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importLocation, location)
 			return importedProgram
 		}
-		vmConfig.ContractValueHandler = func(_ *vm.Context, _ common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+			require.Equal(t, importLocation, location)
 			return importedContractValue
 		}
 		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+			require.Equal(t, importLocation, location)
 			elaboration := importedChecker.Elaboration
-			compositeType := elaboration.CompositeType(typeID)
-			return compositeType
+			return elaboration.CompositeType(typeID)
 		}
 		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			require.Equal(t, importLocation, location)
 			elaboration := importedChecker.Elaboration
-			interfaceType := elaboration.InterfaceType(typeID)
-			return interfaceType
+			return elaboration.InterfaceType(typeID)
 		}
 
 		_, importedContractValue = initializeContract(
@@ -1896,7 +1958,9 @@ func TestContractField(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
-					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					LocationHandler: SingleIdentifierLocationResolver(t),
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.Equal(t, importedChecker.Location, location)
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -1911,6 +1975,7 @@ func TestContractField(t *testing.T) {
 			checker.Location,
 		)
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importedChecker.Location, location)
 			return importedProgram
 		}
 
@@ -2527,7 +2592,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 
 		contractLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			common.MustBytesToAddress([]byte{0x1}),
 			"MyContract",
 		)
 
@@ -2597,12 +2662,13 @@ func TestInterfaceMethodCall(t *testing.T) {
 
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
-					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					LocationHandler: SingleIdentifierLocationResolver(t),
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.Equal(t, importedChecker.Location, location)
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -2614,6 +2680,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 		)
 		comp.Config.LocationHandler = SingleIdentifierLocationResolver(t)
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importedChecker.Location, location)
 			return importedProgram
 		}
 
@@ -2621,20 +2688,22 @@ func TestInterfaceMethodCall(t *testing.T) {
 
 		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importedChecker.Location, location)
 			return importedProgram
 		}
 		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+			require.Equal(t, importedChecker.Location, location)
 			return importedContractValue
 		}
 		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+			require.Equal(t, importedChecker.Location, location)
 			elaboration := importedChecker.Elaboration
-			compositeType := elaboration.CompositeType(typeID)
-			return compositeType
+			return elaboration.CompositeType(typeID)
 		}
 		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			require.Equal(t, importedChecker.Location, location)
 			elaboration := importedChecker.Elaboration
-			interfaceType := elaboration.InterfaceType(typeID)
-			return interfaceType
+			return elaboration.InterfaceType(typeID)
 		}
 
 		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
@@ -2653,7 +2722,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 
 		fooLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			common.MustBytesToAddress([]byte{0x1}),
 			"Foo",
 		)
 
@@ -2688,7 +2757,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 
 		barLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+			common.MustBytesToAddress([]byte{0x2}),
 			"Bar",
 		)
 
@@ -2726,7 +2795,7 @@ func TestInterfaceMethodCall(t *testing.T) {
 
 		bazLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3},
+			common.MustBytesToAddress([]byte{0x3}),
 			"Baz",
 		)
 
@@ -2745,6 +2814,7 @@ func TestInterfaceMethodCall(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						var elaboration *sema.Elaboration
 						switch location {
@@ -2760,7 +2830,6 @@ func TestInterfaceMethodCall(t *testing.T) {
 							Elaboration: elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 				Location: bazLocation,
 			},
@@ -2860,6 +2929,7 @@ func TestInterfaceMethodCall(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						var elaboration *sema.Elaboration
 						switch location {
@@ -2873,7 +2943,6 @@ func TestInterfaceMethodCall(t *testing.T) {
 							Elaboration: elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -2973,6 +3042,7 @@ func TestInterfaceMethodCall(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						var elaboration *sema.Elaboration
 						switch location {
@@ -2988,7 +3058,6 @@ func TestInterfaceMethodCall(t *testing.T) {
 							Elaboration: elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -6284,8 +6353,10 @@ func TestInnerFunction(t *testing.T) {
 func TestContractAccount(t *testing.T) {
 	t.Parallel()
 
-	importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "C")
-
+	importLocation := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{0x1}),
+		Name:    "C",
+	}
 	importedChecker, err := ParseAndCheckWithOptions(t,
 		`
           contract C {
@@ -6323,7 +6394,9 @@ func TestContractAccount(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			CheckerConfig: &sema.Config{
-				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+				LocationHandler: SingleIdentifierLocationResolver(t),
+				ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+					require.Equal(t, importLocation, location)
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
 					}, nil
@@ -6338,6 +6411,7 @@ func TestContractAccount(t *testing.T) {
 		checker.Location,
 	)
 	comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		require.Equal(t, importLocation, location)
 		return importedProgram
 	}
 
@@ -6347,20 +6421,22 @@ func TestContractAccount(t *testing.T) {
 
 	vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 	vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		require.Equal(t, importLocation, location)
 		return importedProgram
 	}
-	vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
+	vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+		require.Equal(t, importLocation, location)
 		return importedContractValue
 	}
 	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+		require.Equal(t, importLocation, location)
 		elaboration := importedChecker.Elaboration
-		compositeType := elaboration.CompositeType(typeID)
-		return compositeType
+		return elaboration.CompositeType(typeID)
 	}
 	vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+		require.Equal(t, importLocation, location)
 		elaboration := importedChecker.Elaboration
-		interfaceType := elaboration.InterfaceType(typeID)
-		return interfaceType
+		return elaboration.InterfaceType(typeID)
 	}
 
 	vmConfig.InjectedCompositeFieldsHandler = func(
@@ -6399,8 +6475,10 @@ func TestContractAccount(t *testing.T) {
 func TestResourceOwner(t *testing.T) {
 	t.Parallel()
 
-	importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "C")
-
+	importLocation := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{0x1}),
+		Name:    "C",
+	}
 	importedChecker, err := ParseAndCheckWithOptions(t,
 		`
           contract C {
@@ -6447,7 +6525,9 @@ func TestResourceOwner(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			CheckerConfig: &sema.Config{
-				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+				LocationHandler: SingleIdentifierLocationResolver(t),
+				ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+					require.Equal(t, importLocation, location)
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
 					}, nil
@@ -6462,6 +6542,7 @@ func TestResourceOwner(t *testing.T) {
 		checker.Location,
 	)
 	comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		require.Equal(t, importLocation, location)
 		return importedProgram
 	}
 
@@ -6472,20 +6553,22 @@ func TestResourceOwner(t *testing.T) {
 	var uuid uint64 = 42
 
 	vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		require.Equal(t, importLocation, location)
 		return importedProgram
 	}
-	vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
+	vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+		require.Equal(t, importLocation, location)
 		return importedContractValue
 	}
 	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+		require.Equal(t, importLocation, location)
 		elaboration := importedChecker.Elaboration
-		compositeType := elaboration.CompositeType(typeID)
-		return compositeType
+		return elaboration.CompositeType(typeID)
 	}
 	vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+		require.Equal(t, importLocation, location)
 		elaboration := importedChecker.Elaboration
-		interfaceType := elaboration.InterfaceType(typeID)
-		return interfaceType
+		return elaboration.InterfaceType(typeID)
 	}
 
 	vmConfig.UUIDHandler = func() (uint64, error) {
@@ -6536,8 +6619,10 @@ func TestResourceOwner(t *testing.T) {
 func TestResourceUUID(t *testing.T) {
 	t.Parallel()
 
-	importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "C")
-
+	importLocation := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{0x1}),
+		Name:    "C",
+	}
 	importedChecker, err := ParseAndCheckWithOptions(t,
 		`
           contract C {
@@ -6581,7 +6666,9 @@ func TestResourceUUID(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			CheckerConfig: &sema.Config{
-				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+				LocationHandler: SingleIdentifierLocationResolver(t),
+				ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+					require.Equal(t, importLocation, location)
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
 					}, nil
@@ -6596,6 +6683,7 @@ func TestResourceUUID(t *testing.T) {
 		checker.Location,
 	)
 	comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		require.Equal(t, importLocation, location)
 		return importedProgram
 	}
 
@@ -6605,20 +6693,22 @@ func TestResourceUUID(t *testing.T) {
 
 	vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 	vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		require.Equal(t, importLocation, location)
 		return importedProgram
 	}
-	vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
+	vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+		require.Equal(t, importLocation, location)
 		return importedContractValue
 	}
 	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+		require.Equal(t, importLocation, location)
 		elaboration := importedChecker.Elaboration
-		compositeType := elaboration.CompositeType(typeID)
-		return compositeType
+		return elaboration.CompositeType(typeID)
 	}
 	vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+		require.Equal(t, importLocation, location)
 		elaboration := importedChecker.Elaboration
-		interfaceType := elaboration.InterfaceType(typeID)
-		return interfaceType
+		return elaboration.InterfaceType(typeID)
 	}
 
 	vmConfig.UUIDHandler = func() (uint64, error) {
@@ -6921,8 +7011,10 @@ func TestContractClosure(t *testing.T) {
 
 	t.Parallel()
 
-	importLocation := common.NewAddressLocation(nil, common.Address{0x1}, "Counter")
-
+	importLocation := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{0x1}),
+		Name:    "Counter",
+	}
 	importedChecker, err := ParseAndCheckWithOptions(t,
 		`
           contract Counter {
@@ -6978,7 +7070,9 @@ func TestContractClosure(t *testing.T) {
         `,
 		ParseAndCheckOptions{
 			CheckerConfig: &sema.Config{
-				ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+				LocationHandler: SingleIdentifierLocationResolver(t),
+				ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+					require.Equal(t, importLocation, location)
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
 					}, nil
@@ -6992,7 +7086,9 @@ func TestContractClosure(t *testing.T) {
 	require.NoError(t, err)
 
 	compConfig := &compiler.Config{
+		LocationHandler: SingleIdentifierLocationResolver(t),
 		ImportHandler: func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importLocation, location)
 			return importedProgram
 		},
 		BuiltinGlobalsProvider: CompilerDefaultBuiltinGlobalsWithDefaultsAndPanic,
@@ -7008,20 +7104,22 @@ func TestContractClosure(t *testing.T) {
 
 	vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 	vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+		require.Equal(t, importLocation, location)
 		return importedProgram
 	}
 	vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+		require.Equal(t, importLocation, location)
 		return importedContractValue
 	}
 	vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+		require.Equal(t, importLocation, location)
 		elaboration := importedChecker.Elaboration
-		compositeType := elaboration.CompositeType(typeID)
-		return compositeType
+		return elaboration.CompositeType(typeID)
 	}
 	vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+		require.Equal(t, importLocation, location)
 		elaboration := importedChecker.Elaboration
-		interfaceType := elaboration.InterfaceType(typeID)
-		return interfaceType
+		return elaboration.InterfaceType(typeID)
 	}
 	vmConfig.BuiltinGlobalsProvider = VMBuiltinGlobalsProviderWithDefaultsAndPanic
 
@@ -8685,11 +8783,11 @@ func TestEnumLookupFailure(t *testing.T) {
 
 	result, err := CompileAndInvoke(t,
 		`
-			enum Test: UInt8 {
-				case a
-				case b
-				case c
-			}
+            enum Test: UInt8 {
+                case a
+                case b
+                case c
+            }
 
             fun test(): AnyStruct {
                 return Test(rawValue: 5)
@@ -8707,13 +8805,13 @@ func TestNestedEnumLookupFailure(t *testing.T) {
 
 	result, err := CompileAndInvoke(t,
 		`
-			contract C {
-				enum Test: UInt8 {
-					case a
-					case b
-					case c
-				}
-			}
+            contract C {
+                enum Test: UInt8 {
+                    case a
+                    case b
+                    case c
+                }
+            }
 
             fun test(): AnyStruct {
                 return C.Test(rawValue: 5)
@@ -9197,11 +9295,11 @@ func TestStringTemplate(t *testing.T) {
 
 		result, err := CompileAndInvoke(t,
 			`
-				fun test(): String {
-					var s = "2+2=\(2+2)"
-					return s
-				}
-			`,
+                fun test(): String {
+                    var s = "2+2=\(2+2)"
+                    return s
+                }
+            `,
 			"test",
 		)
 		require.NoError(t, err)
@@ -9213,14 +9311,14 @@ func TestStringTemplate(t *testing.T) {
 
 		result, err := CompileAndInvoke(t,
 			`
-				fun test(): String {
-					let a = "A"
-					let b = "B"
-					let c = 4
-					let str = "\(a) + \(b) = \(c)"
-					return str
-				}
-			`,
+                fun test(): String {
+                    let a = "A"
+                    let b = "B"
+                    let c = 4
+                    let str = "\(a) + \(b) = \(c)"
+                    return str
+                }
+            `,
 			"test",
 		)
 		require.NoError(t, err)
@@ -9715,31 +9813,34 @@ func TestVMImportAliasing(t *testing.T) {
 
 		t.Parallel()
 
-		importLocation := common.NewAddressLocation(nil, common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1}, "MyContract")
+		importLocation := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "MyContract",
+		}
 
 		importedChecker, err := ParseAndCheckWithOptions(t,
 			`
-				contract MyContract {
+                contract MyContract {
 
-					fun helloText(): String {
-						return "global function of the imported program"
-					}
+                    fun helloText(): String {
+                        return "global function of the imported program"
+                    }
 
-					init() {}
+                    init() {}
 
-					struct Foo {
-						var id : String
+                    struct Foo {
+                        var id : String
 
-						init(_ id: String) {
-							self.id = id
-						}
+                        init(_ id: String) {
+                            self.id = id
+                        }
 
-						fun sayHello(_ id: Int): String {
-							self.id
-							return MyContract.helloText()
-						}
-					}
-				}
+                        fun sayHello(_ id: Int): String {
+                            self.id
+                            return MyContract.helloText()
+                        }
+                    }
+                }
             `,
 			ParseAndCheckOptions{
 				Location: importLocation,
@@ -9762,16 +9863,18 @@ func TestVMImportAliasing(t *testing.T) {
 
 		checker, err := ParseAndCheckWithOptions(t,
 			`
-				import MyContract as TheirContract from 0x01
+                import MyContract as TheirContract from 0x01
 
-				fun test(): String {
-					var r = TheirContract.Foo("Hello from Foo!")
-					return r.sayHello(1)
-				}
+                fun test(): String {
+                    var r = TheirContract.Foo("Hello from Foo!")
+                    return r.sayHello(1)
+                }
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
-					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					LocationHandler: SingleIdentifierLocationResolver(t),
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.Equal(t, importLocation, location)
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -9786,6 +9889,7 @@ func TestVMImportAliasing(t *testing.T) {
 			checker.Location,
 		)
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importLocation, location)
 			return importedProgram
 		}
 
@@ -9793,16 +9897,20 @@ func TestVMImportAliasing(t *testing.T) {
 
 		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importLocation, location)
 			return importedProgram
 		}
-		vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+			require.Equal(t, importLocation, location)
 			return importedContractValue
 		}
 		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
+			require.Equal(t, importLocation, location)
 			elaboration := importedChecker.Elaboration
 			return elaboration.CompositeType(typeID)
 		}
 		vmConfig.InterfaceTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.InterfaceType {
+			require.Equal(t, importLocation, location)
 			elaboration := importedChecker.Elaboration
 			return elaboration.InterfaceType(typeID)
 		}
@@ -9824,17 +9932,17 @@ func TestVMImportAliasing(t *testing.T) {
 
 		fooLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			common.MustBytesToAddress([]byte{0x1}),
 			"Foo",
 		)
 
 		fooChecker, err := ParseAndCheckWithOptions(t,
 			`
-			contract Foo {
-				fun foo(): Int {
-					return 1
-				}
-			}
+            contract Foo {
+                fun foo(): Int {
+                    return 1
+                }
+            }
             `,
 			ParseAndCheckOptions{
 				Location: fooLocation,
@@ -9883,28 +9991,28 @@ func TestVMImportAliasing(t *testing.T) {
 
 		barLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+			common.MustBytesToAddress([]byte{0x2}),
 			"Foo",
 		)
 
 		barChecker, err := ParseAndCheckWithOptions(t,
 			`
-			contract Foo {
-				fun bar(): Int {
-					return 2
-				}
-			}
+            contract Foo {
+                fun bar(): Int {
+                    return 2
+                }
+            }
             `,
 			ParseAndCheckOptions{
 				Location: barLocation,
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.Equal(t, fooLocation, location)
 						return sema.ElaborationImport{
 							Elaboration: fooChecker.Elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -9933,15 +10041,16 @@ func TestVMImportAliasing(t *testing.T) {
 
 		checker, err := ParseAndCheckWithOptions(t,
 			`
-			import Foo as Foo1 from 0x01
-			import Foo as Foo2 from 0x02
+            import Foo as Foo1 from 0x01
+            import Foo as Foo2 from 0x02
 
-			fun test(): Int {
-				return Foo1.foo() + Foo2.bar()
-			}
+            fun test(): Int {
+                return Foo1.foo() + Foo2.bar()
+            }
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.IsType(t, common.AddressLocation{}, location)
 						addressLocation := location.(common.AddressLocation)
@@ -9959,7 +10068,6 @@ func TestVMImportAliasing(t *testing.T) {
 							Elaboration: elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -10057,17 +10165,17 @@ func TestVMImportAliasing(t *testing.T) {
 
 		fooLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			common.MustBytesToAddress([]byte{0x1}),
 			"Foo",
 		)
 
 		fooChecker, err := ParseAndCheckWithOptions(t,
 			`
-			contract Foo {
-				fun value(): Int {
-					return 1
-				}
-			}
+            contract Foo {
+                fun value(): Int {
+                    return 1
+                }
+            }
             `,
 			ParseAndCheckOptions{
 				Location: fooLocation,
@@ -10116,28 +10224,28 @@ func TestVMImportAliasing(t *testing.T) {
 
 		barLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+			common.MustBytesToAddress([]byte{0x2}),
 			"Foo",
 		)
 
 		barChecker, err := ParseAndCheckWithOptions(t,
 			`
-			contract Foo {
-				fun value(): Int {
-					return 2
-				}
-			}
+            contract Foo {
+                fun value(): Int {
+                    return 2
+                }
+            }
             `,
 			ParseAndCheckOptions{
 				Location: barLocation,
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.Equal(t, fooLocation, location)
 						return sema.ElaborationImport{
 							Elaboration: fooChecker.Elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -10166,15 +10274,16 @@ func TestVMImportAliasing(t *testing.T) {
 
 		checker, err := ParseAndCheckWithOptions(t,
 			`
-			import Foo as Foo1 from 0x01
-			import Foo as Foo2 from 0x02
+            import Foo as Foo1 from 0x01
+            import Foo as Foo2 from 0x02
 
-			fun test(): Int {
-				return Foo1.value() + Foo2.value()
-			}
+            fun test(): Int {
+                return Foo1.value() + Foo2.value()
+            }
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.IsType(t, common.AddressLocation{}, location)
 						addressLocation := location.(common.AddressLocation)
@@ -10192,7 +10301,6 @@ func TestVMImportAliasing(t *testing.T) {
 							Elaboration: elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -10290,17 +10398,17 @@ func TestVMImportAliasing(t *testing.T) {
 
 		fooLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			common.MustBytesToAddress([]byte{0x1}),
 			"Foo",
 		)
 
 		fooChecker, err := ParseAndCheckWithOptions(t,
 			`
-			contract Foo {
-				fun value(): Int {
-					return 1
-				}
-			}
+            contract Foo {
+                fun value(): Int {
+                    return 1
+                }
+            }
             `,
 			ParseAndCheckOptions{
 				Location: fooLocation,
@@ -10349,29 +10457,29 @@ func TestVMImportAliasing(t *testing.T) {
 
 		barLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+			common.MustBytesToAddress([]byte{0x2}),
 			"Bar",
 		)
 
 		barChecker, err := ParseAndCheckWithOptions(t,
 			`
-			import Foo as Cab from 0x01
-			contract Bar {
-				fun value(): Int {
-					return Cab.value()
-				}
-			}
+            import Foo as Cab from 0x01
+            contract Bar {
+                fun value(): Int {
+                    return Cab.value()
+                }
+            }
             `,
 			ParseAndCheckOptions{
 				Location: barLocation,
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.Equal(t, fooLocation, location)
 						return sema.ElaborationImport{
 							Elaboration: fooChecker.Elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -10400,14 +10508,15 @@ func TestVMImportAliasing(t *testing.T) {
 
 		checker, err := ParseAndCheckWithOptions(t,
 			`
-			import Bar as Foo from 0x02
+            import Bar as Foo from 0x02
 
-			fun test(): Int {
-				return Foo.value()
-			}
+            fun test(): Int {
+                return Foo.value()
+            }
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.IsType(t, common.AddressLocation{}, location)
 						addressLocation := location.(common.AddressLocation)
@@ -10425,7 +10534,6 @@ func TestVMImportAliasing(t *testing.T) {
 							Elaboration: elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -10519,19 +10627,22 @@ func TestVMImportAliasing(t *testing.T) {
 
 		t.Parallel()
 
-		importLocation := common.NewAddressLocation(nil, common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1}, "MyContract")
+		importLocation := common.AddressLocation{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Name:    "MyContract",
+		}
 
 		importedChecker, err := ParseAndCheckWithOptions(t,
 			`
-				contract MyContract {
-					struct MyStruct {
-						var value : Int
-						init (_ v: Int) {self.value = v}
-						fun getValue(): Int {
-							return self.value
-						}
-					}
-				}
+                contract MyContract {
+                    struct MyStruct {
+                        var value : Int
+                        init (_ v: Int) {self.value = v}
+                        fun getValue(): Int {
+                            return self.value
+                        }
+                    }
+                }
             `,
 			ParseAndCheckOptions{
 				Location: importLocation,
@@ -10554,22 +10665,24 @@ func TestVMImportAliasing(t *testing.T) {
 
 		checker, err := ParseAndCheckWithOptions(t,
 			`
-				import MyContract as TheirContract from 0x01
+                import MyContract as TheirContract from 0x01
 
-				struct Foo {
-					var tmp: TheirContract.MyStruct
-					init() {
-						self.tmp = TheirContract.MyStruct(5)
-					}
-				}
+                struct Foo {
+                    var tmp: TheirContract.MyStruct
+                    init() {
+                        self.tmp = TheirContract.MyStruct(5)
+                    }
+                }
 
-				fun test(): Int {
-					return Foo().tmp.getValue()
-				}
+                fun test(): Int {
+                    return Foo().tmp.getValue()
+                }
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
-					ImportHandler: func(*sema.Checker, common.Location, ast.Range) (sema.Import, error) {
+					LocationHandler: SingleIdentifierLocationResolver(t),
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.Equal(t, importLocation, location)
 						return sema.ElaborationImport{
 							Elaboration: importedChecker.Elaboration,
 						}, nil
@@ -10584,6 +10697,7 @@ func TestVMImportAliasing(t *testing.T) {
 			checker.Location,
 		)
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, importLocation, location)
 			return importedProgram
 		}
 
@@ -10591,9 +10705,18 @@ func TestVMImportAliasing(t *testing.T) {
 
 		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
-			return importedProgram
+			switch location {
+			case importLocation:
+				return importedProgram
+			case checker.Location:
+				return program
+			default:
+				assert.FailNow(t, "invalid location")
+				return nil
+			}
 		}
-		vmConfig.ContractValueHandler = func(*vm.Context, common.Location) *interpreter.CompositeValue {
+		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+			require.Equal(t, importLocation, location)
 			return importedContractValue
 		}
 		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
@@ -10644,7 +10767,7 @@ func TestVMImportAliasing(t *testing.T) {
 
 		fooLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			common.MustBytesToAddress([]byte{0x1}),
 			"Foo",
 		)
 
@@ -10674,7 +10797,7 @@ func TestVMImportAliasing(t *testing.T) {
 
 		barLocation := common.NewAddressLocation(
 			nil,
-			common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+			common.MustBytesToAddress([]byte{0x2}),
 			"Bar",
 		)
 
@@ -10692,13 +10815,13 @@ func TestVMImportAliasing(t *testing.T) {
 			ParseAndCheckOptions{
 				Location: barLocation,
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.Equal(t, fooLocation, location)
 						return sema.ElaborationImport{
 							Elaboration: fooChecker.Elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -10753,6 +10876,7 @@ func TestVMImportAliasing(t *testing.T) {
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.IsType(t, common.AddressLocation{}, location)
 						addressLocation := location.(common.AddressLocation)
@@ -10770,7 +10894,6 @@ func TestVMImportAliasing(t *testing.T) {
 							Elaboration: elaboration,
 						}, nil
 					},
-					LocationHandler: SingleIdentifierLocationResolver(t),
 				},
 			},
 		)
@@ -10845,29 +10968,30 @@ func TestVMImportAliasing(t *testing.T) {
 
 		address := common.MustBytesToAddress([]byte{0x1})
 
+		fooLocation := common.AddressLocation{
+			Address: address,
+			Name:    "Foo",
+		}
 		fooChecker, err := ParseAndCheckWithOptions(t,
 			`
-			contract C {
-				fun v(): Int {
-					return 1
-				}
-			}
+              contract C {
+                  fun v(): Int {
+                      return 1
+                  }
+              }
 
-			struct S {
-				fun v(): Int {
-					return 2
-				}
-			}
+              struct S {
+                  fun v(): Int {
+                      return 2
+                  }
+              }
 
-			fun v(): Int {
-				return 3
-			}
+              fun v(): Int {
+                  return 3
+              }
             `,
 			ParseAndCheckOptions{
-				Location: common.AddressLocation{
-					Address: address,
-					Name:    "C",
-				},
+				Location: fooLocation,
 			},
 		)
 		require.NoError(t, err)
@@ -10880,64 +11004,7 @@ func TestVMImportAliasing(t *testing.T) {
 
 		// Compile and run main program
 
-		checker, err := ParseAndCheckWithOptions(t,
-			`
-			import C as SomeContract, S as SomeStruct, v as SomeFunc from 0x01
-
-			fun test(): Int {
-				return SomeContract.v() + SomeStruct().v() + SomeFunc()
-			}
-            `,
-			ParseAndCheckOptions{
-				CheckerConfig: &sema.Config{
-					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
-						require.IsType(t, common.AddressLocation{}, location)
-						addressLocation := location.(common.AddressLocation)
-						var elaboration *sema.Elaboration
-						switch addressLocation.Address {
-						case address:
-							elaboration = fooChecker.Elaboration
-						default:
-							assert.FailNow(t, "invalid location")
-						}
-
-						return sema.ElaborationImport{
-							Elaboration: elaboration,
-						}, nil
-					},
-					LocationHandler: func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
-
-						require.Equal(t,
-							common.AddressLocation{
-								Address: address,
-								Name:    "",
-							},
-							location,
-						)
-
-						for _, identifier := range identifiers {
-							result = append(result, sema.ResolvedLocation{
-								Location: common.AddressLocation{
-									Address: location.(common.AddressLocation).Address,
-									Name:    identifier.Identifier,
-								},
-								Identifiers: []ast.Identifier{
-									identifier,
-								},
-							})
-						}
-						return
-					},
-				},
-			},
-		)
-		require.NoError(t, err)
-
-		comp := compiler.NewInstructionCompiler(
-			interpreter.ProgramFromChecker(checker),
-			checker.Location,
-		)
-		comp.Config.LocationHandler = func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
+		locationHandler := func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
 
 			require.Equal(t,
 				common.AddressLocation{
@@ -10960,6 +11027,43 @@ func TestVMImportAliasing(t *testing.T) {
 			}
 			return
 		}
+
+		checker, err := ParseAndCheckWithOptions(t,
+			`
+              import C as SomeContract, S as SomeStruct, v as SomeFunc from 0x01
+
+              fun test(): Int {
+                  return SomeContract.v() + SomeStruct().v() + SomeFunc()
+              }
+            `,
+			ParseAndCheckOptions{
+				CheckerConfig: &sema.Config{
+					LocationHandler: locationHandler,
+					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
+						require.IsType(t, common.AddressLocation{}, location)
+						addressLocation := location.(common.AddressLocation)
+						var elaboration *sema.Elaboration
+						switch addressLocation.Address {
+						case address:
+							elaboration = fooChecker.Elaboration
+						default:
+							assert.FailNow(t, "invalid location")
+						}
+
+						return sema.ElaborationImport{
+							Elaboration: elaboration,
+						}, nil
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		comp := compiler.NewInstructionCompiler(
+			interpreter.ProgramFromChecker(checker),
+			checker.Location,
+		)
+		comp.Config.LocationHandler = locationHandler
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
 			return fooProgram
 		}
@@ -10972,14 +11076,12 @@ func TestVMImportAliasing(t *testing.T) {
 		vmConfig.BuiltinGlobalsProvider = VMBuiltinGlobalsProviderWithDefaultsAndPanic
 		_, fooContractValue := initializeContract(
 			t,
-			common.AddressLocation{
-				Address: address,
-				Name:    "C",
-			},
+			fooLocation,
 			fooProgram,
 			vmConfig,
 		)
 		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+			require.Equal(t, fooLocation, location)
 			return fooContractValue
 		}
 		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
@@ -11009,15 +11111,17 @@ func TestVMImportAliasing(t *testing.T) {
 
 		address := common.MustBytesToAddress([]byte{0x1})
 
+		fooLocation := common.AddressLocation{
+			Address: address,
+			Name:    "S",
+		}
+
 		fooChecker, err := ParseAndCheckWithOptions(t,
 			`
-			struct S {}
+            struct S {}
             `,
 			ParseAndCheckOptions{
-				Location: common.AddressLocation{
-					Address: address,
-					Name:    "S",
-				},
+				Location: fooLocation,
 			},
 		)
 		require.NoError(t, err)
@@ -11030,17 +11134,20 @@ func TestVMImportAliasing(t *testing.T) {
 
 		// Compile and run main program
 
+		locationHandler := SingleIdentifierLocationResolver(t)
+
 		checker, err := ParseAndCheckWithOptions(t,
 			`
-			import S as SomeStruct from 0x01
+            import S as SomeStruct from 0x01
 
-			fun test(): String {
-				var s = SomeStruct()
-				return s.getType().identifier
-			}
+            fun test(): String {
+                var s = SomeStruct()
+                return s.getType().identifier
+            }
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
+					LocationHandler: locationHandler,
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.IsType(t, common.AddressLocation{}, location)
 						addressLocation := location.(common.AddressLocation)
@@ -11056,29 +11163,6 @@ func TestVMImportAliasing(t *testing.T) {
 							Elaboration: elaboration,
 						}, nil
 					},
-					LocationHandler: func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
-
-						require.Equal(t,
-							common.AddressLocation{
-								Address: address,
-								Name:    "",
-							},
-							location,
-						)
-
-						for _, identifier := range identifiers {
-							result = append(result, sema.ResolvedLocation{
-								Location: common.AddressLocation{
-									Address: location.(common.AddressLocation).Address,
-									Name:    identifier.Identifier,
-								},
-								Identifiers: []ast.Identifier{
-									identifier,
-								},
-							})
-						}
-						return
-					},
 				},
 			},
 		)
@@ -11088,36 +11172,16 @@ func TestVMImportAliasing(t *testing.T) {
 			interpreter.ProgramFromChecker(checker),
 			checker.Location,
 		)
-		comp.Config.LocationHandler = func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
-
-			require.Equal(t,
-				common.AddressLocation{
-					Address: address,
-					Name:    "",
-				},
-				location,
-			)
-
-			for _, identifier := range identifiers {
-				result = append(result, sema.ResolvedLocation{
-					Location: common.AddressLocation{
-						Address: location.(common.AddressLocation).Address,
-						Name:    identifier.Identifier,
-					},
-					Identifiers: []ast.Identifier{
-						identifier,
-					},
-				})
-			}
-			return
-		}
+		comp.Config.LocationHandler = locationHandler
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, fooLocation, location)
 			return fooProgram
 		}
 
 		program := comp.Compile()
 		vmConfig := vm.NewConfig(NewUnmeteredInMemoryStorage())
 		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, fooLocation, location)
 			return fooProgram
 		}
 		vmConfig.BuiltinGlobalsProvider = VMBuiltinGlobalsProviderWithDefaultsAndPanic
@@ -11148,21 +11212,22 @@ func TestVMImportAliasing(t *testing.T) {
 
 		address := common.MustBytesToAddress([]byte{0x1})
 
+		fooLocation := common.AddressLocation{
+			Address: address,
+			Name:    "Foo",
+		}
 		fooChecker, err := ParseAndCheckWithOptions(t,
 			`
-			access(all) contract Foo {
-				access(all) struct Foo1 {
-					fun Test(): Int {
-						return 1
-					}
-				}
-			}
+            access(all) contract Foo {
+                access(all) struct Foo1 {
+                    fun Test(): Int {
+                        return 1
+                    }
+                }
+            }
             `,
 			ParseAndCheckOptions{
-				Location: common.AddressLocation{
-					Address: address,
-					Name:    "Foo",
-				},
+				Location: fooLocation,
 			},
 		)
 		require.NoError(t, err)
@@ -11175,17 +11240,20 @@ func TestVMImportAliasing(t *testing.T) {
 
 		// Compile and run main program
 
+		locationHandler := SingleIdentifierLocationResolver(t)
+
 		checker, err := ParseAndCheckWithOptions(t,
 			`
-			import Foo as Foo1 from 0x01
+            import Foo as Foo1 from 0x01
 
-			access(all) fun test(): Int {
-				var foo = Foo1.Foo1()
-				return foo.Test()
-			}
+            access(all) fun test(): Int {
+                var foo = Foo1.Foo1()
+                return foo.Test()
+            }
             `,
 			ParseAndCheckOptions{
 				CheckerConfig: &sema.Config{
+					LocationHandler: locationHandler,
 					ImportHandler: func(_ *sema.Checker, location common.Location, _ ast.Range) (sema.Import, error) {
 						require.IsType(t, common.AddressLocation{}, location)
 						addressLocation := location.(common.AddressLocation)
@@ -11201,29 +11269,6 @@ func TestVMImportAliasing(t *testing.T) {
 							Elaboration: elaboration,
 						}, nil
 					},
-					LocationHandler: func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
-
-						require.Equal(t,
-							common.AddressLocation{
-								Address: address,
-								Name:    "",
-							},
-							location,
-						)
-
-						for _, identifier := range identifiers {
-							result = append(result, sema.ResolvedLocation{
-								Location: common.AddressLocation{
-									Address: location.(common.AddressLocation).Address,
-									Name:    identifier.Identifier,
-								},
-								Identifiers: []ast.Identifier{
-									identifier,
-								},
-							})
-						}
-						return
-					},
 				},
 			},
 		)
@@ -11233,30 +11278,9 @@ func TestVMImportAliasing(t *testing.T) {
 			interpreter.ProgramFromChecker(checker),
 			checker.Location,
 		)
-		comp.Config.LocationHandler = func(identifiers []ast.Identifier, location common.Location) (result []sema.ResolvedLocation, err error) {
-
-			require.Equal(t,
-				common.AddressLocation{
-					Address: address,
-					Name:    "",
-				},
-				location,
-			)
-
-			for _, identifier := range identifiers {
-				result = append(result, sema.ResolvedLocation{
-					Location: common.AddressLocation{
-						Address: location.(common.AddressLocation).Address,
-						Name:    identifier.Identifier,
-					},
-					Identifiers: []ast.Identifier{
-						identifier,
-					},
-				})
-			}
-			return
-		}
+		comp.Config.LocationHandler = locationHandler
 		comp.Config.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, fooLocation, location)
 			return fooProgram
 		}
 
@@ -11265,17 +11289,16 @@ func TestVMImportAliasing(t *testing.T) {
 		vmConfig.BuiltinGlobalsProvider = VMBuiltinGlobalsProviderWithDefaultsAndPanic
 		_, fooContractValue := initializeContract(
 			t,
-			common.AddressLocation{
-				Address: address,
-				Name:    "Foo",
-			},
+			fooLocation,
 			fooProgram,
 			vmConfig,
 		)
 		vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
+			require.Equal(t, fooLocation, location)
 			return fooProgram
 		}
 		vmConfig.ContractValueHandler = func(_ *vm.Context, location common.Location) *interpreter.CompositeValue {
+			require.Equal(t, fooLocation, location)
 			return fooContractValue
 		}
 		vmConfig.CompositeTypeHandler = func(location common.Location, typeID interpreter.TypeID) *sema.CompositeType {
@@ -11321,7 +11344,7 @@ func TestImportSameProgramFromMultiplePaths(t *testing.T) {
 
 	locationA := common.NewAddressLocation(
 		nil,
-		common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+		common.MustBytesToAddress([]byte{0x1}),
 		"A",
 	)
 
@@ -11350,7 +11373,7 @@ func TestImportSameProgramFromMultiplePaths(t *testing.T) {
 	// Program B
 	locationB := common.NewAddressLocation(
 		nil,
-		common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+		common.MustBytesToAddress([]byte{0x2}),
 		"B",
 	)
 
@@ -11381,7 +11404,7 @@ func TestImportSameProgramFromMultiplePaths(t *testing.T) {
 
 	locationC := common.NewAddressLocation(
 		nil,
-		common.Address{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3},
+		common.MustBytesToAddress([]byte{0x3}),
 		"C",
 	)
 
@@ -11545,7 +11568,7 @@ func TestBorrowContractLinksGlobals(t *testing.T) {
 		return nil
 	}
 	vmConfig.ImportHandler = func(location common.Location) *bbq.InstructionProgram {
-		assert.Equal(t,
+		require.Equal(t,
 			contractLocation,
 			location,
 		)


### PR DESCRIPTION
Work towards #3804 

## Description

Several benchmarks were broken, as they were not run in CI. Fix CI and the benchmarks. Mostly, new required configuration handlers were missing.

Also improve tests, and add assertions for locations, which were in some cases wrong (checked as `0x1000000000000000` instead of the intended `0x1`, due to `common.Address{0x1}`).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
