### PR TITLE
Decode/import/convert primitive capability static type as/to capability static type

### DIFF
--- a/bbq/commons/constants.go
+++ b/bbq/commons/constants.go
@@ -49,4 +49,5 @@ const (
 	TypeQualifierFunction           = "$Function"
 	TypeQualifierOptional           = "$Optional"
 	TypeQualifierInclusiveRange     = "$InclusiveRange"
+	TypeQualifierCapability         = "$Capability"
 )

--- a/bbq/commons/types.go
+++ b/bbq/commons/types.go
@@ -20,7 +20,6 @@ package commons
 
 import (
 	"github.com/onflow/cadence/common"
-	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
 )
 
@@ -87,7 +86,7 @@ func TypeQualifier(typ sema.Type) string {
 		// TODO: Revisit. Probably this is not needed here?
 		return TypeQualifier(typ.Types[0])
 	case *sema.CapabilityType:
-		return interpreter.PrimitiveStaticTypeCapability.String()
+		return TypeQualifierCapability
 	case *sema.InclusiveRangeType:
 		return TypeQualifierInclusiveRange
 	default:

--- a/bbq/vm/value_capability.go
+++ b/bbq/vm/value_capability.go
@@ -19,6 +19,7 @@
 package vm
 
 import (
+	"github.com/onflow/cadence/bbq/commons"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/interpreter"
 	"github.com/onflow/cadence/sema"
@@ -27,7 +28,7 @@ import (
 // Members
 
 func init() {
-	typeName := interpreter.PrimitiveStaticTypeCapability.String()
+	typeName := commons.TypeQualifierCapability
 
 	// Capability.borrow
 	registerBuiltinTypeBoundFunction(

--- a/encoding/json/decode.go
+++ b/encoding/json/decode.go
@@ -1496,7 +1496,7 @@ var simpleTypes = func() map[string]cadence.Type {
 }()
 
 func canEncodeAsSimpleType(primitiveType cadence.PrimitiveType) bool {
-	return primitiveType != cadence.PrimitiveType(interpreter.PrimitiveStaticTypeCapability)
+	return primitiveType != cadence.PrimitiveType(interpreter.PrimitiveStaticTypeCapability) //nolint:staticcheck
 }
 
 func (d *Decoder) decodeType(valueJSON any, results typeDecodingResults) cadence.Type {

--- a/interpreter/decode.go
+++ b/interpreter/decode.go
@@ -1659,7 +1659,7 @@ func (d TypeDecoder) DecodeStaticType() (StaticType, error) {
 	}
 }
 
-func (d TypeDecoder) decodePrimitiveStaticType() (PrimitiveStaticType, error) {
+func (d TypeDecoder) decodePrimitiveStaticType() (StaticType, error) {
 	encoded, err := decodeUint64(d.decoder, d.memoryGauge)
 	if err != nil {
 		if e, ok := err.(*cbor.WrongTypeError); ok {
@@ -1668,7 +1668,13 @@ func (d TypeDecoder) decodePrimitiveStaticType() (PrimitiveStaticType, error) {
 		}
 		return PrimitiveStaticTypeUnknown, err
 	}
-	return PrimitiveStaticType(encoded), nil
+
+	var staticType StaticType = PrimitiveStaticType(encoded)
+	if staticType == PrimitiveStaticTypeCapability { //nolint:staticcheck
+		staticType = NewCapabilityStaticType(d.memoryGauge, nil)
+	}
+
+	return staticType, nil
 }
 
 func (d TypeDecoder) decodeOptionalStaticType() (StaticType, error) {

--- a/interpreter/memory_metering_test.go
+++ b/interpreter/memory_metering_test.go
@@ -9730,6 +9730,8 @@ func TestInterpretStaticTypeStringConversion(t *testing.T) {
 
 			switch primitiveStaticType {
 			case interpreter.PrimitiveStaticTypeAny,
+				// Capability is converted to CapabilityStaticType
+				interpreter.PrimitiveStaticTypeCapability, //nolint:staticcheck
 				interpreter.PrimitiveStaticTypeUnknown,
 				interpreter.PrimitiveStaticType_Count:
 				continue

--- a/interpreter/primitivestatictype.go
+++ b/interpreter/primitivestatictype.go
@@ -164,6 +164,7 @@ const (
 	// Storage
 
 	PrimitiveStaticTypePath
+	// Deprecated: PrimitiveStaticTypeCapability only exists for encoding/decoding purposes.
 	PrimitiveStaticTypeCapability
 	PrimitiveStaticTypeStoragePath
 	PrimitiveStaticTypeCapabilityPath
@@ -960,16 +961,9 @@ func ConvertSemaToPrimitiveStaticType(
 		typ = PrimitiveStaticTypeAccountMapping
 	}
 
-	switch t := t.(type) {
+	switch t.(type) {
 	case *sema.AddressType:
 		typ = PrimitiveStaticTypeAddress
-
-	// Storage
-	case *sema.CapabilityType:
-		// Only convert unparameterized Capability type
-		if t.BorrowType == nil {
-			typ = PrimitiveStaticTypeCapability
-		}
 	}
 
 	if typ == PrimitiveStaticTypeUnknown {

--- a/interpreter/primitivestatictype_test.go
+++ b/interpreter/primitivestatictype_test.go
@@ -47,6 +47,13 @@ func TestPrimitiveStaticTypeSemaTypeConversion(t *testing.T) {
 		if !ty.IsDefined() || ty.IsDeprecated() { //nolint:staticcheck
 			continue
 		}
+
+		// PrimitiveStaticTypeCapability is converted to sema.CapabilityType,
+		// which converts back to CapabilityStaticType
+		if ty == PrimitiveStaticTypeCapability { //nolint:staticcheck
+			continue
+		}
+
 		test(ty)
 	}
 }

--- a/interpreter/statictype.go
+++ b/interpreter/statictype.go
@@ -1046,12 +1046,10 @@ func ConvertSemaToStaticType(memoryGauge common.MemoryGauge, t sema.Type) Static
 		return ConvertSemaReferenceTypeToStaticReferenceType(memoryGauge, t)
 
 	case *sema.CapabilityType:
-		if t.BorrowType == nil {
-			// Unparameterized Capability type should have been
-			// converted to primitive static type earlier
-			panic(errors.NewUnreachableError())
+		var borrowType StaticType
+		if t.BorrowType != nil {
+			borrowType = ConvertSemaToStaticType(memoryGauge, t.BorrowType)
 		}
-		borrowType := ConvertSemaToStaticType(memoryGauge, t.BorrowType)
 		return NewCapabilityStaticType(memoryGauge, borrowType)
 
 	case *sema.InclusiveRangeType:

--- a/interpreter/statictype_test.go
+++ b/interpreter/statictype_test.go
@@ -1219,11 +1219,6 @@ func TestStaticTypeConversion(t *testing.T) {
 			staticType: PrimitiveStaticTypePath,
 		},
 		{
-			name:       "Capability",
-			semaType:   &sema.CapabilityType{},
-			staticType: PrimitiveStaticTypeCapability,
-		},
-		{
 			name:       "StoragePath",
 			semaType:   sema.StoragePathType,
 			staticType: PrimitiveStaticTypeStoragePath,
@@ -1482,9 +1477,15 @@ func TestStaticTypeConversion(t *testing.T) {
 		},
 
 		{
+			name:           "Capability",
+			staticType:     PrimitiveStaticTypeCapability,
+			semaType:       &sema.CapabilityType{},
+			noSemaToStatic: true,
+		},
+		{
 			name:       "Unparameterized Capability",
 			semaType:   &sema.CapabilityType{},
-			staticType: PrimitiveStaticTypeCapability,
+			staticType: &CapabilityStaticType{},
 		},
 		{
 			name: "Parameterized  Capability",

--- a/runtime/convertTypes.go
+++ b/runtime/convertTypes.go
@@ -775,13 +775,14 @@ func ImportType(memoryGauge common.MemoryGauge, t cadence.Type) interpreter.Stat
 		)
 
 	case *cadence.CapabilityType:
-		if t.BorrowType == nil {
-			return interpreter.PrimitiveStaticTypeCapability
+		var borrowType interpreter.StaticType
+		if t.BorrowType != nil {
+			borrowType = ImportType(memoryGauge, t.BorrowType)
 		}
 
 		return interpreter.NewCapabilityStaticType(
 			memoryGauge,
-			ImportType(memoryGauge, t.BorrowType),
+			borrowType,
 		)
 
 	default:


### PR DESCRIPTION
## Description

Ensure that at run-time, the static type `Capability` is always represented by `CapabilityStaticType` instead of potentially as `PrimitiveStaticTypeCapability` if there is no borrow type.

We need to keep decoding support for `PrimitiveStaticTypeCapability`, because state on-chain might use it.

- Decode stored `PrimitiveStaticTypeCapability` as `CapabilityStaticType`
- Always import `cadence.CapabilityType` as `CapabilityStaticType`
- Always convert `sema.CapabilityType` to `CapabilityStaticType`

While at it, use a dedicated type qualifier for `Capability` types in the compiler/VM.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
