### PR TITLE
Speed up benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,36 +24,80 @@ jobs:
     name: Performance regression check
     runs-on: ubuntu-latest
     steps:
-      - name: Set benchmark settings
-        # reducing repetition and time will speed up execution,
-        # but will be more inaccurate at detecting change
-        run: |
-          echo "benchmark_repetitions=2" >> "$GITHUB_OUTPUT"
-          echo "benchmark_time=2s" >> "$GITHUB_OUTPUT"
-        id: settings
 
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
+      - name: Detect changed components
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            encoding:
+              - 'encoding/**'
+            parser:
+              - 'parser/**'
+            sema:
+              - 'sema/**'
+            bbq:
+              - 'bbq/**'
+
+      - name: Set benchmark settings
+        # reducing repetition and time will speed up execution,
+        # but will be more inaccurate at detecting change
+        run: |
+          echo "benchmark_repetitions=2" >> "$GITHUB_OUTPUT"
+          echo "benchmark_time=2s" >> "$GITHUB_OUTPUT"
+
+        id: settings
+
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Run benchmark on current branch
-        shell: bash
-        run: |
-            make bench BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee new.txt
+      - name: Run unconditional benchmarks, on current branch
+        run: make bench-common BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee new.txt
+
+      - name: Run encoding benchmarks, on current branch
+        if: steps.changes.outputs.encoding == 'true'
+        run: make bench BENCH_PKGS=./encoding/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a new.txt
+
+      - name: Run parser benchmarks, on current branch
+        if: steps.changes.outputs.parser == 'true'
+        run: make bench BENCH_PKGS=./parser/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a new.txt
+
+      - name: Run sema benchmarks, on current branch
+        if: steps.changes.outputs.sema == 'true'
+        run: make bench BENCH_PKGS=./sema/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a new.txt
+
+      - name: Run compiler/VM benchmarks, on current branch
+        if: steps.changes.outputs.bbq == 'true'
+        run: make bench BENCH_PKGS=./bbq/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a new.txt
 
       - name: Checkout base branch
         run: git checkout ${{ github.event.pull_request.base.sha }}
 
-      - name: Run benchmark on base branch
-        shell: bash
-        run: |
-          make bench BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee old.txt
+      - name: Run unconditional benchmarks, on base branch
+        run: make bench-common BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee old.txt
+
+      - name: Run encoding benchmarks, on current branch
+        if: steps.changes.outputs.encoding == 'true'
+        run: make bench BENCH_PKGS=./encoding/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a old.txt
+
+      - name: Run parser benchmarks, on current branch
+        if: steps.changes.outputs.parser == 'true'
+        run: make bench BENCH_PKGS=./parser/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a old.txt
+
+      - name: Run sema benchmarks, on current branch
+        if: steps.changes.outputs.sema == 'true'
+        run: make bench BENCH_PKGS=./sema/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a old.txt
+
+      - name: Run compiler/VM benchmarks, on current branch
+        if: steps.changes.outputs.bbq == 'true'
+        run: make bench BENCH_PKGS=./bbq/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a old.txt
 
       # see https://trstringer.com/github-actions-multiline-strings/ to see why this part is complex
       - name: Use benchstat for comparison
@@ -70,7 +114,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
-          body-includes: "## Cadence [Benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) comparison"
+          body-includes: "## [Benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) comparison"
 
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v1
@@ -78,13 +122,13 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ## Cadence [Benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) comparison
-            This branch with compared with the base branch ${{  github.event.pull_request.base.label }} commit ${{ github.event.pull_request.base.sha }}
-            The command `for i in {1..N}; do go test ./... -run=XXX -bench=. -benchmem -shuffle=on; done` was used.
-            Bench tests were run a total of ${{ steps.settings.outputs.benchmark_repetitions }} times on each branch.
+            ## [Benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) comparison
+
+            - Base branch: ${{  github.event.pull_request.base.label }}
+            - Base commit: ${{ github.event.pull_request.base.sha }}
 
             <details>
-            <summary>Collapsed results for better readability</summary>
+            <summary>Results</summary>
             <p>
 
             ${{ env.BENCHSTAT }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,13 @@ jobs:
       - name: Set benchmark repetitions
         # reducing repetition will speed up execution,
         # but will be more inaccurate at detecting change
-        run: echo "benchmark_repetitions=7" >> "$GITHUB_OUTPUT"
+        run: echo "benchmark_repetitions=2" >> "$GITHUB_OUTPUT"
+        id: settings
+
+      - name: Set benchmark time
+        # reducing time will speed up execution,
+        # but will be more inaccurate at detecting change
+        run: echo "benchmark_time=2s" >> "$GITHUB_OUTPUT"
         id: settings
 
       - name: Install dependencies
@@ -43,14 +49,10 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Build
-        run: make -j8 build
-
       - name: Run benchmark on current branch
         shell: bash
         run: |
-          ( for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./... -run=XXX -bench=. -benchmem -shuffle=on; done | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\//' ) | tee new.txt
-      # the package replace line above is to make the results table more readable, since it is not fragmented by package
+            make bench BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee new.txt
 
       - name: Checkout base branch
         run: git checkout ${{ github.event.pull_request.base.sha }}
@@ -58,7 +60,7 @@ jobs:
       - name: Run benchmark on base branch
         shell: bash
         run: |
-          ( for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./... -run=XXX -bench=. -benchmem -shuffle=on; done | sed 's/pkg:.*/pkg: github.com\/onflow\/cadence\//' ) | tee old.txt
+          make bench BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee old.txt
 
       # see https://trstringer.com/github-actions-multiline-strings/ to see why this part is complex
       - name: Use benchstat for comparison

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,21 +61,11 @@ jobs:
       - name: Run unconditional benchmarks, on current branch
         run: make bench-common BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee new.txt
 
-      - name: Run encoding benchmarks, on current branch
-        if: steps.changes.outputs.encoding == 'true'
-        run: make bench BENCH_PKGS=./encoding/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a new.txt
-
-      - name: Run parser benchmarks, on current branch
-        if: steps.changes.outputs.parser == 'true'
-        run: make bench BENCH_PKGS=./parser/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a new.txt
-
-      - name: Run sema benchmarks, on current branch
-        if: steps.changes.outputs.sema == 'true'
-        run: make bench BENCH_PKGS=./sema/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a new.txt
-
-      - name: Run compiler/VM benchmarks, on current branch
-        if: steps.changes.outputs.bbq == 'true'
-        run: make bench BENCH_PKGS=./bbq/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a new.txt
+      - name: Run benchmarks for changed components, on current branch
+        run: |
+          for component in ${{ join(fromJSON(steps.changes.outputs.changes), ' ') }}; do
+              make bench BENCH_PKGS=./$component/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a new.txt
+          done
 
       - name: Checkout base branch
         run: git checkout ${{ github.event.pull_request.base.sha }}
@@ -83,21 +73,11 @@ jobs:
       - name: Run unconditional benchmarks, on base branch
         run: make bench-common BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee old.txt
 
-      - name: Run encoding benchmarks, on current branch
-        if: steps.changes.outputs.encoding == 'true'
-        run: make bench BENCH_PKGS=./encoding/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a old.txt
-
-      - name: Run parser benchmarks, on current branch
-        if: steps.changes.outputs.parser == 'true'
-        run: make bench BENCH_PKGS=./parser/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a old.txt
-
-      - name: Run sema benchmarks, on current branch
-        if: steps.changes.outputs.sema == 'true'
-        run: make bench BENCH_PKGS=./sema/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a old.txt
-
-      - name: Run compiler/VM benchmarks, on current branch
-        if: steps.changes.outputs.bbq == 'true'
-        run: make bench BENCH_PKGS=./bbq/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a old.txt
+      - name: Run benchmarks for changed components, on base branch
+        run: |
+          for component in ${{ join(fromJSON(steps.changes.outputs.changes), ' ') }}; do
+              make bench BENCH_PKGS=./$component/... BENCH_REPS=${{ steps.settings.outputs.benchmark_repetitions }} BENCH_TIME=${{ steps.settings.outputs.benchmark_time }} | tee -a old.txt
+          done
 
       # see https://trstringer.com/github-actions-multiline-strings/ to see why this part is complex
       - name: Use benchstat for comparison

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,20 +24,13 @@ jobs:
     name: Performance regression check
     runs-on: ubuntu-latest
     steps:
-      - name: Set benchmark repetitions
-        # reducing repetition will speed up execution,
+      - name: Set benchmark settings
+        # reducing repetition and time will speed up execution,
         # but will be more inaccurate at detecting change
-        run: echo "benchmark_repetitions=2" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "benchmark_repetitions=2" >> "$GITHUB_OUTPUT"
+          echo "benchmark_time=2s" >> "$GITHUB_OUTPUT"
         id: settings
-
-      - name: Set benchmark time
-        # reducing time will speed up execution,
-        # but will be more inaccurate at detecting change
-        run: echo "benchmark_time=2s" >> "$GITHUB_OUTPUT"
-        id: settings
-
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install wabt
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -66,10 +59,11 @@ jobs:
       - name: Use benchstat for comparison
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin
-          go install golang.org/x/perf/cmd/benchstat@91a04616dc65ba76dbe9e5cf746b923b1402d303
+          make install-benchstat
           echo "BENCHSTAT<<EOF" >> $GITHUB_ENV
           echo "$(benchstat -html -sort name old.txt new.txt | sed  '/<title/,/<\/style>/d' | sed 's/<!doctype html>//g')" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
+
       - name: Find existing comment on PR
         uses: peter-evans/find-comment@v1
         id: fc

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,17 @@ test-with-compiler:
 test-with-compiler-and-tracing:
 	go test -tags cadence_tracing ./interpreter/... ./runtime/... -compile=true
 
+# Benchmarking
+
+BENCH_REPS ?= 2
+BENCH_TIME ?= 2s
+
+.PHONY: bench
+bench:
+	for i in {1..$(BENCH_REPS)}; do \
+		go test ./... -run=^$$ -bench=. -benchmem -shuffle=on -benchtime=$(BENCH_TIME); \
+	done
+
 # Linting
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,8 @@ test-with-compiler-and-tracing:
 
 # Benchmarking
 
-BENCH_REPS ?= 2
-BENCH_TIME ?= 2s
+BENCH_REPS ?= 1
+BENCH_TIME ?= 3s
 BENCH_PKGS ?= $(shell go list ./... | grep -Ev '/old_parser')
 BENCH_PKGS_COMMON ?= $(shell go list ./... | grep -Ev '/old_parser|/encoding|/parser|/sema|/bbq')
 

--- a/Makefile
+++ b/Makefile
@@ -230,4 +230,5 @@ release:
 
 .PHONY: install-benchstat
 install-benchstat:
-	go install golang.org/x/perf/cmd/benchstat@7e13e04d9366
+	# Last version to support HTML output
+	go install golang.org/x/perf/cmd/benchstat@91a04616dc65ba76dbe9e5cf746b923b1402d303

--- a/Makefile
+++ b/Makefile
@@ -121,13 +121,18 @@ test-with-compiler-and-tracing:
 
 BENCH_REPS ?= 2
 BENCH_TIME ?= 2s
-BENCH_PKGS ?= ./...
+BENCH_PKGS ?= $(shell go list ./... | grep -Ev '/old_parser')
+BENCH_PKGS_COMMON ?= $(shell go list ./... | grep -Ev '/old_parser|/encoding|/parser|/sema|/bbq')
 
 .PHONY: bench
 bench:
 	for i in {1..$(BENCH_REPS)}; do \
-		go test $(BENCH_PKGS) -run=^$$ -bench=. -benchmem -shuffle=on -benchtime=$(BENCH_TIME); \
+		go test -run=^$$ -bench=. -benchmem -shuffle=on -benchtime=$(BENCH_TIME) $(BENCH_PKGS) ; \
 	done
+
+.PHONY: bench-common
+bench-common:
+	$(MAKE) bench BENCH_PKGS="$(BENCH_PKGS_COMMON)"
 
 # Linting
 

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -3417,22 +3417,6 @@ func TestResource(t *testing.T) {
 	})
 }
 
-func fib(n int) int {
-	if n < 2 {
-		return n
-	}
-	return fib(n-1) + fib(n-2)
-}
-
-func BenchmarkGoFib(b *testing.B) {
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		fib(46)
-	}
-}
-
 func TestDefaultFunctions(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
## Description

The benchmarking job works again, but takes 40mins. 

Optimize this by:

- Reducing the number of repetitions 
- Reducing the time spend per benchmark
- Running some benchmarks only when files changed: `sema`, `parser`, `encoding`, `bbq`

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
