### PR TITLE
[Compiler] Fix function conversion

### DIFF
--- a/bbq/vm/context.go
+++ b/bbq/vm/context.go
@@ -678,10 +678,11 @@ func (c *Context) NewFunctionWithType(
 		}
 	case *NativeFunctionValue:
 		return &NativeFunctionValue{
-			Name:         funcValue.Name,
-			Function:     funcValue.Function,
-			functionType: funcStaticType.FunctionType,
-			fields:       funcValue.fields,
+			Name:                funcValue.Name,
+			Function:            funcValue.Function,
+			functionType:        funcStaticType.FunctionType,
+			fields:              funcValue.fields,
+			dereferenceReceiver: funcValue.dereferenceReceiver,
 		}
 	case *BoundFunctionValue:
 		method := c.NewFunctionWithType(funcValue.Method, funcStaticType).(FunctionValue)

--- a/bbq/vm/vm_test.go
+++ b/bbq/vm/vm_test.go
@@ -19,6 +19,7 @@
 package vm
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/onflow/cadence/bbq"
 	"github.com/onflow/cadence/interpreter"
+	"github.com/onflow/cadence/sema"
 )
 
 func TestVM_pop(t *testing.T) {
@@ -300,4 +302,158 @@ func TestVM_popN(t *testing.T) {
 			interpreter.NewUnmeteredIntValueFromInt64(1),
 		},
 	)
+}
+
+func TestContext_NewFunctionWithType_NativeFunctionPreservesDereferenceReceiver(t *testing.T) {
+	t.Parallel()
+
+	// Two genuinely different function types: `fun(): String` and `fun(Int): String`.
+	originalFuncType := sema.NewSimpleFunctionType(
+		sema.FunctionPurityView,
+		nil,
+		sema.StringTypeAnnotation,
+	)
+	newFuncType := sema.NewSimpleFunctionType(
+		sema.FunctionPurityView,
+		[]sema.Parameter{
+			{TypeAnnotation: sema.IntTypeAnnotation},
+		},
+		sema.StringTypeAnnotation,
+	)
+	require.False(
+		t,
+		originalFuncType.Equal(newFuncType),
+		"the two function types must be distinct for this test to be meaningful",
+	)
+
+	newStaticType := interpreter.NewFunctionStaticType(nil, newFuncType)
+	context := NewContext(NewConfig(nil))
+
+	nativeFuncBody := func(
+		_ interpreter.NativeFunctionContext,
+		_ interpreter.TypeArgumentsIterator,
+		_ interpreter.ArgumentTypesIterator,
+		_ interpreter.Value,
+		_ []interpreter.Value,
+	) interpreter.Value {
+		return interpreter.NewUnmeteredStringValue("ok")
+	}
+
+	t.Run("dereferencing receiver stays dereferencing", func(t *testing.T) {
+		t.Parallel()
+
+		// NewNativeFunctionValue defaults dereferenceReceiver to true.
+		original := NewNativeFunctionValue("test-deref", originalFuncType, nativeFuncBody)
+
+		require.True(t, original.DereferenceReceiver())
+
+		// The original function must have the original type.
+		require.Same(
+			t,
+			originalFuncType,
+			original.FunctionType(context),
+		)
+
+		require.NotEqual(
+			t,
+			newStaticType,
+			original.StaticType(context),
+		)
+
+		result := context.NewFunctionWithType(original, newStaticType)
+		newNativeFunc, ok := result.(*NativeFunctionValue)
+		require.True(
+			t,
+			ok,
+			"expected *NativeFunctionValue, got %T",
+			result,
+		)
+
+		// `dereferenceReceiver` must be preserved.
+		assert.True(
+			t,
+			newNativeFunc.DereferenceReceiver(),
+			"dereferenceReceiver=true must be preserved across NewFunctionWithType",
+		)
+
+		// The result must report the NEW type only, not the original.
+		assert.Same(
+			t,
+			newFuncType,
+			newNativeFunc.FunctionType(context),
+			"FunctionType must be the new type passed to NewFunctionWithType, not the original",
+		)
+		assert.Equal(
+			t,
+			newStaticType,
+			newNativeFunc.StaticType(context),
+			"StaticType must be the new type, not the original",
+		)
+
+		// The underlying native closure is shared (same function pointer).
+		assert.Equal(
+			t,
+			reflect.ValueOf(original.Function).Pointer(),
+			reflect.ValueOf(newNativeFunc.Function).Pointer(),
+			"the underlying native function closure must be shared",
+		)
+	})
+
+	t.Run("non-dereferencing receiver stays non-dereferencing", func(t *testing.T) {
+		t.Parallel()
+
+		original := NewNativeFunctionValueWithDerivedType(
+			"test-no-deref",
+			func(_ Value, _ interpreter.ValueStaticTypeContext) *sema.FunctionType {
+				return originalFuncType
+			},
+			nativeFuncBody,
+		).WithDereferenceReceiver(false)
+
+		require.False(t, original.DereferenceReceiver())
+		require.True(t, original.HasComputedFunctionType())
+		require.Same(
+			t,
+			originalFuncType,
+			original.ComputeFunctionType(nil, context),
+		)
+
+		result := context.NewFunctionWithType(original, newStaticType)
+		newNativeFunc, ok := result.(*NativeFunctionValue)
+		require.True(
+			t,
+			ok,
+			"expected *NativeFunctionValue, got %T",
+			result,
+		)
+
+		// `dereferenceReceiver` must be preserved.
+		assert.False(
+			t,
+			newNativeFunc.DereferenceReceiver(),
+			"dereferenceReceiver=false must be preserved across NewFunctionWithType",
+		)
+
+		// A derived-type function is pinned to a concrete type by the cast,
+		// so the getter is intentionally NOT carried over.
+		assert.False(
+			t,
+			newNativeFunc.HasComputedFunctionType(),
+			"NewFunctionWithType pins a concrete type; the getter should not be carried over",
+		)
+
+		// The result must report the NEW type only, not the original.
+		assert.Same(
+			t,
+			newFuncType,
+			newNativeFunc.FunctionType(context),
+			"FunctionType must be the new type passed to NewFunctionWithType, not the original",
+		)
+		assert.Equal(
+			t,
+			newStaticType,
+			newNativeFunc.StaticType(context),
+			"StaticType must be the new type, not the original",
+		)
+	})
 }


### PR DESCRIPTION
## Description

The function conversion (type clamping) wasn't preserving the `dereferenceReceiver` flag.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
