### PR TITLE
[Subtyping Generator] Sync `feature/subtype-gen` branch with `master`

### DIFF
--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -1336,7 +1336,7 @@ func TestCompileEmit(t *testing.T) {
 			opcode.InstructionStatement{},
 			// x
 			opcode.InstructionGetLocal{Local: xIndex},
-			opcode.InstructionTransferAndConvert{Type: 1},
+			opcode.InstructionConvert{Type: 1},
 			// emit
 			opcode.InstructionEmitEvent{
 				Type:     2,

--- a/interpreter/account_test.go
+++ b/interpreter/account_test.go
@@ -417,62 +417,66 @@ type NoOpReferenceCreationContext struct{}
 
 var _ interpreter.ReferenceCreationContext = NoOpReferenceCreationContext{}
 
-func (n NoOpReferenceCreationContext) ClearReferencedResourceKindedValues(_ atree.ValueID) {
+func (NoOpReferenceCreationContext) ClearReferencedResourceKindedValues(_ atree.ValueID) {
 	// NO-OP
 }
 
-func (n NoOpReferenceCreationContext) ReferencedResourceKindedValues(_ atree.ValueID) map[*interpreter.EphemeralReferenceValue]struct{} {
-	// NO-OP
-	return nil
-}
-
-func (n NoOpReferenceCreationContext) MaybeTrackReferencedResourceKindedValue(_ *interpreter.EphemeralReferenceValue) {
-	// NO-OP
-}
-
-func (n NoOpReferenceCreationContext) MeterMemory(_ common.MemoryUsage) error {
+func (NoOpReferenceCreationContext) ReferencedResourceKindedValues(_ atree.ValueID) map[*interpreter.EphemeralReferenceValue]struct{} {
 	// NO-OP
 	return nil
 }
 
-func (n NoOpReferenceCreationContext) MeterComputation(_ common.ComputationUsage) error {
+func (NoOpReferenceCreationContext) MaybeTrackReferencedResourceKindedValue(_ *interpreter.EphemeralReferenceValue) {
+	// NO-OP
+}
+
+func (NoOpReferenceCreationContext) MeterMemory(_ common.MemoryUsage) error {
 	// NO-OP
 	return nil
 }
 
-func (n NoOpReferenceCreationContext) ReadStored(_ common.Address, _ common.StorageDomain, _ interpreter.StorageMapKey) interpreter.Value {
+func (NoOpReferenceCreationContext) MeterComputation(_ common.ComputationUsage) error {
 	// NO-OP
 	return nil
 }
 
-func (n NoOpReferenceCreationContext) GetEntitlementType(_ interpreter.TypeID) (*sema.EntitlementType, error) {
+func (NoOpReferenceCreationContext) ReadStored(_ common.Address, _ common.StorageDomain, _ interpreter.StorageMapKey) interpreter.Value {
+	// NO-OP
+	return nil
+}
+
+func (NoOpReferenceCreationContext) GetEntitlementType(_ interpreter.TypeID) (*sema.EntitlementType, error) {
 	// NO-OP
 	return nil, nil
 }
 
-func (n NoOpReferenceCreationContext) GetEntitlementMapType(_ interpreter.TypeID) (*sema.EntitlementMapType, error) {
+func (NoOpReferenceCreationContext) GetEntitlementMapType(_ interpreter.TypeID) (*sema.EntitlementMapType, error) {
 	// NO-OP
 	return nil, nil
 }
 
-func (n NoOpReferenceCreationContext) GetInterfaceType(_ common.Location, _ string, _ interpreter.TypeID) (*sema.InterfaceType, error) {
+func (NoOpReferenceCreationContext) GetInterfaceType(_ common.Location, _ string, _ interpreter.TypeID) (*sema.InterfaceType, error) {
 	// NO-OP
 	return nil, nil
 }
 
-func (n NoOpReferenceCreationContext) GetCompositeType(_ common.Location, _ string, _ interpreter.TypeID) (*sema.CompositeType, error) {
+func (NoOpReferenceCreationContext) GetCompositeType(_ common.Location, _ string, _ interpreter.TypeID) (*sema.CompositeType, error) {
 	// NO-OP
 	return nil, nil
 }
 
-func (n NoOpReferenceCreationContext) IsTypeInfoRecovered(_ common.Location) bool {
+func (NoOpReferenceCreationContext) IsTypeInfoRecovered(_ common.Location) bool {
 	// NO-OP
 	return false
 }
 
-func (n NoOpReferenceCreationContext) SemaTypeFromStaticType(_ interpreter.StaticType) sema.Type {
+func (NoOpReferenceCreationContext) SemaTypeFromStaticType(_ interpreter.StaticType) sema.Type {
 	// NO-OP
 	return nil
+}
+
+func (NoOpReferenceCreationContext) SemaAccessFromStaticAuthorization(interpreter.Authorization) (sema.Access, error) {
+	panic(errors.NewUnreachableError())
 }
 
 type NoOpFunctionCreationContext struct {
@@ -482,28 +486,28 @@ type NoOpFunctionCreationContext struct {
 
 var _ interpreter.FunctionCreationContext = NoOpFunctionCreationContext{}
 
-func (n NoOpFunctionCreationContext) ClearReferencedResourceKindedValues(_ atree.ValueID) {
+func (NoOpFunctionCreationContext) ClearReferencedResourceKindedValues(_ atree.ValueID) {
 	// NO-OP
 }
 
-func (n NoOpFunctionCreationContext) ReferencedResourceKindedValues(
+func (NoOpFunctionCreationContext) ReferencedResourceKindedValues(
 	_ atree.ValueID,
 ) map[*interpreter.EphemeralReferenceValue]struct{} {
 	// NO-OP
 	return nil
 }
 
-func (n NoOpFunctionCreationContext) CheckInvalidatedResourceOrResourceReference(
+func (NoOpFunctionCreationContext) CheckInvalidatedResourceOrResourceReference(
 	_ interpreter.Value,
 ) {
 	// NO-OP
 }
 
-func (n NoOpFunctionCreationContext) MaybeTrackReferencedResourceKindedValue(_ *interpreter.EphemeralReferenceValue) {
+func (NoOpFunctionCreationContext) MaybeTrackReferencedResourceKindedValue(_ *interpreter.EphemeralReferenceValue) {
 	// NO-OP
 }
 
-func (n NoOpFunctionCreationContext) MeterMemory(_ common.MemoryUsage) error {
+func (NoOpFunctionCreationContext) MeterMemory(_ common.MemoryUsage) error {
 	// NO-OP
 	return nil
 }

--- a/interpreter/interface.go
+++ b/interpreter/interface.go
@@ -30,6 +30,7 @@ type TypeConverter interface {
 	common.MemoryGauge
 	StaticTypeConversionHandler
 	SemaTypeFromStaticType(staticType StaticType) sema.Type
+	SemaAccessFromStaticAuthorization(auth Authorization) (sema.Access, error)
 }
 
 var _ TypeConverter = &Interpreter{}
@@ -538,98 +539,102 @@ type NoOpStringContext struct {
 
 var _ ValueStringContext = NoOpStringContext{}
 
-func (ctx NoOpStringContext) MeterMemory(_ common.MemoryUsage) error {
+func (NoOpStringContext) MeterMemory(_ common.MemoryUsage) error {
 	return nil
 }
 
-func (ctx NoOpStringContext) MeterComputation(_ common.ComputationUsage) error {
+func (NoOpStringContext) MeterComputation(_ common.ComputationUsage) error {
 	return nil
 }
 
-func (ctx NoOpStringContext) WithContainerMutationPrevention(_ atree.ValueID, f func()) {
+func (NoOpStringContext) WithContainerMutationPrevention(_ atree.ValueID, f func()) {
 	f()
 }
 
-func (ctx NoOpStringContext) ValidateContainerMutation(_ atree.ValueID) {
+func (NoOpStringContext) ValidateContainerMutation(_ atree.ValueID) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) EnforceNotResourceDestruction(_ atree.ValueID) {
+func (NoOpStringContext) EnforceNotResourceDestruction(_ atree.ValueID) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) ReadStored(_ common.Address, _ common.StorageDomain, _ StorageMapKey) Value {
+func (NoOpStringContext) ReadStored(_ common.Address, _ common.StorageDomain, _ StorageMapKey) Value {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) WriteStored(_ common.Address, _ common.StorageDomain, _ StorageMapKey, _ Value) (existed bool) {
+func (NoOpStringContext) WriteStored(_ common.Address, _ common.StorageDomain, _ StorageMapKey, _ Value) (existed bool) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) Storage() Storage {
+func (NoOpStringContext) Storage() Storage {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) MaybeValidateAtreeValue(_ atree.Value) {
+func (NoOpStringContext) MaybeValidateAtreeValue(_ atree.Value) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) MaybeValidateAtreeStorage() {
+func (NoOpStringContext) MaybeValidateAtreeStorage() {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) MaybeTrackReferencedResourceKindedValue(_ *EphemeralReferenceValue) {
+func (NoOpStringContext) MaybeTrackReferencedResourceKindedValue(_ *EphemeralReferenceValue) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) ClearReferencedResourceKindedValues(_ atree.ValueID) {
+func (NoOpStringContext) ClearReferencedResourceKindedValues(_ atree.ValueID) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) ReferencedResourceKindedValues(_ atree.ValueID) map[*EphemeralReferenceValue]struct{} {
+func (NoOpStringContext) ReferencedResourceKindedValues(_ atree.ValueID) map[*EphemeralReferenceValue]struct{} {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) OnResourceOwnerChange(_ *CompositeValue, _ common.Address, _ common.Address) {
+func (NoOpStringContext) OnResourceOwnerChange(_ *CompositeValue, _ common.Address, _ common.Address) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) RecordStorageMutation() {
+func (NoOpStringContext) RecordStorageMutation() {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) StorageMutatedDuringIteration() bool {
+func (NoOpStringContext) StorageMutatedDuringIteration() bool {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) InStorageIteration() bool {
+func (NoOpStringContext) InStorageIteration() bool {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) SetInStorageIteration(_ bool) {
+func (NoOpStringContext) SetInStorageIteration(_ bool) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) GetEntitlementType(_ TypeID) (*sema.EntitlementType, error) {
+func (NoOpStringContext) GetEntitlementType(_ TypeID) (*sema.EntitlementType, error) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) GetEntitlementMapType(_ TypeID) (*sema.EntitlementMapType, error) {
+func (NoOpStringContext) GetEntitlementMapType(_ TypeID) (*sema.EntitlementMapType, error) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) GetInterfaceType(_ common.Location, _ string, _ TypeID) (*sema.InterfaceType, error) {
+func (NoOpStringContext) GetInterfaceType(_ common.Location, _ string, _ TypeID) (*sema.InterfaceType, error) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) GetCompositeType(_ common.Location, _ string, _ TypeID) (*sema.CompositeType, error) {
+func (NoOpStringContext) GetCompositeType(_ common.Location, _ string, _ TypeID) (*sema.CompositeType, error) {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) IsTypeInfoRecovered(_ common.Location) bool {
+func (NoOpStringContext) IsTypeInfoRecovered(_ common.Location) bool {
 	panic(errors.NewUnreachableError())
 }
 
-func (ctx NoOpStringContext) SemaTypeFromStaticType(_ StaticType) sema.Type {
+func (NoOpStringContext) SemaTypeFromStaticType(_ StaticType) sema.Type {
+	panic(errors.NewUnreachableError())
+}
+
+func (NoOpStringContext) SemaAccessFromStaticAuthorization(Authorization) (sema.Access, error) {
 	panic(errors.NewUnreachableError())
 }

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5187,17 +5187,6 @@ func (interpreter *Interpreter) GetEntitlementMapType(typeID common.TypeID) (*se
 	return ty, nil
 }
 
-func MustConvertStaticAuthorizationToSemaAccess(
-	handler StaticAuthorizationConversionHandler,
-	auth Authorization,
-) sema.Access {
-	access, err := ConvertStaticAuthorizationToSemaAccess(auth, handler)
-	if err != nil {
-		panic(err)
-	}
-	return access
-}
-
 func (interpreter *Interpreter) getElaboration(location common.Location) *sema.Elaboration {
 
 	// Ensure the program for this location is loaded,
@@ -6398,6 +6387,10 @@ func (interpreter *Interpreter) MaybeUpdateStorageReferenceMemberReceiver(
 	}
 
 	return member
+}
+
+func (interpreter *Interpreter) SemaAccessFromStaticAuthorization(auth Authorization) (sema.Access, error) {
+	return ConvertStaticAuthorizationToSemaAccess(auth, interpreter)
 }
 
 func StorageReference(

--- a/interpreter/interpreter_statement.go
+++ b/interpreter/interpreter_statement.go
@@ -403,7 +403,7 @@ func (interpreter *Interpreter) VisitEmitStatement(statement *ast.EmitStatement)
 			argumentType := argumentTypes[i]
 			parameterType := parameterTypes[i]
 
-			eventFields[i] = TransferAndConvert(
+			eventFields[i] = ConvertAndBoxWithValidation(
 				interpreter,
 				value,
 				argumentType,

--- a/interpreter/statictype.go
+++ b/interpreter/statictype.go
@@ -1184,6 +1184,12 @@ func ConvertSemaTransactionToStaticTransactionType(
 	)
 }
 
+// ConvertStaticAuthorizationToSemaAccess converts authorization of static-types
+// to the sema-type representation of the same.
+//
+// **IMPORTANT**: Do not use this function directly. Instead, use the
+// `SemaAccessFromStaticAuthorization` method of the `TypeConverter` interface,
+// since it will cache and re-use the conversion results.
 func ConvertStaticAuthorizationToSemaAccess(
 	auth Authorization,
 	handler StaticAuthorizationConversionHandler,
@@ -1370,7 +1376,7 @@ func ConvertStaticToSemaType(
 			return nil, err
 		}
 
-		access, err := ConvertStaticAuthorizationToSemaAccess(t.Authorization, context)
+		access, err := context.SemaAccessFromStaticAuthorization(t.Authorization)
 
 		if err != nil {
 			return nil, err

--- a/interpreter/statictype_test.go
+++ b/interpreter/statictype_test.go
@@ -1776,6 +1776,10 @@ func (s staticTypeConversionHandler) SemaTypeFromStaticType(staticType StaticTyp
 	return MustConvertStaticToSemaType(staticType, s)
 }
 
+func (s staticTypeConversionHandler) SemaAccessFromStaticAuthorization(auth Authorization) (sema.Access, error) {
+	return ConvertStaticAuthorizationToSemaAccess(auth, s)
+}
+
 func TestIntersectionStaticType_ID(t *testing.T) {
 	t.Parallel()
 

--- a/interpreter/value_ephemeral_reference.go
+++ b/interpreter/value_ephemeral_reference.go
@@ -186,10 +186,16 @@ func (v *EphemeralReferenceValue) GetTypeKey(context MemberAccessibleContext, ke
 	self := v.Value
 
 	if selfComposite, isComposite := self.(*CompositeValue); isComposite {
+
+		semaAccess, err := context.SemaAccessFromStaticAuthorization(v.Authorization)
+		if err != nil {
+			panic(err)
+		}
+
 		return selfComposite.getTypeKey(
 			context,
 			key,
-			MustConvertStaticAuthorizationToSemaAccess(context, v.Authorization),
+			semaAccess,
 		)
 	}
 

--- a/interpreter/value_storage_reference.go
+++ b/interpreter/value_storage_reference.go
@@ -283,7 +283,10 @@ func (v *StorageReferenceValue) GetTypeKey(
 	self := v.mustReferencedValue(context)
 
 	if selfComposite, isComposite := self.(*CompositeValue); isComposite {
-		access := MustConvertStaticAuthorizationToSemaAccess(context, v.Authorization)
+		access, err := context.SemaAccessFromStaticAuthorization(v.Authorization)
+		if err != nil {
+			panic(err)
+		}
 		return selfComposite.getTypeKey(
 			context,
 			key,


### PR DESCRIPTION
## Description

Sync with master to get the https://github.com/onflow/cadence/pull/4336 changes to the feature branch.

Conflicts:

```diff
Merge: cc0eee2de 589f8271c
Author: Supun Setunga <supun.setunga@gmail.com>
Date:   Thu Nov 13 21:57:37 2025 -0800

    Merge branch 'master' of https://github.com/onflow/cadence into supun/sync-subtype-gen-with-master

diff --git a/sema/type.go b/sema/type.go
remerge CONFLICT (content): Merge conflict in sema/type.go
index 174687738..382da51c3 100644
--- a/sema/type.go
+++ b/sema/type.go
@@ -7985,33 +7985,11 @@ func checkSubTypeWithoutEquality(subType Type, superType Type) bool {
 
                        if subTypeBaseType := typedSubType.BaseType(); subTypeBaseType != nil {
 
-<<<<<<< cc0eee2de (Merge pull request #4330 from onflow/supun/sync-subtype-gen-with-master)
                                if !IsSubType(subTypeBaseType, superTypeBaseType) {
                                        return false
                                }
 
                                return AreTypeArgumentsEqual(typedSubType, typedSuperType)
-=======
-                               if !IsSubType(subTypeBaseType, superTypeBaseType) {
-                                       return false
->>>>>>> 589f8271c (Merge pull request #4336 from onflow/supun/cache-authorization-conversion)
-                               }
-
-                               subTypeTypeArguments := typedSubType.TypeArguments()
-                               superTypeTypeArguments := typedSuperType.TypeArguments()
-
-                               if len(subTypeTypeArguments) != len(superTypeTypeArguments) {
-                                       return false
-                               }
-
-                               for i, superTypeTypeArgument := range superTypeTypeArguments {
-                                       subTypeTypeArgument := subTypeTypeArguments[i]
-                                       if !IsSubType(subTypeTypeArgument, superTypeTypeArgument) {
-                                               return false
-                                       }
-                               }
-
-                               return true
                        }
                } else {
                        // TODO: enforce type arguments, remove this rule
@@ -8026,15 +8004,9 @@ func checkSubTypeWithoutEquality(subType Type, superType Type) bool {
 
                return false
 
-<<<<<<< cc0eee2de (Merge pull request #4330 from onflow/supun/sync-subtype-gen-with-master)
-       // T<Us> <: V
-       // if T <: V
-       return IsParameterizedSubType(subType, superType)
-=======
        }
 
        return false
->>>>>>> 589f8271c (Merge pull request #4336 from onflow/supun/cache-authorization-conversion)
 }
 
 // UnwrapOptionalType returns the type if it is not an optional type,
```

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
