### PR TITLE
Replace for-delete loops with clear

### DIFF
--- a/common/orderedmap/orderedmap.go
+++ b/common/orderedmap/orderedmap.go
@@ -54,10 +54,7 @@ func (om *OrderedMap[K, V]) Clear() {
 	}
 
 	om.list.Init()
-	// NOTE: Range over map is safe, as it is only used to delete entries
-	for key := range om.pairs { //nolint:maprange
-		delete(om.pairs, key)
-	}
+	clear(om.pairs)
 }
 
 // Get returns the value associated with the given key.

--- a/runtime/contract_update_validation_test.go
+++ b/runtime/contract_update_validation_test.go
@@ -3060,9 +3060,7 @@ func TestRuntimeContractUpdateProgramCaching(t *testing.T) {
 			programGets2,
 			programSets2,
 		} {
-			for location := range counts { //nolint:maprange
-				delete(counts, location)
-			}
+			clear(counts)
 		}
 	}
 

--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -266,15 +266,11 @@ func (r *CoverageReport) String() string {
 	return fmt.Sprintf("Coverage: %v of statements", r.Percentage())
 }
 
-// Reset flushes the collected coverage information for all locations
-// and inspected locations. Excluded locations remain intact.
+// Reset clears the collected coverage information for all locations and inspected locations.
+// Excluded locations remain intact.
 func (r *CoverageReport) Reset() {
-	for location := range r.Coverage { // nolint:maprange
-		delete(r.Coverage, location)
-	}
-	for location := range r.Locations { // nolint:maprange
-		delete(r.Locations, location)
-	}
+	clear(r.Coverage)
+	clear(r.Locations)
 }
 
 // Merge adds all the collected coverage information to the

--- a/test_utils/runtime_utils/testinterface.go
+++ b/test_utils/runtime_utils/testinterface.go
@@ -544,10 +544,7 @@ func (i *TestRuntimeInterface) onScriptExecutionStart() {
 
 func (i *TestRuntimeInterface) InvalidateUpdatedPrograms() {
 	if i.updatedContractCode {
-		// iteration order does not matter
-		for location := range i.Programs { //nolint:maprange
-			delete(i.Programs, location)
-		}
+		clear(i.Programs)
 		i.updatedContractCode = false
 	}
 }


### PR DESCRIPTION
## Description

Since v1.21, Go provides the built-in `clear`.

Use the function instead of manual for loops that delete each entry.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
