### PR TITLE
[Subtyping Generator] Add schema

### DIFF
--- a/tools/subtype-gen/rules.schema.json
+++ b/tools/subtype-gen/rules.schema.json
@@ -1,0 +1,344 @@
+{
+  "type": "object",
+  "properties": {
+    "rules": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/rule"
+      }
+    }
+  },
+  "required": [
+    "rules"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "rule": {
+      "type": "object",
+      "properties": {
+        "super": {
+          "type": "string"
+        },
+        "predicate": {
+          "$ref": "#/$defs/predicate"
+        }
+      },
+      "additionalProperties": false
+    },
+    "predicate": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/always"
+        },
+        {
+          "$ref": "#/$defs/never"
+        },
+        {
+          "$ref": "#/$defs/and"
+        },
+        {
+          "$ref": "#/$defs/or"
+        },
+        {
+          "$ref": "#/$defs/not"
+        },
+        {
+          "$ref": "#/$defs/equals"
+        },
+        {
+          "$ref": "#/$defs/subtype"
+        },
+        {
+          "$ref": "#/$defs/mustType"
+        },
+        {
+          "$ref": "#/$defs/permits"
+        },
+        {
+          "$ref": "#/$defs/isParameterizedSubtype"
+        },
+        {
+          "$ref": "#/$defs/setContains"
+        },
+        {
+          "$ref": "#/$defs/isResource"
+        },
+        {
+          "$ref": "#/$defs/isHashableStruct"
+        },
+        {
+          "$ref": "#/$defs/isStorable"
+        },
+        {
+          "$ref": "#/$defs/isAttachment"
+        }
+      ]
+    },
+    "always": {
+      "const": "always"
+    },
+    "never": {
+      "const": "never"
+    },
+    "and": {
+      "type": "object",
+      "properties": {
+        "and": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/predicate"
+          }
+        }
+      },
+      "required": [
+        "and"
+      ],
+      "additionalProperties": false
+    },
+    "or": {
+      "type": "object",
+      "properties": {
+        "or": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/predicate"
+          }
+        }
+      },
+      "required": [
+        "or"
+      ],
+      "additionalProperties": false
+    },
+    "not": {
+      "type": "object",
+      "properties": {
+        "not": {
+          "$ref": "#/$defs/predicate"
+        }
+      },
+      "required": [
+        "not"
+      ],
+      "additionalProperties": false
+    },
+    "equals": {
+      "type": "object",
+      "properties": {
+        "equals": {
+          "type": "object",
+          "properties": {
+            "source": {
+              "type": "string"
+            },
+            "target": {
+              "$ref": "#/$defs/name"
+            }
+          },
+          "required": [
+            "source",
+            "target"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "equals"
+      ],
+      "additionalProperties": false
+    },
+    "subtype": {
+      "type": "object",
+      "properties": {
+        "subtype": {
+          "type": "object",
+          "properties": {
+            "super": {
+              "$ref": "#/$defs/name"
+            },
+            "sub": {
+              "$ref": "#/$defs/name"
+            }
+          },
+          "required": [
+            "super",
+            "sub"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "subtype"
+      ],
+      "additionalProperties": false
+    },
+    "mustType": {
+      "type": "object",
+      "properties": {
+        "mustType": {
+          "type": "object",
+          "properties": {
+            "source": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "type"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "mustType"
+      ],
+      "additionalProperties": false
+    },
+    "permits": {
+      "type": "object",
+      "properties": {
+        "permits": {
+          "type": "object",
+          "properties": {
+            "super": {
+              "type": "string"
+            },
+            "sub": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "super",
+            "sub"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "permits"
+      ],
+      "additionalProperties": false
+    },
+    "isParameterizedSubtype": {
+      "type": "object",
+      "properties": {
+        "isParameterizedSubtype": {
+          "type": "object",
+          "properties": {
+            "super": {
+              "type": "string"
+            },
+            "sub": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "super",
+            "sub"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "isParameterizedSubtype"
+      ],
+      "additionalProperties": false
+    },
+    "setContains": {
+      "type": "object",
+      "properties": {
+        "setContains": {
+          "type": "object",
+          "properties": {
+            "source": {
+              "type": "string"
+            },
+            "target": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "target"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "setContains"
+      ],
+      "additionalProperties": false
+    },
+    "isResource": {
+      "type": "object",
+      "properties": {
+        "isResource": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "isResource"
+      ],
+      "additionalProperties": false
+    },
+    "isHashableStruct": {
+      "type": "object",
+      "properties": {
+        "isHashableStruct": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "isHashableStruct"
+      ],
+      "additionalProperties": false
+    },
+    "isStorable": {
+      "type": "object",
+      "properties": {
+        "isStorable": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "isStorable"
+      ],
+      "additionalProperties": false
+    },
+    "isAttachment": {
+      "type": "object",
+      "properties": {
+        "isAttachment": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "isAttachment"
+      ],
+      "additionalProperties": false
+    },
+    "name": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "oneOf": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "required": [
+            "oneOf"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}

--- a/tools/subtype-gen/rules.yaml
+++ b/tools/subtype-gen/rules.yaml
@@ -1,3 +1,5 @@
+# $schema: ./rules.schema.json
+#
 # Cadence - The resource-oriented smart contract programming language
 #
 # Copyright Flow Foundation


### PR DESCRIPTION
Depends on #4262 

## Description

Add the start of a schema for the rules file/DSL. It supports most basic predicates.

Some feedback / questions on the current format:

- `setContains`:
  - Maybe rename `source` to `set`
  - Maybe rename `target` to `element`

- `constructorEqual`:
  - Can this just be `equals`?
  - If `equals` generates `Equal()` calls, maybe `strictEqual` can generate `==`?

- `typeParamsEqual`, `paramsContravariant`, `typeArgumentsEqual`:
  - Maybe we can generalize this to something like a `forAll` predicate that iterates over two lists and takes a predicate:

    ```yaml
    - forAll:
      source: super.TypeParams  # binds `source` variable in the predicate
      target: sub.TypeParams    # binds `target` variable in the predicate
      predicate:
        equals:
          source: source
          target: target
    ```

- `returnCovariant`:
  - Can this just be `subtype` with something like `super: super.ReturnType` and `sub: sub.ReturnType`?


- What do `isIntersectionSubset` and `isParameterizedSubtype` mean? 
  Could we express them with other predicates?


______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
