### PR TITLE
Transfer enum lookup result in interpreter

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1694,6 +1694,15 @@ func EnumLookupFunction(
 				return Nil
 			}
 
+			caseValue = caseValue.Transfer(
+				inter,
+				atree.Address{},
+				false,
+				nil,
+				nil,
+				true, // value is standalone.
+			)
+
 			return NewSomeValueNonCopying(inter, caseValue)
 		},
 	)


### PR DESCRIPTION
## Description

We should transfer the result of the lookup, like a normal function would, and like the compiler already does.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
