### PR TITLE
Replace mapLoadedValueIterator wrapper by using Atree implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/leanovate/gopter v0.2.11
 	github.com/logrusorgru/aurora/v4 v4.0.0
-	github.com/onflow/atree v0.13.1-0.20260305200207-dad78366916d
+	github.com/onflow/atree v0.13.1-0.20260310140135-94d27fa0e3b3
 	github.com/onflow/crypto v0.25.3
 	github.com/onflow/fixed-point v0.1.1
 	github.com/rivo/uniseg v0.4.7

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/leanovate/gopter v0.2.11
 	github.com/logrusorgru/aurora/v4 v4.0.0
-	github.com/onflow/atree v0.13.1-0.20260310140135-94d27fa0e3b3
+	github.com/onflow/atree v0.14.0
 	github.com/onflow/crypto v0.25.3
 	github.com/onflow/fixed-point v0.1.1
 	github.com/rivo/uniseg v0.4.7

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJE
 github.com/neelance/sourcemap v0.0.0-20200213170602-2833bce08e4c/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/onflow/atree v0.13.1-0.20260305200207-dad78366916d h1:lcP5qPEKL6xDVyQ5xAjr6EvO/q9cT5hT7gpjmV1pgfs=
-github.com/onflow/atree v0.13.1-0.20260305200207-dad78366916d/go.mod h1:qdZcfLQwPirHcNpLiK+2t3KAo+SAb9Si6TqurE6pykE=
+github.com/onflow/atree v0.13.1-0.20260310140135-94d27fa0e3b3 h1:V7SL9jmkGwPt8hSI1rXYEdJZ0lY4OnZefmxXOsGoGOw=
+github.com/onflow/atree v0.13.1-0.20260310140135-94d27fa0e3b3/go.mod h1:qdZcfLQwPirHcNpLiK+2t3KAo+SAb9Si6TqurE6pykE=
 github.com/onflow/crypto v0.25.3 h1:XQ3HtLsw8h1+pBN+NQ1JYM9mS2mVXTyg55OldaAIF7U=
 github.com/onflow/crypto v0.25.3/go.mod h1:+1igaXiK6Tjm9wQOBD1EGwW7bYWMUGKtwKJ/2QL/OWs=
 github.com/onflow/fixed-point v0.1.1 h1:j0jYZVO8VGyk1476alGudEg7XqCkeTVxb5ElRJRKS90=

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJE
 github.com/neelance/sourcemap v0.0.0-20200213170602-2833bce08e4c/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/onflow/atree v0.13.1-0.20260310140135-94d27fa0e3b3 h1:V7SL9jmkGwPt8hSI1rXYEdJZ0lY4OnZefmxXOsGoGOw=
-github.com/onflow/atree v0.13.1-0.20260310140135-94d27fa0e3b3/go.mod h1:qdZcfLQwPirHcNpLiK+2t3KAo+SAb9Si6TqurE6pykE=
+github.com/onflow/atree v0.14.0 h1:VFrvRsDBfBujviAseIYFb/KCo2mD4chcM7LpGbcCDdM=
+github.com/onflow/atree v0.14.0/go.mod h1:qdZcfLQwPirHcNpLiK+2t3KAo+SAb9Si6TqurE6pykE=
 github.com/onflow/crypto v0.25.3 h1:XQ3HtLsw8h1+pBN+NQ1JYM9mS2mVXTyg55OldaAIF7U=
 github.com/onflow/crypto v0.25.3/go.mod h1:+1igaXiK6Tjm9wQOBD1EGwW7bYWMUGKtwKJ/2QL/OWs=
 github.com/onflow/fixed-point v0.1.1 h1:j0jYZVO8VGyk1476alGudEg7XqCkeTVxb5ElRJRKS90=

--- a/interpreter/domain_storagemap.go
+++ b/interpreter/domain_storagemap.go
@@ -374,10 +374,8 @@ func (s *DomainStorageMap) ReadOnlyLoadedValueIterator() DomainStorageMapIterato
 	}
 
 	return DomainStorageMapIterator{
-		mapIterator: mapLoadedValueIterator{
-			MapLoadedValueIterator: mapIterator,
-		},
-		storage: s.orderedMap.Storage,
+		mapIterator: mapIterator,
+		storage:     s.orderedMap.Storage,
 	}
 }
 
@@ -458,24 +456,4 @@ func (i DomainStorageMapIterator) NextValue(gauge common.Gauge) Value {
 	}
 
 	return MustConvertStoredValue(gauge, v)
-}
-
-type mapLoadedValueIterator struct {
-	*atree.MapLoadedValueIterator
-}
-
-var _ atree.MapIterator = mapLoadedValueIterator{}
-
-func (i mapLoadedValueIterator) CanMutate() bool {
-	return false
-}
-
-func (i mapLoadedValueIterator) NextKey() (atree.Value, error) {
-	key, _, err := i.Next()
-	return key, err
-}
-
-func (i mapLoadedValueIterator) NextValue() (atree.Value, error) {
-	_, value, err := i.Next()
-	return value, err
 }

--- a/tools/compatibility-check/go.mod
+++ b/tools/compatibility-check/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/multiformats/go-multibase v0.2.0 // indirect
 	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
-	github.com/onflow/atree v0.13.1-0.20260310140135-94d27fa0e3b3 // indirect
+	github.com/onflow/atree v0.14.0 // indirect
 	github.com/onflow/crypto v0.25.3 // indirect
 	github.com/onflow/fixed-point v0.1.1 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.9.2 // indirect

--- a/tools/compatibility-check/go.mod
+++ b/tools/compatibility-check/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/multiformats/go-multibase v0.2.0 // indirect
 	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
-	github.com/onflow/atree v0.13.1-0.20260305200207-dad78366916d // indirect
+	github.com/onflow/atree v0.13.1-0.20260310140135-94d27fa0e3b3 // indirect
 	github.com/onflow/crypto v0.25.3 // indirect
 	github.com/onflow/fixed-point v0.1.1 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.9.2 // indirect

--- a/tools/compatibility-check/go.sum
+++ b/tools/compatibility-check/go.sum
@@ -347,8 +347,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/onflow/atree v0.13.1-0.20260310140135-94d27fa0e3b3 h1:V7SL9jmkGwPt8hSI1rXYEdJZ0lY4OnZefmxXOsGoGOw=
-github.com/onflow/atree v0.13.1-0.20260310140135-94d27fa0e3b3/go.mod h1:qdZcfLQwPirHcNpLiK+2t3KAo+SAb9Si6TqurE6pykE=
+github.com/onflow/atree v0.14.0 h1:VFrvRsDBfBujviAseIYFb/KCo2mD4chcM7LpGbcCDdM=
+github.com/onflow/atree v0.14.0/go.mod h1:qdZcfLQwPirHcNpLiK+2t3KAo+SAb9Si6TqurE6pykE=
 github.com/onflow/crypto v0.25.3 h1:XQ3HtLsw8h1+pBN+NQ1JYM9mS2mVXTyg55OldaAIF7U=
 github.com/onflow/crypto v0.25.3/go.mod h1:+1igaXiK6Tjm9wQOBD1EGwW7bYWMUGKtwKJ/2QL/OWs=
 github.com/onflow/fixed-point v0.1.1 h1:j0jYZVO8VGyk1476alGudEg7XqCkeTVxb5ElRJRKS90=

--- a/tools/compatibility-check/go.sum
+++ b/tools/compatibility-check/go.sum
@@ -347,8 +347,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/onflow/atree v0.13.1-0.20260305200207-dad78366916d h1:lcP5qPEKL6xDVyQ5xAjr6EvO/q9cT5hT7gpjmV1pgfs=
-github.com/onflow/atree v0.13.1-0.20260305200207-dad78366916d/go.mod h1:qdZcfLQwPirHcNpLiK+2t3KAo+SAb9Si6TqurE6pykE=
+github.com/onflow/atree v0.13.1-0.20260310140135-94d27fa0e3b3 h1:V7SL9jmkGwPt8hSI1rXYEdJZ0lY4OnZefmxXOsGoGOw=
+github.com/onflow/atree v0.13.1-0.20260310140135-94d27fa0e3b3/go.mod h1:qdZcfLQwPirHcNpLiK+2t3KAo+SAb9Si6TqurE6pykE=
 github.com/onflow/crypto v0.25.3 h1:XQ3HtLsw8h1+pBN+NQ1JYM9mS2mVXTyg55OldaAIF7U=
 github.com/onflow/crypto v0.25.3/go.mod h1:+1igaXiK6Tjm9wQOBD1EGwW7bYWMUGKtwKJ/2QL/OWs=
 github.com/onflow/fixed-point v0.1.1 h1:j0jYZVO8VGyk1476alGudEg7XqCkeTVxb5ElRJRKS90=


### PR DESCRIPTION
Requires https://github.com/onflow/atree/pull/635
Updates #4442 

This PR replaces `mapLoadedValueIterator` added by PR #4442.

Atree implements `MapIterator` interface for `MapLoadedValueIterator` in PR:
- https://github.com/onflow/atree/pull/635

This PR removes `mapLoadedValueIterator` and uses the implementation in Atree as suggested by @turbolent. :+1: 


______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
