### PR TITLE
Fix accidental value caching and reuse in native functions when run with VM

### DIFF
--- a/bbq/vm/value_deployedcontract.go
+++ b/bbq/vm/value_deployedcontract.go
@@ -37,7 +37,7 @@ func init() {
 		NewNativeFunctionValue(
 			sema.DeployedContractTypePublicTypesFunctionName,
 			sema.DeployedContractTypePublicTypesFunctionType,
-			interpreter.NewNativeDeployedContractPublicTypesFunctionValue(nil, nil, nil),
+			interpreter.NewNativeDeployedContractPublicTypesFunctionValue(nil, nil),
 		),
 	)
 }

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5937,7 +5937,7 @@ func NativeCapabilityBorrowFunction(
 		var addressValue AddressValue
 
 		if capabilityBorrowTypePointer == nil {
-			// vm does not provide the borrow type
+			// VM does not provide the borrow type
 			var idCapabilityValue *IDCapabilityValue
 
 			switch capabilityValue := receiver.(type) {
@@ -6044,7 +6044,7 @@ func NativeCapabilityCheckFunction(
 		var addressValue AddressValue
 
 		if capabilityBorrowTypePointer == nil {
-			// vm does not provide the borrow type
+			// VM does not provide the borrow type
 			var idCapabilityValue *IDCapabilityValue
 
 			switch capabilityValue := receiver.(type) {

--- a/runtime/crypto_test.go
+++ b/runtime/crypto_test.go
@@ -60,10 +60,11 @@ func TestRuntimeHashAlgorithm_hash(t *testing.T) {
 		script := `
             access(all) fun main() {
                 log(HashAlgorithm.SHA3_256.hash("01020304".decodeHex()))
+                log(HashAlgorithm.SHA2_384.hash("05060708".decodeHex()))
             }
         `
 
-		var called bool
+		var calls int
 
 		var loggedMessages []string
 
@@ -76,10 +77,24 @@ func TestRuntimeHashAlgorithm_hash(t *testing.T) {
 				tag string,
 				hashAlgorithm HashAlgorithm,
 			) ([]byte, error) {
-				called = true
-				assert.Equal(t, []byte{1, 2, 3, 4}, data)
-				assert.Equal(t, HashAlgorithmSHA3_256, hashAlgorithm)
-				return []byte{5, 6, 7, 8}, nil
+				calls++
+
+				assert.Empty(t, tag)
+
+				switch calls {
+				case 1:
+					assert.Equal(t, []byte{1, 2, 3, 4}, data)
+					assert.Equal(t, HashAlgorithmSHA3_256, hashAlgorithm)
+					return []byte{4, 3, 2, 1}, nil
+
+				case 2:
+					assert.Equal(t, []byte{5, 6, 7, 8}, data)
+					assert.Equal(t, HashAlgorithmSHA2_384, hashAlgorithm)
+					return []byte{8, 7, 6, 5}, nil
+
+				default:
+					return nil, fmt.Errorf("unexpected call %d", calls)
+				}
 			},
 			OnProgramLog: func(message string) {
 				loggedMessages = append(loggedMessages, message)
@@ -91,75 +106,74 @@ func TestRuntimeHashAlgorithm_hash(t *testing.T) {
 
 		assert.Equal(t,
 			[]string{
-				"[5, 6, 7, 8]",
+				"[4, 3, 2, 1]",
+				"[8, 7, 6, 5]",
 			},
 			loggedMessages,
 		)
 
-		assert.True(t, called)
+		assert.Equal(t, 2, calls)
 	})
 
-	t.Run("hash - check tag", func(t *testing.T) {
+	t.Run("hashWithTag", func(t *testing.T) {
 		t.Parallel()
 
 		script := `
             access(all) fun main() {
-                HashAlgorithm.SHA3_256.hash("01020304".decodeHex())
+                log(HashAlgorithm.SHA3_256.hashWithTag("01020304".decodeHex(), tag: "tag1"))
+                log(HashAlgorithm.SHA2_384.hashWithTag("05060708".decodeHex(), tag: "tag2"))
             }
         `
 
-		var called bool
-		hashTag := "non-empty-string"
+		var calls int
+
+		var loggedMessages []string
 
 		storage := NewTestLedger(nil, nil)
 
 		runtimeInterface := &TestRuntimeInterface{
 			Storage: storage,
-			OnHash: func(data []byte, tag string, hashAlgorithm HashAlgorithm) ([]byte, error) {
-				called = true
-				hashTag = tag
-				return nil, nil
+			OnHash: func(
+				data []byte,
+				tag string,
+				hashAlgorithm HashAlgorithm,
+			) ([]byte, error) {
+				calls++
+
+				switch calls {
+				case 1:
+					assert.Equal(t, []byte{1, 2, 3, 4}, data)
+					assert.Equal(t, HashAlgorithmSHA3_256, hashAlgorithm)
+					assert.Equal(t, "tag1", tag)
+					return []byte{4, 3, 2, 1}, nil
+
+				case 2:
+					assert.Equal(t, []byte{5, 6, 7, 8}, data)
+					assert.Equal(t, HashAlgorithmSHA2_384, hashAlgorithm)
+					assert.Equal(t, "tag2", tag)
+					return []byte{8, 7, 6, 5}, nil
+
+				default:
+					return nil, fmt.Errorf("unexpected call %d", calls)
+				}
+			},
+			OnProgramLog: func(message string) {
+				loggedMessages = append(loggedMessages, message)
 			},
 		}
 
 		_, err := executeScript(script, runtimeInterface)
 		require.NoError(t, err)
 
-		assert.True(t, called)
-		assert.Empty(t, hashTag)
-	})
-
-	t.Run("hashWithTag - check tag", func(t *testing.T) {
-		t.Parallel()
-
-		script := `
-            access(all) fun main() {
-                HashAlgorithm.SHA3_256.hashWithTag(
-                    "01020304".decodeHex(),
-                    tag: "some-tag"
-                )
-            }
-        `
-
-		var called bool
-		hashTag := ""
-
-		storage := NewTestLedger(nil, nil)
-
-		runtimeInterface := &TestRuntimeInterface{
-			Storage: storage,
-			OnHash: func(data []byte, tag string, hashAlgorithm HashAlgorithm) ([]byte, error) {
-				called = true
-				hashTag = tag
-				return nil, nil
+		assert.Equal(t,
+			[]string{
+				"[4, 3, 2, 1]",
+				"[8, 7, 6, 5]",
 			},
-		}
+			loggedMessages,
+		)
 
-		_, err := executeScript(script, runtimeInterface)
-		require.NoError(t, err)
-
-		assert.True(t, called)
-		assert.Equal(t, "some-tag", hashTag)
+		assert.Equal(t, 2, calls)
 	})
 }
 
@@ -406,66 +420,6 @@ func TestRuntimeHashAlgorithmImport(t *testing.T) {
 	}
 }
 
-func TestRuntimeBLSVerifyPoP(t *testing.T) {
-
-	t.Parallel()
-
-	runtime := NewTestRuntime()
-
-	script := []byte(`
-
-      access(all) fun main(): Bool {
-          let publicKey = PublicKey(
-              publicKey: "0102".decodeHex(),
-              signatureAlgorithm: SignatureAlgorithm.BLS_BLS12_381
-          )
-
-          return publicKey.verifyPoP([1, 2, 3, 4, 5])
-      }
-    `)
-
-	var called bool
-
-	storage := NewTestLedger(nil, nil)
-
-	runtimeInterface := &TestRuntimeInterface{
-		Storage: storage,
-		OnValidatePublicKey: func(
-			pk *stdlib.PublicKey,
-		) error {
-			return nil
-		},
-		OnBLSVerifyPOP: func(
-			pk *stdlib.PublicKey,
-			proof []byte,
-		) (bool, error) {
-			assert.Equal(t, pk.PublicKey, []byte{1, 2})
-			called = true
-			return true, nil
-		},
-	}
-	addPublicKeyValidation(runtimeInterface, nil)
-
-	result, err := runtime.ExecuteScript(
-		Script{
-			Source: script,
-		},
-		Context{
-			Interface: runtimeInterface,
-			Location:  common.ScriptLocation{},
-			UseVM:     *compile,
-		},
-	)
-	require.NoError(t, err)
-
-	assert.Equal(t,
-		cadence.NewBool(true),
-		result,
-	)
-
-	assert.True(t, called)
-}
-
 func TestRuntimeBLSGetTypeAndIsInstance(t *testing.T) {
 
 	t.Parallel()
@@ -535,7 +489,7 @@ func TestRuntimeBLSAggregateSignatures(t *testing.T) {
 		OnBLSAggregateSignatures: func(
 			sigs [][]byte,
 		) ([]byte, error) {
-			assert.Equal(t, len(sigs), 5)
+			assert.Len(t, sigs, 5)
 			ret := make([]byte, 0, len(sigs[0]))
 			for i, sig := range sigs {
 				ret = append(ret, sig[i])
@@ -610,7 +564,7 @@ func TestRuntimeBLSAggregatePublicKeys(t *testing.T) {
 		OnBLSAggregatePublicKeys: func(
 			keys []*stdlib.PublicKey,
 		) (*stdlib.PublicKey, error) {
-			assert.Equal(t, len(keys), 2)
+			assert.Len(t, keys, 2)
 			ret := make([]byte, 0, len(keys))
 			for _, key := range keys {
 				ret = append(ret, key.PublicKey...)

--- a/runtime/deployedcontract_test.go
+++ b/runtime/deployedcontract_test.go
@@ -33,39 +33,72 @@ func TestRuntimeDeployedContracts(t *testing.T) {
 	t.Parallel()
 
 	contractCode := `
-		access(all) contract Test {
-			access(all) struct A {}
-			access(all) resource B {}
-			access(all) event C()
+        access(all) contract Test {
+            access(all) struct A {}
+            access(all) resource B {}
+            access(all) event C()
 
-			init() {}
-		}
-	`
+            init() {}
+        }
+    `
 
-	script :=
-		`
-		transaction {
-			prepare(signer: &Account) {
-				let deployedContract = signer.contracts.get(name: "Test")
-				assert(deployedContract!.name == "Test")
+	contractCode2 := `
+        access(all) contract Test2 {
+            access(all) struct A2 {}
+            access(all) resource B2 {}
+            access(all) event C2()
 
-				let expected: {String: Void} = {
+            init() {}
+        }
+    `
+
+	tx := `
+        transaction {
+            prepare(signer: &Account) {
+                let deployedContract = signer.contracts.get(name: "Test")
+                assert(deployedContract!.name == "Test")
+
+                let expected: {String: Void} = {
                     "A.2a00000000000000.Test.A": (),
-					"A.2a00000000000000.Test.B": (),
-					"A.2a00000000000000.Test.C": ()
-				}
-				let types = deployedContract!.publicTypes()
-				assert(types.length == 3)
+                    "A.2a00000000000000.Test.B": (),
+                    "A.2a00000000000000.Test.C": ()
+                }
+                let types = deployedContract!.publicTypes()
+                assert(types.length == 3)
 
-				for type in types {
-					assert(
+                for type in types {
+                    assert(
                         expected[type.identifier] != nil,
-                        message: type.identifier
+                        message: "type \(type.identifier) missing"
                     )
-				}
-			}
-		}
-		`
+                }
+            }
+        }
+    `
+
+	tx2 := `
+        transaction {
+            prepare(signer: &Account) {
+                let deployedContract = signer.contracts.get(name: "Test2")
+                assert(deployedContract!.name == "Test2")
+
+                let expected: {String: Void} = {
+                    "A.2a00000000000000.Test2.A2": (),
+                    "A.2a00000000000000.Test2.B2": (),
+                    "A.2a00000000000000.Test2.C2": ()
+                }
+                let types = deployedContract!.publicTypes()
+                assert(types.length == 3)
+
+                for type in types {
+                    assert(
+                        expected[type.identifier] != nil,
+                        message: "type \(type.identifier) missing"
+                    )
+                }
+            }
+        }
+    `
 
 	rt := NewTestRuntime()
 	accountCodes := map[Location][]byte{}
@@ -100,30 +133,39 @@ func TestRuntimeDeployedContracts(t *testing.T) {
 
 	nextTransactionLocation := NewTransactionLocationGenerator()
 
-	// deploy the contract
-	err := rt.ExecuteTransaction(
-		Script{
-			Source: DeploymentTransaction("Test", []byte(contractCode)),
-		},
-		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-			UseVM:     *compile,
-		},
-	)
-	require.NoError(t, err)
+	// Deploy contracts
+	for name, code := range map[string]string{
+		"Test":  contractCode,
+		"Test2": contractCode2,
+	} {
 
-	// grab the public types from the deployed contract
-	err = rt.ExecuteTransaction(
-		Script{
-			Source: []byte(script),
-		},
-		Context{
-			Interface: runtimeInterface,
-			Location:  nextTransactionLocation(),
-			UseVM:     *compile,
-		},
-	)
+		err := rt.ExecuteTransaction(
+			Script{
+				Source: DeploymentTransaction(name, []byte(code)),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
+			},
+		)
+		require.NoError(t, err)
+	}
 
-	require.NoError(t, err)
+	// Run test transactions
+	for _, script := range []string{tx, tx2} {
+
+		err := rt.ExecuteTransaction(
+			Script{
+				Source: []byte(script),
+			},
+			Context{
+				Interface: runtimeInterface,
+				Location:  nextTransactionLocation(),
+				UseVM:     *compile,
+			},
+		)
+		require.NoError(t, err)
+	}
+
 }

--- a/stdlib/hashalgorithm.go
+++ b/stdlib/hashalgorithm.go
@@ -76,19 +76,25 @@ func NewHashAlgorithmCase(
 }
 
 // Native hash functions
-func NativeHashAlgorithmHashFunction(hasher Hasher, hashAlgoValue interpreter.MemberAccessibleValue) interpreter.NativeFunction {
+
+func NativeHashAlgorithmHashFunction(
+	hasher Hasher,
+	constantHashAlgoValue interpreter.MemberAccessibleValue,
+) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
-		if hashAlgoValue == nil {
-			// vm does not provide the hash algo value
-			hashAlgoValue = interpreter.AssertValueOfType[interpreter.MemberAccessibleValue](receiver)
-		}
 
 		dataValue := interpreter.AssertValueOfType[*interpreter.ArrayValue](args[0])
+
+		hashAlgoValue := constantHashAlgoValue
+		if hashAlgoValue == nil {
+			// VM does not provide a constant hash algo value
+			hashAlgoValue = interpreter.AssertValueOfType[interpreter.MemberAccessibleValue](receiver)
+		}
 
 		return hash(
 			context,
@@ -100,19 +106,26 @@ func NativeHashAlgorithmHashFunction(hasher Hasher, hashAlgoValue interpreter.Me
 	}
 }
 
-func NativeHashAlgorithmHashWithTagFunction(hasher Hasher, hashAlgoValue interpreter.MemberAccessibleValue) interpreter.NativeFunction {
+func NativeHashAlgorithmHashWithTagFunction(
+	hasher Hasher,
+	constantHashAlgoValue interpreter.MemberAccessibleValue,
+) interpreter.NativeFunction {
 	return func(
 		context interpreter.NativeFunctionContext,
 		_ interpreter.TypeArgumentsIterator,
 		receiver interpreter.Value,
 		args []interpreter.Value,
 	) interpreter.Value {
-		if hashAlgoValue == nil {
-			// vm does not provide the hash algo value
-			hashAlgoValue = interpreter.AssertValueOfType[interpreter.MemberAccessibleValue](receiver)
-		}
+
 		dataValue := interpreter.AssertValueOfType[*interpreter.ArrayValue](args[0])
 		tagValue := interpreter.AssertValueOfType[*interpreter.StringValue](args[1])
+
+		hashAlgoValue := constantHashAlgoValue
+		if hashAlgoValue == nil {
+			// VM does not provide a constant hash algo value
+			hashAlgoValue = interpreter.AssertValueOfType[interpreter.MemberAccessibleValue](receiver)
+		}
+
 		return hash(
 			context,
 			hasher,

--- a/stdlib/publickey.go
+++ b/stdlib/publickey.go
@@ -212,7 +212,7 @@ type PublicKeySignatureVerifier interface {
 }
 
 func NativePublicKeyVerifySignatureFunction(
-	publicKeyValue *interpreter.CompositeValue,
+	constantPublicKeyValue *interpreter.CompositeValue,
 	verifier PublicKeySignatureVerifier,
 ) interpreter.NativeFunction {
 	return func(
@@ -226,7 +226,9 @@ func NativePublicKeyVerifySignatureFunction(
 		domainSeparationTagValue := interpreter.AssertValueOfType[*interpreter.StringValue](args[2])
 		hashAlgorithmValue := interpreter.AssertValueOfType[*interpreter.SimpleCompositeValue](args[3])
 
+		publicKeyValue := constantPublicKeyValue
 		if publicKeyValue == nil {
+			// VM does not provide a constant public key
 			publicKeyValue = interpreter.AssertValueOfType[*interpreter.CompositeValue](receiver)
 		}
 
@@ -322,7 +324,7 @@ type BLSPoPVerifier interface {
 }
 
 func NativePublicKeyVerifyPoPFunction(
-	publicKeyValue *interpreter.CompositeValue,
+	constantPublicKeyValue *interpreter.CompositeValue,
 	verifier BLSPoPVerifier,
 ) interpreter.NativeFunction {
 	return func(
@@ -333,8 +335,10 @@ func NativePublicKeyVerifyPoPFunction(
 	) interpreter.Value {
 		signatureValue := interpreter.AssertValueOfType[*interpreter.ArrayValue](args[0])
 
+		publicKeyValue := constantPublicKeyValue
 		if publicKeyValue == nil {
-			publicKeyValue = receiver.(*interpreter.CompositeValue)
+			// VM does not provide a constant public key
+			publicKeyValue = interpreter.AssertValueOfType[*interpreter.CompositeValue](receiver)
 		}
 
 		return PublicKeyVerifyPoP(


### PR DESCRIPTION
## Description

Fix a regression in the VM introduced in the recent refactor of native functions.

Native functions for methods are called slightly differently by the interpreter and VM:
- In the interpreter, the function is only ever called for the same receiver, which is often passed as a closed over parameter
- In the VM, the function is called for all/different receivers

We have to be careful not to cache the receiver or other values in the first call and reuse it in a subsequent call.

Fix the cases that I could find and ensure the behaviour is correct by extending the existing tests with an additional second call of the tested method.

It would be nice to lint such cases and prevent them in the future, but so far I could not find anything existing.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
