### PR TITLE
Test crypto algorithm enum case values

### DIFF
--- a/sema/crypto_algorithm_types.go
+++ b/sema/crypto_algorithm_types.go
@@ -47,6 +47,11 @@ const (
 	SignatureAlgorithmECDSA_P256
 	SignatureAlgorithmECDSA_secp256k1
 	SignatureAlgorithmBLS_BLS12_381
+
+	// !!! *WARNING* !!!
+	// ADD NEW TYPES *BEFORE* THIS WARNING.
+	// DO *NOT* ADD NEW TYPES AFTER THIS LINE!
+	SignatureAlgorithm_Count
 )
 
 var SignatureAlgorithms = []SignatureAlgorithm{
@@ -185,6 +190,11 @@ const (
 	HashAlgorithmSHA3_384
 	HashAlgorithmKMAC128_BLS_BLS12_381
 	HashAlgorithmKECCAK_256
+
+	// !!! *WARNING* !!!
+	// ADD NEW TYPES *BEFORE* THIS WARNING.
+	// DO *NOT* ADD NEW TYPES AFTER THIS LINE!
+	HashAlgorithm_Count
 )
 
 var HashAlgorithms = []HashAlgorithm{

--- a/sema/crypto_algorithm_types_test.go
+++ b/sema/crypto_algorithm_types_test.go
@@ -19,6 +19,7 @@
 package sema
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,5 +28,105 @@ import (
 func TestHashAlgorithm_IsValid(t *testing.T) {
 	for _, algorithm := range HashAlgorithms {
 		require.True(t, algorithm.IsValid())
+	}
+}
+
+func TestHashAlgorithmValues(t *testing.T) {
+	t.Parallel()
+
+	// Ensure that the values of the HashAlgorithm enum are not accidentally changed,
+	// e.g. by adding a new value in between or by changing an existing value.
+
+	expectedValues := map[HashAlgorithm]uint8{
+		HashAlgorithmUnknown:               0,
+		HashAlgorithmSHA2_256:              1,
+		HashAlgorithmSHA2_384:              2,
+		HashAlgorithmSHA3_256:              3,
+		HashAlgorithmSHA3_384:              4,
+		HashAlgorithmKMAC128_BLS_BLS12_381: 5,
+		HashAlgorithmKECCAK_256:            6,
+		HashAlgorithm_Count:                7,
+	}
+
+	expectedRawValues := map[HashAlgorithm]uint8{
+		HashAlgorithmUnknown:               0,
+		HashAlgorithmSHA2_256:              1,
+		HashAlgorithmSHA2_384:              2,
+		HashAlgorithmSHA3_256:              3,
+		HashAlgorithmSHA3_384:              4,
+		HashAlgorithmKMAC128_BLS_BLS12_381: 5,
+		HashAlgorithmKECCAK_256:            6,
+	}
+
+	// Check all expected values.
+	for algo, expectedValue := range expectedValues {
+		require.Equal(t, expectedValue, uint8(algo), "value mismatch for %s", algo)
+	}
+
+	// Check all expected raw values.
+	for algo, expectedRawValue := range expectedRawValues {
+		require.Equal(t, expectedRawValue, algo.RawValue(), "raw value mismatch for %s", algo)
+	}
+
+	// Check that no new named values have been added
+	// without updating the expected values above.
+	// NOTE: This requires the stringer-generated file to be up to date (CI runs go generate).
+	for i := uint8(0); i < uint8(HashAlgorithm_Count); i++ {
+		algo := HashAlgorithm(i)
+		if _, ok := expectedValues[algo]; ok {
+			continue
+		}
+
+		require.True(t,
+			strings.HasPrefix(algo.String(), "HashAlgorithm("),
+			"unexpected named value %s (%d): update expectedValues", algo, i,
+		)
+	}
+}
+
+func TestSignatureAlgorithmValues(t *testing.T) {
+	t.Parallel()
+
+	// Ensure that the values of the SignatureAlgorithm enum are not accidentally changed,
+	// e.g. by adding a new value in between or by changing an existing value.
+
+	expectedValues := map[SignatureAlgorithm]uint8{
+		SignatureAlgorithmUnknown:         0,
+		SignatureAlgorithmECDSA_P256:      1,
+		SignatureAlgorithmECDSA_secp256k1: 2,
+		SignatureAlgorithmBLS_BLS12_381:   3,
+		SignatureAlgorithm_Count:          4,
+	}
+
+	expectedRawValues := map[SignatureAlgorithm]uint8{
+		SignatureAlgorithmUnknown:         0,
+		SignatureAlgorithmECDSA_P256:      1,
+		SignatureAlgorithmECDSA_secp256k1: 2,
+		SignatureAlgorithmBLS_BLS12_381:   3,
+	}
+
+	// Check all expected values.
+	for algo, expectedValue := range expectedValues {
+		require.Equal(t, expectedValue, uint8(algo), "value mismatch for %s", algo)
+	}
+
+	// Check all expected raw values.
+	for algo, expectedRawValue := range expectedRawValues {
+		require.Equal(t, expectedRawValue, algo.RawValue(), "raw value mismatch for %s", algo)
+	}
+
+	// Check that no new named values have been added
+	// without updating the expected values above.
+	// NOTE: This requires the stringer-generated file to be up to date (CI runs go generate).
+	for i := uint8(0); i < uint8(SignatureAlgorithm_Count); i++ {
+		algo := SignatureAlgorithm(i)
+		if _, ok := expectedValues[algo]; ok {
+			continue
+		}
+
+		require.True(t,
+			strings.HasPrefix(algo.String(), "SignatureAlgorithm("),
+			"unexpected named value %s (%d): update expectedValues", algo, i,
+		)
 	}
 }

--- a/sema/hashalgorithm_string.go
+++ b/sema/hashalgorithm_string.go
@@ -15,11 +15,12 @@ func _() {
 	_ = x[HashAlgorithmSHA3_384-4]
 	_ = x[HashAlgorithmKMAC128_BLS_BLS12_381-5]
 	_ = x[HashAlgorithmKECCAK_256-6]
+	_ = x[HashAlgorithm_Count-7]
 }
 
-const _HashAlgorithm_name = "HashAlgorithmUnknownHashAlgorithmSHA2_256HashAlgorithmSHA2_384HashAlgorithmSHA3_256HashAlgorithmSHA3_384HashAlgorithmKMAC128_BLS_BLS12_381HashAlgorithmKECCAK_256"
+const _HashAlgorithm_name = "HashAlgorithmUnknownHashAlgorithmSHA2_256HashAlgorithmSHA2_384HashAlgorithmSHA3_256HashAlgorithmSHA3_384HashAlgorithmKMAC128_BLS_BLS12_381HashAlgorithmKECCAK_256HashAlgorithm_Count"
 
-var _HashAlgorithm_index = [...]uint8{0, 20, 41, 62, 83, 104, 138, 161}
+var _HashAlgorithm_index = [...]uint8{0, 20, 41, 62, 83, 104, 138, 161, 180}
 
 func (i HashAlgorithm) String() string {
 	if i >= HashAlgorithm(len(_HashAlgorithm_index)-1) {

--- a/sema/signaturealgorithm_string.go
+++ b/sema/signaturealgorithm_string.go
@@ -12,11 +12,12 @@ func _() {
 	_ = x[SignatureAlgorithmECDSA_P256-1]
 	_ = x[SignatureAlgorithmECDSA_secp256k1-2]
 	_ = x[SignatureAlgorithmBLS_BLS12_381-3]
+	_ = x[SignatureAlgorithm_Count-4]
 }
 
-const _SignatureAlgorithm_name = "SignatureAlgorithmUnknownSignatureAlgorithmECDSA_P256SignatureAlgorithmECDSA_secp256k1SignatureAlgorithmBLS_BLS12_381"
+const _SignatureAlgorithm_name = "SignatureAlgorithmUnknownSignatureAlgorithmECDSA_P256SignatureAlgorithmECDSA_secp256k1SignatureAlgorithmBLS_BLS12_381SignatureAlgorithm_Count"
 
-var _SignatureAlgorithm_index = [...]uint8{0, 25, 53, 86, 117}
+var _SignatureAlgorithm_index = [...]uint8{0, 25, 53, 86, 117, 141}
 
 func (i SignatureAlgorithm) String() string {
 	if i >= SignatureAlgorithm(len(_SignatureAlgorithm_index)-1) {


### PR DESCRIPTION

## Description

Just like in #4463, test the values for the crypto algorithms, `HashAlgorithm` and `SignatureAlgorithm`, to ensure their values do not change.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
