### PR TITLE
[Compiler] Fix compilation of inherited post condition with before expression

### DIFF
--- a/ast/expression_extractor.go
+++ b/ast/expression_extractor.go
@@ -146,6 +146,7 @@ type ExpressionExtractor struct {
 	ReferenceExtractor      ReferenceExtractor
 	MemberExtractor         MemberExtractor
 	PathExtractor           PathExtractor
+	IdentifierPrefix        string
 	nextIdentifier          int
 }
 
@@ -156,19 +157,18 @@ func (extractor *ExpressionExtractor) Extract(expression Expression) ExpressionE
 }
 
 func (extractor *ExpressionExtractor) FreshIdentifier() string {
-	defer func() {
-		extractor.nextIdentifier++
-	}()
+	identifier := extractor.nextIdentifier
+	extractor.nextIdentifier++
+	return extractor.FormatIdentifier(identifier)
+}
+
+func (extractor *ExpressionExtractor) FormatIdentifier(identifier int) string {
 	// TODO: improve
 	// NOTE: to avoid naming clashes with identifiers in the program,
 	// include characters that can't be represented in source:
 	//   - \x00 = Null character
 	//   - \x1F = Information Separator One
-	return extractor.FormatIdentifier(extractor.nextIdentifier)
-}
-
-func (extractor *ExpressionExtractor) FormatIdentifier(identifier int) string {
-	return fmt.Sprintf("\x00exp\x1F%d", identifier)
+	return fmt.Sprintf("\x00%s\x1F%d", extractor.IdentifierPrefix, identifier)
 }
 
 type ExtractedExpression struct {

--- a/sema/before_extractor.go
+++ b/sema/before_extractor.go
@@ -25,18 +25,23 @@ import (
 
 type BeforeExtractor struct {
 	ExpressionExtractor *ast.ExpressionExtractor
-	report              func(error)
 	memoryGauge         common.MemoryGauge
+	report              func(error)
 }
 
-func NewBeforeExtractor(memoryGauge common.MemoryGauge, report func(error)) *BeforeExtractor {
+func NewBeforeExtractor(
+	memoryGauge common.MemoryGauge,
+	identifierPrefix string,
+	report func(error),
+) *BeforeExtractor {
 	beforeExtractor := &BeforeExtractor{
-		report:      report,
 		memoryGauge: memoryGauge,
+		report:      report,
 	}
 	expressionExtractor := &ast.ExpressionExtractor{
 		InvocationExtractor: beforeExtractor,
 		FunctionExtractor:   beforeExtractor,
+		IdentifierPrefix:    identifierPrefix,
 		MemoryGauge:         memoryGauge,
 	}
 	beforeExtractor.ExpressionExtractor = expressionExtractor

--- a/sema/before_extractor_test.go
+++ b/sema/before_extractor_test.go
@@ -42,7 +42,7 @@ func TestBeforeExtractor(t *testing.T) {
 
 	require.Empty(t, errs)
 
-	extractor := NewBeforeExtractor(nil, nil)
+	extractor := NewBeforeExtractor(nil, "", nil)
 
 	identifier1 := ast.Identifier{
 		Identifier: extractor.ExpressionExtractor.FormatIdentifier(0),

--- a/sema/checker.go
+++ b/sema/checker.go
@@ -22,6 +22,7 @@ import (
 	goErrors "errors"
 	"math"
 	"math/big"
+	"strings"
 
 	"github.com/rivo/uniseg"
 
@@ -2695,7 +2696,12 @@ func (checker *Checker) maybeAddResourceInvalidation(resource Resource, invalida
 
 func (checker *Checker) beforeExtractor() *BeforeExtractor {
 	if checker._beforeExtractor == nil {
-		checker._beforeExtractor = NewBeforeExtractor(checker.memoryGauge, checker.report)
+		checker._beforeExtractor = NewBeforeExtractor(
+			checker.memoryGauge,
+			// TODO: improve
+			strings.ReplaceAll(checker.Location.ID(), ".", "\x00"),
+			checker.report,
+		)
 	}
 	return checker._beforeExtractor
 }


### PR DESCRIPTION
## Description

Post conditions inherited from interfaces may have `before` expressions. Each checker has one before expression extractor, and each before expression extractor keeps its own state for generating fresh variables for the extracted expressions. The compiler combines the inherited post conditions, leading to potential variable declaration clashes.

Prefix the generated variable declarations with the location of the program to disambiguate and avoid clashes.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
