### PR TITLE
Add freezeTime and unfreezeTime to Test stdlib Blockchain interface

### DIFF
--- a/stdlib/contracts/test.cdc
+++ b/stdlib/contracts/test.cdc
@@ -147,6 +147,24 @@ contract Test {
         self.backend.moveTime(by: delta)
     }
 
+    /// Freezes the clock of the blockchain so that time stops advancing
+    /// automatically. While frozen, `moveTime` still works and offsets the
+    /// frozen timestamp, but the clock no longer tracks real elapsed time.
+    ///
+    access(all)
+    fun freezeTime() {
+        self.backend.freezeTime()
+    }
+
+    /// Unfreezes the clock of the blockchain, allowing time to advance
+    /// automatically again. The clock does not snap back to real time;
+    /// it continues from wherever the frozen timestamp was left.
+    ///
+    access(all)
+    fun unfreezeTime() {
+        self.backend.unfreezeTime()
+    }
+
     /// Creates a snapshot of the blockchain, at the
     /// current ledger state, with the given name.
     ///
@@ -402,6 +420,20 @@ contract Test {
         ///
         access(all)
         fun moveTime(by delta: Fix64)
+
+        /// Freezes the clock of the blockchain so that time stops advancing
+        /// automatically. While frozen, `moveTime` still works and offsets the
+        /// frozen timestamp, but the clock no longer tracks real elapsed time.
+        ///
+        access(all)
+        fun freezeTime()
+
+        /// Unfreezes the clock of the blockchain, allowing time to advance
+        /// automatically again. The clock does not snap back to real time;
+        /// it continues counting from wherever the frozen timestamp was left.
+        ///
+        access(all)
+        fun unfreezeTime()
 
         /// Creates a snapshot of the blockchain, at the
         /// current ledger state, with the given name.

--- a/stdlib/test-framework.go
+++ b/stdlib/test-framework.go
@@ -77,6 +77,10 @@ type Blockchain interface {
 
 	MoveTime(int64)
 
+	FreezeTime()
+
+	UnfreezeTime()
+
 	CreateSnapshot(string) error
 
 	LoadSnapshot(string) error

--- a/stdlib/test_emulatorbackend.go
+++ b/stdlib/test_emulatorbackend.go
@@ -48,6 +48,8 @@ type testEmulatorBackendType struct {
 	eventsFunctionType                 *sema.FunctionType
 	resetFunctionType                  *sema.FunctionType
 	moveTimeFunctionType               *sema.FunctionType
+	freezeTimeFunctionType             *sema.FunctionType
+	unfreezeTimeFunctionType           *sema.FunctionType
 	createSnapshotFunctionType         *sema.FunctionType
 	loadSnapshotFunctionType           *sema.FunctionType
 	getAccountFunctionType             *sema.FunctionType
@@ -109,6 +111,16 @@ func newTestEmulatorBackendType(
 	moveTimeFunctionType := interfaceFunctionType(
 		blockchainBackendInterfaceType,
 		testEmulatorBackendTypeMoveTimeFunctionName,
+	)
+
+	freezeTimeFunctionType := interfaceFunctionType(
+		blockchainBackendInterfaceType,
+		testEmulatorBackendTypeFreezeTimeFunctionName,
+	)
+
+	unfreezeTimeFunctionType := interfaceFunctionType(
+		blockchainBackendInterfaceType,
+		testEmulatorBackendTypeUnfreezeTimeFunctionName,
 	)
 
 	createSnapshotFunctionType := interfaceFunctionType(
@@ -204,6 +216,18 @@ func newTestEmulatorBackendType(
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			compositeType,
+			testEmulatorBackendTypeFreezeTimeFunctionName,
+			freezeTimeFunctionType,
+			testEmulatorBackendTypeFreezeTimeFunctionDocString,
+		),
+		sema.NewUnmeteredPublicFunctionMember(
+			compositeType,
+			testEmulatorBackendTypeUnfreezeTimeFunctionName,
+			unfreezeTimeFunctionType,
+			testEmulatorBackendTypeUnfreezeTimeFunctionDocString,
+		),
+		sema.NewUnmeteredPublicFunctionMember(
+			compositeType,
 			testEmulatorBackendTypeCreateSnapshotFunctionName,
 			createSnapshotFunctionType,
 			testEmulatorBackendTypeCreateSnapshotFunctionDocString,
@@ -238,6 +262,8 @@ func newTestEmulatorBackendType(
 		eventsFunctionType:                 eventsFunctionType,
 		resetFunctionType:                  resetFunctionType,
 		moveTimeFunctionType:               moveTimeFunctionType,
+		freezeTimeFunctionType:             freezeTimeFunctionType,
+		unfreezeTimeFunctionType:           unfreezeTimeFunctionType,
 		createSnapshotFunctionType:         createSnapshotFunctionType,
 		loadSnapshotFunctionType:           loadSnapshotFunctionType,
 		getAccountFunctionType:             getAccountFunctionType,
@@ -760,6 +786,58 @@ func (t *testEmulatorBackendType) newMoveTimeFunction(
 	)
 }
 
+// 'Emulator.freezeTime' function
+
+const testEmulatorBackendTypeFreezeTimeFunctionName = "freezeTime"
+
+const testEmulatorBackendTypeFreezeTimeFunctionDocString = `
+Freezes the clock of the blockchain so that time stops advancing automatically.
+While frozen, moveTime still works and offsets the frozen timestamp, but the
+clock no longer tracks real elapsed time.
+`
+
+func (t *testEmulatorBackendType) newFreezeTimeFunction(
+	inter *interpreter.Interpreter,
+	emulatorBackend interpreter.MemberAccessibleValue,
+	blockchain Blockchain,
+) interpreter.BoundFunctionValue {
+	return interpreter.NewUnmeteredBoundHostFunctionValue(
+		inter,
+		emulatorBackend,
+		t.freezeTimeFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			blockchain.FreezeTime()
+			return interpreter.Void
+		},
+	)
+}
+
+// 'Emulator.unfreezeTime' function
+
+const testEmulatorBackendTypeUnfreezeTimeFunctionName = "unfreezeTime"
+
+const testEmulatorBackendTypeUnfreezeTimeFunctionDocString = `
+Unfreezes the clock of the blockchain, allowing time to advance automatically
+again. The clock does not snap back to real time; it continues counting from
+wherever the frozen timestamp was left.
+`
+
+func (t *testEmulatorBackendType) newUnfreezeTimeFunction(
+	inter *interpreter.Interpreter,
+	emulatorBackend interpreter.MemberAccessibleValue,
+	blockchain Blockchain,
+) interpreter.BoundFunctionValue {
+	return interpreter.NewUnmeteredBoundHostFunctionValue(
+		inter,
+		emulatorBackend,
+		t.unfreezeTimeFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			blockchain.UnfreezeTime()
+			return interpreter.Void
+		},
+	)
+}
+
 // 'Emulator.createSnapshot' function
 
 const testEmulatorBackendTypeCreateSnapshotFunctionName = "createSnapshot"
@@ -851,6 +929,8 @@ func (t *testEmulatorBackendType) newEmulatorBackend(
 		testEmulatorBackendTypeEventsFunctionName:                 t.newEventsFunction(inter, emulatorBackend, blockchain),
 		testEmulatorBackendTypeResetFunctionName:                  t.newResetFunction(inter, emulatorBackend, blockchain),
 		testEmulatorBackendTypeMoveTimeFunctionName:               t.newMoveTimeFunction(inter, emulatorBackend, blockchain),
+		testEmulatorBackendTypeFreezeTimeFunctionName:             t.newFreezeTimeFunction(inter, emulatorBackend, blockchain),
+		testEmulatorBackendTypeUnfreezeTimeFunctionName:           t.newUnfreezeTimeFunction(inter, emulatorBackend, blockchain),
 		testEmulatorBackendTypeCreateSnapshotFunctionName:         t.newCreateSnapshotFunction(inter, emulatorBackend, blockchain),
 		testEmulatorBackendTypeLoadSnapshotFunctionName:           t.newLoadSnapshotFunction(inter, emulatorBackend, blockchain),
 		testEmulatorBackendTypeGetAccountFunctionName:             t.newGetAccountFunction(inter, emulatorBackend, blockchain),

--- a/stdlib/test_test.go
+++ b/stdlib/test_test.go
@@ -2940,6 +2940,8 @@ type mockedBlockchain struct {
 	events             func(context TestFrameworkEventsContext, eventType interpreter.StaticType) interpreter.Value
 	reset              func(uint64)
 	moveTime           func(int64)
+	freezeTime         func()
+	unfreezeTime       func()
 	createSnapshot     func(string) error
 	loadSnapshot       func(string) error
 }
@@ -3058,6 +3060,22 @@ func (m mockedBlockchain) MoveTime(timeDelta int64) {
 	}
 
 	m.moveTime(timeDelta)
+}
+
+func (m mockedBlockchain) FreezeTime() {
+	if m.freezeTime == nil {
+		panic("'FreezeTime' is not implemented")
+	}
+
+	m.freezeTime()
+}
+
+func (m mockedBlockchain) UnfreezeTime() {
+	if m.unfreezeTime == nil {
+		panic("'UnfreezeTime' is not implemented")
+	}
+
+	m.unfreezeTime()
 }
 
 func (m mockedBlockchain) CreateSnapshot(name string) error {


### PR DESCRIPTION
Scheduled transactions execute at a time determined by the emulator clock, which drifts with real wall time. This makes tests that assert on timing-sensitive behavior inherently flaky. 
To fix this, `cadence-tools`' `EmulatorBackend` will implement `FreezeTime`/`UnfreezeTime` implementations, to make them reachable from Cadence test code, they will be added here.