### PR TITLE
[Compiler] Optimize call frames in the VM

### DIFF
--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -298,7 +298,7 @@ func AttachmentBaseAndSelfValues(
 	// CompositeValue.GetMethod, as in the interpreter we need an authorized reference to self
 	var unqualifiedName string
 	switch functionValue := method.(type) {
-	case CompiledFunctionValue:
+	case *CompiledFunctionValue:
 		unqualifiedName = functionValue.Function.Name
 	case *NativeFunctionValue:
 		unqualifiedName = functionValue.Name

--- a/bbq/vm/linker.go
+++ b/bbq/vm/linker.go
@@ -224,7 +224,7 @@ func functionValueFromBBQFunction(
 ) FunctionValue {
 	funcStaticType := getTypeFromExecutable[interpreter.FunctionStaticType](executable, function.TypeIndex)
 
-	return CompiledFunctionValue{
+	return &CompiledFunctionValue{
 		Function:   function,
 		Executable: executable,
 		Type:       funcStaticType,

--- a/bbq/vm/tracinginfo_disabled.go
+++ b/bbq/vm/tracinginfo_disabled.go
@@ -1,3 +1,5 @@
+//go:build !cadence_tracing
+
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
@@ -18,16 +20,14 @@
 
 package vm
 
-type callFrame struct {
-	// Important: keep tracingInfo as the first field, because its size may vary depending on build tags
-	// (zero when tracing is disabled, the default).
-	// This does not work when it is the last field, see https://i.hsfzxjy.site/zst-at-the-rear-of-go-struct/
-	tracingInfo tracingInfo
+import "time"
 
-	openUpvalues map[int]*Upvalue
+type tracingInfo struct{}
 
-	function *CompiledFunctionValue
+func newTracingInfo(_ time.Time) tracingInfo {
+	return tracingInfo{}
+}
 
-	localsOffset uint16
-	localsCount  uint16
+func (tracingInfo) StartTime() time.Time {
+	return time.Time{}
 }

--- a/bbq/vm/tracinginfo_enabled.go
+++ b/bbq/vm/tracinginfo_enabled.go
@@ -1,3 +1,5 @@
+//go:build cadence_tracing
+
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
@@ -18,16 +20,18 @@
 
 package vm
 
-type callFrame struct {
-	// Important: keep tracingInfo as the first field, because its size may vary depending on build tags
-	// (zero when tracing is disabled, the default).
-	// This does not work when it is the last field, see https://i.hsfzxjy.site/zst-at-the-rear-of-go-struct/
-	tracingInfo tracingInfo
+import "time"
 
-	openUpvalues map[int]*Upvalue
+type tracingInfo struct {
+	startTime time.Time
+}
 
-	function *CompiledFunctionValue
+func newTracingInfo(startTime time.Time) tracingInfo {
+	return tracingInfo{
+		startTime: startTime,
+	}
+}
 
-	localsOffset uint16
-	localsCount  uint16
+func (ti tracingInfo) StartTime() time.Time {
+	return ti.startTime
 }

--- a/bbq/vm/value_function.go
+++ b/bbq/vm/value_function.go
@@ -53,30 +53,30 @@ type FunctionValue interface {
 type CompiledFunctionValue struct {
 	Function   *bbq.Function[opcode.Instruction]
 	Executable *ExecutableProgram
-	Upvalues   []*Upvalue
 	Type       interpreter.FunctionStaticType
+	Upvalues   []*Upvalue
 }
 
-var _ Value = CompiledFunctionValue{}
-var _ FunctionValue = CompiledFunctionValue{}
+var _ Value = &CompiledFunctionValue{}
+var _ FunctionValue = &CompiledFunctionValue{}
 
-func (CompiledFunctionValue) IsValue() {}
+func (*CompiledFunctionValue) IsValue() {}
 
-func (v CompiledFunctionValue) IsFunctionValue() {}
+func (*CompiledFunctionValue) IsFunctionValue() {}
 
-func (v CompiledFunctionValue) HasGenericType() bool {
+func (*CompiledFunctionValue) HasGenericType() bool {
 	return false
 }
 
-func (v CompiledFunctionValue) ResolvedFunctionType(_ Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
+func (v *CompiledFunctionValue) ResolvedFunctionType(_ Value, context interpreter.ValueStaticTypeContext) *sema.FunctionType {
 	return v.FunctionType(context)
 }
 
-func (v CompiledFunctionValue) StaticType(interpreter.ValueStaticTypeContext) bbq.StaticType {
+func (v *CompiledFunctionValue) StaticType(interpreter.ValueStaticTypeContext) bbq.StaticType {
 	return v.Type
 }
 
-func (v CompiledFunctionValue) Transfer(
+func (v *CompiledFunctionValue) Transfer(
 	context interpreter.ValueTransferContext,
 	_ atree.Address,
 	remove bool,
@@ -90,73 +90,73 @@ func (v CompiledFunctionValue) Transfer(
 	return v
 }
 
-func (v CompiledFunctionValue) String() string {
+func (v *CompiledFunctionValue) String() string {
 	return v.Type.String()
 }
 
-func (v CompiledFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
+func (v *CompiledFunctionValue) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return interpreter.NonStorable{Value: v}, nil
 }
 
-func (v CompiledFunctionValue) Accept(_ interpreter.ValueVisitContext, _ interpreter.Visitor) {
+func (*CompiledFunctionValue) Accept(_ interpreter.ValueVisitContext, _ interpreter.Visitor) {
 	// Unused for now
 	panic(errors.NewUnreachableError())
 }
 
-func (v CompiledFunctionValue) Walk(_ interpreter.ValueWalkContext, _ func(interpreter.Value)) {
+func (*CompiledFunctionValue) Walk(_ interpreter.ValueWalkContext, _ func(interpreter.Value)) {
 	// NO-OP
 }
 
-func (v CompiledFunctionValue) ConformsToStaticType(
+func (*CompiledFunctionValue) ConformsToStaticType(
 	_ interpreter.ValueStaticTypeConformanceContext,
 	_ interpreter.TypeConformanceResults,
 ) bool {
 	return true
 }
 
-func (v CompiledFunctionValue) RecursiveString(_ interpreter.SeenReferences) string {
+func (v *CompiledFunctionValue) RecursiveString(_ interpreter.SeenReferences) string {
 	return v.String()
 }
 
-func (v CompiledFunctionValue) MeteredString(
+func (v *CompiledFunctionValue) MeteredString(
 	context interpreter.ValueStringContext,
 	_ interpreter.SeenReferences,
 ) string {
 	return v.Type.MeteredString(context)
 }
 
-func (v CompiledFunctionValue) IsResourceKinded(_ interpreter.ValueStaticTypeContext) bool {
+func (*CompiledFunctionValue) IsResourceKinded(_ interpreter.ValueStaticTypeContext) bool {
 	return false
 }
 
-func (v CompiledFunctionValue) NeedsStoreTo(_ atree.Address) bool {
+func (*CompiledFunctionValue) NeedsStoreTo(_ atree.Address) bool {
 	return false
 }
 
-func (v CompiledFunctionValue) DeepRemove(_ interpreter.ValueRemoveContext, _ bool) {
+func (*CompiledFunctionValue) DeepRemove(_ interpreter.ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 
-func (v CompiledFunctionValue) Clone(_ interpreter.ValueCloneContext) interpreter.Value {
+func (v *CompiledFunctionValue) Clone(_ interpreter.ValueCloneContext) interpreter.Value {
 	return v
 }
 
-func (v CompiledFunctionValue) IsImportable(_ interpreter.ValueImportableContext) bool {
+func (*CompiledFunctionValue) IsImportable(_ interpreter.ValueImportableContext) bool {
 	return false
 }
 
-func (v CompiledFunctionValue) FunctionType(interpreter.ValueStaticTypeContext) *sema.FunctionType {
+func (v *CompiledFunctionValue) FunctionType(interpreter.ValueStaticTypeContext) *sema.FunctionType {
 	return v.Type.FunctionType
 }
 
-func (v CompiledFunctionValue) Invoke(invocation interpreter.Invocation) interpreter.Value {
+func (v *CompiledFunctionValue) Invoke(invocation interpreter.Invocation) interpreter.Value {
 	return invocation.InvocationContext.InvokeFunction(
 		v,
 		invocation.Arguments,
 	)
 }
 
-func (v CompiledFunctionValue) IsNative() bool {
+func (v *CompiledFunctionValue) IsNative() bool {
 	return false
 }
 

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -197,7 +197,7 @@ func fill(slice []Value, n int) []Value {
 	return slice
 }
 
-func (vm *VM) pushCallFrame(functionValue CompiledFunctionValue, receiver Value, arguments []Value) {
+func (vm *VM) pushCallFrame(functionValue *CompiledFunctionValue, receiver Value, arguments []Value) {
 	if uint64(len(vm.callstack)) == vm.context.StackDepthLimit {
 		panic(&interpreter.CallStackLimitExceededError{
 			Limit: vm.context.StackDepthLimit,
@@ -225,16 +225,16 @@ func (vm *VM) pushCallFrame(functionValue CompiledFunctionValue, receiver Value,
 		vm.ipStack[len(vm.ipStack)-1] = vm.ip
 	}
 
-	var startTime time.Time
+	var tracingInfo tracingInfo
 	if interpreter.TracingEnabled {
-		startTime = time.Now()
+		tracingInfo = newTracingInfo(time.Now())
 	}
 
 	callFrame := callFrame{
 		localsCount:  localsCount,
 		localsOffset: offset,
 		function:     functionValue,
-		startTime:    startTime,
+		tracingInfo:  tracingInfo,
 	}
 
 	vm.ipStack = append(vm.ipStack, 0)
@@ -247,7 +247,7 @@ func (vm *VM) pushCallFrame(functionValue CompiledFunctionValue, receiver Value,
 func (vm *VM) popCallFrame() {
 
 	if interpreter.TracingEnabled {
-		startTime := vm.callFrame.startTime
+		startTime := vm.callFrame.tracingInfo.StartTime()
 		function := vm.callFrame.function
 		defer func() {
 			vm.context.ReportInvokeTrace(
@@ -869,7 +869,7 @@ func invokeFunction(
 	var receiver Value
 
 	switch functionValue := functionValue.(type) {
-	case CompiledFunctionValue:
+	case *CompiledFunctionValue:
 		if isBoundFunction {
 			// For compiled functions, pass the receiver as an implicit-reference.
 			// Because the `self` value can be accessed by user-code.
@@ -1793,7 +1793,7 @@ func opNewClosure(vm *VM, ins opcode.InstructionNewClosure) {
 
 	funcStaticType := getTypeFromExecutable[interpreter.FunctionStaticType](executable, function.TypeIndex)
 
-	vm.push(CompiledFunctionValue{
+	vm.push(&CompiledFunctionValue{
 		Function:   function,
 		Executable: executable,
 		Upvalues:   upvalues,
@@ -1930,7 +1930,7 @@ func (vm *VM) LocationRange() interpreter.LocationRange {
 	return locationRangeOfInstruction(currentFunction, lastInstructionIndex)
 }
 
-func locationRangeOfInstruction(function CompiledFunctionValue, instructionIndex uint16) interpreter.LocationRange {
+func locationRangeOfInstruction(function *CompiledFunctionValue, instructionIndex uint16) interpreter.LocationRange {
 	lineNumbers := function.Function.LineNumbers
 	position := lineNumbers.GetSourcePosition(instructionIndex)
 

--- a/interpreter/enum_test.go
+++ b/interpreter/enum_test.go
@@ -45,7 +45,7 @@ func TestInterpretEnum(t *testing.T) {
 
 	var expectedType interpreter.Value
 	if *compile {
-		expectedType = vm.CompiledFunctionValue{}
+		expectedType = &vm.CompiledFunctionValue{}
 	} else {
 		expectedType = &interpreter.HostFunctionValue{}
 	}


### PR DESCRIPTION
Work towards #4364

## Description

Tried to optimize call frames in the VM:

- Make compiled function value a pointer type
- Make tracing info a zero-sized struct when tracing is disabled (default)
- Reorder struct fields for optimal alignment (using https://github.com/dkorunic/betteralign)

Theoretically this should be more optimal, but running e.g. `BenchmarkRecursionFib`, there doesn't seem to be any difference. Maybe I'm missing something. Opening this PR anyways

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
