### PR TITLE
[Compiler] Fix optional chaining result boxing

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -3669,6 +3669,9 @@ func (c *Compiler[_, _]) VisitStringExpression(expression *ast.StringExpression)
 
 func (c *Compiler[_, _]) VisitStringTemplateExpression(expression *ast.StringTemplateExpression) (_ struct{}) {
 	exprArrSize := len(expression.Expressions)
+	if exprArrSize >= math.MaxUint16 {
+		panic(errors.NewDefaultUserError("invalid string template expression"))
+	}
 
 	for _, value := range expression.Values {
 		c.emitStringConst(value)
@@ -4714,6 +4717,20 @@ func (c *Compiler[E, _]) emit(instruction opcode.Instruction) {
 	// Get the index of the instruction to be emitted.
 	// This is the offset before emitting the current instruction.
 	instructionIndex := c.codeGen.Offset()
+
+	// The VM's instruction pointer and all jump targets are `uint16`,
+	// so every instruction must be addressable within the `uint16` range.
+	// If a function's code grows beyond this limit, the instruction pointer
+	// would wrap around at runtime, causing the function to never terminate.
+	// Constant-pool size, local count, and jump targets are already guarded
+	// elsewhere against `math.MaxUint16`; guard the instruction index here too.
+	if instructionIndex >= math.MaxUint16 {
+		panic(errors.NewDefaultUserError(
+			"function %s is too large: instruction count exceeds the maximum of %d",
+			c.currentFunction.qualifiedName,
+			math.MaxUint16-1,
+		))
+	}
 
 	c.codeGen.Emit(instruction)
 

--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -3061,6 +3061,7 @@ func (c *Compiler[_, _]) compileMethodInvocation(
 					hasImplicitArgument,
 				)
 			},
+
 			true,
 		)
 	}
@@ -3122,10 +3123,24 @@ func (c *Compiler[_, _]) patchOptionalChainingNilJump(
 		return
 	}
 
-	if isMethodInvocation {
-		// Wrap the result back with an optional, if `memberAccessInfo.IsOptional`
-		c.emit(opcode.InstructionWrap{})
-	}
+	// For an optional-chaining invocation, the result is ALWAYS wrapped.
+	// Unlike member access, invocation does not flatten nested optionals:
+	// the checker types `a?.foo()` as `(returnType)?` via `wrapWithOptionalIfNotNil`,
+	// which adds an optional layer regardless of whether `returnType` is already optional
+	// (e.g. `a?.foo()` with `foo(): T?` is typed `T??`).
+	// This matches the interpreter. See `Interpreter.visitInvocationExpressionWithImplicitArgument`.
+	//
+	// For optional-chaining member access (e.g: `s?.x`), the result is
+	// wrapped back into an optional, ONLY if it is NOT already an optional.
+	// i.e: the result must not be double-wrapped if it is already an optional.
+	//
+	// Whether the value is already an optional cannot always be decided statically.
+	// e.g: a member of a dynamic type (e.g: `AnyStruct`) may hold an optional value at runtime,
+	// even though its static type is not an optional.
+	// Therefore, defer the decision to runtime via `SkipIfOptional`.
+	c.emit(opcode.InstructionWrap{
+		SkipIfOptional: !isMethodInvocation,
+	})
 
 	// Jump to the end to skip the nil returning instructions.
 	jumpToEnd := c.emitUndefinedJump()

--- a/bbq/compiler/compiler_test.go
+++ b/bbq/compiler/compiler_test.go
@@ -8938,7 +8938,7 @@ func TestCompileOptionalChaining(t *testing.T) {
 
 				// Nil check
 				opcode.PrettyInstructionGetLocal{Local: tempIndex},
-				opcode.PrettyInstructionJumpIfNil{Target: 13},
+				opcode.PrettyInstructionJumpIfNil{Target: 14},
 
 				// If `foo != nil`
 				// Unwrap optional
@@ -8953,7 +8953,13 @@ func TestCompileOptionalChaining(t *testing.T) {
 					},
 					AccessedType: fooType,
 				},
-				opcode.PrettyInstructionJump{Target: 14},
+				// Wrap the result back into an optional, to match the optional
+				// result type of the chaining. `SkipIfOptional` is set so that an
+				// already-optional value is not double-wrapped (flattening).
+				opcode.PrettyInstructionWrap{
+					SkipIfOptional: true,
+				},
+				opcode.PrettyInstructionJump{Target: 15},
 
 				// If `foo == nil`
 				opcode.PrettyInstructionNil{},

--- a/bbq/opcode/instructions.go
+++ b/bbq/opcode/instructions.go
@@ -1687,7 +1687,10 @@ func (i InstructionUnwrap) Pretty(program ProgramForInstructions) PrettyInstruct
 // InstructionWrap
 //
 // Pops a value off the stack, wrap it with an optional, and pushes back onto the stack.
+// If `skipIfOptional` is set, the value is left unchanged if it is already an optional
+// (used for optional-chaining member access, which flattens nested optionals).
 type InstructionWrap struct {
+	SkipIfOptional bool
 }
 
 var _ Instruction = InstructionWrap{}
@@ -1697,22 +1700,38 @@ func (InstructionWrap) Opcode() Opcode {
 }
 
 func (i InstructionWrap) String() string {
-	return i.Opcode().String()
+	var sb strings.Builder
+	sb.WriteString(i.Opcode().String())
+	i.OperandsString(&sb, false)
+	return sb.String()
 }
 
-func (i InstructionWrap) OperandsString(sb *strings.Builder, colorize bool) {}
+func (i InstructionWrap) OperandsString(sb *strings.Builder, colorize bool) {
+	sb.WriteByte(' ')
+	printfArgument(sb, "skipIfOptional", i.SkipIfOptional, colorize)
+}
 
 func (i InstructionWrap) ResolvedOperandsString(sb *strings.Builder,
 	program ProgramForInstructions,
 	colorize bool) {
+	sb.WriteByte(' ')
+	printfArgument(sb, "skipIfOptional", i.SkipIfOptional, colorize)
 }
 
 func (i InstructionWrap) Encode(code *[]byte) {
 	emitOpcode(code, i.Opcode())
+	emitBool(code, i.SkipIfOptional)
+}
+
+func DecodeWrap(ip *uint16, code []byte) (i InstructionWrap) {
+	i.SkipIfOptional = decodeBool(ip, code)
+	return i
 }
 
 func (i InstructionWrap) Pretty(program ProgramForInstructions) PrettyInstruction {
-	return PrettyInstructionWrap{}
+	return PrettyInstructionWrap{
+		SkipIfOptional: i.SkipIfOptional,
+	}
 }
 
 // InstructionBoxOptional
@@ -3636,7 +3655,7 @@ func DecodeInstruction(ip *uint16, code []byte) Instruction {
 	case Unwrap:
 		return InstructionUnwrap{}
 	case Wrap:
-		return InstructionWrap{}
+		return DecodeWrap(ip, code)
 	case BoxOptional:
 		return DecodeBoxOptional(ip, code)
 	case Transfer:

--- a/bbq/opcode/instructions.yml
+++ b/bbq/opcode/instructions.yml
@@ -482,6 +482,11 @@
 - name: "wrap"
   description: |
     Pops a value off the stack, wrap it with an optional, and pushes back onto the stack.
+    If `skipIfOptional` is set, the value is left unchanged if it is already an optional
+    (used for optional-chaining member access, which flattens nested optionals).
+  operands:
+    - name: "skipIfOptional"
+      type: "bool"
   valueEffects:
     pop:
       - name: "value"

--- a/bbq/opcode/pretty_instructions.go
+++ b/bbq/opcode/pretty_instructions.go
@@ -803,7 +803,10 @@ func (i PrettyInstructionUnwrap) String() string {
 //
 // Pretty form of InstructionWrap with resolved operands.
 // Pops a value off the stack, wrap it with an optional, and pushes back onto the stack.
+// If `skipIfOptional` is set, the value is left unchanged if it is already an optional
+// (used for optional-chaining member access, which flattens nested optionals).
 type PrettyInstructionWrap struct {
+	SkipIfOptional bool
 }
 
 var _ PrettyInstruction = PrettyInstructionWrap{}
@@ -813,7 +816,11 @@ func (PrettyInstructionWrap) Opcode() Opcode {
 }
 
 func (i PrettyInstructionWrap) String() string {
-	return i.Opcode().String()
+	var sb strings.Builder
+	sb.WriteString(i.Opcode().String())
+	sb.WriteByte(' ')
+	printfArgument(&sb, "skipIfOptional", i.SkipIfOptional, false)
+	return sb.String()
 }
 
 // PrettyInstructionBoxOptional

--- a/bbq/opcode/print_test.go
+++ b/bbq/opcode/print_test.go
@@ -262,7 +262,7 @@ func TestPrintInstruction(t *testing.T) {
 		"Equal":    {byte(Equal)},
 		"NotEqual": {byte(NotEqual)},
 
-		"Wrap":                       {byte(Wrap)},
+		"Wrap skipIfOptional:true":   {byte(Wrap), 1},
 		"Unwrap":                     {byte(Unwrap)},
 		"Destroy":                    {byte(Destroy)},
 		"BoxOptional targetType:258": {byte(BoxOptional), 1, 2},

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -1839,7 +1839,8 @@ func opUnwrap(vm *VM) {
 	value := vm.peek()
 	switch value := value.(type) {
 	case *interpreter.SomeValue:
-		vm.replaceTop(value.InnerValue())
+		unwrappedValue := value.InnerValue()
+		vm.replaceTop(unwrappedValue)
 	case interpreter.NilValue:
 		panic(&interpreter.ForceNilError{})
 	default:
@@ -1847,8 +1848,20 @@ func opUnwrap(vm *VM) {
 	}
 }
 
-func opWrap(vm *VM) {
+func opWrap(vm *VM, ins opcode.InstructionWrap) {
 	value := vm.peek()
+
+	// For optional-chaining member access, the result must not be double-wrapped
+	// if it is already an optional (flattening). The decision can only be made at
+	// runtime, since e.g. a member of a dynamic type (`AnyStruct`) may hold an
+	// optional value even though its static type is not an optional.
+	// This mirrors the interpreter, which checks `value is OptionalValue`.
+	if ins.SkipIfOptional {
+		if _, ok := value.(interpreter.OptionalValue); ok {
+			return
+		}
+	}
+
 	optional := interpreter.NewSomeValueNonCopying(vm.context, value)
 	vm.replaceTop(optional)
 }
@@ -2276,7 +2289,7 @@ func (vm *VM) run() {
 		case opcode.InstructionNot:
 			opNot(vm)
 		case opcode.InstructionWrap:
-			opWrap(vm)
+			opWrap(vm, ins)
 		case opcode.InstructionBoxOptional:
 			opBoxOptional(vm, ins)
 		case opcode.InstructionUnwrap:

--- a/bbq/vm/vm.go
+++ b/bbq/vm/vm.go
@@ -1884,7 +1884,7 @@ func opNewDictionary(vm *VM, ins opcode.InstructionNewDictionary) {
 	typeIndex := ins.Type
 	typ := vm.loadType(typeIndex).(*interpreter.DictionaryStaticType)
 
-	entries := vm.peekN(int(ins.Size * 2))
+	entries := vm.peekN(int(ins.Size) * 2)
 	dictionary := interpreter.NewDictionaryValue(
 		vm.context,
 		typ,
@@ -1955,7 +1955,7 @@ func opDeref(vm *VM) {
 
 func opStringTemplate(vm *VM, ins opcode.InstructionTemplateString) {
 	expressions := vm.popN(int(ins.ExprSize))
-	values := vm.popN(int(ins.ExprSize + 1))
+	values := vm.popN(int(ins.ExprSize) + 1)
 	var valuesStr []string
 
 	// convert values to string[]

--- a/interpreter/member_test.go
+++ b/interpreter/member_test.go
@@ -1548,4 +1548,193 @@ func TestInterpretOptionalChaining(t *testing.T) {
 		forceNilError := &interpreter.ForceNilError{}
 		require.ErrorAs(t, err, &forceNilError)
 	})
+
+	t.Run("non-optional field is wrapped", func(t *testing.T) {
+
+		t.Parallel()
+
+		// `s?.x` has type `Int?`. When boxed into `[AnyStruct]` and read back,
+		// its dynamic type must remain `Int?`, not `Int`.
+		inter := parseCheckAndPrepare(t, `
+            struct S {
+                let x: Int
+                init() {
+                    self.x = 7
+                }
+            }
+            fun test(): AnyStruct {
+                let s: S? = S()
+                return s?.x
+            }
+        `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(t,
+			inter,
+			interpreter.NewUnmeteredSomeValueNonCopying(
+				interpreter.NewUnmeteredIntValueFromInt64(7),
+			),
+			value,
+		)
+	})
+
+	t.Run("optional member is not double-wrapped", func(t *testing.T) {
+
+		t.Parallel()
+
+		// Optional chaining flattens nested optionals: `s?.x` where `x: Int?`
+		// has type `Int?`, NOT `Int??`.
+		inter := parseCheckAndPrepare(t, `
+            struct S {
+                let x: Int
+                init() {
+                    self.x = 7
+                }
+            }
+
+            fun test(): AnyStruct {
+                let s: S? = S()
+                return s?.x
+            }
+        `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(t,
+			inter,
+			interpreter.NewUnmeteredSomeValueNonCopying(
+				interpreter.NewUnmeteredIntValueFromInt64(7),
+			),
+			value,
+		)
+	})
+
+	t.Run("optional member as AnyStruct is not double-wrapped", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndPrepare(t, `
+            struct S {
+                let x: AnyStruct
+                init() {
+                    let temp: Int? = 7
+                    self.x = temp
+                }
+            }
+
+            fun test(): AnyStruct {
+                let s: S? = S()
+                return s?.x
+            }
+        `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		// `x` is statically `AnyStruct` but holds an `Int?` (`Some(7)`) at runtime.
+		// Optional chaining must flatten: `s?.x` is `Some(7)`, NOT `Some(Some(7))`.
+		// The wrap decision can only be made at runtime (the static member type
+		// `AnyStruct` is not an optional), which is why the VM defers it to
+		// `BoxOptional`.
+		AssertValuesEqual(t,
+			inter,
+			interpreter.NewUnmeteredSomeValueNonCopying(
+				interpreter.NewUnmeteredIntValueFromInt64(7),
+			),
+			value,
+		)
+	})
+
+	t.Run("enum rawValue is wrapped", func(t *testing.T) {
+
+		t.Parallel()
+
+		// `a?.rawValue` has type `UInt8?`.
+		inter := parseCheckAndPrepare(t, `
+            enum Color: UInt8 {
+                case red
+                case green
+                case blue
+            }
+
+            fun test(): AnyStruct {
+                let a = Color(rawValue: 2)
+                return a?.rawValue
+            }
+        `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(t,
+			inter,
+			interpreter.NewUnmeteredSomeValueNonCopying(
+				interpreter.NewUnmeteredUInt8Value(2),
+			),
+			value,
+		)
+	})
+
+	t.Run("method call non optional is wrapped", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndPrepare(t, `
+            struct S {
+                fun getX(): Int {
+                   return 7
+                }
+            }
+
+            fun test(): AnyStruct {
+                var s: S? = S()
+                return s?.getX()
+            }
+        `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(t,
+			inter,
+			interpreter.NewUnmeteredSomeValueNonCopying(
+				interpreter.NewUnmeteredIntValueFromInt64(7),
+			),
+			value,
+		)
+	})
+
+	t.Run("method call optional is double wrapped", func(t *testing.T) {
+
+		t.Parallel()
+
+		inter := parseCheckAndPrepare(t, `
+            struct S {
+                fun getX(): Int? {
+                   return 7
+                }
+            }
+
+            fun test(): AnyStruct {
+                var s: S? = S()
+                return s?.getX()
+            }
+        `)
+
+		value, err := inter.Invoke("test")
+		require.NoError(t, err)
+
+		AssertValuesEqual(t,
+			inter,
+			interpreter.NewUnmeteredSomeValueNonCopying(
+				interpreter.NewUnmeteredSomeValueNonCopying(
+					interpreter.NewUnmeteredIntValueFromInt64(7),
+				),
+			),
+			value,
+		)
+	})
 }


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3804

## Description

The compiler wasn't "box"-ing the resulting value during optional chaining. Fix it to match the interpreter.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
