### PR TITLE
Remove unused location range parameter from native functions

### DIFF
--- a/bbq/vm/builtin_globals.go
+++ b/bbq/vm/builtin_globals.go
@@ -100,7 +100,6 @@ func init() {
 			failConditionFunctionType,
 			func(
 				_ interpreter.NativeFunctionContext,
-				_ interpreter.LocationRange,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
 				args ...interpreter.Value,
@@ -120,7 +119,6 @@ func init() {
 			failConditionFunctionType,
 			func(
 				_ interpreter.NativeFunctionContext,
-				_ interpreter.LocationRange,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
 				args ...interpreter.Value,

--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -328,7 +328,6 @@ func (c *Context) DefaultDestroyEvents(resourceValue *interpreter.CompositeValue
 		commons.CollectEventsFunctionType,
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
 			arguments ...interpreter.Value,

--- a/bbq/vm/native_function.go
+++ b/bbq/vm/native_function.go
@@ -65,7 +65,6 @@ func AdaptNativeFunctionForVM(fn interpreter.NativeFunction) NativeFunctionVM {
 
 		return fn(
 			context,
-			interpreter.LocationRange{},
 			typeParameterGetter,
 			receiver,
 			arguments...,

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -425,7 +425,6 @@ func VMBuiltinGlobalsProviderWithDefaultsAndPanic(_ common.Location) *activation
 			stdlib.PanicFunctionType,
 			func(
 				context interpreter.NativeFunctionContext,
-				_ interpreter.LocationRange,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
 				arguments ...interpreter.Value,
@@ -548,7 +547,6 @@ func newConditionLogFunction(logs *[]string) stdlib.StandardLibraryValue {
 		"",
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
 			arguments ...interpreter.Value,

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -8850,7 +8850,6 @@ func TestFunctionInvocationWithOptionalArgs(t *testing.T) {
 		functionType,
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
 			arguments ...vm.Value,
@@ -9437,7 +9436,6 @@ func TestInjectedContract(t *testing.T) {
 		cType,
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			receiver interpreter.Value,
 			args ...interpreter.Value,
@@ -11536,7 +11534,6 @@ func TestBorrowContractLinksGlobals(t *testing.T) {
 		functionType,
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
 			args ...interpreter.Value,

--- a/interpreter/builtinfunctions_test.go
+++ b/interpreter/builtinfunctions_test.go
@@ -1110,7 +1110,6 @@ func TestInterpretNativeFunctionWithMultipleTypeParameters(t *testing.T) {
 
 	nativeFunction := func(
 		_ interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		_ ...interpreter.Value,

--- a/interpreter/container_mutation_test.go
+++ b/interpreter/container_mutation_test.go
@@ -42,7 +42,6 @@ func newAssertHelloLogFunction(t *testing.T, invoked *bool) stdlib.StandardLibra
 		"",
 		func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
 			args ...interpreter.Value,
@@ -61,7 +60,6 @@ func newAssertUnexpectedLogFunction(t *testing.T) stdlib.StandardLibraryValue {
 		"",
 		func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
 			_ ...interpreter.Value,

--- a/interpreter/for_test.go
+++ b/interpreter/for_test.go
@@ -389,7 +389,6 @@ func TestInterpretEphemeralReferencesInForLoop(t *testing.T) {
 			"",
 			func(
 				_ interpreter.NativeFunctionContext,
-				_ interpreter.LocationRange,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
 				args ...interpreter.Value,

--- a/interpreter/import_test.go
+++ b/interpreter/import_test.go
@@ -46,7 +46,6 @@ import (
 func newAddLogFunction(logs *[]string) interpreter.NativeFunction {
 	return func(
 		_ interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		arguments ...interpreter.Value,

--- a/interpreter/interface_test.go
+++ b/interpreter/interface_test.go
@@ -62,7 +62,6 @@ func parseCheckAndPrepareWithConditionLogs(
 		"",
 		func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
 			args ...interpreter.Value,

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -3941,7 +3941,6 @@ type runtimeTypeConstructor struct {
 var NativeMetaTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		typeParameterGetter TypeParameterGetter,
 		_ Value,
 		_ ...Value,
@@ -3955,7 +3954,6 @@ var NativeMetaTypeFunction = NativeFunction(
 var NativeOptionalTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -3969,7 +3967,6 @@ var NativeOptionalTypeFunction = NativeFunction(
 var NativeVariableSizedArrayTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -3983,7 +3980,6 @@ var NativeVariableSizedArrayTypeFunction = NativeFunction(
 var NativeConstantSizedArrayTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -4002,7 +3998,6 @@ var NativeConstantSizedArrayTypeFunction = NativeFunction(
 var NativeDictionaryTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -4021,7 +4016,6 @@ var NativeDictionaryTypeFunction = NativeFunction(
 var NativeCompositeTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -4035,7 +4029,6 @@ var NativeCompositeTypeFunction = NativeFunction(
 var NativeFunctionTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -4054,7 +4047,6 @@ var NativeFunctionTypeFunction = NativeFunction(
 var NativeReferenceTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -4073,7 +4065,6 @@ var NativeReferenceTypeFunction = NativeFunction(
 var NativeIntersectionTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -4090,7 +4081,6 @@ var NativeIntersectionTypeFunction = NativeFunction(
 var NativeCapabilityTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -4104,7 +4094,6 @@ var NativeCapabilityTypeFunction = NativeFunction(
 var NativeInclusiveRangeTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -4118,7 +4107,6 @@ var NativeInclusiveRangeTypeFunction = NativeFunction(
 var NativeAddressFromBytesFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -4132,7 +4120,6 @@ var NativeAddressFromBytesFunction = NativeFunction(
 var NativeAddressFromStringFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -4146,7 +4133,6 @@ var NativeAddressFromStringFunction = NativeFunction(
 func NativeConverterFunction(convert func(memoryGauge common.MemoryGauge, value Value) Value) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -4158,7 +4144,6 @@ func NativeConverterFunction(convert func(memoryGauge common.MemoryGauge, value 
 func NativeFromStringFunction(parser StringValueParser) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -4171,7 +4156,6 @@ func NativeFromStringFunction(parser StringValueParser) NativeFunction {
 func NativeFromBigEndianBytesFunction(byteLength uint, converter func(memoryGauge common.MemoryGauge, bytes []byte) Value) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		args ...Value,
@@ -4195,7 +4179,6 @@ func NativeFromBigEndianBytesFunction(byteLength uint, converter func(memoryGaug
 var NativeStringFunction = NativeFunction(
 	func(
 		_ NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		_ ...Value,
@@ -4423,7 +4406,6 @@ func NativeAccountStorageIterateFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -4640,7 +4622,6 @@ func NativeAccountStorageSaveFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -4725,7 +4706,6 @@ func NativeAccountStorageTypeFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -4820,7 +4800,6 @@ func NativeAccountStorageReadFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -4922,7 +4901,6 @@ func NativeAccountStorageBorrowFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -4997,7 +4975,6 @@ func NativeAccountStorageCheckFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -5440,7 +5417,6 @@ func getBuiltinFunctionMember(context MemberAccessibleContext, self Value, ident
 var NativeIsInstanceFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -5477,7 +5453,6 @@ func IsInstance(invocationContext InvocationContext, self Value, typeValue TypeV
 var NativeGetTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -5930,7 +5905,6 @@ func NativeCapabilityBorrowFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -6038,7 +6012,6 @@ func NativeCapabilityCheckFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,

--- a/interpreter/invocation_test.go
+++ b/interpreter/invocation_test.go
@@ -102,7 +102,6 @@ func TestInterpretSelfDeclaration(t *testing.T) {
 			``,
 			func(
 				context interpreter.NativeFunctionContext,
-				_ interpreter.LocationRange,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
 				args ...interpreter.Value,

--- a/interpreter/memory_metering_test.go
+++ b/interpreter/memory_metering_test.go
@@ -111,7 +111,6 @@ func newMeteredLogFunction(meter *testMemoryGauge, loggedString *string) stdlib.
 		``,
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
 			args ...interpreter.Value,

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -1778,7 +1778,6 @@ func TestInterpretHostFunction(t *testing.T) {
 		``,
 		func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
 			args ...interpreter.Value,
@@ -1829,7 +1828,6 @@ func TestInterpretHostFunction(t *testing.T) {
 func newAssertArgumentsFunction(t *testing.T, called *bool) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,
@@ -4956,7 +4954,6 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 			"",
 			func(
 				context interpreter.NativeFunctionContext,
-				_ interpreter.LocationRange,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
 				args ...interpreter.Value,
@@ -13349,7 +13346,6 @@ func TestInterpretSomeValueChildContainerMutation(t *testing.T) {
 func newCountAndGetKeyFunction(key int64, getKeyInvocationsCount *int) interpreter.NativeFunction {
 	return func(
 		_ interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		_ ...interpreter.Value,
@@ -13382,7 +13378,6 @@ func TestInterpretVariableDeclarationSecondValueEvaluationOrder(t *testing.T) {
 			"",
 			func(
 				_ interpreter.NativeFunctionContext,
-				_ interpreter.LocationRange,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
 				_ ...interpreter.Value,
@@ -13806,7 +13801,6 @@ func TestInterpretInvocationEvaluationAndTransferOrder(t *testing.T) {
 		"",
 		func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
 			args ...interpreter.Value,

--- a/interpreter/native_function.go
+++ b/interpreter/native_function.go
@@ -79,7 +79,6 @@ func (i *InterpreterTypeParameterGetter) NextSema() sema.Type {
 
 type NativeFunction func(
 	context NativeFunctionContext,
-	locationRange LocationRange,
 	typeParameterGetter TypeParameterGetter,
 	receiver Value,
 	args ...Value,
@@ -97,7 +96,12 @@ func AdaptNativeFunctionForInterpreter(fn NativeFunction) HostFunction {
 
 		typeParameterGetter := NewInterpreterTypeParameterGetter(context, invocation.TypeParameterTypes)
 
-		return fn(context, invocation.LocationRange, typeParameterGetter, receiver, invocation.Arguments...)
+		return fn(
+			context,
+			typeParameterGetter,
+			receiver,
+			invocation.Arguments...,
+		)
 	}
 }
 

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -349,7 +349,6 @@ func NewNativeDeletionCheckedAccountCapabilityControllerFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -358,14 +357,18 @@ func NewNativeDeletionCheckedAccountCapabilityControllerFunction(
 		// check if controller is already deleted
 		controller.CheckDeleted()
 
-		return f(context, locationRange, typeParameterGetter, receiver, args...)
+		return f(
+			context,
+			typeParameterGetter,
+			receiver,
+			args...,
+		)
 	}
 }
 
 var NativeAccountCapabilityControllerDeleteFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,
@@ -390,7 +393,6 @@ func (v *AccountCapabilityControllerValue) newDeleteFunction(
 var NativeAccountCapabilityControllerSetTagFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -290,7 +290,6 @@ func AddressValueFromString(gauge common.MemoryGauge, string *StringValue) Value
 var NativeAddressToStringFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,
@@ -303,7 +302,6 @@ var NativeAddressToStringFunction = NativeFunction(
 var NativeAddressToBytesFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -1909,7 +1909,6 @@ func (i *ArrayIterator) ValueID() (atree.ValueID, bool) {
 var NativeArrayAppendFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1925,7 +1924,6 @@ var NativeArrayAppendFunction = NativeFunction(
 var NativeArrayAppendAllFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1941,7 +1939,6 @@ var NativeArrayAppendAllFunction = NativeFunction(
 var NativeArrayConcatFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1956,7 +1953,6 @@ var NativeArrayConcatFunction = NativeFunction(
 var NativeArrayInsertFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1973,7 +1969,6 @@ var NativeArrayInsertFunction = NativeFunction(
 var NativeArrayRemoveFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1988,7 +1983,6 @@ var NativeArrayRemoveFunction = NativeFunction(
 var NativeArrayContainsFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -2003,7 +1997,6 @@ var NativeArrayContainsFunction = NativeFunction(
 var NativeArraySliceFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -2019,7 +2012,6 @@ var NativeArraySliceFunction = NativeFunction(
 var NativeArrayReverseFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,
@@ -2032,7 +2024,6 @@ var NativeArrayReverseFunction = NativeFunction(
 var NativeArrayFilterFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -2047,7 +2038,6 @@ var NativeArrayFilterFunction = NativeFunction(
 var NativeArrayMapFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -2062,7 +2052,6 @@ var NativeArrayMapFunction = NativeFunction(
 var NativeArrayToVariableSizedFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,
@@ -2076,7 +2065,6 @@ var NativeArrayToVariableSizedFunction = NativeFunction(
 var NativeArrayToConstantSizedFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -2094,7 +2082,6 @@ var NativeArrayToConstantSizedFunction = NativeFunction(
 var NativeArrayFirstIndexFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -2109,7 +2096,6 @@ var NativeArrayFirstIndexFunction = NativeFunction(
 var NativeArrayRemoveFirstFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,
@@ -2123,7 +2109,6 @@ var NativeArrayRemoveFirstFunction = NativeFunction(
 var NativeArrayRemoveLastFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -233,7 +233,6 @@ func (v CharacterValue) GetMember(context MemberAccessibleContext, name string) 
 var NativeCharacterValueToStringFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -1739,7 +1739,6 @@ func (v *CompositeValue) forEachAttachmentFunction(context FunctionCreationConte
 var NativeForEachAttachmentFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,

--- a/interpreter/value_deployedcontract.go
+++ b/interpreter/value_deployedcontract.go
@@ -73,7 +73,6 @@ func NewNativeDeployedContractPublicTypesFunctionValue(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -1571,7 +1571,6 @@ func (v *DictionaryValue) Inlined() bool {
 var NativeDictionaryRemoveFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1585,7 +1584,6 @@ var NativeDictionaryRemoveFunction = NativeFunction(
 var NativeDictionaryInsertFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1600,7 +1598,6 @@ var NativeDictionaryInsertFunction = NativeFunction(
 var NativeDictionaryContainsKeyFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1614,7 +1611,6 @@ var NativeDictionaryContainsKeyFunction = NativeFunction(
 var NativeDictionaryForEachKeyFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -98,7 +98,6 @@ var nilValueMapFunction = NewUnmeteredStaticHostFunctionValueFromNativeFunction(
 	sema.OptionalTypeMapFunctionType(NilOptionalValue.InnerValueType(nil)),
 	func(
 		_ NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		_ Value,
 		_ ...Value,

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -142,7 +142,6 @@ type BigNumberValue interface {
 var NativeNumberToStringFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,
@@ -154,7 +153,6 @@ var NativeNumberToStringFunction = NativeFunction(
 var NativeNumberToBigEndianBytesFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,
@@ -166,7 +164,6 @@ var NativeNumberToBigEndianBytesFunction = NativeFunction(
 var NativeNumberSaturatingAddFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -179,7 +176,6 @@ var NativeNumberSaturatingAddFunction = NativeFunction(
 var NativeNumberSaturatingSubtractFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -192,7 +188,6 @@ var NativeNumberSaturatingSubtractFunction = NativeFunction(
 var NativeNumberSaturatingMultiplyFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -205,7 +200,6 @@ var NativeNumberSaturatingMultiplyFunction = NativeFunction(
 var NativeNumberSaturatingDivideFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -120,7 +120,6 @@ func (v PathValue) GetMember(context MemberAccessibleContext, name string) Value
 var NativePathValueToStringFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -135,7 +135,6 @@ func (v *PathCapabilityValue) newBorrowFunction(
 		sema.CapabilityTypeBorrowFunctionType(borrowType),
 		func(
 			_ NativeFunctionContext,
-			_ LocationRange,
 			_ TypeParameterGetter,
 			_ Value,
 			_ ...Value,
@@ -156,7 +155,6 @@ func (v *PathCapabilityValue) newCheckFunction(
 		sema.CapabilityTypeCheckFunctionType(borrowType),
 		func(
 			_ NativeFunctionContext,
-			_ LocationRange,
 			_ TypeParameterGetter,
 			_ Value,
 			_ ...Value,

--- a/interpreter/value_range.go
+++ b/interpreter/value_range.go
@@ -121,7 +121,6 @@ func NewInclusiveRangeValueWithStep(
 var NativeInclusiveRangeContainsFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -508,7 +508,6 @@ func (s SomeStorable) ChildStorables() []atree.Storable {
 var NativeOptionalMapFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -358,7 +358,6 @@ func NewNativeDeletionCheckedStorageCapabilityControllerFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -366,7 +365,7 @@ func NewNativeDeletionCheckedStorageCapabilityControllerFunction(
 		controller := AssertValueOfType[*StorageCapabilityControllerValue](receiver)
 		controller.CheckDeleted()
 
-		return f(context, locationRange, typeParameterGetter, receiver, args...)
+		return f(context, typeParameterGetter, receiver, args...)
 	}
 }
 
@@ -388,7 +387,6 @@ func (v *StorageCapabilityControllerValue) newNativeHostFunctionValue(
 var NativeStorageCapabilityControllerDeleteFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,
@@ -414,7 +412,6 @@ func (v *StorageCapabilityControllerValue) newDeleteFunction(
 var NativeStorageCapabilityControllerTargetFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		_ ...Value,
@@ -437,7 +434,6 @@ func (v *StorageCapabilityControllerValue) newTargetFunction(
 var NativeStorageCapabilityControllerRetargetFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -469,7 +465,6 @@ func (v *StorageCapabilityControllerValue) newRetargetFunction(
 var NativeStorageCapabilityControllerSetTagFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -1052,7 +1052,6 @@ func (*StringValueIterator) ValueID() (atree.ValueID, bool) {
 var NativeStringEncodeHexFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1065,7 +1064,6 @@ var NativeStringEncodeHexFunction = NativeFunction(
 var NativeStringFromUtf8Function = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1078,7 +1076,6 @@ var NativeStringFromUtf8Function = NativeFunction(
 var NativeStringFromCharactersFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1091,7 +1088,6 @@ var NativeStringFromCharactersFunction = NativeFunction(
 var NativeStringJoinFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1299,7 +1295,6 @@ var stringFunction = func() Value {
 var NativeStringConcatFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1317,7 +1312,6 @@ var NativeStringConcatFunction = NativeFunction(
 var NativeStringSliceFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1332,7 +1326,6 @@ var NativeStringSliceFunction = NativeFunction(
 var NativeStringContainsFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1346,7 +1339,6 @@ var NativeStringContainsFunction = NativeFunction(
 var NativeStringIndexFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1360,7 +1352,6 @@ var NativeStringIndexFunction = NativeFunction(
 var NativeStringCountFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1374,7 +1365,6 @@ var NativeStringCountFunction = NativeFunction(
 var NativeStringDecodeHexFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1387,7 +1377,6 @@ var NativeStringDecodeHexFunction = NativeFunction(
 var NativeStringToLowerFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1400,7 +1389,6 @@ var NativeStringToLowerFunction = NativeFunction(
 var NativeStringSplitFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,
@@ -1414,7 +1402,6 @@ var NativeStringSplitFunction = NativeFunction(
 var NativeStringReplaceAllFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,

--- a/interpreter/value_test.go
+++ b/interpreter/value_test.go
@@ -1219,7 +1219,6 @@ func TestStringer(t *testing.T) {
 					},
 					func(
 						_ NativeFunctionContext,
-						_ LocationRange,
 						_ TypeParameterGetter,
 						_ Value,
 						_ ...Value,

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -359,7 +359,6 @@ func (v TypeValue) HashInput(_ common.MemoryGauge, scratch []byte) []byte {
 var NativeMetaTypeIsSubtypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		locationRange LocationRange,
 		_ TypeParameterGetter,
 		receiver Value,
 		args ...Value,

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -202,7 +202,6 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 
 		nativeFunction := func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
 			_ ...interpreter.Value,
@@ -377,7 +376,6 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 				functionType,
 				func(
 					_ interpreter.NativeFunctionContext,
-					_ interpreter.LocationRange,
 					_ interpreter.TypeParameterGetter,
 					_ interpreter.Value,
 					_ ...interpreter.Value,
@@ -453,7 +451,6 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 				functionType,
 				func(
 					_ interpreter.NativeFunctionContext,
-					_ interpreter.LocationRange,
 					_ interpreter.TypeParameterGetter,
 					_ interpreter.Value,
 					_ ...interpreter.Value,
@@ -574,7 +571,6 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 				cType,
 				func(
 					context interpreter.NativeFunctionContext,
-					_ interpreter.LocationRange,
 					_ interpreter.TypeParameterGetter,
 					receiver interpreter.Value,
 					args ...interpreter.Value,
@@ -703,7 +699,6 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 				cType,
 				func(
 					_ interpreter.NativeFunctionContext,
-					_ interpreter.LocationRange,
 					_ interpreter.TypeParameterGetter,
 					_ interpreter.Value,
 					_ ...interpreter.Value,

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -112,7 +112,6 @@ type AccountCreator interface {
 func NativeAccountConstructor(creator AccountCreator) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,
@@ -238,7 +237,6 @@ var GetAuthAccountFunctionType = func() *sema.FunctionType {
 func NativeGetAuthAccountFunction(handler AccountHandler) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		locationRange interpreter.LocationRange,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,
@@ -601,7 +599,6 @@ func nativeAccountKeysAddFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -721,7 +718,6 @@ func nativeAccountKeysGetFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -812,7 +808,6 @@ func nativeAccountKeysForEachFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -965,7 +960,6 @@ func nativeAccountKeysRevokeFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -1055,7 +1049,6 @@ func nativeAccountInboxPublishFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -1151,7 +1144,6 @@ func nativeAccountInboxUnpublishFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -1262,7 +1254,6 @@ func nativeAccountInboxClaimFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -1453,7 +1444,6 @@ func nativeAccountContractsGetFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -1540,7 +1530,6 @@ func nativeAccountContractsBorrowFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -1726,7 +1715,6 @@ func nativeAccountContractsChangeFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -2087,7 +2075,6 @@ func nativeAccountContractsTryUpdateFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -2438,7 +2425,6 @@ func nativeAccountContractsRemoveFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -2599,7 +2585,6 @@ var GetAccountFunctionType = sema.NewSimpleFunctionType(
 func NativeGetAccountFunction(handler AccountHandler) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,
@@ -2759,7 +2744,6 @@ func nativeAccountStorageCapabilitiesGetControllerFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -2840,7 +2824,6 @@ func nativeAccountStorageCapabilitiesGetControllersFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -2951,7 +2934,6 @@ func nativeAccountStorageCapabilitiesForEachControllerFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -3097,7 +3079,6 @@ func nativeAccountStorageCapabilitiesIssueFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -3177,7 +3158,6 @@ func nativeAccountStorageCapabilitiesIssueWithTypeFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -3350,7 +3330,6 @@ func nativeAccountAccountCapabilitiesIssueFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -3403,7 +3382,6 @@ func nativeAccountAccountCapabilitiesIssueWithTypeFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -4039,7 +4017,6 @@ func nativeAccountCapabilitiesPublishFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -4204,7 +4181,6 @@ func nativeAccountCapabilitiesUnpublishFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -4485,7 +4461,6 @@ func nativeAccountCapabilitiesGetFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -4732,7 +4707,6 @@ func nativeAccountCapabilitiesExistsFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		locationRange interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -4830,7 +4804,6 @@ func nativeAccountAccountCapabilitiesGetControllerFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -4897,7 +4870,6 @@ func nativeAccountAccountCapabilitiesGetControllersFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -5012,7 +4984,6 @@ func nativeAccountAccountCapabilitiesForEachControllerFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,

--- a/stdlib/assert.go
+++ b/stdlib/assert.go
@@ -58,7 +58,6 @@ var AssertFunctionType = &sema.FunctionType{
 var NativeAssertFunction = interpreter.NativeFunction(
 	func(
 		_ interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,

--- a/stdlib/block.go
+++ b/stdlib/block.go
@@ -81,7 +81,6 @@ type BlockAtHeightProvider interface {
 func NativeGetBlockFunction(provider BlockAtHeightProvider) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,
@@ -204,7 +203,6 @@ type CurrentBlockProvider interface {
 func NativeGetCurrentBlockFunction(provider CurrentBlockProvider) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		locationRange interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		_ ...interpreter.Value,

--- a/stdlib/bls.go
+++ b/stdlib/bls.go
@@ -40,7 +40,6 @@ func NativeBLSAggregatePublicKeysFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,
@@ -142,7 +141,6 @@ func NativeBLSAggregateSignaturesFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,

--- a/stdlib/hashalgorithm.go
+++ b/stdlib/hashalgorithm.go
@@ -79,7 +79,6 @@ func NewHashAlgorithmCase(
 func NativeHashAlgorithmHashFunction(hasher Hasher, hashAlgoValue interpreter.MemberAccessibleValue) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -104,7 +103,6 @@ func NativeHashAlgorithmHashFunction(hasher Hasher, hashAlgoValue interpreter.Me
 func NativeHashAlgorithmHashWithTagFunction(hasher Hasher, hashAlgoValue interpreter.MemberAccessibleValue) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -239,7 +237,6 @@ func NewVMHashAlgorithmConstructor(hasher Hasher) StandardLibraryValue {
 		hashAlgorithmLookupType,
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
 			args ...interpreter.Value,

--- a/stdlib/log.go
+++ b/stdlib/log.go
@@ -57,7 +57,6 @@ func (f FunctionLogger) ProgramLog(message string) error {
 func NativeLogFunction(logger Logger) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,

--- a/stdlib/panic.go
+++ b/stdlib/panic.go
@@ -65,7 +65,6 @@ var PanicFunctionType = sema.NewSimpleFunctionType(
 var NativePanicFunction = interpreter.NativeFunction(
 	func(
 		_ interpreter.NativeFunctionContext,
-		locationRange interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,

--- a/stdlib/publickey.go
+++ b/stdlib/publickey.go
@@ -74,7 +74,6 @@ func NativePublicKeyConstructorFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,
@@ -218,7 +217,6 @@ func NativePublicKeyVerifySignatureFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,
@@ -329,7 +327,6 @@ func NativePublicKeyVerifyPoPFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
 		args ...interpreter.Value,

--- a/stdlib/random.go
+++ b/stdlib/random.go
@@ -109,7 +109,6 @@ var ZeroModuloError = errors.NewDefaultUserError("modulo argument cannot be zero
 func NativeRevertibleRandomFunction(generator RandomGenerator) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,

--- a/stdlib/range.go
+++ b/stdlib/range.go
@@ -116,7 +116,6 @@ var inclusiveRangeConstructorFunctionType = func() *sema.FunctionType {
 var NativeInclusiveRangeConstructorFunction = interpreter.NativeFunction(
 	func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,

--- a/stdlib/rlp.go
+++ b/stdlib/rlp.go
@@ -54,7 +54,6 @@ const rlpErrMsgInputContainsExtraBytes = "input data is expected to be RLP-encod
 var NativeRLPDecodeStringFunction = interpreter.NativeFunction(
 	func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,
@@ -67,7 +66,6 @@ var NativeRLPDecodeStringFunction = interpreter.NativeFunction(
 var NativeRLPDecodeListFunction = interpreter.NativeFunction(
 	func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,

--- a/stdlib/signaturealgorithm.go
+++ b/stdlib/signaturealgorithm.go
@@ -74,7 +74,6 @@ var vmSignatureAlgorithmConstructorValue = vm.NewNativeFunctionValue(
 	signatureAlgorithmLookupType,
 	func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.LocationRange,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
 		args ...interpreter.Value,

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -173,7 +173,6 @@ func ParseCheckAndPrepareWithLogs(
 		"",
 		func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.LocationRange,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
 			args ...interpreter.Value,
@@ -352,7 +351,6 @@ func ParseCheckAndPrepareWithOptions(
 							functionValue.Type,
 							func(
 								context interpreter.NativeFunctionContext,
-								_ interpreter.LocationRange,
 								_ interpreter.TypeParameterGetter,
 								_ interpreter.Value,
 								arguments ...interpreter.Value,


### PR DESCRIPTION
Work towards #3804 

## Description

The location range parameter of `interpreter.NativeFunction` is now no longer used. Remove it.

Also remove the unnecessary conversion of function expressions to `NativeFunction` (`NativeFunction(func(...` -> `func(...`)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
