### PR TITLE
[Compiler] Fix compiling inherited code from same contract

### DIFF
--- a/bbq/compiler/compiler.go
+++ b/bbq/compiler/compiler.go
@@ -4723,10 +4723,10 @@ func (c *Compiler[_, _]) emitConvert(valueType, targetType sema.Type) {
 
 func (c *Compiler[_, _]) getOrAddType(ty sema.Type) uint16 {
 	// When compiling an inherited code, if we come across a concrete contract type,
-	// then use a reference-type to it.
-	// An inherited code can never refer to the currently compiling contract (i.e: circular imports),
-	// so it's always safe to treat an inherited contract-variable type as a reference type.
-	if c.isInheritedCode {
+	// then use a reference-type to it if the contract is imported.
+	// Non-imported contracts (i.e: the enclosing contract of the current program) should be
+	// used as the concrete type, not as a reference.
+	if c.isInheritedCode && c.isImportedContract(ty) {
 		ty = sema.ImportedType(c.Config.MemoryGauge, ty)
 	}
 
@@ -4743,6 +4743,16 @@ func (c *Compiler[_, _]) getOrAddType(ty sema.Type) uint16 {
 
 	c.typesInPool[cacheKey] = index
 	return index
+}
+
+func (c *Compiler[_, _]) isImportedContract(ty sema.Type) bool {
+	compositeType, isCompositeType := ty.(*sema.CompositeType)
+	if !isCompositeType || compositeType.Kind != common.CompositeKindContract {
+		return false
+	}
+
+	_, isImported := c.addedImports[compositeType.Location]
+	return isImported
 }
 
 func (c *Compiler[_, T]) addCompiledType(ty sema.Type, data T) uint16 {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -14037,6 +14037,12 @@ func TestRuntimeContractAccessInInheritedCode(t *testing.T) {
                     }
                 }
 
+                access(all) struct S: I {
+                    // 'foo' function has an inherited pre-condition.
+                    // It refers to the **same** contract inside the inherited code.
+                    access(all) fun test() {}
+                }
+
                 access(all) view fun someFunction(): Bool {
                     return true
                 }
@@ -14094,12 +14100,21 @@ func TestRuntimeContractAccessInInheritedCode(t *testing.T) {
             import Foo from %s
 
             access(all) struct S: Foo.I {
+                // 'foo' function has an inherited pre-condition.
+                // It refers to an **imported** contract inside the inherited code.
                 access(all) fun test() {}
             }
 
             access(all) fun main() {
+                // 'S' struct is inheriting from a type (Foo.I) defined in an imported contract.
+                // So the pre-condition 'Foo.someFunction()' should refer to 'Foo' via a reference.
                 let s = S()
                 s.test()
+
+                // 'Foo.S' struct is inheriting from a type (Foo.I) defined in the same contract.
+                // So the pre-condition 'Foo.someFunction()' should refer to 'Foo' as the concrete type.
+                let fooS = Foo.S()
+                fooS.test()
             }`,
 			addressValue.ShortHexWithPrefix(),
 		)


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3804

## Description

### Problem

Compiling inherited code (e.g: pre/post condition) always treated contract variables as references (i.e: `Foo` in an expression `Foo.hello()`, where `Foo` is a contract). This was correct if the contract `Foo` is an import.

However, this wasn't correct for scenarios where the inherited code  refers to the same contract, and those should not be treat as references.

### Fix

Treat the contract variable as a reference only if it's an imported contract. Otherwise (it's the enclosing contract of the current code) treat it as the concrete type.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
