### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: Open Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v7
         with:
           branch: release/${{ steps.version-gen.outputs.version }}
           title: 'Merge `release/${{ steps.version-gen.outputs.version }}` to `${{ inputs.base }}`'


### PR DESCRIPTION
## Description

#4362 broke the release workflow: https://github.com/onflow/cadence/actions/runs/19771877562/job/56657448931#step:8:1

The update of `actions/checkout` to v6 causes https://github.com/actions/checkout/issues/2299, which was fixed in `peter-evans/create-pull-request` with https://github.com/peter-evans/create-pull-request/pull/4230.

Update `peter-evans/create-pull-request` to the latest release, v7.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
