### PR TITLE
Improve defensive check for invalid type error reporting

### DIFF
--- a/runtime/import_test.go
+++ b/runtime/import_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
@@ -506,4 +507,89 @@ func TestRuntimeContractImport(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+}
+
+func TestRuntimeImportContractWithErrors(t *testing.T) {
+
+	t.Parallel()
+
+	addressValue := Address{
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
+	}
+
+	rt := NewTestRuntime()
+
+	// Contract code with an error: `z` is not declared.
+	// The exported value `x` will have an invalid type.
+	contractCode := []byte(`
+        access(all) contract Foo {
+            access(all) let x: Int
+            init() {
+                self.x = z
+            }
+        }
+    `)
+
+	// Script that imports the broken contract
+	script := []byte(`
+        import Foo from 0x01
+
+        access(all) fun main() {}
+    `)
+
+	accountCodes := map[Location][]byte{}
+
+	// Inject the broken contract code directly
+	fooLocation := common.AddressLocation{
+		Address: addressValue,
+		Name:    "Foo",
+	}
+	accountCodes[fooLocation] = contractCode
+
+	runtimeInterface := &TestRuntimeInterface{
+		OnGetCode: func(location Location) (bytes []byte, err error) {
+			return accountCodes[location], nil
+		},
+		Storage: NewTestLedger(nil, nil),
+		OnGetSigningAccounts: func() ([]Address, error) {
+			return []Address{addressValue}, nil
+		},
+		OnResolveLocation: NewSingleIdentifierLocationResolver(t),
+		OnGetAccountContractCode: func(location common.AddressLocation) (code []byte, err error) {
+			return accountCodes[location], nil
+		},
+		OnUpdateAccountContractCode: func(location common.AddressLocation, code []byte) error {
+			accountCodes[location] = code
+			return nil
+		},
+		OnEmitEvent: func(event cadence.Event) error {
+			return nil
+		},
+	}
+
+	nextScriptLocation := NewScriptLocationGenerator()
+
+	scriptLocation := nextScriptLocation()
+
+	_, err := rt.ExecuteScript(
+		Script{
+			Source: script,
+		},
+		Context{
+			Interface: runtimeInterface,
+			Location:  scriptLocation,
+			UseVM:     *compile,
+		},
+	)
+	RequireError(t, err)
+
+	var checkerErr *sema.CheckerError
+	require.ErrorAs(t, err, &checkerErr)
+	assert.Equal(t, scriptLocation, checkerErr.Location)
+
+	errs := RequireCheckerErrors(t, checkerErr, 1)
+
+	var importedProgramErr *sema.ImportedProgramError
+	require.ErrorAs(t, errs[0], &importedProgramErr)
+	assert.Equal(t, fooLocation, importedProgramErr.Location)
 }

--- a/sema/check_import_declaration.go
+++ b/sema/check_import_declaration.go
@@ -248,6 +248,10 @@ func (checker *Checker) importResolvedLocation(
 		allImported[imported] = struct{}{}
 	}
 
+	if imp.HasErrors() {
+		checker.importedProgramHadErrors = true
+	}
+
 	// Attempt to import the requested value declarations
 
 	allValueElements := imp.AllValueElements()

--- a/sema/checker.go
+++ b/sema/checker.go
@@ -125,6 +125,7 @@ type Checker struct {
 	inCreate                           bool
 	isChecked                          bool
 	inAssignment                       bool
+	importedProgramHadErrors           bool
 	parent                             ast.Element
 }
 
@@ -311,6 +312,7 @@ func (checker *Checker) Check() error {
 		}
 
 		checker.Elaboration.setIsChecking(false)
+		checker.Elaboration.HasErrors = len(checker.errors) > 0 || checker.importedProgramHadErrors
 		checker.isChecked = true
 
 		checker.resources.Reclaim()
@@ -2630,6 +2632,7 @@ func (checker *Checker) checkErrorsForInvalidExpressionTypes(actualType Type, ex
 	// before checking for an invalid type, which is more expensive.
 
 	if len(checker.errors) == 0 &&
+		!checker.importedProgramHadErrors &&
 		(actualType.IsInvalidType() || (expectedType != nil && expectedType.IsInvalidType())) {
 
 		panic(errors.NewUnexpectedError("invalid type produced without error"))

--- a/sema/elaboration.go
+++ b/sema/elaboration.go
@@ -204,6 +204,9 @@ type Elaboration struct {
 	isChecking                         bool
 	// IsRecovered is true if the program was recovered (see runtime.Interface.RecoverProgram)
 	IsRecovered bool
+	// HasErrors is true if the checker that produced this elaboration had errors,
+	// either directly or transitively from imported programs.
+	HasErrors bool
 }
 
 func NewElaboration(gauge common.MemoryGauge) *Elaboration {

--- a/sema/import.go
+++ b/sema/import.go
@@ -28,6 +28,7 @@ type Import interface {
 	AllValueElements() *StringImportElementOrderedMap
 	AllTypeElements() *StringImportElementOrderedMap
 	IsChecking() bool
+	HasErrors() bool
 }
 
 // ImportElement
@@ -72,6 +73,10 @@ func (i ElaborationImport) IsChecking() bool {
 	return i.Elaboration.IsChecking()
 }
 
+func (i ElaborationImport) HasErrors() bool {
+	return i.Elaboration.HasErrors
+}
+
 // VirtualImport
 
 type VirtualImport struct {
@@ -88,5 +93,9 @@ func (i VirtualImport) AllTypeElements() *StringImportElementOrderedMap {
 }
 
 func (VirtualImport) IsChecking() bool {
+	return false
+}
+
+func (VirtualImport) HasErrors() bool {
 	return false
 }

--- a/sema/invalid_test.go
+++ b/sema/invalid_test.go
@@ -358,6 +358,9 @@ func TestCheckInvalidTypeDefensiveCheckWithImportedError(t *testing.T) {
 		ParseAndCheckOptions{
 			CheckerConfig: &sema.Config{
 				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					// NOTE: always return the elaboration, even if there have been checking errors for the imported program.
+					// In the runtime, the import handler of the checking environment returns the errors.
+					// See test TestRuntimeImportContractWithErrors
 					return sema.ElaborationImport{
 						Elaboration: importedChecker.Elaboration,
 					}, nil

--- a/sema/invalid_test.go
+++ b/sema/invalid_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/ast"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/sema"
@@ -320,4 +321,116 @@ func TestCheckInvalidRemove(t *testing.T) {
 	errs := RequireCheckerErrors(t, err, 1)
 
 	assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+}
+
+func TestCheckInvalidTypeDefensiveCheckWithImportedError(t *testing.T) {
+
+	t.Parallel()
+
+	// Check a program that has errors.
+	// The exported value `x` will have an invalid type
+	// because of the undeclared identifier `z`
+	importedChecker, err := ParseAndCheckWithOptions(t,
+		`
+          access(all) let x = z
+        `,
+		ParseAndCheckOptions{
+			Location: common.StringLocation("imported"),
+		},
+	)
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+
+	xVar, ok := importedChecker.Elaboration.GetGlobalValue("x")
+	require.True(t, ok)
+	assert.True(t, xVar.Type.IsInvalidType())
+	assert.True(t, importedChecker.Elaboration.HasErrors)
+
+	// Import the program with errors.
+	// Using the imported value `x` (which has an invalid type)
+	// must NOT panic, because the invalid type came from the imported program.
+	_, err = ParseAndCheckWithOptions(t,
+		`
+          import x from "imported"
+          access(all) let y = x
+        `,
+		ParseAndCheckOptions{
+			CheckerConfig: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: importedChecker.Elaboration,
+					}, nil
+				},
+			},
+		},
+	)
+	// No panic, no errors in the importing program
+	require.NoError(t, err)
+}
+
+func TestCheckInvalidTypeDefensiveCheckWithTransitiveImportedError(t *testing.T) {
+
+	t.Parallel()
+
+	// Check a program that has errors.
+	// The exported value `x` will have an invalid type
+	// because of the undeclared identifier `z`
+	checkerC, err := ParseAndCheckWithOptions(t,
+		`
+          access(all) let x = z
+        `,
+		ParseAndCheckOptions{
+			Location: common.StringLocation("imported"),
+		},
+	)
+	errs := RequireCheckerErrors(t, err, 1)
+
+	assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
+
+	xVar, ok := checkerC.Elaboration.GetGlobalValue("x")
+	require.True(t, ok)
+	assert.True(t, xVar.Type.IsInvalidType())
+	assert.True(t, checkerC.Elaboration.HasErrors)
+
+	// Program B imports C (which has errors)
+	checkerB, err := ParseAndCheckWithOptions(t,
+		`
+          import x from "C"
+          access(all) let y = x
+        `,
+		ParseAndCheckOptions{
+			Location: common.StringLocation("B"),
+			CheckerConfig: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: checkerC.Elaboration,
+					}, nil
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	// B has no local errors, but transitively imported a program with errors
+	require.True(t, checkerB.Elaboration.HasErrors)
+
+	// Program A imports B.
+	// Using the imported value `y` (which has an invalid type transitively from C)
+	// must NOT panic.
+	_, err = ParseAndCheckWithOptions(t,
+		`
+          import y from "B"
+          access(all) let z = y
+        `,
+		ParseAndCheckOptions{
+			CheckerConfig: &sema.Config{
+				ImportHandler: func(_ *sema.Checker, _ common.Location, _ ast.Range) (sema.Import, error) {
+					return sema.ElaborationImport{
+						Elaboration: checkerB.Elaboration,
+					}, nil
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Description

The defensive check which ensures that producing an invalid type also reported an error currently reports a false positive when the invalid type originated from an imported program, where an error was reported.

Avoid false positives by propagating the information that the imported program had errors.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
