### PR TITLE
Downgrade to Go 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.25'
           cache: true
 
       - name: Build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.26'
+        go-version: '1.25'
         cache: true
 
     - name: Initialize CodeQL

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence
 
-go 1.26.0
+go 1.25
 
 require (
 	github.com/SaveTheRbtz/mph v0.1.1-0.20240117162131-4166ec7869bc

--- a/tools/accounts-script/go.mod
+++ b/tools/accounts-script/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/accounts-script
 
-go 1.26
+go 1.25
 
 require (
 	github.com/ethereum/go-ethereum v1.13.10

--- a/tools/compatibility-check/go.mod
+++ b/tools/compatibility-check/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/compatibility_check
 
-go 1.25
+go 1.25.0
 
 require (
 	github.com/onflow/cadence v1.8.6

--- a/tools/compatibility-check/go.mod
+++ b/tools/compatibility-check/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/compatibility_check
 
-go 1.26.0
+go 1.25
 
 require (
 	github.com/onflow/cadence v1.8.6

--- a/tools/constructorcheck/go.mod
+++ b/tools/constructorcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/constructorcheck
 
-go 1.26
+go 1.25
 
 require golang.org/x/tools v0.32.0
 

--- a/tools/get-contracts/go.mod
+++ b/tools/get-contracts/go.mod
@@ -1,3 +1,3 @@
 module github.com/onflow/cadence/tools/get-contracts
 
-go 1.26
+go 1.25

--- a/tools/go-apply-expr-diff/go.mod
+++ b/tools/go-apply-expr-diff/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/go-apply-expr-diff
 
-go 1.26
+go 1.25
 
 require (
 	github.com/dave/dst v0.27.3

--- a/tools/golangci-lint/go.mod
+++ b/tools/golangci-lint/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/golangci-lint
 
-go 1.26
+go 1.25
 
 require github.com/golangci/golangci-lint/v2 v2.1.6
 

--- a/tools/maprange/go.mod
+++ b/tools/maprange/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/maprange
 
-go 1.26
+go 1.25
 
 require golang.org/x/tools v0.32.0
 

--- a/tools/storage-explorer/go.mod
+++ b/tools/storage-explorer/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/storage-explorer
 
-go 1.26
+go 1.25
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/tools/unkeyed/go.mod
+++ b/tools/unkeyed/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/cadence/tools/unkeyed
 
-go 1.26
+go 1.25
 
 require (
 	golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac


### PR DESCRIPTION

## Description

We had to revert the upgrade of flow-go to Go 1.26 for now, as the crypto library is not ready for it yet.

Downgrade back to Go 1.25 for now.

This unblocks https://github.com/onflow/flow-go/pull/8593

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
