### PR TITLE
Fix mismatch indexing expression key transfer mismatch between interpreter and compiler

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -3109,7 +3109,8 @@ func (c *Compiler[_, _]) compileIndexAccess(expression *ast.IndexExpression) {
 	}
 
 	indexedType := indexExpressionTypes.IndexedType
-	c.emitConvert(indexedType.IndexingType())
+	// TODO: optimize: once interpreter is removed, avoid redundant transfer and only convert
+	c.emitTransferIfNotResourceAndConvert(indexedType.IndexingType())
 
 	isNestedResourceMove := c.DesugaredElaboration.IsNestedResourceMoveExpression(expression)
 	if isNestedResourceMove {

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -1780,8 +1780,7 @@ func TestCompileIndex(t *testing.T) {
 			// array[index]
 			opcode.InstructionGetLocal{Local: arrayIndex},
 			opcode.InstructionGetLocal{Local: indexIndex},
-			// NOTE: no transfer
-			opcode.InstructionConvert{Type: 1},
+			opcode.InstructionTransferAndConvert{Type: 1},
 			opcode.InstructionGetIndex{},
 
 			// return
@@ -7444,7 +7443,7 @@ func TestCompileSecondValueAssignment(t *testing.T) {
 				// Evaluate the index expression, `y["r"]`, using temp locals.
 				opcode.InstructionGetLocal{Local: tempYIndex},
 				opcode.InstructionGetLocal{Local: tempIndexingValueIndex},
-				opcode.InstructionConvert{Type: 3},
+				opcode.InstructionTransferAndConvert{Type: 3},
 				opcode.InstructionRemoveIndex{},
 				opcode.InstructionTransferAndConvert{Type: 4},
 
@@ -8465,14 +8464,14 @@ func TestCompileSwapIndex(t *testing.T) {
 
 			opcode.InstructionGetLocal{Local: tempIndex1},
 			opcode.InstructionGetLocal{Local: tempIndex2},
-			opcode.InstructionConvert{Type: 3},
+			opcode.InstructionTransferAndConvert{Type: 3},
 			opcode.InstructionGetIndex{},
 			opcode.InstructionTransferAndConvert{Type: 2},
 			opcode.InstructionSetLocal{Local: tempIndex5},
 
 			opcode.InstructionGetLocal{Local: tempIndex3},
 			opcode.InstructionGetLocal{Local: tempIndex4},
-			opcode.InstructionConvert{Type: 3},
+			opcode.InstructionTransferAndConvert{Type: 3},
 			opcode.InstructionGetIndex{},
 			opcode.InstructionTransferAndConvert{Type: 2},
 			opcode.InstructionSetLocal{Local: tempIndex6},

--- a/interpreter/indexing_test.go
+++ b/interpreter/indexing_test.go
@@ -106,7 +106,7 @@ func TestInterpretIndexingExpressionTransferReadStatement(t *testing.T) {
 	require.NoError(t, err)
 
 	var expectedSlabIndex atree.SlabIndex
-	binary.BigEndian.PutUint64(expectedSlabIndex[:], 4)
+	binary.BigEndian.PutUint64(expectedSlabIndex[:], 5)
 
 	require.Equal(
 		t,

--- a/interpreter/interpreter_expression.go
+++ b/interpreter/interpreter_expression.go
@@ -40,10 +40,14 @@ func (interpreter *Interpreter) assignmentGetterSetter(expression ast.Expression
 		return interpreter.identifierExpressionGetterSetter(expression)
 
 	case *ast.IndexExpression:
+		// NOTE: check `AttachmentAccessTypes` instead of switching on `TypeIndexableValue` or `ValueIndexableValue`.
+		// An `*EphemeralReferenceValue` value is both a `TypeIndexableValue` and a `ValueIndexableValue` statically,
+		// but at runtime can only be used as one or the other.
 		if attachmentType, ok := interpreter.Program.Elaboration.AttachmentAccessTypes(expression); ok {
 			return interpreter.typeIndexExpressionGetterSetter(expression, attachmentType)
+		} else {
+			return interpreter.valueIndexExpressionGetterSetter(expression)
 		}
-		return interpreter.valueIndexExpressionGetterSetter(expression)
 
 	case *ast.MemberExpression:
 		return interpreter.memberExpressionGetterSetter(expression)
@@ -1032,27 +1036,14 @@ func (interpreter *Interpreter) VisitMemberExpression(expression *ast.MemberExpr
 }
 
 func (interpreter *Interpreter) VisitIndexExpression(expression *ast.IndexExpression) Value {
-	// note that this check in `AttachmentAccessTypes` must proceed the casting to the `TypeIndexableValue`
-	// or `ValueIndexableValue` interfaces. A `*EphemeralReferenceValue` value is both a `TypeIndexableValue`
-	// and a `ValueIndexableValue` statically, but at runtime can only be used as one or the other. Whether
-	// or not an expression is present in this map allows us to disambiguate between these two cases.
+	const allowMissing = false
+	// NOTE: check `AttachmentAccessTypes` instead of switching on `TypeIndexableValue` or `ValueIndexableValue`.
+	// An `*EphemeralReferenceValue` value is both a `TypeIndexableValue` and a `ValueIndexableValue` statically,
+	// but at runtime can only be used as one or the other.
 	if attachmentType, ok := interpreter.Program.Elaboration.AttachmentAccessTypes(expression); ok {
-		typedResult, ok := interpreter.evalExpression(expression.TargetExpression).(TypeIndexableValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
-		return typedResult.GetTypeKey(interpreter, attachmentType)
+		return interpreter.typeIndexExpressionGetterSetter(expression, attachmentType).get(allowMissing)
 	} else {
-		typedResult, ok := interpreter.evalExpression(expression.TargetExpression).(ValueIndexableValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-		indexingValue := interpreter.evalExpression(expression.IndexingExpression)
-		value := typedResult.GetKey(interpreter, indexingValue)
-
-		// If the indexing value is a reference, then return a reference for the resulting value.
-		return interpreter.maybeGetReference(expression, value)
+		return interpreter.valueIndexExpressionGetterSetter(expression).get(allowMissing)
 	}
 }
 


### PR DESCRIPTION
Work towards #4307

## Description

#4348 had previously attempted to fix the mismatch between interpreter and compiler in transferring the key expression of an indexing expression.

However, it was incorrect that the interpreter only transfers on writes, and not on reads. Instead, the behaviour of the interpreter was based on context: A read in a variable declaration would transfer, but a read e.g. in a statement expression would not.

Unify the behaviour and consistently always transfer the key in both interpreter and compiler.

Effectively:
- Revert compiler changes of #4348, ie. have the compiler always transfer the key, even on reads, like before that PR
- Change the interpreter to also transfer in `VisitIndexingExpression`, by simply calling `assignmentGetterSetter`, just like e.g. `VisitMemberExpression` already does

This basically adds additional, theoretically unnecessary transfers to both interpreter and compiler, but this approach is simpler than modifying the interpreter to match the compiler. We can eventually bring back #4348 once we removed the interpreter.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
