### PR TITLE
[Compiler] Defensively check resource construction location at runtime

### DIFF
--- a/bbq/vm/test/vm_test.go
+++ b/bbq/vm/test/vm_test.go
@@ -3368,7 +3368,9 @@ func TestResource(t *testing.T) {
 
 		vmConfig := PrepareVMConfig(t, nil, programs)
 
-		vmInstance := vm.NewVM(scriptLocation(), program, vmConfig)
+		// Run the VM at the same location the program was compiled at (TestLocation),
+		// so that the resource `Foo` is constructed within its declaring location.
+		vmInstance := vm.NewVM(TestLocation, program, vmConfig)
 
 		vmContext := vmInstance.Context()
 

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -293,6 +293,17 @@ func (vm *VM) popCallFrame() (poppedCallFrame *callFrame) {
 	return poppedCallFrame
 }
 
+// callerLocation returns the location of the function that invoked the
+// currently executing function, or nil if there is no caller.
+// (i.e. the current function is the top-level invocation)
+func (vm *VM) callerLocation() common.Location {
+	callstackLen := len(vm.callstack)
+	if callstackLen < 2 {
+		return nil
+	}
+	return vm.callstack[callstackLen-2].function.Executable.Location
+}
+
 func (vm *VM) getGlobalFunction(name string) (FunctionValue, error) {
 	functionVariable := vm.globals.Find(name)
 	if functionVariable == nil {
@@ -1421,6 +1432,24 @@ func newCompositeValue(
 	compositeStaticType := staticType.(*interpreter.CompositeStaticType)
 
 	context := vm.context
+
+	// Check that the resource is constructed in the same location as it was declared.
+	// This guards against constructing a resource outside of its declaring location,
+	// e.g. by invoking a resource constructor that was obtained as a first-class
+	// function value from another program.
+	if compositeKind == common.CompositeKindResource {
+		callerLocation := vm.callerLocation()
+		if callerLocation != nil &&
+			callerLocation != compositeStaticType.Location {
+
+			compositeType, ok := context.SemaTypeFromStaticType(compositeStaticType).(*sema.CompositeType)
+			if ok {
+				panic(&interpreter.ResourceConstructionError{
+					CompositeType: compositeType,
+				})
+			}
+		}
+	}
 
 	compositeFields := newCompositeValueFields(context, compositeKind)
 

--- a/interpreter/import_test.go
+++ b/interpreter/import_test.go
@@ -350,89 +350,141 @@ func TestInterpretResourceConstructionThroughIndirectImport(t *testing.T) {
 
 	address := common.MustBytesToAddress([]byte{0x1})
 
-	importedChecker, err := ParseAndCheckWithOptions(t,
-		`
-          resource R {}
-        `,
-		ParseAndCheckOptions{
-			Location: common.AddressLocation{
-				Address: address,
-			},
-		},
-	)
-	require.NoError(t, err)
+	rLocation := common.AddressLocation{
+		Address: address,
+		Name:    "R",
+	}
 
-	importingChecker, err := ParseAndCheckWithOptions(t,
-		`
+	const importedCode = `
+          resource R {}
+        `
+
+	const code = `
           import R from 0x1
 
           fun test(createR: fun(): @R) {
               let r <- createR()
               destroy r
           }
-        `,
-		ParseAndCheckOptions{
-			CheckerConfig: &sema.Config{
-				ImportHandler: func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
-					require.IsType(t, common.AddressLocation{}, importedLocation)
-					addressLocation := importedLocation.(common.AddressLocation)
+        `
+
+	var invocationError error
+
+	if *compile {
+		// Run with compiler
+
+		programs := CompiledPrograms{}
+
+		importedProgram := ParseCheckAndCompileCodeWithOptions(t,
+			importedCode,
+			rLocation,
+			ParseCheckAndCompileOptions{},
+			programs,
+		)
+
+		mainLocation := common.ScriptLocation{0x1}
+		mainProgram := ParseCheckAndCompileCodeWithOptions(t,
+			code,
+			mainLocation,
+			ParseCheckAndCompileOptions{
+				ParseAndCheckOptions: &ParseAndCheckOptions{
+					CheckerConfig: &sema.Config{
+						LocationHandler: SingleIdentifierLocationResolver(t),
+					},
+				},
+			},
+			programs,
+		)
+
+		vmConfig := test.PrepareVMConfig(t, nil, programs)
+
+		// Obtain the resource constructor from the imported program,
+		// so it can be passed as a first-class function value to the main program.
+		importVM := vm.NewVM(rLocation, importedProgram, vmConfig)
+		rConstructor := importVM.Global("R")
+
+		mainVM := vm.NewVM(mainLocation, mainProgram, vmConfig)
+
+		// Use the unchecked invocation to bypass the argument type-checking,
+		// which would otherwise reject the resource constructor argument
+		// (due to a purity mismatch) before the resource-construction guard is reached.
+		_, invocationError = mainVM.InvokeExternallyUncheckedForTestingOnly("test", rConstructor) //nolint:staticcheck
+
+	} else {
+		// Run with interpreter
+		importedChecker, err := ParseAndCheckWithOptions(t,
+			importedCode,
+			ParseAndCheckOptions{
+				Location: rLocation,
+			},
+		)
+		require.NoError(t, err)
+
+		importingChecker, err := ParseAndCheckWithOptions(t,
+			code,
+			ParseAndCheckOptions{
+				CheckerConfig: &sema.Config{
+					LocationHandler: SingleIdentifierLocationResolver(t),
+					ImportHandler: func(checker *sema.Checker, importedLocation common.Location, _ ast.Range) (sema.Import, error) {
+						require.IsType(t, common.AddressLocation{}, importedLocation)
+						addressLocation := importedLocation.(common.AddressLocation)
+
+						assert.Equal(t, address, addressLocation.Address)
+
+						return sema.ElaborationImport{
+							Elaboration: importedChecker.Elaboration,
+						}, nil
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		var subInterpreter *interpreter.Interpreter
+
+		inter, err := interpreter.NewInterpreter(
+			interpreter.ProgramFromChecker(importingChecker),
+			importingChecker.Location,
+			&interpreter.Config{
+				ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
+					require.IsType(t, common.AddressLocation{}, location)
+					addressLocation := location.(common.AddressLocation)
 
 					assert.Equal(t, address, addressLocation.Address)
 
-					return sema.ElaborationImport{
-						Elaboration: importedChecker.Elaboration,
-					}, nil
+					program := interpreter.ProgramFromChecker(importedChecker)
+					var err error
+					subInterpreter, err = inter.NewSubInterpreter(program, location)
+					if err != nil {
+						panic(err)
+					}
+
+					return interpreter.InterpreterImport{
+						Interpreter: subInterpreter,
+					}
+				},
+				UUIDHandler: func() (uint64, error) {
+					return 0, nil
 				},
 			},
-		},
-	)
-	require.NoError(t, err)
+		)
+		require.NoError(t, err)
 
-	var subInterpreter *interpreter.Interpreter
+		err = inter.Interpret()
+		require.NoError(t, err)
 
-	inter, err := interpreter.NewInterpreter(
-		interpreter.ProgramFromChecker(importingChecker),
-		importingChecker.Location,
-		&interpreter.Config{
-			ImportLocationHandler: func(inter *interpreter.Interpreter, location common.Location) interpreter.Import {
-				require.IsType(t, common.AddressLocation{}, location)
-				addressLocation := location.(common.AddressLocation)
+		rConstructor := subInterpreter.Globals.Get("R").GetValue(inter)
+		_, invocationError = inter.InvokeUncheckedForTestingOnly("test", rConstructor)
+	}
 
-				assert.Equal(t, address, addressLocation.Address)
-
-				program := interpreter.ProgramFromChecker(importedChecker)
-				var err error
-				subInterpreter, err = inter.NewSubInterpreter(program, location)
-				if err != nil {
-					panic(err)
-				}
-
-				return interpreter.InterpreterImport{
-					Interpreter: subInterpreter,
-				}
-			},
-			UUIDHandler: func() (uint64, error) {
-				return 0, nil
-			},
-		},
-	)
-	require.NoError(t, err)
-
-	err = inter.Interpret()
-	require.NoError(t, err)
-
-	rConstructor := subInterpreter.Globals.Get("R").GetValue(inter)
-
-	_, err = inter.InvokeUncheckedForTestingOnly("test", rConstructor)
-	RequireError(t, err)
+	RequireError(t, invocationError)
 
 	var resourceConstructionError *interpreter.ResourceConstructionError
-	require.ErrorAs(t, err, &resourceConstructionError)
+	require.ErrorAs(t, invocationError, &resourceConstructionError)
 
-	assert.Equal(t,
-		RequireGlobalType(t, subInterpreter, "R"),
-		resourceConstructionError.CompositeType,
-	)
+	compositeType := resourceConstructionError.CompositeType
+	assert.Equal(t, rLocation, compositeType.Location)
+	assert.Equal(t, "R", compositeType.QualifiedIdentifier())
 }
 
 // TestInterpretImportWithAlias shows importing two funs of the same name from different addresses


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3804

## Description

Defensively check whether the resource is constructed at the same location as it is defined. Already exists in the interpreter; Just adding the same to the VM.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
