### PR TITLE
Fix version in NPM package

### DIFF
--- a/npm-packages/cadence-parser/package.json
+++ b/npm-packages/cadence-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onflow/cadence-parser",
-  "version": "1.10.2",
+  "version": "1.10.3-rc.3",
   "description": "The Cadence parser",
   "homepage": "https://github.com/onflow/cadence",
   "repository": {


### PR DESCRIPTION

## Description

Releasing fails (again) because the NPM package version wasn't bumped: https://github.com/onflow/cadence/actions/runs/26044680425/job/76565532687

Fix the version so we can release.

I'll open a separate PR to improve the version bumping.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
