### PR TITLE
Add tool which allows changing contract in CSV

### DIFF
--- a/tools/change-contract/README.md
+++ b/tools/change-contract/README.md
@@ -1,0 +1,21 @@
+# change-contract
+
+Takes a `location, code` CSV on stdin and writes it to stdout,
+replacing the `code` cell of the row matching `-location`
+with the contents of the file given by `-file`.
+
+The first row is preserved as-is (so a `location,code` header passes through).
+Rows whose location does not match are emitted unchanged.
+
+The input format matches the CSV produced by the sibling `get-contracts` tool.
+
+## Flags
+
+- `-location` — the location whose code should be replaced
+- `-file` — path to a file containing the new code
+
+## Example
+
+```sh
+cat contracts.csv | go run . -file SomeContract.cdc -location A.0123456789.SomeContract > updated_contracts.csv
+```

--- a/tools/change-contract/go.mod
+++ b/tools/change-contract/go.mod
@@ -1,0 +1,3 @@
+module github.com/onflow/cadence/tools/change-contract
+
+go 1.24

--- a/tools/change-contract/main.go
+++ b/tools/change-contract/main.go
@@ -1,0 +1,77 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Read a (location, code) CSV from stdin and write it to stdout,
+// replacing the code of the row matching the given location with
+// the contents of the given file. The first row is preserved as-is.
+package main
+
+import (
+	"encoding/csv"
+	"flag"
+	"io"
+	"log"
+	"os"
+)
+
+var locationFlag = flag.String("location", "", "location whose code should be replaced")
+var fileFlag = flag.String("file", "", "path to file containing the new code")
+
+func main() {
+	flag.Parse()
+
+	if *locationFlag == "" || *fileFlag == "" {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	newCode, err := os.ReadFile(*fileFlag)
+	if err != nil {
+		log.Fatalf("failed to read %s: %s", *fileFlag, err)
+	}
+
+	r := csv.NewReader(os.Stdin)
+	r.FieldsPerRecord = -1
+
+	w := csv.NewWriter(os.Stdout)
+
+	first := true
+	for {
+		row, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Fatalf("failed to read CSV: %s", err)
+		}
+
+		if !first && len(row) >= 2 && row[0] == *locationFlag {
+			row[1] = string(newCode)
+		}
+		first = false
+
+		if err := w.Write(row); err != nil {
+			log.Fatalf("failed to write CSV: %s", err)
+		}
+	}
+
+	w.Flush()
+	if err := w.Error(); err != nil {
+		log.Fatalf("failed to flush CSV: %s", err)
+	}
+}


### PR DESCRIPTION

## Description

Add a new tool which allows changing a contract with different code in a contracts CSV file (e.g. from `get-contracts` tool)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
