### PR TITLE
[Compiler] Re-use static to sema conversions in vm.

### DIFF
--- a/bbq/compiler/config.go
+++ b/bbq/compiler/config.go
@@ -22,11 +22,14 @@ import (
 	"github.com/onflow/cadence/activations"
 	"github.com/onflow/cadence/bbq/commons"
 	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/sema"
 )
 
 type BuiltinGlobalsProvider func(location common.Location) *activations.Activation[GlobalImport]
 
 type ElaborationResolver func(location common.Location) (*DesugaredElaboration, error)
+
+type GetSemaTypeCache func() map[sema.TypeID]sema.Type
 
 type Config struct {
 	MemoryGauge         common.MemoryGauge
@@ -38,4 +41,6 @@ type Config struct {
 	BuiltinGlobalsProvider BuiltinGlobalsProvider
 
 	PeepholeOptimizationsEnabled bool
+
+	GetSemaTypeCache GetSemaTypeCache
 }

--- a/bbq/program.go
+++ b/bbq/program.go
@@ -21,18 +21,16 @@ package bbq
 import (
 	"github.com/onflow/cadence/bbq/constant"
 	"github.com/onflow/cadence/bbq/opcode"
-	"github.com/onflow/cadence/sema"
 )
 
 type Program[E, T any] struct {
-	Contracts     []*Contract
-	Imports       []Import
-	Functions     []Function[E]
-	Constants     []constant.DecodedConstant
-	Variables     []Variable[E]
-	Types         []T
-	Globals       []Global
-	SemaTypeCache map[sema.TypeID]sema.Type
+	Contracts []*Contract
+	Imports   []Import
+	Functions []Function[E]
+	Constants []constant.DecodedConstant
+	Variables []Variable[E]
+	Types     []T
+	Globals   []Global
 }
 
 type InstructionProgram = Program[opcode.Instruction, StaticType]

--- a/bbq/vm/config.go
+++ b/bbq/vm/config.go
@@ -74,6 +74,8 @@ type Config struct {
 	StackDepthLimit uint64
 
 	debugEnabled bool
+
+	GetSemaTypeCache GetSemaTypeCache
 }
 
 func NewConfig(storage interpreter.Storage) *Config {
@@ -85,6 +87,9 @@ func NewConfig(storage interpreter.Storage) *Config {
 		storage:         storage,
 		StackDepthLimit: math.MaxInt,
 		Tracer:          tracer,
+		GetSemaTypeCache: func() map[sema.TypeID]sema.Type {
+			return nil
+		},
 	}
 }
 
@@ -300,6 +305,8 @@ type ContractValueHandler func(
 ) *interpreter.CompositeValue
 
 type ElaborationResolver func(location common.Location) (*sema.Elaboration, error)
+
+type GetSemaTypeCache func() map[sema.TypeID]sema.Type
 
 type EntitlementTypeHandlerFunc func(location common.Location, typeID interpreter.TypeID) *sema.EntitlementType
 

--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -19,6 +19,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/onflow/atree"
 
 	"github.com/onflow/cadence/bbq"
@@ -28,6 +30,9 @@ import (
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 )
+
+var cacheHitCount int = 0
+var cacheMissCount int = 0
 
 // Context holds the information about the current execution at any given point of time.
 // It consists of:
@@ -76,7 +81,8 @@ var _ interpreter.InvocationContext = &Context{}
 
 func NewContext(config *Config) *Context {
 	return &Context{
-		Config: config,
+		Config:        config,
+		semaTypeCache: config.GetSemaTypeCache(),
 	}
 }
 
@@ -427,6 +433,7 @@ func (c *Context) SemaTypeFromStaticType(staticType interpreter.StaticType) sema
 	typeID := staticType.ID()
 	semaType, ok := c.semaTypeCache[typeID]
 	if ok {
+		cacheHitCount++
 		return semaType
 	}
 
@@ -437,6 +444,8 @@ func (c *Context) SemaTypeFromStaticType(staticType interpreter.StaticType) sema
 		c.semaTypeCache = make(map[sema.TypeID]sema.Type)
 	}
 	c.semaTypeCache[typeID] = semaType
+
+	cacheMissCount++
 
 	return semaType
 }
@@ -550,4 +559,14 @@ func (c *Context) SemaAccessFromStaticAuthorization(auth interpreter.Authorizati
 	c.semaAccessCache[auth] = semaAccess
 
 	return semaAccess, nil
+}
+
+func (c *Context) GetCacheStatistics() {
+	fmt.Printf("Cache hit count: %d\n", cacheHitCount)
+	fmt.Printf("Cache miss count: %d\n", cacheMissCount)
+}
+
+func (c *Context) ResetCacheStatistics() {
+	cacheHitCount = 0
+	cacheMissCount = 0
 }

--- a/bbq/vm/test/ft_test.go
+++ b/bbq/vm/test/ft_test.go
@@ -61,6 +61,8 @@ func compiledFTTransfer(tb testing.TB) {
 	nonFungibleTokenLocation := common.NewAddressLocation(nil, contractsAddress, "NonFungibleToken")
 	flowTokenLocation := common.NewAddressLocation(nil, contractsAddress, "FlowToken")
 
+	semaTypeCache := make(map[sema.TypeID]sema.Type)
+
 	codes := map[common.Location][]byte{
 		burnerLocation:                     []byte(contracts.RealBurnerContract),
 		viewResolverLocation:               []byte(contracts.RealViewResolverContract),
@@ -91,7 +93,10 @@ func compiledFTTransfer(tb testing.TB) {
 
 	compilerConfig := &compiler.Config{
 		LocationHandler: locationHandler,
-		ImportHandler:   importHandler,
+		GetSemaTypeCache: func() map[sema.TypeID]sema.Type {
+			return semaTypeCache
+		},
+		ImportHandler: importHandler,
 		ElaborationResolver: func(location common.Location) (*compiler.DesugaredElaboration, error) {
 			imported, ok := compiledPrograms[location]
 			if !ok {
@@ -163,6 +168,10 @@ func compiledFTTransfer(tb testing.TB) {
 	storage := NewUnmeteredInMemoryStorage()
 
 	vmConfig := vm.NewConfig(storage)
+
+	// vmConfig.GetSemaTypeCache = func() map[sema.TypeID]sema.Type {
+	// 	return semaTypeCache
+	// }
 
 	vmConfig.CapabilityBorrowHandler = func(
 		context interpreter.BorrowCapabilityControllerContext,
@@ -483,6 +492,8 @@ func compiledFTTransfer(tb testing.TB) {
 			)
 		}
 	}
+
+	tokenTransferTxVM.Context().GetCacheStatistics()
 }
 
 func TestFTTransfer(t *testing.T) {

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -67,7 +67,6 @@ func NewVM(
 	vm.configureContext()
 
 	context.recoverErrors = vm.RecoverErrors
-	context.semaTypeCache = program.SemaTypeCache
 
 	// Link global variables and functions.
 	linkedGlobals := context.linkGlobals(


### PR DESCRIPTION
Work towards #4273 

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Re-use static to sema conversions from the compiler in the vm. Tried various changes in the linker to no success, tried caching static type ID calls, which was an improvement but affects execution, so not included.

```
              │ ./bbq/vm/test/old-3.txt │   ./bbq/vm/test/optimized-2.txt   │
              │         sec/op          │   sec/op     vs base              │
FTTransfer-14               39.10µ ± 2%   38.43µ ± 2%  -1.73% (p=0.007 n=8)

              │ ./bbq/vm/test/old-3.txt │ ./bbq/vm/test/optimized-2.txt │
              │          B/op           │     B/op      vs base         │
FTTransfer-14              36.93Ki ± 0%   36.93Ki ± 0%  ~ (p=0.660 n=8)

              │ ./bbq/vm/test/old-3.txt │ ./bbq/vm/test/optimized-2.txt │
              │        allocs/op        │ allocs/op   vs base           │
FTTransfer-14                965.0 ± 0%   965.0 ± 0%  ~ (p=1.000 n=8) ¹
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
