### PR TITLE
[Compiler] Avoid redundant set-local/get-local instructions in empty non-attachment constructors

### DIFF
--- a/bbq/compiler/compiler_metering_test.go
+++ b/bbq/compiler/compiler_metering_test.go
@@ -212,7 +212,7 @@ func TestCompilerMemoryMetering(t *testing.T) {
 			common.MemoryKindCompilerLocal:       1,
 			common.MemoryKindCompilerConstant:    0,
 			common.MemoryKindCompilerFunction:    3,
-			common.MemoryKindCompilerInstruction: 6,
+			common.MemoryKindCompilerInstruction: 4,
 
 			common.MemoryKindCompilerBBQProgram:  1,
 			common.MemoryKindCompilerBBQConstant: 0,
@@ -259,7 +259,7 @@ func TestCompilerMemoryMetering(t *testing.T) {
 			common.MemoryKindCompilerLocal:       4,
 			common.MemoryKindCompilerConstant:    1,
 			common.MemoryKindCompilerFunction:    6,
-			common.MemoryKindCompilerInstruction: 26,
+			common.MemoryKindCompilerInstruction: 24,
 
 			common.MemoryKindCompilerBBQProgram:  1,
 			common.MemoryKindCompilerBBQConstant: 1,

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -2827,29 +2827,20 @@ func TestCompileMethodInvocation(t *testing.T) {
 		)
 	}
 
-	{
-		const parameterCount = 0
-
-		const selfIndex = parameterCount
-
-		assert.Equal(t,
-			[]opcode.Instruction{
-				// Foo()
-				opcode.InstructionNewComposite{
-					Kind: common.CompositeKindStructure,
-					Type: 1,
-				},
-
-				// assign to self
-				opcode.InstructionSetLocal{Local: selfIndex},
-
-				// return self
-				opcode.InstructionGetLocal{Local: selfIndex},
-				opcode.InstructionReturnValue{},
+	assert.Equal(t,
+		[]opcode.Instruction{
+			// Foo()
+			opcode.InstructionNewComposite{
+				Kind: common.CompositeKindStructure,
+				Type: 1,
 			},
-			functions[initFuncIndex].Code,
-		)
-	}
+
+			// NOTE: no redundant set-local / get-local for self in struct init
+
+			opcode.InstructionReturnValue{},
+		},
+		functions[initFuncIndex].Code,
+	)
 
 	assert.Equal(t,
 		[]opcode.Instruction{
@@ -2917,29 +2908,20 @@ func TestCompileResourceCreateAndDestroy(t *testing.T) {
 		)
 	}
 
-	{
-		const parameterCount = 0
-
-		const selfIndex = parameterCount
-
-		assert.Equal(t,
-			[]opcode.Instruction{
-				// Foo()
-				opcode.InstructionNewComposite{
-					Kind: common.CompositeKindResource,
-					Type: 1,
-				},
-
-				// assign to self
-				opcode.InstructionSetLocal{Local: selfIndex},
-
-				// return self
-				opcode.InstructionGetLocal{Local: selfIndex},
-				opcode.InstructionReturnValue{},
+	assert.Equal(t,
+		[]opcode.Instruction{
+			// Foo()
+			opcode.InstructionNewComposite{
+				Kind: common.CompositeKindResource,
+				Type: 1,
 			},
-			functions[initFuncIndex].Code,
-		)
-	}
+
+			// NOTE: no redundant set-local / get-local for self in resource init
+
+			opcode.InstructionReturnValue{},
+		},
+		functions[initFuncIndex].Code,
+	)
 }
 
 func TestCompilePath(t *testing.T) {
@@ -5065,8 +5047,6 @@ func TestCompileTransaction(t *testing.T) {
 				Kind: common.CompositeKindStructure,
 				Type: 1,
 			},
-			opcode.InstructionSetLocal{Local: 0},
-			opcode.InstructionGetLocal{Local: 0},
 			opcode.InstructionReturnValue{},
 		},
 		constructor.Code,


### PR DESCRIPTION
## Description

When compiling the constructor for an empty initializer of a non-attachment, do not emit a redundant set-local/get-local pair.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
