### PR TITLE
[Compiler] Fix continue statement inside a switch-case

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -1447,18 +1447,32 @@ func (c *Compiler[_, _]) VisitContinueStatement(_ *ast.ContinueStatement) (_ str
 }
 
 func (c *Compiler[_, _]) emitContinue() {
-	currentControlFlow := c.currentControlFlow
+	// `continue` targets the nearest enclosing loop.
+	// Skip any intervening control-flow frames that do not support continue
+	// (e.g. switch statements, which are pushed with an invalid start offset).
+	// This allows `continue` to be used inside a switch that is itself nested in a loop.
+	loopControlFlow := c.nearestLoopControlFlow()
 
-	preContinue := currentControlFlow.preContinue
+	preContinue := loopControlFlow.preContinue
 	if preContinue != nil {
 		preContinue()
 	}
 
-	start := currentControlFlow.start
-	if start <= 0 {
-		panic(errors.NewUnreachableError())
+	c.emitJump(loopControlFlow.start)
+}
+
+// nearestLoopControlFlow returns the innermost control-flow frame that supports
+// `continue` (i.e. a loop, which has a valid, positive start offset).
+// Switch frames are pushed with an invalid start offset and are skipped.
+func (c *Compiler[_, _]) nearestLoopControlFlow() *controlFlow {
+	for i := len(c.controlFlows) - 1; i >= 0; i-- {
+		controlFlow := &c.controlFlows[i]
+		if controlFlow.start > 0 {
+			return controlFlow
+		}
 	}
-	c.emitJump(start)
+
+	panic(errors.NewUnreachableError())
 }
 
 func (c *Compiler[_, _]) VisitIfStatement(statement *ast.IfStatement) (_ struct{}) {

--- a/interpreter/switch_test.go
+++ b/interpreter/switch_test.go
@@ -234,3 +234,159 @@ func TestInterpretSwitchStatement(t *testing.T) {
 		}
 	})
 }
+
+func TestInterpretSwitchStatementControlFlowInLoop(t *testing.T) {
+
+	t.Parallel()
+
+	test := func(t *testing.T, code string, expected int64) {
+		inter := parseCheckAndPrepare(t, code)
+		actual, err := inter.Invoke("test")
+		require.NoError(t, err)
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredIntValueFromInt64(expected),
+			actual,
+		)
+	}
+
+	t.Run("continue in switch in while", func(t *testing.T) {
+		t.Parallel()
+
+		test(t, `
+            fun test(): Int {
+                var sum = 0
+                var i = 0
+                while i < 5 {
+                    i = i + 1
+                    switch i {
+                        case 3:
+                            continue
+                        case 4:
+                            break
+                    }
+                    sum = sum + i
+                }
+                return sum
+            }
+        `,
+			1+2+4+5,
+		)
+	})
+
+	t.Run("continue in switch in for", func(t *testing.T) {
+		t.Parallel()
+
+		test(t, `
+            fun test(): Int {
+                var sum = 0
+                for i in [1, 2, 3, 4, 5] {
+                    switch i {
+                        case 3:
+                            continue
+                        case 4:
+                            break
+                    }
+                    sum = sum + i
+                }
+                return sum
+            }
+        `,
+			1+2+4+5,
+		)
+	})
+
+	t.Run("continue in switch in for with index", func(t *testing.T) {
+		t.Parallel()
+
+		test(t, `
+            fun test(): Int {
+                var sum = 0
+                for i, x in [10, 20, 30, 40] {
+                    switch i {
+                        case 1:
+                            continue
+                    }
+                    sum = sum + x
+                }
+                return sum
+            }
+        `,
+			10+30+40,
+		)
+	})
+
+	t.Run("continue in switch in nested loops", func(t *testing.T) {
+		t.Parallel()
+
+		test(t, `
+            fun test(): Int {
+                var sum = 0
+                var i = 0
+                while i < 3 {
+                    i = i + 1
+                    var j = 0
+                    while j < 3 {
+                        j = j + 1
+                        switch j {
+                            case 2:
+                                continue
+                        }
+                        sum = sum + (i * 10 + j)
+                    }
+                }
+                return sum
+            }
+        `,
+			(11+13)+(21+23)+(31+33),
+		)
+	})
+
+	t.Run("continue in nested switches in loop", func(t *testing.T) {
+		t.Parallel()
+
+		test(t, `
+            fun test(): Int {
+                var sum = 0
+                for i in [1, 2, 3, 4] {
+                    switch i % 2 {
+                        case 0:
+                            switch i {
+                                case 4:
+                                    continue
+                            }
+                    }
+                    sum = sum + i
+                }
+                return sum
+            }
+        `,
+			1+2+3,
+		)
+	})
+
+	t.Run("break in switch only exits switch", func(t *testing.T) {
+		t.Parallel()
+
+		test(
+			t,
+			`
+            fun test(): Int {
+                var sum = 0
+                var i = 0
+                while i < 3 {
+                    i = i + 1
+                    switch i {
+                        case 2:
+                            break
+                    }
+                    sum = sum + i
+                }
+                return sum
+            }
+        `,
+			6,
+		)
+	})
+}


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3804

## Description

Currently the compiler crashes when trying to compile a `continue` statement nested inside a `switch` statement that is also inside a loop.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
