### PR TITLE
[Compiler] Separate attachment-base passing from arguments

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -2811,7 +2811,6 @@ func (c *Compiler[_, _]) emitVariableStore(name string) {
 func (c *Compiler[_, _]) visitInvocationExpressionWithImplicitArgument(
 	expression *ast.InvocationExpression,
 	implicitArgIndex *uint16,
-	implicitArgType sema.Type,
 ) (_ struct{}) {
 
 	invocationTypes := c.DesugaredElaboration.InvocationExpressionTypes(expression)
@@ -2848,7 +2847,6 @@ func (c *Compiler[_, _]) visitInvocationExpressionWithImplicitArgument(
 				memberExpression,
 				invocationTypes,
 				implicitArgIndex,
-				implicitArgType,
 				returnTypeIndex,
 				hasImplicitArgument,
 			)
@@ -2867,7 +2865,6 @@ func (c *Compiler[_, _]) visitInvocationExpressionWithImplicitArgument(
 	c.emitInvocation(
 		expression,
 		implicitArgIndex,
-		implicitArgType,
 		invocationTypes,
 		returnTypeIndex,
 		hasImplicitArgument,
@@ -2879,18 +2876,23 @@ func (c *Compiler[_, _]) visitInvocationExpressionWithImplicitArgument(
 func (c *Compiler[_, _]) emitInvocation(
 	expression *ast.InvocationExpression,
 	implicitArgIndex *uint16,
-	implicitArgType sema.Type,
 	invocationTypes sema.InvocationExpressionTypes,
 	returnTypeIndex uint16,
 	hasImplicitArgument bool,
 ) {
+	// Load the `base` argument first explicitly rather than including it the arguments.
+	// This keeps the placement of base consistent with attachment methods.
+	if implicitArgIndex != nil {
+		c.emitGetLocal(*implicitArgIndex)
+	}
+
 	// Compile arguments
 	c.compileArguments(expression.Arguments, invocationTypes)
 
 	typeArgs := c.loadTypeArguments(invocationTypes)
 
 	argTypes := c.loadTypes(invocationTypes.ArgumentTypes)
-	argTypes = c.addImplicitArgumentTyped(implicitArgIndex, implicitArgType, argTypes)
+
 	paramTypes := c.loadTypes(invocationTypes.ParameterTypes)
 
 	c.emit(opcode.InstructionInvoke{
@@ -2903,31 +2905,8 @@ func (c *Compiler[_, _]) emitInvocation(
 	})
 }
 
-func (c *Compiler[_, _]) addImplicitArgumentTyped(
-	implicitArgIndex *uint16,
-	implicitArgType sema.Type,
-	argTypes []uint16,
-) []uint16 {
-	if implicitArgIndex == nil {
-		return argTypes
-	}
-
-	// Add the implicit argument to the end of the argument list, if it exists.
-	// Used in attachments, the attachment constructor/init expects an implicit argument:
-	// a reference to the base value used to set base.
-	// This hides the base argument away from the user.
-
-	// Load implicit argument from locals
-	// Base is at the back of the argument list, only for attachment initialization.
-	c.emitGetLocal(*implicitArgIndex)
-
-	argTypes = append(argTypes, c.getOrAddType(implicitArgType))
-
-	return argTypes
-}
-
 func (c *Compiler[_, _]) VisitInvocationExpression(expression *ast.InvocationExpression) (_ struct{}) {
-	c.visitInvocationExpressionWithImplicitArgument(expression, nil, nil)
+	c.visitInvocationExpressionWithImplicitArgument(expression, nil)
 
 	return
 }
@@ -2962,7 +2941,6 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 	invokedExpr *ast.MemberExpression,
 	invocationTypes sema.InvocationExpressionTypes,
 	implicitArgIndex *uint16,
-	implicitArgType sema.Type,
 	returnTypeIndex uint16,
 	hasImplicitArgument bool,
 ) {
@@ -2983,7 +2961,6 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 		c.emitInvocation(
 			expression,
 			implicitArgIndex,
-			implicitArgType,
 			invocationTypes,
 			returnTypeIndex,
 			hasImplicitArgument,
@@ -3029,7 +3006,6 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 				c.emitInvocation(
 					expression,
 					implicitArgIndex,
-					implicitArgType,
 					invocationTypes,
 					returnTypeIndex,
 					hasImplicitArgument,
@@ -3060,7 +3036,6 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 		c.emitInvocation(
 			expression,
 			implicitArgIndex,
-			implicitArgType,
 			invocationTypes,
 			returnTypeIndex,
 			hasImplicitArgument,
@@ -3081,7 +3056,6 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 				c.emitInvocation(
 					expression,
 					implicitArgIndex,
-					implicitArgType,
 					invocationTypes,
 					returnTypeIndex,
 					hasImplicitArgument,
@@ -3828,21 +3802,13 @@ func (c *Compiler[_, _]) compileInitializer(declaration *ast.SpecialFunctionDecl
 	c.targetFunction(function)
 	defer c.targetFunction(previousFunction)
 
-	// cannot declare base as parameter because it is at the end of the argument list
-	// this is only true for initialization of attachments.
-	// otherwise, base is declared as the second parameter after self.
-	c.declareParameters(parameterList, false, false)
+	isAttachmentConstructor := kind == common.CompositeKindAttachment
 
+	// Declare parameters.
+	c.declareParameters(parameterList, false, isAttachmentConstructor)
+
+	// Declare a local variable to store `self`.
 	memoryGauge := c.Config.MemoryGauge
-
-	var base *local
-	// must do this before declaring self
-	if kind == common.CompositeKindAttachment {
-		// base is provided as an argument at the end of the argument list implicitly
-		base = c.currentFunction.declareLocal(memoryGauge, sema.BaseIdentifier)
-	}
-
-	// Declare `self`
 	self := c.currentFunction.declareLocal(memoryGauge, sema.SelfIdentifier)
 
 	// Initialize an empty struct and assign to `self`.
@@ -3881,7 +3847,7 @@ func (c *Compiler[_, _]) compileInitializer(declaration *ast.SpecialFunctionDecl
 			)
 		}
 	} else {
-		addressValue := interpreter.NewAddressValue(c.Config.MemoryGauge, address)
+		addressValue := interpreter.NewAddressValue(memoryGauge, address)
 		addressConstant := c.addConstant(
 			constant.Address,
 			addressValue,
@@ -3900,23 +3866,29 @@ func (c *Compiler[_, _]) compileInitializer(declaration *ast.SpecialFunctionDecl
 
 	// stores the return value of the constructor
 	var returnLocalIndex uint16
+
 	// `self` in attachments is a reference.
-	if kind == common.CompositeKindAttachment {
+	if isAttachmentConstructor {
 		// Store the new composite as the return value.
 		returnLocalIndex = c.currentFunction.generateLocalIndex()
 		c.emitSetLocal(returnLocalIndex)
+
 		attachType := enclosingType.(sema.EntitlementSupportingType)
 		baseAccess := attachType.SupportedEntitlements().Access()
 		refType := &sema.ReferenceType{
 			Type:          attachType,
 			Authorization: baseAccess,
 		}
+
 		// we need to set the attachment's base value
 		// because it may be used in function calls in the initializer.
 		// see `call function in initializer` test.
+		base := c.currentFunction.findLocal(sema.BaseIdentifier)
 		c.emitGetLocal(base.index)
+
 		c.emitGetLocal(returnLocalIndex)
 		c.emit(opcode.InstructionSetAttachmentBase{})
+
 		// Set `self` to be a reference.
 		c.emitGetLocal(returnLocalIndex)
 		c.emit(opcode.InstructionNewRef{
@@ -4500,7 +4472,6 @@ func (c *Compiler[_, _]) VisitAttachExpression(expression *ast.AttachExpression)
 	c.visitInvocationExpressionWithImplicitArgument(
 		expression.Attachment,
 		&refLocalIndex,
-		refType,
 	)
 	// attachment on stack
 

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -12236,6 +12236,10 @@ func TestCompileAttachments(t *testing.T) {
 				},
 				// get A constructor
 				opcode.PrettyInstructionGetGlobal{Global: aConstructorGlobalIndex},
+				// get s reference (base is loaded before the explicit arguments).
+				// base is passed as an implicit argument (see HasImplicitArgument),
+				// so its type is not part of ArgTypes.
+				opcode.PrettyInstructionGetLocal{Local: sRefLocalIndex},
 				// get 3
 				opcode.PrettyInstructionGetConstant{
 					Constant: constant.DecodedConstant{
@@ -12244,13 +12248,10 @@ func TestCompileAttachments(t *testing.T) {
 					},
 				},
 				opcode.PrettyInstructionTransfer{},
-				// get s reference
-				opcode.PrettyInstructionGetLocal{Local: sRefLocalIndex},
 				// invoke A constructor with &s as arg, puts A on stack
 				opcode.PrettyInstructionInvoke{
 					ArgTypes: []interpreter.StaticType{
 						interpreter.PrimitiveStaticTypeInt,
-						sRefType,
 					},
 					ParamTypes: []interpreter.StaticType{
 						interpreter.PrimitiveStaticTypeInt,
@@ -12311,9 +12312,10 @@ func TestCompileAttachments(t *testing.T) {
 		)
 
 		// local variables
+		// base is prepended before the explicit parameters
 		const (
-			xLocalIndex = iota
-			baseLocalIndex
+			baseLocalIndex = iota
+			xLocalIndex
 			selfLocalIndex
 			returnLocalIndex
 		)

--- a/bbq/vm/callframe.go
+++ b/bbq/vm/callframe.go
@@ -31,7 +31,6 @@ type callFrame struct {
 
 	function *CompiledFunctionValue
 
-	localsOffset        uint16
-	localsCount         uint16
-	hasImplicitArgument bool
+	localsOffset uint16
+	localsCount  uint16
 }

--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -437,23 +437,14 @@ func (c *Context) DefaultDestroyEvents(resourceValue *interpreter.CompositeValue
 	// Safe to assume the receiver is not a reference.
 	var accessedReference interpreter.ReferenceValue = nil
 
-	method := c.GetMethod(resourceValue, commons.ResourceDestroyedEventsFunctionName, accessedReference)
+	method := c.GetMethod(
+		resourceValue,
+		commons.ResourceDestroyedEventsFunctionName,
+		accessedReference,
+	)
 
 	if method == nil {
 		return nil
-	}
-
-	var arguments []Value
-
-	if resourceValue.Kind == common.CompositeKindAttachment {
-		base, _ := interpreter.AttachmentBaseAndSelfValues(
-			c,
-			sema.UnauthorizedAccess,
-			resourceValue,
-		)
-		arguments = []Value{
-			base,
-		}
 	}
 
 	eventValues := make([]*interpreter.CompositeValue, 0)
@@ -476,7 +467,12 @@ func (c *Context) DefaultDestroyEvents(resourceValue *interpreter.CompositeValue
 		},
 	)
 
-	arguments = append(arguments, collectFunction)
+	// The `base` (for attachments) is not included in the arguments list.
+	// It is carried by the bound-method value (see `GetMethod` /
+	// `attachmentBaseForMethod`), and is supplied to the call frame implicitly,
+	// just like for any other attachment method invocation.
+
+	arguments := []Value{collectFunction}
 
 	// The generated function takes no arguments unless it's an attachment, and returns nothing.
 	returnType := sema.VoidType

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -245,9 +245,6 @@ func (vm *VM) pushCallFrame(
 		function:     functionValue,
 		tracingInfo:  tracingInfo,
 		returnType:   returnType,
-
-		// TODO: Can we remove this?
-		hasImplicitArgument: base != nil,
 	}
 
 	vm.ipStack = append(vm.ipStack, 0)
@@ -1994,11 +1991,13 @@ func opSetTypeIndex(vm *VM, ins opcode.InstructionSetTypeIndex) {
 }
 
 func opSetAttachmentBase(vm *VM) {
-	if !vm.callFrame.hasImplicitArgument {
+	base, attachment := vm.pop2()
+
+	// If the attachment was constructed outside an attach-statement,
+	// then the base variable is nil / not set.
+	if base == nil {
 		panic(&interpreter.InvalidAttachmentConstructorError{})
 	}
-
-	base, attachment := vm.pop2()
 
 	attachmentComposite, ok := attachment.(*interpreter.CompositeValue)
 	if !ok {

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -199,10 +199,9 @@ func fill(slice []Value, n int) []Value {
 
 func (vm *VM) pushCallFrame(
 	functionValue *CompiledFunctionValue,
-	receiver Value,
+	receiver, base Value,
 	arguments []Value,
 	returnType bbq.StaticType,
-	hasImplicitArgument bool,
 ) {
 	if uint64(len(vm.callstack)) == vm.context.StackDepthLimit {
 		panic(&interpreter.CallStackLimitExceededError{
@@ -215,6 +214,10 @@ func (vm *VM) pushCallFrame(
 	passedInLocalsCount := len(arguments)
 	if receiver != nil {
 		vm.locals = append(vm.locals, receiver)
+		passedInLocalsCount++
+	}
+	if base != nil {
+		vm.locals = append(vm.locals, base)
 		passedInLocalsCount++
 	}
 
@@ -237,12 +240,14 @@ func (vm *VM) pushCallFrame(
 	}
 
 	callFrame := callFrame{
-		localsCount:         localsCount,
-		localsOffset:        offset,
-		function:            functionValue,
-		tracingInfo:         tracingInfo,
-		returnType:          returnType,
-		hasImplicitArgument: hasImplicitArgument,
+		localsCount:  localsCount,
+		localsOffset: offset,
+		function:     functionValue,
+		tracingInfo:  tracingInfo,
+		returnType:   returnType,
+
+		// TODO: Can we remove this?
+		hasImplicitArgument: base != nil,
 	}
 
 	vm.ipStack = append(vm.ipStack, 0)
@@ -443,12 +448,12 @@ func (vm *VM) invokeExternally(
 	invokeFunction(
 		vm,
 		functionValue,
+		nil,
 		arguments,
 		nil,
 		nil,
 		nil,
 		staticReturnType,
-		false,
 		skipArgumentConversion,
 		withValidation,
 	)
@@ -995,33 +1000,27 @@ func opInvoke(vm *VM, ins opcode.InstructionInvoke) {
 	// Load arguments
 	arguments := vm.popN(len(ins.ArgTypes))
 
+	// Load base: Only applicable for attachment constructors.
+	var base Value
+	if ins.HasImplicitArgument {
+		base = vm.pop()
+	}
+
 	// Load the invoked value
 	functionValue := vm.pop()
 
 	// Return value type
 	returnType := vm.loadType(ins.ReturnType)
 
-	// Add base to front of arguments if the function is bound and base is defined.
-	if boundFunction, isBoundFunction := functionValue.(*BoundFunctionValue); isBoundFunction {
-		base := boundFunction.Base
-		if base != nil {
-			arguments = append([]Value{base}, arguments...)
-			argumentTypes = append(
-				[]bbq.StaticType{base.StaticType(vm.context)},
-				argumentTypes...,
-			)
-		}
-	}
-
 	invokeFunction(
 		vm,
 		functionValue,
+		base,
 		arguments,
 		typeArguments,
 		argumentTypes,
 		parameterTypes,
 		returnType,
-		ins.HasImplicitArgument,
 		ins.SkipArgumentConversion,
 		true,
 	)
@@ -1106,12 +1105,12 @@ var emptyTypeParametersMap = &sema.TypeParameterTypeOrderedMap{}
 func invokeFunction(
 	vm *VM,
 	functionValue Value,
+	base Value,
 	arguments []Value,
 	typeArguments []bbq.StaticType,
 	argumentTypes []bbq.StaticType,
 	parameterTypes []bbq.StaticType,
 	returnType bbq.StaticType,
-	hasImplicitArgument bool,
 	skipArgumentConversion bool,
 	withValidation bool,
 ) {
@@ -1125,17 +1124,23 @@ func invokeFunction(
 	boundFunction, isBoundFunction := functionValue.(*BoundFunctionValue)
 	if isBoundFunction {
 		functionValue = boundFunction.Method
+
+		// Only override the base if the bound function actually carries one
+		// (i.e. for attachment methods). `BoundFunctionValue.Base` is a concrete
+		// pointer type, so assigning a nil pointer directly to the `base Value`
+		// interface would produce a non-nil (typed-nil) interface value.
+		if boundFunction.Base != nil {
+			base = boundFunction.Base
+		}
 	}
 
 	if !skipArgumentConversion {
 		arguments = convertAndBoxArguments(
 			context,
 			originalFunctionValue,
-			boundFunction,
 			arguments,
 			argumentTypes,
 			parameterTypes,
-			hasImplicitArgument,
 			withValidation,
 		)
 	}
@@ -1155,9 +1160,9 @@ func invokeFunction(
 		vm.pushCallFrame(
 			functionValue,
 			receiver,
+			base,
 			arguments,
 			returnType,
-			hasImplicitArgument,
 		)
 
 	case *NativeFunctionValue:
@@ -1205,11 +1210,9 @@ func invokeFunction(
 func convertAndBoxArguments(
 	context *Context,
 	originalFunctionValue FunctionValue,
-	boundFunctionValue *BoundFunctionValue,
 	arguments []Value,
 	argumentTypes []bbq.StaticType,
 	parameterTypes []bbq.StaticType,
-	hasImplicitArgument bool,
 	withValidation bool,
 ) []Value {
 	// Convert arguments to match the actual function's parameter types.
@@ -1222,7 +1225,6 @@ func convertAndBoxArguments(
 	actualParams := actualFuncType.Parameters
 
 	paramIndex := 0
-	lastArgIndex := len(arguments) - 1
 
 	// Catch and re-panic transfer/conversion errors for arguments as user-errors.
 	defer func() {
@@ -1240,16 +1242,6 @@ func convertAndBoxArguments(
 	}()
 
 	for currentArgIndex, arg := range arguments {
-		// Attachment-base is an implicit argument. Skip it form conversions.
-		if isImplicitArgument(
-			currentArgIndex,
-			lastArgIndex,
-			boundFunctionValue,
-			hasImplicitArgument,
-		) {
-			continue
-		}
-
 		var paramType bbq.StaticType
 		if paramIndex < len(actualParams) {
 			// TODO: Properly resolve the type parameters.
@@ -1298,20 +1290,25 @@ func convertAndBoxArguments(
 
 func isImplicitArgument(
 	currentArgIndex int,
-	lastArgIndex int,
 	boundFunction *BoundFunctionValue,
 	hasImplicitArgument bool,
 ) bool {
 	// TODO: See if we can simplify the passing of `base` to be more explicit.
 
-	// When invoking a bound function of an attachment, base is the very first argument.
-	if currentArgIndex == 0 && boundFunction != nil &&
-		boundFunction.Base != nil {
-		return true
+	// The attachment `base` is an implicit argument and is always placed before the explicit/user arguments.
+	// This is the same for both attachment methods (bound functions) and attachment initializers (`attach A() to T`).
+	// Skip it from conversions.
+
+	if currentArgIndex != 0 {
+		return false
 	}
 
-	// During `attach A() to T`, the base is passed in as the last argument.
-	return hasImplicitArgument && currentArgIndex == lastArgIndex
+	// Attachment constructors relies on the `hasImplicitArgument` flag
+	// to determine whether there is a "base" value at the start of the arguments.
+	// Attachments methods are bound functions, and they rely on the "Base"
+	// variable of the bound function.
+	return hasImplicitArgument ||
+		(boundFunction != nil && boundFunction.Base != nil)
 }
 
 func loadTypeArguments(vm *VM, typeArgs []uint16) []bbq.StaticType {

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -1285,29 +1285,6 @@ func convertAndBoxArguments(
 	return arguments
 }
 
-func isImplicitArgument(
-	currentArgIndex int,
-	boundFunction *BoundFunctionValue,
-	hasImplicitArgument bool,
-) bool {
-	// TODO: See if we can simplify the passing of `base` to be more explicit.
-
-	// The attachment `base` is an implicit argument and is always placed before the explicit/user arguments.
-	// This is the same for both attachment methods (bound functions) and attachment initializers (`attach A() to T`).
-	// Skip it from conversions.
-
-	if currentArgIndex != 0 {
-		return false
-	}
-
-	// Attachment constructors relies on the `hasImplicitArgument` flag
-	// to determine whether there is a "base" value at the start of the arguments.
-	// Attachments methods are bound functions, and they rely on the "Base"
-	// variable of the bound function.
-	return hasImplicitArgument ||
-		(boundFunction != nil && boundFunction.Base != nil)
-}
-
 func loadTypeArguments(vm *VM, typeArgs []uint16) []bbq.StaticType {
 	var typeArguments []bbq.StaticType
 	if len(typeArgs) > 0 {

--- a/interpreter/attachments_test.go
+++ b/interpreter/attachments_test.go
@@ -60,6 +60,41 @@ func TestInterpretAttachmentStruct(t *testing.T) {
 		AssertValuesEqual(t, inter, interpreter.NewUnmeteredIntValueFromInt64(3), value)
 	})
 
+	t.Run("basic with arguments", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndPrepare(t, `
+        struct S {}
+
+        attachment A for S {
+            let i: Int
+
+            init(_ i: Int) {
+                self.i = i
+            }
+
+            fun foo(): Int { return self.i }
+        }
+
+        fun test(): Int {
+            var s = S()
+            s = attach A(3) to s
+            return s[A]?.foo()!
+        }
+    `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredIntValueFromInt64(3),
+			value,
+		)
+	})
+
 	t.Run("duplicate attach", func(t *testing.T) {
 
 		t.Parallel()


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3804

## Description

So far, `base` reference for attachment functions/constructor was passed-in as part of the arguments list. This had complicated things, since `base` needed to be special cased in several places. Simplify this by separating the `base` from normal arguments, and handle the same way as `self` is being passed into functions.

Also fixes an inconsistency where `base` was placed **before** the normal arguments for attachment bound-functions, where as `base` was placed **after** the normal arguments for attachment constructors. Again, this was both complicating things, as well as inconsistent. So improved this by always placing the `base` before the normal arguments, regardless of the scenario.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
