### PR TITLE
Add Bool.toString()

### DIFF
--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -9512,6 +9512,43 @@ func TestGetAuthAccount(t *testing.T) {
 	})
 }
 
+func TestBoolToString(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("true", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := CompileAndInvoke(t,
+			`
+                fun test(): String {
+                    let x: Bool = true
+                    return x.toString()
+                }
+            `,
+			"test",
+		)
+		require.NoError(t, err)
+		require.Equal(t, interpreter.NewUnmeteredStringValue("true"), result)
+	})
+
+	t.Run("false", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := CompileAndInvoke(t,
+			`
+                fun test(): String {
+                    let x: Bool = false
+                    return x.toString()
+                }
+            `,
+			"test",
+		)
+		require.NoError(t, err)
+		require.Equal(t, interpreter.NewUnmeteredStringValue("false"), result)
+	})
+}
+
 func TestStringTemplate(t *testing.T) {
 
 	t.Parallel()
@@ -9549,6 +9586,23 @@ func TestStringTemplate(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, interpreter.NewUnmeteredStringValue("A + B = 4"), result)
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := CompileAndInvoke(t,
+			`
+                fun test(): String {
+                    let x = true
+                    let y = false
+                    return "\(x) and \(y)"
+                }
+            `,
+			"test",
+		)
+		require.NoError(t, err)
+		require.Equal(t, interpreter.NewUnmeteredStringValue("true and false"), result)
 	})
 }
 

--- a/bbq/vm/value_bool.go
+++ b/bbq/vm/value_bool.go
@@ -28,17 +28,14 @@ import (
 
 func init() {
 
-	for _, pathType := range sema.AllPathTypes {
-		typeName := commons.TypeQualifier(pathType)
+	typeName := commons.TypeQualifier(sema.BoolType)
 
-		registerBuiltinTypeBoundFunction(
-			typeName,
-			NewNativeFunctionValue(
-				sema.ToStringFunctionName,
-				sema.ToStringFunctionType,
-				interpreter.NativePathValueToStringFunction,
-			),
-		)
-
-	}
+	registerBuiltinTypeBoundFunction(
+		typeName,
+		NewNativeFunctionValue(
+			sema.ToStringFunctionName,
+			sema.ToStringFunctionType,
+			interpreter.NativeBoolValueToStringFunction,
+		),
+	)
 }

--- a/interpreter/builtinfunctions_test.go
+++ b/interpreter/builtinfunctions_test.go
@@ -82,6 +82,40 @@ func TestInterpretToString(t *testing.T) {
 		)
 	})
 
+	t.Run("Bool, true", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndPrepare(t, `
+          let x: Bool = true
+          let y = x.toString()
+        `)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredStringValue("true"),
+			inter.GetGlobal("y"),
+		)
+	})
+
+	t.Run("Bool, false", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndPrepare(t, `
+          let x: Bool = false
+          let y = x.toString()
+        `)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredStringValue("false"),
+			inter.GetGlobal("y"),
+		)
+	})
+
 	for _, ty := range sema.AllFixedPointTypes {
 
 		t.Run(ty.String(), func(t *testing.T) {

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -34,6 +34,7 @@ type BoolValue values.BoolValue
 var _ Value = BoolValue(false)
 var _ EquatableValue = BoolValue(false)
 var _ HashableValue = BoolValue(false)
+var _ MemberAccessibleValue = BoolValue(false)
 
 const TrueValue = BoolValue(true)
 const FalseValue = BoolValue(false)
@@ -190,4 +191,56 @@ func (v BoolValue) Clone(_ ValueCloneContext) Value {
 
 func (BoolValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
+}
+
+func (v BoolValue) GetMember(context MemberAccessibleContext, name string, memberKind common.DeclarationKind) Value {
+	return GetMember(
+		context,
+		v,
+		name,
+		memberKind,
+		nil,
+	)
+}
+
+func (v BoolValue) GetMethod(context MemberAccessibleContext, name string) FunctionValue {
+	switch name {
+	case sema.ToStringFunctionName:
+		return NewBoundHostFunctionValue(
+			context,
+			v,
+			sema.ToStringFunctionType,
+			NativeBoolValueToStringFunction,
+		)
+	}
+
+	return nil
+}
+
+var TrueStringValue = NewUnmeteredStringValue("true")
+var FalseStringValue = NewUnmeteredStringValue("false")
+
+var NativeBoolValueToStringFunction = NativeFunction(
+	func(
+		context NativeFunctionContext,
+		_ TypeArgumentsIterator,
+		_ ArgumentTypesIterator,
+		receiver Value,
+		_ []Value,
+	) Value {
+		if AssertValueOfType[BoolValue](receiver) {
+			return TrueStringValue
+		}
+		return FalseStringValue
+	},
+)
+
+func (BoolValue) RemoveMember(_ ValueTransferContext, _ string) Value {
+	// Bool has no removable members (fields / functions)
+	panic(errors.NewUnreachableError())
+}
+
+func (BoolValue) SetMember(_ ValueTransferContext, _ string, _ Value) bool {
+	// Bool has no settable members (fields / functions)
+	panic(errors.NewUnreachableError())
 }

--- a/sema/builtinfunctions_test.go
+++ b/sema/builtinfunctions_test.go
@@ -37,8 +37,11 @@ func TestCheckToString(t *testing.T) {
 
 	for _, numberOrAddressType := range common.Concat(
 		sema.AllNumberTypes,
+		sema.AllPathTypes,
 		[]sema.Type{
 			sema.TheAddressType,
+			sema.BoolType,
+			sema.CharacterType,
 		},
 	) {
 

--- a/sema/check_string_template_expression.go
+++ b/sema/check_string_template_expression.go
@@ -46,11 +46,13 @@ func (checker *Checker) VisitStringTemplateExpression(stringTemplateExpression *
 		for _, element := range stringTemplateExpression.Expressions {
 			valueType := checker.VisitExpression(element, stringTemplateExpression, elementType)
 
-			if !isValidStringTemplateValue(valueType) {
+			if !valueType.IsInvalidType() &&
+				!isValidStringTemplateValue(valueType) {
+
 				checker.report(
 					&TypeMismatchWithDescriptionError{
 						ActualType:              valueType,
-						ExpectedTypeDescription: "a type with built-in toString() or bool",
+						ExpectedTypeDescription: "a built-in type with toString()",
 						Range:                   ast.NewRangeFromPositioned(checker.memoryGauge, element),
 					},
 				)

--- a/sema/string_test.go
+++ b/sema/string_test.go
@@ -727,6 +727,18 @@ func TestCheckStringTemplate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("valid, bool", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			let a = true
+			let x: String = "The value of a is: \(a)"
+		`)
+
+		require.NoError(t, err)
+	})
+
 	t.Run("invalid, struct", func(t *testing.T) {
 
 		t.Parallel()
@@ -785,10 +797,9 @@ func TestCheckStringTemplate(t *testing.T) {
 			let x: String = "\(a)" 
 		`)
 
-		errs := RequireCheckerErrors(t, err, 2)
+		errs := RequireCheckerErrors(t, err, 1)
 
 		assert.IsType(t, &sema.NotDeclaredError{}, errs[0])
-		assert.IsType(t, &sema.TypeMismatchWithDescriptionError{}, errs[1])
 	})
 
 	t.Run("invalid, resource", func(t *testing.T) {

--- a/sema/type.go
+++ b/sema/type.go
@@ -808,7 +808,8 @@ func withBuiltinMembers(ty Type, members map[string]MemberResolver) map[string]M
 
 func HasToStringFunction(ty Type) bool {
 	switch ty {
-	case CharacterType:
+	case BoolType,
+		CharacterType:
 		return true
 	default:
 		return IsSubType(ty, NumberType) ||
@@ -4711,6 +4712,14 @@ var AllNumberTypes = common.Concat(
 		SignedNumberType,
 	},
 )
+
+var AllPathTypes = []Type{
+	PathType,
+	StoragePathType,
+	CapabilityPathType,
+	PublicPathType,
+	PrivatePathType,
+}
 
 var BuiltinEntitlements = map[string]*EntitlementType{}
 


### PR DESCRIPTION


## Description

Add `toString()` function to `Bool`.

Also, avoid an unnecessary diagnostic when a string template expression is an invalid type (upstream error, e.g. undeclared variable).

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
