### PR TITLE
Fix naming of "type parameters" which are actually type arguments

### DIFF
--- a/bbq/vm/builtin_globals.go
+++ b/bbq/vm/builtin_globals.go
@@ -100,7 +100,7 @@ func init() {
 			failConditionFunctionType,
 			func(
 				_ interpreter.NativeFunctionContext,
-				_ interpreter.TypeParameterGetter,
+				_ interpreter.TypeArgumentsIterator,
 				_ interpreter.Value,
 				args []interpreter.Value,
 			) interpreter.Value {
@@ -119,7 +119,7 @@ func init() {
 			failConditionFunctionType,
 			func(
 				_ interpreter.NativeFunctionContext,
-				_ interpreter.TypeParameterGetter,
+				_ interpreter.TypeArgumentsIterator,
 				_ interpreter.Value,
 				args []interpreter.Value,
 			) interpreter.Value {

--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -328,7 +328,7 @@ func (c *Context) DefaultDestroyEvents(resourceValue *interpreter.CompositeValue
 		commons.CollectEventsFunctionType,
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			_ interpreter.Value,
 			arguments []interpreter.Value,
 		) interpreter.Value {

--- a/bbq/vm/native_function.go
+++ b/bbq/vm/native_function.go
@@ -24,33 +24,33 @@ import (
 	"github.com/onflow/cadence/sema"
 )
 
-type VMTypeParameterGetter struct {
-	index              int
-	context            *Context
-	typeParameterTypes []bbq.StaticType
+type VMTypeArgumentsIterator struct {
+	index         int
+	context       *Context
+	typeArguments []bbq.StaticType
 }
 
-func NewVMTypeParameterGetter(context *Context, typeParameterTypes []bbq.StaticType) *VMTypeParameterGetter {
-	return &VMTypeParameterGetter{
-		index:              0,
-		context:            context,
-		typeParameterTypes: typeParameterTypes,
+func NewVMTypeArgumentsIterator(context *Context, typeArguments []bbq.StaticType) *VMTypeArgumentsIterator {
+	return &VMTypeArgumentsIterator{
+		index:         0,
+		context:       context,
+		typeArguments: typeArguments,
 	}
 }
 
-var _ interpreter.TypeParameterGetter = &VMTypeParameterGetter{}
+var _ interpreter.TypeArgumentsIterator = &VMTypeArgumentsIterator{}
 
-func (g *VMTypeParameterGetter) NextStatic() interpreter.StaticType {
+func (g *VMTypeArgumentsIterator) NextStatic() interpreter.StaticType {
 	current := g.index
-	if current >= len(g.typeParameterTypes) {
+	if current >= len(g.typeArguments) {
 		// much like the interpreter, there can be no type parameters provided, which is valid
 		return nil
 	}
 	g.index++
-	return g.typeParameterTypes[current]
+	return g.typeArguments[current]
 }
 
-func (g *VMTypeParameterGetter) NextSema() sema.Type {
+func (g *VMTypeArgumentsIterator) NextSema() sema.Type {
 	staticType := g.NextStatic()
 	if staticType == nil {
 		return nil
@@ -66,11 +66,11 @@ func AdaptNativeFunctionForVM(fn interpreter.NativeFunction) NativeFunctionVM {
 		receiver Value,
 		arguments []Value,
 	) Value {
-		typeParameterGetter := NewVMTypeParameterGetter(context, typeArguments)
+		typeArgumentsIterator := NewVMTypeArgumentsIterator(context, typeArguments)
 
 		return fn(
 			context,
-			typeParameterGetter,
+			typeArgumentsIterator,
 			receiver,
 			arguments,
 		)

--- a/bbq/vm/test/utils.go
+++ b/bbq/vm/test/utils.go
@@ -425,7 +425,7 @@ func VMBuiltinGlobalsProviderWithDefaultsAndPanic(_ common.Location) *activation
 			stdlib.PanicFunctionType,
 			func(
 				context interpreter.NativeFunctionContext,
-				_ interpreter.TypeParameterGetter,
+				_ interpreter.TypeArgumentsIterator,
 				_ interpreter.Value,
 				arguments []interpreter.Value,
 			) vm.Value {
@@ -547,7 +547,7 @@ func newConditionLogFunction(logs *[]string) stdlib.StandardLibraryValue {
 		"",
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			_ interpreter.Value,
 			arguments []interpreter.Value,
 		) interpreter.Value {

--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -8850,7 +8850,7 @@ func TestFunctionInvocationWithOptionalArgs(t *testing.T) {
 		functionType,
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			_ interpreter.Value,
 			arguments []vm.Value,
 		) vm.Value {
@@ -9436,7 +9436,7 @@ func TestInjectedContract(t *testing.T) {
 		cType,
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			receiver interpreter.Value,
 			args []interpreter.Value,
 		) interpreter.Value {
@@ -11534,7 +11534,7 @@ func TestBorrowContractLinksGlobals(t *testing.T) {
 		functionType,
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			_ interpreter.Value,
 			args []interpreter.Value,
 		) vm.Value {

--- a/encoding/ccf/decode.go
+++ b/encoding/ccf/decode.go
@@ -2210,7 +2210,7 @@ func (d *Decoder) decodeTypeParameterTypeValues(visited *cadenceTypeByCCFTypeID)
 	})
 
 	for i := 0; i < int(count); i++ {
-		// Decode type parameter.
+		// Decode type argument.
 		typeParam, err := d.decodeTypeParameterTypeValue(visited)
 		if err != nil {
 			return nil, err

--- a/interpreter/builtinfunctions_test.go
+++ b/interpreter/builtinfunctions_test.go
@@ -1110,17 +1110,17 @@ func TestInterpretNativeFunctionWithMultipleTypeParameters(t *testing.T) {
 
 	nativeFunction := func(
 		_ interpreter.NativeFunctionContext,
-		typeParameterGetter interpreter.TypeParameterGetter,
+		typeArguments interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		_ []interpreter.Value,
 	) interpreter.Value {
-		typeValue := typeParameterGetter.NextStatic()
+		typeValue := typeArguments.NextStatic()
 		require.Equal(t, interpreter.PrimitiveStaticTypeInt, typeValue)
 
-		typeValue2 := typeParameterGetter.NextStatic()
+		typeValue2 := typeArguments.NextStatic()
 		require.Equal(t, interpreter.PrimitiveStaticTypeBool, typeValue2)
 
-		typeValue3 := typeParameterGetter.NextStatic()
+		typeValue3 := typeArguments.NextStatic()
 		require.Equal(t, nil, typeValue3)
 
 		return interpreter.Void

--- a/interpreter/container_mutation_test.go
+++ b/interpreter/container_mutation_test.go
@@ -42,7 +42,7 @@ func newAssertHelloLogFunction(t *testing.T, invoked *bool) stdlib.StandardLibra
 		"",
 		func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			_ interpreter.Value,
 			args []interpreter.Value,
 		) interpreter.Value {
@@ -60,7 +60,7 @@ func newAssertUnexpectedLogFunction(t *testing.T) stdlib.StandardLibraryValue {
 		"",
 		func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			_ interpreter.Value,
 			_ []interpreter.Value,
 		) interpreter.Value {

--- a/interpreter/for_test.go
+++ b/interpreter/for_test.go
@@ -389,7 +389,7 @@ func TestInterpretEphemeralReferencesInForLoop(t *testing.T) {
 			"",
 			func(
 				_ interpreter.NativeFunctionContext,
-				_ interpreter.TypeParameterGetter,
+				_ interpreter.TypeArgumentsIterator,
 				_ interpreter.Value,
 				args []interpreter.Value,
 			) interpreter.Value {

--- a/interpreter/import_test.go
+++ b/interpreter/import_test.go
@@ -46,7 +46,7 @@ import (
 func newAddLogFunction(logs *[]string) interpreter.NativeFunction {
 	return func(
 		_ interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		arguments []interpreter.Value,
 	) interpreter.Value {

--- a/interpreter/interface_test.go
+++ b/interpreter/interface_test.go
@@ -62,7 +62,7 @@ func parseCheckAndPrepareWithConditionLogs(
 		"",
 		func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			_ interpreter.Value,
 			args []interpreter.Value,
 		) interpreter.Value {

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -3941,11 +3941,11 @@ type runtimeTypeConstructor struct {
 var NativeMetaTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		typeParameterGetter TypeParameterGetter,
+		typeArguments TypeArgumentsIterator,
 		_ Value,
 		_ []Value,
 	) Value {
-		staticType := typeParameterGetter.NextStatic()
+		staticType := typeArguments.NextStatic()
 
 		return NewTypeValue(context, staticType)
 	},
@@ -3954,7 +3954,7 @@ var NativeMetaTypeFunction = NativeFunction(
 var NativeOptionalTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -3967,7 +3967,7 @@ var NativeOptionalTypeFunction = NativeFunction(
 var NativeVariableSizedArrayTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -3980,7 +3980,7 @@ var NativeVariableSizedArrayTypeFunction = NativeFunction(
 var NativeConstantSizedArrayTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -3998,7 +3998,7 @@ var NativeConstantSizedArrayTypeFunction = NativeFunction(
 var NativeDictionaryTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -4016,7 +4016,7 @@ var NativeDictionaryTypeFunction = NativeFunction(
 var NativeCompositeTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -4029,7 +4029,7 @@ var NativeCompositeTypeFunction = NativeFunction(
 var NativeFunctionTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -4047,7 +4047,7 @@ var NativeFunctionTypeFunction = NativeFunction(
 var NativeReferenceTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -4065,7 +4065,7 @@ var NativeReferenceTypeFunction = NativeFunction(
 var NativeIntersectionTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -4081,7 +4081,7 @@ var NativeIntersectionTypeFunction = NativeFunction(
 var NativeCapabilityTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -4094,7 +4094,7 @@ var NativeCapabilityTypeFunction = NativeFunction(
 var NativeInclusiveRangeTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -4107,7 +4107,7 @@ var NativeInclusiveRangeTypeFunction = NativeFunction(
 var NativeAddressFromBytesFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -4120,7 +4120,7 @@ var NativeAddressFromBytesFunction = NativeFunction(
 var NativeAddressFromStringFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -4133,7 +4133,7 @@ var NativeAddressFromStringFunction = NativeFunction(
 func NativeConverterFunction(convert func(memoryGauge common.MemoryGauge, value Value) Value) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -4144,7 +4144,7 @@ func NativeConverterFunction(convert func(memoryGauge common.MemoryGauge, value 
 func NativeFromStringFunction(parser StringValueParser) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -4156,7 +4156,7 @@ func NativeFromStringFunction(parser StringValueParser) NativeFunction {
 func NativeFromBigEndianBytesFunction(byteLength uint, converter func(memoryGauge common.MemoryGauge, bytes []byte) Value) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		args []Value,
 	) Value {
@@ -4179,7 +4179,7 @@ func NativeFromBigEndianBytesFunction(byteLength uint, converter func(memoryGaug
 var NativeStringFunction = NativeFunction(
 	func(
 		_ NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		_ []Value,
 	) Value {
@@ -4406,7 +4406,7 @@ func NativeAccountStorageIterateFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -4622,7 +4622,7 @@ func NativeAccountStorageSaveFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -4706,7 +4706,7 @@ func NativeAccountStorageTypeFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -4800,12 +4800,12 @@ func NativeAccountStorageReadFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		typeParameterGetter TypeParameterGetter,
+		typeArguments TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
 		address := GetAddressValue(receiver, addressPointer).ToAddress()
-		semaBorrowType := typeParameterGetter.NextSema()
+		semaBorrowType := typeArguments.NextSema()
 
 		return AccountStorageRead(
 			context,
@@ -4901,12 +4901,12 @@ func NativeAccountStorageBorrowFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		typeParameterGetter TypeParameterGetter,
+		typeArguments TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
 		address := GetAddressValue(receiver, addressPointer).ToAddress()
-		typeParameter := typeParameterGetter.NextSema()
+		typeParameter := typeArguments.NextSema()
 
 		return AccountStorageBorrow(
 			context,
@@ -4975,18 +4975,18 @@ func NativeAccountStorageCheckFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		typeParameterGetter TypeParameterGetter,
+		typeArguments TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
 		address := GetAddressValue(receiver, addressPointer).ToAddress()
-		typeParameter := typeParameterGetter.NextSema()
+		typeArgument := typeArguments.NextSema()
 
 		return AccountStorageCheck(
 			context,
 			address,
 			args,
-			typeParameter,
+			typeArgument,
 		)
 	}
 }
@@ -5417,7 +5417,7 @@ func getBuiltinFunctionMember(context MemberAccessibleContext, self Value, ident
 var NativeIsInstanceFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -5453,7 +5453,7 @@ func IsInstance(invocationContext InvocationContext, self Value, typeValue TypeV
 var NativeGetTypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -5905,7 +5905,7 @@ func NativeCapabilityBorrowFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		typeParameterGetter TypeParameterGetter,
+		typeArguments TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -5942,11 +5942,11 @@ func NativeCapabilityBorrowFunction(
 			addressValue = *addressValuePointer
 		}
 
-		typeParameter := typeParameterGetter.NextSema()
+		typeArgument := typeArguments.NextSema()
 
 		return CapabilityBorrow(
 			context,
-			typeParameter,
+			typeArgument,
 			addressValue,
 			capabilityID,
 			capabilityBorrowType,
@@ -6012,7 +6012,7 @@ func NativeCapabilityCheckFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		typeParameterGetter TypeParameterGetter,
+		typeArguments TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -6050,7 +6050,7 @@ func NativeCapabilityCheckFunction(
 			addressValue = *addressValuePointer
 		}
 
-		typeArgument := typeParameterGetter.NextSema()
+		typeArgument := typeArguments.NextSema()
 
 		return CapabilityCheck(
 			context,

--- a/interpreter/interpreter_expression.go
+++ b/interpreter/interpreter_expression.go
@@ -1142,7 +1142,7 @@ func (interpreter *Interpreter) visitInvocationExpressionWithImplicitArgument(in
 
 	invocationExpressionTypes := elaboration.InvocationExpressionTypes(invocationExpression)
 
-	typeParameterTypes := invocationExpressionTypes.TypeArguments
+	typeArguments := invocationExpressionTypes.TypeArguments
 	argumentTypes := invocationExpressionTypes.ArgumentTypes
 	parameterTypes := invocationExpressionTypes.ParameterTypes
 	returnType := invocationExpressionTypes.ReturnType
@@ -1160,7 +1160,7 @@ func (interpreter *Interpreter) visitInvocationExpressionWithImplicitArgument(in
 		argumentTypes,
 		parameterTypes,
 		returnType,
-		typeParameterTypes,
+		typeArguments,
 	)
 
 	interpreter.reportInvokedFunctionReturn()

--- a/interpreter/interpreter_invocation.go
+++ b/interpreter/interpreter_invocation.go
@@ -60,7 +60,7 @@ func invokeFunctionValue(
 	argumentTypes []sema.Type,
 	parameterTypes []sema.Type,
 	returnType sema.Type,
-	typeParameterTypes *sema.TypeParameterTypeOrderedMap,
+	typeArguments *sema.TypeParameterTypeOrderedMap,
 ) Value {
 	return invokeFunctionValueWithEval(
 		context,
@@ -73,7 +73,7 @@ func invokeFunctionValue(
 		argumentTypes,
 		parameterTypes,
 		returnType,
-		typeParameterTypes,
+		typeArguments,
 	)
 }
 
@@ -86,7 +86,7 @@ func invokeFunctionValueWithEval[T any](
 	argumentTypes []sema.Type,
 	parameterTypes []sema.Type,
 	returnType sema.Type,
-	typeParameterTypes *sema.TypeParameterTypeOrderedMap,
+	typeArguments *sema.TypeParameterTypeOrderedMap,
 ) Value {
 
 	parameterTypeCount := len(parameterTypes)
@@ -144,7 +144,7 @@ func invokeFunctionValueWithEval[T any](
 		nil,
 		transferredArguments,
 		argumentTypes,
-		typeParameterTypes,
+		typeArguments,
 		context.LocationRange(),
 	)
 

--- a/interpreter/invocation.go
+++ b/interpreter/invocation.go
@@ -25,13 +25,13 @@ import (
 
 // Invocation
 type Invocation struct {
-	LocationRange      LocationRange
-	Self               *Value
-	Base               *EphemeralReferenceValue
-	TypeParameterTypes *sema.TypeParameterTypeOrderedMap
-	InvocationContext  InvocationContext
-	Arguments          []Value
-	ArgumentTypes      []sema.Type
+	LocationRange     LocationRange
+	Self              *Value
+	Base              *EphemeralReferenceValue
+	TypeArguments     *sema.TypeParameterTypeOrderedMap
+	InvocationContext InvocationContext
+	Arguments         []Value
+	ArgumentTypes     []sema.Type
 }
 
 func NewInvocation(
@@ -40,19 +40,19 @@ func NewInvocation(
 	base *EphemeralReferenceValue,
 	arguments []Value,
 	argumentTypes []sema.Type,
-	typeParameterTypes *sema.TypeParameterTypeOrderedMap,
+	typeArguments *sema.TypeParameterTypeOrderedMap,
 	locationRange LocationRange,
 ) Invocation {
 	common.UseMemory(invocationContext, common.InvocationMemoryUsage)
 
 	return Invocation{
-		Self:               self,
-		Base:               base,
-		Arguments:          arguments,
-		ArgumentTypes:      argumentTypes,
-		TypeParameterTypes: typeParameterTypes,
-		LocationRange:      locationRange,
-		InvocationContext:  invocationContext,
+		Self:              self,
+		Base:              base,
+		Arguments:         arguments,
+		ArgumentTypes:     argumentTypes,
+		TypeArguments:     typeArguments,
+		LocationRange:     locationRange,
+		InvocationContext: invocationContext,
 	}
 }
 

--- a/interpreter/invocation_test.go
+++ b/interpreter/invocation_test.go
@@ -102,7 +102,7 @@ func TestInterpretSelfDeclaration(t *testing.T) {
 			``,
 			func(
 				context interpreter.NativeFunctionContext,
-				_ interpreter.TypeParameterGetter,
+				_ interpreter.TypeArgumentsIterator,
 				_ interpreter.Value,
 				args []interpreter.Value,
 			) interpreter.Value {

--- a/interpreter/memory_metering_test.go
+++ b/interpreter/memory_metering_test.go
@@ -111,7 +111,7 @@ func newMeteredLogFunction(meter *testMemoryGauge, loggedString *string) stdlib.
 		``,
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			_ interpreter.Value,
 			args []interpreter.Value,
 		) interpreter.Value {

--- a/interpreter/misc_test.go
+++ b/interpreter/misc_test.go
@@ -1778,7 +1778,7 @@ func TestInterpretHostFunction(t *testing.T) {
 		``,
 		func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			_ interpreter.Value,
 			args []interpreter.Value,
 		) interpreter.Value {
@@ -1828,7 +1828,7 @@ func TestInterpretHostFunction(t *testing.T) {
 func newAssertArgumentsFunction(t *testing.T, called *bool) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -4954,7 +4954,7 @@ func TestInterpretReferenceFailableDowncasting(t *testing.T) {
 			"",
 			func(
 				context interpreter.NativeFunctionContext,
-				_ interpreter.TypeParameterGetter,
+				_ interpreter.TypeArgumentsIterator,
 				_ interpreter.Value,
 				args []interpreter.Value,
 			) interpreter.Value {
@@ -13346,7 +13346,7 @@ func TestInterpretSomeValueChildContainerMutation(t *testing.T) {
 func newCountAndGetKeyFunction(key int64, getKeyInvocationsCount *int) interpreter.NativeFunction {
 	return func(
 		_ interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		_ []interpreter.Value,
 	) interpreter.Value {
@@ -13378,7 +13378,7 @@ func TestInterpretVariableDeclarationSecondValueEvaluationOrder(t *testing.T) {
 			"",
 			func(
 				_ interpreter.NativeFunctionContext,
-				_ interpreter.TypeParameterGetter,
+				_ interpreter.TypeArgumentsIterator,
 				_ interpreter.Value,
 				_ []interpreter.Value,
 			) interpreter.Value {
@@ -13801,7 +13801,7 @@ func TestInterpretInvocationEvaluationAndTransferOrder(t *testing.T) {
 		"",
 		func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			_ interpreter.Value,
 			args []interpreter.Value,
 		) interpreter.Value {

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -349,7 +349,7 @@ func NewNativeDeletionCheckedAccountCapabilityControllerFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		typeParameterGetter TypeParameterGetter,
+		typeArguments TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -359,7 +359,7 @@ func NewNativeDeletionCheckedAccountCapabilityControllerFunction(
 
 		return f(
 			context,
-			typeParameterGetter,
+			typeArguments,
 			receiver,
 			args,
 		)
@@ -369,7 +369,7 @@ func NewNativeDeletionCheckedAccountCapabilityControllerFunction(
 var NativeAccountCapabilityControllerDeleteFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {
@@ -393,7 +393,7 @@ func (v *AccountCapabilityControllerValue) newDeleteFunction(
 var NativeAccountCapabilityControllerSetTagFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -290,7 +290,7 @@ func AddressValueFromString(gauge common.MemoryGauge, string *StringValue) Value
 var NativeAddressToStringFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {
@@ -302,7 +302,7 @@ var NativeAddressToStringFunction = NativeFunction(
 var NativeAddressToBytesFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -1909,7 +1909,7 @@ func (i *ArrayIterator) ValueID() (atree.ValueID, bool) {
 var NativeArrayAppendFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1924,7 +1924,7 @@ var NativeArrayAppendFunction = NativeFunction(
 var NativeArrayAppendAllFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1939,7 +1939,7 @@ var NativeArrayAppendAllFunction = NativeFunction(
 var NativeArrayConcatFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1953,7 +1953,7 @@ var NativeArrayConcatFunction = NativeFunction(
 var NativeArrayInsertFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1969,7 +1969,7 @@ var NativeArrayInsertFunction = NativeFunction(
 var NativeArrayRemoveFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1983,7 +1983,7 @@ var NativeArrayRemoveFunction = NativeFunction(
 var NativeArrayContainsFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1997,7 +1997,7 @@ var NativeArrayContainsFunction = NativeFunction(
 var NativeArraySliceFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -2012,7 +2012,7 @@ var NativeArraySliceFunction = NativeFunction(
 var NativeArrayReverseFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {
@@ -2024,7 +2024,7 @@ var NativeArrayReverseFunction = NativeFunction(
 var NativeArrayFilterFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -2038,7 +2038,7 @@ var NativeArrayFilterFunction = NativeFunction(
 var NativeArrayMapFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -2052,7 +2052,7 @@ var NativeArrayMapFunction = NativeFunction(
 var NativeArrayToVariableSizedFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {
@@ -2065,12 +2065,12 @@ var NativeArrayToVariableSizedFunction = NativeFunction(
 var NativeArrayToConstantSizedFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		typeParameterGetter TypeParameterGetter,
+		typeArguments TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
 		thisArray := AssertValueOfType[*ArrayValue](receiver)
-		constantSizedArrayType, ok := typeParameterGetter.NextStatic().(*ConstantSizedStaticType)
+		constantSizedArrayType, ok := typeArguments.NextStatic().(*ConstantSizedStaticType)
 		if !ok {
 			panic(errors.NewUnreachableError())
 		}
@@ -2082,7 +2082,7 @@ var NativeArrayToConstantSizedFunction = NativeFunction(
 var NativeArrayFirstIndexFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -2096,7 +2096,7 @@ var NativeArrayFirstIndexFunction = NativeFunction(
 var NativeArrayRemoveFirstFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {
@@ -2109,7 +2109,7 @@ var NativeArrayRemoveFirstFunction = NativeFunction(
 var NativeArrayRemoveLastFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -233,7 +233,7 @@ func (v CharacterValue) GetMember(context MemberAccessibleContext, name string) 
 var NativeCharacterValueToStringFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -1739,7 +1739,7 @@ func (v *CompositeValue) forEachAttachmentFunction(context FunctionCreationConte
 var NativeForEachAttachmentFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {

--- a/interpreter/value_deployedcontract.go
+++ b/interpreter/value_deployedcontract.go
@@ -73,7 +73,7 @@ func NewNativeDeployedContractPublicTypesFunctionValue(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -1571,7 +1571,7 @@ func (v *DictionaryValue) Inlined() bool {
 var NativeDictionaryRemoveFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1584,7 +1584,7 @@ var NativeDictionaryRemoveFunction = NativeFunction(
 var NativeDictionaryInsertFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1598,7 +1598,7 @@ var NativeDictionaryInsertFunction = NativeFunction(
 var NativeDictionaryContainsKeyFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1611,7 +1611,7 @@ var NativeDictionaryContainsKeyFunction = NativeFunction(
 var NativeDictionaryForEachKeyFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -98,7 +98,7 @@ var nilValueMapFunction = NewUnmeteredStaticHostFunctionValueFromNativeFunction(
 	sema.OptionalTypeMapFunctionType(NilOptionalValue.InnerValueType(nil)),
 	func(
 		_ NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		_ Value,
 		_ []Value,
 	) Value {

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -142,7 +142,7 @@ type BigNumberValue interface {
 var NativeNumberToStringFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {
@@ -153,7 +153,7 @@ var NativeNumberToStringFunction = NativeFunction(
 var NativeNumberToBigEndianBytesFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {
@@ -164,7 +164,7 @@ var NativeNumberToBigEndianBytesFunction = NativeFunction(
 var NativeNumberSaturatingAddFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -176,7 +176,7 @@ var NativeNumberSaturatingAddFunction = NativeFunction(
 var NativeNumberSaturatingSubtractFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -188,7 +188,7 @@ var NativeNumberSaturatingSubtractFunction = NativeFunction(
 var NativeNumberSaturatingMultiplyFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -200,7 +200,7 @@ var NativeNumberSaturatingMultiplyFunction = NativeFunction(
 var NativeNumberSaturatingDivideFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -120,7 +120,7 @@ func (v PathValue) GetMember(context MemberAccessibleContext, name string) Value
 var NativePathValueToStringFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -135,7 +135,7 @@ func (v *PathCapabilityValue) newBorrowFunction(
 		sema.CapabilityTypeBorrowFunctionType(borrowType),
 		func(
 			_ NativeFunctionContext,
-			_ TypeParameterGetter,
+			_ TypeArgumentsIterator,
 			_ Value,
 			_ []Value,
 		) Value {
@@ -155,7 +155,7 @@ func (v *PathCapabilityValue) newCheckFunction(
 		sema.CapabilityTypeCheckFunctionType(borrowType),
 		func(
 			_ NativeFunctionContext,
-			_ TypeParameterGetter,
+			_ TypeArgumentsIterator,
 			_ Value,
 			_ []Value,
 		) Value {

--- a/interpreter/value_range.go
+++ b/interpreter/value_range.go
@@ -121,7 +121,7 @@ func NewInclusiveRangeValueWithStep(
 var NativeInclusiveRangeContainsFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -508,7 +508,7 @@ func (s SomeStorable) ChildStorables() []atree.Storable {
 var NativeOptionalMapFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -358,7 +358,7 @@ func NewNativeDeletionCheckedStorageCapabilityControllerFunction(
 ) NativeFunction {
 	return func(
 		context NativeFunctionContext,
-		typeParameterGetter TypeParameterGetter,
+		typeArguments TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -367,7 +367,7 @@ func NewNativeDeletionCheckedStorageCapabilityControllerFunction(
 
 		return f(
 			context,
-			typeParameterGetter,
+			typeArguments,
 			receiver,
 			args,
 		)
@@ -392,7 +392,7 @@ func (v *StorageCapabilityControllerValue) newNativeHostFunctionValue(
 var NativeStorageCapabilityControllerDeleteFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {
@@ -417,7 +417,7 @@ func (v *StorageCapabilityControllerValue) newDeleteFunction(
 var NativeStorageCapabilityControllerTargetFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		_ []Value,
 	) Value {
@@ -439,7 +439,7 @@ func (v *StorageCapabilityControllerValue) newTargetFunction(
 var NativeStorageCapabilityControllerRetargetFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -470,7 +470,7 @@ func (v *StorageCapabilityControllerValue) newRetargetFunction(
 var NativeStorageCapabilityControllerSetTagFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -1052,7 +1052,7 @@ func (*StringValueIterator) ValueID() (atree.ValueID, bool) {
 var NativeStringEncodeHexFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1064,7 +1064,7 @@ var NativeStringEncodeHexFunction = NativeFunction(
 var NativeStringFromUtf8Function = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1076,7 +1076,7 @@ var NativeStringFromUtf8Function = NativeFunction(
 var NativeStringFromCharactersFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1088,7 +1088,7 @@ var NativeStringFromCharactersFunction = NativeFunction(
 var NativeStringJoinFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1295,7 +1295,7 @@ var stringFunction = func() Value {
 var NativeStringConcatFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1312,7 +1312,7 @@ var NativeStringConcatFunction = NativeFunction(
 var NativeStringSliceFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1326,7 +1326,7 @@ var NativeStringSliceFunction = NativeFunction(
 var NativeStringContainsFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1339,7 +1339,7 @@ var NativeStringContainsFunction = NativeFunction(
 var NativeStringIndexFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1352,7 +1352,7 @@ var NativeStringIndexFunction = NativeFunction(
 var NativeStringCountFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1365,7 +1365,7 @@ var NativeStringCountFunction = NativeFunction(
 var NativeStringDecodeHexFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1377,7 +1377,7 @@ var NativeStringDecodeHexFunction = NativeFunction(
 var NativeStringToLowerFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1389,7 +1389,7 @@ var NativeStringToLowerFunction = NativeFunction(
 var NativeStringSplitFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {
@@ -1402,7 +1402,7 @@ var NativeStringSplitFunction = NativeFunction(
 var NativeStringReplaceAllFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {

--- a/interpreter/value_test.go
+++ b/interpreter/value_test.go
@@ -1219,7 +1219,7 @@ func TestStringer(t *testing.T) {
 					},
 					func(
 						_ NativeFunctionContext,
-						_ TypeParameterGetter,
+						_ TypeArgumentsIterator,
 						_ Value,
 						_ []Value,
 					) Value {

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -359,7 +359,7 @@ func (v TypeValue) HashInput(_ common.MemoryGauge, scratch []byte) []byte {
 var NativeMetaTypeIsSubtypeFunction = NativeFunction(
 	func(
 		context NativeFunctionContext,
-		_ TypeParameterGetter,
+		_ TypeArgumentsIterator,
 		receiver Value,
 		args []Value,
 	) Value {

--- a/runtime/predeclaredvalues_test.go
+++ b/runtime/predeclaredvalues_test.go
@@ -202,7 +202,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 
 		nativeFunction := func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			_ interpreter.Value,
 			_ []interpreter.Value,
 		) interpreter.Value {
@@ -376,7 +376,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 				functionType,
 				func(
 					_ interpreter.NativeFunctionContext,
-					_ interpreter.TypeParameterGetter,
+					_ interpreter.TypeArgumentsIterator,
 					_ interpreter.Value,
 					_ []interpreter.Value,
 				) interpreter.Value {
@@ -451,7 +451,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 				functionType,
 				func(
 					_ interpreter.NativeFunctionContext,
-					_ interpreter.TypeParameterGetter,
+					_ interpreter.TypeArgumentsIterator,
 					_ interpreter.Value,
 					_ []interpreter.Value,
 				) interpreter.Value {
@@ -571,7 +571,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 				cType,
 				func(
 					context interpreter.NativeFunctionContext,
-					_ interpreter.TypeParameterGetter,
+					_ interpreter.TypeArgumentsIterator,
 					receiver interpreter.Value,
 					args []interpreter.Value,
 				) interpreter.Value {
@@ -699,7 +699,7 @@ func TestRuntimePredeclaredValues(t *testing.T) {
 				cType,
 				func(
 					_ interpreter.NativeFunctionContext,
-					_ interpreter.TypeParameterGetter,
+					_ interpreter.TypeArgumentsIterator,
 					_ interpreter.Value,
 					_ []interpreter.Value,
 				) interpreter.Value {

--- a/sema/check_invocation_expression.go
+++ b/sema/check_invocation_expression.go
@@ -579,7 +579,7 @@ func (checker *Checker) checkInvocationRequiredArgument(
 	argumentIndex int,
 	functionType *FunctionType,
 	argumentTypes []Type,
-	typeParameters *TypeParameterTypeOrderedMap,
+	typeArguments *TypeParameterTypeOrderedMap,
 ) (
 	parameterType Type,
 ) {
@@ -595,12 +595,12 @@ func (checker *Checker) checkInvocationRequiredArgument(
 	// If all type parameters have been bound to a type,
 	// then resolve the parameter type with the type arguments,
 	// and propose the parameter type as the expected type for the argument.
-	if typeParameters.Len() == typeParameterCount {
+	if typeArguments.Len() == typeParameterCount {
 
 		// Optimization: only resolve if there are type parameters.
 		// This avoids unnecessary work for non-generic functions.
 		if typeParameterCount > 0 {
-			parameterType = parameterType.Resolve(typeParameters)
+			parameterType = parameterType.Resolve(typeArguments)
 			// If the type parameter could not be resolved, use the invalid type.
 			if parameterType == nil {
 				checker.report(&InvocationTypeInferenceError{
@@ -676,12 +676,12 @@ func (checker *Checker) checkInvocationRequiredArgument(
 
 		if parameterType.Unify(
 			argumentType,
-			typeParameters,
+			typeArguments,
 			checker.report,
 			checker.memoryGauge,
 			argument.Expression,
 		) {
-			parameterType = parameterType.Resolve(typeParameters)
+			parameterType = parameterType.Resolve(typeArguments)
 			// If the type parameter could not be resolved, use the invalid type.
 			if parameterType == nil {
 				checker.report(&InvocationTypeInferenceError{
@@ -769,7 +769,7 @@ func (checker *Checker) reportInvalidTypeArgumentCount(
 func (checker *Checker) checkAndBindGenericTypeParameterTypeArguments(
 	typeArguments []*ast.TypeAnnotation,
 	typeParameters []*TypeParameter,
-	typeParameterTypes *TypeParameterTypeOrderedMap,
+	typeArgumentsMap *TypeParameterTypeOrderedMap,
 ) {
 	for i := 0; i < len(typeArguments); i++ {
 		rawTypeArgument := typeArguments[i]
@@ -795,7 +795,7 @@ func (checker *Checker) checkAndBindGenericTypeParameterTypeArguments(
 
 		// Bind the type argument to the type parameter
 
-		typeParameterTypes.Set(typeParameter, ty)
+		typeArgumentsMap.Set(typeParameter, ty)
 	}
 }
 

--- a/sema/genericfunction_test.go
+++ b/sema/genericfunction_test.go
@@ -375,9 +375,9 @@ func TestCheckGenericFunctionInvocation(t *testing.T) {
 		require.IsType(t, &ast.InvocationExpression{}, variableDeclaration.Value)
 		invocationExpression := variableDeclaration.Value.(*ast.InvocationExpression)
 
-		typeParameterTypes := checker.Elaboration.InvocationExpressionTypes(invocationExpression).TypeArguments
+		typeArguments := checker.Elaboration.InvocationExpressionTypes(invocationExpression).TypeArguments
 
-		ty, present := typeParameterTypes.Get(typeParameter)
+		ty, present := typeArguments.Get(typeParameter)
 		require.True(t, present, "could not find type argument for type parameter %#+v", typeParameter)
 		assert.IsType(t, sema.IntType, ty)
 	})

--- a/sema/type.go
+++ b/sema/type.go
@@ -192,7 +192,7 @@ type Type interface {
 	//
 	Unify(
 		other Type,
-		typeParameters *TypeParameterTypeOrderedMap,
+		typeArguments *TypeParameterTypeOrderedMap,
 		report func(err error),
 		memoryGauge common.MemoryGauge,
 		outerRange ast.HasPosition,
@@ -789,7 +789,7 @@ func (t *OptionalType) RewriteWithIntersectionTypes() (Type, bool) {
 
 func (t *OptionalType) Unify(
 	other Type,
-	typeParameters *TypeParameterTypeOrderedMap,
+	typeArguments *TypeParameterTypeOrderedMap,
 	report func(err error),
 	memoryGauge common.MemoryGauge,
 	outerRange ast.HasPosition,
@@ -802,7 +802,7 @@ func (t *OptionalType) Unify(
 
 	return t.Type.Unify(
 		otherOptional.Type,
-		typeParameters,
+		typeArguments,
 		report,
 		memoryGauge,
 		outerRange,
@@ -1014,13 +1014,13 @@ func (t *GenericType) RewriteWithIntersectionTypes() (result Type, rewritten boo
 
 func (t *GenericType) Unify(
 	other Type,
-	typeParameters *TypeParameterTypeOrderedMap,
+	typeArguments *TypeParameterTypeOrderedMap,
 	report func(err error),
 	memoryGauge common.MemoryGauge,
 	outerRange ast.HasPosition,
 ) bool {
 
-	if unifiedType, ok := typeParameters.Get(t.TypeParameter); ok {
+	if unifiedType, ok := typeArguments.Get(t.TypeParameter); ok {
 
 		// If the type parameter is already unified with a type argument
 		// (either explicit by a type argument, or implicit through an argument's type),
@@ -1040,7 +1040,7 @@ func (t *GenericType) Unify(
 	} else {
 		// If the type parameter is not yet unified to a type argument, unify it.
 
-		typeParameters.Set(t.TypeParameter, other)
+		typeArguments.Set(t.TypeParameter, other)
 
 		// If the type parameter corresponding to the type argument has a type bound,
 		// then check that the argument's type is a subtype of the type bound.
@@ -3155,7 +3155,7 @@ func (t *VariableSizedType) IndexingType() Type {
 
 func (t *VariableSizedType) Unify(
 	other Type,
-	typeParameters *TypeParameterTypeOrderedMap,
+	typeArguments *TypeParameterTypeOrderedMap,
 	report func(err error),
 	memoryGauge common.MemoryGauge,
 	outerRange ast.HasPosition,
@@ -3168,7 +3168,7 @@ func (t *VariableSizedType) Unify(
 
 	return t.Type.Unify(
 		otherArray.Type,
-		typeParameters,
+		typeArguments,
 		report,
 		memoryGauge,
 		outerRange,
@@ -3343,7 +3343,7 @@ func (t *ConstantSizedType) IndexingType() Type {
 
 func (t *ConstantSizedType) Unify(
 	other Type,
-	typeParameters *TypeParameterTypeOrderedMap,
+	typeArguments *TypeParameterTypeOrderedMap,
 	report func(err error),
 	memoryGauge common.MemoryGauge,
 	outerRange ast.HasPosition,
@@ -3360,7 +3360,7 @@ func (t *ConstantSizedType) Unify(
 
 	return t.Type.Unify(
 		otherArray.Type,
-		typeParameters,
+		typeArguments,
 		report,
 		memoryGauge,
 		outerRange,
@@ -4057,7 +4057,7 @@ func (t *FunctionType) ArgumentLabels() (argumentLabels []string) {
 
 func (t *FunctionType) Unify(
 	other Type,
-	typeParameters *TypeParameterTypeOrderedMap,
+	typeArguments *TypeParameterTypeOrderedMap,
 	report func(err error),
 	memoryGauge common.MemoryGauge,
 	outerRange ast.HasPosition,
@@ -4088,7 +4088,7 @@ func (t *FunctionType) Unify(
 		otherParameter := otherFunction.Parameters[i]
 		parameterUnified := parameter.TypeAnnotation.Type.Unify(
 			otherParameter.TypeAnnotation.Type,
-			typeParameters,
+			typeArguments,
 			report,
 			memoryGauge,
 			outerRange,
@@ -4100,7 +4100,7 @@ func (t *FunctionType) Unify(
 
 	returnTypeUnified := t.ReturnTypeAnnotation.Type.Unify(
 		otherFunction.ReturnTypeAnnotation.Type,
-		typeParameters,
+		typeArguments,
 		report,
 		memoryGauge,
 		outerRange,
@@ -6566,7 +6566,7 @@ type DictionaryEntryType struct {
 
 func (t *DictionaryType) Unify(
 	other Type,
-	typeParameters *TypeParameterTypeOrderedMap,
+	typeArguments *TypeParameterTypeOrderedMap,
 	report func(err error),
 	memoryGauge common.MemoryGauge,
 	outerRange ast.HasPosition,
@@ -6579,7 +6579,7 @@ func (t *DictionaryType) Unify(
 
 	keyUnified := t.KeyType.Unify(
 		otherDictionary.KeyType,
-		typeParameters,
+		typeArguments,
 		report,
 		memoryGauge,
 		outerRange,
@@ -6587,7 +6587,7 @@ func (t *DictionaryType) Unify(
 
 	valueUnified := t.ValueType.Unify(
 		otherDictionary.ValueType,
-		typeParameters,
+		typeArguments,
 		report,
 		memoryGauge,
 		outerRange,
@@ -6948,7 +6948,7 @@ func (*InclusiveRangeType) AllowsValueIndexingAssignment() bool {
 
 func (t *InclusiveRangeType) Unify(
 	other Type,
-	typeParameters *TypeParameterTypeOrderedMap,
+	typeArguments *TypeParameterTypeOrderedMap,
 	report func(err error),
 	memoryGauge common.MemoryGauge,
 	outerRange ast.HasPosition,
@@ -6960,7 +6960,7 @@ func (t *InclusiveRangeType) Unify(
 
 	return t.MemberType.Unify(
 		otherRange.MemberType,
-		typeParameters,
+		typeArguments,
 		report,
 		memoryGauge,
 		outerRange,
@@ -7232,7 +7232,7 @@ func (t *ReferenceType) IndexingType() Type {
 
 func (t *ReferenceType) Unify(
 	other Type,
-	typeParameters *TypeParameterTypeOrderedMap,
+	typeArguments *TypeParameterTypeOrderedMap,
 	report func(err error),
 	memoryGauge common.MemoryGauge,
 	outerRange ast.HasPosition,
@@ -7244,7 +7244,7 @@ func (t *ReferenceType) Unify(
 
 	return t.Type.Unify(
 		otherReference.Type,
-		typeParameters,
+		typeArguments,
 		report,
 		memoryGauge,
 		outerRange,
@@ -8715,7 +8715,7 @@ func (t *CapabilityType) RewriteWithIntersectionTypes() (Type, bool) {
 
 func (t *CapabilityType) Unify(
 	other Type,
-	typeParameters *TypeParameterTypeOrderedMap,
+	typeArguments *TypeParameterTypeOrderedMap,
 	report func(err error),
 	memoryGauge common.MemoryGauge,
 	outerRange ast.HasPosition,
@@ -8731,7 +8731,7 @@ func (t *CapabilityType) Unify(
 
 	return t.BorrowType.Unify(
 		otherCap.BorrowType,
-		typeParameters,
+		typeArguments,
 		report,
 		memoryGauge,
 		outerRange,

--- a/stdlib/account.go
+++ b/stdlib/account.go
@@ -112,7 +112,7 @@ type AccountCreator interface {
 func NativeAccountConstructor(creator AccountCreator) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -237,13 +237,13 @@ var GetAuthAccountFunctionType = func() *sema.FunctionType {
 func NativeGetAuthAccountFunction(handler AccountHandler) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		typeParameterGetter interpreter.TypeParameterGetter,
+		typeArguments interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
 		accountAddress := interpreter.AssertValueOfType[interpreter.AddressValue](args[0])
 
-		ty := typeParameterGetter.NextStatic()
+		ty := typeArguments.NextStatic()
 		referenceType, ok := ty.(*interpreter.ReferenceStaticType)
 		if !ok {
 			panic(errors.NewUnreachableError())
@@ -599,7 +599,7 @@ func nativeAccountKeysAddFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -718,7 +718,7 @@ func nativeAccountKeysGetFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -808,7 +808,7 @@ func nativeAccountKeysForEachFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -960,7 +960,7 @@ func nativeAccountKeysRevokeFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -1049,7 +1049,7 @@ func nativeAccountInboxPublishFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -1144,12 +1144,12 @@ func nativeAccountInboxUnpublishFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		typeParameterGetter interpreter.TypeParameterGetter,
+		typeArguments interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
 		nameValue := interpreter.AssertValueOfType[*interpreter.StringValue](args[0])
-		borrowType := typeParameterGetter.NextSema()
+		borrowType := typeArguments.NextSema()
 
 		providerValue := interpreter.GetAddressValue(receiver, providerPointer)
 
@@ -1254,13 +1254,13 @@ func nativeAccountInboxClaimFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		typeParameterGetter interpreter.TypeParameterGetter,
+		typeArguments interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
 		nameValue := interpreter.AssertValueOfType[*interpreter.StringValue](args[0])
 		providerValue := interpreter.AssertValueOfType[interpreter.AddressValue](args[1])
-		borrowType := typeParameterGetter.NextSema()
+		borrowType := typeArguments.NextSema()
 
 		recipientValue := interpreter.GetAddressValue(receiver, recipientPointer)
 
@@ -1444,7 +1444,7 @@ func nativeAccountContractsGetFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -1530,12 +1530,12 @@ func nativeAccountContractsBorrowFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		typeParameterGetter interpreter.TypeParameterGetter,
+		typeArguments interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
 		nameValue := interpreter.AssertValueOfType[*interpreter.StringValue](args[0])
-		borrowType := typeParameterGetter.NextSema()
+		borrowType := typeArguments.NextSema()
 
 		address := interpreter.GetAddress(receiver, addressPointer)
 
@@ -1715,7 +1715,7 @@ func nativeAccountContractsChangeFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -2075,7 +2075,7 @@ func nativeAccountContractsTryUpdateFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) (deploymentResult interpreter.Value) {
@@ -2425,7 +2425,7 @@ func nativeAccountContractsRemoveFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -2585,7 +2585,7 @@ var GetAccountFunctionType = sema.NewSimpleFunctionType(
 func NativeGetAccountFunction(handler AccountHandler) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -2744,7 +2744,7 @@ func nativeAccountStorageCapabilitiesGetControllerFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -2824,7 +2824,7 @@ func nativeAccountStorageCapabilitiesGetControllersFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -2934,7 +2934,7 @@ func nativeAccountStorageCapabilitiesForEachControllerFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -3079,11 +3079,11 @@ func nativeAccountStorageCapabilitiesIssueFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		typeParameterGetter interpreter.TypeParameterGetter,
+		typeArguments interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
-		borrowType := typeParameterGetter.NextSema()
+		borrowType := typeArguments.NextSema()
 
 		address := interpreter.GetAddress(receiver, addressPointer)
 
@@ -3158,7 +3158,7 @@ func nativeAccountStorageCapabilitiesIssueWithTypeFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -3330,11 +3330,11 @@ func nativeAccountAccountCapabilitiesIssueFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		typeParameterGetter interpreter.TypeParameterGetter,
+		typeArguments interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
-		borrowType := typeParameterGetter.NextSema()
+		borrowType := typeArguments.NextSema()
 
 		address := interpreter.GetAddress(receiver, addressPointer)
 
@@ -3382,7 +3382,7 @@ func nativeAccountAccountCapabilitiesIssueWithTypeFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -4017,7 +4017,7 @@ func nativeAccountCapabilitiesPublishFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -4181,7 +4181,7 @@ func nativeAccountCapabilitiesUnpublishFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -4461,12 +4461,12 @@ func nativeAccountCapabilitiesGetFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		typeParameterGetter interpreter.TypeParameterGetter,
+		typeArguments interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
 		pathValue := interpreter.AssertValueOfType[interpreter.PathValue](args[0])
-		typeParameter := typeParameterGetter.NextSema()
+		typeArgument := typeArguments.NextSema()
 
 		addressValue := interpreter.GetAddressValue(receiver, addressPointer)
 
@@ -4474,7 +4474,7 @@ func nativeAccountCapabilitiesGetFunction(
 			context,
 			controllerHandler,
 			pathValue,
-			typeParameter,
+			typeArgument,
 			borrow,
 			addressValue,
 		)
@@ -4707,7 +4707,7 @@ func nativeAccountCapabilitiesExistsFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -4804,7 +4804,7 @@ func nativeAccountAccountCapabilitiesGetControllerFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -4870,7 +4870,7 @@ func nativeAccountAccountCapabilitiesGetControllersFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -4984,7 +4984,7 @@ func nativeAccountAccountCapabilitiesForEachControllerFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {

--- a/stdlib/assert.go
+++ b/stdlib/assert.go
@@ -58,7 +58,7 @@ var AssertFunctionType = &sema.FunctionType{
 var NativeAssertFunction = interpreter.NativeFunction(
 	func(
 		_ interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {

--- a/stdlib/block.go
+++ b/stdlib/block.go
@@ -81,7 +81,7 @@ type BlockAtHeightProvider interface {
 func NativeGetBlockFunction(provider BlockAtHeightProvider) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -203,7 +203,7 @@ type CurrentBlockProvider interface {
 func NativeGetCurrentBlockFunction(provider CurrentBlockProvider) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		_ []interpreter.Value,
 	) interpreter.Value {

--- a/stdlib/bls.go
+++ b/stdlib/bls.go
@@ -40,7 +40,7 @@ func NativeBLSAggregatePublicKeysFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -141,7 +141,7 @@ func NativeBLSAggregateSignaturesFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {

--- a/stdlib/hashalgorithm.go
+++ b/stdlib/hashalgorithm.go
@@ -79,7 +79,7 @@ func NewHashAlgorithmCase(
 func NativeHashAlgorithmHashFunction(hasher Hasher, hashAlgoValue interpreter.MemberAccessibleValue) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -103,7 +103,7 @@ func NativeHashAlgorithmHashFunction(hasher Hasher, hashAlgoValue interpreter.Me
 func NativeHashAlgorithmHashWithTagFunction(hasher Hasher, hashAlgoValue interpreter.MemberAccessibleValue) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -237,7 +237,7 @@ func NewVMHashAlgorithmConstructor(hasher Hasher) StandardLibraryValue {
 		hashAlgorithmLookupType,
 		func(
 			context interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			_ interpreter.Value,
 			args []interpreter.Value,
 		) interpreter.Value {

--- a/stdlib/log.go
+++ b/stdlib/log.go
@@ -57,7 +57,7 @@ func (f FunctionLogger) ProgramLog(message string) error {
 func NativeLogFunction(logger Logger) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {

--- a/stdlib/panic.go
+++ b/stdlib/panic.go
@@ -65,7 +65,7 @@ var PanicFunctionType = sema.NewSimpleFunctionType(
 var NativePanicFunction = interpreter.NativeFunction(
 	func(
 		_ interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {

--- a/stdlib/publickey.go
+++ b/stdlib/publickey.go
@@ -74,7 +74,7 @@ func NativePublicKeyConstructorFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -217,7 +217,7 @@ func NativePublicKeyVerifySignatureFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -327,7 +327,7 @@ func NativePublicKeyVerifyPoPFunction(
 ) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {

--- a/stdlib/random.go
+++ b/stdlib/random.go
@@ -109,11 +109,11 @@ var ZeroModuloError = errors.NewDefaultUserError("modulo argument cannot be zero
 func NativeRevertibleRandomFunction(generator RandomGenerator) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
-		typeParameterGetter interpreter.TypeParameterGetter,
+		typeArguments interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
-		returnIntegerType := typeParameterGetter.NextSema()
+		returnIntegerType := typeArguments.NextSema()
 
 		var moduloValue interpreter.Value
 		if len(args) == 1 {

--- a/stdlib/range.go
+++ b/stdlib/range.go
@@ -116,7 +116,7 @@ var inclusiveRangeConstructorFunctionType = func() *sema.FunctionType {
 var NativeInclusiveRangeConstructorFunction = interpreter.NativeFunction(
 	func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {

--- a/stdlib/rlp.go
+++ b/stdlib/rlp.go
@@ -54,7 +54,7 @@ const rlpErrMsgInputContainsExtraBytes = "input data is expected to be RLP-encod
 var NativeRLPDecodeStringFunction = interpreter.NativeFunction(
 	func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
@@ -66,7 +66,7 @@ var NativeRLPDecodeStringFunction = interpreter.NativeFunction(
 var NativeRLPDecodeListFunction = interpreter.NativeFunction(
 	func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {

--- a/stdlib/signaturealgorithm.go
+++ b/stdlib/signaturealgorithm.go
@@ -74,7 +74,7 @@ var vmSignatureAlgorithmConstructorValue = vm.NewNativeFunctionValue(
 	signatureAlgorithmLookupType,
 	func(
 		context interpreter.NativeFunctionContext,
-		_ interpreter.TypeParameterGetter,
+		_ interpreter.TypeArgumentsIterator,
 		_ interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {

--- a/stdlib/test.go
+++ b/stdlib/test.go
@@ -400,7 +400,7 @@ func newMatcherWithGenericTestFunction(
 	matcherTestFunctionType *sema.FunctionType,
 ) interpreter.Value {
 
-	typeParameterPair := invocation.TypeParameterTypes.Oldest()
+	typeParameterPair := invocation.TypeArguments.Oldest()
 	if typeParameterPair == nil {
 		panic(errors.NewUnreachableError())
 	}

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -173,7 +173,7 @@ func ParseCheckAndPrepareWithLogs(
 		"",
 		func(
 			_ interpreter.NativeFunctionContext,
-			_ interpreter.TypeParameterGetter,
+			_ interpreter.TypeArgumentsIterator,
 			_ interpreter.Value,
 			args []interpreter.Value,
 		) interpreter.Value {
@@ -351,7 +351,7 @@ func ParseCheckAndPrepareWithOptions(
 							functionValue.Type,
 							func(
 								context interpreter.NativeFunctionContext,
-								_ interpreter.TypeParameterGetter,
+								_ interpreter.TypeArgumentsIterator,
 								_ interpreter.Value,
 								arguments []interpreter.Value,
 							) interpreter.Value {


### PR DESCRIPTION
Work towards #3804 

## Description

Improve naming of "type parameters" which are actually type arguments

- Rename "type parameters" to "type arguments" where appropriate, in new compiler/Vm code, but also in existing type checker and interpreter code
- Rename type arguments "getter" to more descriptive "iterator": "getter" implies stateless computation of single value, but a stateful sequence of values is produced

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
