### PR TITLE
[v1.8] Fix NPM package version

### DIFF
--- a/npm-packages/cadence-parser/package.json
+++ b/npm-packages/cadence-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-parser",
-  "version": "1.8.7",
+  "version": "1.8.8-rc.1",
   "description": "The Cadence parser",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {


### PR DESCRIPTION

## Description

The release of v1.8.8 is currently broken (https://github.com/onflow/cadence/actions/runs/19936327964) because the version in the NPM package is outdated. Fix it.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
