### PR TITLE
[Compiler] Fix performance regression

### DIFF
--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -50,12 +50,12 @@ type Context struct {
 	containerValueIteration       map[atree.ValueID]int
 	destroyedResources            map[atree.ValueID]struct{}
 
-	// semaTypes is a cache-alike for temporary storing sema-types by their ID,
+	// semaTypeCache is a cache-alike for temporary storing sema-types by their ID,
 	// to avoid repeated conversions from static-types to sema-types.
 	// This cache-alike is maintained per execution.
 	// TODO: Re-use the conversions from the compiler.
 	// TODO: Maybe extend/share this between executions.
-	semaTypes map[sema.TypeID]sema.Type
+	semaTypeCache map[sema.TypeID]sema.Type
 
 	// linkedGlobalsCache is a local cache-alike that is being used to hold already linked imports.
 	linkedGlobalsCache map[common.Location]LinkedGlobals
@@ -73,6 +73,15 @@ func NewContext(config *Config) *Context {
 	return &Context{
 		Config: config,
 	}
+}
+
+func (c *Context) newReusing() *Context {
+	newContext := NewContext(c.Config)
+
+	newContext.semaTypeCache = c.semaTypeCache
+	newContext.linkedGlobalsCache = c.linkedGlobalsCache
+
+	return newContext
 }
 
 func (c *Context) RecordStorageMutation() {
@@ -347,7 +356,7 @@ func (c *Context) DefaultDestroyEvents(
 
 func (c *Context) SemaTypeFromStaticType(staticType interpreter.StaticType) sema.Type {
 	typeID := staticType.ID()
-	semaType, ok := c.semaTypes[typeID]
+	semaType, ok := c.semaTypeCache[typeID]
 	if ok {
 		return semaType
 	}
@@ -355,10 +364,10 @@ func (c *Context) SemaTypeFromStaticType(staticType interpreter.StaticType) sema
 	// TODO: avoid the sema-type conversion
 	semaType = interpreter.MustConvertStaticToSemaType(staticType, c)
 
-	if c.semaTypes == nil {
-		c.semaTypes = make(map[sema.TypeID]sema.Type)
+	if c.semaTypeCache == nil {
+		c.semaTypeCache = make(map[sema.TypeID]sema.Type)
 	}
-	c.semaTypes[typeID] = semaType
+	c.semaTypeCache[typeID] = semaType
 
 	return semaType
 }

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -64,9 +64,7 @@ func NewVM(
 		context: context,
 	}
 
-	// Delegate the function invocations to the vm.
-	context.invokeFunction = vm.invokeFunction
-	context.lookupFunction = vm.lookupFunction
+	vm.configureContext()
 
 	context.recoverErrors = vm.RecoverErrors
 
@@ -1822,10 +1820,8 @@ func (vm *VM) Reset() {
 	vm.callstack = vm.callstack[:0]
 	vm.ipStack = vm.ipStack[:0]
 
-	context := NewContext(vm.context.Config)
-	context.invokeFunction = vm.invokeFunction
-	context.lookupFunction = vm.lookupFunction
-	vm.context = context
+	vm.context = vm.context.newReusing()
+	vm.configureContext()
 }
 
 func (vm *VM) Global(name string) Value {
@@ -1935,6 +1931,14 @@ func (vm *VM) RecoverErrors(onError func(error)) {
 
 		onError(interpreterErr)
 	}
+}
+
+func (vm *VM) configureContext() {
+	context := vm.context
+
+	// Delegate function invocations to the VM
+	context.invokeFunction = vm.invokeFunction
+	context.lookupFunction = vm.lookupFunction
 }
 
 func printInstructionError(


### PR DESCRIPTION
Work towards #3804 

## Description

Previous refactors of the sema type and linking caches caused a performance regression. 

Reuse the caches when reusing contexts.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
