### PR TITLE
Optimize event emission

### DIFF
--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -1336,7 +1336,7 @@ func TestCompileEmit(t *testing.T) {
 			opcode.InstructionStatement{},
 			// x
 			opcode.InstructionGetLocal{Local: xIndex},
-			opcode.InstructionTransferAndConvert{Type: 1},
+			opcode.InstructionConvert{Type: 1},
 			// emit
 			opcode.InstructionEmitEvent{
 				Type:     2,

--- a/interpreter/interpreter_statement.go
+++ b/interpreter/interpreter_statement.go
@@ -403,7 +403,7 @@ func (interpreter *Interpreter) VisitEmitStatement(statement *ast.EmitStatement)
 			argumentType := argumentTypes[i]
 			parameterType := parameterTypes[i]
 
-			eventFields[i] = TransferAndConvert(
+			eventFields[i] = ConvertAndBoxWithValidation(
 				interpreter,
 				value,
 				argumentType,


### PR DESCRIPTION
## Description

Looking at the optimizations of the FastBreak contract (https://github.com/dapperlabs/nba-smart-contracts/pull/294) I noticed this change to an event parameter: https://github.com/dapperlabs/nba-smart-contracts/pull/294/files#diff-9f296e6a8c507b02a639681b7295fafccaf5868f24299c03efda0bde31a18047L68. 

Given the event emission handler exports the event arguments immediately, we can avoid transfers (copies) in general.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
