### PR TITLE
Add multiplyDivide function to fixed-point types

### DIFF
--- a/bbq/vm/builtin_globals.go
+++ b/bbq/vm/builtin_globals.go
@@ -303,6 +303,8 @@ func init() {
 	registerBuiltinSaturatingArithmeticFunctions()
 
 	registerBuiltinFixedPointPowFunctions()
+
+	registerBuiltinFixedPointMultiplyDivideFunctions()
 }
 
 func registerBuiltinCommonTypeBoundFunctions() {
@@ -439,6 +441,19 @@ func registerBuiltinFixedPointPowFunctions() {
 				sema.FixedPointNumericTypePowFunctionName,
 				funcType,
 				interpreter.NativeFixedPointPowFunction,
+			),
+		)
+	}
+}
+
+func registerBuiltinFixedPointMultiplyDivideFunctions() {
+	for baseType, funcType := range sema.FixedPointMultiplyDivideFunctionTypes {
+		registerBuiltinTypeBoundFunction(
+			commons.TypeQualifier(baseType),
+			NewNativeFunctionValue(
+				sema.FixedPointNumericTypeMultiplyDivideFunctionName,
+				funcType,
+				interpreter.NativeFixedPointMultiplyDivideFunction,
 			),
 		)
 	}

--- a/bbq/vm/builtin_globals.go
+++ b/bbq/vm/builtin_globals.go
@@ -447,7 +447,7 @@ func registerBuiltinFixedPointPowFunctions() {
 }
 
 func registerBuiltinFixedPointMultiplyDivideFunctions() {
-	for baseType, funcType := range sema.FixedPointMultiplyDivideFunctionTypes {
+	for baseType, funcType := range sema.FixedPointMultiplyDivideFunctionTypes { //nolint:maprange
 		registerBuiltinTypeBoundFunction(
 			commons.TypeQualifier(baseType),
 			NewNativeFunctionValue(

--- a/interpreter/fixedpoint_test.go
+++ b/interpreter/fixedpoint_test.go
@@ -248,11 +248,7 @@ func TestInterpretFixedPointMultiplyDivide(t *testing.T) {
 					result, err := inter.Invoke("test")
 					require.NoError(t, err)
 
-					expected := parseCheckAndPrepare(t, fmt.Sprintf(
-						`let expected: UFix128 = %s`,
-						tc.expected,
-					)).GetGlobal("expected")
-
+					expected := interpreter.NewUFix128ValueFromBigInt(nil, fix128BigInt(tc.expected))
 					AssertValuesEqual(t, inter, expected, result)
 				}
 			})
@@ -308,11 +304,7 @@ func TestInterpretFixedPointMultiplyDivide(t *testing.T) {
 					result, err := inter.Invoke("test")
 					require.NoError(t, err)
 
-					expected := parseCheckAndPrepare(t, fmt.Sprintf(
-						`let expected: Fix128 = %s`,
-						tc.expected,
-					)).GetGlobal("expected")
-
+					expected := interpreter.NewFix128ValueFromBigInt(nil, fix128BigInt(tc.expected))
 					AssertValuesEqual(t, inter, expected, result)
 				}
 			})
@@ -566,11 +558,7 @@ func TestInterpretFixedPointPow(t *testing.T) {
 					result, err := inter.Invoke("test")
 					require.NoError(t, err)
 
-					expected := parseCheckAndPrepare(t, fmt.Sprintf(
-						`let expected: UFix128 = %s`,
-						tc.expected,
-					)).GetGlobal("expected")
-
+					expected := interpreter.NewUFix128ValueFromBigInt(nil, fix128BigInt(tc.expected))
 					AssertValuesEqual(t, inter, expected, result)
 				}
 			})

--- a/interpreter/fixedpoint_test.go
+++ b/interpreter/fixedpoint_test.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"math/big"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,6 +40,30 @@ import (
 	. "github.com/onflow/cadence/test_utils/interpreter_utils"
 	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
+
+func fix128BigInt(s string) *big.Int {
+	// Parse a decimal string like "33.333333333333333333333333"
+	// into the raw scaled big.Int (removing the decimal point).
+	// The fractional part must have exactly Fix128Scale (24) digits.
+	parts := strings.SplitN(s, ".", 2)
+	if len(parts) == 1 {
+		// No decimal point — treat as integer, scale up
+		v, ok := new(big.Int).SetString(s, 10)
+		if !ok {
+			panic("invalid fix128 string: " + s)
+		}
+		return v.Mul(v, sema.Fix128FactorIntBig)
+	}
+	if len(parts[1]) != sema.Fix128Scale {
+		panic(fmt.Sprintf("expected %d fractional digits, got %d: %s", sema.Fix128Scale, len(parts[1]), s))
+	}
+	raw := parts[0] + parts[1]
+	v, ok := new(big.Int).SetString(raw, 10)
+	if !ok {
+		panic("invalid fix128 string: " + s)
+	}
+	return v
+}
 
 func TestInterpretFixedPointMultiplyDivide(t *testing.T) {
 
@@ -292,6 +317,87 @@ func TestInterpretFixedPointMultiplyDivide(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("default rounding (truncate)", func(t *testing.T) {
+
+		t.Parallel()
+
+		t.Run("UFix64", func(t *testing.T) {
+			t.Parallel()
+
+			inter := parseCheckAndPrepareWithRoundingRule(t, `
+				fun test(): UFix64 {
+					let a: UFix64 = 10.0
+					let b: UFix64 = 10.0
+					let c: UFix64 = 3.0
+					return a.multiplyDivide(b, c)
+				}
+			`)
+			result, err := inter.Invoke("test")
+			require.NoError(t, err)
+
+			// 10*10/3 truncated = 33.33333333
+			expected := interpreter.NewUnmeteredUFix64Value(3333333333)
+			AssertValuesEqual(t, inter, expected, result)
+		})
+
+		t.Run("Fix64", func(t *testing.T) {
+			t.Parallel()
+
+			inter := parseCheckAndPrepareWithRoundingRule(t, `
+				fun test(): Fix64 {
+					let a: Fix64 = 10.0
+					let b: Fix64 = 10.0
+					let c: Fix64 = 3.0
+					return a.multiplyDivide(b, c)
+				}
+			`)
+			result, err := inter.Invoke("test")
+			require.NoError(t, err)
+
+			// 10*10/3 truncated = 33.33333333
+			expected := interpreter.NewUnmeteredFix64Value(3333333333)
+			AssertValuesEqual(t, inter, expected, result)
+		})
+
+		t.Run("UFix128", func(t *testing.T) {
+			t.Parallel()
+
+			inter := parseCheckAndPrepareWithRoundingRule(t, `
+				fun test(): UFix128 {
+					let a: UFix128 = 10.0
+					let b: UFix128 = 10.0
+					let c: UFix128 = 3.0
+					return a.multiplyDivide(b, c)
+				}
+			`)
+			result, err := inter.Invoke("test")
+			require.NoError(t, err)
+
+			// 10*10/3 truncated = 33.333333333333333333333333
+			expected := interpreter.NewUFix128ValueFromBigInt(nil, fix128BigInt("33.333333333333333333333333"))
+			AssertValuesEqual(t, inter, expected, result)
+		})
+
+		t.Run("Fix128", func(t *testing.T) {
+			t.Parallel()
+
+			inter := parseCheckAndPrepareWithRoundingRule(t, `
+				fun test(): Fix128 {
+					let a: Fix128 = 10.0
+					let b: Fix128 = 10.0
+					let c: Fix128 = 3.0
+					return a.multiplyDivide(b, c)
+				}
+			`)
+			result, err := inter.Invoke("test")
+			require.NoError(t, err)
+
+			// 10*10/3 truncated = 33.333333333333333333333333
+			expected := interpreter.NewFix128ValueFromBigInt(nil, fix128BigInt("33.333333333333333333333333"))
+			AssertValuesEqual(t, inter, expected, result)
+		})
 	})
 }
 

--- a/interpreter/fixedpoint_test.go
+++ b/interpreter/fixedpoint_test.go
@@ -40,6 +40,261 @@ import (
 	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
 
+func TestInterpretFixedPointMultiplyDivide(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("UFix64", func(t *testing.T) {
+
+		t.Parallel()
+
+		type testCase struct {
+			a, b, c       string
+			rounding      string
+			expected      uint64
+			expectedError bool
+		}
+
+		// Expected values pre-computed using the fixed-point library's UFix64.FMD().
+		testCases := []testCase{
+			// Basic: 2*3/1 = 6
+			{a: "2.00000000", b: "3.00000000", c: "1.00000000", rounding: "towardZero", expected: 600000000},
+			// Rounding modes: 10*10/3
+			{a: "10.00000000", b: "10.00000000", c: "3.00000000", rounding: "towardZero", expected: 3333333333},
+			{a: "10.00000000", b: "10.00000000", c: "3.00000000", rounding: "awayFromZero", expected: 3333333334},
+			{a: "10.00000000", b: "10.00000000", c: "3.00000000", rounding: "nearestHalfAway", expected: 3333333333},
+			// Fractional: 0.5*0.5/1.0 = 0.25
+			{a: "0.50000000", b: "0.50000000", c: "1.00000000", rounding: "towardZero", expected: 25000000},
+			// Zero factor
+			{a: "0.00000000", b: "5.00000000", c: "2.00000000", rounding: "towardZero", expected: 0},
+			{a: "5.00000000", b: "0.00000000", c: "2.00000000", rounding: "towardZero", expected: 0},
+			// Larger values: 100*200/50 = 400
+			{a: "100.00000000", b: "200.00000000", c: "50.00000000", rounding: "towardZero", expected: 40000000000},
+			// 1*1/3 with different rounding
+			{a: "1.00000000", b: "1.00000000", c: "3.00000000", rounding: "towardZero", expected: 33333333},
+			{a: "1.00000000", b: "1.00000000", c: "3.00000000", rounding: "awayFromZero", expected: 33333334},
+			// Division by zero
+			{a: "1.00000000", b: "2.00000000", c: "0.00000000", rounding: "towardZero", expectedError: true},
+		}
+
+		for _, tc := range testCases {
+
+			testName := fmt.Sprintf("%s * %s / %s (%s)", tc.a, tc.b, tc.c, tc.rounding)
+
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+
+				code := fmt.Sprintf(
+					`
+					fun test(): UFix64 {
+						let a: UFix64 = %s
+						let b: UFix64 = %s
+						let c: UFix64 = %s
+						return a.multiplyDivide(b, c, rounding: RoundingRule.%s)
+					}
+					`,
+					tc.a, tc.b, tc.c, tc.rounding,
+				)
+
+				inter := parseCheckAndPrepareWithRoundingRule(t, code)
+
+				if tc.expectedError {
+					_, err := inter.Invoke("test")
+					require.Error(t, err)
+				} else {
+					result, err := inter.Invoke("test")
+					require.NoError(t, err)
+
+					expected := interpreter.NewUnmeteredUFix64Value(tc.expected)
+					AssertValuesEqual(t, inter, expected, result)
+				}
+			})
+		}
+	})
+
+	t.Run("Fix64", func(t *testing.T) {
+
+		t.Parallel()
+
+		type testCase struct {
+			a, b, c       string
+			rounding      string
+			expected      int64
+			expectedError bool
+		}
+
+		testCases := []testCase{
+			// Basic: 2*3/1 = 6
+			{a: "2.00000000", b: "3.00000000", c: "1.00000000", rounding: "towardZero", expected: 600000000},
+			// Signed: (-2)*3/1 = -6
+			{a: "-2.00000000", b: "3.00000000", c: "1.00000000", rounding: "towardZero", expected: -600000000},
+			// (-5)*(-3)/2 = 7.5
+			{a: "-5.00000000", b: "-3.00000000", c: "2.00000000", rounding: "towardZero", expected: 750000000},
+			// Rounding: 10*10/3
+			{a: "10.00000000", b: "10.00000000", c: "3.00000000", rounding: "towardZero", expected: 3333333333},
+			{a: "10.00000000", b: "10.00000000", c: "3.00000000", rounding: "awayFromZero", expected: 3333333334},
+			// 1/3 truncated
+			{a: "1.00000000", b: "1.00000000", c: "3.00000000", rounding: "towardZero", expected: 33333333},
+			// Division by zero
+			{a: "1.00000000", b: "2.00000000", c: "0.00000000", rounding: "towardZero", expectedError: true},
+		}
+
+		for _, tc := range testCases {
+
+			testName := fmt.Sprintf("%s * %s / %s (%s)", tc.a, tc.b, tc.c, tc.rounding)
+
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+
+				code := fmt.Sprintf(
+					`
+					fun test(): Fix64 {
+						let a: Fix64 = %s
+						let b: Fix64 = %s
+						let c: Fix64 = %s
+						return a.multiplyDivide(b, c, rounding: RoundingRule.%s)
+					}
+					`,
+					tc.a, tc.b, tc.c, tc.rounding,
+				)
+
+				inter := parseCheckAndPrepareWithRoundingRule(t, code)
+
+				if tc.expectedError {
+					_, err := inter.Invoke("test")
+					require.Error(t, err)
+				} else {
+					result, err := inter.Invoke("test")
+					require.NoError(t, err)
+
+					expected := interpreter.NewUnmeteredFix64Value(tc.expected)
+					AssertValuesEqual(t, inter, expected, result)
+				}
+			})
+		}
+	})
+
+	t.Run("UFix128", func(t *testing.T) {
+
+		t.Parallel()
+
+		type testCase struct {
+			a, b, c       string
+			rounding      string
+			expected      string
+			expectedError bool
+		}
+
+		testCases := []testCase{
+			{a: "2.000000000000000000000000", b: "3.000000000000000000000000", c: "1.000000000000000000000000", rounding: "towardZero", expected: "6.000000000000000000000000"},
+			{a: "10.000000000000000000000000", b: "10.000000000000000000000000", c: "3.000000000000000000000000", rounding: "towardZero", expected: "33.333333333333333333333333"},
+			{a: "10.000000000000000000000000", b: "10.000000000000000000000000", c: "3.000000000000000000000000", rounding: "awayFromZero", expected: "33.333333333333333333333334"},
+			{a: "0.500000000000000000000000", b: "0.500000000000000000000000", c: "1.000000000000000000000000", rounding: "towardZero", expected: "0.250000000000000000000000"},
+			{a: "100.000000000000000000000000", b: "200.000000000000000000000000", c: "50.000000000000000000000000", rounding: "towardZero", expected: "400.000000000000000000000000"},
+			// Division by zero
+			{a: "1.000000000000000000000000", b: "2.000000000000000000000000", c: "0.000000000000000000000000", rounding: "towardZero", expectedError: true},
+		}
+
+		for _, tc := range testCases {
+
+			testName := fmt.Sprintf("%s * %s / %s (%s)", tc.a, tc.b, tc.c, tc.rounding)
+
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+
+				code := fmt.Sprintf(
+					`
+					fun test(): UFix128 {
+						let a: UFix128 = %s
+						let b: UFix128 = %s
+						let c: UFix128 = %s
+						return a.multiplyDivide(b, c, rounding: RoundingRule.%s)
+					}
+					`,
+					tc.a, tc.b, tc.c, tc.rounding,
+				)
+
+				inter := parseCheckAndPrepareWithRoundingRule(t, code)
+
+				if tc.expectedError {
+					_, err := inter.Invoke("test")
+					require.Error(t, err)
+				} else {
+					result, err := inter.Invoke("test")
+					require.NoError(t, err)
+
+					expected := parseCheckAndPrepare(t, fmt.Sprintf(
+						`let expected: UFix128 = %s`,
+						tc.expected,
+					)).GetGlobal("expected")
+
+					AssertValuesEqual(t, inter, expected, result)
+				}
+			})
+		}
+	})
+
+	t.Run("Fix128", func(t *testing.T) {
+
+		t.Parallel()
+
+		type testCase struct {
+			a, b, c       string
+			rounding      string
+			expected      string
+			expectedError bool
+		}
+
+		testCases := []testCase{
+			{a: "2.000000000000000000000000", b: "3.000000000000000000000000", c: "1.000000000000000000000000", rounding: "towardZero", expected: "6.000000000000000000000000"},
+			{a: "-2.000000000000000000000000", b: "3.000000000000000000000000", c: "1.000000000000000000000000", rounding: "towardZero", expected: "-6.000000000000000000000000"},
+			{a: "-2.000000000000000000000000", b: "-3.000000000000000000000000", c: "1.000000000000000000000000", rounding: "towardZero", expected: "6.000000000000000000000000"},
+			{a: "10.000000000000000000000000", b: "10.000000000000000000000000", c: "3.000000000000000000000000", rounding: "towardZero", expected: "33.333333333333333333333333"},
+			{a: "10.000000000000000000000000", b: "10.000000000000000000000000", c: "3.000000000000000000000000", rounding: "awayFromZero", expected: "33.333333333333333333333334"},
+			// Division by zero
+			{a: "1.000000000000000000000000", b: "2.000000000000000000000000", c: "0.000000000000000000000000", rounding: "towardZero", expectedError: true},
+		}
+
+		for _, tc := range testCases {
+
+			testName := fmt.Sprintf("%s * %s / %s (%s)", tc.a, tc.b, tc.c, tc.rounding)
+
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+
+				code := fmt.Sprintf(
+					`
+					fun test(): Fix128 {
+						let a: Fix128 = %s
+						let b: Fix128 = %s
+						let c: Fix128 = %s
+						return a.multiplyDivide(b, c, rounding: RoundingRule.%s)
+					}
+					`,
+					tc.a, tc.b, tc.c, tc.rounding,
+				)
+
+				inter := parseCheckAndPrepareWithRoundingRule(t, code)
+
+				if tc.expectedError {
+					_, err := inter.Invoke("test")
+					require.Error(t, err)
+				} else {
+					result, err := inter.Invoke("test")
+					require.NoError(t, err)
+
+					expected := parseCheckAndPrepare(t, fmt.Sprintf(
+						`let expected: Fix128 = %s`,
+						tc.expected,
+					)).GetGlobal("expected")
+
+					AssertValuesEqual(t, inter, expected, result)
+				}
+			})
+		}
+	})
+}
+
 func TestInterpretFixedPointPow(t *testing.T) {
 
 	t.Parallel()

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/onflow/atree"
 
+	fix "github.com/onflow/fixed-point"
+
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/sema"
 )
@@ -322,6 +324,12 @@ type FixedPointValue interface {
 	NumberValue
 	IntegerPart() NumberValue
 	Scale() int
+	MultiplyDivide(
+		context NumberValueArithmeticContext,
+		factor FixedPointValue,
+		divisor FixedPointValue,
+		rounding fix.RoundingMode,
+	) NumberValue
 }
 
 type AuthorizedValue interface {

--- a/interpreter/value_bool.go
+++ b/interpreter/value_bool.go
@@ -193,22 +193,33 @@ func (BoolValue) DeepRemove(_ ValueRemoveContext, _ bool) {
 	// NO-OP
 }
 
-func (v BoolValue) GetMember(context MemberAccessibleContext, name string, memberKind common.DeclarationKind) Value {
+func (v BoolValue) GetMember(
+	context MemberAccessibleContext,
+	name string,
+	memberKind common.DeclarationKind,
+	accessedReference ReferenceValue,
+) Value {
 	return GetMember(
 		context,
 		v,
+		accessedReference,
 		name,
 		memberKind,
 		nil,
 	)
 }
 
-func (v BoolValue) GetMethod(context MemberAccessibleContext, name string) FunctionValue {
+func (v BoolValue) GetMethod(
+	context MemberAccessibleContext,
+	name string,
+	accessedReference ReferenceValue,
+) FunctionValue {
 	switch name {
 	case sema.ToStringFunctionName:
 		return NewBoundHostFunctionValue(
 			context,
 			v,
+			accessedReference,
 			sema.ToStringFunctionType,
 			NativeBoolValueToStringFunction,
 		)

--- a/interpreter/value_fix128.go
+++ b/interpreter/value_fix128.go
@@ -370,6 +370,43 @@ func (v Fix128Value) Mod(context NumberValueArithmeticContext, other NumberValue
 	return NewFix128Value(context, valueGetter)
 }
 
+func (v Fix128Value) MultiplyDivide(
+	context NumberValueArithmeticContext,
+	factor FixedPointValue,
+	divisor FixedPointValue,
+	rounding fix.RoundingMode,
+) NumberValue {
+	f, ok := factor.(Fix128Value)
+	if !ok {
+		panic(&InvalidOperandsError{
+			FunctionName: sema.FixedPointNumericTypeMultiplyDivideFunctionName,
+			LeftType:     v.StaticType(context),
+			RightType:    factor.StaticType(context),
+		})
+	}
+
+	d, ok := divisor.(Fix128Value)
+	if !ok {
+		panic(&InvalidOperandsError{
+			FunctionName: sema.FixedPointNumericTypeMultiplyDivideFunctionName,
+			LeftType:     v.StaticType(context),
+			RightType:    divisor.StaticType(context),
+		})
+	}
+
+	valueGetter := func() fix.Fix128 {
+		result, err := fix.Fix128(v).FMD(
+			fix.Fix128(f),
+			fix.Fix128(d),
+			rounding,
+		)
+		handleFixedpointError(err)
+		return result
+	}
+
+	return NewFix128Value(context, valueGetter)
+}
+
 func (v Fix128Value) Less(context ValueComparisonContext, other ComparableValue) BoolValue {
 	o, ok := other.(Fix128Value)
 	if !ok {

--- a/interpreter/value_fix64.go
+++ b/interpreter/value_fix64.go
@@ -387,6 +387,42 @@ func (v Fix64Value) Mod(context NumberValueArithmeticContext, other NumberValue)
 	return v.Minus(context, truncatedQuotient.Mul(context, o))
 }
 
+func (v Fix64Value) MultiplyDivide(
+	context NumberValueArithmeticContext,
+	factor FixedPointValue,
+	divisor FixedPointValue,
+	rounding fix.RoundingMode,
+) NumberValue {
+	f, ok := factor.(Fix64Value)
+	if !ok {
+		panic(&InvalidOperandsError{
+			FunctionName: sema.FixedPointNumericTypeMultiplyDivideFunctionName,
+			LeftType:     v.StaticType(context),
+			RightType:    factor.StaticType(context),
+		})
+	}
+
+	d, ok := divisor.(Fix64Value)
+	if !ok {
+		panic(&InvalidOperandsError{
+			FunctionName: sema.FixedPointNumericTypeMultiplyDivideFunctionName,
+			LeftType:     v.StaticType(context),
+			RightType:    divisor.StaticType(context),
+		})
+	}
+
+	valueGetter := func() int64 {
+		a := fix.Fix64(uint64(v))
+		b := fix.Fix64(uint64(f))
+		c := fix.Fix64(uint64(d))
+		result, err := a.FMD(b, c, rounding)
+		handleFixedpointError(err)
+		return int64(result)
+	}
+
+	return NewFix64Value(context, valueGetter)
+}
+
 func (v Fix64Value) Less(context ValueComparisonContext, other ComparableValue) BoolValue {
 	o, ok := other.(Fix64Value)
 	if !ok {

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -116,6 +116,18 @@ func getNumberValueFunctionMember(
 			funcType,
 			NativeFixedPointPowFunction,
 		)
+
+	case sema.FixedPointNumericTypeMultiplyDivideFunctionName:
+		funcType, ok := sema.FixedPointMultiplyDivideFunctionTypes[typ]
+		if !ok {
+			return nil
+		}
+		return NewBoundHostFunctionValue(
+			context,
+			v,
+			funcType,
+			NativeFixedPointMultiplyDivideFunction,
+		)
 	}
 
 	return nil
@@ -225,6 +237,21 @@ var NativeNumberSaturatingDivideFunction = NativeFunction(
 	) Value {
 		other := AssertValueOfType[NumberValue](args[0])
 		return receiver.(NumberValue).SaturatingDiv(context, other)
+	},
+)
+
+var NativeFixedPointMultiplyDivideFunction = NativeFunction(
+	func(
+		context NativeFunctionContext,
+		_ TypeArgumentsIterator,
+		_ ArgumentTypesIterator,
+		receiver Value,
+		args []Value,
+	) Value {
+		factor := AssertValueOfType[FixedPointValue](args[0])
+		divisor := AssertValueOfType[FixedPointValue](args[1])
+		rounding := extractRoundingRule(args[2])
+		return receiver.(FixedPointValue).MultiplyDivide(context, factor, divisor, rounding)
 	},
 )
 

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -21,6 +21,8 @@ package interpreter
 import (
 	"math/big"
 
+	fix "github.com/onflow/fixed-point"
+
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
 	"github.com/onflow/cadence/sema"
@@ -250,7 +252,12 @@ var NativeFixedPointMultiplyDivideFunction = NativeFunction(
 	) Value {
 		factor := AssertValueOfType[FixedPointValue](args[0])
 		divisor := AssertValueOfType[FixedPointValue](args[1])
-		rounding := extractRoundingRule(args[2])
+		var rounding fix.RoundingMode
+		if len(args) > 2 {
+			rounding = extractRoundingRule(args[2])
+		} else {
+			rounding = fix.RoundTruncate
+		}
 		return receiver.(FixedPointValue).MultiplyDivide(context, factor, divisor, rounding)
 	},
 )

--- a/interpreter/value_number.go
+++ b/interpreter/value_number.go
@@ -122,6 +122,7 @@ func getNumberValueFunctionMember(
 		return NewBoundHostFunctionValue(
 			context,
 			v,
+			accessedReference,
 			funcType,
 			NativeFixedPointPowFunction,
 		)
@@ -134,6 +135,7 @@ func getNumberValueFunctionMember(
 		return NewBoundHostFunctionValue(
 			context,
 			v,
+			accessedReference,
 			funcType,
 			NativeFixedPointMultiplyDivideFunction,
 		)

--- a/interpreter/value_ufix128.go
+++ b/interpreter/value_ufix128.go
@@ -362,6 +362,43 @@ func (v UFix128Value) Mod(context NumberValueArithmeticContext, other NumberValu
 	return NewUFix128Value(context, valueGetter)
 }
 
+func (v UFix128Value) MultiplyDivide(
+	context NumberValueArithmeticContext,
+	factor FixedPointValue,
+	divisor FixedPointValue,
+	rounding fix.RoundingMode,
+) NumberValue {
+	f, ok := factor.(UFix128Value)
+	if !ok {
+		panic(&InvalidOperandsError{
+			FunctionName: sema.FixedPointNumericTypeMultiplyDivideFunctionName,
+			LeftType:     v.StaticType(context),
+			RightType:    factor.StaticType(context),
+		})
+	}
+
+	d, ok := divisor.(UFix128Value)
+	if !ok {
+		panic(&InvalidOperandsError{
+			FunctionName: sema.FixedPointNumericTypeMultiplyDivideFunctionName,
+			LeftType:     v.StaticType(context),
+			RightType:    divisor.StaticType(context),
+		})
+	}
+
+	valueGetter := func() fix.UFix128 {
+		result, err := fix.UFix128(v).FMD(
+			fix.UFix128(f),
+			fix.UFix128(d),
+			rounding,
+		)
+		handleFixedpointError(err)
+		return result
+	}
+
+	return NewUFix128Value(context, valueGetter)
+}
+
 func (v UFix128Value) Pow(context NumberValueArithmeticContext, other Fix128Value) NumberValue {
 	valueGetter := func() fix.UFix128 {
 		result, err := fix.UFix128(v).Pow(fix.Fix128(other))

--- a/interpreter/value_ufix64.go
+++ b/interpreter/value_ufix64.go
@@ -393,6 +393,42 @@ func (v UFix64Value) Mod(context NumberValueArithmeticContext, other NumberValue
 	return UFix64Value{UFix64Value: result}
 }
 
+func (v UFix64Value) MultiplyDivide(
+	context NumberValueArithmeticContext,
+	factor FixedPointValue,
+	divisor FixedPointValue,
+	rounding fix.RoundingMode,
+) NumberValue {
+	f, ok := factor.(UFix64Value)
+	if !ok {
+		panic(&InvalidOperandsError{
+			FunctionName: sema.FixedPointNumericTypeMultiplyDivideFunctionName,
+			LeftType:     v.StaticType(context),
+			RightType:    factor.StaticType(context),
+		})
+	}
+
+	d, ok := divisor.(UFix64Value)
+	if !ok {
+		panic(&InvalidOperandsError{
+			FunctionName: sema.FixedPointNumericTypeMultiplyDivideFunctionName,
+			LeftType:     v.StaticType(context),
+			RightType:    divisor.StaticType(context),
+		})
+	}
+
+	valueGetter := func() uint64 {
+		a := fix.UFix64(uint64(v.UFix64Value))
+		b := fix.UFix64(uint64(f.UFix64Value))
+		c := fix.UFix64(uint64(d.UFix64Value))
+		result, err := a.FMD(b, c, rounding)
+		handleFixedpointError(err)
+		return uint64(result)
+	}
+
+	return NewUFix64Value(context, valueGetter)
+}
+
 func (v UFix64Value) Pow(context NumberValueArithmeticContext, other Fix64Value) NumberValue {
 	valueGetter := func() uint64 {
 		a := fix.UFix64(uint64(v.UFix64Value))

--- a/runtime/rounding_rule_test.go
+++ b/runtime/rounding_rule_test.go
@@ -178,16 +178,16 @@ func TestRuntimeFix64ConversionWithRoundingRuleArgument(t *testing.T) {
 
 	t.Parallel()
 
-	runtime := NewTestRuntime()
-	runtimeInterface := &TestRuntimeInterface{
-		OnDecodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
-			return json.Decode(nil, b)
-		},
-	}
-	nextScriptLocation := NewScriptLocationGenerator()
-
 	t.Run("Fix128 to Fix64 with rounding", func(t *testing.T) {
 		t.Parallel()
+
+		runtime := NewTestRuntime()
+		runtimeInterface := &TestRuntimeInterface{
+			OnDecodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
+				return json.Decode(nil, b)
+			},
+		}
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		const script = `
           access(all) fun main(rule: RoundingRule): Fix64 {
@@ -215,6 +215,14 @@ func TestRuntimeFix64ConversionWithRoundingRuleArgument(t *testing.T) {
 
 	t.Run("UFix128 to UFix64 with rounding", func(t *testing.T) {
 		t.Parallel()
+
+		runtime := NewTestRuntime()
+		runtimeInterface := &TestRuntimeInterface{
+			OnDecodeArgument: func(b []byte, t cadence.Type) (cadence.Value, error) {
+				return json.Decode(nil, b)
+			},
+		}
+		nextScriptLocation := NewScriptLocationGenerator()
 
 		const script = `
           access(all) fun main(rule: RoundingRule): UFix64 {

--- a/sema/fixedpoint_test.go
+++ b/sema/fixedpoint_test.go
@@ -27,10 +27,110 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/format"
 	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/stdlib"
 	. "github.com/onflow/cadence/test_utils/sema_utils"
 )
+
+func TestCheckFixedPointMultiplyDivide(t *testing.T) {
+
+	t.Parallel()
+
+	baseValueActivation := sema.NewVariableActivation(sema.BaseValueActivation)
+	for _, value := range stdlib.InterpreterDefaultScriptStandardLibraryValues(nil) {
+		baseValueActivation.DeclareValue(value)
+	}
+
+	parseAndCheckWithRoundingRule := func(t *testing.T, code string) (*sema.Checker, error) {
+		return ParseAndCheckWithOptions(t,
+			code,
+			ParseAndCheckOptions{
+				CheckerConfig: &sema.Config{
+					BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+						return baseValueActivation
+					},
+				},
+			},
+		)
+	}
+
+	for _, fixedPointType := range common.Concat(
+		sema.AllSignedFixedPointTypes,
+		sema.AllUnsignedFixedPointTypes,
+	) {
+
+		t.Run(fixedPointType.String(), func(t *testing.T) {
+
+			t.Parallel()
+
+			t.Run("valid", func(t *testing.T) {
+				t.Parallel()
+
+				checker, err := parseAndCheckWithRoundingRule(t,
+					fmt.Sprintf(
+						`
+						let a: %[1]s = 2.0
+						let b: %[1]s = 3.0
+						let c: %[1]s = 1.0
+						let result = a.multiplyDivide(b, c, rounding: RoundingRule.towardZero)
+						`,
+						fixedPointType,
+					),
+				)
+				require.NoError(t, err)
+
+				resultType := RequireGlobalValue(t, checker.Elaboration, "result")
+				assert.Equal(t, fixedPointType, resultType)
+			})
+
+			t.Run("invalid, wrong factor type", func(t *testing.T) {
+				t.Parallel()
+
+				_, err := parseAndCheckWithRoundingRule(t,
+					fmt.Sprintf(
+						`
+						let a: %[1]s = 2.0
+						let b: Int = 3
+						let c: %[1]s = 1.0
+						let result = a.multiplyDivide(b, c, rounding: RoundingRule.towardZero)
+						`,
+						fixedPointType,
+					),
+				)
+				require.Error(t, err)
+			})
+
+			t.Run("invalid, missing rounding", func(t *testing.T) {
+				t.Parallel()
+
+				_, err := ParseAndCheck(t,
+					fmt.Sprintf(
+						`
+						let a: %[1]s = 2.0
+						let b: %[1]s = 3.0
+						let c: %[1]s = 1.0
+						let result = a.multiplyDivide(b, c)
+						`,
+						fixedPointType,
+					),
+				)
+				require.Error(t, err)
+			})
+		})
+	}
+
+	t.Run("not available on integer types", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			let a: Int = 2
+			let result = a.multiplyDivide(3, 1, rounding: RoundingRule.towardZero)
+		`)
+		require.Error(t, err)
+	})
+}
 
 func TestCheckFixedPointPow(t *testing.T) {
 

--- a/sema/fixedpoint_test.go
+++ b/sema/fixedpoint_test.go
@@ -102,7 +102,7 @@ func TestCheckFixedPointMultiplyDivide(t *testing.T) {
 				require.Error(t, err)
 			})
 
-			t.Run("invalid, missing rounding", func(t *testing.T) {
+			t.Run("valid, without rounding", func(t *testing.T) {
 				t.Parallel()
 
 				_, err := ParseAndCheck(t,
@@ -116,7 +116,7 @@ func TestCheckFixedPointMultiplyDivide(t *testing.T) {
 						fixedPointType,
 					),
 				)
-				require.Error(t, err)
+				require.NoError(t, err)
 			})
 		})
 	}

--- a/sema/type.go
+++ b/sema/type.go
@@ -1425,6 +1425,60 @@ func addFixedPointPowFunction(
 	}
 }
 
+const FixedPointNumericTypeMultiplyDivideFunctionName = "multiplyDivide"
+const fixedPointNumericTypeMultiplyDivideFunctionDocString = `
+Returns self * factor / divisor, without intermediate rounding
+`
+
+var FixedPointMultiplyDivideFunctionTypes = map[Type]*FunctionType{}
+
+func addFixedPointMultiplyDivideFunction(
+	fixedPointType *FixedPointNumericType,
+	members map[string]MemberResolver,
+) {
+	funcType := NewSimpleFunctionType(
+		FunctionPurityView,
+		[]Parameter{
+			{
+				Label:          ArgumentLabelNotRequired,
+				Identifier:     "factor",
+				TypeAnnotation: NewTypeAnnotation(fixedPointType),
+			},
+			{
+				Label:          ArgumentLabelNotRequired,
+				Identifier:     "divisor",
+				TypeAnnotation: NewTypeAnnotation(fixedPointType),
+			},
+			{
+				Label:          "rounding",
+				Identifier:     "rounding",
+				TypeAnnotation: RoundingRuleTypeAnnotation,
+			},
+		},
+		NewTypeAnnotation(fixedPointType),
+	)
+
+	FixedPointMultiplyDivideFunctionTypes[fixedPointType] = funcType
+
+	members[FixedPointNumericTypeMultiplyDivideFunctionName] = MemberResolver{
+		Kind: common.DeclarationKindFunction,
+		Resolve: func(
+			memoryGauge common.MemoryGauge,
+			_ string,
+			_ ast.HasPosition,
+			_ func(error),
+		) *Member {
+			return NewPublicFunctionMember(
+				memoryGauge,
+				fixedPointType,
+				FixedPointNumericTypeMultiplyDivideFunctionName,
+				funcType,
+				fixedPointNumericTypeMultiplyDivideFunctionDocString,
+			)
+		},
+	}
+}
+
 // NumericType represent all the types in the integer range
 // and non-fractional ranged types.
 type NumericType struct {
@@ -1870,6 +1924,12 @@ func (t *FixedPointNumericType) GetMembers() map[string]MemberResolver {
 		addFixedPointPowFunction(t, Fix64Type, computedMembers)
 	case UFix128Type:
 		addFixedPointPowFunction(t, Fix128Type, computedMembers)
+	}
+
+	// Add multiplyDivide function for all concrete fixed-point types
+	switch t {
+	case Fix64Type, UFix64Type, Fix128Type, UFix128Type:
+		addFixedPointMultiplyDivideFunction(t, computedMembers)
 	}
 
 	computedMembers = withBuiltinMembers(t, computedMembers)

--- a/sema/type.go
+++ b/sema/type.go
@@ -1442,22 +1442,19 @@ Returns self * factor / divisor, without intermediate rounding
 
 var FixedPointMultiplyDivideFunctionTypes = map[Type]*FunctionType{}
 
-func addFixedPointMultiplyDivideFunction(
-	fixedPointType *FixedPointNumericType,
-	members map[string]MemberResolver,
-) {
-	funcType := NewSimpleFunctionType(
+func registerFixedPointMultiplyDivideFunction(t *FixedPointNumericType) {
+	FixedPointMultiplyDivideFunctionTypes[t] = NewSimpleFunctionType(
 		FunctionPurityView,
 		[]Parameter{
 			{
 				Label:          ArgumentLabelNotRequired,
 				Identifier:     "factor",
-				TypeAnnotation: NewTypeAnnotation(fixedPointType),
+				TypeAnnotation: NewTypeAnnotation(t),
 			},
 			{
 				Label:          ArgumentLabelNotRequired,
 				Identifier:     "divisor",
-				TypeAnnotation: NewTypeAnnotation(fixedPointType),
+				TypeAnnotation: NewTypeAnnotation(t),
 			},
 			{
 				Label:          "rounding",
@@ -1465,10 +1462,15 @@ func addFixedPointMultiplyDivideFunction(
 				TypeAnnotation: RoundingRuleTypeAnnotation,
 			},
 		},
-		NewTypeAnnotation(fixedPointType),
+		NewTypeAnnotation(t),
 	)
+}
 
-	FixedPointMultiplyDivideFunctionTypes[fixedPointType] = funcType
+func addFixedPointMultiplyDivideFunction(
+	t *FixedPointNumericType,
+	members map[string]MemberResolver,
+) {
+	functionType := FixedPointMultiplyDivideFunctionTypes[t]
 
 	members[FixedPointNumericTypeMultiplyDivideFunctionName] = MemberResolver{
 		Kind: common.DeclarationKindFunction,
@@ -1480,9 +1482,9 @@ func addFixedPointMultiplyDivideFunction(
 		) *Member {
 			return NewPublicFunctionMember(
 				memoryGauge,
-				fixedPointType,
+				t,
 				FixedPointNumericTypeMultiplyDivideFunctionName,
-				funcType,
+				functionType,
 				fixedPointNumericTypeMultiplyDivideFunctionDocString,
 			)
 		},
@@ -1744,9 +1746,11 @@ var _ FractionalRangedType = &FixedPointNumericType{}
 var _ SaturatingArithmeticType = &FixedPointNumericType{}
 
 func NewFixedPointNumericType(typeName string) *FixedPointNumericType {
-	return &FixedPointNumericType{
+	t := &FixedPointNumericType{
 		name: typeName,
 	}
+	registerFixedPointMultiplyDivideFunction(t)
+	return t
 }
 
 func (t *FixedPointNumericType) Tag() TypeTag {

--- a/sema/type.go
+++ b/sema/type.go
@@ -1443,9 +1443,9 @@ Returns self * factor / divisor, without intermediate rounding
 var FixedPointMultiplyDivideFunctionTypes = map[Type]*FunctionType{}
 
 func registerFixedPointMultiplyDivideFunction(t *FixedPointNumericType) {
-	FixedPointMultiplyDivideFunctionTypes[t] = NewSimpleFunctionType(
-		FunctionPurityView,
-		[]Parameter{
+	FixedPointMultiplyDivideFunctionTypes[t] = &FunctionType{
+		Purity: FunctionPurityView,
+		Parameters: []Parameter{
 			{
 				Label:          ArgumentLabelNotRequired,
 				Identifier:     "factor",
@@ -1462,8 +1462,9 @@ func registerFixedPointMultiplyDivideFunction(t *FixedPointNumericType) {
 				TypeAnnotation: RoundingRuleTypeAnnotation,
 			},
 		},
-		NewTypeAnnotation(t),
-	)
+		Arity:                &Arity{Min: 2, Max: 3},
+		ReturnTypeAnnotation: NewTypeAnnotation(t),
+	}
 }
 
 func addFixedPointMultiplyDivideFunction(


### PR DESCRIPTION


## Description

Add a `multiplyDivide` function to all fixed-point types, backed by `FMD` methods in https://github.com/onflow/fixed-point:

- `Fix64.multiplyDivide(_ factor: Fix64, _ divisor: Fix64, rounding: RoundingRule): Fix64`
- `UFix64.multiplyDivide(_ factor: UFix64, _ divisor: UFix64, rounding: RoundingRule): UFix64`
- `Fix128.multiplyDivide(_ factor: Fix128, _ divisor: Fix128, rounding: RoundingRule): Fix128`
- `UFix128.multiplyDivide(_ factor: UFix128, _ divisor: UFix128, rounding: RoundingRule): UFix128`

The `rounding` parameter is optional and defaults to `RoundingRule.towardZero`

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

