### PR TITLE
Replace variadic arguments parameters with slices

### DIFF
--- a/bbq/vm/builtin_globals.go
+++ b/bbq/vm/builtin_globals.go
@@ -102,7 +102,7 @@ func init() {
 				_ interpreter.NativeFunctionContext,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
-				args ...interpreter.Value,
+				args []interpreter.Value,
 			) interpreter.Value {
 				messageValue := args[0].(*interpreter.StringValue)
 				panic(&interpreter.ConditionError{
@@ -121,7 +121,7 @@ func init() {
 				_ interpreter.NativeFunctionContext,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
-				args ...interpreter.Value,
+				args []interpreter.Value,
 			) interpreter.Value {
 				messageValue := args[0].(*interpreter.StringValue)
 				panic(&interpreter.ConditionError{

--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -330,7 +330,7 @@ func (c *Context) DefaultDestroyEvents(resourceValue *interpreter.CompositeValue
 			context interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
-			arguments ...interpreter.Value,
+			arguments []interpreter.Value,
 		) interpreter.Value {
 			for _, argument := range arguments {
 				event := argument.(*interpreter.CompositeValue)

--- a/bbq/vm/native_function.go
+++ b/bbq/vm/native_function.go
@@ -60,14 +60,19 @@ func (g *VMTypeParameterGetter) NextSema() sema.Type {
 
 // Like in the interpreter's native_function, these are all the functions that need to exist to work with the VM
 func AdaptNativeFunctionForVM(fn interpreter.NativeFunction) NativeFunctionVM {
-	return func(context *Context, typeArguments []bbq.StaticType, receiver Value, arguments ...Value) Value {
+	return func(
+		context *Context,
+		typeArguments []bbq.StaticType,
+		receiver Value,
+		arguments []Value,
+	) Value {
 		typeParameterGetter := NewVMTypeParameterGetter(context, typeArguments)
 
 		return fn(
 			context,
 			typeParameterGetter,
 			receiver,
-			arguments...,
+			arguments,
 		)
 	}
 }

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -427,7 +427,7 @@ func VMBuiltinGlobalsProviderWithDefaultsAndPanic(_ common.Location) *activation
 				context interpreter.NativeFunctionContext,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
-				arguments ...interpreter.Value,
+				arguments []interpreter.Value,
 			) vm.Value {
 				messageValue := interpreter.AssertValueOfType[*interpreter.StringValue](arguments[0])
 
@@ -549,7 +549,7 @@ func newConditionLogFunction(logs *[]string) stdlib.StandardLibraryValue {
 			context interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
-			arguments ...interpreter.Value,
+			arguments []interpreter.Value,
 		) interpreter.Value {
 			message := arguments[0].String()
 			*logs = append(*logs, message)

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -8852,7 +8852,7 @@ func TestFunctionInvocationWithOptionalArgs(t *testing.T) {
 			context interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
-			arguments ...vm.Value,
+			arguments []vm.Value,
 		) vm.Value {
 			require.GreaterOrEqual(t, len(arguments), 1)
 
@@ -9438,7 +9438,7 @@ func TestInjectedContract(t *testing.T) {
 			context interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			receiver interpreter.Value,
-			args ...interpreter.Value,
+			args []interpreter.Value,
 		) interpreter.Value {
 			assert.Same(t, bValue, receiver)
 
@@ -11536,7 +11536,7 @@ func TestBorrowContractLinksGlobals(t *testing.T) {
 			context interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
-			args ...interpreter.Value,
+			args []interpreter.Value,
 		) vm.Value {
 			stdlib.AccountContractsBorrow(
 				context,

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -164,7 +164,7 @@ type NativeFunctionVM func(
 	context *Context,
 	typeArguments []bbq.StaticType,
 	receiver Value,
-	arguments ...Value,
+	arguments []Value,
 ) Value
 
 type NativeFunctionValue struct {

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -875,7 +875,12 @@ func invokeFunction(
 			}()
 		}
 
-		result := functionValue.Function(context, typeArguments, receiver, arguments...)
+		result := functionValue.Function(
+			context,
+			typeArguments,
+			receiver,
+			arguments,
+		)
 		vm.push(result)
 
 	default:

--- a/interpreter/builtinfunctions_test.go
+++ b/interpreter/builtinfunctions_test.go
@@ -1112,7 +1112,7 @@ func TestInterpretNativeFunctionWithMultipleTypeParameters(t *testing.T) {
 		_ interpreter.NativeFunctionContext,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		_ ...interpreter.Value,
+		_ []interpreter.Value,
 	) interpreter.Value {
 		typeValue := typeParameterGetter.NextStatic()
 		require.Equal(t, interpreter.PrimitiveStaticTypeInt, typeValue)

--- a/interpreter/container_mutation_test.go
+++ b/interpreter/container_mutation_test.go
@@ -44,7 +44,7 @@ func newAssertHelloLogFunction(t *testing.T, invoked *bool) stdlib.StandardLibra
 			_ interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
-			args ...interpreter.Value,
+			args []interpreter.Value,
 		) interpreter.Value {
 			*invoked = true
 			assert.Equal(t, "\"hello\"", args[0].String())
@@ -62,7 +62,7 @@ func newAssertUnexpectedLogFunction(t *testing.T) stdlib.StandardLibraryValue {
 			_ interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
-			_ ...interpreter.Value,
+			_ []interpreter.Value,
 		) interpreter.Value {
 			assert.Fail(t, "unexpected call of log")
 			return interpreter.Void

--- a/interpreter/for_test.go
+++ b/interpreter/for_test.go
@@ -391,7 +391,7 @@ func TestInterpretEphemeralReferencesInForLoop(t *testing.T) {
 				_ interpreter.NativeFunctionContext,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
-				args ...interpreter.Value,
+				args []interpreter.Value,
 			) interpreter.Value {
 				check(args[0])
 				return interpreter.Void

--- a/interpreter/import_test.go
+++ b/interpreter/import_test.go
@@ -48,7 +48,7 @@ func newAddLogFunction(logs *[]string) interpreter.NativeFunction {
 		_ interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		arguments ...interpreter.Value,
+		arguments []interpreter.Value,
 	) interpreter.Value {
 		value := arguments[0]
 		*logs = append(*logs, value.String())

--- a/interpreter/interface_test.go
+++ b/interpreter/interface_test.go
@@ -64,7 +64,7 @@ func parseCheckAndPrepareWithConditionLogs(
 			_ interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
-			args ...interpreter.Value,
+			args []interpreter.Value,
 		) interpreter.Value {
 			value := args[0]
 			logs = append(logs, value.String())

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -3943,7 +3943,7 @@ var NativeMetaTypeFunction = NativeFunction(
 		context NativeFunctionContext,
 		typeParameterGetter TypeParameterGetter,
 		_ Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		staticType := typeParameterGetter.NextStatic()
 
@@ -3956,7 +3956,7 @@ var NativeOptionalTypeFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		typeValue := AssertValueOfType[TypeValue](args[0])
 
@@ -3969,7 +3969,7 @@ var NativeVariableSizedArrayTypeFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		typeValue := AssertValueOfType[TypeValue](args[0])
 
@@ -3982,7 +3982,7 @@ var NativeConstantSizedArrayTypeFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		typeValue := AssertValueOfType[TypeValue](args[0])
 		sizeValue := AssertValueOfType[IntValue](args[1])
@@ -4000,7 +4000,7 @@ var NativeDictionaryTypeFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		keyTypeValue := AssertValueOfType[TypeValue](args[0])
 		valueTypeValue := AssertValueOfType[TypeValue](args[1])
@@ -4018,7 +4018,7 @@ var NativeCompositeTypeFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		typeIDValue := AssertValueOfType[*StringValue](args[0])
 
@@ -4031,7 +4031,7 @@ var NativeFunctionTypeFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		parameterTypeValues := AssertValueOfType[*ArrayValue](args[0])
 		returnTypeValue := AssertValueOfType[TypeValue](args[1])
@@ -4049,7 +4049,7 @@ var NativeReferenceTypeFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		entitlementValues := AssertValueOfType[*ArrayValue](args[0])
 		typeValue := AssertValueOfType[TypeValue](args[1])
@@ -4067,7 +4067,7 @@ var NativeIntersectionTypeFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		intersectionIDs := AssertValueOfType[*ArrayValue](args[0])
 
@@ -4083,7 +4083,7 @@ var NativeCapabilityTypeFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		typeValue := AssertValueOfType[TypeValue](args[0])
 
@@ -4096,7 +4096,7 @@ var NativeInclusiveRangeTypeFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		typeValue := AssertValueOfType[TypeValue](args[0])
 
@@ -4109,7 +4109,7 @@ var NativeAddressFromBytesFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		byteArray := AssertValueOfType[*ArrayValue](args[0])
 
@@ -4122,7 +4122,7 @@ var NativeAddressFromStringFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		string := AssertValueOfType[*StringValue](args[0])
 
@@ -4135,7 +4135,7 @@ func NativeConverterFunction(convert func(memoryGauge common.MemoryGauge, value 
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		return convert(context, args[0])
 	}
@@ -4146,7 +4146,7 @@ func NativeFromStringFunction(parser StringValueParser) NativeFunction {
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		argument := AssertValueOfType[*StringValue](args[0])
 		return parser(context, argument.Str)
@@ -4158,7 +4158,7 @@ func NativeFromBigEndianBytesFunction(byteLength uint, converter func(memoryGaug
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		argument := AssertValueOfType[*ArrayValue](args[0])
 
@@ -4181,7 +4181,7 @@ var NativeStringFunction = NativeFunction(
 		_ NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		return EmptyString
 	},
@@ -4408,7 +4408,7 @@ func NativeAccountStorageIterateFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		address := GetAddressValue(receiver, addressPointer).ToAddress()
 
@@ -4624,7 +4624,7 @@ func NativeAccountStorageSaveFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		addressValue := GetAddressValue(receiver, addressPointer)
 
@@ -4708,7 +4708,7 @@ func NativeAccountStorageTypeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		address := GetAddressValue(receiver, addressPointer).ToAddress()
 
@@ -4802,7 +4802,7 @@ func NativeAccountStorageReadFunction(
 		context NativeFunctionContext,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		address := GetAddressValue(receiver, addressPointer).ToAddress()
 		semaBorrowType := typeParameterGetter.NextSema()
@@ -4903,7 +4903,7 @@ func NativeAccountStorageBorrowFunction(
 		context NativeFunctionContext,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		address := GetAddressValue(receiver, addressPointer).ToAddress()
 		typeParameter := typeParameterGetter.NextSema()
@@ -4977,7 +4977,7 @@ func NativeAccountStorageCheckFunction(
 		context NativeFunctionContext,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		address := GetAddressValue(receiver, addressPointer).ToAddress()
 		typeParameter := typeParameterGetter.NextSema()
@@ -5419,7 +5419,7 @@ var NativeIsInstanceFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		typeValue := AssertValueOfType[TypeValue](args[0])
 		return IsInstance(context, receiver, typeValue)
@@ -5455,7 +5455,7 @@ var NativeGetTypeFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		return ValueGetType(context, receiver)
 	},
@@ -5907,7 +5907,7 @@ func NativeCapabilityBorrowFunction(
 		context NativeFunctionContext,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		var capabilityBorrowType *sema.ReferenceType
 		var capabilityID UInt64Value
@@ -6014,7 +6014,7 @@ func NativeCapabilityCheckFunction(
 		context NativeFunctionContext,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		var capabilityBorrowType *sema.ReferenceType
 		var capabilityID UInt64Value

--- a/interpreter/invocation_test.go
+++ b/interpreter/invocation_test.go
@@ -104,7 +104,7 @@ func TestInterpretSelfDeclaration(t *testing.T) {
 				context interpreter.NativeFunctionContext,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
-				args ...interpreter.Value,
+				args []interpreter.Value,
 			) interpreter.Value {
 				// Check that the *caller's* self
 

--- a/interpreter/memory_metering_test.go
+++ b/interpreter/memory_metering_test.go
@@ -113,7 +113,7 @@ func newMeteredLogFunction(meter *testMemoryGauge, loggedString *string) stdlib.
 			context interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
-			args ...interpreter.Value,
+			args []interpreter.Value,
 		) interpreter.Value {
 			// Reset gauge, to only capture the values metered during string conversion
 			meter.meter = make(map[common.MemoryKind]uint64)

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -1780,7 +1780,7 @@ func TestInterpretHostFunction(t *testing.T) {
 			_ interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
-			args ...interpreter.Value,
+			args []interpreter.Value,
 		) interpreter.Value {
 			a := args[0].(interpreter.IntValue).ToBigInt(nil)
 			b := args[1].(interpreter.IntValue).ToBigInt(nil)
@@ -1830,7 +1830,7 @@ func newAssertArgumentsFunction(t *testing.T, called *bool) interpreter.NativeFu
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		*called = true
 
@@ -4956,7 +4956,7 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 				context interpreter.NativeFunctionContext,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
-				args ...interpreter.Value,
+				args []interpreter.Value,
 			) interpreter.Value {
 				authorized := bool(args[0].(interpreter.BoolValue))
 
@@ -13348,7 +13348,7 @@ func newCountAndGetKeyFunction(key int64, getKeyInvocationsCount *int) interpret
 		_ interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		_ ...interpreter.Value,
+		_ []interpreter.Value,
 	) interpreter.Value {
 		*getKeyInvocationsCount++
 		return interpreter.NewUnmeteredIntValueFromInt64(key)
@@ -13380,7 +13380,7 @@ func TestInterpretVariableDeclarationSecondValueEvaluationOrder(t *testing.T) {
 				_ interpreter.NativeFunctionContext,
 				_ interpreter.TypeParameterGetter,
 				_ interpreter.Value,
-				_ ...interpreter.Value,
+				_ []interpreter.Value,
 			) interpreter.Value {
 				getKeyInvocationsCount++
 				return interpreter.NewUnmeteredStringValue(key)
@@ -13803,7 +13803,7 @@ func TestInterpretInvocationEvaluationAndTransferOrder(t *testing.T) {
 			_ interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
-			args ...interpreter.Value,
+			args []interpreter.Value,
 		) interpreter.Value {
 			require.Len(t, args, 2)
 

--- a/interpreter/native_function.go
+++ b/interpreter/native_function.go
@@ -81,7 +81,7 @@ type NativeFunction func(
 	context NativeFunctionContext,
 	typeParameterGetter TypeParameterGetter,
 	receiver Value,
-	args ...Value,
+	args []Value,
 ) Value
 
 // These are all the functions that need to exist to work with the interpreter
@@ -100,7 +100,7 @@ func AdaptNativeFunctionForInterpreter(fn NativeFunction) HostFunction {
 			context,
 			typeParameterGetter,
 			receiver,
-			invocation.Arguments...,
+			invocation.Arguments,
 		)
 	}
 }

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -351,7 +351,7 @@ func NewNativeDeletionCheckedAccountCapabilityControllerFunction(
 		context NativeFunctionContext,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		controller := AssertValueOfType[*AccountCapabilityControllerValue](receiver)
 		// check if controller is already deleted
@@ -361,7 +361,7 @@ func NewNativeDeletionCheckedAccountCapabilityControllerFunction(
 			context,
 			typeParameterGetter,
 			receiver,
-			args...,
+			args,
 		)
 	}
 }
@@ -371,7 +371,7 @@ var NativeAccountCapabilityControllerDeleteFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		controller := AssertValueOfType[*AccountCapabilityControllerValue](receiver)
 		controller.Delete(context)
@@ -395,7 +395,7 @@ var NativeAccountCapabilityControllerSetTagFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		controller := AssertValueOfType[*AccountCapabilityControllerValue](receiver)
 		newTagValue := AssertValueOfType[*StringValue](args[0])

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -292,7 +292,7 @@ var NativeAddressToStringFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		address := AssertValueOfType[AddressValue](receiver)
 		return AddressValueToStringFunction(context, address)
@@ -304,7 +304,7 @@ var NativeAddressToBytesFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		address := common.Address(AssertValueOfType[AddressValue](receiver))
 		return ByteSliceToByteArrayValue(context, address[:])

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -1911,7 +1911,7 @@ var NativeArrayAppendFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 		element := args[0]
@@ -1926,7 +1926,7 @@ var NativeArrayAppendAllFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 		otherArray := AssertValueOfType[*ArrayValue](args[0])
@@ -1941,7 +1941,7 @@ var NativeArrayConcatFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 		otherArray := AssertValueOfType[*ArrayValue](args[0])
@@ -1955,7 +1955,7 @@ var NativeArrayInsertFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 		index := AssertValueOfType[NumberValue](args[0])
@@ -1971,7 +1971,7 @@ var NativeArrayRemoveFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 		index := AssertValueOfType[NumberValue](args[0])
@@ -1985,7 +1985,7 @@ var NativeArrayContainsFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 		element := args[0]
@@ -1999,7 +1999,7 @@ var NativeArraySliceFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 		fromValue := AssertValueOfType[IntValue](args[0])
@@ -2014,7 +2014,7 @@ var NativeArrayReverseFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 		return thisArray.Reverse(context)
@@ -2026,7 +2026,7 @@ var NativeArrayFilterFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 		funcValue := AssertValueOfType[FunctionValue](args[0])
@@ -2040,7 +2040,7 @@ var NativeArrayMapFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 		funcValue := AssertValueOfType[FunctionValue](args[0])
@@ -2054,7 +2054,7 @@ var NativeArrayToVariableSizedFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 
@@ -2067,7 +2067,7 @@ var NativeArrayToConstantSizedFunction = NativeFunction(
 		context NativeFunctionContext,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 		constantSizedArrayType, ok := typeParameterGetter.NextStatic().(*ConstantSizedStaticType)
@@ -2084,7 +2084,7 @@ var NativeArrayFirstIndexFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 		element := args[0]
@@ -2098,7 +2098,7 @@ var NativeArrayRemoveFirstFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 
@@ -2111,7 +2111,7 @@ var NativeArrayRemoveLastFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
 

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -235,7 +235,7 @@ var NativeCharacterValueToStringFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		character := AssertValueOfType[CharacterValue](receiver)
 		return CharacterValueToString(context, character)

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -1741,7 +1741,7 @@ var NativeForEachAttachmentFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		v := AssertValueOfType[*CompositeValue](receiver)
 		functionValue := AssertValueOfType[FunctionValue](args[0])

--- a/interpreter/value_deployedcontract.go
+++ b/interpreter/value_deployedcontract.go
@@ -75,7 +75,7 @@ func NewNativeDeployedContractPublicTypesFunctionValue(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		var address common.Address
 		if addressPointer == nil {

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -1573,7 +1573,7 @@ var NativeDictionaryRemoveFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		keyValue := args[0]
 		dictionary := AssertValueOfType[*DictionaryValue](receiver)
@@ -1586,7 +1586,7 @@ var NativeDictionaryInsertFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		keyValue := args[0]
 		newValue := args[1]
@@ -1600,7 +1600,7 @@ var NativeDictionaryContainsKeyFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		keyValue := args[0]
 		dictionary := AssertValueOfType[*DictionaryValue](receiver)
@@ -1613,7 +1613,7 @@ var NativeDictionaryForEachKeyFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		funcArgument := AssertValueOfType[FunctionValue](args[0])
 		dictionary := AssertValueOfType[*DictionaryValue](receiver)

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -100,7 +100,7 @@ var nilValueMapFunction = NewUnmeteredStaticHostFunctionValueFromNativeFunction(
 		_ NativeFunctionContext,
 		_ TypeParameterGetter,
 		_ Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		return Nil
 	},

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -144,7 +144,7 @@ var NativeNumberToStringFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		return NumberValueToString(context, receiver.(NumberValue))
 	},
@@ -155,7 +155,7 @@ var NativeNumberToBigEndianBytesFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		return ByteSliceToByteArrayValue(context, receiver.(NumberValue).ToBigEndianBytes())
 	},
@@ -166,7 +166,7 @@ var NativeNumberSaturatingAddFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		other := AssertValueOfType[NumberValue](args[0])
 		return receiver.(NumberValue).SaturatingPlus(context, other)
@@ -178,7 +178,7 @@ var NativeNumberSaturatingSubtractFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		other := AssertValueOfType[NumberValue](args[0])
 		return receiver.(NumberValue).SaturatingMinus(context, other)
@@ -190,7 +190,7 @@ var NativeNumberSaturatingMultiplyFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		other := AssertValueOfType[NumberValue](args[0])
 		return receiver.(NumberValue).SaturatingMul(context, other)
@@ -202,7 +202,7 @@ var NativeNumberSaturatingDivideFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		other := AssertValueOfType[NumberValue](args[0])
 		return receiver.(NumberValue).SaturatingDiv(context, other)

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -122,7 +122,7 @@ var NativePathValueToStringFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		path := AssertValueOfType[PathValue](receiver)
 		return PathValueToStringFunction(context, path)

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -137,7 +137,7 @@ func (v *PathCapabilityValue) newBorrowFunction(
 			_ NativeFunctionContext,
 			_ TypeParameterGetter,
 			_ Value,
-			_ ...Value,
+			_ []Value,
 		) Value {
 			// Borrowing is never allowed
 			return Nil
@@ -157,7 +157,7 @@ func (v *PathCapabilityValue) newCheckFunction(
 			_ NativeFunctionContext,
 			_ TypeParameterGetter,
 			_ Value,
-			_ ...Value,
+			_ []Value,
 		) Value {
 			// Borrowing is never allowed
 			return FalseValue

--- a/interpreter/value_range.go
+++ b/interpreter/value_range.go
@@ -123,7 +123,7 @@ var NativeInclusiveRangeContainsFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		rangeValue := AssertValueOfType[*CompositeValue](receiver)
 		needleInteger := convertAndAssertIntegerValue(args[0])

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -510,7 +510,7 @@ var NativeOptionalMapFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		optionalValue := AssertValueOfType[OptionalValue](receiver)
 		innerValueType := optionalValue.InnerValueType(context)

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -360,12 +360,17 @@ func NewNativeDeletionCheckedStorageCapabilityControllerFunction(
 		context NativeFunctionContext,
 		typeParameterGetter TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		controller := AssertValueOfType[*StorageCapabilityControllerValue](receiver)
 		controller.CheckDeleted()
 
-		return f(context, typeParameterGetter, receiver, args...)
+		return f(
+			context,
+			typeParameterGetter,
+			receiver,
+			args,
+		)
 	}
 }
 
@@ -389,7 +394,7 @@ var NativeStorageCapabilityControllerDeleteFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		controller := AssertValueOfType[*StorageCapabilityControllerValue](receiver)
 		controller.Delete(context)
@@ -414,7 +419,7 @@ var NativeStorageCapabilityControllerTargetFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		_ ...Value,
+		_ []Value,
 	) Value {
 		controller := AssertValueOfType[*StorageCapabilityControllerValue](receiver)
 		return controller.TargetPath
@@ -436,7 +441,7 @@ var NativeStorageCapabilityControllerRetargetFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		controller := AssertValueOfType[*StorageCapabilityControllerValue](receiver)
 
@@ -467,7 +472,7 @@ var NativeStorageCapabilityControllerSetTagFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		controller := AssertValueOfType[*StorageCapabilityControllerValue](receiver)
 

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -1054,7 +1054,7 @@ var NativeStringEncodeHexFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		argument := AssertValueOfType[*ArrayValue](args[0])
 		return StringFunctionEncodeHex(context, argument)
@@ -1066,7 +1066,7 @@ var NativeStringFromUtf8Function = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		argument := AssertValueOfType[*ArrayValue](args[0])
 		return StringFunctionFromUtf8(context, argument)
@@ -1078,7 +1078,7 @@ var NativeStringFromCharactersFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		argument := AssertValueOfType[*ArrayValue](args[0])
 		return StringFunctionFromCharacters(context, argument)
@@ -1090,7 +1090,7 @@ var NativeStringJoinFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		stringArray := AssertValueOfType[*ArrayValue](args[0])
 		separator := AssertValueOfType[*StringValue](args[1])
@@ -1297,7 +1297,7 @@ var NativeStringConcatFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		this := AssertValueOfType[*StringValue](receiver)
 		other := args[0]
@@ -1314,7 +1314,7 @@ var NativeStringSliceFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		from := AssertValueOfType[IntValue](args[0])
 		to := AssertValueOfType[IntValue](args[1])
@@ -1328,7 +1328,7 @@ var NativeStringContainsFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		other := AssertValueOfType[*StringValue](args[0])
 		stringValue := AssertValueOfType[*StringValue](receiver)
@@ -1341,7 +1341,7 @@ var NativeStringIndexFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		other := AssertValueOfType[*StringValue](args[0])
 		stringValue := AssertValueOfType[*StringValue](receiver)
@@ -1354,7 +1354,7 @@ var NativeStringCountFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		other := AssertValueOfType[*StringValue](args[0])
 		stringValue := AssertValueOfType[*StringValue](receiver)
@@ -1367,7 +1367,7 @@ var NativeStringDecodeHexFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		stringValue := AssertValueOfType[*StringValue](receiver)
 		return stringValue.DecodeHex(context)
@@ -1379,7 +1379,7 @@ var NativeStringToLowerFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		stringValue := AssertValueOfType[*StringValue](receiver)
 		return stringValue.ToLower(context)
@@ -1391,7 +1391,7 @@ var NativeStringSplitFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		separator := AssertValueOfType[*StringValue](args[0])
 		stringValue := AssertValueOfType[*StringValue](receiver)
@@ -1404,7 +1404,7 @@ var NativeStringReplaceAllFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		original := AssertValueOfType[*StringValue](args[0])
 		replacement := AssertValueOfType[*StringValue](args[1])

--- a/interpreter/value_test.go
+++ b/interpreter/value_test.go
@@ -1221,7 +1221,7 @@ func TestStringer(t *testing.T) {
 						_ NativeFunctionContext,
 						_ TypeParameterGetter,
 						_ Value,
-						_ ...Value,
+						_ []Value,
 					) Value {
 						return NewUnmeteredStringValue("hello")
 					},

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -361,7 +361,7 @@ var NativeMetaTypeIsSubtypeFunction = NativeFunction(
 		context NativeFunctionContext,
 		_ TypeParameterGetter,
 		receiver Value,
-		args ...Value,
+		args []Value,
 	) Value {
 		typeValue := AssertValueOfType[TypeValue](receiver)
 		otherTypeValue := AssertValueOfType[TypeValue](args[0])

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -204,7 +204,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 			_ interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
-			_ ...interpreter.Value,
+			_ []interpreter.Value,
 		) interpreter.Value {
 			return interpreter.NewUnmeteredIntValueFromInt64(2)
 		}
@@ -378,7 +378,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 					_ interpreter.NativeFunctionContext,
 					_ interpreter.TypeParameterGetter,
 					_ interpreter.Value,
-					_ ...interpreter.Value,
+					_ []interpreter.Value,
 				) interpreter.Value {
 					return interpreter.NewUnmeteredIntValueFromInt64(2)
 				},
@@ -453,7 +453,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 					_ interpreter.NativeFunctionContext,
 					_ interpreter.TypeParameterGetter,
 					_ interpreter.Value,
-					_ ...interpreter.Value,
+					_ []interpreter.Value,
 				) interpreter.Value {
 					return interpreter.NewUnmeteredIntValueFromInt64(2)
 				},
@@ -573,7 +573,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 					context interpreter.NativeFunctionContext,
 					_ interpreter.TypeParameterGetter,
 					receiver interpreter.Value,
-					args ...interpreter.Value,
+					args []interpreter.Value,
 				) interpreter.Value {
 					assert.Same(t, bValue, receiver)
 
@@ -701,7 +701,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 					_ interpreter.NativeFunctionContext,
 					_ interpreter.TypeParameterGetter,
 					_ interpreter.Value,
-					_ ...interpreter.Value,
+					_ []interpreter.Value,
 				) interpreter.Value {
 					require.Fail(t, "function should have not been called")
 					return nil

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -114,7 +114,7 @@ func NativeAccountConstructor(creator AccountCreator) interpreter.NativeFunction
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		payer := interpreter.AssertValueOfType[interpreter.MemberAccessibleValue](args[0])
 		return NewAccount(
@@ -239,7 +239,7 @@ func NativeGetAuthAccountFunction(handler AccountHandler) interpreter.NativeFunc
 		context interpreter.NativeFunctionContext,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		accountAddress := interpreter.AssertValueOfType[interpreter.AddressValue](args[0])
 
@@ -601,7 +601,7 @@ func nativeAccountKeysAddFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		publicKeyValue := interpreter.AssertValueOfType[*interpreter.CompositeValue](args[0])
 		hashAlgoValue := args[1]
@@ -720,7 +720,7 @@ func nativeAccountKeysGetFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		indexValue := interpreter.AssertValueOfType[interpreter.IntValue](args[0])
 
@@ -810,7 +810,7 @@ func nativeAccountKeysForEachFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		fnValue := interpreter.AssertValueOfType[interpreter.FunctionValue](args[0])
 
@@ -962,7 +962,7 @@ func nativeAccountKeysRevokeFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		indexValue := interpreter.AssertValueOfType[interpreter.IntValue](args[0])
 
@@ -1051,7 +1051,7 @@ func nativeAccountInboxPublishFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		value := interpreter.AssertValueOfType[interpreter.CapabilityValue](args[0])
 		nameValue := interpreter.AssertValueOfType[*interpreter.StringValue](args[1])
@@ -1146,7 +1146,7 @@ func nativeAccountInboxUnpublishFunction(
 		context interpreter.NativeFunctionContext,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		nameValue := interpreter.AssertValueOfType[*interpreter.StringValue](args[0])
 		borrowType := typeParameterGetter.NextSema()
@@ -1256,7 +1256,7 @@ func nativeAccountInboxClaimFunction(
 		context interpreter.NativeFunctionContext,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		nameValue := interpreter.AssertValueOfType[*interpreter.StringValue](args[0])
 		providerValue := interpreter.AssertValueOfType[interpreter.AddressValue](args[1])
@@ -1446,7 +1446,7 @@ func nativeAccountContractsGetFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		nameValue := interpreter.AssertValueOfType[*interpreter.StringValue](args[0])
 
@@ -1532,7 +1532,7 @@ func nativeAccountContractsBorrowFunction(
 		context interpreter.NativeFunctionContext,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		nameValue := interpreter.AssertValueOfType[*interpreter.StringValue](args[0])
 		borrowType := typeParameterGetter.NextSema()
@@ -1717,7 +1717,7 @@ func nativeAccountContractsChangeFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		argumentTypes := make([]sema.Type, len(args))
 		for i := 0; i < len(args); i++ {
@@ -2077,7 +2077,7 @@ func nativeAccountContractsTryUpdateFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) (deploymentResult interpreter.Value) {
 		var deployedContract interpreter.Value
 
@@ -2427,7 +2427,7 @@ func nativeAccountContractsRemoveFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		nameValue := interpreter.AssertValueOfType[*interpreter.StringValue](args[0])
 
@@ -2587,7 +2587,7 @@ func NativeGetAccountFunction(handler AccountHandler) interpreter.NativeFunction
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		accountAddress := interpreter.AssertValueOfType[interpreter.AddressValue](args[0])
 		return NewAccountReferenceValue(
@@ -2746,7 +2746,7 @@ func nativeAccountStorageCapabilitiesGetControllerFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		capabilityIDValue := interpreter.AssertValueOfType[interpreter.UInt64Value](args[0])
 
@@ -2826,7 +2826,7 @@ func nativeAccountStorageCapabilitiesGetControllersFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		targetPathValue := interpreter.AssertValueOfType[interpreter.PathValue](args[0])
 
@@ -2936,7 +2936,7 @@ func nativeAccountStorageCapabilitiesForEachControllerFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		targetPathValue := interpreter.AssertValueOfType[interpreter.PathValue](args[0])
 		functionValue := interpreter.AssertValueOfType[interpreter.FunctionValue](args[1])
@@ -3081,7 +3081,7 @@ func nativeAccountStorageCapabilitiesIssueFunction(
 		context interpreter.NativeFunctionContext,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		borrowType := typeParameterGetter.NextSema()
 
@@ -3160,7 +3160,7 @@ func nativeAccountStorageCapabilitiesIssueWithTypeFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		targetPathValue := interpreter.AssertValueOfType[interpreter.PathValue](args[0])
 		borrowType := interpreter.AssertValueOfType[interpreter.TypeValue](args[1])
@@ -3332,7 +3332,7 @@ func nativeAccountAccountCapabilitiesIssueFunction(
 		context interpreter.NativeFunctionContext,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		borrowType := typeParameterGetter.NextSema()
 
@@ -3384,7 +3384,7 @@ func nativeAccountAccountCapabilitiesIssueWithTypeFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		typeValue := interpreter.AssertValueOfType[interpreter.TypeValue](args[0])
 		ty, err := interpreter.ConvertStaticToSemaType(context, typeValue.Type)
@@ -4019,7 +4019,7 @@ func nativeAccountCapabilitiesPublishFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		capabilityValue := interpreter.AssertValueOfType[interpreter.CapabilityValue](args[0])
 		pathValue := interpreter.AssertValueOfType[interpreter.PathValue](args[1])
@@ -4183,7 +4183,7 @@ func nativeAccountCapabilitiesUnpublishFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		pathValue := interpreter.AssertValueOfType[interpreter.PathValue](args[0])
 
@@ -4463,7 +4463,7 @@ func nativeAccountCapabilitiesGetFunction(
 		context interpreter.NativeFunctionContext,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		pathValue := interpreter.AssertValueOfType[interpreter.PathValue](args[0])
 		typeParameter := typeParameterGetter.NextSema()
@@ -4709,7 +4709,7 @@ func nativeAccountCapabilitiesExistsFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		pathValue := interpreter.AssertValueOfType[interpreter.PathValue](args[0])
 
@@ -4806,7 +4806,7 @@ func nativeAccountAccountCapabilitiesGetControllerFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		capabilityIDValue := interpreter.AssertValueOfType[interpreter.UInt64Value](args[0])
 
@@ -4872,7 +4872,7 @@ func nativeAccountAccountCapabilitiesGetControllersFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		address := interpreter.GetAddress(receiver, addressPointer)
 
@@ -4986,7 +4986,7 @@ func nativeAccountAccountCapabilitiesForEachControllerFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		functionValue := interpreter.AssertValueOfType[interpreter.FunctionValue](args[0])
 

--- a/stdlib/assert.go
+++ b/stdlib/assert.go
@@ -60,7 +60,7 @@ var NativeAssertFunction = interpreter.NativeFunction(
 		_ interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		result := interpreter.AssertValueOfType[interpreter.BoolValue](args[0])
 		var message string

--- a/stdlib/block.go
+++ b/stdlib/block.go
@@ -83,7 +83,7 @@ func NativeGetBlockFunction(provider BlockAtHeightProvider) interpreter.NativeFu
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		heightValue := interpreter.AssertValueOfType[interpreter.UInt64Value](args[0])
 
@@ -205,7 +205,7 @@ func NativeGetCurrentBlockFunction(provider CurrentBlockProvider) interpreter.Na
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		_ ...interpreter.Value,
+		_ []interpreter.Value,
 	) interpreter.Value {
 		height, err := provider.GetCurrentBlockHeight()
 		if err != nil {

--- a/stdlib/bls.go
+++ b/stdlib/bls.go
@@ -42,7 +42,7 @@ func NativeBLSAggregatePublicKeysFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		publicKeysValue := interpreter.AssertValueOfType[*interpreter.ArrayValue](args[0])
 		return BLSAggregatePublicKeys(
@@ -143,7 +143,7 @@ func NativeBLSAggregateSignaturesFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		signaturesValue := interpreter.AssertValueOfType[*interpreter.ArrayValue](args[0])
 		return BLSAggregateSignatures(

--- a/stdlib/hashalgorithm.go
+++ b/stdlib/hashalgorithm.go
@@ -81,7 +81,7 @@ func NativeHashAlgorithmHashFunction(hasher Hasher, hashAlgoValue interpreter.Me
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		if hashAlgoValue == nil {
 			// vm does not provide the hash algo value
@@ -105,7 +105,7 @@ func NativeHashAlgorithmHashWithTagFunction(hasher Hasher, hashAlgoValue interpr
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		if hashAlgoValue == nil {
 			// vm does not provide the hash algo value
@@ -239,7 +239,7 @@ func NewVMHashAlgorithmConstructor(hasher Hasher) StandardLibraryValue {
 			context interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
-			args ...interpreter.Value,
+			args []interpreter.Value,
 		) interpreter.Value {
 			rawValue := args[0].(interpreter.UInt8Value)
 

--- a/stdlib/log.go
+++ b/stdlib/log.go
@@ -59,7 +59,7 @@ func NativeLogFunction(logger Logger) interpreter.NativeFunction {
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		value := args[0]
 		return Log(

--- a/stdlib/panic.go
+++ b/stdlib/panic.go
@@ -67,7 +67,7 @@ var NativePanicFunction = interpreter.NativeFunction(
 		_ interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		message := args[0]
 		return PanicWithError(message)

--- a/stdlib/publickey.go
+++ b/stdlib/publickey.go
@@ -76,7 +76,7 @@ func NativePublicKeyConstructorFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		publicKey := interpreter.AssertValueOfType[*interpreter.ArrayValue](args[0])
 		signAlgo := interpreter.AssertValueOfType[*interpreter.SimpleCompositeValue](args[1])
@@ -219,7 +219,7 @@ func NativePublicKeyVerifySignatureFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		signatureValue := interpreter.AssertValueOfType[*interpreter.ArrayValue](args[0])
 		signedDataValue := interpreter.AssertValueOfType[*interpreter.ArrayValue](args[1])
@@ -329,7 +329,7 @@ func NativePublicKeyVerifyPoPFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		receiver interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		signatureValue := interpreter.AssertValueOfType[*interpreter.ArrayValue](args[0])
 

--- a/stdlib/random.go
+++ b/stdlib/random.go
@@ -111,7 +111,7 @@ func NativeRevertibleRandomFunction(generator RandomGenerator) interpreter.Nativ
 		context interpreter.NativeFunctionContext,
 		typeParameterGetter interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		returnIntegerType := typeParameterGetter.NextSema()
 

--- a/stdlib/range.go
+++ b/stdlib/range.go
@@ -118,7 +118,7 @@ var NativeInclusiveRangeConstructorFunction = interpreter.NativeFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		start := interpreter.AssertValueOfType[interpreter.IntegerValue](args[0])
 		end := interpreter.AssertValueOfType[interpreter.IntegerValue](args[1])

--- a/stdlib/rlp.go
+++ b/stdlib/rlp.go
@@ -56,7 +56,7 @@ var NativeRLPDecodeStringFunction = interpreter.NativeFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		input := interpreter.AssertValueOfType[*interpreter.ArrayValue](args[0])
 		return RLPDecodeString(input, context)
@@ -68,7 +68,7 @@ var NativeRLPDecodeListFunction = interpreter.NativeFunction(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		input := interpreter.AssertValueOfType[*interpreter.ArrayValue](args[0])
 		return RLPDecodeList(input, context)

--- a/stdlib/signaturealgorithm.go
+++ b/stdlib/signaturealgorithm.go
@@ -76,7 +76,7 @@ var vmSignatureAlgorithmConstructorValue = vm.NewNativeFunctionValue(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeParameterGetter,
 		_ interpreter.Value,
-		args ...interpreter.Value,
+		args []interpreter.Value,
 	) interpreter.Value {
 		rawValue := args[0].(interpreter.UInt8Value)
 

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -175,7 +175,7 @@ func ParseCheckAndPrepareWithLogs(
 			_ interpreter.NativeFunctionContext,
 			_ interpreter.TypeParameterGetter,
 			_ interpreter.Value,
-			args ...interpreter.Value,
+			args []interpreter.Value,
 		) interpreter.Value {
 			value := args[0]
 			logs = append(logs, value.String())
@@ -353,7 +353,7 @@ func ParseCheckAndPrepareWithOptions(
 								context interpreter.NativeFunctionContext,
 								_ interpreter.TypeParameterGetter,
 								_ interpreter.Value,
-								arguments ...interpreter.Value,
+								arguments []interpreter.Value,
 							) interpreter.Value {
 
 								var argumentTypes []sema.Type


### PR DESCRIPTION
Work towards #3804 

## Description

Minor clean up:

Variadic parameters are usually a convenience for avoiding the need to passing a slice to the function.

In the case of `vm.NativeFunctionVM` and `interpreter.NativeFunction`, the arguments are already available as a slice and can be passed as such.

Change the variadic `arguments ...Value` parameters of the types to slices, avoiding the need to spread at call-sites.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
