### PR TITLE
[v1.8] Extend defensive check for member accesses on values of built-in types

### DIFF
--- a/interpreter/member_test.go
+++ b/interpreter/member_test.go
@@ -121,6 +121,36 @@ func TestInterpretMemberAccessType(t *testing.T) {
 				RequireError(t, err)
 				require.ErrorAs(t, err, &memberAccessTypeError)
 			})
+
+			t.Run("invalid, built-in", func(t *testing.T) {
+
+				t.Parallel()
+
+				inter := parseCheckAndPrepare(t, `
+                    struct Foo {
+                        let publicKey: [UInt8]
+                        init() {
+                            self.publicKey = []
+                        }
+                    }
+
+                    fun get(pubKey: PublicKey) {
+                        pubKey.publicKey
+                    }
+                `)
+
+				// Construct an instance of type Foo
+				// by calling its constructor function of the same name
+
+				value, err := inter.Invoke("Foo")
+				require.NoError(t, err)
+
+				_, err = inter.Invoke("get", value)
+				RequireError(t, err)
+
+				var memberAccessTypeError *interpreter.MemberAccessTypeError
+				require.ErrorAs(t, err, &memberAccessTypeError)
+			})
 		})
 
 		t.Run("optional", func(t *testing.T) {


### PR DESCRIPTION
## Description

Also check values of built-in types, if their type is available.

Thank you for the suggestion, @bluesign!

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
