### PR TITLE
Remove special handling of empty identifier in member access

### DIFF
--- a/sema/check_member_expression.go
+++ b/sema/check_member_expression.go
@@ -163,13 +163,6 @@ func (checker *Checker) visitMember(expression *ast.MemberExpression, isAssignme
 
 	checker.checkUnusedExpressionResourceLoss(accessedType, accessedExpression)
 
-	// The access expression might have no name,
-	// as the parser accepts invalid programs
-
-	if expression.Identifier.Identifier == "" {
-		return accessedType, resultingType, member, isOptional
-	}
-
 	// If the access is to a member of `self` and a resource,
 	// its use must be recorded/checked, so that it isn't used after it was invalidated
 


### PR DESCRIPTION

## Description

Thanks to @bluesign for reporting this issue in the language server:

The language server is not able to check a program like

```cadence
fun main() {
    let a = 1
    let b = a.
}
```

This is because:
- The parser is resilient and returns ASTs with partially invalid nodes. In this example, the member access on `a` has an empty identifier
- The language server runs the checker on partially invalid ASTs to report semantic errors even when there are syntax errors
- The checker has a defensive check which ensures that any expression resulting in an invalid type also at least reported one error. In this example, the missing member results in an invalid type but no error is reported

As callers of `Checker.visitMember` will return an invalid type for a missing member, `visitMember` must always report an error. By removing the early exit / short circuiting, the default `if member == nil` handling later will report an error.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
