### PR TITLE
[Compiler] Resolve type parameters dynamically at runtime in VM

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -3204,12 +3204,34 @@ func (c *Compiler[_, _]) loadTypeArguments(invocationTypes sema.InvocationExpres
 
 	var typeArgs []uint16
 	if typeArgsCount > 0 {
+		typeParameters := invocationTypes.TypeParameters
+
+		// A mix of bound and unbound type arguments is not supported (yet), because the VM
+		// reconstructs the TypeParameterTypeOrderedMap by positionally pairing each
+		// emitted type argument with `funcType.TypeParameters[i]`.
+		// See `reconstructTypeArguments` in the VM.
+		//
+		// Therefore, the type parameters must either be all bound, or none.
+		if typeArgsCount != len(typeParameters) {
+			panic(errors.NewUnexpectedError(
+				"unsupported: %d out of %d type parameters are bound; "+
+					"type parameters must either be all bound, or none",
+				typeArgsCount,
+				len(typeParameters),
+			))
+		}
+
 		common.UseMemory(c.Config.MemoryGauge, common.NewGoSliceMemoryUsages(typeArgsCount))
 		typeArgs = make([]uint16, 0, typeArgsCount)
 
-		typeArguments.Foreach(func(key *sema.TypeParameter, typeParam sema.Type) {
-			typeArgs = append(typeArgs, c.getOrAddType(typeParam))
-		})
+		// Type arguments are constructed in the order they were resolved,
+		// rather than the order in which type parameters are declared.
+		// Therefore, emit type arguments in TypeParameters declaration order,
+		// so that the map can be reconstructed at runtime (See `reconstructTypeArguments` in the VM).
+		for _, typeParameter := range typeParameters {
+			resolvedType, _ := typeArguments.Get(typeParameter)
+			typeArgs = append(typeArgs, c.getOrAddType(resolvedType))
+		}
 	}
 
 	return typeArgs

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -1101,8 +1101,6 @@ func opGetMethodDynamic(vm *VM, ins opcode.InstructionGetMethodDynamic) {
 	vm.push(method)
 }
 
-var emptyTypeParametersMap = &sema.TypeParameterTypeOrderedMap{}
-
 func invokeFunction(
 	vm *VM,
 	functionValue Value,
@@ -1133,6 +1131,7 @@ func invokeFunction(
 			originalFunctionValue,
 			boundFunction,
 			arguments,
+			typeArguments,
 			argumentTypes,
 			parameterTypes,
 			hasImplicitArgument,
@@ -1207,6 +1206,7 @@ func convertAndBoxArguments(
 	originalFunctionValue FunctionValue,
 	boundFunctionValue *BoundFunctionValue,
 	arguments []Value,
+	typeArguments []bbq.StaticType,
 	argumentTypes []bbq.StaticType,
 	parameterTypes []bbq.StaticType,
 	hasImplicitArgument bool,
@@ -1239,6 +1239,8 @@ func convertAndBoxArguments(
 		panic(r)
 	}()
 
+	var typeArgumentsMap *sema.TypeParameterTypeOrderedMap
+
 	for currentArgIndex, arg := range arguments {
 		// Attachment-base is an implicit argument. Skip it form conversions.
 		if isImplicitArgument(
@@ -1252,8 +1254,11 @@ func convertAndBoxArguments(
 
 		var paramType bbq.StaticType
 		if paramIndex < len(actualParams) {
-			// TODO: Properly resolve the type parameters.
-			paramSemaType := actualParams[paramIndex].TypeAnnotation.Type.Resolve(emptyTypeParametersMap)
+			if typeArgumentsMap == nil {
+				typeArgumentsMap = reconstructTypeArguments(context, actualFuncType, typeArguments)
+			}
+
+			paramSemaType := actualParams[paramIndex].TypeAnnotation.Type.Resolve(typeArgumentsMap)
 			if paramSemaType != nil {
 				paramType = interpreter.ConvertSemaToStaticType(context, paramSemaType)
 			}
@@ -1294,6 +1299,45 @@ func convertAndBoxArguments(
 	}
 
 	return arguments
+}
+
+// reconstructTypeArguments builds a TypeParameterTypeOrderedMap by pairing
+// the function's declared TypeParameters with the concrete type arguments
+// resolved at compile time and passed through the invoke instruction.
+//
+// The pairing is positional: the i-th type argument corresponds to the i-th
+// declared type parameter. The type parameters must either be all bound, or none:
+// `typeArguments` is therefore either empty, or has exactly one entry per declared
+// type parameter (see `loadTypeArguments` in the compiler, which enforces this).
+func reconstructTypeArguments(
+	context *Context,
+	funcType *sema.FunctionType,
+	typeArguments []bbq.StaticType,
+) *sema.TypeParameterTypeOrderedMap {
+	typeParameterMap := &sema.TypeParameterTypeOrderedMap{}
+
+	typeParameters := funcType.TypeParameters
+
+	typeArgumentsLength := len(typeArguments)
+	typeParametersLength := len(typeParameters)
+
+	// The type parameters are either all bound, or none.
+	if typeArgumentsLength != 0 && typeArgumentsLength != typeParametersLength {
+		panic(errors.NewUnexpectedError(
+			"invalid number of type arguments: got %d, expected 0 or %d",
+			typeArgumentsLength,
+			typeParametersLength,
+		))
+	}
+
+	for i, typeArgument := range typeArguments {
+		semaType := context.SemaTypeFromStaticType(typeArgument)
+		if semaType != nil {
+			typeParameterMap.Set(typeParameters[i], semaType)
+		}
+	}
+
+	return typeParameterMap
 }
 
 func isImplicitArgument(

--- a/interpreter/invocation_test.go
+++ b/interpreter/invocation_test.go
@@ -720,19 +720,9 @@ func TestInterpretFunctionParameterContravariance(t *testing.T) {
 			methodInvoked = true
 			assert.Len(t, args, 1)
 
-			var expectedArg interpreter.Value
-			if *compile {
-				// Currently, VM does not resolve type-parameters at runtime.
-				// Therefore, it takes the statically known parameter type, which is `Int`.
-				// So the argument does not get boxed.
-				// TODO: Update the assert once the type-parameter resolving is
-				// supported for invocations in the VM.
-				expectedArg = interpreter.NewUnmeteredIntValueFromInt64(4)
-			} else {
-				expectedArg = interpreter.NewUnmeteredSomeValueNonCopying(
-					interpreter.NewUnmeteredIntValueFromInt64(4),
-				)
-			}
+			expectedArg := interpreter.NewUnmeteredSomeValueNonCopying(
+				interpreter.NewUnmeteredIntValueFromInt64(4),
+			)
 			assert.Equal(t, expectedArg, args[0])
 
 			return interpreter.Void

--- a/sema/check_invocation_expression.go
+++ b/sema/check_invocation_expression.go
@@ -541,6 +541,7 @@ func (checker *Checker) checkInvocation(
 		invocationExpression,
 		InvocationExpressionTypes{
 			TypeArguments:     typeArguments,
+			TypeParameters:    functionType.TypeParameters,
 			ParameterTypes:    parameterTypes,
 			ReturnType:        returnType,
 			ArgumentTypes:     argumentTypes,

--- a/sema/elaboration.go
+++ b/sema/elaboration.go
@@ -74,6 +74,7 @@ type AssignmentStatementTypes struct {
 type InvocationExpressionTypes struct {
 	ReturnType     Type
 	TypeArguments  *TypeParameterTypeOrderedMap
+	TypeParameters []*TypeParameter
 	ArgumentTypes  []Type
 	ParameterTypes []Type
 


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3804

## Description

Fixes a tech-debt that got introduced while improving safety checks:

> ❗Properly resolve type-parameters for invocations at runtime. See
> - https://github.com/onflow/cadence-internal/pull/452#discussion_r2926789413
> - https://github.com/onflow/cadence-internal/pull/454


Achieved by reconstructing the type-arguments map at runtime to dynamically resolve parameter types.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
