### PR TITLE
Improve computation profiling

### DIFF
--- a/runtime/pprof.go
+++ b/runtime/pprof.go
@@ -23,30 +23,30 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/google/pprof/profile"
+	pprof "github.com/google/pprof/profile"
 
 	"github.com/onflow/cadence/common"
 )
 
 type PProfExporter struct {
 	ComputationProfile *ComputationProfile
-	profile            *profile.Profile
-	locations          map[profile.Line]*profile.Location
-	functions          map[profiledFunction]*profile.Function
+	profile            *pprof.Profile
+	lineLocations      map[pprof.Line]*pprof.Location
+	functions          map[profiledFunction]*pprof.Function
 }
 
 func NewPProfExporter(computationProfile *ComputationProfile) *PProfExporter {
 	return &PProfExporter{
 		ComputationProfile: computationProfile,
-		locations:          make(map[profile.Line]*profile.Location),
-		functions:          make(map[profiledFunction]*profile.Function),
+		lineLocations:      make(map[pprof.Line]*pprof.Location),
+		functions:          make(map[profiledFunction]*pprof.Function),
 	}
 }
 
-func (e *PProfExporter) Export() (*profile.Profile, error) {
-	e.profile = &profile.Profile{}
+func (e *PProfExporter) Export() (*pprof.Profile, error) {
+	e.profile = &pprof.Profile{}
 
-	e.profile.SampleType = []*profile.ValueType{
+	e.profile.SampleType = []*pprof.ValueType{
 		{
 			Type: "computation",
 			Unit: "count",
@@ -54,7 +54,6 @@ func (e *PProfExporter) Export() (*profile.Profile, error) {
 	}
 
 	e.exportFunctions()
-
 	e.exportSamples()
 
 	return e.profile, nil
@@ -71,20 +70,20 @@ func (e *PProfExporter) exportFunctions() {
 	})
 
 	for _, location := range locations {
-		profiledFunction := e.ComputationProfile.locationFunctions[location]
+		functions := e.ComputationProfile.locationFunctions[location]
 
-		for _, profiledFunction := range profiledFunction.Values() {
-			function := &profile.Function{
+		for _, function := range functions.Values() {
+			pprofFunction := &pprof.Function{
 				ID:        e.nextFunctionID(),
-				Name:      profiledFunction.name,
+				Name:      function.name,
 				Filename:  e.ComputationProfile.sourcePathForLocation(location),
-				StartLine: int64(profiledFunction.startLine),
+				StartLine: int64(function.startLine),
 			}
 			e.profile.Function = append(
 				e.profile.Function,
-				function,
+				pprofFunction,
 			)
-			e.functions[profiledFunction] = function
+			e.functions[function] = pprofFunction
 		}
 	}
 }
@@ -105,7 +104,7 @@ func (e *PProfExporter) exportSamples() {
 	for _, aggregateKey := range aggregateKeys {
 		usage := e.ComputationProfile.stackTraceUsages[aggregateKey]
 
-		var sampleLocations []*profile.Location
+		var sampleLocations []*pprof.Location
 
 		for i := len(usage.stackTrace) - 1; i >= 0; i-- {
 			locationLine := usage.stackTrace[i]
@@ -117,7 +116,7 @@ func (e *PProfExporter) exportSamples() {
 
 			line := locationLine.Line
 
-			profiledFunction, ok := e.ComputationProfile.functionAtLine(locationLine)
+			function, ok := e.ComputationProfile.functionAtLine(locationLine)
 			if !ok {
 				panic(fmt.Errorf(
 					"missing profile function at %s:%d",
@@ -126,7 +125,7 @@ func (e *PProfExporter) exportSamples() {
 				))
 			}
 
-			function, ok := e.functions[profiledFunction]
+			pprofFunction, ok := e.functions[function]
 			if !ok {
 				panic(fmt.Errorf(
 					"missing exported function at %s:%d",
@@ -135,11 +134,11 @@ func (e *PProfExporter) exportSamples() {
 				))
 			}
 
-			sampleLocation := e.getOrAddLocation(function, line)
+			sampleLocation := e.getOrAddLocation(pprofFunction, line)
 			sampleLocations = append(sampleLocations, sampleLocation)
 		}
 
-		sample := &profile.Sample{
+		pprofSample := &pprof.Sample{
 			Location: sampleLocations,
 			Value: []int64{
 				int64(usage.computation),
@@ -148,33 +147,33 @@ func (e *PProfExporter) exportSamples() {
 
 		e.profile.Sample = append(
 			e.profile.Sample,
-			sample,
+			pprofSample,
 		)
 	}
 }
 
-func (e *PProfExporter) getOrAddLocation(function *profile.Function, line int) *profile.Location {
-	pLine := profile.Line{
-		Function: function,
+func (e *PProfExporter) getOrAddLocation(pprofFunction *pprof.Function, line int) *pprof.Location {
+	pprofLine := pprof.Line{
+		Function: pprofFunction,
 		Line:     int64(line),
 	}
 
-	location, ok := e.locations[pLine]
+	pprofLocation, ok := e.lineLocations[pprofLine]
 	if ok {
-		return location
+		return pprofLocation
 	}
 
-	location = &profile.Location{
+	pprofLocation = &pprof.Location{
 		ID:   e.nextLocationID(),
-		Line: []profile.Line{pLine},
+		Line: []pprof.Line{pprofLine},
 	}
-	e.locations[pLine] = location
+	e.lineLocations[pprofLine] = pprofLocation
 	e.profile.Location = append(
 		e.profile.Location,
-		location,
+		pprofLocation,
 	)
 
-	return location
+	return pprofLocation
 }
 
 func (e *PProfExporter) nextLocationID() uint64 {

--- a/runtime/profile.go
+++ b/runtime/profile.go
@@ -273,3 +273,10 @@ func (p *ComputationProfile) sourcePathForLocation(location common.Location) str
 
 	return locationSource
 }
+
+// Reset clears the collected profiling information for all locations and inspected locations.
+func (p *ComputationProfile) Reset() {
+	p.currentStackTrace = nil
+	clear(p.stackTraceUsages)
+	clear(p.locationFunctions)
+}

--- a/runtime/profile.go
+++ b/runtime/profile.go
@@ -51,10 +51,11 @@ type profiledFunction struct {
 
 // ComputationProfile collects computation profiling information per location.
 type ComputationProfile struct {
-	locationFunctions map[common.Location]*intervalst.IntervalST[profiledFunction]
-	currentStackTrace profileStackTrace
-	stackTraceUsages  map[string]stackTraceUsage
-	locationMappings  map[string]string
+	locationFunctions  map[common.Location]*intervalst.IntervalST[profiledFunction]
+	currentStackTrace  profileStackTrace
+	stackTraceUsages   map[string]stackTraceUsage
+	locationMappings   map[string]string
+	computationWeights map[common.ComputationKind]uint64
 	// DelegatedComputationGauge is the computation gauge to which
 	// delegated computation metering is reported.
 	// It may be nil, in which case no delegation occurs.
@@ -76,6 +77,13 @@ func (p *ComputationProfile) WithLocationMappings(
 	locationMappings map[string]string,
 ) {
 	p.locationMappings = locationMappings
+}
+
+// WithComputationWeights sets the computation weights for this profile.
+func (p *ComputationProfile) WithComputationWeights(
+	weights map[common.ComputationKind]uint64,
+) {
+	p.computationWeights = weights
 }
 
 type LocationLine struct {
@@ -146,13 +154,6 @@ func (p *ComputationProfile) newOnStatementHandler() interpreter.OnStatementFunc
 
 func (p *ComputationProfile) MeterComputation(computationUsage common.ComputationUsage) error {
 
-	aggregateKey := p.currentStackTrace.aggregateKey()
-	traceUsage := p.stackTraceUsages[aggregateKey]
-	traceUsage.stackTrace = p.currentStackTrace
-	// TODO: apply weight
-	traceUsage.computation += computationUsage.Intensity
-	p.stackTraceUsages[aggregateKey] = traceUsage
-
 	gauge := p.DelegatedComputationGauge
 	if gauge != nil {
 		err := gauge.MeterComputation(computationUsage)
@@ -160,6 +161,18 @@ func (p *ComputationProfile) MeterComputation(computationUsage common.Computatio
 			return err
 		}
 	}
+
+	weight := p.computationWeights[computationUsage.Kind]
+	if weight == 0 {
+		// No need to record zero-weight computation
+		return nil
+	}
+
+	aggregateKey := p.currentStackTrace.aggregateKey()
+	traceUsage := p.stackTraceUsages[aggregateKey]
+	traceUsage.stackTrace = p.currentStackTrace
+	traceUsage.computation += computationUsage.Intensity * weight
+	p.stackTraceUsages[aggregateKey] = traceUsage
 
 	return nil
 }

--- a/runtime/profile_test.go
+++ b/runtime/profile_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"testing"
 
-	profile2 "github.com/google/pprof/profile"
+	pprof "github.com/google/pprof/profile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -129,7 +129,7 @@ func TestRuntimeProfile(t *testing.T) {
 
 	assert.Equal(
 		t,
-		[]profile2.Line{{
+		[]pprof.Line{{
 			Function: profile.Function[1], // main
 			Line:     5,
 		}},
@@ -137,7 +137,7 @@ func TestRuntimeProfile(t *testing.T) {
 	)
 	assert.Equal(
 		t,
-		[]profile2.Line{{
+		[]pprof.Line{{
 			Function: profile.Function[0], // factorial
 			Line:     12,
 		}},
@@ -145,7 +145,7 @@ func TestRuntimeProfile(t *testing.T) {
 	)
 	assert.Equal(
 		t,
-		[]profile2.Line{{
+		[]pprof.Line{{
 			Function: profile.Function[0], // factorial
 			Line:     16,
 		}},
@@ -153,7 +153,7 @@ func TestRuntimeProfile(t *testing.T) {
 	)
 	assert.Equal(
 		t,
-		[]profile2.Line{{
+		[]pprof.Line{{
 			Function: profile.Function[0], // factorial
 			Line:     13,
 		}},
@@ -161,7 +161,7 @@ func TestRuntimeProfile(t *testing.T) {
 	)
 	assert.Equal(
 		t,
-		[]profile2.Line{{
+		[]pprof.Line{{
 			Function: profile.Function[0], // factorial
 			Line:     4,
 		}},
@@ -169,7 +169,7 @@ func TestRuntimeProfile(t *testing.T) {
 	)
 	assert.Equal(
 		t,
-		[]profile2.Line{{
+		[]pprof.Line{{
 			Function: profile.Function[0], // factorial
 			Line:     8,
 		}},
@@ -177,7 +177,7 @@ func TestRuntimeProfile(t *testing.T) {
 	)
 	assert.Equal(
 		t,
-		[]profile2.Line{{
+		[]pprof.Line{{
 			Function: profile.Function[1], // main
 			Line:     6,
 		}},
@@ -194,7 +194,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[0].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[0],
 		},
 		profile.Sample[0].Location,
@@ -205,7 +205,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[1].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[1],
 			profile.Location[0],
 		},
@@ -217,7 +217,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[2].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[2],
 			profile.Location[0],
 		},
@@ -229,7 +229,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[3].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[1],
 			profile.Location[2],
 			profile.Location[0],
@@ -242,7 +242,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[4].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[2],
 			profile.Location[2],
 			profile.Location[0],
@@ -255,7 +255,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[5].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[1],
 			profile.Location[2],
 			profile.Location[2],
@@ -269,7 +269,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[6].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[3],
 			profile.Location[2],
 			profile.Location[2],
@@ -283,7 +283,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[7].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[4],
 			profile.Location[2],
 			profile.Location[2],
@@ -297,7 +297,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[8].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[5],
 			profile.Location[2],
 			profile.Location[2],
@@ -311,7 +311,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[9].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[4],
 			profile.Location[2],
 			profile.Location[0],
@@ -324,7 +324,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[10].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[5],
 			profile.Location[2],
 			profile.Location[0],
@@ -337,7 +337,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[11].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[4],
 			profile.Location[0],
 		},
@@ -349,7 +349,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[12].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[5],
 			profile.Location[0],
 		},
@@ -361,7 +361,7 @@ func TestRuntimeProfile(t *testing.T) {
 		profile.Sample[13].Value,
 	)
 	assert.Equal(t,
-		[]*profile2.Location{
+		[]*pprof.Location{
 			profile.Location[6],
 		},
 		profile.Sample[13].Location,

--- a/runtime/profile_test.go
+++ b/runtime/profile_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 
+	profile2 "github.com/google/pprof/profile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -58,7 +59,7 @@ func TestRuntimeProfile(t *testing.T) {
 	  import "imported"
 
 	  access(all) fun main(): Int {
-	    factorial(5)
+	    factorial(2)
 	    return 42
 	  }
 	`)
@@ -68,6 +69,13 @@ func TestRuntimeProfile(t *testing.T) {
 		map[string]string{
 			"imported":                   "imported.cdc",
 			common.ScriptLocation{}.ID(): "script.cdc",
+		},
+	)
+	computationProfile.WithComputationWeights(
+		map[common.ComputationKind]uint64{
+			common.ComputationKindStatement:          2,
+			common.ComputationKindLoop:               2,
+			common.ComputationKindFunctionInvocation: 2,
 		},
 	)
 
@@ -102,8 +110,6 @@ func TestRuntimeProfile(t *testing.T) {
 	profile, err := NewPProfExporter(computationProfile).Export()
 	require.NoError(t, err)
 
-	assert.Len(t, profile.Sample, 26)
-
 	require.Len(t, profile.Function, 2)
 
 	factorialFunction := profile.Function[0]
@@ -118,31 +124,246 @@ func TestRuntimeProfile(t *testing.T) {
 
 	assert.Len(t, profile.Location, 7)
 
-	for _, location := range profile.Location {
-		require.Len(t, location.Line, 1)
-		line := location.Line[0]
+	// Locations. NOT in execution  or appearance order,
+	// but lexically ordered aggregate key of stack trace
 
-		switch line.Function {
+	assert.Equal(
+		t,
+		[]profile2.Line{{
+			Function: profile.Function[1], // main
+			Line:     5,
+		}},
+		profile.Location[0].Line,
+	)
+	assert.Equal(
+		t,
+		[]profile2.Line{{
+			Function: profile.Function[0], // factorial
+			Line:     12,
+		}},
+		profile.Location[1].Line,
+	)
+	assert.Equal(
+		t,
+		[]profile2.Line{{
+			Function: profile.Function[0], // factorial
+			Line:     16,
+		}},
+		profile.Location[2].Line,
+	)
+	assert.Equal(
+		t,
+		[]profile2.Line{{
+			Function: profile.Function[0], // factorial
+			Line:     13,
+		}},
+		profile.Location[3].Line,
+	)
+	assert.Equal(
+		t,
+		[]profile2.Line{{
+			Function: profile.Function[0], // factorial
+			Line:     4,
+		}},
+		profile.Location[4].Line,
+	)
+	assert.Equal(
+		t,
+		[]profile2.Line{{
+			Function: profile.Function[0], // factorial
+			Line:     8,
+		}},
+		profile.Location[5].Line,
+	)
+	assert.Equal(
+		t,
+		[]profile2.Line{{
+			Function: profile.Function[1], // main
+			Line:     6,
+		}},
+		profile.Location[6].Line,
+	)
 
-		case profile.Function[0]: // factorial
-			switch line.Line {
-			case 4, 8, 12, 13, 16:
-				// valid lines
-			default:
-				t.Fatalf("unexpected line number for factorial: %d", line.Line)
-			}
+	// Samples. NOT in execution / appearance order,
+	// but lexically ordered aggregate key of stack trace
 
-		case profile.Function[1]: // main
-			switch line.Line {
-			case 5, 6:
-				// valid lines
-			default:
-				t.Fatalf("unexpected line number for main: %d", line.Line)
-			}
+	require.Len(t, profile.Sample, 14)
 
-		default:
-			t.Fatalf("unexpected function for location: %s", line.Function.Name)
-		}
-	}
+	assert.Equal(t,
+		[]int64{4},
+		profile.Sample[0].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[0],
+		},
+		profile.Sample[0].Location,
+	)
 
+	assert.Equal(t,
+		[]int64{2},
+		profile.Sample[1].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[1],
+			profile.Location[0],
+		},
+		profile.Sample[1].Location,
+	)
+
+	assert.Equal(t,
+		[]int64{4},
+		profile.Sample[2].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[2],
+			profile.Location[0],
+		},
+		profile.Sample[2].Location,
+	)
+
+	assert.Equal(t,
+		[]int64{2},
+		profile.Sample[3].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[1],
+			profile.Location[2],
+			profile.Location[0],
+		},
+		profile.Sample[3].Location,
+	)
+
+	assert.Equal(t,
+		[]int64{4},
+		profile.Sample[4].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[2],
+			profile.Location[2],
+			profile.Location[0],
+		},
+		profile.Sample[4].Location,
+	)
+
+	assert.Equal(t,
+		[]int64{2},
+		profile.Sample[5].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[1],
+			profile.Location[2],
+			profile.Location[2],
+			profile.Location[0],
+		},
+		profile.Sample[5].Location,
+	)
+
+	assert.Equal(t,
+		[]int64{2},
+		profile.Sample[6].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[3],
+			profile.Location[2],
+			profile.Location[2],
+			profile.Location[0],
+		},
+		profile.Sample[6].Location,
+	)
+
+	assert.Equal(t,
+		[]int64{2},
+		profile.Sample[7].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[4],
+			profile.Location[2],
+			profile.Location[2],
+			profile.Location[0],
+		},
+		profile.Sample[7].Location,
+	)
+
+	assert.Equal(t,
+		[]int64{2},
+		profile.Sample[8].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[5],
+			profile.Location[2],
+			profile.Location[2],
+			profile.Location[0],
+		},
+		profile.Sample[8].Location,
+	)
+
+	assert.Equal(t,
+		[]int64{2},
+		profile.Sample[9].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[4],
+			profile.Location[2],
+			profile.Location[0],
+		},
+		profile.Sample[9].Location,
+	)
+
+	assert.Equal(t,
+		[]int64{2},
+		profile.Sample[10].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[5],
+			profile.Location[2],
+			profile.Location[0],
+		},
+		profile.Sample[10].Location,
+	)
+
+	assert.Equal(t,
+		[]int64{2},
+		profile.Sample[11].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[4],
+			profile.Location[0],
+		},
+		profile.Sample[11].Location,
+	)
+
+	assert.Equal(t,
+		[]int64{2},
+		profile.Sample[12].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[5],
+			profile.Location[0],
+		},
+		profile.Sample[12].Location,
+	)
+
+	assert.Equal(t,
+		[]int64{2},
+		profile.Sample[13].Value,
+	)
+	assert.Equal(t,
+		[]*profile2.Location{
+			profile.Location[6],
+		},
+		profile.Sample[13].Location,
+	)
 }


### PR DESCRIPTION
## Description

- Apply weights to profiled computation usage
- Add a method to clear collected profiling info
- Improve test

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
