### PR TITLE
[Compiler] Remove unnecessary copy of arguments

### DIFF
--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -485,13 +485,9 @@ func (v *BoundFunctionValue) initializeFunctionType(context interpreter.ValueSta
 
 func (v *BoundFunctionValue) Invoke(invocation interpreter.Invocation) interpreter.Value {
 	context := invocation.InvocationContext
-
-	arguments := make([]Value, 0, len(invocation.Arguments))
-	arguments = append(arguments, invocation.Arguments...)
-
 	return context.InvokeFunction(
 		v,
-		arguments,
+		invocation.Arguments,
 	)
 }
 


### PR DESCRIPTION
Work towards #4364

## Description

There should be no need to copy the arguments when a bound function value is invoked anymore.

Initially #3934 created the copy to prepend the receiver, see https://github.com/onflow/cadence/pull/3934/files#diff-019f4401f818f062cdd1c06aa65eb59b979b3462a0a2c98d9318b3d9007a4b91R482-R485.
Later the prepending of the receiver was refactored/removed in #4105, see https://github.com/onflow/cadence/commit/253628ac022224ffa44b1abec3c65113eb15d8bf#diff-019f4401f818f062cdd1c06aa65eb59b979b3462a0a2c98d9318b3d9007a4b91R564.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
