### PR TITLE
Bump onflow/atree to v0.12.0 and fxamacker/cbor to v2.9.0 of stream-mode branch

### DIFF
--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -94,7 +94,7 @@ func (v CompiledFunctionValue) String() string {
 	return v.Type.String()
 }
 
-func (v CompiledFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v CompiledFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return interpreter.NonStorable{Value: v}, nil
 }
 
@@ -210,7 +210,7 @@ func (v *NativeFunctionValue) String() string {
 	return v.functionType.String()
 }
 
-func (v *NativeFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v *NativeFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return interpreter.NonStorable{Value: v}, nil
 }
 
@@ -409,7 +409,7 @@ func (v *BoundFunctionValue) String() string {
 	return v.Method.String()
 }
 
-func (v *BoundFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v *BoundFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return interpreter.NonStorable{Value: v}, nil
 }
 

--- a/bbq/vm/value_implicit_reference.go
+++ b/bbq/vm/value_implicit_reference.go
@@ -79,7 +79,7 @@ func (v ImplicitReferenceValue) GetAuthorization() interpreter.Authorization {
 	panic(errors.NewUnreachableError())
 }
 
-func (v ImplicitReferenceValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v ImplicitReferenceValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	// ImplicitReferenceValue is an internal-only value.
 	// Hence, this should never be called.
 	panic(errors.NewUnreachableError())

--- a/bbq/vm/value_iterator.go
+++ b/bbq/vm/value_iterator.go
@@ -39,7 +39,7 @@ func NewIteratorWrapperValue(iterator interpreter.ValueIterator) *IteratorWrappe
 
 func (v IteratorWrapperValue) IsValue() {}
 
-func (v IteratorWrapperValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v IteratorWrapperValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	// Iterator is an internal-only value.
 	// Hence, this should never be called.
 	panic(errors.NewUnreachableError())

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.24.0
 	github.com/c-bata/go-prompt v0.2.6
 	github.com/dave/dst v0.27.3
-	github.com/fxamacker/cbor/v2 v2.8.1-0.20250402194037-6f932b086829
+	github.com/fxamacker/cbor/v2 v2.9.1-0.20251019205732-39888e6be013
 	github.com/goccy/go-yaml v1.18.0
 	github.com/google/pprof v0.0.0-20250630185457-6e76a2b096b5
 	github.com/itchyny/gojq v0.12.17
@@ -16,7 +16,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/leanovate/gopter v0.2.11
 	github.com/logrusorgru/aurora/v4 v4.0.0
-	github.com/onflow/atree v0.11.0
+	github.com/onflow/atree v0.12.0
 	github.com/onflow/crypto v0.25.3
 	github.com/onflow/fixed-point v0.1.1
 	github.com/rivo/uniseg v0.4.7

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fxamacker/cbor/v2 v2.8.1-0.20250402194037-6f932b086829 h1:qOglMkJ5YBwog/GU/NXhP9gFqxUGMuqnmCkbj65JMhk=
-github.com/fxamacker/cbor/v2 v2.8.1-0.20250402194037-6f932b086829/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/fxamacker/cbor/v2 v2.9.1-0.20251019205732-39888e6be013 h1:jcwW+JBYGe3qgiPQ4deXaannYxVdxjMw57/dw+gcEfQ=
+github.com/fxamacker/cbor/v2 v2.9.1-0.20251019205732-39888e6be013/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/fxamacker/circlehash v0.3.0 h1:XKdvTtIJV9t7DDUtsf0RIpC1OcxZtPbmgIH7ekx28WA=
 github.com/fxamacker/circlehash v0.3.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -251,8 +251,8 @@ github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJE
 github.com/neelance/sourcemap v0.0.0-20200213170602-2833bce08e4c/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/onflow/atree v0.11.0 h1:NrGHb7l3pKvFPFAdYfEyezg6D7xBNcMSwQHliOHtZug=
-github.com/onflow/atree v0.11.0/go.mod h1:uZE/bzDfMLXJH9BYL8HxNisw9pHZGyc+mDLuSMeUAVY=
+github.com/onflow/atree v0.12.0 h1:X7/UEPyCaaEQ1gCg11KDvfyEtEeQLhtRtxMHjAiH/Co=
+github.com/onflow/atree v0.12.0/go.mod h1:qdZcfLQwPirHcNpLiK+2t3KAo+SAb9Si6TqurE6pykE=
 github.com/onflow/crypto v0.25.3 h1:XQ3HtLsw8h1+pBN+NQ1JYM9mS2mVXTyg55OldaAIF7U=
 github.com/onflow/crypto v0.25.3/go.mod h1:+1igaXiK6Tjm9wQOBD1EGwW7bYWMUGKtwKJ/2QL/OWs=
 github.com/onflow/fixed-point v0.1.1 h1:j0jYZVO8VGyk1476alGudEg7XqCkeTVxb5ElRJRKS90=

--- a/interpreter/encoding_test.go
+++ b/interpreter/encoding_test.go
@@ -48,7 +48,7 @@ type encodeDecodeTest struct {
 	deepEquality         bool
 	storage              Storage
 	slabStorageID        atree.SlabID
-	maxInlineElementSize uint64
+	maxInlineElementSize uint32
 }
 
 var testOwner = common.MustBytesToAddress([]byte{0x42})
@@ -66,7 +66,7 @@ func testEncodeDecode(t *testing.T, test encodeDecodeTest) {
 			if test.storable == nil {
 				maxInlineElementSize := test.maxInlineElementSize
 				if maxInlineElementSize == 0 {
-					maxInlineElementSize = math.MaxUint64
+					maxInlineElementSize = math.MaxUint32
 				}
 				storable, err := test.value.Storable(
 					test.storage,
@@ -2973,12 +2973,12 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 		t.Parallel()
 
 		var str *StringValue
-		maxInlineElementSize := uint64(64) // use a small max inline size for testing
-		for i := uint64(0); i < maxInlineElementSize; i++ {
+		maxInlineElementSize := uint32(64) // use a small max inline size for testing
+		for i := uint32(0); i < maxInlineElementSize; i++ {
 			str = NewUnmeteredStringValue(strings.Repeat("x", int(maxInlineElementSize-i)))
 			size, err := StorableSize(str)
 			require.NoError(t, err)
-			if uint64(size) < maxInlineElementSize-values.CBORTagSize {
+			if size < maxInlineElementSize-values.CBORTagSize {
 				break
 			}
 		}
@@ -3019,12 +3019,12 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 		)
 
 		var str *StringValue
-		maxInlineElementSize := uint64(64) // use a small max inline size for testing
-		for i := uint64(0); i < maxInlineElementSize; i++ {
+		maxInlineElementSize := uint32(64) // use a small max inline size for testing
+		for i := uint32(0); i < maxInlineElementSize; i++ {
 			str = NewUnmeteredStringValue(strings.Repeat("x", int(maxInlineElementSize-i)))
 			size, err := StorableSize(str)
 			require.NoError(t, err)
-			if uint64(size) < maxInlineElementSize-values.CBORTagSize-arraySize-nestedLevelsSize {
+			if size < maxInlineElementSize-values.CBORTagSize-arraySize-nestedLevelsSize {
 				break
 			}
 		}
@@ -3066,11 +3066,11 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 
 		var str *StringValue
 		maxInlineElementSize := atree.MaxInlineArrayElementSize()
-		for i := uint64(0); i < maxInlineElementSize; i++ {
+		for i := uint32(0); i < maxInlineElementSize; i++ {
 			str = NewUnmeteredStringValue(strings.Repeat("x", int(maxInlineElementSize-i)))
 			size, err := StorableSize(str)
 			require.NoError(t, err)
-			if uint64(size) == maxInlineElementSize+1 {
+			if size == maxInlineElementSize+1 {
 				break
 			}
 		}
@@ -3101,11 +3101,11 @@ func TestEncodeDecodeSomeValue(t *testing.T) {
 
 		var str *StringValue
 		maxInlineElementSize := atree.MaxInlineArrayElementSize()
-		for i := uint64(0); i < maxInlineElementSize; i++ {
+		for i := uint32(0); i < maxInlineElementSize; i++ {
 			str = NewUnmeteredStringValue(strings.Repeat("x", int(maxInlineElementSize-i)))
 			size, err := StorableSize(str)
 			require.NoError(t, err)
-			if uint64(size) == maxInlineElementSize+1 {
+			if size == maxInlineElementSize+1 {
 				break
 			}
 		}
@@ -3853,7 +3853,7 @@ func TestEncodeDecodeCapabilityValue(t *testing.T) {
 		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		var borrowType StaticType = PrimitiveStaticTypeNever
 
-		for i := uint64(0); i < maxInlineElementSize; i++ {
+		for i := uint32(0); i < maxInlineElementSize; i++ {
 			borrowType = &OptionalStaticType{
 				Type: borrowType,
 			}
@@ -4749,7 +4749,7 @@ func TestEncodeDecodeAccountCapabilityControllerValue(t *testing.T) {
 		maxInlineElementSize := atree.MaxInlineArrayElementSize()
 		var borrowType StaticType = PrimitiveStaticTypeNever
 
-		for i := uint64(0); i < maxInlineElementSize; i++ {
+		for i := uint32(0); i < maxInlineElementSize; i++ {
 			borrowType = &OptionalStaticType{
 				Type: borrowType,
 			}

--- a/interpreter/simplecompositevalue.go
+++ b/interpreter/simplecompositevalue.go
@@ -259,7 +259,7 @@ func (v *SimpleCompositeValue) ConformsToStaticType(
 	return true
 }
 
-func (v *SimpleCompositeValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v *SimpleCompositeValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return NonStorable{Value: v}, nil
 }
 

--- a/interpreter/stringatreevalue.go
+++ b/interpreter/stringatreevalue.go
@@ -34,7 +34,7 @@ var _ atree.ComparableStorable = StringAtreeValue("")
 func (v StringAtreeValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
-	maxInlineSize uint64,
+	maxInlineSize uint32,
 ) (
 	atree.Storable,
 	error,

--- a/interpreter/uint64atreevalue.go
+++ b/interpreter/uint64atreevalue.go
@@ -35,7 +35,7 @@ var _ atree.Storable = Uint64AtreeValue(0)
 func (v Uint64AtreeValue) Storable(
 	_ atree.SlabStorage,
 	_ atree.Address,
-	_ uint64,
+	_ uint32,
 ) (
 	atree.Storable,
 	error,

--- a/interpreter/value_accountcapabilitycontroller.go
+++ b/interpreter/value_accountcapabilitycontroller.go
@@ -152,7 +152,7 @@ func (*AccountCapabilityControllerValue) IsStorable() bool {
 func (v *AccountCapabilityControllerValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
-	maxInlineSize uint64,
+	maxInlineSize uint32,
 ) (
 	atree.Storable,
 	error,

--- a/interpreter/value_address.go
+++ b/interpreter/value_address.go
@@ -222,7 +222,7 @@ func (AddressValue) IsStorable() bool {
 	return true
 }
 
-func (v AddressValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v AddressValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_array.go
+++ b/interpreter/value_array.go
@@ -1179,14 +1179,14 @@ func (v *ArrayValue) Equal(context ValueComparisonContext, other Value) bool {
 func (v *ArrayValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
-	maxInlineSize uint64,
+	maxInlineSize uint32,
 ) (atree.Storable, error) {
 	// NOTE: Need to change ArrayValue.UnwrapAtreeValue()
 	// if ArrayValue is stored with wrapping.
 	return v.array.Storable(storage, address, maxInlineSize)
 }
 
-func (v *ArrayValue) UnwrapAtreeValue() (atree.Value, uint64) {
+func (v *ArrayValue) UnwrapAtreeValue() (atree.Value, uint32) {
 	// Wrapper size is 0 because ArrayValue is stored as
 	// atree.Array without any physical wrapping (see ArrayValue.Storable()).
 	return v.array, 0

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -158,7 +158,7 @@ func (v BoolValue) ConformsToStaticType(
 	return true
 }
 
-func (v BoolValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v BoolValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return values.BoolValue(v), nil
 }
 

--- a/interpreter/value_capability.go
+++ b/interpreter/value_capability.go
@@ -212,7 +212,7 @@ func (v *IDCapabilityValue) Address() AddressValue {
 func (v *IDCapabilityValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
-	maxInlineSize uint64,
+	maxInlineSize uint32,
 ) (atree.Storable, error) {
 	return values.MaybeLargeImmutableStorable(
 		v,

--- a/interpreter/value_character.go
+++ b/interpreter/value_character.go
@@ -206,7 +206,7 @@ func (v CharacterValue) ConformsToStaticType(
 	return true
 }
 
-func (v CharacterValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v CharacterValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_composite.go
+++ b/interpreter/value_composite.go
@@ -1197,7 +1197,7 @@ func (v *CompositeValue) IsStorable() bool {
 func (v *CompositeValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
-	maxInlineSize uint64,
+	maxInlineSize uint32,
 ) (atree.Storable, error) {
 	if !v.IsStorable() {
 		return NonStorable{Value: v}, nil
@@ -1209,7 +1209,7 @@ func (v *CompositeValue) Storable(
 	return v.dictionary.Storable(storage, address, maxInlineSize)
 }
 
-func (v *CompositeValue) UnwrapAtreeValue() (atree.Value, uint64) {
+func (v *CompositeValue) UnwrapAtreeValue() (atree.Value, uint32) {
 	// Wrapper size is 0 because CompositeValue is stored as
 	// atree.OrderedMap without any physical wrapping (see CompositeValue.Storable()).
 	return v.dictionary, 0

--- a/interpreter/value_dictionary.go
+++ b/interpreter/value_dictionary.go
@@ -1290,14 +1290,14 @@ func (v *DictionaryValue) Equal(context ValueComparisonContext, other Value) boo
 func (v *DictionaryValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
-	maxInlineSize uint64,
+	maxInlineSize uint32,
 ) (atree.Storable, error) {
 	// NOTE: Need to change DictionaryValue.UnwrapAtreeValue()
 	// if DictionaryValue is stored with wrapping.
 	return v.dictionary.Storable(storage, address, maxInlineSize)
 }
 
-func (v *DictionaryValue) UnwrapAtreeValue() (atree.Value, uint64) {
+func (v *DictionaryValue) UnwrapAtreeValue() (atree.Value, uint32) {
 	// Wrapper size is 0 because DictionaryValue is stored as
 	// atree.OrderedMap without any physical wrapping (see DictionaryValue.Storable()).
 	return v.dictionary, 0

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -259,7 +259,7 @@ func (*EphemeralReferenceValue) IsStorable() bool {
 	return false
 }
 
-func (v *EphemeralReferenceValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v *EphemeralReferenceValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return NonStorable{Value: v}, nil
 }
 

--- a/interpreter/value_fix128.go
+++ b/interpreter/value_fix128.go
@@ -534,7 +534,7 @@ func (Fix128Value) IsStorable() bool {
 	return true
 }
 
-func (v Fix128Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Fix128Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -549,7 +549,7 @@ func (Fix64Value) IsStorable() bool {
 	return true
 }
 
-func (v Fix64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Fix64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_function.go
+++ b/interpreter/value_function.go
@@ -135,7 +135,7 @@ func (f *InterpretedFunctionValue) ConformsToStaticType(
 	return true
 }
 
-func (f *InterpretedFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (f *InterpretedFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return NonStorable{Value: f}, nil
 }
 
@@ -292,7 +292,7 @@ func (f *HostFunctionValue) ConformsToStaticType(
 	return true
 }
 
-func (f *HostFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (f *HostFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return NonStorable{Value: f}, nil
 }
 
@@ -499,7 +499,7 @@ func (f BoundFunctionValue) ConformsToStaticType(
 	)
 }
 
-func (f BoundFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (f BoundFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return NonStorable{Value: f}, nil
 }
 

--- a/interpreter/value_int128.go
+++ b/interpreter/value_int128.go
@@ -729,7 +729,7 @@ func (v Int128Value) ConformsToStaticType(
 	return true
 }
 
-func (v Int128Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Int128Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_int16.go
+++ b/interpreter/value_int16.go
@@ -603,7 +603,7 @@ func (v Int16Value) ConformsToStaticType(
 	return true
 }
 
-func (v Int16Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Int16Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_int256.go
+++ b/interpreter/value_int256.go
@@ -697,7 +697,7 @@ func (v Int256Value) ConformsToStaticType(
 	return true
 }
 
-func (v Int256Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Int256Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_int32.go
+++ b/interpreter/value_int32.go
@@ -602,7 +602,7 @@ func (v Int32Value) ConformsToStaticType(
 	return true
 }
 
-func (v Int32Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Int32Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_int64.go
+++ b/interpreter/value_int64.go
@@ -599,7 +599,7 @@ func (v Int64Value) ConformsToStaticType(
 	return true
 }
 
-func (v Int64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Int64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_int8.go
+++ b/interpreter/value_int8.go
@@ -598,7 +598,7 @@ func (v Int8Value) ConformsToStaticType(
 	return true
 }
 
-func (v Int8Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Int8Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_link.go
+++ b/interpreter/value_link.go
@@ -115,7 +115,7 @@ func (PathLinkValue) IsStorable() bool {
 	panic(errors.NewUnreachableError())
 }
 
-func (v PathLinkValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
+func (v PathLinkValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint32) (atree.Storable, error) {
 	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 
@@ -239,7 +239,7 @@ func (AccountLinkValue) IsStorable() bool {
 	panic(errors.NewUnreachableError())
 }
 
-func (v AccountLinkValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
+func (v AccountLinkValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint32) (atree.Storable, error) {
 	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 

--- a/interpreter/value_nil.go
+++ b/interpreter/value_nil.go
@@ -145,7 +145,7 @@ func (NilValue) IsStorable() bool {
 	return true
 }
 
-func (v NilValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v NilValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_path.go
+++ b/interpreter/value_path.go
@@ -244,7 +244,7 @@ func newPathFromStringValue(gauge common.MemoryGauge, domain common.PathDomain, 
 func (v PathValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
-	maxInlineSize uint64,
+	maxInlineSize uint32,
 ) (atree.Storable, error) {
 	return values.MaybeLargeImmutableStorable(
 		v,

--- a/interpreter/value_pathcapability.go
+++ b/interpreter/value_pathcapability.go
@@ -240,7 +240,7 @@ func (*PathCapabilityValue) IsStorable() bool {
 func (v *PathCapabilityValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
-	maxInlineSize uint64,
+	maxInlineSize uint32,
 ) (atree.Storable, error) {
 	return values.MaybeLargeImmutableStorable(
 		v,

--- a/interpreter/value_placeholder.go
+++ b/interpreter/value_placeholder.go
@@ -69,7 +69,7 @@ func (PlaceholderValue) ConformsToStaticType(
 	return true
 }
 
-func (v PlaceholderValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v PlaceholderValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return NonStorable{Value: v}, nil
 }
 

--- a/interpreter/value_published.go
+++ b/interpreter/value_published.go
@@ -115,7 +115,7 @@ func (*PublishedValue) IsStorable() bool {
 	return true
 }
 
-func (v *PublishedValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
+func (v *PublishedValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint32) (atree.Storable, error) {
 	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 

--- a/interpreter/value_some.go
+++ b/interpreter/value_some.go
@@ -56,7 +56,7 @@ var _ atree.Value = &SomeValue{}
 var _ atree.WrapperValue = &SomeValue{}
 
 // UnwrapAtreeValue returns non-SomeValue and wrapper size.
-func (v *SomeValue) UnwrapAtreeValue() (atree.Value, uint64) {
+func (v *SomeValue) UnwrapAtreeValue() (atree.Value, uint32) {
 	// NOTE:
 	// - non-SomeValue is the same as non-SomeValue in SomeValue.Storable()
 	// - non-SomeValue wrapper size is the same as encoded wrapper size in SomeStorable.ByteSize().
@@ -71,10 +71,10 @@ func (v *SomeValue) UnwrapAtreeValue() (atree.Value, uint64) {
 	switch nonSomeValue := nonSomeValue.(type) {
 	case atree.WrapperValue:
 		unwrappedValue, wrapperSize := nonSomeValue.UnwrapAtreeValue()
-		return unwrappedValue, wrapperSize + uint64(someStorableEncodedPrefixSize)
+		return unwrappedValue, wrapperSize + someStorableEncodedPrefixSize
 
 	default:
-		return nonSomeValue, uint64(someStorableEncodedPrefixSize)
+		return nonSomeValue, someStorableEncodedPrefixSize
 	}
 }
 
@@ -244,7 +244,7 @@ func (v *SomeValue) Equal(context ValueComparisonContext, other Value) bool {
 func (v *SomeValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
-	maxInlineSize uint64,
+	maxInlineSize uint32,
 ) (atree.Storable, error) {
 
 	// SomeStorable returned from this function can be encoded in two ways:
@@ -273,7 +273,7 @@ func (v *SomeValue) Storable(
 
 		// Reduce maxInlineSize for non-SomeValue to make sure
 		// that SomeStorable wrapper is always encoded inline.
-		maxInlineSize -= uint64(someStorableEncodedPrefixSize)
+		maxInlineSize -= someStorableEncodedPrefixSize
 
 		nonSomeValueStorable, err := nonSomeValue.Storable(
 			storage,

--- a/interpreter/value_some_test.go
+++ b/interpreter/value_some_test.go
@@ -51,7 +51,7 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 
 		unwrappedValue, wrapperSize := v.UnwrapAtreeValue()
 		require.Equal(t, bv, unwrappedValue)
-		require.Equal(t, uint64(values.CBORTagSize), wrapperSize)
+		require.Equal(t, uint32(values.CBORTagSize), wrapperSize)
 	})
 
 	t.Run("SomeValue(SomeValue(bool))", func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 
 		unwrappedValue, wrapperSize := v.UnwrapAtreeValue()
 		require.Equal(t, bv, unwrappedValue)
-		require.Equal(t, uint64(values.CBORTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
+		require.Equal(t, uint32(values.CBORTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
 	})
 
 	t.Run("SomeValue(SomeValue(ArrayValue(...)))", func(t *testing.T) {
@@ -115,7 +115,7 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 
 		unwrappedValue, wrapperSize := v.UnwrapAtreeValue()
 		require.IsType(t, &atree.Array{}, unwrappedValue)
-		require.Equal(t, uint64(values.CBORTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
+		require.Equal(t, uint32(values.CBORTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
 
 		atreeArray := unwrappedValue.(*atree.Array)
 		require.Equal(t, atree.Address(address), atreeArray.Address())
@@ -180,7 +180,7 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 
 		unwrappedValue, wrapperSize := v.UnwrapAtreeValue()
 		require.IsType(t, &atree.OrderedMap{}, unwrappedValue)
-		require.Equal(t, uint64(values.CBORTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
+		require.Equal(t, uint32(values.CBORTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
 
 		// Verify unwrapped value
 		atreeMap := unwrappedValue.(*atree.OrderedMap)
@@ -284,7 +284,7 @@ func TestSomeValueUnwrapAtreeValue(t *testing.T) {
 
 		unwrappedValue, wrapperSize := v.UnwrapAtreeValue()
 		require.IsType(t, &atree.OrderedMap{}, unwrappedValue)
-		require.Equal(t, uint64(values.CBORTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
+		require.Equal(t, uint32(values.CBORTagSize+someStorableWithMultipleNestedLevelsArraySize+1), wrapperSize)
 
 		// Verify unwrapped value
 		atreeMap := unwrappedValue.(*atree.OrderedMap)

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -354,7 +354,7 @@ func (*StorageReferenceValue) IsStorable() bool {
 	return false
 }
 
-func (v *StorageReferenceValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v *StorageReferenceValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return NonStorable{Value: v}, nil
 }
 

--- a/interpreter/value_storagecapabilitycontroller.go
+++ b/interpreter/value_storagecapabilitycontroller.go
@@ -176,7 +176,7 @@ func (*StorageCapabilityControllerValue) IsStorable() bool {
 func (v *StorageCapabilityControllerValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
-	maxInlineSize uint64,
+	maxInlineSize uint32,
 ) (
 	atree.Storable,
 	error,

--- a/interpreter/value_string.go
+++ b/interpreter/value_string.go
@@ -730,7 +730,7 @@ func (v *StringValue) ReplaceAll(
 	)
 }
 
-func (v *StringValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
+func (v *StringValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint32) (atree.Storable, error) {
 	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 

--- a/interpreter/value_type.go
+++ b/interpreter/value_type.go
@@ -283,7 +283,7 @@ func (v TypeValue) ConformsToStaticType(
 func (v TypeValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
-	maxInlineSize uint64,
+	maxInlineSize uint32,
 ) (atree.Storable, error) {
 	return values.MaybeLargeImmutableStorable(
 		v,

--- a/interpreter/value_ufix128.go
+++ b/interpreter/value_ufix128.go
@@ -527,7 +527,7 @@ func (UFix128Value) IsStorable() bool {
 	return true
 }
 
-func (v UFix128Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v UFix128Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_uint.go
+++ b/interpreter/value_uint.go
@@ -641,7 +641,7 @@ func (v UIntValue) ConformsToStaticType(
 	return true
 }
 
-func (v UIntValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
+func (v UIntValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint32) (atree.Storable, error) {
 	return values.MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 

--- a/interpreter/value_uint128.go
+++ b/interpreter/value_uint128.go
@@ -642,7 +642,7 @@ func (UInt128Value) IsStorable() bool {
 	return true
 }
 
-func (v UInt128Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v UInt128Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_uint16.go
+++ b/interpreter/value_uint16.go
@@ -516,7 +516,7 @@ func (UInt16Value) IsStorable() bool {
 	return true
 }
 
-func (v UInt16Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v UInt16Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_uint256.go
+++ b/interpreter/value_uint256.go
@@ -642,7 +642,7 @@ func (UInt256Value) IsStorable() bool {
 	return true
 }
 
-func (v UInt256Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v UInt256Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_uint32.go
+++ b/interpreter/value_uint32.go
@@ -517,7 +517,7 @@ func (UInt32Value) IsStorable() bool {
 	return true
 }
 
-func (v UInt32Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v UInt32Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_uint64.go
+++ b/interpreter/value_uint64.go
@@ -543,7 +543,7 @@ func (UInt64Value) IsStorable() bool {
 	return true
 }
 
-func (v UInt64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v UInt64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_uint8.go
+++ b/interpreter/value_uint8.go
@@ -550,7 +550,7 @@ func (v UInt8Value) ConformsToStaticType(
 	return true
 }
 
-func (v UInt8Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v UInt8Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_void.go
+++ b/interpreter/value_void.go
@@ -83,7 +83,7 @@ func (v VoidValue) Equal(_ ValueComparisonContext, other Value) bool {
 	return ok
 }
 
-func (v VoidValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v VoidValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_word128.go
+++ b/interpreter/value_word128.go
@@ -562,7 +562,7 @@ func (Word128Value) IsStorable() bool {
 	return true
 }
 
-func (v Word128Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Word128Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_word16.go
+++ b/interpreter/value_word16.go
@@ -423,7 +423,7 @@ func (Word16Value) IsStorable() bool {
 	return true
 }
 
-func (v Word16Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Word16Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_word256.go
+++ b/interpreter/value_word256.go
@@ -562,7 +562,7 @@ func (Word256Value) IsStorable() bool {
 	return true
 }
 
-func (v Word256Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Word256Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_word32.go
+++ b/interpreter/value_word32.go
@@ -424,7 +424,7 @@ func (Word32Value) IsStorable() bool {
 	return true
 }
 
-func (v Word32Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Word32Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_word64.go
+++ b/interpreter/value_word64.go
@@ -450,7 +450,7 @@ func (Word64Value) IsStorable() bool {
 	return true
 }
 
-func (v Word64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Word64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/interpreter/value_word8.go
+++ b/interpreter/value_word8.go
@@ -420,7 +420,7 @@ func (Word8Value) IsStorable() bool {
 	return true
 }
 
-func (v Word8Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Word8Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/tools/compatibility-check/go.mod
+++ b/tools/compatibility-check/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/ethereum/go-ethereum v1.13.10 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/fxamacker/cbor/v2 v2.8.1-0.20250402194037-6f932b086829 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.1-0.20251019205732-39888e6be013 // indirect
 	github.com/fxamacker/circlehash v0.3.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -45,7 +45,7 @@ require (
 	github.com/multiformats/go-multibase v0.2.0 // indirect
 	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
-	github.com/onflow/atree v0.11.0 // indirect
+	github.com/onflow/atree v0.12.0 // indirect
 	github.com/onflow/crypto v0.25.3 // indirect
 	github.com/onflow/fixed-point v0.1.1 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.3-0.20241017220455-79fdc6c8ba53 // indirect

--- a/tools/compatibility-check/go.sum
+++ b/tools/compatibility-check/go.sum
@@ -122,8 +122,8 @@ github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUork
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
-github.com/fxamacker/cbor/v2 v2.8.1-0.20250402194037-6f932b086829 h1:qOglMkJ5YBwog/GU/NXhP9gFqxUGMuqnmCkbj65JMhk=
-github.com/fxamacker/cbor/v2 v2.8.1-0.20250402194037-6f932b086829/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/fxamacker/cbor/v2 v2.9.1-0.20251019205732-39888e6be013 h1:jcwW+JBYGe3qgiPQ4deXaannYxVdxjMw57/dw+gcEfQ=
+github.com/fxamacker/cbor/v2 v2.9.1-0.20251019205732-39888e6be013/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/fxamacker/circlehash v0.3.0 h1:XKdvTtIJV9t7DDUtsf0RIpC1OcxZtPbmgIH7ekx28WA=
 github.com/fxamacker/circlehash v0.3.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
@@ -206,6 +206,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20250630185457-6e76a2b096b5 h1:xhMrHhTJ6zxu3gA4enFM9MLn9AY7613teCdFnlUVbSQ=
+github.com/google/pprof v0.0.0-20250630185457-6e76a2b096b5/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -339,8 +341,8 @@ github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/n
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/onflow/atree v0.11.0 h1:NrGHb7l3pKvFPFAdYfEyezg6D7xBNcMSwQHliOHtZug=
-github.com/onflow/atree v0.11.0/go.mod h1:uZE/bzDfMLXJH9BYL8HxNisw9pHZGyc+mDLuSMeUAVY=
+github.com/onflow/atree v0.12.0 h1:X7/UEPyCaaEQ1gCg11KDvfyEtEeQLhtRtxMHjAiH/Co=
+github.com/onflow/atree v0.12.0/go.mod h1:qdZcfLQwPirHcNpLiK+2t3KAo+SAb9Si6TqurE6pykE=
 github.com/onflow/crypto v0.25.3 h1:XQ3HtLsw8h1+pBN+NQ1JYM9mS2mVXTyg55OldaAIF7U=
 github.com/onflow/crypto v0.25.3/go.mod h1:+1igaXiK6Tjm9wQOBD1EGwW7bYWMUGKtwKJ/2QL/OWs=
 github.com/onflow/fixed-point v0.1.1 h1:j0jYZVO8VGyk1476alGudEg7XqCkeTVxb5ElRJRKS90=

--- a/values/encode.go
+++ b/values/encode.go
@@ -239,13 +239,13 @@ func MaybeLargeImmutableStorable(
 	storable atree.Storable,
 	storage atree.SlabStorage,
 	address atree.Address,
-	maxInlineSize uint64,
+	maxInlineSize uint32,
 ) (
 	atree.Storable,
 	error,
 ) {
 
-	if uint64(storable.ByteSize()) < maxInlineSize {
+	if storable.ByteSize() < maxInlineSize {
 		return storable, nil
 	}
 

--- a/values/value_bool.go
+++ b/values/value_bool.go
@@ -75,7 +75,7 @@ func (v BoolValue) GreaterEqual(_ common.Gauge, other BoolValue) bool {
 	return bool(v || !other)
 }
 
-func (v BoolValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v BoolValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/values/value_int.go
+++ b/values/value_int.go
@@ -335,7 +335,7 @@ func (v IntValue) ToBigEndianBytes() []byte {
 	return SignedBigIntToBigEndianBytes(v.BigInt)
 }
 
-func (v IntValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
+func (v IntValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint32) (atree.Storable, error) {
 	return MaybeLargeImmutableStorable(v, storage, address, maxInlineSize)
 }
 

--- a/values/value_ufix64.go
+++ b/values/value_ufix64.go
@@ -265,7 +265,7 @@ func (v UFix64Value) ToBigEndianBytes() []byte {
 	return b
 }
 
-func (v UFix64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v UFix64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 


### PR DESCRIPTION
This PR bumps atree version to v0.12.0 and also bumps fxamacker/cbor to stream-mode branch based on v2.9.0.

This PR also updates the following API to match the changes introduced by atree v0.12:
- Old API: `Value.Storable(SlabStorage, Address, uint64) (Storable, error)` 
  New API: `Value.Storable(SlabStorage, Address, uint32) (Storable, error)`
- Old API: `WrapperValue.UnwrapAtreeValue() (Value, uint64)`
  New API: `WrapperValue.UnwrapAtreeValue() (Value, uint32)`

The API changes reduce frequent type casting in both atree and cadence. The changes in Atree v0.12 do not affect stored data.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
