### PR TITLE
Remove wabt

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,9 +30,6 @@ jobs:
         run: echo "benchmark_repetitions=7" >> "$GITHUB_OUTPUT"
         id: settings
 
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install wabt
-
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,6 @@ jobs:
     name: "${{ github.event.inputs.version }}"
     runs-on: ubuntu-latest
     steps:
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install wabt
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,6 @@ While not perfect, number of comments is a reasonable proxy for impact a given c
 You need some software installed to build and test Cadence:
 
 - [Go](https://golang.org/doc/install)
-- [wasm2wat](https://github.com/WebAssembly/wabt)
 
 ### Pull Requests
 


### PR DESCRIPTION

## Description

Wabt / wat2wasm was used for the PoC WebAssembly compiler/VM, which was removed in #3705

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
