### PR TITLE
[Compiler] Fix tests

### DIFF
--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -10578,21 +10578,15 @@ func TestCompileBoundFunctionClosure(t *testing.T) {
 		getAnswerDirectFuncIndex
 	)
 
-	{
-		const selfLocalIndex = 0
-
-		assert.Equal(t,
-			[]opcode.Instruction{
-				opcode.InstructionNewComposite{Kind: common.CompositeKindContract, Type: 1},
-				opcode.InstructionDup{},
-				opcode.InstructionSetGlobal{Global: 0},
-				opcode.InstructionSetLocal{Local: selfLocalIndex},
-				opcode.InstructionGetLocal{Local: selfLocalIndex},
-				opcode.InstructionReturnValue{},
-			},
-			functions[initFuncIndex].Code,
-		)
-	}
+	assert.Equal(t,
+		[]opcode.Instruction{
+			opcode.InstructionNewComposite{Kind: common.CompositeKindContract, Type: 1},
+			opcode.InstructionDup{},
+			opcode.InstructionSetGlobal{Global: 0},
+			opcode.InstructionReturnValue{},
+		},
+		functions[initFuncIndex].Code,
+	)
 
 	assert.Equal(t,
 		[]opcode.Instruction{


### PR DESCRIPTION

## Description

The merge of #4383 before #4382 caused the added test to fail on `master`.

Fix the tests by removing the now redundant set-local/get-local pair which is no longer generated.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
