### PR TITLE
update test to match fvm benchmark

### DIFF
--- a/runtime/ft_test.go
+++ b/runtime/ft_test.go
@@ -570,6 +570,34 @@ transaction(amount: UFix64, to: Address) {
     }
 }
 `
+const jansRealFlowTokenTransferTransaction = `
+import FungibleToken from 0x1
+import FlowToken from 0x1
+
+transaction(amount: UFix64, to: Address){
+
+    prepare(signer: auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account) {
+        var f: fun(): Void = fun(){}
+        f = fun() {
+                var i = 0
+                while i < 26 {
+                    i = i + 1
+
+            let vaultRef = signer.storage.borrow<auth(FungibleToken.Withdraw) &FlowToken.Vault>(from: /storage/flowTokenVault)!
+            let receiverRef = getAccount(to)
+                .capabilities.borrow<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)!
+            receiverRef.deposit(from: <-vaultRef.withdraw(amount: 0.00001))
+
+                }
+        }
+        f()
+    }
+
+    execute {
+        var f: fun(): Void = fun(){}
+    }
+}
+`
 
 const realFlowTokenBalanceScript = `
 import FungibleToken from 0x1
@@ -755,7 +783,7 @@ func testRuntimeFungibleTokenTransfer(tb testing.TB, useVM bool) {
 
 		err = runtime.ExecuteTransaction(
 			Script{
-				Source: []byte(realFlowTokenTransferTransaction),
+				Source: []byte(jansRealFlowTokenTransferTransaction),
 				Arguments: encodeArgs([]cadence.Value{
 					sendAmount,
 					cadence.Address(receiverAddress),


### PR DESCRIPTION
**DO NOT MERGE - experiment**

I was just curious how fvm vs cadence benchmark compares for same (at least close to same) token transfer tx. 

I took FVM benchmark @janezpodhostnik added here: https://github.com/onflow/flow-execution-effort-estimation/pull/80
The Tx this runs is:
```
transaction(){


    prepare(signer: auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account) {
        var f: fun(): Void = fun(){}
        f = fun() {
                var i = 0
                while i < 26 {
                    i = i + 1

            let vaultRef = signer.storage.borrow<auth(FungibleToken.Withdraw) &FlowToken.Vault>(from: /storage/flowTokenVault)!
            let receiverRef = getAccount(signer.address)
                .capabilities.borrow<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)!
            receiverRef.deposit(from: <-vaultRef.withdraw(amount: 0.00001))

                }
        }
        f()
    }

    execute {
        var f: fun(): Void = fun(){}
    }
}
```

Then  I updated Cadence testRuntimeFungibleTokenTransfer test to match the transaction above (see the change in this PR).

**FVM** 
Benchmark_GlobalRegistry/[TTS_26]-14         	     230	   **5,147,458 ns/op**

**Cadence interpreter**
BenchmarkRuntimeFungibleTokenTransferInterpreter-14    	     690	   **1,618,031 ns/op**	 1672294 B/op	   36598 allocs/op

**Cadence VM**
BenchmarkRuntimeFungibleTokenTransferVM-14    	     972	   **1,124,029 ns/op**	 1160718 B/op	   26218 allocs/op