### PR TITLE
Return user-facing error from Test.readFile on file-not-found

### DIFF
--- a/stdlib/test_contract.go
+++ b/stdlib/test_contract.go
@@ -391,7 +391,7 @@ func newTestTypeReadFileFunction(
 
 			content, err := testFramework.ReadFile(pathString.Str)
 			if err != nil {
-				panic(err)
+				panic(errors.NewDefaultUserError("cannot read file %q: %s", pathString.Str, err))
 			}
 
 			return interpreter.NewUnmeteredStringValue(content)

--- a/stdlib/test_test.go
+++ b/stdlib/test_test.go
@@ -2903,6 +2903,68 @@ func TestBlockchainAccount(t *testing.T) {
 	})
 }
 
+func TestReadFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		const script = `
+            import Test
+
+            access(all)
+            fun test(): String {
+                return Test.readFile("some/file.cdc")
+            }
+        `
+
+		testFramework := &mockedTestFramework{
+			emulatorBackend: func() Blockchain {
+				return &mockedBlockchain{}
+			},
+			readFile: func(path string) (string, error) {
+				return "file contents", nil
+			},
+		}
+
+		inter, err := newTestContractInterpreterWithTestFramework(t, script, testFramework)
+		require.NoError(t, err)
+
+		result, err := inter.Invoke("test")
+		require.NoError(t, err)
+		assert.Equal(t, interpreter.NewUnmeteredStringValue("file contents"), result)
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		t.Parallel()
+
+		const script = `
+            import Test
+
+            access(all)
+            fun test() {
+                Test.readFile("does/not/exist.cdc")
+            }
+        `
+
+		testFramework := &mockedTestFramework{
+			emulatorBackend: func() Blockchain {
+				return &mockedBlockchain{}
+			},
+			readFile: func(path string) (string, error) {
+				return "", fmt.Errorf("open %s: no such file or directory", path)
+			},
+		}
+
+		inter, err := newTestContractInterpreterWithTestFramework(t, script, testFramework)
+		require.NoError(t, err)
+
+		_, err = inter.Invoke("test")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, `cannot read file "does/not/exist.cdc"`)
+	})
+}
+
 type mockedTestFramework struct {
 	emulatorBackend func() Blockchain
 	readFile        func(s string) (string, error)


### PR DESCRIPTION
Closes #4468 

## Summary

- `Test.readFile` previously panicked with the raw OS error, which the interpreter wrapped in `internal error: unexpected`, producing a confusing full goroutine stack trace instead of a useful message
- Wrapped the error in `errors.NewDefaultUserError` so callers see a clean, actionable message: `cannot read file "does/not/exist.cdc": open does/not/exist.cdc: no such file or directory`
- Added `TestReadFile` covering both the success path and the file-not-found error case